### PR TITLE
feat: add reserved field IDs for metadata columns

### DIFF
--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -997,8 +997,18 @@ impl TryFrom<&ArrowField> for Field {
             LogicalType::try_from(field.data_type())?
         };
 
+        // Assign dedicated field IDs for metadata columns
+        let field_id = match field.name().as_str() {
+            crate::ROW_ID => crate::ROW_ID_FIELD_ID,
+            crate::ROW_ADDR => crate::ROW_ADDR_FIELD_ID,
+            crate::ROW_OFFSET => crate::ROW_OFFSET_FIELD_ID,
+            crate::ROW_LAST_UPDATED_AT_VERSION => crate::ROW_LAST_UPDATED_AT_VERSION_FIELD_ID,
+            crate::ROW_CREATED_AT_VERSION => crate::ROW_CREATED_AT_VERSION_FIELD_ID,
+            _ => -1,
+        };
+
         Ok(Self {
-            id: -1,
+            id: field_id,
             parent_id: -1,
             name: field.name().clone(),
             logical_type,

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -497,9 +497,11 @@ impl Schema {
     }
 
     // Recursively collect all the field IDs, in pre-order traversal order.
+    // Only includes fields with non-negative IDs (i.e., actual data fields).
+    // Metadata fields like _rowid and _rowaddr have id=-1 and are excluded.
     // TODO: pub(crate)
     pub fn field_ids(&self) -> Vec<i32> {
-        self.fields_pre_order().map(|f| f.id).collect()
+        self.fields_pre_order().filter(|f| f.id >= 0).map(|f| f.id).collect()
     }
 
     /// Get field by its id.

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -583,8 +583,9 @@ impl Schema {
     /// over this method. This method does not take into account the field IDs
     /// of dropped fields.
     ///
-    /// This method excludes metadata fields (which have dedicated IDs like i32::MAX)
-    /// to avoid overflow issues when allocating new field IDs.
+    /// Note2: This method excludes metadata fields (which have dedicated IDs like i32::MAX),
+    /// because caller of this method is typically only interested in the max field ID of
+    /// actual data fields.
     pub fn max_field_id(&self) -> Option<i32> {
         self.fields
             .iter()

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -24,6 +24,17 @@ pub const ROW_LAST_UPDATED_AT_VERSION: &str = "_row_last_updated_at_version";
 /// Column name for the row's created at dataset version.
 pub const ROW_CREATED_AT_VERSION: &str = "_row_created_at_version";
 
+/// Field ID for the meta row ID column. Uses i32::MAX to avoid conflicts with actual data fields.
+pub const ROW_ID_FIELD_ID: i32 = i32::MAX;
+/// Field ID for the meta row address column.
+pub const ROW_ADDR_FIELD_ID: i32 = i32::MAX - 1;
+/// Field ID for the meta row offset column.
+pub const ROW_OFFSET_FIELD_ID: i32 = i32::MAX - 2;
+/// Field ID for the row last updated at version column.
+pub const ROW_LAST_UPDATED_AT_VERSION_FIELD_ID: i32 = i32::MAX - 3;
+/// Field ID for the row created at version column.
+pub const ROW_CREATED_AT_VERSION_FIELD_ID: i32 = i32::MAX - 4;
+
 /// Row ID field. This is nullable because its validity bitmap is sometimes used
 /// as a selection vector.
 pub static ROW_ID_FIELD: LazyLock<ArrowField> =


### PR DESCRIPTION
After https://github.com/lancedb/lance/pull/4794, a schema can now include _rowid and _rowaddr fields with id=-1, this is unexpected for processes that tries to get the field IDs of the schema. Also different metadata columns share the same field ID which is prune to future errors.

This PR reserves field IDs to these metadata columns. This is similar to how Iceberg does it as a reference: https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/MetadataColumns.java