### PR TITLE
chore: allow Java api to set fragment id

### DIFF
--- a/java/src/main/java/com/lancedb/lance/Fragment.java
+++ b/java/src/main/java/com/lancedb/lance/Fragment.java
@@ -208,9 +208,30 @@ public class Fragment {
    */
   public static List<FragmentMetadata> create(
       String datasetUri, BufferAllocator allocator, VectorSchemaRoot root, WriteParams params) {
+    return create(datasetUri, allocator, root, Optional.empty(), params);
+  }
+
+  /**
+   * Create a fragment from the given data with a specified fragment ID.
+   *
+   * @param datasetUri the dataset uri
+   * @param allocator the buffer allocator
+   * @param root the vector schema root
+   * @param fragmentId the fragment id (optional). If not provided, fragments will be auto-assigned
+   *     IDs starting from 0
+   * @param params the write params
+   * @return the fragment metadata
+   */
+  public static List<FragmentMetadata> create(
+      String datasetUri,
+      BufferAllocator allocator,
+      VectorSchemaRoot root,
+      Optional<Integer> fragmentId,
+      WriteParams params) {
     Preconditions.checkNotNull(datasetUri);
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(root);
+    Preconditions.checkNotNull(fragmentId);
     Preconditions.checkNotNull(params);
     try (ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
         ArrowArray arrowArray = ArrowArray.allocateNew(allocator)) {
@@ -219,6 +240,7 @@ public class Fragment {
           datasetUri,
           arrowArray.memoryAddress(),
           arrowSchema.memoryAddress(),
+          fragmentId,
           params.getMaxRowsPerFile(),
           params.getMaxRowsPerGroup(),
           params.getMaxBytesPerFile(),
@@ -239,12 +261,32 @@ public class Fragment {
    */
   public static List<FragmentMetadata> create(
       String datasetUri, ArrowArrayStream stream, WriteParams params) {
+    return create(datasetUri, stream, Optional.empty(), params);
+  }
+
+  /**
+   * Create a fragment from the given arrow stream with a specified fragment ID.
+   *
+   * @param datasetUri the dataset uri
+   * @param stream the arrow stream
+   * @param fragmentId the fragment id (optional). If not provided, fragments will be auto-assigned
+   *     IDs starting from 0
+   * @param params the write params
+   * @return the fragment metadata
+   */
+  public static List<FragmentMetadata> create(
+      String datasetUri,
+      ArrowArrayStream stream,
+      Optional<Integer> fragmentId,
+      WriteParams params) {
     Preconditions.checkNotNull(datasetUri);
     Preconditions.checkNotNull(stream);
+    Preconditions.checkNotNull(fragmentId);
     Preconditions.checkNotNull(params);
     return createWithFfiStream(
         datasetUri,
         stream.memoryAddress(),
+        fragmentId,
         params.getMaxRowsPerFile(),
         params.getMaxRowsPerGroup(),
         params.getMaxBytesPerFile(),
@@ -263,6 +305,7 @@ public class Fragment {
       String datasetUri,
       long arrowArrayMemoryAddress,
       long arrowSchemaMemoryAddress,
+      Optional<Integer> fragmentId,
       Optional<Integer> maxRowsPerFile,
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
@@ -279,6 +322,7 @@ public class Fragment {
   private static native List<FragmentMetadata> createWithFfiStream(
       String datasetUri,
       long arrowStreamMemoryAddress,
+      Optional<Integer> fragmentId,
       Optional<Integer> maxRowsPerFile,
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,

--- a/java/src/test/java/com/lancedb/lance/DatasetTest.java
+++ b/java/src/test/java/com/lancedb/lance/DatasetTest.java
@@ -1523,7 +1523,10 @@ public class DatasetTest {
             assertEquals(2, branch1V2.version());
 
             // Write batch B on branch1: 3 rows -> global@3
-            FragmentMetadata fragB = suite.createNewFragment(3);
+            // Create fragment using the branch's URI, not the main dataset URI
+            TestUtils.SimpleTestDataset branch1Suite =
+                new TestUtils.SimpleTestDataset(allocator, branch1V2.uri());
+            FragmentMetadata fragB = branch1Suite.createNewFragment(3);
             Append appendB = Append.builder().fragments(Collections.singletonList(fragB)).build();
             try (Dataset branch1V3 =
                 branch1V2.newTransactionBuilder().operation(appendB).build().commit()) {
@@ -1538,7 +1541,10 @@ public class DatasetTest {
                 assertEquals(8, branch2V3.countRows()); // A(5) + B(3)
 
                 // Step 4. Write batch C on branch2: 2 rows -> branch2:4
-                FragmentMetadata fragC = suite.createNewFragment(2);
+                // Create fragment using branch2's URI
+                TestUtils.SimpleTestDataset branch2Suite =
+                    new TestUtils.SimpleTestDataset(allocator, branch2V3.uri());
+                FragmentMetadata fragC = branch2Suite.createNewFragment(2);
                 Append appendC = Append.builder().fragments(Arrays.asList(fragC)).build();
                 try (Dataset branch2V4 =
                     branch2V3.newTransactionBuilder().operation(appendC).build().commit()) {


### PR DESCRIPTION
The Python and Java APIs for `Fragment.create()` had significant behavioral differences:
* Python API allows specifying fragment id
* Python API always create a single fragment

This PR updates Java API to match Python API.