### PR TITLE
feat: add graph query interface with Cypher support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4554,6 +4554,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-graph"
+version = "0.37.0"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
+ "async-trait",
+ "criterion",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-sql",
+ "futures",
+ "lance",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "nom 7.1.3",
+ "petgraph 0.6.5",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lance-index"
 version = "0.37.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "rust/lance-datagen",
     "rust/lance-encoding",
     "rust/lance-file",
+    "rust/lance-graph",
     "rust/lance-index",
     "rust/lance-io",
     "rust/lance-linalg",
@@ -52,6 +53,7 @@ lance-datafusion = { version = "=0.37.0", path = "./rust/lance-datafusion" }
 lance-datagen = { version = "=0.37.0", path = "./rust/lance-datagen" }
 lance-encoding = { version = "=0.37.0", path = "./rust/lance-encoding" }
 lance-file = { version = "=0.37.0", path = "./rust/lance-file" }
+lance-graph = { version = "=0.37.0", path = "./rust/lance-graph" }
 lance-index = { version = "=0.37.0", path = "./rust/lance-index" }
 lance-io = { version = "=0.37.0", path = "./rust/lance-io", default-features = false }
 lance-linalg = { version = "=0.37.0", path = "./rust/lance-linalg" }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4061,6 +4061,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-graph"
