### PR TITLE
test: simplify memory tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,11 +103,13 @@ jobs:
         run: docker compose -f docker-compose.yml up -d --wait
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
       - name: Run tests
         if: ${{ matrix.toolchain == 'stable' }}
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v protoc | sort | uniq | paste -s -d "," -`
-          cargo llvm-cov  --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
+          cargo llvm-cov nextest  --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
+
       - name: Upload coverage to Codecov
         if: ${{ matrix.toolchain == 'stable' }}
         uses: codecov/codecov-action@v4
@@ -127,6 +129,7 @@ jobs:
           rustup toolchain install stable
           rustup default stable
       - uses: rui314/setup-mold@v1
+      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           cache-targets: false
@@ -144,7 +147,7 @@ jobs:
       - name: Run tests
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v protoc | sort | uniq | paste -s -d "," -`
-          cargo test --locked --features ${ALL_FEATURES}
+          cargo nextest run --locked --features ${ALL_FEATURES}
   build-no-lock:
     runs-on: warp-ubuntu-2404-x64-8x
     timeout-minutes: 30
@@ -158,6 +161,7 @@ jobs:
       - name: Remove Cargo.lock
         run: rm -f Cargo.lock
       - uses: rui314/setup-mold@v1
+      - uses: taiki-e/install-action@nextest
       - name: Install dependencies
         run: |
           sudo apt update
@@ -185,6 +189,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Install dependencies
         run: brew install protobuf
+      - uses: taiki-e/install-action@nextest
       - name: Set up Rust
         run: |
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -197,7 +202,7 @@ jobs:
           cargo test --locked --features fp16kernels,cli,tensorflow,dynamodb,substrait --no-run
       - name: Run tests
         run: |
-          cargo test --features fp16kernels,cli,tensorflow,dynamodb,substrait
+          cargo nextest run --features fp16kernels,cli,tensorflow,dynamodb,substrait
       - name: Check benchmarks
         run: |
           cargo check --benches --features fp16kernels,cli,tensorflow,dynamodb,substrait
@@ -221,10 +226,11 @@ jobs:
           7z x protoc.zip
           Add-Content $env:GITHUB_PATH "C:\protoc\bin"
         shell: powershell
+      - uses: taiki-e/install-action@nextest
       - name: Build tests
         run: cargo test --locked --no-run
       - name: Run tests
-        run: cargo test
+        run: cargo nextest run
       - name: Check benchmarks
         run: cargo check --benches
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,7 +4390,6 @@ dependencies = [
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
- "tracking-allocator",
  "url",
  "uuid",
 ]
@@ -8749,16 +8748,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracking-allocator"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b61e0cb3385e17df7db29c565b40fd0350dfe8a076c7eea83d416e30cfd0581"
-dependencies = [
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -105,7 +105,6 @@ tempfile.workspace = true
 test-log.workspace = true
 tracing-chrome = "0.7.1"
 rstest = { workspace = true }
-tracking-allocator = { version = "0.4", features = ["tracing-compat"] }
 # For S3 / DynamoDB tests
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }

--- a/rust/lance/tests/README.md
+++ b/rust/lance/tests/README.md
@@ -1,5 +1,10 @@
 Tests for memory and IO usage.
 
+> [!IMPORTANT]
+> These tests cannot be run with multi-threading. If using `cargo test`, then
+> you must pass `-- --test-threads=1` to disable multi-threading. To run tests,
+> in parallel, you can use `cargo nextest`, which runs each test in its own process.
+
 ## Debugging memory usage
 
 Once you've identified a test that is using too much memory, you can use

--- a/rust/lance/tests/resource_test/utils.rs
+++ b/rust/lance/tests/resource_test/utils.rs
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
-use all_asserts::assert_ge;
 use std::alloc::System;
-use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, Mutex, Once};
-use tracing::Instrument;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::Registry;
-use tracking_allocator::{
-    AllocationGroupId, AllocationGroupToken, AllocationLayer, AllocationRegistry,
-    AllocationTracker, Allocator,
-};
+use std::alloc::{GlobalAlloc, Layout};
+use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering};
 
 #[global_allocator]
-static GLOBAL: Allocator<System> = Allocator::system();
+static GLOBAL: TrackingAllocator<System> = TrackingAllocator::new(System);
+static GLOBAL_STATS: AllocStatsAtomic = AllocStatsAtomic::new();
+
+pub fn reset_alloc_stats() {
+    GLOBAL_STATS.reset();
+}
+
+pub fn get_alloc_stats() -> AllocStats {
+    GLOBAL_STATS.get_stats()
+}
 
 #[derive(Default, Clone, Debug)]
 pub struct AllocStats {
@@ -30,163 +31,122 @@ impl AllocStats {
     }
 }
 
