### PR TITLE
fix: always wait_for_io to prevent crash when rows are scheduled but not loaded in decoder

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1619,6 +1619,11 @@ impl<T: RootDecoderType> BatchDecodeIterator<T> {
                 let under_scheduled = desired_scheduled - actually_scheduled;
                 to_take -= under_scheduled;
             }
+        } else {
+            // Although we have scheduled enough rows, the I/O may not have completed.
+            // We must wait for I/O before draining, otherwise drain_batch may fail
+            // with message 'drain was called ... but the decoder was never awaited ...'.
+            self.wait_for_io(0, to_take)?;
         }
 
         if to_take == 0 {

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -1584,6 +1584,15 @@ pub mod tests {
     use lance_encoding::decoder::DecoderConfig;
 
     async fn create_some_file(fs: &FsFixture, version: LanceFileVersion) -> WrittenFile {
+        create_test_file(fs, version, 1000, 100).await
+    }
+
+    async fn create_test_file(
+        fs: &FsFixture,
+        version: LanceFileVersion,
+        row_count: u64,
+        batch_count: u32,
+    ) -> WrittenFile {
         let location_type = DataType::Struct(Fields::from(vec![
             Field::new("x", DataType::Float64, true),
             Field::new("y", DataType::Float64, true),
@@ -1598,7 +1607,8 @@ pub mod tests {
         if version <= LanceFileVersion::V2_0 {
             reader = reader.col("large_bin", array::rand_type(&DataType::LargeBinary));
         }
-        let reader = reader.into_reader_rows(RowCount::from(1000), BatchCount::from(100));
+        let reader =
+            reader.into_reader_rows(RowCount::from(row_count), BatchCount::from(batch_count));
 
         write_lance_file(
             reader,
@@ -2063,6 +2073,54 @@ pub mod tests {
 
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].num_rows(), 5);
+        assert_eq!(batches[0].num_columns(), 1);
+    }
+
+    /// Test that blocking read works correctly when IO is scheduled but not yet completed.
+    #[rstest]
+    #[tokio::test]
+    async fn test_blocking_take_with_many_rows(
+        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
+    ) {
+        let fs = FsFixture::default();
+        let WrittenFile { data, schema, .. } = create_test_file(&fs, version, 1000, 1000).await;
+        let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
+
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+        let file_reader = FileReader::try_open(
+            file_scheduler.clone(),
+            Some(ReaderProjection::from_column_names(version, &schema, &["categories"]).unwrap()),
+            Arc::<DecoderPlugins>::default(),
+            &test_cache(),
+            FileReaderOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        // Use a small batch_size to ensure multiple drain_batch calls.
+        let batch_size = 1024u32;
+        let batches = tokio::task::spawn_blocking(move || {
+            file_reader
+                .read_stream_projected_blocking(
+                    lance_io::ReadBatchParams::RangeFull,
+                    batch_size,
+                    None,
+                    FilterExpression::no_filter(),
+                )
+                .unwrap()
+                .collect::<ArrowResult<Vec<_>>>()
+                .unwrap()
+        })
+        .await
+        .unwrap();
+
+        let total_read_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_read_rows, total_rows);
+        assert_eq!(batches[0].num_rows(), batch_size as usize);
         assert_eq!(batches[0].num_columns(), 1);
     }
 


### PR DESCRIPTION
Recently, my collaborator was testing the Lance file format and encountered a crash with the following error message:

> Encountered internal error. Please file a bug report at lancedb/lance. drain was called on primitive field decoder for data type Float32 on column 2 but the decoder was never awaited, /aoneci/runner/work/source/rust/lance-encoding/src/previous/encodings/logical/primitive.rs:348:27

After some investigation, I found that this should be a bug.

The test used both LanceFileVersion `V2_0` and `V2_1`. This issue occurred with `V2_0`. If data is written in the `V2_0` format, there is a chance this bug will be triggered, even though the reading comes from the current latest Lance reader. Considering that `V2_1` was only stable after v0.38.0, this bug should be worth fixing.

The cause of this bug is in the `next_batch_task` function in `rust/lance-encoding/src/decoder.rs`, where `rows_scheduled` only represents the scheduled length, not the length of completed I/O. When a piece of data is only scheduled but has not completed I/O, the above error occurs.

The specific flow of how the bug occurs is as follows:
1. `BatchDecodeIterator` calls `next_batch_task` for the first time, at which point `rows_scheduled` is initially zero, entering the `scheduled_need > 0` branch.
2. In `wait_for_io`, `rows_scheduled` gets updated and synchronously waits for the data needed (`to_take`). Note there is a key difference here. `rows_scheduled` is the scheduled length, but only waits for `to_take` length of data. `rows_scheduled` may far exceeds `to_take`, and the data exceeding `to_take` may not have completed I/O yet.
3. When entering `next_batch_task` again, `rows_scheduled` may already be a large value. If `to_take` is small, it may miss the `scheduled_need > 0` branch, completely skipping `wait_for_io`.
4. However, the scheduled data may not have completed I/O yet, so when the program proceeds to `drain_batch`, it crashes.

The fix for this bug is also in the `next_batch_task` function. The logic is to perform `wait_for_io` on the `else` branch. If the data is actually ready, `wait_for_io` should not cause new I/O or context switching, thus having almost no negative impact.

I have added a new UT `test_blocking_take_with_many_rows` in `rust/lance-file/src/reader.rs`. When the version is `V2_0`, this bug can be reproduced without this fix.