+version = "0.37.0"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
+ "async-trait",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-sql",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "nom 7.1.3",
+ "petgraph 0.6.5",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "lance-index"
 version = "0.37.0"
 dependencies = [
@@ -5774,6 +5799,7 @@ dependencies = [
  "lance-datagen",
  "lance-encoding",
  "lance-file",
+ "lance-graph",
  "lance-index",
  "lance-io",
  "lance-linalg",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -47,6 +47,7 @@ lance-io = { path = "../rust/lance-io" }
 lance-linalg = { path = "../rust/lance-linalg" }
 lance-table = { path = "../rust/lance-table" }
 lance-datafusion = { path = "../rust/lance-datafusion" }
+lance-graph = { path = "../rust/lance-graph" }
 log = "0.4"
 prost = "0.13"
 prost-types = "0.13"

--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,3 @@
 # Lance Python SDK
 
-Please read the contribution guide at https://lancedb.github.io/community/contributing#python-development.pipx install maturin
+Please read the contribution guide at https://lancedb.github.io/community/contributing#python-development.

--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,3 @@
 # Lance Python SDK
 
-Please read the contribution guide at https://lancedb.github.io/community/contributing#python-development.
+Please read the contribution guide at https://lancedb.github.io/community/contributing#python-development.pipx install maturin

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -29,6 +29,7 @@ from .lance import (
     FFILanceTableProvider,
     ScanStatistics,
     bytes_read_counter,
+    graph,
     iops_counter,
 )
 from .schema import json_to_schema, schema_to_json
@@ -60,6 +61,7 @@ __all__ = [
     "Transaction",
     "__version__",
     "bytes_read_counter",
+    "graph",
     "iops_counter",
     "write_dataset",
     "schema_to_json",

--- a/python/python/lance/graph.py
+++ b/python/python/lance/graph.py
@@ -49,7 +49,9 @@ class GraphConfigBuilder:
         Returns:
             Self for method chaining
         """
-        self._builder.with_node_label(label, id_field)
+        # The underlying builder follows a functional style and returns a new builder
+        # instance, so we must retain the result to keep the accumulated state.
+        self._builder = self._builder.with_node_label(label, id_field)
         return self
 
     def with_relationship(self, rel_type: str, source_field: str, target_field: str):
@@ -63,7 +65,11 @@ class GraphConfigBuilder:
         Returns:
             Self for method chaining
         """
-        self._builder.with_relationship(rel_type, source_field, target_field)
+        # As with node mappings, capture the newly returned builder so that
+        # subsequent chained calls see the updated configuration.
+        self._builder = self._builder.with_relationship(
+            rel_type, source_field, target_field
+        )
         return self
 
     def build(self):

--- a/python/python/lance/graph.py
+++ b/python/python/lance/graph.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Graph query functionality for Lance datasets.
+
+This module provides Cypher query support for interpreting Lance datasets
+as property graphs. It allows you to configure how tabular data maps to
+nodes and relationships, then query using Cypher syntax.
+
+Example:
+    >>> import lance
+    >>> from lance.graph import GraphConfig, CypherQuery
+    >>>
+    >>> # Configure graph mapping
+    >>> config = GraphConfig.builder() \\
+    ...     .with_node_label("Person", "person_id") \\
+    ...     .with_relationship("KNOWS", "person_id", "friend_id") \\
+    ...     .build()
+    >>>
+    >>> # Create and execute query
+    >>> query = CypherQuery("MATCH (p:Person) WHERE p.age > 30 RETURN p.name") \\
+    ...     .with_config(config)
+    >>>
+    >>> # Get generated SQL
+    >>> sql = query.to_sql()
+"""
+
+import lance
+
+# Import the base classes
+_GraphConfig = lance.lance.graph.GraphConfig
+_GraphConfigBuilder = lance.lance.graph.GraphConfigBuilder
+_CypherQuery = lance.lance.graph.CypherQuery
+
+
+class GraphConfigBuilder:
+    """Builder for GraphConfig with fluent interface support."""
+
+    def __init__(self):
+        self._builder = _GraphConfigBuilder()
+
+    def with_node_label(self, label: str, id_field: str):
+        """Add a node label mapping.
+
+        Args:
+            label: The node label (e.g., "Person")
+            id_field: The field in the dataset that serves as the node ID
+
+        Returns:
+            Self for method chaining
+        """
+        self._builder.with_node_label(label, id_field)
+        return self
+
+    def with_relationship(self, rel_type: str, source_field: str, target_field: str):
+        """Add a relationship mapping.
+
+        Args:
+            rel_type: The relationship type (e.g., "KNOWS")
+            source_field: The field containing source node IDs
+            target_field: The field containing target node IDs
+
+        Returns:
+            Self for method chaining
+        """
+        self._builder.with_relationship(rel_type, source_field, target_field)
+        return self
+
+    def build(self):
+        """Build the GraphConfig.
+
+        Returns:
+            GraphConfig: The configured graph config
+        """
+        inner_config = self._builder.build()
+        return GraphConfig(inner_config)
+
+
+class GraphConfig:
+    """Graph configuration for interpreting Lance datasets as property graphs."""
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    @staticmethod
+    def builder():
+        """Create a new GraphConfig builder.
+
+        Returns:
+            GraphConfigBuilder: A new builder instance
+        """
+        return GraphConfigBuilder()
+
+    def node_labels(self):
+        """Get node labels.
+
+        Returns:
+            List[str]: List of node labels
+        """
+        return self._inner.node_labels()
+
+    def relationship_types(self):
+        """Get relationship types.
+
+        Returns:
+            List[str]: List of relationship types
+        """
+        return self._inner.relationship_types()
+
+    def __repr__(self):
+        return self._inner.__repr__()
+
+
+class CypherQuery:
+    """Cypher query interface for Lance datasets."""
+
+    def __init__(self, query_text: str):
+        """Create a new Cypher query.
+
+        Args:
+            query_text: The Cypher query string
+        """
+        self._inner = _CypherQuery(query_text)
+
+    def with_config(self, config: GraphConfig):
+        """Set the graph configuration.
+
+        Args:
+            config: The graph configuration
+
+        Returns:
+            CypherQuery: A new query instance with the config set
+        """
+        # Extract the inner config from our wrapper
+        inner_config = config._inner
+        new_inner = self._inner.with_config(inner_config)
+
+        # Create a new CypherQuery wrapper
+        new_query = CypherQuery.__new__(CypherQuery)
+        new_query._inner = new_inner
+        return new_query
+
+    def with_parameter(self, key: str, value):
+        """Add a query parameter.
+
+        Args:
+            key: Parameter name
+            value: Parameter value (will be converted to JSON)
+
+        Returns:
+            CypherQuery: A new query instance with the parameter added
+        """
+        new_inner = self._inner.with_parameter(key, value)
+        new_query = CypherQuery.__new__(CypherQuery)
+        new_query._inner = new_inner
+        return new_query
+
+    def query_text(self):
+        """Get the query text.
+
+        Returns:
+            str: The query text
+        """
+        return self._inner.query_text()
+
+    def parameters(self):
+        """Get query parameters.
+
+        Returns:
+            dict: Query parameters
+        """
+        return self._inner.parameters()
+
+    def to_sql(self):
+        """Convert query to SQL.
+
+        Returns:
+            str: The generated SQL query
+        """
+        return self._inner.to_sql()
+
+    def execute(self, datasets):
+        """Execute query against Lance datasets.
+
+        Args:
+            datasets (dict): Dictionary mapping table names to Lance datasets
+
+        Returns:
+            pyarrow.Table: Query results as Arrow table
+        """
+        # Always use Rust execution - no Python fallback
+        return self._inner.execute(datasets)
+
+    def variables(self):
+        """Get variables used in the query.
+
+        Returns:
+            List[str]: List of variables
+        """
+        return self._inner.variables()
+
+    def node_labels(self):
+        """Get node labels referenced in the query.
+
+        Returns:
+            List[str]: List of node labels
+        """
+        return self._inner.node_labels()
+
+    def relationship_types(self):
+        """Get relationship types referenced in the query.
+
+        Returns:
+            List[str]: List of relationship types
+        """
+        return self._inner.relationship_types()
+
+    def __repr__(self):
+        return self._inner.__repr__()
+
+
+__all__ = ["GraphConfig", "GraphConfigBuilder", "CypherQuery"]

--- a/python/python/tests/test_graph.py
+++ b/python/python/tests/test_graph.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+import os
+
+import lance
+import pandas as pd
+import pytest
+from lance.graph import CypherQuery, GraphConfig
+
+
+@pytest.fixture
+def graph_env(tmp_path):
+    people_data = pd.DataFrame(
+        {
+            "person_id": [1, 2, 3, 4],
+            "name": ["Alice", "Bob", "Carol", "David"],
+            "age": [28, 34, 29, 42],
+            "city": ["New York", "San Francisco", "New York", "Chicago"],
+        }
+    )
+
+    companies_data = pd.DataFrame(
+        {
+            "company_id": [101, 102, 103],
+            "company_name": ["TechCorp", "DataInc", "CloudSoft"],
+            "industry": ["Technology", "Analytics", "Cloud"],
+        }
+    )
+
+    employment_data = pd.DataFrame(
+        {
+            "person_id": [1, 2, 3, 4],
+            "company_id": [101, 101, 102, 103],
+            "position": ["Engineer", "Designer", "Manager", "Director"],
+            "salary": [120000, 95000, 130000, 180000],
+        }
+    )
+
+    friendship_data = pd.DataFrame(
+        {
+            "person1_id": [1, 1, 2, 3],
+            "person2_id": [2, 3, 4, 4],
+            "friendship_type": ["close", "casual", "close", "casual"],
+            "years_known": [5, 2, 3, 1],
+        }
+    )
+
+    config = (
+        GraphConfig.builder()
+        .with_node_label("Person", "person_id")
+        .with_node_label("Company", "company_id")
+        .with_relationship("WORKS_FOR", "person_id", "company_id")
+        .with_relationship("FRIEND_OF", "person1_id", "person2_id")
+        .build()
+    )
+
+    people_ds = lance.write_dataset(
+        people_data, os.path.join(str(tmp_path), "people.lance")
+    )
+    companies_ds = lance.write_dataset(
+        companies_data, os.path.join(str(tmp_path), "companies.lance")
+    )
+    employment_ds = lance.write_dataset(
+        employment_data, os.path.join(str(tmp_path), "employment.lance")
+    )
+    friendship_ds = lance.write_dataset(
+        friendship_data, os.path.join(str(tmp_path), "friendship.lance")
+    )
+
+    datasets = {
+        "Person": people_ds,
+        "Company": companies_ds,
+        "WORKS_FOR": employment_ds,
+        "FRIEND_OF": friendship_ds,
+    }
+
+    return config, datasets, people_data
+
+
+def test_basic_node_selection(graph_env):
+    config, datasets, _ = graph_env
+    query = CypherQuery("MATCH (p:Person) RETURN p.name, p.age").with_config(config)
+    result = query.execute({"Person": datasets["Person"]})
+    df = result.to_pandas()
+    assert len(df) == 4
+    assert set(df.columns) == {"name", "age"}
+    assert "Alice" in set(df["name"].values)
+
+
+def test_filtered_query(graph_env):
+    config, datasets, _ = graph_env
+    query = CypherQuery(
+        "MATCH (p:Person) WHERE p.age > 30 RETURN p.name, p.age"
+    ).with_config(config)
+    result = query.execute({"Person": datasets["Person"]})
+    df = result.to_pandas()
+    assert len(df) == 2
+    assert set(df["name"].values) == {"Bob", "David"}
+    assert all(age > 30 for age in df["age"])
+
+
+def test_relationship_query(graph_env):
+    config, datasets, _ = graph_env
+    # Alias outputs to stable column names regardless of internal qualification
+    query = CypherQuery(
+        "MATCH (p:Person)-[:WORKS_FOR]->(c:Company) "
+        "RETURN p.person_id AS person_id, p.name AS name, c.company_id AS company_id"
+    ).with_config(config)
+
+    result = query.execute(
+        {
+            "Person": datasets["Person"],
+            "Company": datasets["Company"],
+            "WORKS_FOR": datasets["WORKS_FOR"],
+        }
+    )
+    df = result.to_pandas()
+    assert len(df) == 4
+    assert list(df["person_id"].values) == [1, 2, 3, 4]
+    assert list(df["company_id"].values) == [101, 101, 102, 103]
+
+
+def test_friendship_direct_and_network(graph_env):
+    config, datasets, _ = graph_env
+    # Direct friends of Alice (person_id = 1)
+    query_direct = CypherQuery(
+        "MATCH (a:Person)-[:FRIEND_OF]->(b:Person) "
+        "WHERE a.person_id = 1 "
+        "RETURN b.person_id AS friend_id"
+    ).with_config(config)
+
+    result_direct = query_direct.execute(
+        {
+            "Person": datasets["Person"],
+            "FRIEND_OF": datasets["FRIEND_OF"],
+        }
+    )
+    df_direct = result_direct.to_pandas()
+    assert set(df_direct["friend_id"].values) == {2, 3}
+
+    # Full friendship edges
+    query_edges = CypherQuery(
+        "MATCH (f:Person)-[r:FRIEND_OF]->(t:Person) "
+        "RETURN f.person_id AS person1_id, t.person_id AS person2_id"
+    ).with_config(config)
+
+    result_edges = query_edges.execute(
+        {
+            "Person": datasets["Person"],
+            "FRIEND_OF": datasets["FRIEND_OF"],
+        }
+    )
+    df_edges = result_edges.to_pandas()
+    got = set(
+        (int(a), int(b)) for a, b in zip(df_edges["person1_id"], df_edges["person2_id"])
+    )
+    assert got == {(1, 2), (1, 3), (2, 4), (3, 4)}
+
+
+def test_two_hop_friends_of_friends(graph_env):
+    config, datasets, _ = graph_env
+    query = CypherQuery(
+        "MATCH (a:Person)-[:FRIEND_OF]->(b:Person)-[:FRIEND_OF]->(c:Person) "
+        "WHERE a.person_id = 1 "
+        "RETURN a.person_id AS a_id, b.person_id AS b_id, c.person_id AS c_id"
+    ).with_config(config)
+
+    result = query.execute(
+        {
+            "Person": datasets["Person"],
+            "FRIEND_OF": datasets["FRIEND_OF"],
+        }
+    )
+    df = result.to_pandas()
+    # Expect two 2-hop paths ending at 4
+    assert set(df["c_id"].values) == {4}
+
+
+@pytest.mark.xfail(reason="Variable-length path (*1..2) support pending in executor")
+def test_variable_length_path(graph_env):
+    config, datasets, _ = graph_env
+    query = CypherQuery(
+        "MATCH (p1:Person)-[:FRIEND_OF*1..2]-(p2:Person) "
+        "RETURN p1.person_id AS p1, p2.person_id AS p2"
+    ).with_config(config)
+    _ = query.execute(
+        {
+            "Person": datasets["Person"],
+            "FRIEND_OF": datasets["FRIEND_OF"],
+        }
+    )

--- a/python/src/graph.rs
+++ b/python/src/graph.rs
@@ -1,0 +1,435 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Graph query functionality for Lance datasets
+
+use lance_graph::{
+    CypherQuery as RustCypherQuery, GraphConfig as RustGraphConfig, GraphError as RustGraphError,
+};
+use pyo3::{
+    exceptions::{PyRuntimeError, PyValueError},
+    prelude::*,
+    types::PyDict,
+};
+use serde_json::Value as JsonValue;
+
+/// Convert GraphError to PyErr
+fn graph_error_to_pyerr(err: RustGraphError) -> PyErr {
+    PyRuntimeError::new_err(format!("Graph error: {}", err))
+}
+
+/// Graph configuration for interpreting Lance datasets as property graphs
+#[pyclass(module = "lance")]
+#[derive(Clone)]
+pub struct GraphConfig {
+    inner: RustGraphConfig,
+}
+
+#[pymethods]
+impl GraphConfig {
+    /// Create a new GraphConfig builder
+    #[staticmethod]
+    fn builder() -> GraphConfigBuilder {
+        GraphConfigBuilder::new()
+    }
+
+    /// Get node labels
+    fn node_labels(&self) -> Vec<String> {
+        // Extract from the config's node mappings
+        self.inner.node_mappings.keys().cloned().collect()
+    }
+
+    /// Get relationship types
+    fn relationship_types(&self) -> Vec<String> {
+        // Extract from the config's relationship mappings
+        self.inner.relationship_mappings.keys().cloned().collect()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "GraphConfig(nodes={:?}, relationships={:?})",
+            self.node_labels(),
+            self.relationship_types()
+        )
+    }
+}
+
+/// Builder for GraphConfig
+#[pyclass(module = "lance")]
+pub struct GraphConfigBuilder {
+    inner: lance_graph::config::GraphConfigBuilder,
+}
+
+#[pymethods]
+impl GraphConfigBuilder {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: RustGraphConfig::builder(),
+        }
+    }
+
+    /// Add a node label mapping
+    ///
+    /// Parameters
+    /// ----------
+    /// label : str
+    ///     The node label (e.g., "Person")
+    /// id_field : str
+    ///     The field in the dataset that serves as the node ID
+    ///
+    /// Returns
+    /// -------
+    /// None
+    fn with_node_label(&mut self, label: &str, id_field: &str) -> PyResult<()> {
+        self.inner = self.inner.clone().with_node_label(label, id_field);
+        Ok(())
+    }
+
+    /// Add a relationship mapping
+    ///
+    /// Parameters
+    /// ----------
+    /// rel_type : str
+    ///     The relationship type (e.g., "KNOWS")
+    /// source_field : str
+    ///     The field containing source node IDs
+    /// target_field : str
+    ///     The field containing target node IDs
+    ///
+    /// Returns
+    /// -------
+    /// None
+    fn with_relationship(
+        &mut self,
+        rel_type: &str,
+        source_field: &str,
+        target_field: &str,
+    ) -> PyResult<()> {
+        self.inner = self
+            .inner
+            .clone()
+            .with_relationship(rel_type, source_field, target_field);
+        Ok(())
+    }
+
+    /// Build the GraphConfig
+    ///
+    /// Returns
+    /// -------
+    /// GraphConfig
+    ///     The configured graph config
+    ///
+    /// Raises
+    /// ------
+    /// RuntimeError
+    ///     If the configuration is invalid
+    fn build(&self) -> PyResult<GraphConfig> {
+        let config = self.inner.clone().build().map_err(graph_error_to_pyerr)?;
+        Ok(GraphConfig { inner: config })
+    }
+}
+
+/// Cypher query interface for Lance datasets
+#[pyclass(module = "lance")]
+#[derive(Clone)]
+pub struct CypherQuery {
+    inner: RustCypherQuery,
+}
+
+#[pymethods]
+impl CypherQuery {
+    /// Create a new Cypher query
+    ///
+    /// Parameters
+    /// ----------
+    /// query_text : str
+    ///     The Cypher query string
+    ///
+    /// Returns
+    /// -------
+    /// CypherQuery
+    ///     The parsed query
+    ///
+    /// Raises
+    /// ------
+    /// RuntimeError
+    ///     If the query cannot be parsed
+    #[new]
+    fn new(query_text: &str) -> PyResult<Self> {
+        let query = RustCypherQuery::new(query_text).map_err(graph_error_to_pyerr)?;
+        Ok(Self { inner: query })
+    }
+
+    /// Set the graph configuration
+    ///
+    /// Parameters
+    /// ----------
+    /// config : GraphConfig
+    ///     The graph configuration
+    ///
+    /// Returns
+    /// -------
+    /// CypherQuery
+    ///     A new query instance with the config set
+    fn with_config(&self, config: &GraphConfig) -> Self {
+        Self {
+            inner: self.inner.clone().with_config(config.inner.clone()),
+        }
+    }
+
+    /// Add a query parameter
+    ///
+    /// Parameters
+    /// ----------
+    /// key : str
+    ///     Parameter name
+    /// value : object
+    ///     Parameter value (will be converted to JSON)
+    ///
+    /// Returns
+    /// -------
+    /// CypherQuery
+    ///     A new query instance with the parameter added
+    fn with_parameter(&self, key: &str, value: &Bound<'_, PyAny>) -> PyResult<Self> {
+        // Convert Python value to JSON
+        let json_value = python_to_json(value)?;
+        Ok(Self {
+            inner: self.inner.clone().with_parameter(key, json_value),
+        })
+    }
+
+    /// Get the query text
+    fn query_text(&self) -> &str {
+        self.inner.query_text()
+    }
+
+    /// Get query parameters
+    fn parameters(&self) -> PyResult<Py<PyDict>> {
+        Python::with_gil(|py| {
+            let dict = PyDict::new(py);
+            for (key, value) in self.inner.parameters() {
+                let py_value = json_to_python(py, value)?;
+                dict.set_item(key, py_value)?;
+            }
+            Ok(dict.unbind())
+        })
+    }
+
+    /// Convert query to SQL
+    ///
+    /// Returns
+    /// -------
+    /// str
+    ///     The generated SQL query
+    ///
+    /// Raises
+    /// ------
+    /// RuntimeError
+    ///     If SQL generation fails
+    fn to_sql(&self) -> PyResult<String> {
+        self.inner.to_sql().map_err(graph_error_to_pyerr)
+    }
+
+    /// Execute query against Lance datasets
+    ///
+    /// Parameters
+    /// ----------
+    /// datasets : dict
+    ///     Dictionary mapping table names to Lance datasets
+    ///
+    /// Returns
+    /// -------
+    /// pyarrow.Table
+    ///     Query results as Arrow table
+    ///
+    /// Raises
+    /// ------
+    /// RuntimeError
+    ///     If query execution fails
+    fn execute(&self, py: Python, datasets: &Bound<'_, PyDict>) -> PyResult<PyObject> {
+        use std::collections::HashMap;
+
+        // Convert provided Python datasets into Arrow RecordBatches without any Python-side execution logic
+        let mut arrow_datasets = HashMap::new();
+
+        for (key, value) in datasets.iter() {
+            let table_name: String = key.extract()?;
+
+            // Accept either a Lance Dataset (has to_table) or a PyArrow Table/Reader
+            let batch = if value.hasattr("to_table")? {
+                let table = value.call_method0("to_table")?;
+                python_table_to_record_batch(py, &table)?
+            } else {
+                // Assume value is a PyArrow table-like object supporting to_batches / __arrow_c_stream__
+                python_table_to_record_batch(py, &value)?
+            };
+
+            arrow_datasets.insert(table_name, batch);
+        }
+
+        // Call into Rust lance-graph for execution
+        let runtime = tokio::runtime::Runtime::new().map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to create async runtime: {}", e))
+        })?;
+
+        let result_batch = runtime
+            .block_on(async { self.inner.execute(arrow_datasets).await })
+            .map_err(graph_error_to_pyerr)?;
+
+        // Return a PyArrow Table via Arrow C stream
+        record_batch_to_python_table(py, &result_batch)
+    }
+
+    /// Get variables used in the query
+    fn variables(&self) -> Vec<String> {
+        self.inner.variables()
+    }
+
+    /// Get node labels referenced in the query
+    fn node_labels(&self) -> Vec<String> {
+        self.inner.ast().get_node_labels()
+    }
+
+    /// Get relationship types referenced in the query
+    fn relationship_types(&self) -> Vec<String> {
+        self.inner.ast().get_relationship_types()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("CypherQuery(\"{}\")", self.inner.query_text())
+    }
+}
+
+// Helper functions to convert between Python and JSON values
+fn python_to_json(value: &Bound<'_, PyAny>) -> PyResult<JsonValue> {
+    if value.is_none() {
+        Ok(JsonValue::Null)
+    } else if let Ok(b) = value.extract::<bool>() {
+        Ok(JsonValue::Bool(b))
+    } else if let Ok(i) = value.extract::<i64>() {
+        Ok(JsonValue::Number(i.into()))
+    } else if let Ok(f) = value.extract::<f64>() {
+        Ok(JsonValue::Number(
+            serde_json::Number::from_f64(f)
+                .ok_or_else(|| PyValueError::new_err("Invalid float value"))?,
+        ))
+    } else if let Ok(s) = value.extract::<String>() {
+        Ok(JsonValue::String(s))
+    } else {
+        Err(PyValueError::new_err("Unsupported parameter type"))
+    }
+}
+
+fn json_to_python(py: Python, value: &JsonValue) -> PyResult<PyObject> {
+    match value {
+        JsonValue::Null => Ok(py.None()),
+        JsonValue::Bool(b) => Ok(b.into_py(py)),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(i.into_py(py))
+            } else if let Some(f) = n.as_f64() {
+                Ok(f.into_py(py))
+            } else {
+                Ok(n.to_string().into_py(py))
+            }
+        }
+        JsonValue::String(s) => Ok(s.into_py(py)),
+        JsonValue::Array(_) | JsonValue::Object(_) => {
+            // For complex types, convert to string representation
+            Ok(value.to_string().into_py(py))
+        }
+    }
+}
+
+// Helper functions for Arrow conversion
+fn python_table_to_record_batch(
+    py: Python,
+    table: &Bound<'_, PyAny>,
+) -> PyResult<arrow::record_batch::RecordBatch> {
+    // Import PyArrow's Table.to_batches() and take the first batch
+    let batches = table.call_method0("to_batches")?;
+    let batch_list: Vec<&PyAny> = batches.extract()?;
+
+    if batch_list.is_empty() {
+        return Err(PyRuntimeError::new_err("Table has no data"));
+    }
+
+    // Use Arrow's Python integration to convert the first batch
+    let batch_py = batch_list[0];
+
+    // Convert PyArrow RecordBatch to Rust RecordBatch via FFI
+    use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
+    use arrow::record_batch::RecordBatch;
+    use pyo3::ffi::Py_uintptr_t;
+
+    // Get the Arrow C interface pointers
+    let capsule = batch_py.call_method0("__arrow_c_stream__")?;
+    let stream_ptr: Py_uintptr_t = capsule.extract()?;
+
+    // Create ArrowArrayStream from the pointer
+    let stream = unsafe {
+        FFI_ArrowArrayStream::from_raw(stream_ptr as *mut arrow::ffi_stream::FFI_ArrowArrayStream)
+    };
+
+    let mut reader = ArrowArrayStreamReader::try_new(stream).map_err(|e| {
+        PyRuntimeError::new_err(format!("Failed to create Arrow stream reader: {}", e))
+    })?;
+
+    // Read the first batch
+    reader
+        .next()
+        .transpose()
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to read Arrow batch: {}", e)))?
+        .ok_or_else(|| PyRuntimeError::new_err("No batches available"))
+}
+
+fn record_batch_to_python_table(
+    py: Python,
+    batch: &arrow::record_batch::RecordBatch,
+) -> PyResult<PyObject> {
+    use arrow::ffi_stream::{ArrowArrayStreamWriter, FFI_ArrowArrayStream};
+    use pyo3::types::PyCapsule;
+
+    // Create an Arrow stream from the batch
+    let batches = vec![batch.clone()];
+    let schema = batch.schema();
+
+    let mut stream = FFI_ArrowArrayStream::empty();
+    let writer =
+        ArrowArrayStreamWriter::try_new(&mut stream as *mut _, schema, Some(batches.into_iter()))
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to create Arrow stream: {}", e)))?;
+
+    // Convert to Python using the Arrow C interface
+    let stream_ptr = &stream as *const FFI_ArrowArrayStream as usize;
+    let capsule = PyCapsule::new(py, stream_ptr, None)?;
+
+    // Import PyArrow and create Table from stream
+    let pyarrow = py.import("pyarrow")?;
+    let table = pyarrow.call_method1("table", (capsule,))?;
+
+    Ok(table.into())
+}
+
+/// Register graph functionality with the Python module
+pub fn register_graph_module(py: Python, parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
+    let graph_module = PyModule::new(py, "graph")?;
+
+    graph_module.add_class::<GraphConfig>()?;
+    graph_module.add_class::<GraphConfigBuilder>()?;
+    graph_module.add_class::<CypherQuery>()?;
+
+    parent_module.add_submodule(&graph_module)?;
+    Ok(())
+}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -70,6 +70,7 @@ pub(crate) mod error;
 pub(crate) mod executor;
 pub(crate) mod file;
 pub(crate) mod fragment;
+pub(crate) mod graph;
 pub(crate) mod indices;
 pub(crate) mod reader;
 pub(crate) mod scanner;
@@ -248,6 +249,7 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     register_datagen(py, m)?;
     register_indices(py, m)?;
+    graph::register_graph_module(py, m)?;
     Ok(())
 }
 

--- a/rust/lance-graph/Cargo.toml
+++ b/rust/lance-graph/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "lance-graph"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Graph query engine for Lance datasets with Cypher support"
+
+[dependencies]
+arrow.workspace = true
+arrow-array.workspace = true
+arrow-schema.workspace = true
+async-trait.workspace = true
+datafusion.workspace = true
+datafusion-common.workspace = true
+datafusion-expr.workspace = true
+datafusion-sql.workspace = true
+futures.workspace = true
+lance-arrow.workspace = true
+lance-core.workspace = true
+lance-datafusion.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snafu.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+# Graph-specific dependencies
+petgraph = "0.6"
+nom = "7.1"
+
+[dev-dependencies]
+tempfile.workspace = true
+criterion.workspace = true
+lance = { workspace = true }
+futures.workspace = true
+
+[[bench]]
+name = "graph_execution"
+harness = false
+
+
+[lints]
+workspace = true

--- a/rust/lance-graph/README.md
+++ b/rust/lance-graph/README.md
@@ -1,0 +1,297 @@
+# Lance Graph Query Engine
+
+A graph query engine for Lance datasets with Cypher syntax support. This crate enables querying Lance's columnar datasets using familiar graph query patterns, interpreting tabular data as property graphs.
+
+## Features
+
+- **Cypher Query Support**: Parse and execute Cypher queries against Lance datasets
+- **Property Graph Model**: Interpret columnar data as nodes and relationships  
+- **SQL Translation**: Convert Cypher queries to optimized DataFusion SQL
+- **Flexible Configuration**: Map dataset columns to graph elements
+- **Type Safety**: Full Rust type safety with comprehensive error handling
+- **Performance**: Leverage Lance's columnar storage and DataFusion's query optimization
+
+## Quick Start
+
+### Basic Usage
+
+```rust
+use lance_graph::{CypherQuery, GraphConfig};
+
+// Configure how your dataset maps to a property graph
+let config = GraphConfig::builder()
+    .with_node_label("Person", "person_id")
+    .with_relationship("KNOWS", "src_person_id", "dst_person_id")
+    .build()?;
+
+// Parse and configure a Cypher query
+let query = CypherQuery::new("MATCH (p:Person) WHERE p.age > 30 RETURN p.name")?
+    .with_config(config);
+
+// Convert to SQL for execution
+let sql = query.to_sql()?;
+println!("Generated SQL: {}", sql);
+```
+
+### Query Examples
+
+#### Simple Node Queries
+```cypher
+-- Find all persons
+MATCH (p:Person) RETURN p.name, p.age
+
+-- Filter by properties
+MATCH (p:Person) WHERE p.age > 30 RETURN p.name
+
+-- Node with property constraints
+MATCH (p:Person {city: "New York"}) RETURN p.name
+```
+
+#### Relationship Queries
+```cypher
+-- Find relationships
+MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN a.name, b.name
+
+-- Multi-hop paths
+MATCH (a:Person)-[:KNOWS]->(b:Person)-[:WORKS_WITH]->(c:Person)
+RETURN a.name, b.name, c.name
+
+-- Relationship properties
+MATCH (a:Person)-[r:KNOWS {since: 2020}]->(b:Person) RETURN a.name, b.name
+```
+
+#### Advanced Queries
+```cypher
+-- Parameterized queries
+MATCH (p:Person) WHERE p.age > $minAge RETURN p.name
+
+-- Aggregations
+MATCH (p:Person) RETURN p.city, COUNT(p) AS population
+
+-- Sorting and limiting
+MATCH (p:Person) RETURN p.name ORDER BY p.age DESC LIMIT 10
+```
+
+## Architecture
+
+### Components
+
+1. **AST (`ast.rs`)**: Abstract syntax tree representation of Cypher queries
+2. **Parser (`parser.rs`)**: Nom-based parser for Cypher syntax
+3. **Config (`config.rs`)**: Graph configuration for dataset mapping
+4. **Planner (`planner.rs`)**: Query planner for Cypher-to-SQL translation
+5. **Query (`query.rs`)**: High-level query interface and validation
+6. **Error (`error.rs`)**: Comprehensive error handling
+
+### Query Flow
+
+```
+Cypher Query → Parser → AST → Planner → SQL → DataFusion → Results
+                ↓
+          Configuration
+```
+
+## Configuration
+
+### Node Mappings
+
+Configure how dataset rows become graph nodes:
+
+```rust
+let config = GraphConfig::builder()
+    .with_node_label("Person", "person_id")        // Label and ID field
+    .with_node_label("Company", "company_id")
+    .build()?;
+```
+
+### Relationship Mappings
+
+Configure how relationships are represented:
+
+```rust
+let config = GraphConfig::builder()
+    .with_relationship("WORKS_FOR", "person_id", "company_id")
+    .with_relationship("KNOWS", "person_id", "friend_id")
+    .build()?;
+```
+
+### Advanced Configuration
+
+```rust
+let node_mapping = NodeMapping::new("person_id")
+    .with_filter("type = 'person'")                // Filter conditions
+    .with_property_mapping("name", "full_name");   // Property mappings
+
+let rel_mapping = RelationshipMapping::new("src_id", "dst_id")
+    .with_filter("relationship_type = 'knows'")
+    .with_property_mapping("strength", "weight");
+```
+
+## Data Model
+
+### Unified Table Approach
+
+Store both nodes and relationships in a single table:
+
+```sql
+CREATE TABLE graph_data (
+    id BIGINT,
+    type VARCHAR,           -- 'person', 'company', 'relationship'
+    name VARCHAR,           -- Node properties
+    age INT,
+    source_id BIGINT,       -- Relationship properties  
+    target_id BIGINT,
+    relationship_type VARCHAR
+);
+```
+
+### Separate Tables Approach
+
+Use separate tables for nodes and relationships:
+
+```sql
+-- Nodes table
+CREATE TABLE persons (
+    person_id BIGINT,
+    name VARCHAR,
+    age INT,
+    city VARCHAR
+);
+
+-- Relationships table  
+CREATE TABLE relationships (
+    id BIGINT,
+    source_person_id BIGINT,
+    target_person_id BIGINT,
+    relationship_type VARCHAR,
+    since_year INT
+);
+```
+
+## Supported Cypher Features
+
+### Currently Supported
+
+- ✅ Node patterns: `(n:Label)`, `(n:Label {prop: value})`
+- ✅ Relationship patterns: `-[r:TYPE]->`, `<-[r:TYPE]-`, `-[r:TYPE]-`
+- ✅ WHERE clauses with comparisons (`=`, `<>`, `<`, `>`, `<=`, `>=`)
+- ✅ RETURN clauses with properties and aliases
+- ✅ ORDER BY and LIMIT clauses
+- ✅ Query parameters (`$param`)
+- ✅ Variable references in RETURN
+
+### Planned Features
+
+- 🔄 Boolean operators in WHERE (`AND`, `OR`, `NOT`)
+- 🔄 Pattern expressions (`EXISTS`, `OPTIONAL MATCH`)
+- 🔄 Aggregation functions (`COUNT`, `SUM`, `AVG`, etc.)
+- 🔄 Path expressions and variable-length paths
+- 🔄 UNION and subqueries
+- 🔄 CREATE, UPDATE, DELETE operations
+- 🔄 Two-hop and multi-hop expansions in DataFusion execution (e.g., `(p)-[:R1]->(m)-[:R2]->(q)`), including small bounded variable-length unrolling (e.g., `*1..2`).
+
+## Error Handling
+
+The crate provides comprehensive error handling:
+
+```rust
+use lance_graph::{GraphError, Result};
+
+match CypherQuery::new("INVALID QUERY") {
+    Ok(query) => println!("Query parsed successfully"),
+    Err(GraphError::ParseError { message, position, .. }) => {
+        println!("Parse error at position {}: {}", position, message);
+    }
+    Err(e) => println!("Other error: {}", e),
+}
+```
+
+## Performance Considerations
+
+### Query Optimization
+
+- **Predicate Pushdown**: WHERE clauses are pushed down to the dataset scan
+- **Join Optimization**: DataFusion optimizes relationship traversals
+- **Column Pruning**: Only required columns are read from storage
+- **Index Usage**: Leverage Lance's scalar and vector indices
+
+### Best Practices
+
+1. **Use Selective Filters**: Add WHERE clauses to reduce data scanned
+2. **Limit Results**: Use LIMIT for large result sets
+3. **Index Key Fields**: Create indices on ID fields used in joins
+4. **Batch Queries**: Process multiple queries together when possible
+
+## Testing
+
+Run the test suite:
+
+```bash
+cargo test -p lance-graph
+```
+
+Run specific tests:
+
+```bash
+cargo test -p lance-graph parser::tests::test_parse_simple_node_query
+```
+
+## Examples
+
+See the `tests/` directory for comprehensive examples:
+
+- `test_parser.rs`: Cypher parsing examples
+- `test_planner.rs`: SQL translation examples  
+- `test_query.rs`: End-to-end query examples
+- `test_config.rs`: Configuration examples
+
+## Integration
+
+### With Lance Datasets
+
+```rust
+// This would be the integration point with Lance datasets
+// (Implementation depends on Lance's dataset APIs)
+
+let dataset = lance::Dataset::open("path/to/dataset")?;
+let config = GraphConfig::builder()...;
+let query = CypherQuery::new("MATCH (n) RETURN n")?;
+
+// Execute via DataFusion
+let ctx = SessionContext::new();
+let sql = query.to_sql()?;
+let df = ctx.sql(&sql).await?;
+let results = df.collect().await?;
+```
+
+### With Python
+
+Python bindings would provide a clean interface:
+
+```python
+import lance
+from lance.graph import GraphConfig, CypherQuery
+
+# Configure graph interpretation
+config = GraphConfig.builder() \
+    .with_node_label("Person", "person_id") \
+    .build()
+
+# Execute query
+query = CypherQuery("MATCH (p:Person) RETURN p.name") \
+    .with_config(config)
+
+dataset = lance.dataset("path/to/data")
+result = query.execute(dataset)
+```
+
+## Contributing
+
+1. Follow Rust conventions and the existing code style
+2. Add tests for new features
+3. Update documentation for API changes
+4. Run `cargo fmt` and `cargo clippy` before submitting
+
+## License
+
+Apache-2.0 License - see LICENSE file for details.

--- a/rust/lance-graph/benches/graph_execution.rs
+++ b/rust/lance-graph/benches/graph_execution.rs
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Graph query execution benchmarks with actual data processing
+//!
+//! This benchmark measures ACTUAL query execution performance:
+//! - Creates Arrow datasets
+//! - Executes Cypher queries
+//! - Processes query results
+//! - Full end-to-end execution!
+//!
+//! Run with:
+//! ```
+//! cargo bench --bench graph_execution
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::{Int32Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures::TryStreamExt;
+use lance::dataset::{Dataset, WriteMode, WriteParams};
+use lance_graph::{CypherQuery, GraphConfig};
+use tempfile::TempDir;
+
+fn create_people_batch() -> RecordBatch {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("person_id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]));
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+            Arc::new(StringArray::from(vec![
+                "Alice", "Bob", "Carol", "David", "Eve",
+            ])),
+            Arc::new(Int32Array::from(vec![28, 34, 29, 42, 31])),
+        ],
+    )
+    .unwrap()
+}
+
+fn create_friendship_batch() -> RecordBatch {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("person1_id", DataType::Int32, false),
+        Field::new("person2_id", DataType::Int32, false),
+        Field::new("friendship_type", DataType::Utf8, false),
+    ]));
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 1, 2, 3, 4])),
+            Arc::new(Int32Array::from(vec![2, 3, 4, 4, 5])),
+            Arc::new(StringArray::from(vec![
+                "close", "casual", "close", "casual", "close",
+            ])),
+        ],
+    )
+    .unwrap()
+}
+
+// Execute query using CypherQuery::execute against in-memory batches
+fn execute_cypher_query(
+    rt: &tokio::runtime::Runtime,
+    q: &CypherQuery,
+    datasets: HashMap<String, RecordBatch>,
+) -> RecordBatch {
+    rt.block_on(async move { q.execute(datasets).await.unwrap() })
+}
+
+fn make_people_batch(n: usize) -> RecordBatch {
+    if n == 5 {
+        return create_people_batch();
+    }
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("person_id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]));
+    let ids: Vec<i32> = (0..n as i32).collect();
+    let names: Vec<String> = (0..n).map(|i| format!("name_{}", i)).collect();
+    let ages: Vec<i32> = (0..n as i32).map(|i| 20 + (i % 60)).collect();
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(ids)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(Int32Array::from(ages)),
+        ],
+    )
+    .unwrap()
+}
+
+fn make_friendship_batch(n: usize) -> RecordBatch {
+    if n == 5 {
+        return create_friendship_batch();
+    }
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("person1_id", DataType::Int32, false),
+        Field::new("person2_id", DataType::Int32, false),
+        Field::new("friendship_type", DataType::Utf8, false),
+    ]));
+    let src: Vec<i32> = (0..n as i32).collect();
+    let dst: Vec<i32> = (0..n as i32).map(|i| (i + 1) % n as i32).collect();
+    let ftype: Vec<&str> = std::iter::repeat("friend").take(n).collect();
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(src)),
+            Arc::new(Int32Array::from(dst)),
+            Arc::new(StringArray::from(ftype)),
+        ],
+    )
+    .unwrap()
+}
+
+fn bench_cypher_execution(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cypher_execution");
+    let sizes = [100usize, 10_000usize, 1_000_000usize];
+
+    // Global runtime reused across iterations
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    // Prebuild graph config and queries (reuse per iteration)
+    let cfg = GraphConfig::builder()
+        .with_node_label("Person", "person_id")
+        .with_relationship("FRIEND_OF", "person1_id", "person2_id")
+        .build()
+        .unwrap();
+    let q_basic = CypherQuery::new("MATCH (n:Person) WHERE n.age > 50 RETURN n.name")
+        .unwrap()
+        .with_config(cfg.clone());
+    let q_single_hop = CypherQuery::new("MATCH (a:Person)-[:FRIEND_OF]->(b:Person) RETURN b.name")
+        .unwrap()
+        .with_config(cfg.clone());
+    let q_two_hop = CypherQuery::new(
+        "MATCH (a:Person)-[:FRIEND_OF]->(b:Person)-[:FRIEND_OF]->(c:Person) RETURN c.name",
+    )
+    .unwrap()
+    .with_config(cfg.clone());
+
+    // Prebuild small (100) datasets once and reuse
+    let person_small = make_people_batch(100);
+    let friendship_small = make_friendship_batch(100);
+
+    // Persist medium datasets once and reuse
+    let (_medium_tmpdir, person_medium, friendship_medium): (TempDir, RecordBatch, RecordBatch) = {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let person_path = tmpdir.path().join("person.lance");
+        let friend_path = tmpdir.path().join("friendship.lance");
+
+        let person_b = make_people_batch(10_000);
+        let friend_b = make_friendship_batch(10_000);
+
+        rt.block_on(async {
+            Dataset::write(
+                arrow_array::RecordBatchIterator::new(
+                    vec![Ok(person_b.clone())].into_iter(),
+                    person_b.schema(),
+                ),
+                person_path.to_str().unwrap(),
+                Some(WriteParams {
+                    mode: WriteMode::Create,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+            Dataset::write(
+                arrow_array::RecordBatchIterator::new(
+                    vec![Ok(friend_b.clone())].into_iter(),
+                    friend_b.schema(),
+                ),
+                friend_path.to_str().unwrap(),
+                Some(WriteParams {
+                    mode: WriteMode::Create,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+            let person_ds = Dataset::open(person_path.to_str().unwrap()).await.unwrap();
+            let p_batches = person_ds
+                .scan()
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let person_one = p_batches.into_iter().next().unwrap();
+
+            let friend_ds = Dataset::open(friend_path.to_str().unwrap()).await.unwrap();
+            let f_batches = friend_ds
+                .scan()
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let friend_one = f_batches.into_iter().next().unwrap();
+
+            (tmpdir, person_one, friend_one)
+        })
+    };
+
+    // Persist large (1_000_000) datasets once and reuse
+    let (_large_tmpdir, person_large, friendship_large): (TempDir, RecordBatch, RecordBatch) = {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let person_path = tmpdir.path().join("person.lance");
+        let friend_path = tmpdir.path().join("friendship.lance");
+
+        let person_b = make_people_batch(1_000_000);
+        let friend_b = make_friendship_batch(1_000_000);
+
+        rt.block_on(async {
+            use arrow_array::RecordBatchIterator;
+            Dataset::write(
+                RecordBatchIterator::new(vec![Ok(person_b.clone())].into_iter(), person_b.schema()),
+                person_path.to_str().unwrap(),
+                Some(WriteParams {
+                    mode: WriteMode::Create,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+            Dataset::write(
+                RecordBatchIterator::new(vec![Ok(friend_b.clone())].into_iter(), friend_b.schema()),
+                friend_path.to_str().unwrap(),
+                Some(WriteParams {
+                    mode: WriteMode::Create,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+            let person_ds = Dataset::open(person_path.to_str().unwrap()).await.unwrap();
+            let p_batches = person_ds
+                .scan()
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let person_one = p_batches.into_iter().next().unwrap();
+
+            let friend_ds = Dataset::open(friend_path.to_str().unwrap()).await.unwrap();
+            let f_batches = friend_ds
+                .scan()
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let friend_one = f_batches.into_iter().next().unwrap();
+
+            (tmpdir, person_one, friend_one)
+        })
+    };
+
+    // 1) Basic node filter + projection
+    for &n in &sizes {
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::new("basic_node_filter", n), &n, |b, &n| {
+            b.iter(|| {
+                let people_batch = match n {
+                    100 => person_small.clone(),
+                    10_000 => person_medium.clone(),
+                    _ => person_large.clone(),
+                };
+                let mut ds = HashMap::new();
+                ds.insert("Person".to_string(), people_batch);
+                let out = execute_cypher_query(&rt, &q_basic, ds);
+                black_box(out.num_rows());
+            })
+        });
+    }
+
+    // 2) Single-hop relationship expansion
+    for &n in &sizes {
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::new("single_hop_expand", n), &n, |b, &n| {
+            b.iter(|| {
+                let people_batch = match n {
+                    100 => person_small.clone(),
+                    10_000 => person_medium.clone(),
+                    _ => person_large.clone(),
+                };
+                let friendship = match n {
+                    100 => friendship_small.clone(),
+                    10_000 => friendship_medium.clone(),
+                    _ => friendship_large.clone(),
+                };
+                let mut ds = HashMap::new();
+                ds.insert("Person".to_string(), people_batch);
+                ds.insert("FRIEND_OF".to_string(), friendship);
+                let out = execute_cypher_query(&rt, &q_single_hop, ds);
+                black_box(out.num_rows());
+            })
+        });
+    }
+
+    // 3) Two-hop relationship expansion
+    for &n in &sizes {
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::new("two_hop_expand", n), &n, |b, &n| {
+            b.iter(|| {
+                let people_batch = match n {
+                    100 => person_small.clone(),
+                    10_000 => person_medium.clone(),
+                    _ => person_large.clone(),
+                };
+                let friendship = match n {
+                    100 => friendship_small.clone(),
+                    10_000 => friendship_medium.clone(),
+                    _ => friendship_large.clone(),
+                };
+                let mut ds = HashMap::new();
+                ds.insert("Person".to_string(), people_batch);
+                ds.insert("FRIEND_OF".to_string(), friendship);
+                let out = execute_cypher_query(&rt, &q_two_hop, ds);
+                black_box(out.num_rows());
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cypher_execution);
+criterion_main!(benches);

--- a/rust/lance-graph/src/ast.rs
+++ b/rust/lance-graph/src/ast.rs
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Abstract Syntax Tree for Cypher queries
+//!
+//! This module defines the AST nodes for representing parsed Cypher queries.
+//! The AST is designed to capture the essential graph patterns while being
+//! simple enough to translate to SQL efficiently.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A complete Cypher query
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CypherQuery {
+    /// MATCH clauses
+    pub match_clauses: Vec<MatchClause>,
+    /// WHERE clause (optional)
+    pub where_clause: Option<WhereClause>,
+    /// RETURN clause
+    pub return_clause: ReturnClause,
+    /// LIMIT clause (optional)
+    pub limit: Option<u64>,
+    /// ORDER BY clause (optional)
+    pub order_by: Option<OrderByClause>,
+}
+
+impl CypherQuery {
+    /// Extract all node labels referenced in the query
+    pub fn get_node_labels(&self) -> Vec<String> {
+        let mut labels = Vec::new();
+        for match_clause in &self.match_clauses {
+            for pattern in &match_clause.patterns {
+                match pattern {
+                    GraphPattern::Node(node) => {
+                        for label in &node.labels {
+                            if !labels.contains(label) {
+                                labels.push(label.clone());
+                            }
+                        }
+                    }
+                    GraphPattern::Path(path) => {
+                        for label in &path.start_node.labels {
+                            if !labels.contains(label) {
+                                labels.push(label.clone());
+                            }
+                        }
+                        for segment in &path.segments {
+                            for label in &segment.end_node.labels {
+                                if !labels.contains(label) {
+                                    labels.push(label.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        labels
+    }
+
+    /// Extract all relationship types referenced in the query
+    pub fn get_relationship_types(&self) -> Vec<String> {
+        let mut types = Vec::new();
+        for match_clause in &self.match_clauses {
+            for pattern in &match_clause.patterns {
+                if let GraphPattern::Path(path) = pattern {
+                    for segment in &path.segments {
+                        for rel_type in &segment.relationship.types {
+                            if !types.contains(rel_type) {
+                                types.push(rel_type.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        types
+    }
+}
+
+/// A MATCH clause containing graph patterns
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MatchClause {
+    /// Graph patterns to match
+    pub patterns: Vec<GraphPattern>,
+}
+
+/// A graph pattern (nodes and relationships)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum GraphPattern {
+    /// A single node pattern
+    Node(NodePattern),
+    /// A path pattern (node-relationship-node sequence)
+    Path(PathPattern),
+}
+
+/// A node pattern in a graph query
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodePattern {
+    /// Variable name for the node (e.g., 'n' in (n:Person))
+    pub variable: Option<String>,
+    /// Node labels (e.g., ['Person', 'Employee'])
+    pub labels: Vec<String>,
+    /// Property constraints (e.g., {name: 'John', age: 30})
+    pub properties: HashMap<String, PropertyValue>,
+}
+
+/// A path pattern connecting nodes through relationships
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PathPattern {
+    /// Starting node
+    pub start_node: NodePattern,
+    /// Relationships and intermediate nodes
+    pub segments: Vec<PathSegment>,
+}
+
+/// A segment of a path (relationship + end node)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PathSegment {
+    /// The relationship in this segment
+    pub relationship: RelationshipPattern,
+    /// The end node of this segment
+    pub end_node: NodePattern,
+}
+
+/// A relationship pattern
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RelationshipPattern {
+    /// Variable name for the relationship (e.g., 'r' in [r:KNOWS])
+    pub variable: Option<String>,
+    /// Relationship types (e.g., ['KNOWS', 'FRIEND_OF'])
+    pub types: Vec<String>,
+    /// Direction of the relationship
+    pub direction: RelationshipDirection,
+    /// Property constraints on the relationship
+    pub properties: HashMap<String, PropertyValue>,
+    /// Length constraints (for variable-length paths)
+    pub length: Option<LengthRange>,
+}
+
+/// Direction of a relationship
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum RelationshipDirection {
+    /// Outgoing relationship (->)
+    Outgoing,
+    /// Incoming relationship (<-)
+    Incoming,
+    /// Undirected relationship (-)
+    Undirected,
+}
+
+/// Length range for variable-length paths
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LengthRange {
+    /// Minimum length (inclusive)
+    pub min: Option<u32>,
+    /// Maximum length (inclusive)
+    pub max: Option<u32>,
+}
+
+/// Property value in patterns and expressions
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PropertyValue {
+    /// String literal
+    String(String),
+    /// Integer literal
+    Integer(i64),
+    /// Float literal
+    Float(f64),
+    /// Boolean literal
+    Boolean(bool),
+    /// Null value
+    Null,
+    /// Parameter reference (e.g., $param)
+    Parameter(String),
+    /// Property reference (e.g., node.property)
+    Property(PropertyRef),
+}
+
+/// Reference to a property of a node or relationship
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PropertyRef {
+    /// Variable name (e.g., 'n' in n.name)
+    pub variable: String,
+    /// Property name
+    pub property: String,
+}
+
+/// WHERE clause for filtering
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WhereClause {
+    /// Boolean expression for filtering
+    pub expression: BooleanExpression,
+}
+
+/// Boolean expressions in WHERE clauses
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum BooleanExpression {
+    /// Comparison operation (=, <>, <, >, <=, >=)
+    Comparison {
+        left: ValueExpression,
+        operator: ComparisonOperator,
+        right: ValueExpression,
+    },
+    /// Logical AND
+    And(Box<BooleanExpression>, Box<BooleanExpression>),
+    /// Logical OR
+    Or(Box<BooleanExpression>, Box<BooleanExpression>),
+    /// Logical NOT
+    Not(Box<BooleanExpression>),
+    /// Property existence check
+    Exists(PropertyRef),
+    /// IN clause
+    In {
+        expression: ValueExpression,
+        list: Vec<ValueExpression>,
+    },
+    /// LIKE pattern matching
+    Like {
+        expression: ValueExpression,
+        pattern: String,
+    },
+}
+
+/// Comparison operators
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ComparisonOperator {
+    Equal,
+    NotEqual,
+    LessThan,
+    LessThanOrEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+}
+
+/// Value expressions (for comparisons and return values)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ValueExpression {
+    /// Variable reference
+    Variable(String),
+    /// Property reference
+    Property(PropertyRef),
+    /// Literal value
+    Literal(PropertyValue),
+    /// Function call
+    Function {
+        name: String,
+        args: Vec<ValueExpression>,
+    },
+    /// Arithmetic operation
+    Arithmetic {
+        left: Box<ValueExpression>,
+        operator: ArithmeticOperator,
+        right: Box<ValueExpression>,
+    },
+}
+
+/// Arithmetic operators
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ArithmeticOperator {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Modulo,
+}
+
+/// RETURN clause specifying what to return
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReturnClause {
+    /// Whether DISTINCT was specified
+    pub distinct: bool,
+    /// Items to return
+    pub items: Vec<ReturnItem>,
+}
+
+/// An item in the RETURN clause
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReturnItem {
+    /// The expression to return
+    pub expression: ValueExpression,
+    /// Alias for the returned value
+    pub alias: Option<String>,
+}
+
+/// ORDER BY clause
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OrderByClause {
+    /// Items to order by
+    pub items: Vec<OrderByItem>,
+}
+
+/// An item in the ORDER BY clause
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OrderByItem {
+    /// Expression to order by
+    pub expression: ValueExpression,
+    /// Sort direction
+    pub direction: SortDirection,
+}
+
+/// Sort direction for ORDER BY
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum SortDirection {
+    Ascending,
+    Descending,
+}
+
+impl NodePattern {
+    /// Create a new node pattern
+    pub fn new(variable: Option<String>) -> Self {
+        Self {
+            variable,
+            labels: Vec::new(),
+            properties: HashMap::new(),
+        }
+    }
+
+    /// Add a label to the node pattern
+    pub fn with_label<S: Into<String>>(mut self, label: S) -> Self {
+        self.labels.push(label.into());
+        self
+    }
+
+    /// Add a property constraint to the node pattern
+    pub fn with_property<S: Into<String>>(mut self, key: S, value: PropertyValue) -> Self {
+        self.properties.insert(key.into(), value);
+        self
+    }
+}
+
+impl RelationshipPattern {
+    /// Create a new relationship pattern
+    pub fn new(direction: RelationshipDirection) -> Self {
+        Self {
+            variable: None,
+            types: Vec::new(),
+            direction,
+            properties: HashMap::new(),
+            length: None,
+        }
+    }
+
+    /// Set the variable name for the relationship
+    pub fn with_variable<S: Into<String>>(mut self, variable: S) -> Self {
+        self.variable = Some(variable.into());
+        self
+    }
+
+    /// Add a type to the relationship pattern
+    pub fn with_type<S: Into<String>>(mut self, rel_type: S) -> Self {
+        self.types.push(rel_type.into());
+        self
+    }
+
+    /// Add a property constraint to the relationship pattern
+    pub fn with_property<S: Into<String>>(mut self, key: S, value: PropertyValue) -> Self {
+        self.properties.insert(key.into(), value);
+        self
+    }
+}
+
+impl PropertyRef {
+    /// Create a new property reference
+    pub fn new<S: Into<String>>(variable: S, property: S) -> Self {
+        Self {
+            variable: variable.into(),
+            property: property.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_node_pattern_creation() {
+        let node = NodePattern::new(Some("n".to_string()))
+            .with_label("Person")
+            .with_property("name", PropertyValue::String("John".to_string()));
+
+        assert_eq!(node.variable, Some("n".to_string()));
+        assert_eq!(node.labels, vec!["Person"]);
+        assert_eq!(node.properties.len(), 1);
+    }
+
+    #[test]
+    fn test_relationship_pattern_creation() {
+        let rel = RelationshipPattern::new(RelationshipDirection::Outgoing)
+            .with_variable("r")
+            .with_type("KNOWS");
+
+        assert_eq!(rel.variable, Some("r".to_string()));
+        assert_eq!(rel.types, vec!["KNOWS"]);
+        assert_eq!(rel.direction, RelationshipDirection::Outgoing);
+    }
+
+    #[test]
+    fn test_property_ref() {
+        let prop_ref = PropertyRef::new("n", "name");
+        assert_eq!(prop_ref.variable, "n");
+        assert_eq!(prop_ref.property, "name");
+    }
+}

--- a/rust/lance-graph/src/config.rs
+++ b/rust/lance-graph/src/config.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Graph configuration for mapping Lance datasets to property graphs
+
+use crate::error::{GraphError, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Configuration for mapping Lance datasets to property graphs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphConfig {
+    /// Mapping of node labels to their field configurations
+    pub node_mappings: HashMap<String, NodeMapping>,
+    /// Mapping of relationship types to their field configurations  
+    pub relationship_mappings: HashMap<String, RelationshipMapping>,
+    /// Default node ID field if not specified in mappings
+    pub default_node_id_field: String,
+    /// Default relationship type field if not specified in mappings
+    pub default_relationship_type_field: String,
+}
+
+/// Configuration for mapping node labels to dataset fields
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeMapping {
+    /// The node label (e.g., "Person", "Product")
+    pub label: String,
+    /// Field name that serves as the node identifier
+    pub id_field: String,
+    /// Optional fields that define node properties
+    pub property_fields: Vec<String>,
+    /// Optional filter conditions for this node type
+    pub filter_conditions: Option<String>,
+}
+
+/// Configuration for mapping relationship types to dataset fields
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationshipMapping {
+    /// The relationship type (e.g., "KNOWS", "PURCHASED")
+    pub relationship_type: String,
+    /// Field containing the source node ID
+    pub source_id_field: String,
+    /// Field containing the target node ID
+    pub target_id_field: String,
+    /// Optional field containing the relationship type
+    pub type_field: Option<String>,
+    /// Optional fields that define relationship properties
+    pub property_fields: Vec<String>,
+    /// Optional filter conditions for this relationship type
+    pub filter_conditions: Option<String>,
+}
+
+impl Default for GraphConfig {
+    fn default() -> Self {
+        Self {
+            node_mappings: HashMap::new(),
+            relationship_mappings: HashMap::new(),
+            default_node_id_field: "id".to_string(),
+            default_relationship_type_field: "type".to_string(),
+        }
+    }
+}
+
+impl GraphConfig {
+    /// Create a new builder for GraphConfig
+    pub fn builder() -> GraphConfigBuilder {
+        GraphConfigBuilder::new()
+    }
+
+    /// Get node mapping for a given label
+    pub fn get_node_mapping(&self, label: &str) -> Option<&NodeMapping> {
+        self.node_mappings.get(label)
+    }
+
+    /// Get relationship mapping for a given type
+    pub fn get_relationship_mapping(&self, rel_type: &str) -> Option<&RelationshipMapping> {
+        self.relationship_mappings.get(rel_type)
+    }
+
+    /// Validate the configuration
+    pub fn validate(&self) -> Result<()> {
+        // Check for conflicting field names
+        for (label, mapping) in &self.node_mappings {
+            if mapping.id_field.is_empty() {
+                return Err(GraphError::ConfigError {
+                    message: format!("Node mapping for '{}' has empty id_field", label),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+        }
+
+        for (rel_type, mapping) in &self.relationship_mappings {
+            if mapping.source_id_field.is_empty() || mapping.target_id_field.is_empty() {
+                return Err(GraphError::ConfigError {
+                    message: format!(
+                        "Relationship mapping for '{}' has empty source or target id field",
+                        rel_type
+                    ),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Builder for GraphConfig
+#[derive(Debug, Default, Clone)]
+pub struct GraphConfigBuilder {
+    node_mappings: HashMap<String, NodeMapping>,
+    relationship_mappings: HashMap<String, RelationshipMapping>,
+    default_node_id_field: Option<String>,
+    default_relationship_type_field: Option<String>,
+}
+
+impl GraphConfigBuilder {
+    /// Create a new builder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a node label mapping
+    pub fn with_node_label<S: Into<String>>(mut self, label: S, id_field: S) -> Self {
+        let label_str = label.into();
+        self.node_mappings.insert(
+            label_str.clone(),
+            NodeMapping {
+                label: label_str,
+                id_field: id_field.into(),
+                property_fields: Vec::new(),
+                filter_conditions: None,
+            },
+        );
+        self
+    }
+
+    /// Add a node mapping with additional configuration
+    pub fn with_node_mapping(mut self, mapping: NodeMapping) -> Self {
+        self.node_mappings.insert(mapping.label.clone(), mapping);
+        self
+    }
+
+    /// Add a relationship type mapping
+    pub fn with_relationship<S: Into<String>>(
+        mut self,
+        rel_type: S,
+        source_field: S,
+        target_field: S,
+    ) -> Self {
+        let type_str = rel_type.into();
+        self.relationship_mappings.insert(
+            type_str.clone(),
+            RelationshipMapping {
+                relationship_type: type_str,
+                source_id_field: source_field.into(),
+                target_id_field: target_field.into(),
+                type_field: None,
+                property_fields: Vec::new(),
+                filter_conditions: None,
+            },
+        );
+        self
+    }
+
+    /// Add a relationship mapping with additional configuration
+    pub fn with_relationship_mapping(mut self, mapping: RelationshipMapping) -> Self {
+        self.relationship_mappings
+            .insert(mapping.relationship_type.clone(), mapping);
+        self
+    }
+
+    /// Set the default node ID field
+    pub fn with_default_node_id_field<S: Into<String>>(mut self, field: S) -> Self {
+        self.default_node_id_field = Some(field.into());
+        self
+    }
+
+    /// Set the default relationship type field
+    pub fn with_default_relationship_type_field<S: Into<String>>(mut self, field: S) -> Self {
+        self.default_relationship_type_field = Some(field.into());
+        self
+    }
+
+    /// Build the GraphConfig
+    pub fn build(self) -> Result<GraphConfig> {
+        let config = GraphConfig {
+            node_mappings: self.node_mappings,
+            relationship_mappings: self.relationship_mappings,
+            default_node_id_field: self
+                .default_node_id_field
+                .unwrap_or_else(|| "id".to_string()),
+            default_relationship_type_field: self
+                .default_relationship_type_field
+                .unwrap_or_else(|| "type".to_string()),
+        };
+
+        config.validate()?;
+        Ok(config)
+    }
+}
+
+impl NodeMapping {
+    /// Create a new node mapping
+    pub fn new<S: Into<String>>(label: S, id_field: S) -> Self {
+        Self {
+            label: label.into(),
+            id_field: id_field.into(),
+            property_fields: Vec::new(),
+            filter_conditions: None,
+        }
+    }
+
+    /// Add property fields to the mapping
+    pub fn with_properties(mut self, fields: Vec<String>) -> Self {
+        self.property_fields = fields;
+        self
+    }
+
+    /// Add filter conditions for this node type
+    pub fn with_filter<S: Into<String>>(mut self, filter: S) -> Self {
+        self.filter_conditions = Some(filter.into());
+        self
+    }
+}
+
+impl RelationshipMapping {
+    /// Create a new relationship mapping
+    pub fn new<S: Into<String>>(rel_type: S, source_field: S, target_field: S) -> Self {
+        Self {
+            relationship_type: rel_type.into(),
+            source_id_field: source_field.into(),
+            target_id_field: target_field.into(),
+            type_field: None,
+            property_fields: Vec::new(),
+            filter_conditions: None,
+        }
+    }
+
+    /// Set the type field for this relationship
+    pub fn with_type_field<S: Into<String>>(mut self, type_field: S) -> Self {
+        self.type_field = Some(type_field.into());
+        self
+    }
+
+    /// Add property fields to the mapping
+    pub fn with_properties(mut self, fields: Vec<String>) -> Self {
+        self.property_fields = fields;
+        self
+    }
+
+    /// Add filter conditions for this relationship type
+    pub fn with_filter<S: Into<String>>(mut self, filter: S) -> Self {
+        self.filter_conditions = Some(filter.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_graph_config_builder() {
+        let config = GraphConfig::builder()
+            .with_node_label("Person", "person_id")
+            .with_node_label("Company", "company_id")
+            .with_relationship("WORKS_FOR", "person_id", "company_id")
+            .build()
+            .unwrap();
+
+        assert_eq!(config.node_mappings.len(), 2);
+        assert_eq!(config.relationship_mappings.len(), 1);
+
+        let person_mapping = config.get_node_mapping("Person").unwrap();
+        assert_eq!(person_mapping.id_field, "person_id");
+
+        let works_for_mapping = config.get_relationship_mapping("WORKS_FOR").unwrap();
+        assert_eq!(works_for_mapping.source_id_field, "person_id");
+        assert_eq!(works_for_mapping.target_id_field, "company_id");
+    }
+
+    #[test]
+    fn test_validation_empty_id_field() {
+        let mut config = GraphConfig::default();
+        config.node_mappings.insert(
+            "Person".to_string(),
+            NodeMapping {
+                label: "Person".to_string(),
+                id_field: "".to_string(),
+                property_fields: Vec::new(),
+                filter_conditions: None,
+            },
+        );
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_node_mapping_with_properties() {
+        let mapping = NodeMapping::new("Person", "id")
+            .with_properties(vec!["name".to_string(), "age".to_string()])
+            .with_filter("age > 18".to_string());
+
+        assert_eq!(mapping.property_fields.len(), 2);
+        assert!(mapping.filter_conditions.is_some());
+    }
+}

--- a/rust/lance-graph/src/datafusion_planner.rs
+++ b/rust/lance-graph/src/datafusion_planner.rs
@@ -280,7 +280,7 @@ impl DataFusionPlanner {
             VE::Property(prop) => col(&prop.property),
             VE::Variable(v) => col(v),
             VE::Literal(PV::String(s)) => lit(s.clone()),
-            VE::Literal(PV::Integer(i)) => lit(*i as i64),
+            VE::Literal(PV::Integer(i)) => lit(*i),
             VE::Literal(PV::Float(f)) => lit(*f),
             VE::Literal(PV::Boolean(b)) => lit(*b),
             VE::Literal(PV::Null) => {

--- a/rust/lance-graph/src/datafusion_planner.rs
+++ b/rust/lance-graph/src/datafusion_planner.rs
@@ -1,0 +1,476 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! DataFusion-based physical planner for graph queries
+//!
+//! This module implements the proper graph-to-relational mapping:
+//! - Nodes as Tables: Each node label becomes a table
+//! - Relationships as Tables: Each relationship type becomes a linking table
+//! - Cypher traversal becomes SQL joins
+//!
+//! Uses DataFusion's LogicalPlan and optimizer for world-class query optimization.
+
+use crate::error::Result;
+use crate::logical_plan::*;
+use crate::source_catalog::GraphSourceCatalog;
+use datafusion::common::DFSchema;
+use datafusion::logical_expr::{
+    col, lit, BinaryExpr, EmptyRelation, Expr, LogicalPlan, LogicalPlanBuilder, Operator,
+};
+use std::sync::Arc;
+
+/// Planner abstraction for graph-to-physical planning
+pub trait GraphPhysicalPlanner {
+    fn plan(&self, logical_plan: &LogicalOperator) -> Result<LogicalPlan>;
+}
+
+/// DataFusion-based physical planner
+/// TODO: Fix DataFusion API compatibility issues
+pub struct DataFusionPlanner {
+    #[allow(dead_code)]
+    config: crate::config::GraphConfig,
+    catalog: Option<Arc<dyn GraphSourceCatalog>>,
+}
+
+impl DataFusionPlanner {
+    pub fn new(config: crate::config::GraphConfig) -> Self {
+        Self {
+            config,
+            catalog: None,
+        }
+    }
+
+    pub fn with_catalog(
+        config: crate::config::GraphConfig,
+        catalog: Arc<dyn GraphSourceCatalog>,
+    ) -> Self {
+        Self {
+            config,
+            catalog: Some(catalog),
+        }
+    }
+}
+
+impl GraphPhysicalPlanner for DataFusionPlanner {
+    fn plan(&self, logical_plan: &LogicalOperator) -> Result<LogicalPlan> {
+        use std::collections::HashMap;
+        let mut var_labels: HashMap<String, String> = HashMap::new();
+        self.plan_operator_with_ctx(logical_plan, &mut var_labels)
+    }
+}
+
+impl DataFusionPlanner {
+    fn empty_plan(&self) -> LogicalPlanBuilder {
+        let schema = Arc::new(DFSchema::empty());
+        LogicalPlanBuilder::from(LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema,
+        }))
+    }
+    fn plan_operator_with_ctx(
+        &self,
+        op: &LogicalOperator,
+        var_labels: &mut std::collections::HashMap<String, String>,
+    ) -> Result<LogicalPlan> {
+        match op {
+            LogicalOperator::ScanByLabel {
+                variable,
+                label,
+                properties,
+                ..
+            } => {
+                // Track variable -> label mapping
+                var_labels.insert(variable.clone(), label.clone());
+                if let Some(cat) = &self.catalog {
+                    if let Some(source) = cat.node_source(label) {
+                        let mut builder = LogicalPlanBuilder::scan(label, source, None).unwrap();
+                        for (k, v) in properties.iter() {
+                            let lit_expr = self
+                                .to_df_value_expr(&crate::ast::ValueExpression::Literal(v.clone()));
+                            let filter_expr = Expr::BinaryExpr(BinaryExpr {
+                                left: Box::new(col(k)),
+                                op: Operator::Eq,
+                                right: Box::new(lit_expr),
+                            });
+                            builder = builder.filter(filter_expr).unwrap();
+                        }
+                        return Ok(builder.build().unwrap());
+                    }
+                }
+                Ok(self.empty_plan().build().unwrap())
+            }
+            LogicalOperator::Filter { input, predicate } => {
+                if self.catalog.is_none() {
+                    return self.plan_operator_with_ctx(input, var_labels);
+                }
+                let input_plan = self.plan_operator_with_ctx(input, var_labels)?;
+                let expr = self.to_df_boolean_expr(predicate);
+                Ok(LogicalPlanBuilder::from(input_plan)
+                    .filter(expr)
+                    .unwrap()
+                    .build()
+                    .unwrap())
+            }
+            LogicalOperator::Project { input, projections } => {
+                if self.catalog.is_none() {
+                    return self.plan_operator_with_ctx(input, var_labels);
+                }
+                let input_plan = self.plan_operator_with_ctx(input, var_labels)?;
+                let exprs: Vec<Expr> = projections
+                    .iter()
+                    .map(|p| self.to_df_value_expr(&p.expression))
+                    .collect();
+                Ok(LogicalPlanBuilder::from(input_plan)
+                    .project(exprs)
+                    .unwrap()
+                    .build()
+                    .unwrap())
+            }
+            LogicalOperator::Distinct { input } => {
+                let input_plan = self.plan_operator_with_ctx(input, var_labels)?;
+                Ok(LogicalPlanBuilder::from(input_plan)
+                    .distinct()
+                    .unwrap()
+                    .build()
+                    .unwrap())
+            }
+            LogicalOperator::Sort { input, .. } => {
+                // Schema-less placeholder: skip sort for now
+                self.plan_operator_with_ctx(input, var_labels)
+            }
+            LogicalOperator::Limit { input, count } => {
+                let input_plan = self.plan_operator_with_ctx(input, var_labels)?;
+                Ok(LogicalPlanBuilder::from(input_plan)
+                    .limit(0, Some((*count) as usize))
+                    .unwrap()
+                    .build()
+                    .unwrap())
+            }
+            LogicalOperator::Expand {
+                input,
+                source_variable,
+                target_variable,
+                relationship_types,
+                direction,
+                ..
+            }
+            | LogicalOperator::VariableLengthExpand {
+                input,
+                source_variable,
+                target_variable,
+                relationship_types,
+                direction,
+                ..
+            } => {
+                let left_plan = self.plan_operator_with_ctx(input, var_labels)?;
+                // TODO(two-hop+): Support chaining multiple hops in the physical plan.
+                // For single hop we scan the relationship table and filter with an ON expression.
+                // For two-hop (e.g., a-[:R1]->m-[:R2]->b), we should:
+                //   1) Join a with R1 (as done here)
+                //   2) Join the result with R2
+                //   3) Join the result with the b node scan
+                // Ensure we maintain/propagate variable->label mapping (var_labels) and
+                // project/qualify columns to avoid ambiguity across joins.
+                // For VariableLengthExpand with bounds, consider unrolling small fixed bounds
+                // (e.g., *1..2) into a UNION ALL of 1-hop and 2-hop plans.
+                // Attempt first hop: source node -> relationship table
+                if let (Some(cat), Some(rel_type)) = (&self.catalog, relationship_types.first()) {
+                    if let Some(rel_map) = self.config.relationship_mappings.get(rel_type) {
+                        if let Some(src_label) = var_labels.get(source_variable) {
+                            if let Some(node_map) = self.config.node_mappings.get(src_label) {
+                                if let Some(rel_source) =
+                                    cat.relationship_source(&rel_map.relationship_type)
+                                {
+                                    let rel_scan = LogicalPlanBuilder::scan(
+                                        &rel_map.relationship_type,
+                                        rel_source,
+                                        None,
+                                    )
+                                    .unwrap()
+                                    .build()
+                                    .unwrap();
+                                    let mut builder = LogicalPlanBuilder::from(left_plan)
+                                        .cross_join(rel_scan)
+                                        .unwrap();
+                                    let (left_key, right_key) = match direction {
+                                        crate::ast::RelationshipDirection::Outgoing => {
+                                            (&node_map.id_field, &rel_map.source_id_field)
+                                        }
+                                        crate::ast::RelationshipDirection::Incoming => {
+                                            (&node_map.id_field, &rel_map.target_id_field)
+                                        }
+                                        crate::ast::RelationshipDirection::Undirected => {
+                                            (&node_map.id_field, &rel_map.source_id_field)
+                                        }
+                                    };
+                                    let on_expr = Expr::BinaryExpr(BinaryExpr {
+                                        left: Box::new(col(left_key)),
+                                        op: Operator::Eq,
+                                        right: Box::new(col(right_key)),
+                                    });
+                                    builder = builder.filter(on_expr).unwrap();
+                                    // Track target variable placeholder label for downstream
+                                    var_labels
+                                        .entry(target_variable.clone())
+                                        .or_insert_with(|| "Node".to_string());
+                                    return Ok(builder.build().unwrap());
+                                }
+                            }
+                        }
+                    }
+                }
+                // Fallback: pass-through
+                var_labels
+                    .entry(target_variable.clone())
+                    .or_insert_with(|| "Node".to_string());
+                Ok(self.plan_operator_with_ctx(input, var_labels)?)
+            }
+            LogicalOperator::Join { left, .. } => {
+                // Not yet implemented: explicit join. For now, use left branch
+                self.plan_operator_with_ctx(left, var_labels)
+            }
+        }
+    }
+
+    fn to_df_boolean_expr(&self, expr: &crate::ast::BooleanExpression) -> Expr {
+        use crate::ast::{BooleanExpression as BE, ComparisonOperator as CO};
+        match expr {
+            BE::Comparison {
+                left,
+                operator,
+                right,
+            } => {
+                let l = self.to_df_value_expr(left);
+                let r = self.to_df_value_expr(right);
+                let op = match operator {
+                    CO::Equal => Operator::Eq,
+                    CO::NotEqual => Operator::NotEq,
+                    CO::LessThan => Operator::Lt,
+                    CO::LessThanOrEqual => Operator::LtEq,
+                    CO::GreaterThan => Operator::Gt,
+                    CO::GreaterThanOrEqual => Operator::GtEq,
+                };
+                Expr::BinaryExpr(BinaryExpr {
+                    left: Box::new(l),
+                    op,
+                    right: Box::new(r),
+                })
+            }
+            BE::And(l, r) => Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(self.to_df_boolean_expr(l)),
+                op: Operator::And,
+                right: Box::new(self.to_df_boolean_expr(r)),
+            }),
+            BE::Or(l, r) => Expr::BinaryExpr(BinaryExpr {
+                left: Box::new(self.to_df_boolean_expr(l)),
+                op: Operator::Or,
+                right: Box::new(self.to_df_boolean_expr(r)),
+            }),
+            BE::Not(inner) => Expr::Not(Box::new(self.to_df_boolean_expr(inner))),
+            BE::Exists(prop) => Expr::IsNotNull(Box::new(
+                self.to_df_value_expr(&crate::ast::ValueExpression::Property(prop.clone())),
+            )),
+            _ => lit(true),
+        }
+    }
+
+    fn to_df_value_expr(&self, expr: &crate::ast::ValueExpression) -> Expr {
+        use crate::ast::{PropertyValue as PV, ValueExpression as VE};
+        match expr {
+            VE::Property(prop) => col(&prop.property),
+            VE::Variable(v) => col(v),
+            VE::Literal(PV::String(s)) => lit(s.clone()),
+            VE::Literal(PV::Integer(i)) => lit(*i as i64),
+            VE::Literal(PV::Float(f)) => lit(*f),
+            VE::Literal(PV::Boolean(b)) => lit(*b),
+            VE::Literal(PV::Null) => {
+                datafusion::logical_expr::Expr::Literal(datafusion::scalar::ScalarValue::Null, None)
+            }
+            VE::Literal(PV::Parameter(_)) => lit(0),
+            VE::Literal(PV::Property(prop)) => col(&prop.property),
+            VE::Function { .. } | VE::Arithmetic { .. } => lit(0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{
+        BooleanExpression, ComparisonOperator, PropertyRef, PropertyValue, ValueExpression,
+    };
+    use crate::logical_plan::{LogicalOperator, ProjectionItem};
+    use crate::source_catalog::{InMemoryCatalog, SimpleTableSource};
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn person_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("age", DataType::Int64, true),
+        ]))
+    }
+
+    fn make_catalog() -> Arc<dyn crate::source_catalog::GraphSourceCatalog> {
+        let person_src = Arc::new(SimpleTableSource::new(person_schema()));
+        let knows_schema = Arc::new(Schema::new(vec![
+            Field::new("src_person_id", DataType::Int64, false),
+            Field::new("dst_person_id", DataType::Int64, false),
+        ]));
+        let knows_src = Arc::new(SimpleTableSource::new(knows_schema));
+        Arc::new(
+            InMemoryCatalog::new()
+                .with_node_source("Person", person_src)
+                .with_relationship_source("KNOWS", knows_src),
+        )
+    }
+
+    #[test]
+    fn test_df_planner_scan_filter_project() {
+        let scan = LogicalOperator::ScanByLabel {
+            variable: "n".to_string(),
+            label: "Person".to_string(),
+            properties: Default::default(),
+        };
+
+        let pred = BooleanExpression::Comparison {
+            left: ValueExpression::Property(PropertyRef {
+                variable: "n".to_string(),
+                property: "age".to_string(),
+            }),
+            operator: ComparisonOperator::GreaterThan,
+            right: ValueExpression::Literal(PropertyValue::Integer(30)),
+        };
+
+        let filter = LogicalOperator::Filter {
+            input: Box::new(scan),
+            predicate: pred,
+        };
+
+        let project = LogicalOperator::Project {
+            input: Box::new(filter),
+            projections: vec![ProjectionItem {
+                expression: ValueExpression::Property(PropertyRef {
+                    variable: "n".into(),
+                    property: "name".into(),
+                }),
+                alias: None,
+            }],
+        };
+
+        let cfg = crate::config::GraphConfig::builder()
+            .with_node_label("Person", "id")
+            .build()
+            .unwrap();
+        let planner = DataFusionPlanner::with_catalog(cfg, make_catalog());
+        let df_plan = planner.plan(&project).unwrap();
+
+        let s = format!("{:?}", df_plan);
+        assert!(s.contains("Projection"), "plan missing Projection: {}", s);
+        assert!(s.contains("Filter"), "plan missing Filter: {}", s);
+        assert!(s.contains("TableScan"), "plan missing TableScan: {}", s);
+        assert!(
+            s.contains("Person") || s.contains("person"),
+            "plan missing table name: {}",
+            s
+        );
+    }
+
+    #[test]
+    fn test_df_planner_property_pushdown_filter() {
+        let mut props = std::collections::HashMap::new();
+        props.insert(
+            "name".to_string(),
+            PropertyValue::String("Alice".to_string()),
+        );
+
+        let scan = LogicalOperator::ScanByLabel {
+            variable: "n".to_string(),
+            label: "Person".to_string(),
+            properties: props,
+        };
+
+        let cfg = crate::config::GraphConfig::builder()
+            .with_node_label("Person", "id")
+            .build()
+            .unwrap();
+        let planner = DataFusionPlanner::with_catalog(cfg, make_catalog());
+        let df_plan = planner.plan(&scan).unwrap();
+
+        let s = format!("{:?}", df_plan);
+        assert!(s.contains("Filter"), "plan missing Filter: {}", s);
+        assert!(s.contains("TableScan"), "plan missing TableScan: {}", s);
+        assert!(
+            s.contains("Person") || s.contains("person"),
+            "plan missing table name: {}",
+            s
+        );
+    }
+
+    #[test]
+    fn test_df_planner_expand_creates_join_filter() {
+        // MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.name
+        let scan_a = LogicalOperator::ScanByLabel {
+            variable: "a".to_string(),
+            label: "Person".to_string(),
+            properties: Default::default(),
+        };
+        let expand = LogicalOperator::Expand {
+            input: Box::new(scan_a),
+            source_variable: "a".to_string(),
+            target_variable: "b".to_string(),
+            relationship_types: vec!["KNOWS".to_string()],
+            direction: crate::ast::RelationshipDirection::Outgoing,
+            properties: Default::default(),
+        };
+        let project = LogicalOperator::Project {
+            input: Box::new(expand),
+            projections: vec![ProjectionItem {
+                expression: ValueExpression::Property(PropertyRef {
+                    variable: "b".into(),
+                    property: "name".into(),
+                }),
+                alias: None,
+            }],
+        };
+
+        let cfg = crate::config::GraphConfig::builder()
+            .with_node_label("Person", "id")
+            .with_relationship("KNOWS", "src_person_id", "dst_person_id")
+            .build()
+            .unwrap();
+        let planner = DataFusionPlanner::with_catalog(cfg, make_catalog());
+        let df_plan = planner.plan(&project).unwrap();
+
+        let s = format!("{:?}", df_plan);
+        assert!(
+            s.contains("CrossJoin") || s.contains("Join("),
+            "plan missing CrossJoin/Join: {}",
+            s
+        );
+        assert!(s.contains("Filter"), "plan missing Filter (ON): {}", s);
+        assert!(
+            s.contains("TableScan") && s.contains("person"),
+            "plan missing person scan: {}",
+            s
+        );
+        assert!(
+            s.contains("TableScan") && (s.contains("KNOWS") || s.contains("knows")),
+            "plan missing relationship scan: {}",
+            s
+        );
+    }
+}
+
+/*
+TODO: Re-implement DataFusion integration after fixing API compatibility issues.
+
+The main issues to fix:
+1. Column import path: Use datafusion::common::Column instead of datafusion::logical_expr::Column
+2. TableSource trait: Need to use LogicalTableSource or create proper table sources
+3. ScalarValue::Null needs Option<FieldMetadata> parameter
+4. SortExpr type issues with DataFusion's Expr system
+
+Reference implementation should be here when these issues are resolved.
+*/

--- a/rust/lance-graph/src/error.rs
+++ b/rust/lance-graph/src/error.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Error types for the Lance graph query engine
+
+use snafu::{prelude::*, Location};
+
+pub type Result<T> = std::result::Result<T, GraphError>;
+
+/// Errors that can occur during graph query processing
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum GraphError {
+    /// Error parsing Cypher query syntax
+    #[snafu(display("Cypher parse error at position {position}: {message}"))]
+    ParseError {
+        message: String,
+        position: usize,
+        location: Location,
+    },
+
+    /// Error with graph configuration
+    #[snafu(display("Graph configuration error: {message}"))]
+    ConfigError { message: String, location: Location },
+
+    /// Error during query planning
+    #[snafu(display("Query planning error: {message}"))]
+    PlanError { message: String, location: Location },
+
+    /// Error during query execution
+    #[snafu(display("Query execution error: {message}"))]
+    ExecutionError { message: String, location: Location },
+
+    /// Unsupported Cypher feature
+    #[snafu(display("Unsupported Cypher feature: {feature}"))]
+    UnsupportedFeature { feature: String, location: Location },
+
+    /// Invalid graph pattern
+    #[snafu(display("Invalid graph pattern: {message}"))]
+    InvalidPattern { message: String, location: Location },
+
+    /// DataFusion integration error
+    #[snafu(display("DataFusion error: {source}"))]
+    DataFusion {
+        source: datafusion_common::DataFusionError,
+        location: Location,
+    },
+
+    /// Lance core error
+    #[snafu(display("Lance core error: {source}"))]
+    LanceCore {
+        source: lance_core::Error,
+        location: Location,
+    },
+
+    /// Arrow error
+    #[snafu(display("Arrow error: {source}"))]
+    Arrow {
+        source: arrow::error::ArrowError,
+        location: Location,
+    },
+}
+
+impl From<datafusion_common::DataFusionError> for GraphError {
+    fn from(source: datafusion_common::DataFusionError) -> Self {
+        Self::DataFusion {
+            source,
+            location: Location::new(file!(), line!(), column!()),
+        }
+    }
+}
+
+impl From<lance_core::Error> for GraphError {
+    fn from(source: lance_core::Error) -> Self {
+        Self::LanceCore {
+            source,
+            location: Location::new(file!(), line!(), column!()),
+        }
+    }
+}
+
+impl From<arrow::error::ArrowError> for GraphError {
+    fn from(source: arrow::error::ArrowError) -> Self {
+        Self::Arrow {
+            source,
+            location: Location::new(file!(), line!(), column!()),
+        }
+    }
+}

--- a/rust/lance-graph/src/lance_native_planner.rs
+++ b/rust/lance-graph/src/lance_native_planner.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Lance Native physical planner (placeholder)
+//!
+//! This planner is intended to compile logical graph plans into a physical
+//! execution plan that leverages Lance's native scan and filter engine.
+//!
+//! For now, this is a placeholder implementation that conforms to the
+//! `GraphPhysicalPlanner` trait and returns an empty DataFusion logical plan
+//! until the native pipeline is wired up.
+
+use crate::config::GraphConfig;
+use crate::datafusion_planner::GraphPhysicalPlanner;
+use crate::error::Result;
+use crate::logical_plan::LogicalOperator;
+use datafusion::common::DFSchema;
+use datafusion::logical_expr::{EmptyRelation, LogicalPlan};
+use std::sync::Arc;
+
+/// Placeholder Lance-native planner
+pub struct LanceNativePlanner {
+    #[allow(dead_code)]
+    config: GraphConfig,
+}
+
+impl LanceNativePlanner {
+    pub fn new(config: GraphConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl GraphPhysicalPlanner for LanceNativePlanner {
+    fn plan(&self, _logical_plan: &LogicalOperator) -> Result<LogicalPlan> {
+        // Placeholder: return an empty relation. A future implementation will
+        // produce a runnable pipeline using Lance's native execution engine.
+        let schema = Arc::new(DFSchema::empty());
+        Ok(LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lance_native_planner_placeholder() {
+        let cfg = GraphConfig::builder()
+            .with_node_label("Person", "id")
+            .build()
+            .unwrap();
+        let planner = LanceNativePlanner::new(cfg);
+        // Minimal logical plan to feed into placeholder
+        let lp = LogicalOperator::Distinct {
+            input: Box::new(LogicalOperator::Limit {
+                input: Box::new(LogicalOperator::Project {
+                    input: Box::new(LogicalOperator::ScanByLabel {
+                        variable: "n".to_string(),
+                        label: "Person".to_string(),
+                        properties: Default::default(),
+                    }),
+                    projections: vec![],
+                }),
+                count: 1,
+            }),
+        };
+        let df_plan = planner.plan(&lp).unwrap();
+        // Empty relation is acceptable as a placeholder
+        match df_plan {
+            LogicalPlan::EmptyRelation(_) => {}
+            _ => panic!("expected empty relation placeholder"),
+        }
+    }
+}

--- a/rust/lance-graph/src/lib.rs
+++ b/rust/lance-graph/src/lib.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Lance Graph Query Engine
+//!
+//! This crate provides graph query capabilities for Lance datasets using Cypher syntax.
+//! It interprets Lance datasets as property graphs and translates Cypher queries into
+//! DataFusion SQL queries for execution.
+//!
+//! # Features
+//!
+//! - Cypher query parsing and AST representation
+//! - Graph pattern matching on columnar data
+//! - Property graph interpretation of Lance datasets  
+//! - Translation to optimized SQL via DataFusion
+//! - Support for nodes, relationships, and properties
+//!
+//! # Example
+//!
+//! ```no_run
+//! use lance_graph::{CypherQuery, GraphConfig, Result};
+//!
+//! # fn example() -> Result<()> {
+//! let config = GraphConfig::builder()
+//!     .with_node_label("Person", "person_id")
+//!     .with_relationship("KNOWS", "src_person_id", "dst_person_id")
+//!     .build()?;
+//!
+//! let query = CypherQuery::new("MATCH (p:Person) WHERE p.age > 30 RETURN p.name")?
+//!     .with_config(config);
+//!
+//! // Execute against a dataset (would need actual dataset integration)
+//! // let results = query.execute(&dataset).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod ast;
+pub mod config;
+pub mod datafusion_planner;
+pub mod error;
+pub mod lance_native_planner;
+pub mod logical_plan;
+pub mod parser;
+pub mod query;
+pub mod query_processor;
+pub mod semantic;
+pub mod source_catalog;
+
+pub use config::{GraphConfig, NodeMapping, RelationshipMapping};
+pub use error::{GraphError, Result};
+pub use query::CypherQuery;

--- a/rust/lance-graph/src/logical_plan.rs
+++ b/rust/lance-graph/src/logical_plan.rs
@@ -324,6 +324,7 @@ impl LogicalPlanner {
     }
 
     /// Extract the main variable from a logical plan (for chaining)
+    #[allow(clippy::only_used_in_recursion)]
     fn extract_variable_from_plan(&self, plan: &LogicalOperator) -> Result<String> {
         match plan {
             LogicalOperator::ScanByLabel { variable, .. } => Ok(variable.clone()),

--- a/rust/lance-graph/src/logical_plan.rs
+++ b/rust/lance-graph/src/logical_plan.rs
@@ -1,0 +1,956 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Logical planning for graph queries
+//!
+//! This module implements the logical planning phase of the query pipeline:
+//! Parse → Semantic Analysis → **Logical Plan** → Physical Plan
+//!
+//! Logical plans describe WHAT operations to perform, not HOW to perform them.
+
+use crate::ast::*;
+use crate::error::{GraphError, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A logical plan operator - describes what operation to perform
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum LogicalOperator {
+    /// Scan all nodes with a specific label
+    ScanByLabel {
+        variable: String,
+        label: String,
+        properties: HashMap<String, PropertyValue>,
+    },
+
+    /// Apply a filter predicate (WHERE clause)
+    Filter {
+        input: Box<LogicalOperator>,
+        predicate: BooleanExpression,
+    },
+
+    /// Traverse relationships (the core graph operation)
+    Expand {
+        input: Box<LogicalOperator>,
+        source_variable: String,
+        target_variable: String,
+        relationship_types: Vec<String>,
+        direction: RelationshipDirection,
+        properties: HashMap<String, PropertyValue>,
+    },
+
+    /// Variable-length path expansion (*1..2 syntax)
+    VariableLengthExpand {
+        input: Box<LogicalOperator>,
+        source_variable: String,
+        target_variable: String,
+        relationship_types: Vec<String>,
+        direction: RelationshipDirection,
+        min_length: Option<u32>,
+        max_length: Option<u32>,
+    },
+
+    /// Project specific columns (RETURN clause)
+    Project {
+        input: Box<LogicalOperator>,
+        projections: Vec<ProjectionItem>,
+    },
+
+    /// Join multiple disconnected patterns
+    Join {
+        left: Box<LogicalOperator>,
+        right: Box<LogicalOperator>,
+        join_type: JoinType,
+    },
+
+    /// Apply DISTINCT
+    Distinct { input: Box<LogicalOperator> },
+
+    /// Apply ORDER BY
+    Sort {
+        input: Box<LogicalOperator>,
+        sort_items: Vec<SortItem>,
+    },
+
+    /// Apply LIMIT
+    Limit {
+        input: Box<LogicalOperator>,
+        count: u64,
+    },
+}
+
+/// Projection item for SELECT/RETURN clauses
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProjectionItem {
+    pub expression: ValueExpression,
+    pub alias: Option<String>,
+}
+
+/// Join types for combining multiple patterns
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum JoinType {
+    Inner,
+    Left,
+    Right,
+    Full,
+    Cross,
+}
+
+/// Sort specification for ORDER BY
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SortItem {
+    pub expression: ValueExpression,
+    pub direction: SortDirection,
+}
+
+/// Logical plan builder - converts AST to logical plan
+pub struct LogicalPlanner {
+    /// Track variables in scope
+    variables: HashMap<String, String>, // variable -> label
+}
+
+impl LogicalPlanner {
+    pub fn new() -> Self {
+        Self {
+            variables: HashMap::new(),
+        }
+    }
+
+    /// Convert a Cypher AST to a logical plan
+    pub fn plan(&mut self, query: &CypherQuery) -> Result<LogicalOperator> {
+        // Start with the MATCH clause(s)
+        let mut plan = self.plan_match_clauses(&query.match_clauses)?;
+
+        // Apply WHERE clause if present
+        if let Some(where_clause) = &query.where_clause {
+            plan = LogicalOperator::Filter {
+                input: Box::new(plan),
+                predicate: where_clause.expression.clone(),
+            };
+        }
+
+        // Apply RETURN clause
+        plan = self.plan_return_clause(&query.return_clause, plan)?;
+
+        // Apply ORDER BY if present
+        if let Some(order_by) = &query.order_by {
+            plan = LogicalOperator::Sort {
+                input: Box::new(plan),
+                sort_items: order_by
+                    .items
+                    .iter()
+                    .map(|item| SortItem {
+                        expression: item.expression.clone(),
+                        direction: item.direction.clone(),
+                    })
+                    .collect(),
+            };
+        }
+
+        // Apply LIMIT if present
+        if let Some(limit) = query.limit {
+            plan = LogicalOperator::Limit {
+                input: Box::new(plan),
+                count: limit,
+            };
+        }
+
+        Ok(plan)
+    }
+
+    /// Plan MATCH clauses - the core graph pattern matching
+    fn plan_match_clauses(&mut self, match_clauses: &[MatchClause]) -> Result<LogicalOperator> {
+        if match_clauses.is_empty() {
+            return Err(GraphError::PlanError {
+                message: "Query must have at least one MATCH clause".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+
+        let plan = match_clauses.iter().try_fold(None, |plan, clause| {
+            self.plan_match_clause_with_base(plan, clause).map(Some)
+        })?;
+
+        plan.ok_or_else(|| GraphError::PlanError {
+            message: "Failed to plan MATCH clauses".to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })
+    }
+
+    /// Plan a single MATCH clause, optionally starting from an existing base plan
+    fn plan_match_clause_with_base(
+        &mut self,
+        base: Option<LogicalOperator>,
+        match_clause: &MatchClause,
+    ) -> Result<LogicalOperator> {
+        if match_clause.patterns.is_empty() {
+            return Err(GraphError::PlanError {
+                message: "MATCH clause must have at least one pattern".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+
+        let mut plan = base;
+        for pattern in &match_clause.patterns {
+            match pattern {
+                GraphPattern::Node(node) => {
+                    let already_bound = node
+                        .variable
+                        .as_deref()
+                        .is_some_and(|v| self.variables.contains_key(v));
+
+                    match (already_bound, plan.as_ref()) {
+                        (true, _) => { /* no-op */ }
+                        (false, None) => plan = Some(self.plan_node_scan(node)?),
+                        (false, Some(_)) => {
+                            let right = self.plan_node_scan(node)?;
+                            plan = Some(LogicalOperator::Join {
+                                left: Box::new(plan.unwrap()),
+                                right: Box::new(right),
+                                join_type: JoinType::Cross, // TODO: infer better join type based on shared vars
+                            });
+                        }
+                    }
+                }
+                GraphPattern::Path(path) => plan = Some(self.plan_path(plan, path)?),
+            }
+        }
+
+        plan.ok_or_else(|| GraphError::PlanError {
+            message: "Failed to plan MATCH clause".to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })
+    }
+
+    /// Plan a node scan (ScanByLabel)
+    fn plan_node_scan(&mut self, node: &NodePattern) -> Result<LogicalOperator> {
+        let variable = node
+            .variable
+            .clone()
+            .unwrap_or_else(|| format!("_node_{}", self.variables.len()));
+
+        let label = node
+            .labels
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "Node".to_string());
+
+        // Register variable
+        self.variables.insert(variable.clone(), label.clone());
+
+        Ok(LogicalOperator::ScanByLabel {
+            variable,
+            label,
+            properties: node.properties.clone(),
+        })
+    }
+
+    // (removed) plan_path_segment is superseded by plan_path
+
+    /// Plan a full path pattern, respecting the starting variable if provided
+    fn plan_path(
+        &mut self,
+        base: Option<LogicalOperator>,
+        path: &PathPattern,
+    ) -> Result<LogicalOperator> {
+        // Establish a base plan
+        let mut plan = if let Some(p) = base {
+            p
+        } else {
+            self.plan_node_scan(&path.start_node)?
+        };
+
+        // Determine the current source variable for the first hop
+        let mut current_src = match &path.start_node.variable {
+            Some(var) => var.clone(),
+            None => self.extract_variable_from_plan(&plan)?,
+        };
+
+        // For each segment, add an expand
+        for segment in &path.segments {
+            // Determine / register target variable
+            let target_variable = segment
+                .end_node
+                .variable
+                .clone()
+                .unwrap_or_else(|| format!("_node_{}", self.variables.len()));
+
+            let target_label = segment
+                .end_node
+                .labels
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "Node".to_string());
+            self.variables.insert(target_variable.clone(), target_label);
+
+            // Optimize fixed-length var-length expansions (*1 or *1..1)
+            let next_plan = match segment.relationship.length.as_ref() {
+                Some(length_range)
+                    if length_range.min == Some(1) && length_range.max == Some(1) =>
+                {
+                    LogicalOperator::Expand {
+                        input: Box::new(plan),
+                        source_variable: current_src.clone(),
+                        target_variable: target_variable.clone(),
+                        relationship_types: segment.relationship.types.clone(),
+                        direction: segment.relationship.direction.clone(),
+                        properties: segment.relationship.properties.clone(),
+                    }
+                }
+                Some(length_range) => LogicalOperator::VariableLengthExpand {
+                    input: Box::new(plan),
+                    source_variable: current_src.clone(),
+                    target_variable: target_variable.clone(),
+                    relationship_types: segment.relationship.types.clone(),
+                    direction: segment.relationship.direction.clone(),
+                    min_length: length_range.min,
+                    max_length: length_range.max,
+                },
+                None => LogicalOperator::Expand {
+                    input: Box::new(plan),
+                    source_variable: current_src.clone(),
+                    target_variable: target_variable.clone(),
+                    relationship_types: segment.relationship.types.clone(),
+                    direction: segment.relationship.direction.clone(),
+                    properties: segment.relationship.properties.clone(),
+                },
+            };
+
+            plan = next_plan;
+            current_src = target_variable;
+        }
+
+        Ok(plan)
+    }
+
+    /// Extract the main variable from a logical plan (for chaining)
+    fn extract_variable_from_plan(&self, plan: &LogicalOperator) -> Result<String> {
+        match plan {
+            LogicalOperator::ScanByLabel { variable, .. } => Ok(variable.clone()),
+            LogicalOperator::Expand {
+                target_variable, ..
+            } => Ok(target_variable.clone()),
+            LogicalOperator::VariableLengthExpand {
+                target_variable, ..
+            } => Ok(target_variable.clone()),
+            LogicalOperator::Filter { input, .. } => self.extract_variable_from_plan(input),
+            LogicalOperator::Project { input, .. } => self.extract_variable_from_plan(input),
+            LogicalOperator::Distinct { input } => self.extract_variable_from_plan(input),
+            LogicalOperator::Sort { input, .. } => self.extract_variable_from_plan(input),
+            LogicalOperator::Limit { input, .. } => self.extract_variable_from_plan(input),
+            LogicalOperator::Join { left, right, .. } => {
+                // Prefer the right branch's tail variable, else fall back to left
+                self.extract_variable_from_plan(right)
+                    .or_else(|_| self.extract_variable_from_plan(left))
+            }
+        }
+    }
+
+    /// Plan RETURN clause (Project)
+    fn plan_return_clause(
+        &self,
+        return_clause: &ReturnClause,
+        input: LogicalOperator,
+    ) -> Result<LogicalOperator> {
+        let projections = return_clause
+            .items
+            .iter()
+            .map(|item| ProjectionItem {
+                expression: item.expression.clone(),
+                alias: item.alias.clone(),
+            })
+            .collect();
+
+        let mut plan = LogicalOperator::Project {
+            input: Box::new(input),
+            projections,
+        };
+
+        // Add DISTINCT if needed
+        if return_clause.distinct {
+            plan = LogicalOperator::Distinct {
+                input: Box::new(plan),
+            };
+        }
+
+        Ok(plan)
+    }
+}
+
+impl Default for LogicalPlanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse_cypher_query;
+
+    #[test]
+    fn test_relationship_query_logical_plan_structure() {
+        let query_text = r#"MATCH (p:Person {name: "Alice"})-[:KNOWS]->(f:Person) WHERE f.age > 30 RETURN f.name"#;
+
+        // Parse the query
+        let ast = parse_cypher_query(query_text).unwrap();
+
+        // Plan to logical operators
+        let mut planner = LogicalPlanner::new();
+        let logical_plan = planner.plan(&ast).unwrap();
+
+        // Verify the overall structure is a projection
+        match &logical_plan {
+            LogicalOperator::Project { input, projections } => {
+                // Verify projection is f.name
+                assert_eq!(projections.len(), 1);
+                match &projections[0].expression {
+                    ValueExpression::Property(prop_ref) => {
+                        assert_eq!(prop_ref.variable, "f");
+                        assert_eq!(prop_ref.property, "name");
+                    }
+                    _ => panic!("Expected property reference for f.name"),
+                }
+
+                // Verify input is a filter for f.age > 30
+                match input.as_ref() {
+                    LogicalOperator::Filter {
+                        predicate,
+                        input: filter_input,
+                    } => {
+                        // Verify the predicate is f.age > 30
+                        match predicate {
+                            BooleanExpression::Comparison {
+                                left,
+                                operator,
+                                right,
+                            } => {
+                                match left {
+                                    ValueExpression::Property(prop_ref) => {
+                                        assert_eq!(prop_ref.variable, "f");
+                                        assert_eq!(prop_ref.property, "age");
+                                    }
+                                    _ => panic!("Expected property reference for f.age"),
+                                }
+                                assert_eq!(*operator, ComparisonOperator::GreaterThan);
+                                match right {
+                                    ValueExpression::Literal(PropertyValue::Integer(val)) => {
+                                        assert_eq!(*val, 30);
+                                    }
+                                    _ => panic!("Expected integer literal 30"),
+                                }
+                            }
+                            _ => panic!("Expected comparison expression"),
+                        }
+
+                        // Verify the input to the filter is an expand operation
+                        match filter_input.as_ref() {
+                            LogicalOperator::Expand {
+                                input: expand_input,
+                                source_variable,
+                                target_variable,
+                                relationship_types,
+                                direction,
+                                ..
+                            } => {
+                                assert_eq!(source_variable, "p");
+                                assert_eq!(target_variable, "f");
+                                assert_eq!(relationship_types, &vec!["KNOWS".to_string()]);
+                                assert_eq!(*direction, RelationshipDirection::Outgoing);
+
+                                // Verify the input to expand is a scan with properties for p.name = 'Alice'
+                                match expand_input.as_ref() {
+                                    LogicalOperator::ScanByLabel {
+                                        variable,
+                                        label,
+                                        properties,
+                                    } => {
+                                        assert_eq!(variable, "p");
+                                        assert_eq!(label, "Person");
+
+                                        // Verify the properties contain name = "Alice"
+                                        assert_eq!(properties.len(), 1);
+                                        match properties.get("name") {
+                                            Some(PropertyValue::String(val)) => {
+                                                assert_eq!(val, "Alice");
+                                            }
+                                            _ => {
+                                                panic!("Expected name property with value 'Alice'")
+                                            }
+                                        }
+                                    }
+                                    _ => panic!("Expected ScanByLabel with properties for Person"),
+                                }
+                            }
+                            _ => panic!("Expected Expand operation"),
+                        }
+                    }
+                    _ => panic!("Expected Filter for f.age > 30"),
+                }
+            }
+            _ => panic!("Expected Project at the top level"),
+        }
+    }
+
+    #[test]
+    fn test_simple_node_query_logical_plan() {
+        let query_text = "MATCH (n:Person) RETURN n.name";
+
+        let ast = parse_cypher_query(query_text).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical_plan = planner.plan(&ast).unwrap();
+
+        // Should be: Project { input: ScanByLabel }
+        match &logical_plan {
+            LogicalOperator::Project { input, projections } => {
+                assert_eq!(projections.len(), 1);
+                match input.as_ref() {
+                    LogicalOperator::ScanByLabel {
+                        variable, label, ..
+                    } => {
+                        assert_eq!(variable, "n");
+                        assert_eq!(label, "Person");
+                    }
+                    _ => panic!("Expected ScanByLabel"),
+                }
+            }
+            _ => panic!("Expected Project"),
+        }
+    }
+
+    #[test]
+    fn test_node_with_properties_logical_plan() {
+        let query_text = "MATCH (n:Person {age: 25}) RETURN n.name";
+
+        let ast = parse_cypher_query(query_text).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical_plan = planner.plan(&ast).unwrap();
+
+        // Should be: Project { input: ScanByLabel with properties }
+        // Properties from MATCH clause are pushed down to the scan level
+        match &logical_plan {
+            LogicalOperator::Project { input, .. } => {
+                match input.as_ref() {
+                    LogicalOperator::ScanByLabel {
+                        variable,
+                        label,
+                        properties,
+                    } => {
+                        assert_eq!(variable, "n");
+                        assert_eq!(label, "Person");
+
+                        // Verify the properties are in the scan
+                        assert_eq!(properties.len(), 1);
+                        match properties.get("age") {
+                            Some(PropertyValue::Integer(25)) => {}
+                            _ => panic!("Expected age property with value 25"),
+                        }
+                    }
+                    _ => panic!("Expected ScanByLabel with properties"),
+                }
+            }
+            _ => panic!("Expected Project"),
+        }
+    }
+
+    #[test]
+    fn test_variable_length_path_logical_plan() {
+        let query_text = "MATCH (a:Person)-[:KNOWS*1..2]->(b:Person) RETURN b.name";
+
+        let ast = parse_cypher_query(query_text).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical_plan = planner.plan(&ast).unwrap();
+
+        // Should be: Project { input: VariableLengthExpand { input: ScanByLabel } }
+        match &logical_plan {
+            LogicalOperator::Project { input, .. } => match input.as_ref() {
+                LogicalOperator::VariableLengthExpand {
+                    input: expand_input,
+                    source_variable,
+                    target_variable,
+                    relationship_types,
+                    min_length,
+                    max_length,
+                    ..
+                } => {
+                    assert_eq!(source_variable, "a");
+                    assert_eq!(target_variable, "b");
+                    assert_eq!(relationship_types, &vec!["KNOWS".to_string()]);
+                    assert_eq!(*min_length, Some(1));
+                    assert_eq!(*max_length, Some(2));
+
+                    match expand_input.as_ref() {
+                        LogicalOperator::ScanByLabel {
+                            variable, label, ..
+                        } => {
+                            assert_eq!(variable, "a");
+                            assert_eq!(label, "Person");
+                        }
+                        _ => panic!("Expected ScanByLabel"),
+                    }
+                }
+                _ => panic!("Expected VariableLengthExpand"),
+            },
+            _ => panic!("Expected Project"),
+        }
+    }
+
+    #[test]
+    fn test_where_clause_logical_plan() {
+        // Note: Current parser only supports simple comparisons, not AND/OR
+        let query_text = r#"MATCH (n:Person) WHERE n.age > 25 RETURN n.name"#;
+
+        let ast = parse_cypher_query(query_text).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical_plan = planner.plan(&ast).unwrap();
+
+        // Should be: Project { input: Filter { input: ScanByLabel } }
+        match &logical_plan {
+            LogicalOperator::Project { input, .. } => {
+                match input.as_ref() {
+                    LogicalOperator::Filter {
+                        predicate,
+                        input: scan_input,
+                    } => {
+                        // Verify it's a simple comparison: n.age > 25
+                        match predicate {
+                            BooleanExpression::Comparison {
+                                left,
+                                operator,
+                                right: _,
+                            } => {
+                                match left {
+                                    ValueExpression::Property(prop_ref) => {
+                                        assert_eq!(prop_ref.variable, "n");
+                                        assert_eq!(prop_ref.property, "age");
+                                    }
+                                    _ => panic!("Expected property reference for age"),
+                                }
+                                assert_eq!(*operator, ComparisonOperator::GreaterThan);
+                            }
+                            _ => panic!("Expected comparison expression"),
+                        }
+
+                        match scan_input.as_ref() {
+                            LogicalOperator::ScanByLabel { .. } => {}
+                            _ => panic!("Expected ScanByLabel"),
+                        }
+                    }
+                    _ => panic!("Expected Filter"),
+                }
+            }
+            _ => panic!("Expected Project"),
+        }
+    }
+
+    #[test]
+    fn test_multiple_node_patterns_join_in_match() {
+        let query_text = "MATCH (a:Person), (b:Company) RETURN a.name, b.name";
+
+        let ast = parse_cypher_query(query_text).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical_plan = planner.plan(&ast).unwrap();
+
+        // Expect: Project { input: Join { left: Scan(a:Person), right: Scan(b:Company) } }
+        match &logical_plan {
+            LogicalOperator::Project { input, projections } => {
+                assert_eq!(projections.len(), 2);
+                match input.as_ref() {
+                    LogicalOperator::Join {
+                        left,
+                        right,
+                        join_type,
+                    } => {
+                        assert!(matches!(join_type, JoinType::Cross));
+                        match left.as_ref() {
+                            LogicalOperator::ScanByLabel {
+                                variable, label, ..
+                            } => {
+                                assert_eq!(variable, "a");
+                                assert_eq!(label, "Person");
+                            }
+                            _ => panic!("Expected left ScanByLabel for a:Person"),
+                        }
+                        match right.as_ref() {
+                            LogicalOperator::ScanByLabel {
+                                variable, label, ..
+                            } => {
+                                assert_eq!(variable, "b");
+                                assert_eq!(label, "Company");
+                            }
+                            _ => panic!("Expected right ScanByLabel for b:Company"),
+                        }
+                    }
+                    _ => panic!("Expected Join after Project"),
+                }
+            }
+            _ => panic!("Expected Project at top level"),
+        }
+    }
+
+    #[test]
+    fn test_shared_variable_chained_paths_in_match() {
+        let query_text =
+            "MATCH (a:Person)-[:KNOWS]->(b:Person), (b)-[:LIKES]->(c:Thing) RETURN c.name";
+
+        let ast = parse_cypher_query(query_text).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical_plan = planner.plan(&ast).unwrap();
+
+        // Expect: Project { input: Expand (b->c) { input: Expand (a->b) { input: Scan(a) } } }
+        match &logical_plan {
+            LogicalOperator::Project { input, .. } => match input.as_ref() {
+                LogicalOperator::Expand {
+                    source_variable: src2,
+                    target_variable: tgt2,
+                    input: inner2,
+                    ..
+                } => {
+                    assert_eq!(src2, "b");
+                    assert_eq!(tgt2, "c");
+                    match inner2.as_ref() {
+                        LogicalOperator::Expand {
+                            source_variable: src1,
+                            target_variable: tgt1,
+                            input: inner1,
+                            ..
+                        } => {
+                            assert_eq!(src1, "a");
+                            assert_eq!(tgt1, "b");
+                            match inner1.as_ref() {
+                                LogicalOperator::ScanByLabel {
+                                    variable, label, ..
+                                } => {
+                                    assert_eq!(variable, "a");
+                                    assert_eq!(label, "Person");
+                                }
+                                _ => panic!("Expected ScanByLabel for a:Person"),
+                            }
+                        }
+                        _ => panic!("Expected first Expand a->b"),
+                    }
+                }
+                _ => panic!("Expected second Expand b->c at top of input"),
+            },
+            _ => panic!("Expected Project at top level"),
+        }
+    }
+
+    #[test]
+    fn test_fixed_length_variable_path_is_expand() {
+        let query_text = "MATCH (a:Person)-[:KNOWS*1..1]->(b:Person) RETURN b.name";
+
+        let ast = parse_cypher_query(query_text).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical_plan = planner.plan(&ast).unwrap();
+
+        match &logical_plan {
+            LogicalOperator::Project { input, .. } => match input.as_ref() {
+                LogicalOperator::Expand {
+                    source_variable,
+                    target_variable,
+                    ..
+                } => {
+                    assert_eq!(source_variable, "a");
+                    assert_eq!(target_variable, "b");
+                }
+                _ => panic!("Expected Expand for fixed-length *1..1"),
+            },
+            _ => panic!("Expected Project at top level"),
+        }
+    }
+
+    #[test]
+    fn test_distinct_and_order_limit_wrapping() {
+        // DISTINCT should wrap Project with Distinct
+        let q1 = "MATCH (n:Person) RETURN DISTINCT n.name";
+        let ast1 = parse_cypher_query(q1).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical1 = planner.plan(&ast1).unwrap();
+        match logical1 {
+            LogicalOperator::Distinct { input } => match *input {
+                LogicalOperator::Project { .. } => {}
+                _ => panic!("Expected Project under Distinct"),
+            },
+            _ => panic!("Expected Distinct at top level"),
+        }
+
+        // ORDER BY + LIMIT should be Limit(Sort(Project(..)))
+        let q2 = "MATCH (n:Person) RETURN n.name ORDER BY n.name LIMIT 10";
+        let ast2 = parse_cypher_query(q2).unwrap();
+        let mut planner2 = LogicalPlanner::new();
+        let logical2 = planner2.plan(&ast2).unwrap();
+        match logical2 {
+            LogicalOperator::Limit { input, count } => {
+                assert_eq!(count, 10);
+                match *input {
+                    LogicalOperator::Sort { input: inner, .. } => match *inner {
+                        LogicalOperator::Project { .. } => {}
+                        _ => panic!("Expected Project under Sort"),
+                    },
+                    _ => panic!("Expected Sort under Limit"),
+                }
+            }
+            _ => panic!("Expected Limit at top level"),
+        }
+    }
+
+    #[test]
+    fn test_relationship_properties_pushed_into_expand() {
+        let q = "MATCH (a)-[:KNOWS {since: 2020}]->(b) RETURN b";
+        let ast = parse_cypher_query(q).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical = planner.plan(&ast).unwrap();
+        match logical {
+            LogicalOperator::Project { input, .. } => match *input {
+                LogicalOperator::Expand { properties, .. } => match properties.get("since") {
+                    Some(PropertyValue::Integer(2020)) => {}
+                    _ => panic!("Expected relationship property since=2020 in Expand"),
+                },
+                _ => panic!("Expected Expand under Project"),
+            },
+            _ => panic!("Expected Project at top level"),
+        }
+    }
+
+    #[test]
+    fn test_multiple_match_clauses_cross_join() {
+        let q = "MATCH (a:Person) MATCH (b:Company) RETURN a.name, b.name";
+        let ast = parse_cypher_query(q).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical = planner.plan(&ast).unwrap();
+        match logical {
+            LogicalOperator::Project { input, .. } => match *input {
+                LogicalOperator::Join {
+                    left,
+                    right,
+                    join_type,
+                } => {
+                    assert!(matches!(join_type, JoinType::Cross));
+                    match (*left, *right) {
+                        (
+                            LogicalOperator::ScanByLabel {
+                                variable: va,
+                                label: la,
+                                ..
+                            },
+                            LogicalOperator::ScanByLabel {
+                                variable: vb,
+                                label: lb,
+                                ..
+                            },
+                        ) => {
+                            assert_eq!(va, "a");
+                            assert_eq!(la, "Person");
+                            assert_eq!(vb, "b");
+                            assert_eq!(lb, "Company");
+                        }
+                        _ => panic!("Expected two scans under Join"),
+                    }
+                }
+                _ => panic!("Expected Join under Project"),
+            },
+            _ => panic!("Expected Project at top level"),
+        }
+    }
+
+    #[test]
+    fn test_variable_only_node_default_label() {
+        let q = "MATCH (x) RETURN x";
+        let ast = parse_cypher_query(q).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical = planner.plan(&ast).unwrap();
+        match logical {
+            LogicalOperator::Project { input, .. } => match *input {
+                LogicalOperator::ScanByLabel {
+                    variable, label, ..
+                } => {
+                    assert_eq!(variable, "x");
+                    assert_eq!(label, "Node");
+                }
+                _ => panic!("Expected ScanByLabel under Project"),
+            },
+            _ => panic!("Expected Project at top level"),
+        }
+    }
+
+    #[test]
+    fn test_multi_label_node_uses_first_label() {
+        let q = "MATCH (n:Person:Employee) RETURN n";
+        let ast = parse_cypher_query(q).unwrap();
+        let mut planner = LogicalPlanner::new();
+        let logical = planner.plan(&ast).unwrap();
+        match logical {
+            LogicalOperator::Project { input, .. } => match *input {
+                LogicalOperator::ScanByLabel { label, .. } => {
+                    assert_eq!(label, "Person");
+                }
+                _ => panic!("Expected ScanByLabel under Project"),
+            },
+            _ => panic!("Expected Project at top level"),
+        }
+    }
+
+    #[test]
+    fn test_open_ended_and_partial_var_length_ranges() {
+        // * (unbounded)
+        let q1 = "MATCH (a)-[:R*]->(b) RETURN b";
+        let ast1 = parse_cypher_query(q1).unwrap();
+        let mut planner1 = LogicalPlanner::new();
+        let plan1 = planner1.plan(&ast1).unwrap();
+        match plan1 {
+            LogicalOperator::Project { input, .. } => match *input {
+                LogicalOperator::VariableLengthExpand {
+                    min_length,
+                    max_length,
+                    ..
+                } => {
+                    assert_eq!(min_length, None);
+                    assert_eq!(max_length, None);
+                }
+                _ => panic!("Expected VariableLengthExpand for *"),
+            },
+            _ => panic!("Expected Project at top level"),
+        }
+
+        // *2.. (min only)
+        let q2 = "MATCH (a)-[:R*2..]->(b) RETURN b";
+        let ast2 = parse_cypher_query(q2).unwrap();
+        let mut planner2 = LogicalPlanner::new();
+        let plan2 = planner2.plan(&ast2).unwrap();
+        match plan2 {
+            LogicalOperator::Project { input, .. } => match *input {
+                LogicalOperator::VariableLengthExpand {
+                    min_length,
+                    max_length,
+                    ..
+                } => {
+                    assert_eq!(min_length, Some(2));
+                    assert_eq!(max_length, None);
+                }
+                _ => panic!("Expected VariableLengthExpand for *2.."),
+            },
+            _ => panic!("Expected Project at top level"),
+        }
+
+        // *..3 (max only)
+        let q3 = "MATCH (a)-[:R*..3]->(b) RETURN b";
+        let ast3 = parse_cypher_query(q3).unwrap();
+        let mut planner3 = LogicalPlanner::new();
+        let plan3 = planner3.plan(&ast3).unwrap();
+        match plan3 {
+            LogicalOperator::Project { input, .. } => match *input {
+                LogicalOperator::VariableLengthExpand {
+                    min_length,
+                    max_length,
+                    ..
+                } => {
+                    assert_eq!(min_length, None);
+                    assert_eq!(max_length, Some(3));
+                }
+                _ => panic!("Expected VariableLengthExpand for *..3"),
+            },
+            _ => panic!("Expected Project at top level"),
+        }
+    }
+}

--- a/rust/lance-graph/src/parser.rs
+++ b/rust/lance-graph/src/parser.rs
@@ -185,18 +185,16 @@ fn relationship_pattern(input: &str) -> IResult<&str, RelationshipPattern> {
     ))
 }
 
+// Type alias for complex relationship content return type
+type RelationshipContentResult<'a> = (
+    Option<&'a str>,
+    Vec<&'a str>,
+    Option<HashMap<String, PropertyValue>>,
+    Option<LengthRange>,
+);
+
 // Parse relationship content inside brackets
-fn relationship_content(
-    input: &str,
-) -> IResult<
-    &str,
-    (
-        Option<&str>,
-        Vec<&str>,
-        Option<HashMap<String, PropertyValue>>,
-        Option<LengthRange>,
-    ),
-> {
+fn relationship_content(input: &str) -> IResult<&str, RelationshipContentResult<'_>> {
     let (input, _) = multispace0(input)?;
     let (input, variable) = opt(identifier)(input)?;
     let (input, types) = many0(preceded(char(':'), identifier))(input)?;

--- a/rust/lance-graph/src/parser.rs
+++ b/rust/lance-graph/src/parser.rs
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Cypher query parser
+//!
+//! This module provides parsing functionality for Cypher queries using nom parser combinators.
+//! It supports a subset of Cypher syntax focused on graph pattern matching and property access.
+
+use crate::ast::*;
+use crate::error::{GraphError, Result};
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, tag_no_case, take_while1},
+    character::complete::{char, multispace0, multispace1},
+    combinator::{map, opt, recognize},
+    multi::{many0, separated_list0},
+    sequence::{delimited, pair, preceded, tuple},
+    IResult,
+};
+use std::collections::HashMap;
+
+/// Parse a complete Cypher query
+pub fn parse_cypher_query(input: &str) -> Result<CypherQuery> {
+    let (remaining, query) = cypher_query(input).map_err(|e| GraphError::ParseError {
+        message: format!("Failed to parse Cypher query: {}", e),
+        position: 0,
+        location: snafu::Location::new(file!(), line!(), column!()),
+    })?;
+
+    if !remaining.trim().is_empty() {
+        return Err(GraphError::ParseError {
+            message: format!("Unexpected input after query: {}", remaining),
+            position: input.len() - remaining.len(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        });
+    }
+
+    Ok(query)
+}
+
+// Top-level parser for a complete Cypher query
+fn cypher_query(input: &str) -> IResult<&str, CypherQuery> {
+    let (input, _) = multispace0(input)?;
+    let (input, match_clauses) = many0(match_clause)(input)?;
+    let (input, where_clause) = opt(where_clause)(input)?;
+    let (input, return_clause) = return_clause(input)?;
+    let (input, order_by) = opt(order_by_clause)(input)?;
+    let (input, limit) = opt(limit_clause)(input)?;
+    let (input, _) = multispace0(input)?;
+
+    Ok((
+        input,
+        CypherQuery {
+            match_clauses,
+            where_clause,
+            return_clause,
+            limit,
+            order_by,
+        },
+    ))
+}
+
+// Parse a MATCH clause
+fn match_clause(input: &str) -> IResult<&str, MatchClause> {
+    let (input, _) = multispace0(input)?;
+    let (input, _) = tag_no_case("MATCH")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, patterns) = separated_list0(comma_ws, graph_pattern)(input)?;
+
+    Ok((input, MatchClause { patterns }))
+}
+
+// Parse a graph pattern (node or path)
+fn graph_pattern(input: &str) -> IResult<&str, GraphPattern> {
+    alt((
+        map(path_pattern, GraphPattern::Path),
+        map(node_pattern, GraphPattern::Node),
+    ))(input)
+}
+
+// Parse a path pattern (only if there are segments)
+fn path_pattern(input: &str) -> IResult<&str, PathPattern> {
+    let (input, start_node) = node_pattern(input)?;
+    let (input, segments) = many0(path_segment)(input)?;
+
+    // Only succeed if we actually have path segments
+    if segments.is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    Ok((
+        input,
+        PathPattern {
+            start_node,
+            segments,
+        },
+    ))
+}
+
+// Parse a path segment (relationship + node)
+fn path_segment(input: &str) -> IResult<&str, PathSegment> {
+    let (input, relationship) = relationship_pattern(input)?;
+    let (input, end_node) = node_pattern(input)?;
+
+    Ok((
+        input,
+        PathSegment {
+            relationship,
+            end_node,
+        },
+    ))
+}
+
+// Parse a node pattern: (variable:Label {prop: value})
+fn node_pattern(input: &str) -> IResult<&str, NodePattern> {
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char('(')(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, variable) = opt(identifier)(input)?;
+    let (input, labels) = many0(preceded(char(':'), identifier))(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, properties) = opt(property_map)(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char(')')(input)?;
+
+    Ok((
+        input,
+        NodePattern {
+            variable: variable.map(|s| s.to_string()),
+            labels: labels.into_iter().map(|s| s.to_string()).collect(),
+            properties: properties.unwrap_or_default(),
+        },
+    ))
+}
+
+// Parse a relationship pattern: -[variable:TYPE {prop: value}]->
+fn relationship_pattern(input: &str) -> IResult<&str, RelationshipPattern> {
+    let (input, _) = multispace0(input)?;
+
+    // Parse direction and bracket content
+    let (input, (direction, content)) = alt((
+        // Outgoing: -[...]->
+        map(
+            tuple((
+                char('-'),
+                delimited(char('['), relationship_content, char(']')),
+                tag("->"),
+            )),
+            |(_, content, _)| (RelationshipDirection::Outgoing, content),
+        ),
+        // Incoming: <-[...]-
+        map(
+            tuple((
+                tag("<-"),
+                delimited(char('['), relationship_content, char(']')),
+                char('-'),
+            )),
+            |(_, content, _)| (RelationshipDirection::Incoming, content),
+        ),
+        // Undirected: -[...]-
+        map(
+            tuple((
+                char('-'),
+                delimited(char('['), relationship_content, char(']')),
+                char('-'),
+            )),
+            |(_, content, _)| (RelationshipDirection::Undirected, content),
+        ),
+    ))(input)?;
+
+    let (variable, types, properties, length) = content;
+
+    Ok((
+        input,
+        RelationshipPattern {
+            variable: variable.map(|s| s.to_string()),
+            types: types.into_iter().map(|s| s.to_string()).collect(),
+            direction,
+            properties: properties.unwrap_or_default(),
+            length,
+        },
+    ))
+}
+
+// Parse relationship content inside brackets
+fn relationship_content(
+    input: &str,
+) -> IResult<
+    &str,
+    (
+        Option<&str>,
+        Vec<&str>,
+        Option<HashMap<String, PropertyValue>>,
+        Option<LengthRange>,
+    ),
+> {
+    let (input, _) = multispace0(input)?;
+    let (input, variable) = opt(identifier)(input)?;
+    let (input, types) = many0(preceded(char(':'), identifier))(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, length) = opt(length_range)(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, properties) = opt(property_map)(input)?;
+    let (input, _) = multispace0(input)?;
+
+    Ok((input, (variable, types, properties, length)))
+}
+
+// Parse a property map: {key: value, key2: value2}
+fn property_map(input: &str) -> IResult<&str, HashMap<String, PropertyValue>> {
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char('{')(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, pairs) = separated_list0(comma_ws, property_pair)(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char('}')(input)?;
+
+    Ok((input, pairs.into_iter().collect()))
+}
+
+// Parse a property key-value pair
+fn property_pair(input: &str) -> IResult<&str, (String, PropertyValue)> {
+    let (input, _) = multispace0(input)?;
+    let (input, key) = identifier(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char(':')(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, value) = property_value(input)?;
+
+    Ok((input, (key.to_string(), value)))
+}
+
+// Parse a property value
+fn property_value(input: &str) -> IResult<&str, PropertyValue> {
+    alt((
+        map(string_literal, PropertyValue::String),
+        map(integer_literal, PropertyValue::Integer),
+        map(float_literal, PropertyValue::Float),
+        map(boolean_literal, PropertyValue::Boolean),
+        map(tag("null"), |_| PropertyValue::Null),
+        map(parameter, PropertyValue::Parameter),
+    ))(input)
+}
+
+// Parse a WHERE clause
+fn where_clause(input: &str) -> IResult<&str, WhereClause> {
+    let (input, _) = multispace0(input)?;
+    let (input, _) = tag_no_case("WHERE")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, expression) = boolean_expression(input)?;
+
+    Ok((input, WhereClause { expression }))
+}
+
+// Parse a boolean expression (simplified)
+fn boolean_expression(input: &str) -> IResult<&str, BooleanExpression> {
+    // For now, just parse simple comparisons
+    let (input, left) = value_expression(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, operator) = comparison_operator(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, right) = value_expression(input)?;
+
+    Ok((
+        input,
+        BooleanExpression::Comparison {
+            left,
+            operator,
+            right,
+        },
+    ))
+}
+
+// Parse a comparison operator
+fn comparison_operator(input: &str) -> IResult<&str, ComparisonOperator> {
+    alt((
+        map(tag("="), |_| ComparisonOperator::Equal),
+        map(tag("<>"), |_| ComparisonOperator::NotEqual),
+        map(tag("!="), |_| ComparisonOperator::NotEqual),
+        map(tag("<="), |_| ComparisonOperator::LessThanOrEqual),
+        map(tag(">="), |_| ComparisonOperator::GreaterThanOrEqual),
+        map(tag("<"), |_| ComparisonOperator::LessThan),
+        map(tag(">"), |_| ComparisonOperator::GreaterThan),
+    ))(input)
+}
+
+// Parse a value expression
+fn value_expression(input: &str) -> IResult<&str, ValueExpression> {
+    alt((
+        map(property_reference, ValueExpression::Property),
+        map(property_value, ValueExpression::Literal),
+        map(identifier, |id| ValueExpression::Variable(id.to_string())),
+    ))(input)
+}
+
+// Parse a property reference: variable.property
+fn property_reference(input: &str) -> IResult<&str, PropertyRef> {
+    let (input, variable) = identifier(input)?;
+    let (input, _) = char('.')(input)?;
+    let (input, property) = identifier(input)?;
+
+    Ok((
+        input,
+        PropertyRef {
+            variable: variable.to_string(),
+            property: property.to_string(),
+        },
+    ))
+}
+
+// Parse a RETURN clause
+fn return_clause(input: &str) -> IResult<&str, ReturnClause> {
+    let (input, _) = multispace0(input)?;
+    let (input, _) = tag_no_case("RETURN")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, distinct) = opt(tag_no_case("DISTINCT"))(input)?;
+    let (input, _) = if distinct.is_some() {
+        multispace1(input)?
+    } else {
+        (input, "")
+    };
+    let (input, items) = separated_list0(comma_ws, return_item)(input)?;
+
+    Ok((
+        input,
+        ReturnClause {
+            distinct: distinct.is_some(),
+            items,
+        },
+    ))
+}
+
+// Parse a return item
+fn return_item(input: &str) -> IResult<&str, ReturnItem> {
+    let (input, expression) = value_expression(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, alias) = opt(preceded(
+        tuple((tag_no_case("AS"), multispace1)),
+        identifier,
+    ))(input)?;
+
+    Ok((
+        input,
+        ReturnItem {
+            expression,
+            alias: alias.map(|s| s.to_string()),
+        },
+    ))
+}
+
+// Parse an ORDER BY clause
+fn order_by_clause(input: &str) -> IResult<&str, OrderByClause> {
+    let (input, _) = multispace0(input)?;
+    let (input, _) = tag_no_case("ORDER")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, _) = tag_no_case("BY")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, items) = separated_list0(comma_ws, order_by_item)(input)?;
+
+    Ok((input, OrderByClause { items }))
+}
+
+// Parse an order by item
+fn order_by_item(input: &str) -> IResult<&str, OrderByItem> {
+    let (input, expression) = value_expression(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, direction) = opt(alt((
+        map(tag_no_case("ASC"), |_| SortDirection::Ascending),
+        map(tag_no_case("DESC"), |_| SortDirection::Descending),
+    )))(input)?;
+
+    Ok((
+        input,
+        OrderByItem {
+            expression,
+            direction: direction.unwrap_or(SortDirection::Ascending),
+        },
+    ))
+}
+
+// Parse a LIMIT clause
+fn limit_clause(input: &str) -> IResult<&str, u64> {
+    let (input, _) = multispace0(input)?;
+    let (input, _) = tag_no_case("LIMIT")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, limit) = integer_literal(input)?;
+
+    Ok((input, limit as u64))
+}
+
+// Helper parsers
+
+// Parse an identifier
+fn identifier(input: &str) -> IResult<&str, &str> {
+    take_while1(|c: char| c.is_alphanumeric() || c == '_')(input)
+}
+
+// Parse a string literal
+fn string_literal(input: &str) -> IResult<&str, String> {
+    let (input, _) = char('"')(input)?;
+    let (input, content) = take_while1(|c| c != '"')(input)?;
+    let (input, _) = char('"')(input)?;
+    Ok((input, content.to_string()))
+}
+
+// Parse an integer literal
+fn integer_literal(input: &str) -> IResult<&str, i64> {
+    let (input, digits) = recognize(pair(
+        opt(char('-')),
+        take_while1(|c: char| c.is_ascii_digit()),
+    ))(input)?;
+
+    Ok((input, digits.parse().unwrap()))
+}
+
+// Parse a float literal
+fn float_literal(input: &str) -> IResult<&str, f64> {
+    let (input, number) = recognize(tuple((
+        opt(char('-')),
+        take_while1(|c: char| c.is_ascii_digit()),
+        char('.'),
+        take_while1(|c: char| c.is_ascii_digit()),
+    )))(input)?;
+
+    Ok((input, number.parse().unwrap()))
+}
+
+// Parse a boolean literal
+fn boolean_literal(input: &str) -> IResult<&str, bool> {
+    alt((
+        map(tag_no_case("true"), |_| true),
+        map(tag_no_case("false"), |_| false),
+    ))(input)
+}
+
+// Parse a parameter reference
+fn parameter(input: &str) -> IResult<&str, String> {
+    let (input, _) = char('$')(input)?;
+    let (input, name) = identifier(input)?;
+    Ok((input, name.to_string()))
+}
+
+// Parse comma with optional whitespace
+fn comma_ws(input: &str) -> IResult<&str, ()> {
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char(',')(input)?;
+    let (input, _) = multispace0(input)?;
+    Ok((input, ()))
+}
+
+// Parse variable-length path syntax: *1..2, *..3, *2.., *
+fn length_range(input: &str) -> IResult<&str, LengthRange> {
+    let (input, _) = char('*')(input)?;
+    let (input, _) = multispace0(input)?;
+
+    // Parse different length patterns
+    alt((
+        // *min..max (e.g., *1..3)
+        map(
+            tuple((
+                nom::character::complete::u32,
+                tag(".."),
+                nom::character::complete::u32,
+            )),
+            |(min, _, max)| LengthRange {
+                min: Some(min),
+                max: Some(max),
+            },
+        ),
+        // *..max (e.g., *..3)
+        map(preceded(tag(".."), nom::character::complete::u32), |max| {
+            LengthRange {
+                min: None,
+                max: Some(max),
+            }
+        }),
+        // *min.. (e.g., *2..)
+        map(
+            tuple((nom::character::complete::u32, tag(".."))),
+            |(min, _)| LengthRange {
+                min: Some(min),
+                max: None,
+            },
+        ),
+        // *min (e.g., *2)
+        map(nom::character::complete::u32, |min| LengthRange {
+            min: Some(min),
+            max: Some(min),
+        }),
+        // * (unlimited)
+        map(multispace0, |_| LengthRange {
+            min: None,
+            max: None,
+        }),
+    ))(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_node_query() {
+        let query = "MATCH (n:Person) RETURN n.name";
+        let result = parse_cypher_query(query).unwrap();
+
+        assert_eq!(result.match_clauses.len(), 1);
+        assert_eq!(result.return_clause.items.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_node_with_properties() {
+        let query = r#"MATCH (n:Person {name: "John", age: 30}) RETURN n"#;
+        let result = parse_cypher_query(query).unwrap();
+
+        if let GraphPattern::Node(node) = &result.match_clauses[0].patterns[0] {
+            assert_eq!(node.labels, vec!["Person"]);
+            assert_eq!(node.properties.len(), 2);
+        } else {
+            panic!("Expected node pattern");
+        }
+    }
+
+    #[test]
+    fn test_parse_simple_relationship_query() {
+        let query = "MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN a.name, b.name";
+        let result = parse_cypher_query(query).unwrap();
+
+        assert_eq!(result.match_clauses.len(), 1);
+        assert_eq!(result.return_clause.items.len(), 2);
+
+        if let GraphPattern::Path(path) = &result.match_clauses[0].patterns[0] {
+            assert_eq!(path.segments.len(), 1);
+            assert_eq!(path.segments[0].relationship.types, vec!["KNOWS"]);
+        } else {
+            panic!("Expected path pattern");
+        }
+    }
+
+    #[test]
+    fn test_parse_variable_length_path() {
+        let query = "MATCH (a:Person)-[:FRIEND_OF*1..2]-(b:Person) RETURN a.name, b.name";
+        let result = parse_cypher_query(query).unwrap();
+
+        assert_eq!(result.match_clauses.len(), 1);
+
+        if let GraphPattern::Path(path) = &result.match_clauses[0].patterns[0] {
+            assert_eq!(path.segments.len(), 1);
+            assert_eq!(path.segments[0].relationship.types, vec!["FRIEND_OF"]);
+
+            let length = path.segments[0].relationship.length.as_ref().unwrap();
+            assert_eq!(length.min, Some(1));
+            assert_eq!(length.max, Some(2));
+        } else {
+            panic!("Expected path pattern");
+        }
+    }
+
+    #[test]
+    fn test_parse_query_with_where_clause() {
+        let query = "MATCH (n:Person) WHERE n.age > 30 RETURN n.name";
+        let result = parse_cypher_query(query).unwrap();
+
+        assert!(result.where_clause.is_some());
+    }
+
+    #[test]
+    fn test_parse_query_with_limit() {
+        let query = "MATCH (n:Person) RETURN n.name LIMIT 10";
+        let result = parse_cypher_query(query).unwrap();
+
+        assert_eq!(result.limit, Some(10));
+    }
+}

--- a/rust/lance-graph/src/query.rs
+++ b/rust/lance-graph/src/query.rs
@@ -1,0 +1,1740 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! High-level Cypher query interface for Lance datasets
+
+use crate::ast::CypherQuery as CypherAST;
+use crate::config::GraphConfig;
+use crate::error::{GraphError, Result};
+use crate::parser::parse_cypher_query;
+use datafusion::logical_expr::JoinType;
+use std::collections::HashMap;
+
+/// A Cypher query that can be executed against Lance datasets
+#[derive(Debug, Clone)]
+pub struct CypherQuery {
+    /// The original Cypher query string
+    query_text: String,
+    /// Parsed AST representation
+    ast: CypherAST,
+    /// Graph configuration for mapping
+    config: Option<GraphConfig>,
+    /// Query parameters
+    parameters: HashMap<String, serde_json::Value>,
+}
+
+// Internal helper that plans and executes a single path by chaining joins.
+struct PathExecutor<'a> {
+    ctx: &'a datafusion::prelude::SessionContext,
+    path: &'a crate::ast::PathPattern,
+    start_label: &'a str,
+    start_alias: String,
+    segs: Vec<SegMeta<'a>>,
+    node_maps: std::collections::HashMap<String, &'a crate::config::NodeMapping>,
+    rel_maps: std::collections::HashMap<String, &'a crate::config::RelationshipMapping>,
+}
+
+#[derive(Clone)]
+struct SegMeta<'a> {
+    rel_type: &'a str,
+    end_label: &'a str,
+    dir: crate::ast::RelationshipDirection,
+    rel_alias: String,
+    end_alias: String,
+}
+
+impl<'a> PathExecutor<'a> {
+    fn new(
+        ctx: &'a datafusion::prelude::SessionContext,
+        cfg: &'a crate::config::GraphConfig,
+        path: &'a crate::ast::PathPattern,
+    ) -> Result<Self> {
+        use std::collections::{HashMap, HashSet};
+        let mut used: HashSet<String> = HashSet::new();
+        let mut uniq = |desired: &str| -> String {
+            if used.insert(desired.to_string()) {
+                return desired.to_string();
+            }
+            let mut i = 2usize;
+            loop {
+                let cand = format!("{}_{}", desired, i);
+                if used.insert(cand.clone()) {
+                    break cand;
+                }
+                i += 1;
+            }
+        };
+
+        let start_label = path
+            .start_node
+            .labels
+            .first()
+            .map(|s| s.as_str())
+            .ok_or_else(|| GraphError::PlanError {
+                message: "Start node must have a label".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let start_alias = uniq(
+            &path
+                .start_node
+                .variable
+                .as_deref()
+                .unwrap_or(start_label)
+                .to_lowercase(),
+        );
+
+        let mut segs: Vec<SegMeta> = Vec::with_capacity(path.segments.len());
+        for seg in &path.segments {
+            let rel_type = seg
+                .relationship
+                .types
+                .first()
+                .map(|s| s.as_str())
+                .ok_or_else(|| GraphError::PlanError {
+                    message: "Relationship must have a type".to_string(),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            let end_label = seg
+                .end_node
+                .labels
+                .first()
+                .map(|s| s.as_str())
+                .ok_or_else(|| GraphError::PlanError {
+                    message: "End node must have a label".to_string(),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            let rel_alias = uniq(
+                &seg.relationship
+                    .variable
+                    .as_deref()
+                    .unwrap_or(rel_type)
+                    .to_lowercase(),
+            );
+            let end_alias = uniq(
+                &seg.end_node
+                    .variable
+                    .as_deref()
+                    .unwrap_or(end_label)
+                    .to_lowercase(),
+            );
+            segs.push(SegMeta {
+                rel_type,
+                end_label,
+                dir: seg.relationship.direction.clone(),
+                rel_alias,
+                end_alias,
+            });
+        }
+
+        let mut node_maps: HashMap<String, &crate::config::NodeMapping> = HashMap::new();
+        let mut rel_maps: HashMap<String, &crate::config::RelationshipMapping> = HashMap::new();
+        node_maps.insert(
+            start_alias.clone(),
+            cfg.get_node_mapping(start_label)
+                .ok_or_else(|| GraphError::PlanError {
+                    message: format!("No node mapping for '{}'", start_label),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?,
+        );
+        for seg in &segs {
+            node_maps.insert(
+                seg.end_alias.clone(),
+                cfg.get_node_mapping(seg.end_label)
+                    .ok_or_else(|| GraphError::PlanError {
+                        message: format!("No node mapping for '{}'", seg.end_label),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    })?,
+            );
+            rel_maps.insert(
+                seg.rel_alias.clone(),
+                cfg.get_relationship_mapping(seg.rel_type).ok_or_else(|| {
+                    GraphError::PlanError {
+                        message: format!("No relationship mapping for '{}'", seg.rel_type),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    }
+                })?,
+            );
+        }
+
+        Ok(Self {
+            ctx,
+            path,
+            start_label,
+            start_alias,
+            segs,
+            node_maps,
+            rel_maps,
+        })
+    }
+
+    async fn open_aliased(
+        &self,
+        table: &str,
+        alias: &str,
+    ) -> Result<datafusion::dataframe::DataFrame> {
+        let df = self
+            .ctx
+            .table(table)
+            .await
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Failed to read table '{}': {}", table, e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let schema = df.schema();
+        let proj: Vec<datafusion::logical_expr::Expr> = schema
+            .fields()
+            .iter()
+            .map(|f| {
+                datafusion::logical_expr::col(f.name()).alias(&format!("{}__{}", alias, f.name()))
+            })
+            .collect();
+        df.alias(alias)?
+            .select(proj)
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Failed to alias/select '{}': {}", table, e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })
+    }
+
+    async fn build_chain(&self) -> Result<datafusion::dataframe::DataFrame> {
+        // Start node
+        let mut df = self
+            .open_aliased(self.start_label, &self.start_alias)
+            .await?;
+        // Inline property filters on start node
+        for (k, v) in &self.path.start_node.properties {
+            let expr = to_df_literal(v);
+            df = df
+                .filter(datafusion::logical_expr::Expr::BinaryExpr(
+                    datafusion::logical_expr::BinaryExpr {
+                        left: Box::new(datafusion::logical_expr::col(&format!(
+                            "{}__{}",
+                            self.start_alias, k
+                        ))),
+                        op: datafusion::logical_expr::Operator::Eq,
+                        right: Box::new(expr),
+                    },
+                ))
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to apply filter: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+        }
+
+        // Chain joins for each hop
+        let mut current_node_alias = self.start_alias.as_str();
+        for s in &self.segs {
+            let rel_df = self.open_aliased(s.rel_type, &s.rel_alias).await?;
+            let node_map = self.node_maps.get(current_node_alias).unwrap();
+            let rel_map = self.rel_maps.get(&s.rel_alias).unwrap();
+            let (left_key, right_key) = match s.dir {
+                crate::ast::RelationshipDirection::Outgoing
+                | crate::ast::RelationshipDirection::Undirected => (
+                    format!("{}__{}", current_node_alias, node_map.id_field),
+                    format!("{}__{}", s.rel_alias, rel_map.source_id_field),
+                ),
+                crate::ast::RelationshipDirection::Incoming => (
+                    format!("{}__{}", current_node_alias, node_map.id_field),
+                    format!("{}__{}", s.rel_alias, rel_map.target_id_field),
+                ),
+            };
+            df = df
+                .join(
+                    rel_df,
+                    JoinType::Inner,
+                    &[left_key.as_str()],
+                    &[right_key.as_str()],
+                    None,
+                )
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Join failed (node->rel): {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+
+            let end_df = self.open_aliased(s.end_label, &s.end_alias).await?;
+            let (left_key2, right_key2) = match s.dir {
+                crate::ast::RelationshipDirection::Outgoing
+                | crate::ast::RelationshipDirection::Undirected => (
+                    format!("{}__{}", s.rel_alias, rel_map.target_id_field),
+                    format!(
+                        "{}__{}",
+                        s.end_alias,
+                        self.node_maps.get(&s.end_alias).unwrap().id_field
+                    ),
+                ),
+                crate::ast::RelationshipDirection::Incoming => (
+                    format!("{}__{}", s.rel_alias, rel_map.source_id_field),
+                    format!(
+                        "{}__{}",
+                        s.end_alias,
+                        self.node_maps.get(&s.end_alias).unwrap().id_field
+                    ),
+                ),
+            };
+            df = df
+                .join(
+                    end_df,
+                    JoinType::Inner,
+                    &[left_key2.as_str()],
+                    &[right_key2.as_str()],
+                    None,
+                )
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Join failed (rel->node): {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            current_node_alias = &s.end_alias;
+        }
+
+        Ok(df)
+    }
+
+    fn resolve_var_alias<'b>(&'b self, var: &str) -> Option<&'b str> {
+        if Some(var) == self.path.start_node.variable.as_deref() {
+            return Some(self.start_alias.as_str());
+        }
+        for (i, seg) in self.path.segments.iter().enumerate() {
+            if Some(var) == seg.relationship.variable.as_deref() {
+                return Some(self.segs[i].rel_alias.as_str());
+            }
+            if Some(var) == seg.end_node.variable.as_deref() {
+                return Some(self.segs[i].end_alias.as_str());
+            }
+        }
+        None
+    }
+
+    fn apply_where(
+        &self,
+        mut df: datafusion::dataframe::DataFrame,
+        ast: &crate::ast::CypherQuery,
+    ) -> Result<datafusion::dataframe::DataFrame> {
+        if let Some(where_clause) = &ast.where_clause {
+            if let Some(expr) =
+                to_df_boolean_expr_with_vars(&where_clause.expression, &|var, prop| {
+                    let alias = self.resolve_var_alias(var).unwrap_or(var);
+                    format!("{}__{}", alias, prop)
+                })
+            {
+                df = df.filter(expr).map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to apply WHERE: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            }
+        }
+        Ok(df)
+    }
+
+    fn apply_return(
+        &self,
+        mut df: datafusion::dataframe::DataFrame,
+        ast: &crate::ast::CypherQuery,
+    ) -> Result<datafusion::dataframe::DataFrame> {
+        use datafusion::logical_expr::Expr;
+        let mut proj: Vec<Expr> = Vec::new();
+        for item in &ast.return_clause.items {
+            if let crate::ast::ValueExpression::Property(prop) = &item.expression {
+                let alias = self
+                    .resolve_var_alias(&prop.variable)
+                    .unwrap_or(&prop.variable);
+                let mut e = datafusion::logical_expr::col(&format!("{}__{}", alias, prop.property));
+                if let Some(a) = &item.alias {
+                    e = e.alias(a);
+                }
+                proj.push(e);
+            }
+        }
+        if !proj.is_empty() {
+            df = df.select(proj).map_err(|e| GraphError::PlanError {
+                message: format!("Failed to project: {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        }
+        if ast.return_clause.distinct {
+            df = df.distinct().map_err(|e| GraphError::PlanError {
+                message: format!("Failed to apply DISTINCT: {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        }
+        if let Some(limit) = ast.limit {
+            df = df
+                .limit(0, Some(limit as usize))
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to apply LIMIT: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+        }
+        Ok(df)
+    }
+}
+
+impl CypherQuery {
+    /// Create a new Cypher query from a query string
+    pub fn new(query: &str) -> Result<Self> {
+        let ast = parse_cypher_query(query)?;
+
+        Ok(Self {
+            query_text: query.to_string(),
+            ast,
+            config: None,
+            parameters: HashMap::new(),
+        })
+    }
+
+    /// Set the graph configuration for this query
+    pub fn with_config(mut self, config: GraphConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    /// Add a parameter to the query
+    pub fn with_parameter<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<String>,
+        V: Into<serde_json::Value>,
+    {
+        self.parameters.insert(key.into(), value.into());
+        self
+    }
+
+    /// Add multiple parameters to the query
+    pub fn with_parameters(mut self, params: HashMap<String, serde_json::Value>) -> Self {
+        self.parameters.extend(params);
+        self
+    }
+
+    /// Get the original query text
+    pub fn query_text(&self) -> &str {
+        &self.query_text
+    }
+
+    /// Get the parsed AST
+    pub fn ast(&self) -> &CypherAST {
+        &self.ast
+    }
+
+    /// Get the graph configuration
+    pub fn config(&self) -> Option<&GraphConfig> {
+        self.config.as_ref()
+    }
+
+    /// Get query parameters
+    pub fn parameters(&self) -> &HashMap<String, serde_json::Value> {
+        &self.parameters
+    }
+
+    /// Execute this Cypher query against Lance datasets
+    ///
+    /// Note: This initial implementation supports a single-table projection/filter/limit
+    /// workflow to enable basic end-to-end execution. Multi-table/path execution will be
+    /// wired up via the DataFusion planner in a follow-up.
+    pub async fn execute(
+        &self,
+        datasets: HashMap<String, arrow::record_batch::RecordBatch>,
+    ) -> Result<arrow::record_batch::RecordBatch> {
+        use arrow::compute::concat_batches;
+        use datafusion::datasource::MemTable;
+        use datafusion::prelude::*;
+        use std::sync::Arc;
+
+        // Require a config for now, even if we don't fully exploit it yet
+        let _config = self.config.as_ref().ok_or_else(|| GraphError::PlanError {
+            message: "Graph configuration is required for query execution".to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
+
+        if datasets.is_empty() {
+            return Err(GraphError::PlanError {
+                message: "No input datasets provided".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+
+        // Create DataFusion context and register all provided tables
+        let ctx = SessionContext::new();
+        for (name, batch) in &datasets {
+            let table =
+                MemTable::try_new(batch.schema(), vec![vec![batch.clone()]]).map_err(|e| {
+                    GraphError::PlanError {
+                        message: format!("Failed to create DataFusion table: {}", e),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    }
+                })?;
+            ctx.register_table(name, Arc::new(table))
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to register table '{}': {}", name, e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+        }
+
+        // Try to execute a path (1+ hops) if the query is a simple pattern
+        if let Some(df) = self.try_execute_path_generic(&ctx).await? {
+            let batches = df.collect().await.map_err(|e| GraphError::PlanError {
+                message: format!("Failed to collect results: {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+            if batches.is_empty() {
+                let schema = datasets.values().next().unwrap().schema();
+                return Ok(arrow_array::RecordBatch::new_empty(schema));
+            }
+            let merged = concat_batches(&batches[0].schema(), &batches).map_err(|e| {
+                GraphError::PlanError {
+                    message: format!("Failed to concatenate result batches: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                }
+            })?;
+            return Ok(merged);
+        }
+
+        // Fallback: single-table style query on the first provided table
+        let (table_name, batch) = datasets.iter().next().unwrap();
+        let schema = batch.schema();
+
+        // Start a DataFrame from the registered table
+        let mut df = ctx
+            .table(table_name)
+            .await
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Failed to create DataFrame for '{}': {}", table_name, e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        // Apply WHERE if present (limited support: simple comparisons on a single column)
+        if let Some(where_clause) = &self.ast.where_clause {
+            if let Some(filter_expr) = to_df_boolean_expr_simple(&where_clause.expression) {
+                df = df.filter(filter_expr).map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to apply filter: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            }
+        }
+
+        // Build projection from RETURN clause
+        let proj_exprs: Vec<Expr> = self
+            .ast
+            .return_clause
+            .items
+            .iter()
+            .map(|item| to_df_value_expr_simple(&item.expression))
+            .collect();
+        if !proj_exprs.is_empty() {
+            df = df.select(proj_exprs).map_err(|e| GraphError::PlanError {
+                message: format!("Failed to project: {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        }
+
+        // Apply DISTINCT
+        if self.ast.return_clause.distinct {
+            df = df.distinct().map_err(|e| GraphError::PlanError {
+                message: format!("Failed to apply DISTINCT: {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        }
+
+        // Apply LIMIT if present
+        if let Some(limit) = self.ast.limit {
+            df = df
+                .limit(0, Some(limit as usize))
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to apply LIMIT: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+        }
+
+        // Collect results and concat into a single RecordBatch
+        let batches = df.collect().await.map_err(|e| GraphError::PlanError {
+            message: format!("Failed to collect results: {}", e),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
+
+        if batches.is_empty() {
+            // Return an empty batch with the source schema
+            return Ok(arrow_array::RecordBatch::new_empty(schema));
+        }
+
+        let merged =
+            concat_batches(&batches[0].schema(), &batches).map_err(|e| GraphError::PlanError {
+                message: format!("Failed to concatenate result batches: {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        Ok(merged)
+    }
+
+    /// Validate the query against the provided configuration
+    pub fn validate(&self) -> Result<()> {
+        // Check that all referenced labels exist in configuration
+        for match_clause in &self.ast.match_clauses {
+            for pattern in &match_clause.patterns {
+                self.validate_pattern(pattern)?;
+            }
+        }
+
+        // Validate WHERE clause if present
+        if let Some(where_clause) = &self.ast.where_clause {
+            self.validate_boolean_expression(&where_clause.expression)?;
+        }
+
+        // Validate RETURN clause
+        for item in &self.ast.return_clause.items {
+            self.validate_value_expression(&item.expression)?;
+        }
+
+        Ok(())
+    }
+
+    /// Get all node labels referenced in this query
+    pub fn referenced_node_labels(&self) -> Vec<String> {
+        let mut labels = Vec::new();
+
+        for match_clause in &self.ast.match_clauses {
+            for pattern in &match_clause.patterns {
+                self.collect_node_labels_from_pattern(pattern, &mut labels);
+            }
+        }
+
+        labels.sort();
+        labels.dedup();
+        labels
+    }
+
+    /// Get all relationship types referenced in this query
+    pub fn referenced_relationship_types(&self) -> Vec<String> {
+        let mut types = Vec::new();
+
+        for match_clause in &self.ast.match_clauses {
+            for pattern in &match_clause.patterns {
+                self.collect_relationship_types_from_pattern(pattern, &mut types);
+            }
+        }
+
+        types.sort();
+        types.dedup();
+        types
+    }
+
+    /// Get all variables used in this query
+    pub fn variables(&self) -> Vec<String> {
+        let mut variables = Vec::new();
+
+        for match_clause in &self.ast.match_clauses {
+            for pattern in &match_clause.patterns {
+                self.collect_variables_from_pattern(pattern, &mut variables);
+            }
+        }
+
+        variables.sort();
+        variables.dedup();
+        variables
+    }
+
+    // Validation helper methods
+
+    fn validate_pattern(&self, pattern: &crate::ast::GraphPattern) -> Result<()> {
+        match pattern {
+            crate::ast::GraphPattern::Node(node) => {
+                for label in &node.labels {
+                    if let Some(config) = &self.config {
+                        if config.get_node_mapping(label).is_none() {
+                            return Err(GraphError::PlanError {
+                                message: format!("No mapping found for node label '{}'", label),
+                                location: snafu::Location::new(file!(), line!(), column!()),
+                            });
+                        }
+                    }
+                }
+                Ok(())
+            }
+            crate::ast::GraphPattern::Path(path) => {
+                self.validate_pattern(&crate::ast::GraphPattern::Node(path.start_node.clone()))?;
+                for segment in &path.segments {
+                    for rel_type in &segment.relationship.types {
+                        if let Some(config) = &self.config {
+                            if config.get_relationship_mapping(rel_type).is_none() {
+                                return Err(GraphError::PlanError {
+                                    message: format!(
+                                        "No mapping found for relationship type '{}'",
+                                        rel_type
+                                    ),
+                                    location: snafu::Location::new(file!(), line!(), column!()),
+                                });
+                            }
+                        }
+                    }
+                    self.validate_pattern(&crate::ast::GraphPattern::Node(
+                        segment.end_node.clone(),
+                    ))?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn validate_boolean_expression(&self, _expr: &crate::ast::BooleanExpression) -> Result<()> {
+        // TODO: Implement validation of boolean expressions
+        Ok(())
+    }
+
+    fn validate_value_expression(&self, _expr: &crate::ast::ValueExpression) -> Result<()> {
+        // TODO: Implement validation of value expressions
+        Ok(())
+    }
+
+    // Collection helper methods
+
+    fn collect_node_labels_from_pattern(
+        &self,
+        pattern: &crate::ast::GraphPattern,
+        labels: &mut Vec<String>,
+    ) {
+        match pattern {
+            crate::ast::GraphPattern::Node(node) => {
+                labels.extend(node.labels.clone());
+            }
+            crate::ast::GraphPattern::Path(path) => {
+                labels.extend(path.start_node.labels.clone());
+                for segment in &path.segments {
+                    labels.extend(segment.end_node.labels.clone());
+                }
+            }
+        }
+    }
+
+    fn collect_relationship_types_from_pattern(
+        &self,
+        pattern: &crate::ast::GraphPattern,
+        types: &mut Vec<String>,
+    ) {
+        if let crate::ast::GraphPattern::Path(path) = pattern {
+            for segment in &path.segments {
+                types.extend(segment.relationship.types.clone());
+            }
+        }
+    }
+
+    fn collect_variables_from_pattern(
+        &self,
+        pattern: &crate::ast::GraphPattern,
+        variables: &mut Vec<String>,
+    ) {
+        match pattern {
+            crate::ast::GraphPattern::Node(node) => {
+                if let Some(var) = &node.variable {
+                    variables.push(var.clone());
+                }
+            }
+            crate::ast::GraphPattern::Path(path) => {
+                if let Some(var) = &path.start_node.variable {
+                    variables.push(var.clone());
+                }
+                for segment in &path.segments {
+                    if let Some(var) = &segment.relationship.variable {
+                        variables.push(var.clone());
+                    }
+                    if let Some(var) = &segment.end_node.variable {
+                        variables.push(var.clone());
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl CypherQuery {
+    // Generic path executor (N-hop) entrypoint.
+    async fn try_execute_path_generic(
+        &self,
+        ctx: &datafusion::prelude::SessionContext,
+    ) -> Result<Option<datafusion::dataframe::DataFrame>> {
+        use crate::ast::GraphPattern;
+        let match_clause = match self.ast.match_clauses.as_slice() {
+            [mc] => mc,
+            _ => return Ok(None),
+        };
+        let path = match match_clause.patterns.as_slice() {
+            [GraphPattern::Path(p)] if !p.segments.is_empty() => p,
+            _ => return Ok(None),
+        };
+        let cfg = self.config.as_ref().ok_or_else(|| GraphError::PlanError {
+            message: "Graph configuration is required for execution".to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
+        let exec = PathExecutor::new(ctx, cfg, path)?;
+        let df = exec.build_chain().await?;
+        let df = exec.apply_where(df, &self.ast)?;
+        let df = exec.apply_return(df, &self.ast)?;
+        Ok(Some(df))
+    }
+
+    // Attempt execution for a single-path pattern using joins.
+    // Supports single-hop and two-hop expansions
+    #[allow(dead_code)]
+    async fn try_execute_single_hop_path(
+        &self,
+        ctx: &datafusion::prelude::SessionContext,
+    ) -> Result<Option<datafusion::dataframe::DataFrame>> {
+        use crate::ast::{GraphPattern, RelationshipDirection, ValueExpression};
+        use datafusion::prelude::*;
+
+        // Only handle a single MATCH with a single path and exactly one segment
+        let match_clause = match self.ast.match_clauses.as_slice() {
+            [mc] => mc,
+            _ => return Ok(None),
+        };
+        let path = match match_clause.patterns.as_slice() {
+            [GraphPattern::Path(p)] if (p.segments.len() == 1 || p.segments.len() == 2) => p,
+            _ => return Ok(None),
+        };
+        let seg = &path.segments[0];
+        let rel_type = match seg.relationship.types.first() {
+            Some(t) => t.as_str(),
+            None => return Ok(None),
+        };
+        let start_label = match path.start_node.labels.first() {
+            Some(l) => l.as_str(),
+            None => return Ok(None),
+        };
+        let end_label = match seg.end_node.labels.first() {
+            Some(l) => l.as_str(),
+            None => return Ok(None),
+        };
+
+        let start_alias = path.start_node.variable.as_deref().unwrap_or(start_label);
+        let rel_alias = seg.relationship.variable.as_deref().unwrap_or(rel_type);
+        let end_alias = seg.end_node.variable.as_deref().unwrap_or(end_label);
+
+        // Validate mappings
+        let cfg = self.config.as_ref().ok_or_else(|| GraphError::PlanError {
+            message: "Graph configuration is required for execution".to_string(),
+            location: snafu::Location::new(file!(), line!(), column!()),
+        })?;
+        let start_map = cfg
+            .get_node_mapping(start_label)
+            .ok_or_else(|| GraphError::PlanError {
+                message: format!("No node mapping for '{}'", start_label),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let end_map = cfg
+            .get_node_mapping(end_label)
+            .ok_or_else(|| GraphError::PlanError {
+                message: format!("No node mapping for '{}'", end_label),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let rel_map =
+            cfg.get_relationship_mapping(rel_type)
+                .ok_or_else(|| GraphError::PlanError {
+                    message: format!("No relationship mapping for '{}'", rel_type),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+
+        // Read tables and alias
+        let mut left = ctx
+            .table(start_label)
+            .await
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Failed to read table '{}': {}", start_label, e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        // Alias and flatten columns to '<alias>__<col>' to avoid ambiguity
+        let left_schema = left.schema();
+        let left_proj: Vec<datafusion::logical_expr::Expr> = left_schema
+            .fields()
+            .iter()
+            .map(|f| {
+                datafusion::logical_expr::col(f.name()).alias(&format!(
+                    "{}__{}",
+                    start_alias,
+                    f.name()
+                ))
+            })
+            .collect();
+        left = left
+            .alias(start_alias)?
+            .select(left_proj)
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Failed to alias/select '{}': {}", start_label, e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        for (k, v) in &path.start_node.properties {
+            let expr = to_df_literal(v);
+            left = left
+                .filter(datafusion::logical_expr::Expr::BinaryExpr(
+                    datafusion::logical_expr::BinaryExpr {
+                        left: Box::new(datafusion::logical_expr::col(&format!(
+                            "{}__{}",
+                            start_alias, k
+                        ))),
+                        op: datafusion::logical_expr::Operator::Eq,
+                        right: Box::new(expr),
+                    },
+                ))
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to apply filter: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+        }
+
+        let mut rel_df = ctx
+            .table(rel_type)
+            .await
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Failed to read table '{}': {}", rel_type, e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let rel_schema = rel_df.schema();
+        let rel_proj: Vec<datafusion::logical_expr::Expr> = rel_schema
+            .fields()
+            .iter()
+            .map(|f| {
+                datafusion::logical_expr::col(f.name()).alias(&format!(
+                    "{}__{}",
+                    rel_alias,
+                    f.name()
+                ))
+            })
+            .collect();
+        rel_df = rel_df
+            .alias(rel_alias)?
+            .select(rel_proj)
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Failed to alias/select '{}': {}", rel_type, e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        // Join start -> relationship
+        let (left_key, right_key) = match seg.relationship.direction {
+            RelationshipDirection::Outgoing | RelationshipDirection::Undirected => (
+                format!("{}__{}", start_alias, start_map.id_field),
+                format!("{}__{}", rel_alias, rel_map.source_id_field),
+            ),
+            RelationshipDirection::Incoming => (
+                format!("{}__{}", start_alias, start_map.id_field),
+                format!("{}__{}", rel_alias, rel_map.target_id_field),
+            ),
+        };
+        let mut joined = left
+            .join(
+                rel_df,
+                JoinType::Inner,
+                &[left_key.as_str()],
+                &[right_key.as_str()],
+                None,
+            )
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Join failed (node->rel): {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        // Join relationship -> end (or mid, for 2-hop)
+        let mut right = ctx
+            .table(end_label)
+            .await
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Failed to read table '{}': {}", end_label, e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let right_schema = right.schema();
+        let right_proj: Vec<datafusion::logical_expr::Expr> = right_schema
+            .fields()
+            .iter()
+            .map(|f| {
+                datafusion::logical_expr::col(f.name()).alias(&format!(
+                    "{}__{}",
+                    end_alias,
+                    f.name()
+                ))
+            })
+            .collect();
+        right = right
+            .alias(end_alias)?
+            .select(right_proj)
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Failed to alias/select '{}': {}", end_label, e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        let (left_key2, right_key2) = match seg.relationship.direction {
+            RelationshipDirection::Outgoing | RelationshipDirection::Undirected => (
+                format!("{}__{}", rel_alias, rel_map.target_id_field),
+                format!("{}__{}", end_alias, end_map.id_field),
+            ),
+            RelationshipDirection::Incoming => (
+                format!("{}__{}", rel_alias, rel_map.source_id_field),
+                format!("{}__{}", end_alias, end_map.id_field),
+            ),
+        };
+        joined = joined
+            .join(
+                right,
+                JoinType::Inner,
+                &[left_key2.as_str()],
+                &[right_key2.as_str()],
+                None,
+            )
+            .map_err(|e| GraphError::PlanError {
+                message: format!("Join failed (rel->node): {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+
+        // If there is a second segment (two-hop), continue chaining joins
+        if path.segments.len() == 2 {
+            let seg2 = &path.segments[1];
+            let rel_type2 = match seg2.relationship.types.first() {
+                Some(t) => t.as_str(),
+                None => return Ok(None),
+            };
+            let end2_label = match seg2.end_node.labels.first() {
+                Some(l) => l.as_str(),
+                None => return Ok(None),
+            };
+
+            let mid_alias = end_alias; // end of seg1 is the mid node
+            let mut rel2_alias = seg2
+                .relationship
+                .variable
+                .as_deref()
+                .unwrap_or(rel_type2)
+                .to_string();
+            let mut end2_alias = seg2
+                .end_node
+                .variable
+                .as_deref()
+                .unwrap_or(end2_label)
+                .to_string();
+            // Ensure unique aliases to avoid duplicate-qualified column names
+            use std::collections::HashSet;
+            let mut used_aliases: HashSet<String> = [
+                start_alias.to_string(),
+                rel_alias.to_string(),
+                end_alias.to_string(),
+            ]
+            .into_iter()
+            .collect();
+            let mut uniquify = |alias: &mut String| {
+                if used_aliases.insert(alias.clone()) {
+                    return;
+                }
+                let base = alias.clone();
+                let mut i = 2usize;
+                loop {
+                    let cand = format!("{}_{}", base, i);
+                    if used_aliases.insert(cand.clone()) {
+                        *alias = cand;
+                        break;
+                    }
+                    i += 1;
+                }
+            };
+            uniquify(&mut rel2_alias);
+            uniquify(&mut end2_alias);
+
+            // Validate mappings
+            let _mid_map = end_map; // end of seg1
+            let rel2_map =
+                cfg.get_relationship_mapping(rel_type2)
+                    .ok_or_else(|| GraphError::PlanError {
+                        message: format!("No relationship mapping for '{}'", rel_type2),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    })?;
+            let end2_map =
+                cfg.get_node_mapping(end2_label)
+                    .ok_or_else(|| GraphError::PlanError {
+                        message: format!("No node mapping for '{}'", end2_label),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    })?;
+
+            // Read rel2 and end2
+            let mut rel2_df = ctx
+                .table(rel_type2)
+                .await
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to read table '{}': {}", rel_type2, e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            rel2_df = rel2_df.alias(&rel2_alias)?;
+
+            // Determine the mid-equivalent column from rel1 to avoid ambiguous mid.id on the left
+            let mid_equiv_from_rel1 = match seg.relationship.direction {
+                RelationshipDirection::Outgoing | RelationshipDirection::Undirected => {
+                    rel_map.target_id_field.as_str()
+                }
+                RelationshipDirection::Incoming => rel_map.source_id_field.as_str(),
+            };
+
+            // Join mid -> rel2 using mid-equivalent column from rel1
+            let (left_key3, right_key3) = match seg2.relationship.direction {
+                RelationshipDirection::Outgoing | RelationshipDirection::Undirected => {
+                    (mid_equiv_from_rel1, rel2_map.source_id_field.as_str())
+                }
+                RelationshipDirection::Incoming => {
+                    (mid_equiv_from_rel1, rel2_map.target_id_field.as_str())
+                }
+            };
+            joined = joined
+                .join(rel2_df, JoinType::Inner, &[left_key3], &[right_key3], None)
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Join failed (mid->rel2): {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+
+            // Join rel2 -> end2
+            let mut end2_df = ctx
+                .table(end2_label)
+                .await
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to read table '{}': {}", end2_label, e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            end2_df = end2_df.alias(&end2_alias)?;
+            // If left side already contains a column with the same name as the right join key,
+            // rename the right key to avoid ambiguous unqualified field references.
+            let mut right_join_key = end2_map.id_field.clone();
+            {
+                let left_schema = joined.schema();
+                if left_schema
+                    .fields()
+                    .iter()
+                    .any(|f| f.name() == &right_join_key)
+                {
+                    use datafusion::logical_expr::{col, Expr};
+                    let new_key = format!("{}__rhs", right_join_key);
+                    let schema = end2_df.schema();
+                    let mut proj: Vec<Expr> = Vec::with_capacity(schema.fields().len());
+                    for f in schema.fields() {
+                        if f.name() == &right_join_key {
+                            proj.push(col(f.name()).alias(&new_key));
+                        } else {
+                            proj.push(col(f.name()));
+                        }
+                    }
+                    end2_df = end2_df.select(proj).map_err(|e| GraphError::PlanError {
+                        message: format!("Failed to prepare right join side: {}", e),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    })?;
+                    right_join_key = new_key;
+                }
+            }
+
+            let (left_key4, right_key4) = match seg2.relationship.direction {
+                RelationshipDirection::Outgoing | RelationshipDirection::Undirected => {
+                    (rel2_map.target_id_field.as_str(), right_join_key.as_str())
+                }
+                RelationshipDirection::Incoming => {
+                    (rel2_map.source_id_field.as_str(), right_join_key.as_str())
+                }
+            };
+            joined = joined
+                .join(end2_df, JoinType::Inner, &[left_key4], &[right_key4], None)
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Join failed (rel2->end2): {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+
+            // Update end_alias to refer to final node for projection/WHERE qualification below
+            let end_alias = end2_alias.as_str();
+
+            // WHERE (qualified across all known aliases)
+            if let Some(where_clause) = &self.ast.where_clause {
+                if let Some(expr) =
+                    to_df_boolean_expr_with_vars(&where_clause.expression, &|var, prop| {
+                        let alias = if Some(var)
+                            == path.start_node.variable.as_ref().map(String::as_str)
+                        {
+                            start_alias
+                        } else if Some(var)
+                            == seg.relationship.variable.as_ref().map(String::as_str)
+                        {
+                            rel_alias
+                        } else if Some(var) == seg.end_node.variable.as_ref().map(String::as_str) {
+                            mid_alias
+                        } else if Some(var)
+                            == seg2.relationship.variable.as_ref().map(String::as_str)
+                        {
+                            &rel2_alias
+                        } else if Some(var) == seg2.end_node.variable.as_ref().map(String::as_str) {
+                            end_alias
+                        } else {
+                            var
+                        };
+                        format!("{}.{}", alias, prop)
+                    })
+                {
+                    joined = joined.filter(expr).map_err(|e| GraphError::PlanError {
+                        message: format!("Failed to apply WHERE: {}", e),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    })?;
+                }
+            }
+
+            // Project RETURN across aliases
+            let mut proj: Vec<datafusion::logical_expr::Expr> = Vec::new();
+            for item in &self.ast.return_clause.items {
+                if let ValueExpression::Property(prop) = &item.expression {
+                    let col_name = if Some(prop.variable.as_str())
+                        == path.start_node.variable.as_ref().map(String::as_str)
+                    {
+                        format!("{}.{}", start_alias, prop.property)
+                    } else if Some(prop.variable.as_str())
+                        == seg.relationship.variable.as_ref().map(String::as_str)
+                    {
+                        format!("{}.{}", rel_alias, prop.property)
+                    } else if Some(prop.variable.as_str())
+                        == seg.end_node.variable.as_ref().map(String::as_str)
+                    {
+                        format!("{}.{}", mid_alias, prop.property)
+                    } else if Some(prop.variable.as_str())
+                        == seg2.relationship.variable.as_ref().map(String::as_str)
+                    {
+                        format!("{}.{}", rel2_alias, prop.property)
+                    } else if Some(prop.variable.as_str())
+                        == seg2.end_node.variable.as_ref().map(String::as_str)
+                    {
+                        format!("{}.{}", end_alias, prop.property)
+                    } else {
+                        format!("{}.{}", prop.variable, prop.property)
+                    };
+                    let mut e = datafusion::logical_expr::col(&col_name);
+                    if let Some(a) = &item.alias {
+                        e = e.alias(a);
+                    }
+                    proj.push(e);
+                }
+            }
+            if !proj.is_empty() {
+                joined = joined.select(proj).map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to project: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            }
+
+            // DISTINCT and LIMIT
+            if self.ast.return_clause.distinct {
+                joined = joined.distinct().map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to apply DISTINCT: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            }
+            if let Some(limit) = self.ast.limit {
+                joined =
+                    joined
+                        .limit(0, Some(limit as usize))
+                        .map_err(|e| GraphError::PlanError {
+                            message: format!("Failed to apply LIMIT: {}", e),
+                            location: snafu::Location::new(file!(), line!(), column!()),
+                        })?;
+            }
+
+            return Ok(Some(joined));
+        }
+
+        // WHERE (qualified)
+        if let Some(where_clause) = &self.ast.where_clause {
+            if let Some(expr) =
+                to_df_boolean_expr_with_vars(&where_clause.expression, &|var, prop| {
+                    let alias = if Some(var)
+                        == path.start_node.variable.as_ref().map(String::as_str)
+                    {
+                        start_alias
+                    } else if Some(var) == seg.relationship.variable.as_ref().map(String::as_str) {
+                        rel_alias
+                    } else if Some(var) == seg.end_node.variable.as_ref().map(String::as_str) {
+                        end_alias
+                    } else {
+                        var
+                    };
+                    format!("{}.{}", alias, prop)
+                })
+            {
+                joined = joined.filter(expr).map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to apply WHERE: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+            }
+        }
+
+        // Project RETURN
+        let mut proj: Vec<datafusion::logical_expr::Expr> = Vec::new();
+        for item in &self.ast.return_clause.items {
+            if let ValueExpression::Property(prop) = &item.expression {
+                let col_name = if Some(prop.variable.as_str())
+                    == path.start_node.variable.as_ref().map(String::as_str)
+                {
+                    format!("{}.{}", start_alias, prop.property)
+                } else if Some(prop.variable.as_str())
+                    == seg.relationship.variable.as_ref().map(String::as_str)
+                {
+                    format!("{}.{}", rel_alias, prop.property)
+                } else if Some(prop.variable.as_str())
+                    == seg.end_node.variable.as_ref().map(String::as_str)
+                {
+                    format!("{}.{}", end_alias, prop.property)
+                } else {
+                    format!("{}.{}", prop.variable, prop.property)
+                };
+                let mut e = datafusion::logical_expr::col(&col_name);
+                if let Some(a) = &item.alias {
+                    e = e.alias(a);
+                }
+                proj.push(e);
+            }
+        }
+        if !proj.is_empty() {
+            joined = joined.select(proj).map_err(|e| GraphError::PlanError {
+                message: format!("Failed to project: {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        }
+
+        // DISTINCT and LIMIT
+        if self.ast.return_clause.distinct {
+            joined = joined.distinct().map_err(|e| GraphError::PlanError {
+                message: format!("Failed to apply DISTINCT: {}", e),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            })?;
+        }
+        if let Some(limit) = self.ast.limit {
+            joined = joined
+                .limit(0, Some(limit as usize))
+                .map_err(|e| GraphError::PlanError {
+                    message: format!("Failed to apply LIMIT: {}", e),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                })?;
+        }
+
+        Ok(Some(joined))
+    }
+}
+
+fn to_df_boolean_expr_with_vars<F>(
+    expr: &crate::ast::BooleanExpression,
+    qualify: &F,
+) -> Option<datafusion::logical_expr::Expr>
+where
+    F: Fn(&str, &str) -> String,
+{
+    use crate::ast::{BooleanExpression as BE, ComparisonOperator as CO, ValueExpression as VE};
+    use datafusion::logical_expr::{col, Expr, Operator};
+    match expr {
+        BE::Comparison {
+            left,
+            operator,
+            right,
+        } => {
+            let (var, prop, lit_expr) = match (left, right) {
+                (VE::Property(p), VE::Literal(val)) => {
+                    (p.variable.as_str(), p.property.as_str(), to_df_literal(val))
+                }
+                (VE::Literal(val), VE::Property(p)) => {
+                    (p.variable.as_str(), p.property.as_str(), to_df_literal(val))
+                }
+                _ => return None,
+            };
+            let qualified = qualify(var, prop);
+            let op = match operator {
+                CO::Equal => Operator::Eq,
+                CO::NotEqual => Operator::NotEq,
+                CO::LessThan => Operator::Lt,
+                CO::LessThanOrEqual => Operator::LtEq,
+                CO::GreaterThan => Operator::Gt,
+                CO::GreaterThanOrEqual => Operator::GtEq,
+            };
+            Some(Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr {
+                left: Box::new(col(&qualified)),
+                op,
+                right: Box::new(lit_expr),
+            }))
+        }
+        BE::And(l, r) => Some(datafusion::logical_expr::Expr::BinaryExpr(
+            datafusion::logical_expr::BinaryExpr {
+                left: Box::new(to_df_boolean_expr_with_vars(l, qualify)?),
+                op: Operator::And,
+                right: Box::new(to_df_boolean_expr_with_vars(r, qualify)?),
+            },
+        )),
+        BE::Or(l, r) => Some(datafusion::logical_expr::Expr::BinaryExpr(
+            datafusion::logical_expr::BinaryExpr {
+                left: Box::new(to_df_boolean_expr_with_vars(l, qualify)?),
+                op: Operator::Or,
+                right: Box::new(to_df_boolean_expr_with_vars(r, qualify)?),
+            },
+        )),
+        BE::Not(inner) => Some(datafusion::logical_expr::Expr::Not(Box::new(
+            to_df_boolean_expr_with_vars(inner, qualify)?,
+        ))),
+        _ => None,
+    }
+}
+
+/// Builder for constructing Cypher queries programmatically
+#[derive(Debug, Default)]
+pub struct CypherQueryBuilder {
+    match_clauses: Vec<crate::ast::MatchClause>,
+    where_expression: Option<crate::ast::BooleanExpression>,
+    return_items: Vec<crate::ast::ReturnItem>,
+    order_by_items: Vec<crate::ast::OrderByItem>,
+    limit: Option<u64>,
+    distinct: bool,
+    config: Option<GraphConfig>,
+    parameters: HashMap<String, serde_json::Value>,
+}
+
+impl CypherQueryBuilder {
+    /// Create a new query builder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a MATCH clause for a node pattern
+    pub fn match_node(mut self, variable: &str, label: &str) -> Self {
+        let node = crate::ast::NodePattern {
+            variable: Some(variable.to_string()),
+            labels: vec![label.to_string()],
+            properties: HashMap::new(),
+        };
+
+        let match_clause = crate::ast::MatchClause {
+            patterns: vec![crate::ast::GraphPattern::Node(node)],
+        };
+
+        self.match_clauses.push(match_clause);
+        self
+    }
+
+    /// Set the graph configuration
+    pub fn with_config(mut self, config: GraphConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    /// Add a RETURN item
+    pub fn return_property(mut self, variable: &str, property: &str) -> Self {
+        let prop_ref = crate::ast::PropertyRef::new(variable, property);
+        let return_item = crate::ast::ReturnItem {
+            expression: crate::ast::ValueExpression::Property(prop_ref),
+            alias: None,
+        };
+
+        self.return_items.push(return_item);
+        self
+    }
+
+    /// Set DISTINCT flag
+    pub fn distinct(mut self, distinct: bool) -> Self {
+        self.distinct = distinct;
+        self
+    }
+
+    /// Add a LIMIT clause
+    pub fn limit(mut self, limit: u64) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Build the final CypherQuery
+    pub fn build(self) -> Result<CypherQuery> {
+        if self.match_clauses.is_empty() {
+            return Err(GraphError::PlanError {
+                message: "Query must have at least one MATCH clause".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+
+        if self.return_items.is_empty() {
+            return Err(GraphError::PlanError {
+                message: "Query must have at least one RETURN item".to_string(),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+
+        let ast = crate::ast::CypherQuery {
+            match_clauses: self.match_clauses,
+            where_clause: self
+                .where_expression
+                .map(|expr| crate::ast::WhereClause { expression: expr }),
+            return_clause: crate::ast::ReturnClause {
+                distinct: self.distinct,
+                items: self.return_items,
+            },
+            order_by: if self.order_by_items.is_empty() {
+                None
+            } else {
+                Some(crate::ast::OrderByClause {
+                    items: self.order_by_items,
+                })
+            },
+            limit: self.limit,
+        };
+
+        // Generate query text from AST (simplified)
+        let query_text = format!("MATCH ... RETURN ..."); // TODO: Implement AST->text conversion
+
+        let query = CypherQuery {
+            query_text,
+            ast,
+            config: self.config,
+            parameters: self.parameters,
+        };
+
+        query.validate()?;
+        Ok(query)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::GraphConfig;
+
+    #[test]
+    fn test_parse_simple_cypher_query() {
+        let query = CypherQuery::new("MATCH (n:Person) RETURN n.name").unwrap();
+        assert_eq!(query.query_text(), "MATCH (n:Person) RETURN n.name");
+        assert_eq!(query.referenced_node_labels(), vec!["Person"]);
+        assert_eq!(query.variables(), vec!["n"]);
+    }
+
+    #[test]
+    fn test_query_with_parameters() {
+        let mut params = HashMap::new();
+        params.insert("minAge".to_string(), serde_json::Value::Number(30.into()));
+
+        let query = CypherQuery::new("MATCH (n:Person) WHERE n.age > $minAge RETURN n.name")
+            .unwrap()
+            .with_parameters(params);
+
+        assert!(query.parameters().contains_key("minAge"));
+    }
+
+    #[test]
+    fn test_query_builder() {
+        let config = GraphConfig::builder()
+            .with_node_label("Person", "person_id")
+            .build()
+            .unwrap();
+
+        let query = CypherQueryBuilder::new()
+            .with_config(config)
+            .match_node("n", "Person")
+            .return_property("n", "name")
+            .limit(10)
+            .build()
+            .unwrap();
+
+        assert_eq!(query.referenced_node_labels(), vec!["Person"]);
+        assert_eq!(query.variables(), vec!["n"]);
+    }
+
+    #[test]
+    fn test_relationship_query_parsing() {
+        let query =
+            CypherQuery::new("MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN a.name, b.name")
+                .unwrap();
+        assert_eq!(query.referenced_node_labels(), vec!["Person"]);
+        assert_eq!(query.referenced_relationship_types(), vec!["KNOWS"]);
+        assert_eq!(query.variables(), vec!["a", "b", "r"]);
+    }
+
+    #[tokio::test]
+    async fn test_execute_basic_projection_and_filter() {
+        use arrow_array::{Int64Array, RecordBatch, StringArray};
+        use arrow_schema::{DataType, Field, Schema};
+        use std::sync::Arc;
+
+        // Build a simple batch: name (Utf8), age (Int64)
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("age", DataType::Int64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["Alice", "Bob", "Carol", "David"])),
+                Arc::new(Int64Array::from(vec![28, 34, 29, 42])),
+            ],
+        )
+        .unwrap();
+
+        let cfg = GraphConfig::builder()
+            .with_node_label("Person", "id")
+            .build()
+            .unwrap();
+
+        let q = CypherQuery::new("MATCH (p:Person) WHERE p.age > 30 RETURN p.name, p.age")
+            .unwrap()
+            .with_config(cfg);
+
+        let mut data = HashMap::new();
+        data.insert("people".to_string(), batch);
+
+        let out = q.execute(data).await.unwrap();
+        assert_eq!(out.num_rows(), 2);
+        let names = out
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let ages = out.column(1).as_any().downcast_ref::<Int64Array>().unwrap();
+        // Expect Bob (34) and David (42)
+        let result: Vec<(String, i64)> = (0..out.num_rows())
+            .map(|i| (names.value(i).to_string(), ages.value(i)))
+            .collect();
+        assert!(result.contains(&("Bob".to_string(), 34)));
+        assert!(result.contains(&("David".to_string(), 42)));
+    }
+
+    #[tokio::test]
+    async fn test_execute_single_hop_path_join_projection() {
+        use arrow_array::{Int64Array, RecordBatch, StringArray};
+        use arrow_schema::{DataType, Field, Schema};
+        use std::sync::Arc;
+
+        // People table: id, name, age
+        let person_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("age", DataType::Int64, true),
+        ]));
+        let people = RecordBatch::try_new(
+            person_schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["Alice", "Bob", "Carol"])),
+                Arc::new(Int64Array::from(vec![28, 34, 29])),
+            ],
+        )
+        .unwrap();
+
+        // KNOWS relationship: src_person_id -> dst_person_id
+        let rel_schema = Arc::new(Schema::new(vec![
+            Field::new("src_person_id", DataType::Int64, false),
+            Field::new("dst_person_id", DataType::Int64, false),
+        ]));
+        let knows = RecordBatch::try_new(
+            rel_schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2])), // Alice -> Bob, Bob -> Carol
+                Arc::new(Int64Array::from(vec![2, 3])),
+            ],
+        )
+        .unwrap();
+
+        // Config: Person(id) and KNOWS(src_person_id -> dst_person_id)
+        let cfg = GraphConfig::builder()
+            .with_node_label("Person", "id")
+            .with_relationship("KNOWS", "src_person_id", "dst_person_id")
+            .build()
+            .unwrap();
+
+        // Query: MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.name
+        let q = CypherQuery::new("MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN b.name")
+            .unwrap()
+            .with_config(cfg);
+
+        let mut data = HashMap::new();
+        // Register tables using labels / rel types as names
+        data.insert("Person".to_string(), people);
+        data.insert("KNOWS".to_string(), knows);
+
+        let out = q.execute(data).await.unwrap();
+        // Expect two rows: Bob, Carol (the targets)
+        let names = out
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let got: Vec<String> = (0..out.num_rows())
+            .map(|i| names.value(i).to_string())
+            .collect();
+        assert_eq!(got.len(), 2);
+        assert!(got.contains(&"Bob".to_string()));
+        assert!(got.contains(&"Carol".to_string()));
+    }
+}
+
+/// Minimal translator for simple boolean expressions into DataFusion Expr
+fn to_df_boolean_expr_simple(
+    expr: &crate::ast::BooleanExpression,
+) -> Option<datafusion::logical_expr::Expr> {
+    use crate::ast::{BooleanExpression as BE, ComparisonOperator as CO, ValueExpression as VE};
+    use datafusion::logical_expr::{col, Expr, Operator};
+    match expr {
+        BE::Comparison {
+            left,
+            operator,
+            right,
+        } => {
+            // Only support property <op> literal
+            let (col_name, lit_expr) = match (left, right) {
+                (VE::Property(prop), VE::Literal(val)) => {
+                    (prop.property.clone(), to_df_literal(val))
+                }
+                (VE::Literal(val), VE::Property(prop)) => {
+                    (prop.property.clone(), to_df_literal(val))
+                }
+                _ => return None,
+            };
+            let op = match operator {
+                CO::Equal => Operator::Eq,
+                CO::NotEqual => Operator::NotEq,
+                CO::LessThan => Operator::Lt,
+                CO::LessThanOrEqual => Operator::LtEq,
+                CO::GreaterThan => Operator::Gt,
+                CO::GreaterThanOrEqual => Operator::GtEq,
+            };
+            Some(Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr {
+                left: Box::new(col(col_name)),
+                op,
+                right: Box::new(lit_expr),
+            }))
+        }
+        BE::And(l, r) => Some(datafusion::logical_expr::Expr::BinaryExpr(
+            datafusion::logical_expr::BinaryExpr {
+                left: Box::new(to_df_boolean_expr_simple(l)?),
+                op: Operator::And,
+                right: Box::new(to_df_boolean_expr_simple(r)?),
+            },
+        )),
+        BE::Or(l, r) => Some(datafusion::logical_expr::Expr::BinaryExpr(
+            datafusion::logical_expr::BinaryExpr {
+                left: Box::new(to_df_boolean_expr_simple(l)?),
+                op: Operator::Or,
+                right: Box::new(to_df_boolean_expr_simple(r)?),
+            },
+        )),
+        BE::Not(inner) => Some(datafusion::logical_expr::Expr::Not(Box::new(
+            to_df_boolean_expr_simple(inner)?,
+        ))),
+        BE::Exists(prop) => Some(datafusion::logical_expr::Expr::IsNotNull(Box::new(
+            datafusion::logical_expr::Expr::Column(datafusion::common::Column::from_name(
+                prop.property.clone(),
+            )),
+        ))),
+        _ => None,
+    }
+}
+
+fn to_df_value_expr_simple(expr: &crate::ast::ValueExpression) -> datafusion::logical_expr::Expr {
+    use crate::ast::ValueExpression as VE;
+    use datafusion::logical_expr::{col, lit};
+    match expr {
+        VE::Property(prop) => col(&prop.property),
+        VE::Variable(v) => col(v),
+        VE::Literal(v) => to_df_literal(v),
+        VE::Function { .. } | VE::Arithmetic { .. } => lit(0),
+    }
+}
+
+fn to_df_literal(val: &crate::ast::PropertyValue) -> datafusion::logical_expr::Expr {
+    use datafusion::logical_expr::lit;
+    match val {
+        crate::ast::PropertyValue::String(s) => lit(s.clone()),
+        crate::ast::PropertyValue::Integer(i) => lit(*i as i64),
+        crate::ast::PropertyValue::Float(f) => lit(*f),
+        crate::ast::PropertyValue::Boolean(b) => lit(*b),
+        crate::ast::PropertyValue::Null => {
+            datafusion::logical_expr::Expr::Literal(datafusion::scalar::ScalarValue::Null, None)
+        }
+        crate::ast::PropertyValue::Parameter(_) => lit(0),
+        crate::ast::PropertyValue::Property(prop) => datafusion::logical_expr::col(&prop.property),
+    }
+}

--- a/rust/lance-graph/src/query_processor.rs
+++ b/rust/lance-graph/src/query_processor.rs
@@ -80,13 +80,13 @@ impl QueryProcessor {
         let plan = self.process_query(query_text)?;
 
         let mut explanation = String::new();
-        explanation.push_str(&format!("=== Query Processing Pipeline ===\n\n"));
+        explanation.push_str("=== Query Processing Pipeline ===\n\n");
         explanation.push_str(&format!("Original Query:\n{}\n\n", plan.query_text));
 
-        explanation.push_str(&format!("=== Phase 1: Parsing ===\n"));
+        explanation.push_str("=== Phase 1: Parsing ===\n");
         explanation.push_str(&format!("AST: {:#?}\n\n", plan.ast));
 
-        explanation.push_str(&format!("=== Phase 2: Semantic Analysis ===\n"));
+        explanation.push_str("=== Phase 2: Semantic Analysis ===\n");
         explanation.push_str(&format!(
             "Variables: {:#?}\n",
             plan.semantic_result.variables
@@ -94,12 +94,12 @@ impl QueryProcessor {
         if !plan.semantic_result.warnings.is_empty() {
             explanation.push_str(&format!("Warnings: {:?}\n", plan.semantic_result.warnings));
         }
-        explanation.push_str("\n");
+        explanation.push('\n');
 
-        explanation.push_str(&format!("=== Phase 3: Logical Planning ===\n"));
+        explanation.push_str("=== Phase 3: Logical Planning ===\n");
         explanation.push_str(&format!("Logical Plan: {:#?}\n\n", plan.logical_plan));
 
-        explanation.push_str(&format!("=== Phase 4: DataFusion Planning ===\n"));
+        explanation.push_str("=== Phase 4: DataFusion Planning ===\n");
         explanation.push_str(&format!("DataFusion Plan: {:#?}\n\n", plan.datafusion_plan));
 
         // No legacy SQL generation layer; DataFusion plan is the physical output.
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_new_pipeline_vs_old() {
         let config = create_test_config();
-        let processor = QueryProcessor::new(config.clone());
+        let processor = QueryProcessor::new(config);
 
         // Test the new pipeline
         let query = "MATCH (n:Person) WHERE n.age > 30 RETURN n.name";

--- a/rust/lance-graph/src/query_processor.rs
+++ b/rust/lance-graph/src/query_processor.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Unified query processor implementing the full pipeline
+//!
+//! This module implements the complete query processing pipeline:
+//! Parse → Semantic Analysis → Logical Plan → Physical Plan → Execution
+
+use crate::ast::CypherQuery;
+use crate::config::GraphConfig;
+// use crate::datafusion_planner::DataFusionPlanner;
+use crate::datafusion_planner::{DataFusionPlanner, GraphPhysicalPlanner};
+use crate::error::{GraphError, Result};
+use crate::logical_plan::{LogicalOperator, LogicalPlanner};
+use crate::parser::parse_cypher_query;
+use crate::semantic::{SemanticAnalyzer, SemanticResult};
+use datafusion::logical_expr::LogicalPlan;
+
+/// Complete query processing pipeline
+pub struct QueryProcessor {
+    config: GraphConfig,
+}
+
+/// Query execution plan with all intermediate representations
+#[derive(Debug, Clone)]
+pub struct QueryPlan {
+    /// Original query string
+    pub query_text: String,
+    /// Parsed AST
+    pub ast: CypherQuery,
+    /// Semantic analysis result
+    pub semantic_result: SemanticResult,
+    /// Logical plan
+    pub logical_plan: LogicalOperator,
+    /// DataFusion physical plan
+    pub datafusion_plan: LogicalPlan,
+}
+
+impl QueryProcessor {
+    pub fn new(config: GraphConfig) -> Self {
+        Self { config }
+    }
+
+    /// Process a Cypher query through the complete pipeline
+    pub fn process_query(&self, query_text: &str) -> Result<QueryPlan> {
+        // Phase 1: Parse - Convert text to AST
+        let ast = parse_cypher_query(query_text)?;
+
+        // Phase 2: Semantic Analysis - Validate and enrich AST
+        let mut semantic_analyzer = SemanticAnalyzer::new(self.config.clone());
+        let semantic_result = semantic_analyzer.analyze(&ast)?;
+
+        // Check for semantic errors
+        if !semantic_result.errors.is_empty() {
+            return Err(GraphError::PlanError {
+                message: format!("Semantic errors: {}", semantic_result.errors.join(", ")),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+
+        // Phase 3: Logical Planning - Convert AST to logical operators
+        let mut logical_planner = LogicalPlanner::new();
+        let logical_plan = logical_planner.plan(&ast)?;
+
+        // Phase 4: Physical Planning - Convert logical plan to DataFusion plan
+        let df_planner = DataFusionPlanner::new(self.config.clone());
+        let datafusion_plan = df_planner.plan(&logical_plan)?;
+
+        Ok(QueryPlan {
+            query_text: query_text.to_string(),
+            ast,
+            semantic_result,
+            logical_plan,
+            datafusion_plan,
+        })
+    }
+
+    /// Process and explain a query (for debugging)
+    pub fn explain_query(&self, query_text: &str) -> Result<String> {
+        let plan = self.process_query(query_text)?;
+
+        let mut explanation = String::new();
+        explanation.push_str(&format!("=== Query Processing Pipeline ===\n\n"));
+        explanation.push_str(&format!("Original Query:\n{}\n\n", plan.query_text));
+
+        explanation.push_str(&format!("=== Phase 1: Parsing ===\n"));
+        explanation.push_str(&format!("AST: {:#?}\n\n", plan.ast));
+
+        explanation.push_str(&format!("=== Phase 2: Semantic Analysis ===\n"));
+        explanation.push_str(&format!(
+            "Variables: {:#?}\n",
+            plan.semantic_result.variables
+        ));
+        if !plan.semantic_result.warnings.is_empty() {
+            explanation.push_str(&format!("Warnings: {:?}\n", plan.semantic_result.warnings));
+        }
+        explanation.push_str("\n");
+
+        explanation.push_str(&format!("=== Phase 3: Logical Planning ===\n"));
+        explanation.push_str(&format!("Logical Plan: {:#?}\n\n", plan.logical_plan));
+
+        explanation.push_str(&format!("=== Phase 4: DataFusion Planning ===\n"));
+        explanation.push_str(&format!("DataFusion Plan: {:#?}\n\n", plan.datafusion_plan));
+
+        // No legacy SQL generation layer; DataFusion plan is the physical output.
+
+        Ok(explanation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_config() -> GraphConfig {
+        GraphConfig::builder()
+            .with_node_label("Person", "person_id")
+            .with_relationship("KNOWS", "src_person_id", "dst_person_id")
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_simple_query_pipeline() {
+        let config = create_test_config();
+        let processor = QueryProcessor::new(config);
+
+        let query = "MATCH (n:Person) RETURN n.name";
+        let plan = processor.process_query(query).unwrap();
+
+        // Verify we have all phases
+        // DataFusion plan is present (placeholder or concrete)
+        let _ = plan.datafusion_plan;
+        assert_eq!(plan.query_text, query);
+        assert!(!plan.semantic_result.variables.is_empty());
+    }
+
+    #[test]
+    fn test_query_explanation() {
+        let config = create_test_config();
+        let processor = QueryProcessor::new(config);
+
+        let query = "MATCH (n:Person) WHERE n.age > 30 RETURN n.name";
+        let explanation = processor.explain_query(query).unwrap();
+
+        assert!(explanation.contains("Query Processing Pipeline"));
+        assert!(explanation.contains("Phase 1: Parsing"));
+        assert!(explanation.contains("Phase 2: Semantic Analysis"));
+        assert!(explanation.contains("Phase 3: Logical Planning"));
+        assert!(explanation.contains("Phase 4: DataFusion Planning"));
+    }
+
+    #[test]
+    fn test_semantic_error_detection() {
+        let config = create_test_config();
+        let processor = QueryProcessor::new(config);
+
+        // Query with undefined variable
+        let query = "MATCH (n:Person) RETURN m.name"; // 'm' is not defined
+        let result = processor.process_query(query);
+
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("Undefined variable"));
+    }
+
+    #[test]
+    fn test_new_pipeline_vs_old() {
+        let config = create_test_config();
+        let processor = QueryProcessor::new(config.clone());
+
+        // Test the new pipeline
+        let query = "MATCH (n:Person) WHERE n.age > 30 RETURN n.name";
+        let new_plan = processor.process_query(query).unwrap();
+
+        // The new pipeline should produce a DataFusion plan
+        let _ = new_plan.datafusion_plan;
+
+        // Verify we have logical plan structure
+        match &new_plan.logical_plan {
+            LogicalOperator::Limit { input, .. }
+            | LogicalOperator::Sort { input, .. }
+            | LogicalOperator::Project { input, .. } => {
+                // We should have nested structure
+                assert!(matches!(**input, LogicalOperator::Filter { .. }));
+            }
+            _ => panic!("Expected nested logical plan structure"),
+        }
+
+        // Verify semantic analysis found variables
+        assert!(new_plan.semantic_result.variables.contains_key("n"));
+    }
+}

--- a/rust/lance-graph/src/semantic.rs
+++ b/rust/lance-graph/src/semantic.rs
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Semantic analysis for graph queries
+//!
+//! This module implements the semantic analysis phase of the query pipeline:
+//! Parse → **Semantic Analysis** → Logical Plan → Physical Plan
+//!
+//! Semantic analysis validates the query and enriches the AST with type information.
+
+use crate::ast::*;
+use crate::config::GraphConfig;
+use crate::error::{GraphError, Result};
+use std::collections::{HashMap, HashSet};
+
+/// Semantic analyzer - validates and enriches the AST
+pub struct SemanticAnalyzer {
+    config: GraphConfig,
+    variables: HashMap<String, VariableInfo>,
+    current_scope: ScopeType,
+}
+
+/// Information about a variable in the query
+#[derive(Debug, Clone)]
+pub struct VariableInfo {
+    pub name: String,
+    pub variable_type: VariableType,
+    pub labels: Vec<String>,
+    pub properties: HashSet<String>,
+    pub defined_in: ScopeType,
+}
+
+/// Type of a variable
+#[derive(Debug, Clone, PartialEq)]
+pub enum VariableType {
+    Node,
+    Relationship,
+    Path,
+    Property,
+}
+
+/// Scope where a variable is defined
+#[derive(Debug, Clone, PartialEq)]
+pub enum ScopeType {
+    Match,
+    Where,
+    Return,
+    OrderBy,
+}
+
+/// Semantic analysis result with validated and enriched AST
+#[derive(Debug, Clone)]
+pub struct SemanticResult {
+    pub query: CypherQuery,
+    pub variables: HashMap<String, VariableInfo>,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl SemanticAnalyzer {
+    pub fn new(config: GraphConfig) -> Self {
+        Self {
+            config,
+            variables: HashMap::new(),
+            current_scope: ScopeType::Match,
+        }
+    }
+
+    /// Analyze a Cypher query AST
+    pub fn analyze(&mut self, query: &CypherQuery) -> Result<SemanticResult> {
+        let mut errors = Vec::new();
+        let mut warnings = Vec::new();
+
+        // Phase 1: Variable discovery in MATCH clauses
+        self.current_scope = ScopeType::Match;
+        for match_clause in &query.match_clauses {
+            if let Err(e) = self.analyze_match_clause(match_clause) {
+                errors.push(format!("MATCH clause error: {}", e));
+            }
+        }
+
+        // Phase 2: Validate WHERE clause
+        if let Some(where_clause) = &query.where_clause {
+            self.current_scope = ScopeType::Where;
+            if let Err(e) = self.analyze_where_clause(where_clause) {
+                errors.push(format!("WHERE clause error: {}", e));
+            }
+        }
+
+        // Phase 3: Validate RETURN clause
+        self.current_scope = ScopeType::Return;
+        if let Err(e) = self.analyze_return_clause(&query.return_clause) {
+            errors.push(format!("RETURN clause error: {}", e));
+        }
+
+        // Phase 4: Validate ORDER BY clause
+        if let Some(order_by) = &query.order_by {
+            self.current_scope = ScopeType::OrderBy;
+            if let Err(e) = self.analyze_order_by_clause(order_by) {
+                errors.push(format!("ORDER BY clause error: {}", e));
+            }
+        }
+
+        // Phase 5: Schema validation
+        self.validate_schema(&mut warnings);
+
+        // Phase 6: Type checking
+        self.validate_types(&mut errors);
+
+        Ok(SemanticResult {
+            query: query.clone(),
+            variables: self.variables.clone(),
+            errors,
+            warnings,
+        })
+    }
+
+    /// Analyze MATCH clause and discover variables
+    fn analyze_match_clause(&mut self, match_clause: &MatchClause) -> Result<()> {
+        for pattern in &match_clause.patterns {
+            self.analyze_graph_pattern(pattern)?;
+        }
+        Ok(())
+    }
+
+    /// Analyze a graph pattern and register variables
+    fn analyze_graph_pattern(&mut self, pattern: &GraphPattern) -> Result<()> {
+        match pattern {
+            GraphPattern::Node(node) => {
+                self.register_node_variable(node)?;
+            }
+            GraphPattern::Path(path) => {
+                // Register start node
+                self.register_node_variable(&path.start_node)?;
+
+                // Register variables in each segment
+                for segment in &path.segments {
+                    // Register relationship variable if present
+                    if let Some(rel_var) = &segment.relationship.variable {
+                        self.register_relationship_variable(rel_var, &segment.relationship)?;
+                    }
+
+                    // Register end node
+                    self.register_node_variable(&segment.end_node)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Register a node variable
+    fn register_node_variable(&mut self, node: &NodePattern) -> Result<()> {
+        if let Some(var_name) = &node.variable {
+            let var_info = VariableInfo {
+                name: var_name.clone(),
+                variable_type: VariableType::Node,
+                labels: node.labels.clone(),
+                properties: node.properties.keys().cloned().collect(),
+                defined_in: self.current_scope.clone(),
+            };
+
+            if self.variables.contains_key(var_name) {
+                // Variable redefinition - check if it's consistent
+                let existing = &self.variables[var_name];
+                if existing.variable_type != VariableType::Node {
+                    return Err(GraphError::PlanError {
+                        message: format!("Variable '{}' redefined with different type", var_name),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    });
+                }
+            }
+
+            self.variables.insert(var_name.clone(), var_info);
+        }
+        Ok(())
+    }
+
+    /// Register a relationship variable
+    fn register_relationship_variable(
+        &mut self,
+        var_name: &str,
+        rel: &RelationshipPattern,
+    ) -> Result<()> {
+        let var_info = VariableInfo {
+            name: var_name.to_string(),
+            variable_type: VariableType::Relationship,
+            labels: rel.types.clone(), // Relationship types are like labels
+            properties: rel.properties.keys().cloned().collect(),
+            defined_in: self.current_scope.clone(),
+        };
+
+        if self.variables.contains_key(var_name) {
+            let existing = &self.variables[var_name];
+            if existing.variable_type != VariableType::Relationship {
+                return Err(GraphError::PlanError {
+                    message: format!("Variable '{}' redefined with different type", var_name),
+                    location: snafu::Location::new(file!(), line!(), column!()),
+                });
+            }
+        }
+
+        self.variables.insert(var_name.to_string(), var_info);
+        Ok(())
+    }
+
+    /// Analyze WHERE clause
+    fn analyze_where_clause(&mut self, where_clause: &WhereClause) -> Result<()> {
+        self.analyze_boolean_expression(&where_clause.expression)
+    }
+
+    /// Analyze boolean expression and check variable references
+    fn analyze_boolean_expression(&mut self, expr: &BooleanExpression) -> Result<()> {
+        match expr {
+            BooleanExpression::Comparison { left, right, .. } => {
+                self.analyze_value_expression(left)?;
+                self.analyze_value_expression(right)?;
+            }
+            BooleanExpression::And(left, right) | BooleanExpression::Or(left, right) => {
+                self.analyze_boolean_expression(left)?;
+                self.analyze_boolean_expression(right)?;
+            }
+            BooleanExpression::Not(inner) => {
+                self.analyze_boolean_expression(inner)?;
+            }
+            BooleanExpression::Exists(prop_ref) => {
+                self.validate_property_reference(prop_ref)?;
+            }
+            BooleanExpression::In { expression, list } => {
+                self.analyze_value_expression(expression)?;
+                for item in list {
+                    self.analyze_value_expression(item)?;
+                }
+            }
+            BooleanExpression::Like { expression, .. } => {
+                self.analyze_value_expression(expression)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Analyze value expression and check variable references
+    fn analyze_value_expression(&mut self, expr: &ValueExpression) -> Result<()> {
+        match expr {
+            ValueExpression::Property(prop_ref) => {
+                self.validate_property_reference(prop_ref)?;
+            }
+            ValueExpression::Literal(_) => {
+                // Literals are always valid
+            }
+            ValueExpression::Variable(var) => {
+                if !self.variables.contains_key(var) {
+                    return Err(GraphError::PlanError {
+                        message: format!("Undefined variable: '{}'", var),
+                        location: snafu::Location::new(file!(), line!(), column!()),
+                    });
+                }
+            }
+            ValueExpression::Function { .. } => {
+                // TODO: Implement function validation
+            }
+            ValueExpression::Arithmetic { .. } => {
+                // TODO: Implement arithmetic validation
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate property reference
+    fn validate_property_reference(&self, prop_ref: &PropertyRef) -> Result<()> {
+        if !self.variables.contains_key(&prop_ref.variable) {
+            return Err(GraphError::PlanError {
+                message: format!("Undefined variable: '{}'", prop_ref.variable),
+                location: snafu::Location::new(file!(), line!(), column!()),
+            });
+        }
+        Ok(())
+    }
+
+    /// Analyze RETURN clause
+    fn analyze_return_clause(&mut self, return_clause: &ReturnClause) -> Result<()> {
+        for item in &return_clause.items {
+            self.analyze_value_expression(&item.expression)?;
+        }
+        Ok(())
+    }
+
+    /// Analyze ORDER BY clause
+    fn analyze_order_by_clause(&mut self, order_by: &OrderByClause) -> Result<()> {
+        for item in &order_by.items {
+            self.analyze_value_expression(&item.expression)?;
+        }
+        Ok(())
+    }
+
+    /// Validate schema references against configuration
+    fn validate_schema(&self, warnings: &mut Vec<String>) {
+        for var_info in self.variables.values() {
+            match var_info.variable_type {
+                VariableType::Node => {
+                    for label in &var_info.labels {
+                        if self.config.get_node_mapping(label).is_none() {
+                            warnings.push(format!("Node label '{}' not found in schema", label));
+                        }
+                    }
+                }
+                VariableType::Relationship => {
+                    for rel_type in &var_info.labels {
+                        if self.config.get_relationship_mapping(rel_type).is_none() {
+                            warnings.push(format!(
+                                "Relationship type '{}' not found in schema",
+                                rel_type
+                            ));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Validate types and operations
+    fn validate_types(&self, errors: &mut Vec<String>) {
+        // TODO: Implement type checking
+        // - Check that properties exist on nodes/relationships
+        // - Check that comparison operations are valid for data types
+        // - Check that arithmetic operations are valid
+
+        // For now, just check that variables are properly scoped
+        for var_info in self.variables.values() {
+            if var_info.defined_in == ScopeType::Return
+                && !self
+                    .variables
+                    .values()
+                    .any(|v| v.name == var_info.name && v.defined_in == ScopeType::Match)
+            {
+                errors.push(format!(
+                    "Variable '{}' used in RETURN but not defined in MATCH",
+                    var_info.name
+                ));
+            }
+        }
+    }
+}

--- a/rust/lance-graph/src/source_catalog.rs
+++ b/rust/lance-graph/src/source_catalog.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Context-free source catalog for DataFusion logical planning.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_schema::{Schema, SchemaRef};
+use datafusion::logical_expr::TableSource;
+
+/// A minimal catalog to resolve node labels and relationship types to logical table sources.
+pub trait GraphSourceCatalog: Send + Sync {
+    fn node_source(&self, label: &str) -> Option<Arc<dyn TableSource>>;
+    fn relationship_source(&self, rel_type: &str) -> Option<Arc<dyn TableSource>>;
+}
+
+/// A simple in-memory catalog useful for tests and bootstrap wiring.
+pub struct InMemoryCatalog {
+    node_sources: HashMap<String, Arc<dyn TableSource>>,
+    rel_sources: HashMap<String, Arc<dyn TableSource>>,
+}
+
+impl InMemoryCatalog {
+    pub fn new() -> Self {
+        Self {
+            node_sources: HashMap::new(),
+            rel_sources: HashMap::new(),
+        }
+    }
+
+    pub fn with_node_source(
+        mut self,
+        label: impl Into<String>,
+        source: Arc<dyn TableSource>,
+    ) -> Self {
+        self.node_sources.insert(label.into(), source);
+        self
+    }
+
+    pub fn with_relationship_source(
+        mut self,
+        rel_type: impl Into<String>,
+        source: Arc<dyn TableSource>,
+    ) -> Self {
+        self.rel_sources.insert(rel_type.into(), source);
+        self
+    }
+}
+
+impl Default for InMemoryCatalog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GraphSourceCatalog for InMemoryCatalog {
+    fn node_source(&self, label: &str) -> Option<Arc<dyn TableSource>> {
+        self.node_sources.get(label).cloned()
+    }
+
+    fn relationship_source(&self, rel_type: &str) -> Option<Arc<dyn TableSource>> {
+        self.rel_sources.get(rel_type).cloned()
+    }
+}
+
+/// A trivial logical table source with a fixed schema.
+pub struct SimpleTableSource {
+    schema: SchemaRef,
+}
+
+impl SimpleTableSource {
+    pub fn new(schema: SchemaRef) -> Self {
+        Self { schema }
+    }
+    pub fn empty() -> Self {
+        Self {
+            schema: Arc::new(Schema::empty()),
+        }
+    }
+}
+
+impl TableSource for SimpleTableSource {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}


### PR DESCRIPTION
This adds a new graph query interface that allows Lance datasets to be interpreted as property graphs and queried using Cypher syntax.

Key features:
- New lance-graph Rust crate with Cypher parser and query execution engine
- Python bindings with GraphConfig, GraphConfigBuilder, and CypherQuery classes
- Support for configuring node labels and relationship mappings
- Query parameter binding and direct execution against Lance datasets
- Logical and physical query planning with native execution (datafusion for now, lance native is on the way)



Python example:

```python
  query = CypherQuery(
      "MATCH (a:Person)-[:FRIEND_OF]->(b:Person) "
      "RETURN a.name AS person, b.name AS friend"
  ).with_config(config)

  result = query.execute({
      "Person": people_ds,
      "FRIEND_OF": friendship_ds
  })
  df = result.to_pandas()
  print(df)
  #  person friend
  # 0  Alice    Bob
  # 1  Alice  Carol
  # 2    Bob  David
  # 3  Carol  David

  5. Complex Queries with Parameters

  # Parameterized query
  query = CypherQuery(
      "MATCH (p:Person) WHERE p.age > $min_age RETURN p.name, p.age"
  ).with_config(config) \
   .with_parameter("min_age", 30)

  result = query.execute({"Person": people_ds})
  df = result.to_pandas()
  print(df)

  # Multi-hop friendship query
  query = CypherQuery(
      "MATCH (a:Person)-[:FRIEND_OF]->(b:Person)-[:FRIEND_OF]->(c:Person) "
      "WHERE a.person_id = $start_person "
      "RETURN a.name AS person, b.name AS intermediate, c.name AS friend_of_friend"
  ).with_config(config) \
   .with_parameter("start_person", 1)

  result = query.execute({
      "Person": people_ds,
      "FRIEND_OF": friendship_ds
  })
  df = result.to_pandas()
  print(df)
```