-static GLOBAL_STATS: LazyLock<Arc<Mutex<HashMap<AllocationGroupId, AllocStats>>>> =
-    std::sync::LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));
-
-struct MemoryTracker;
-
-impl AllocationTracker for MemoryTracker {
-    fn allocated(
-        &self,
-        _addr: usize,
-        object_size: usize,
-        _wrapped_size: usize,
-        group_id: AllocationGroupId,
-    ) {
-        if group_id == AllocationGroupId::ROOT {
-            // We don't track root allocations
-            return;
-        }
-        let mut guard = GLOBAL_STATS.lock().unwrap();
-        let stats = guard.entry(group_id).or_default();
-        stats.total_bytes_allocated += object_size as isize;
-        stats.total_allocations += 1;
-        stats.max_bytes_allocated = stats.max_bytes_allocated.max(stats.net_bytes_allocated());
-    }
-
-    fn deallocated(
-        &self,
-        _addr: usize,
-        object_size: usize,
-        _wrapped_size: usize,
-        source_group_id: AllocationGroupId,
-        current_group_id: AllocationGroupId,
-    ) {
-        let group_id = if source_group_id != AllocationGroupId::ROOT {
-            source_group_id
-        } else {
-            current_group_id
-        };
-        if group_id == AllocationGroupId::ROOT {
-            // We don't track root allocations
-            return;
-        }
-        let mut guard = GLOBAL_STATS.lock().unwrap();
-        let stats = guard.entry(group_id).or_default();
-        stats.total_bytes_deallocated += object_size as isize;
-        stats.total_deallocations += 1;
-    }
+struct AllocStatsAtomic {
+    current_bytes: AtomicIsize,
+    max_bytes: AtomicIsize,
+    total_allocated: AtomicIsize,
+    total_deallocated: AtomicIsize,
+    total_alloc_count: AtomicUsize,
+    total_dealloc_count: AtomicUsize,
 }
 
-static INIT: Once = Once::new();
-
-// The alloc tracker holds a span and an associated allocation group id.
-pub struct AllocTracker {
-    group_id: AllocationGroupId,
-    span: tracing::Span,
-}
-
-impl AllocTracker {
-    pub fn init() {
-        INIT.call_once(init_memory_tracking);
-    }
-
-    pub fn new() -> Self {
-        Self::init();
-
-        let token = AllocationGroupToken::register().expect("failed to register token");
-        let group_id = token.id();
-
-        let span = tracing::span!(tracing::Level::INFO, "AllocTracker");
-        token.attach_to_span(&span);
-
-        Self { group_id, span }
-    }
-
-    pub fn enter(&self) -> AllocGuard<'_> {
-        AllocGuard::new(self)
-    }
-
-    pub fn stats(self) -> AllocStats {
-        let mut stats = GLOBAL_STATS.lock().unwrap();
-        stats.remove(&self.group_id).unwrap_or_default()
-    }
-}
-
-pub struct AllocGuard<'a> {
-    _guard: tracing::span::Entered<'a>,
-}
-
-impl<'a> AllocGuard<'a> {
-    #[allow(clippy::print_stderr)]
-    pub fn new(tracker: &'a AllocTracker) -> Self {
-        if std::env::var("RUST_ALLOC_TIMINGS").is_ok() {
-            eprintln!("alloc:enter:{}", chrono::Utc::now().to_rfc3339());
-        }
-        AllocGuard {
-            _guard: tracker.span.enter(),
+impl AllocStatsAtomic {
+    const fn new() -> Self {
+        Self {
+            current_bytes: AtomicIsize::new(0),
+            max_bytes: AtomicIsize::new(0),
+            total_allocated: AtomicIsize::new(0),
+            total_deallocated: AtomicIsize::new(0),
+            total_alloc_count: AtomicUsize::new(0),
+            total_dealloc_count: AtomicUsize::new(0),
         }
     }
-}
 
-impl Drop for AllocGuard<'_> {
-    #[allow(clippy::print_stderr)]
-    fn drop(&mut self) {
-        if std::env::var("RUST_ALLOC_TIMINGS").is_ok() {
-            eprintln!("alloc:exit:{}", chrono::Utc::now().to_rfc3339());
+    fn record_alloc(&self, size: isize) {
+        self.total_allocated.fetch_add(size, Ordering::Relaxed);
+        self.total_alloc_count.fetch_add(1, Ordering::Relaxed);
+
+        let current = self.current_bytes.fetch_add(size, Ordering::Relaxed) + size;
+
+        // Update max if current exceeds it
+        self.max_bytes.fetch_max(current, Ordering::Relaxed);
+    }
+
+    fn record_dealloc(&self, size: isize) {
+        self.total_deallocated.fetch_add(size, Ordering::Relaxed);
+        self.total_dealloc_count.fetch_add(1, Ordering::Relaxed);
+        self.current_bytes.fetch_sub(size, Ordering::Relaxed);
+    }
+
+    fn get_stats(&self) -> AllocStats {
+        AllocStats {
+            max_bytes_allocated: self.max_bytes.load(Ordering::Relaxed),
+            total_bytes_allocated: self.total_allocated.load(Ordering::Relaxed),
+            total_bytes_deallocated: self.total_deallocated.load(Ordering::Relaxed),
+            total_allocations: self.total_alloc_count.load(Ordering::Relaxed),
+            total_deallocations: self.total_dealloc_count.load(Ordering::Relaxed),
         }
+    }
+
+    fn reset(&self) {
+        self.current_bytes.store(0, Ordering::Relaxed);
+        self.max_bytes.store(0, Ordering::Relaxed);
+        self.total_allocated.store(0, Ordering::Relaxed);
+        self.total_deallocated.store(0, Ordering::Relaxed);
+        self.total_alloc_count.store(0, Ordering::Relaxed);
+        self.total_dealloc_count.store(0, Ordering::Relaxed);
     }
 }
 
-pub fn init_memory_tracking() {
-    let registry = Registry::default().with(AllocationLayer::new());
-    tracing::subscriber::set_global_default(registry)
-        .expect("failed to install tracing subscriber");
+/// Global allocator wrapper that tracks memory usage
+pub struct TrackingAllocator<A: GlobalAlloc> {
+    inner: A,
+}
 
-    let tracker = MemoryTracker;
-    AllocationRegistry::set_global_tracker(tracker).expect("failed to set global tracker");
-    AllocationRegistry::enable_tracking();
+impl<A: GlobalAlloc> TrackingAllocator<A> {
+    pub const fn new(inner: A) -> Self {
+        Self { inner }
+    }
+}
+
+unsafe impl<A: GlobalAlloc> GlobalAlloc for TrackingAllocator<A> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = self.inner.alloc(layout);
+        if !ptr.is_null() {
+            GLOBAL_STATS.record_alloc(layout.size() as isize);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.inner.dealloc(ptr, layout);
+        GLOBAL_STATS.record_dealloc(layout.size() as isize);
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = self.inner.alloc_zeroed(layout);
+        if !ptr.is_null() {
+            GLOBAL_STATS.record_alloc(layout.size() as isize);
+        }
+        ptr
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = self.inner.realloc(ptr, layout, new_size);
+        if !new_ptr.is_null() {
+            // Record deallocation of old size and allocation of new size
+            GLOBAL_STATS.record_dealloc(layout.size() as isize);
+            GLOBAL_STATS.record_alloc(new_size as isize);
+        }
+        new_ptr
+    }
 }
 
 #[test]
 fn check_memory_leak() {
     // Make sure AllocTracker can detect leaks
     let mut leaked = Vec::new();
-    let tracker = AllocTracker::new();
-    {
-        let _guard = tracker.enter();
-        let v = vec![0u8; 1024 * 1024];
-        leaked.resize(1024, 0u8);
-        drop(v);
-    }
-    let stats = tracker.stats();
+    reset_alloc_stats();
+    let v = vec![0u8; 1024 * 1024];
+    leaked.resize(1024, 0u8);
+    drop(v);
+
+    let stats = get_alloc_stats();
+    assert_eq!(stats.total_allocations, 2);
+    assert_eq!(stats.total_deallocations, 1);
     assert_eq!(stats.max_bytes_allocated, (1024 * 1024) + 1024);
     assert_eq!(stats.total_bytes_allocated, (1024 * 1024) + 1024);
     assert_eq!(stats.total_bytes_deallocated, (1024 * 1024));
-    assert_eq!(stats.total_allocations, 2);
-    assert_eq!(stats.net_bytes_allocated(), 1024);
-}
 
-#[tokio::test]
-async fn check_test_spawn_alloc() {
-    let tracker = AllocTracker::new();
-    {
-        let _guard = tracker.enter();
-        let future1 = async {
-            let v = vec![0u8; 256 * 1024];
-            drop(v);
-        };
-        let handle = tokio::spawn(future1.in_current_span());
-        let future2 = async {
-            let v = vec![0u8; 512 * 1024];
-            drop(v);
-        };
-        let handle2 = tokio::spawn(future2.in_current_span());
-        handle.await.unwrap();
-        handle2.await.unwrap();
-    }
-    let stats = tracker.stats();
-    assert_eq!(stats.total_allocations, 4);
-    assert_ge!(stats.total_bytes_allocated, 256 * 1024 + 512 * 1024);
-    assert_ge!(stats.total_bytes_deallocated, 256 * 1024 + 512 * 1024);
+    assert_eq!(stats.net_bytes_allocated(), 1024);
 }

--- a/rust/lance/tests/resource_test/write.rs
+++ b/rust/lance/tests/resource_test/write.rs
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
-use super::utils::AllocTracker;
-use all_asserts::assert_le;
+use all_asserts::assert_gt;
 use arrow_schema::DataType;
 use lance::dataset::InsertBuilder;
 use lance_datafusion::datagen::DatafusionDatagenExt;
 use lance_datagen::{array, gen_batch, BatchCount, ByteCount, RoundingBehavior};
 
+use crate::resource_test::utils::{get_alloc_stats, reset_alloc_stats};
+
 #[tokio::test]
 async fn test_insert_memory() {
+    reset_alloc_stats();
     // Create a stream of 100MB of data, in batches
     let batch_size = 10 * 1024 * 1024; // 10MB
     let num_batches = BatchCount::from(10);
@@ -21,25 +23,27 @@ async fn test_insert_memory() {
         )
         .unwrap();
 
-    let alloc_tracker = AllocTracker::new();
-    {
-        let _guard = alloc_tracker.enter();
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_path = tmp_dir.path().to_str().unwrap();
+    let _dataset = InsertBuilder::new(tmp_path)
+        .execute_stream(data)
+        .await
+        .unwrap();
 
-        // write out to temporary directory
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let tmp_path = tmp_dir.path().to_str().unwrap();
-        let _dataset = InsertBuilder::new(tmp_path)
-            .execute_stream(data)
-            .await
-            .unwrap();
-    }
+    let stats = get_alloc_stats();
 
-    let stats = alloc_tracker.stats();
-    // Allow for 2x the batch size to account for overheads.
-    // The key test is that we don't load all 100MB into memory at once
-    assert_le!(
-        stats.max_bytes_allocated,
-        (batch_size * 2) as isize,
-        "Max memory usage exceeded"
+    assert_gt!(stats.total_bytes_allocated, 100 * 1024 * 1024);
+
+    // The key test: we shouldn't load all 100MB at once
+    // Allow 2x the batch size to account for overhead and buffering
+    let max_allowed_bytes = (batch_size * 2) as isize;
+
+    let peak_mb = stats.max_bytes_allocated as f64 / (1024.0 * 1024.0);
+
+    assert!(
+        stats.max_bytes_allocated <= max_allowed_bytes,
+        "Peak memory {:.2} MB exceeded limit {:.2} MB",
+        peak_mb,
+        max_allowed_bytes as f64 / (1024.0 * 1024.0)
     );
 }

--- a/rust/lance/tests/resource_tests.rs
+++ b/rust/lance/tests/resource_tests.rs
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-// If NEXTEST_RUN_ID is set, or --test-threads=1 is passed, then we are running in single-threaded mode.
-// Otherwise, we should skip these tests to avoid interference.
-
-use std::sync::LazyLock;
-
 #[test]
 fn test_settings() {
     let can_run = std::env::var("NEXTEST_RUN_ID").is_ok()
@@ -15,7 +10,7 @@ fn test_settings() {
     assert!(
         can_run,
         "Memory tests require single-threaded execution. \
-            Please run with `-- --test-threads=1` or use `cargo nextest`."
+            Please run with `CARGO_TEST_THREADS=1` or use `cargo nextest`."
     );
 }
 

--- a/rust/lance/tests/resource_tests.rs
+++ b/rust/lance/tests/resource_tests.rs
@@ -1,7 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-// The memory tests don't work currently on MacOS because they rely on thread
-// local storage in the allocator, which seems to have some issues on MacOS.
-#[cfg(target_os = "linux")]
+// If NEXTEST_RUN_ID is set, or --test-threads=1 is passed, then we are running in single-threaded mode.
+// Otherwise, we should skip these tests to avoid interference.
+
+use std::sync::LazyLock;
+
+#[test]
+fn test_settings() {
+    let can_run = std::env::var("NEXTEST_RUN_ID").is_ok()
+        || std::env::var("CARGO_TEST_THREADS")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+    assert!(
+        can_run,
+        "Memory tests require single-threaded execution. \
+            Please run with `-- --test-threads=1` or use `cargo nextest`."
+    );
+}
+
 mod resource_test;


### PR DESCRIPTION
Replace the memory integration tests that used spans with one that tracks general statistics in an custom allocator. Advantages:

* Guaranteed not to miss any allocations. Previously due to issues with spans not propagated across all Tokio tasks, we would miss allocations.
* Works on multiple platforms

Disadvantages:

* Running with plain `cargo test` will have failures
* Still can't run in unit tests.

As a side note, I did look into exposing this in Python, so we could use it in Python tests. However, I found it wasn't useful in many cases because it only tracked allocations from the Lance binary. This meant it missed allocations made by PyArrow, for example, so the insertion tests couldn't be written in Python. If we want to do allocation tracking in Python, we will probably have to do something that uses the `LD_PRELOAD` trick.