### PR TITLE
Rust memcpy in FTS paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4658,6 +4658,7 @@ dependencies = [
  "fst",
  "futures",
  "half",
+ "hashbrown 0.15.5",
  "itertools 0.13.0",
  "jieba-rs",
  "jsonb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ either = "1.0"
 fst = { version = "0.4.7", features = ["levenshtein"] }
 fsst = { version = "=0.38.3", path = "./rust/compression/fsst" }
 futures = "0.3"
+hashbrown = "0.15"
 http = "1.1.0"
 humantime = "2.2.0"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4086,6 +4086,7 @@ dependencies = [
  "fst",
  "futures",
  "half",
+ "hashbrown 0.15.4",
  "itertools 0.13.0",
  "jieba-rs",
  "jsonb",

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -30,6 +30,7 @@ deepsize.workspace = true
 dirs.workspace = true
 fst.workspace = true
 futures.workspace = true
+hashbrown.workspace = true
 half.workspace = true
 itertools.workspace = true
 jieba-rs = { workspace = true, optional = true }

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -584,8 +584,7 @@ impl IndexWorker {
                 let mut token_stream = self.tokenizer.token_stream_for_doc(doc);
                 while token_stream.advance() {
                     let token = token_stream.token_mut();
-                    let token_text = std::mem::take(&mut token.text);
-                    let token_id = self.builder.tokens.add(token_text) as usize;
+                    let token_id = self.builder.tokens.add(&token.text) as usize;
                     token_occurrences
                         .entry(token_id as u32)
                         .or_insert_with(|| PositionRecorder::new(with_position))

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -581,9 +581,10 @@ impl IndexWorker {
             let mut token_occurrences = HashMap::new();
             let mut token_num = 0;
             {
+                // TODO: we are still creating an allocation for each document here. Where is it coming from?
                 let mut token_stream = self.tokenizer.token_stream_for_doc(doc);
                 while token_stream.advance() {
-                    let token = token_stream.token_mut();
+                    let token = token_stream.token();
                     let token_id = self.builder.tokens.add(&token.text) as usize;
                     token_occurrences
                         .entry(token_id as u32)
@@ -592,6 +593,7 @@ impl IndexWorker {
                     token_num += 1;
                 }
             }
+            // TODO: this causes a lot of allocations. Can we do this more efficiently?
             self.builder
                 .posting_lists
                 .resize_with(self.builder.tokens.len(), || {

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -14,6 +14,7 @@ use std::{
 
 use crate::metrics::NoOpMetricsCollector;
 use crate::prefilter::NoFilter;
+use crate::scalar::inverted::index::token_set::AppendableTokenSet;
 use crate::scalar::registry::{TrainingCriteria, TrainingOrdering};
 use arrow::datatypes::{self, Float32Type, Int32Type, UInt64Type};
 use arrow::{
@@ -82,6 +83,8 @@ use crate::scalar::{
 use crate::Index;
 use crate::{prefilter::PreFilter, scalar::inverted::iter::take_fst_keys};
 use std::str::FromStr;
+
+pub(crate) mod token_set;
 
 // Version 0: Arrow TokenSetFormat (legacy)
 // Version 1: Fst TokenSetFormat (new default, incompatible clients < 0.38)
@@ -807,20 +810,20 @@ impl InvertedPartition {
 // at searching, we use fst::Map because it's more efficient
 #[derive(Debug, Clone)]
 pub enum TokenMap {
-    HashMap(HashMap<String, u32>),
+    Appendable(AppendableTokenSet),
     Fst(fst::Map<Vec<u8>>),
 }
 
 impl Default for TokenMap {
     fn default() -> Self {
-        Self::HashMap(HashMap::new())
+        Self::Appendable(AppendableTokenSet::new())
     }
 }
 
 impl DeepSizeOf for TokenMap {
     fn deep_size_of_children(&self, ctx: &mut deepsize::Context) -> usize {
         match self {
-            Self::HashMap(map) => map.deep_size_of_children(ctx),
+            Self::Appendable(map) => map.deep_size_of_children(ctx),
             Self::Fst(map) => map.as_fst().size(),
         }
     }
@@ -829,7 +832,7 @@ impl DeepSizeOf for TokenMap {
 impl TokenMap {
     pub fn len(&self) -> usize {
         match self {
-            Self::HashMap(map) => map.len(),
+            Self::Appendable(map) => map.len(),
             Self::Fst(map) => map.len(),
         }
     }
@@ -851,20 +854,12 @@ pub struct TokenSet {
 impl TokenSet {
     pub fn into_mut(self) -> Self {
         let tokens = match self.tokens {
-            TokenMap::HashMap(map) => map,
-            TokenMap::Fst(map) => {
-                let mut new_map = HashMap::with_capacity(map.len());
-                let mut stream = map.into_stream();
-                while let Some((token, token_id)) = stream.next() {
-                    new_map.insert(String::from_utf8_lossy(token).into_owned(), token_id as u32);
-                }
-
-                new_map
-            }
+            TokenMap::Appendable(map) => map,
+            TokenMap::Fst(map) => map.into(),
         };
 
         Self {
-            tokens: TokenMap::HashMap(tokens),
+            tokens: TokenMap::Appendable(tokens),
             next_id: self.next_id,
             total_length: self.total_length,
         }
@@ -880,7 +875,7 @@ impl TokenSet {
 
     pub(crate) fn iter(&self) -> TokenIterator<'_> {
         TokenIterator::new(match &self.tokens {
-            TokenMap::HashMap(map) => TokenSource::HashMap(map.iter()),
+            TokenMap::Appendable(map) => TokenSource::Appendable(map.iter()),
             TokenMap::Fst(map) => TokenSource::Fst(map.stream()),
         })
     }
@@ -893,27 +888,20 @@ impl TokenSet {
     }
 
     fn into_arrow_batch(self) -> Result<RecordBatch> {
-        let mut token_builder = StringBuilder::with_capacity(self.tokens.len(), self.total_length);
-        let mut token_id_builder = UInt32Builder::with_capacity(self.tokens.len());
-
-        match self.tokens {
+        let (token_col, token_id_col) = match self.tokens {
             TokenMap::Fst(map) => {
+                let mut token_builder = StringBuilder::with_capacity(map.len(), self.total_length);
+                let mut token_id_builder = UInt32Builder::with_capacity(map.len());
                 let mut stream = map.stream();
                 while let Some((token, token_id)) = stream.next() {
                     token_builder.append_value(String::from_utf8_lossy(token));
                     token_id_builder.append_value(token_id as u32);
                 }
-            }
-            TokenMap::HashMap(map) => {
-                for (token, token_id) in map.into_iter().sorted_unstable() {
-                    token_builder.append_value(token);
-                    token_id_builder.append_value(token_id);
-                }
-            }
-        }
 
-        let token_col = token_builder.finish();
-        let token_id_col = token_id_builder.finish();
+                (token_builder.finish(), token_id_builder.finish())
+            }
+            TokenMap::Appendable(map) => map.into_arrow(),
+        };
 
         let schema = arrow_schema::Schema::new(vec![
             arrow_schema::Field::new(TOKEN_COL, DataType::Utf8, false),
@@ -933,7 +921,7 @@ impl TokenSet {
     fn into_fst_batch(mut self) -> Result<RecordBatch> {
         let fst_map = match std::mem::take(&mut self.tokens) {
             TokenMap::Fst(map) => map,
-            TokenMap::HashMap(map) => Self::build_fst_from_map(map)?,
+            TokenMap::Appendable(map) => map.into(),
         };
         let bytes = fst_map.into_fst().into_inner();
 
@@ -1074,25 +1062,15 @@ impl TokenSet {
     }
 
     pub fn add(&mut self, token: &str) -> u32 {
-        // TODO: What if we had something more efficient than HashMap here?
-        let map = match self.tokens {
-            TokenMap::HashMap(ref mut map) => map,
+        match self.tokens {
+            TokenMap::Appendable(ref mut map) => map.add(token),
             _ => panic!("tokens must be HashMap while indexing"),
-        };
-        if let Some(&id) = map.get(token) {
-            id
-        } else {
-            let id = self.next_id;
-            map.insert(token.to_string(), id);
-            self.next_id += 1;
-            self.total_length += token.len();
-            id
         }
     }
 
     pub fn get(&self, token: &str) -> Option<u32> {
         match self.tokens {
-            TokenMap::HashMap(ref map) => map.get(token).copied(),
+            TokenMap::Appendable(ref map) => map.get(token).copied(),
             TokenMap::Fst(ref map) => map.get(token).map(|id| id as u32),
         }
     }
@@ -1103,28 +1081,17 @@ impl TokenSet {
             return;
         }
 
-        let mut map = match std::mem::take(&mut self.tokens) {
-            TokenMap::HashMap(map) => map,
-            TokenMap::Fst(map) => {
-                let mut new_map = HashMap::with_capacity(map.len());
-                let mut stream = map.into_stream();
-                while let Some((token, token_id)) = stream.next() {
-                    new_map.insert(String::from_utf8_lossy(token).into_owned(), token_id as u32);
-                }
+        let expected_len = self.len() - removed_token_ids.len();
 
-                new_map
-            }
-        };
-
-        map.retain(
-            |_, token_id| match removed_token_ids.binary_search(token_id) {
-                Ok(_) => false,
-                Err(index) => {
-                    *token_id -= index as u32;
-                    true
-                }
-            },
-        );
+        let map = self
+            .iter()
+            .filter(
+                |(_, token_id)| match removed_token_ids.binary_search(token_id) {
+                    Ok(_) => false,
+                    Err(_) => true,
+                },
+            )
+            .collect::<AppendableTokenSet>();
 
         self.tokens = TokenMap::HashMap(map);
     }

--- a/rust/lance-index/src/scalar/inverted/index/token_set.rs
+++ b/rust/lance-index/src/scalar/inverted/index/token_set.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{
+    borrow::Cow,
+    hash::{Hash, Hasher},
+};
+
+use arrow::buffer::{Buffer, OffsetBuffer, ScalarBuffer};
+use arrow_array::{StringArray, UInt32Array};
+use deepsize::DeepSizeOf;
+use fst::Streamer;
+
+/// A token set that can be appended to.
+#[derive(Debug, Clone)]
+pub struct AppendableTokenSet {
+    // We use a single buffer to store all tokens.
+    data: String,
+    // Offsets of each token in the data buffer, similar to Arrow's LargeBinaryArray.
+    offsets: Vec<i32>,
+    /// Token ids
+    token_ids: Vec<u32>,
+    /// A hash table mapping from token hash to token id.
+    hash_table: hashbrown::hash_table::HashTable<usize>,
+    // TODO: track ids separately, to support deletions.
+}
+
+impl DeepSizeOf for AppendableTokenSet {
+    fn deep_size_of_children(&self, ctx: &mut deepsize::Context) -> usize {
+        let mut size = 0;
+        size += self.data.deep_size_of_children(ctx);
+        size += self.offsets.deep_size_of_children(ctx);
+        size +=
+            self.hash_table.capacity() * (std::mem::size_of::<u32>() + std::mem::size_of::<u64>());
+        size
+    }
+}
+
+impl AppendableTokenSet {
+    pub fn new() -> Self {
+        Self {
+            data: String::new(),
+            offsets: vec![0],
+            hash_table: hashbrown::hash_table::HashTable::new(),
+        }
+    }
+
+    /// Returns the number of tokens in the set.
+    pub fn len(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
+    pub fn get(&self, token: &str) -> Option<u32> {
+        let hash = Self::hash(token);
+        self.hash_table
+            .find(hash, |i| {
+                let start = self.offsets[*i as usize] as usize;
+                let end = self.offsets[*i as usize + 1] as usize;
+                &self.data[start..end] == token
+            })
+            .copied()
+    }
+
+    fn hash(token: &str) -> u64 {
+        let mut hasher = std::hash::DefaultHasher::new();
+        token.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    pub fn add(&mut self, token: &str) -> u32 {
+        let hash = Self::hash(token);
+        let token_id = self.hash_table.find(hash, |i| {
+            let start = self.offsets[*i as usize] as usize;
+            let end = self.offsets[*i as usize + 1] as usize;
+            &self.data[start..end] == token
+        });
+
+        if let Some(token_id) = token_id {
+            *token_id
+        } else {
+            let token_id = (self.offsets.len() - 1) as u32;
+            self.data.push_str(token);
+            self.offsets.push(self.data.len() as i32);
+            token_id
+        }
+    }
+
+    pub fn iter(&self) -> AppendableTokenSetIterator<'_> {
+        AppendableTokenSetIterator {
+            token_set: self,
+            index: 0,
+        }
+    }
+
+    pub fn into_arrow(self) -> (StringArray, UInt32Array) {
+        let token_ids =
+            UInt32Array::from_iter_values((0..(self.offsets.len() - 1)).map(|i| i as u32));
+
+        let offsets = OffsetBuffer::new(ScalarBuffer::from(self.offsets));
+        let values = Buffer::from(self.data.into_bytes());
+
+        // Safety: offsets were constructed correctly.
+        let tokens = unsafe { StringArray::new_unchecked(offsets, values, None) };
+
+        (tokens, token_ids)
+    }
+}
+
+impl From<AppendableTokenSet> for fst::Map<Vec<u8>> {
+    fn from(token_set: AppendableTokenSet) -> Self {
+        // We need to insert in sorted order for fst::MapBuilder.
+        let mut tokens = token_set.iter().collect::<Vec<_>>();
+        tokens.sort_unstable_by_key(|(token, _)| *token);
+
+        let mut builder = fst::MapBuilder::memory();
+        for (token, token_id) in tokens {
+            builder.insert(token, token_id as u64).unwrap();
+        }
+        let bytes = builder.into_inner().unwrap();
+        fst::Map::new(bytes).unwrap()
+    }
+}
+
+impl From<fst::Map<Vec<u8>>> for AppendableTokenSet {
+    fn from(fst_map: fst::Map<Vec<u8>>) -> Self {
+        let mut token_set = AppendableTokenSet::new();
+        let mut stream = fst_map.stream();
+        while let Some((token, token_id)) = stream.next() {
+            let token_str = String::from_utf8_lossy(token);
+            let id = token_set.add(&token_str);
+            assert_eq!(id as u64, token_id);
+        }
+        token_set
+    }
+}
+
+impl FromIterator<(Cow<'_, str>, u32)> for AppendableTokenSet {
+    fn from_iter<I: IntoIterator<Item = (Cow<'_, str>, u32)>>(iter: I) -> Self {
+        let mut token_set = AppendableTokenSet::new();
+        for (token, token_id) in iter {
+            let id = token_set.add(token);
+            assert_eq!(id, token_id);
+        }
+        token_set
+    }
+}
+
+pub struct AppendableTokenSetIterator<'a> {
+    token_set: &'a AppendableTokenSet,
+    index: usize,
+}
+
+impl<'a> Iterator for AppendableTokenSetIterator<'a> {
+    type Item = (&'a str, u32);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.token_set.offsets.len() - 1 {
+            return None;
+        }
+        let start = self.token_set.offsets[self.index] as usize;
+        let end = self.token_set.offsets[self.index + 1] as usize;
+        let token = &self.token_set.data[start..end];
+        let token_id = self.index as u32;
+        self.index += 1;
+        Some((token, token_id))
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/index/token_set.rs
+++ b/rust/lance-index/src/scalar/inverted/index/token_set.rs
@@ -9,15 +9,15 @@ use deepsize::DeepSizeOf;
 use fst::Streamer;
 
 /// A token set that can be appended to.
+///
+/// Token IDs are sequential indices (0, 1, 2, ...) corresponding to insertion order.
 #[derive(Debug, Clone)]
 pub struct AppendableTokenSet {
     // We use a single buffer to store all tokens.
     data: String,
     // Offsets of each token in the data buffer, similar to Arrow's LargeBinaryArray.
     offsets: Vec<i32>,
-    /// Token ids
-    token_ids: Vec<u32>,
-    /// A hash table mapping from token hash to token id.
+    /// A hash table mapping from token hash to token index (which is the token id).
     hash_table: hashbrown::hash_table::HashTable<u32>,
 }
 
@@ -26,7 +26,6 @@ impl DeepSizeOf for AppendableTokenSet {
         let mut size = 0;
         size += self.data.deep_size_of_children(ctx);
         size += self.offsets.deep_size_of_children(ctx);
-        size += self.token_ids.deep_size_of_children(ctx);
         size +=
             self.hash_table.capacity() * (std::mem::size_of::<u32>() + std::mem::size_of::<u64>());
         size
@@ -39,7 +38,6 @@ impl AppendableTokenSet {
             data: String::new(),
             offsets: vec![0],
             hash_table: hashbrown::hash_table::HashTable::new(),
-            token_ids: Vec::new(),
         }
     }
 
@@ -51,26 +49,25 @@ impl AppendableTokenSet {
             data: String::with_capacity(capacity * average_token_length),
             offsets,
             hash_table: hashbrown::hash_table::HashTable::with_capacity(capacity),
-            token_ids: Vec::with_capacity(capacity),
         }
     }
 
     /// Returns the number of tokens in the set.
     pub fn len(&self) -> usize {
-        self.token_ids.len()
+        // offsets has one more element than the number of tokens (the initial 0)
+        self.offsets.len() - 1
     }
 
     pub fn get(&self, token: &str) -> Option<u32> {
         let hash = Self::hash(token);
-        let offset = self
-            .hash_table
+        // The hash table stores the index, which is also the token_id
+        self.hash_table
             .find(hash, |i| {
                 let start = self.offsets[*i as usize] as usize;
                 let end = self.offsets[*i as usize + 1] as usize;
                 &self.data[start..end] == token
             })
-            .copied();
-        offset.map(|i| self.token_ids[i as usize])
+            .copied()
     }
 
     fn hash(token: &str) -> u64 {
@@ -81,9 +78,11 @@ impl AppendableTokenSet {
 
     /// Insert a new token into the set without checking for duplicates.
     ///
+    /// Returns the assigned token ID (which is the index of the token).
+    ///
     /// # Safety
     /// The caller must ensure that the token does not already exist in the set.
-    pub unsafe fn insert_unchecked(&mut self, token: &str, token_id: u32) {
+    pub unsafe fn insert_unchecked(&mut self, token: &str) -> u32 {
         let hash = Self::hash(token);
 
         debug_assert!(
@@ -98,15 +97,18 @@ impl AppendableTokenSet {
             "Token already exists in the set"
         );
 
-        self.hash_table
-            .insert_unique(hash, dbg!(self.offsets.len() as u32), |offset| {
-                let start = self.offsets[*offset as usize] as usize;
-                let end = self.offsets[*offset as usize + 1] as usize;
-                Self::hash(&self.data[start..end])
-            });
+        // The token_id is the current length (number of existing tokens)
+        let token_id = self.len() as u32;
+
+        self.hash_table.insert_unique(hash, token_id, |offset| {
+            let start = self.offsets[*offset as usize] as usize;
+            let end = self.offsets[*offset as usize + 1] as usize;
+            Self::hash(&self.data[start..end])
+        });
         self.data.push_str(token);
         self.offsets.push(self.data.len() as i32);
-        self.token_ids.push(token_id);
+
+        token_id
     }
 
     pub fn iter(&self) -> AppendableTokenSetIterator<'_> {
@@ -149,10 +151,11 @@ impl From<fst::Map<Vec<u8>>> for AppendableTokenSet {
     fn from(fst_map: fst::Map<Vec<u8>>) -> Self {
         let mut token_set = AppendableTokenSet::new();
         let mut stream = fst_map.stream();
-        while let Some((token, token_id)) = stream.next() {
+        while let Some((token, _token_id)) = stream.next() {
             let token_str = String::from_utf8_lossy(token);
             // Safety: fst::Map does not allow duplicate keys.
-            unsafe { token_set.insert_unchecked(&token_str, token_id as u32) };
+            // Note: We ignore the token_id from FST and assign sequential IDs
+            unsafe { token_set.insert_unchecked(&token_str) };
         }
         token_set
     }
@@ -173,6 +176,7 @@ impl<'a> Iterator for AppendableTokenSetIterator<'a> {
         let start = self.token_set.offsets[self.index] as usize;
         let end = self.token_set.offsets[self.index + 1] as usize;
         let token = &self.token_set.data[start..end];
+        // Token ID is the index
         let token_id = self.index as u32;
         self.index += 1;
         Some((token, token_id))

--- a/rust/lance-index/src/scalar/inverted/iter.rs
+++ b/rust/lance-index/src/scalar/inverted/iter.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::collections::hash_map;
+use std::{borrow::Cow, collections::hash_map};
 
 use arrow::array::AsArray;
 use arrow_array::{Array, LargeBinaryArray, ListArray};
@@ -17,6 +17,7 @@ pub enum TokenSource<'a> {
     HashMap(hash_map::Iter<'a, String, u32>),
     Fst(fst::map::Stream<'a>),
 }
+
 pub struct TokenIterator<'a> {
     source: TokenSource<'a>,
 }
@@ -27,16 +28,21 @@ impl<'a> TokenIterator<'a> {
     }
 }
 
-impl Iterator for TokenIterator<'_> {
-    type Item = (String, u32);
+impl<'a> Iterator for TokenIterator<'a> {
+    type Item = (Cow<'a, str>, u32);
 
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.source {
             TokenSource::HashMap(iter) => iter
                 .next()
-                .map(|(token, token_id)| (token.clone(), *token_id)),
+                .map(|(token, token_id)| (Cow::Borrowed(token.as_str()), *token_id)),
             TokenSource::Fst(iter) => iter.next().map(|(token, token_id)| {
-                (String::from_utf8_lossy(token).into_owned(), token_id as u32)
+                // FST tokens are &[u8], so we must allocate a String.
+                // TODO: we should be able to avoid this allocation
+                (
+                    Cow::Owned(String::from_utf8_lossy(token).into_owned()),
+                    token_id as u32,
+                )
             }),
         }
     }

--- a/rust/lance-index/src/scalar/inverted/iter.rs
+++ b/rust/lance-index/src/scalar/inverted/iter.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{borrow::Cow, collections::hash_map};
+use std::borrow::Cow;
 
 use arrow::array::AsArray;
 use arrow_array::{Array, LargeBinaryArray, ListArray};
 use fst::Streamer;
-use lance_table::format::pb::transaction::Append;
 
 use crate::scalar::inverted::token_set::AppendableTokenSetIterator;
 

--- a/rust/lance-index/src/scalar/inverted/merger.rs
+++ b/rust/lance-index/src/scalar/inverted/merger.rs
@@ -126,7 +126,7 @@ impl Merger for SizeBasedMerger<'_> {
             let mut inv_token = HashMap::with_capacity(part.tokens.len());
             // merge token set
             for (token, token_id) in part.tokens.iter() {
-                self.builder.tokens.add(token.clone());
+                self.builder.tokens.add(&token);
                 inv_token.insert(token_id, token);
             }
             // merge doc set


### PR DESCRIPTION
Playing around with better allocation strategy when building FTS indices.

```shell
git checkout main
cargo bench -p lance-index --bench inverted -- --save-baseline main
git checkout reduce-fts-copies
cargo bench -p lance-index --bench inverted -- --baseline main
```

```
invert_indexing(1000000)
                        time:   [22.419 s 22.495 s 22.569 s]
                        change: [-5.0549% -4.5926% -4.0937%] (p = 0.00 < 0.05)
                        Performance has improved.

invert_search(1000000)  time:   [18.266 µs 21.792 µs 25.441 µs]
                        change: [-87.712% -77.592% -62.216%] (p = 0.00 < 0.05)
                        Performance has improved.
```