### PR TITLE
feat: add describeIndex method for detailed index metadata retrieval

### DIFF
--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -18,6 +18,7 @@ import org.lance.cleanup.RemovalStats;
 import org.lance.compaction.CompactionOptions;
 import org.lance.delta.DatasetDelta;
 import org.lance.index.Index;
+import org.lance.index.IndexDescription;
 import org.lance.index.IndexOptions;
 import org.lance.index.IndexParams;
 import org.lance.index.IndexType;
@@ -980,6 +981,27 @@ public class Dataset implements Closeable {
   }
 
   private native List<Index> nativeGetIndexes();
+
+  /**
+   * Describe an index by name, providing detailed statistics and metadata.
+   *
+   * <p>This returns information about the index including its type, distance metric (for vector
+   * indices), and coverage statistics showing how many rows are indexed vs unindexed.
+   *
+   * @param indexName the name of the index to describe
+   * @return IndexDescription containing index metadata and statistics
+   * @throws IllegalArgumentException if the index does not exist
+   */
+  public IndexDescription describeIndex(String indexName) {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      Preconditions.checkArgument(
+          indexName != null && !indexName.isEmpty(), "indexName cannot be null or empty");
+      return nativeDescribeIndex(indexName);
+    }
+  }
+
+  private native IndexDescription nativeDescribeIndex(String indexName);
 
   /**
    * Get the table config of the dataset.

--- a/java/src/main/java/org/lance/index/IndexDescription.java
+++ b/java/src/main/java/org/lance/index/IndexDescription.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.index;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Description of an index containing its metadata and statistics.
+ * This provides detailed information about an index including its type, distance metric,
+ * and coverage statistics.
+ */
+public class IndexDescription {
+  public static final String JSON_PROPERTY_DISTANCE_TYPE = "distance_type";
+  @Nullable
+  private String distanceType;
+
+  public static final String JSON_PROPERTY_INDEX_TYPE = "index_type";
+  @Nullable
+  private String indexType;
+
+  public static final String JSON_PROPERTY_NUM_INDEXED_ROWS = "num_indexed_rows";
+  @Nullable
+  private Long numIndexedRows;
+
+  public static final String JSON_PROPERTY_NUM_UNINDEXED_ROWS = "num_unindexed_rows";
+  @Nullable
+  private Long numUnindexedRows;
+
+  private IndexDescription(
+      String distanceType,
+      String indexType,
+      Long numIndexedRows,
+      Long numUnindexedRows) {
+    this.distanceType = distanceType;
+    this.indexType = indexType;
+    this.numIndexedRows = numIndexedRows;
+    this.numUnindexedRows = numUnindexedRows;
+  }
+
+  /**
+   * Get the distance type used by the index (e.g., "l2", "cosine", "dot").
+   * This is only applicable for vector indices.
+   *
+   * @return the distance type, or null if not applicable
+   */
+  @Nullable
+  public String getDistanceType() {
+    return distanceType;
+  }
+
+  /**
+   * Get the type of the index (e.g., "IVF_PQ", "BTREE", "BITMAP", "HNSW").
+   *
+   * @return the index type
+   */
+  @Nullable
+  public String getIndexType() {
+    return indexType;
+  }
+
+  /**
+   * Get the number of rows covered by this index.
+   *
+   * @return the number of indexed rows, or null if unavailable
+   */
+  @Nullable
+  public Long getNumIndexedRows() {
+    return numIndexedRows;
+  }
+
+  /**
+   * Get the number of rows in the dataset not covered by this index.
+   *
+   * @return the number of unindexed rows, or null if unavailable
+   */
+  @Nullable
+  public Long getNumUnindexedRows() {
+    return numUnindexedRows;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    IndexDescription that = (IndexDescription) o;
+    return Objects.equals(distanceType, that.distanceType)
+        && Objects.equals(indexType, that.indexType)
+        && Objects.equals(numIndexedRows, that.numIndexedRows)
+        && Objects.equals(numUnindexedRows, that.numUnindexedRows);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(distanceType, indexType, numIndexedRows, numUnindexedRows);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("distanceType", distanceType)
+        .add("indexType", indexType)
+        .add("numIndexedRows", numIndexedRows)
+        .add("numUnindexedRows", numUnindexedRows)
+        .toString();
+  }
+
+  /**
+   * Create a new builder for IndexDescription.
+   *
+   * @return a new builder
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String distanceType;
+    private String indexType;
+    private Long numIndexedRows;
+    private Long numUnindexedRows;
+
+    private Builder() {}
+
+    public Builder distanceType(String distanceType) {
+      this.distanceType = distanceType;
+      return this;
+    }
+
+    public Builder indexType(String indexType) {
+      this.indexType = indexType;
+      return this;
+    }
+
+    public Builder numIndexedRows(Long numIndexedRows) {
+      this.numIndexedRows = numIndexedRows;
+      return this;
+    }
+
+    public Builder numUnindexedRows(Long numUnindexedRows) {
+      this.numUnindexedRows = numUnindexedRows;
+      return this;
+    }
+
+    public IndexDescription build() {
+      return new IndexDescription(distanceType, indexType, numIndexedRows, numUnindexedRows);
+    }
+  }
+}

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -669,6 +669,49 @@ class LanceDataset(pa.dataset.Dataset):
         """Returns index information for all indices in the dataset."""
         return self._ds.describe_indices()
 
+    def describe_index(self, index_name: str) -> IndexDescription:
+        """
+        Returns index information for a specific index by name.
+
+        This is a convenience method that provides information about a single index
+        including its type, the number of rows indexed, and other metadata.
+
+        Parameters
+        ----------
+        index_name : str
+            The name of the index to describe.
+
+        Returns
+        -------
+        IndexDescription
+            An object containing metadata and statistics about the index.
+
+        Raises
+        ------
+        KeyError
+            If no index with the given name exists.
+
+        Examples
+        --------
+        >>> import lance
+        >>> dataset = lance.dataset("path/to/dataset")
+        >>> # Create an index
+        >>> dataset.create_index("id", "BTREE", name="id_index")
+        >>> # Describe the index
+        >>> desc = dataset.describe_index("id_index")
+        >>> print(f"Index type: {desc.index_type}")
+        >>> print(f"Rows indexed: {desc.num_rows_indexed}")
+
+        See Also
+        --------
+        describe_indices : Get information about all indices in the dataset.
+        """
+        indices = self.describe_indices()
+        for index in indices:
+            if index.name == index_name:
+                return index
+        raise KeyError(f"Index '{index_name}' not found")
+
     def index_statistics(self, index_name: str) -> Dict[str, Any]:
         warnings.warn(
             "LanceDataset.index_statistics() is deprecated, "

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -706,11 +706,7 @@ class LanceDataset(pa.dataset.Dataset):
         --------
         describe_indices : Get information about all indices in the dataset.
         """
-        indices = self.describe_indices()
-        for index in indices:
-            if index.name == index_name:
-                return index
-        raise KeyError(f"Index '{index_name}' not found")
+        return self._ds.describe_index(index_name)
 
     def index_statistics(self, index_name: str) -> Dict[str, Any]:
         warnings.warn(

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2650,6 +2650,22 @@ impl Dataset {
             .collect())
     }
 
+    #[pyo3(signature=(index_name))]
+    fn describe_index(&self, py: Python<'_>, index_name: &str) -> PyResult<PyIndexDescription> {
+        let new_self = self.ds.as_ref().clone();
+        let index = rt()
+            .block_on(Some(py), new_self.describe_index(index_name))?
+            .infer_error()?;
+        
+        match index {
+            Some(desc) => Ok(PyIndexDescription::new(desc.as_ref(), self.ds.as_ref())),
+            None => Err(PyKeyError::new_err(format!(
+                "Index '{}' not found",
+                index_name
+            ))),
+        }
+    }
+
     /// Create a delta builder to explore changes between dataset versions.
     #[pyo3(signature=())]
     fn delta(&self) -> PyResult<DatasetDeltaBuilder> {

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -255,6 +255,47 @@ pub trait DatasetIndexExt {
         criteria: Option<IndexCriteria<'b>>,
     ) -> Result<Vec<Arc<dyn IndexDescription>>>;
 
+    /// Describes a single index by name
+    ///
+    /// This is a convenience method that filters `describe_indices` to a single index.
+    ///
+    /// This method should only access the index metadata and should not load the index into memory.
+    ///
+    /// # Parameters
+    /// - `index_name`: the name of the index to describe
+    ///
+    /// # Returns
+    /// - `Ok(Some(description))`: if the index exists
+    /// - `Ok(None)`: if no index with the given name exists
+    /// - `Err(e)`: if there is an error loading index metadata
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use lance::dataset::Dataset;
+    /// use lance_index::DatasetIndexExt;
+    ///
+    /// # async fn example() -> lance_core::Result<()> {
+    /// let dataset = Dataset::open("path/to/dataset").await?;
+    /// 
+    /// if let Some(desc) = dataset.describe_index("my_index").await? {
+    ///     println!("Index name: {}", desc.name());
+    ///     println!("Index type: {}", desc.index_type());
+    ///     println!("Rows indexed: {}", desc.rows_indexed());
+    /// } else {
+    ///     println!("Index not found");
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn describe_index(
+        &self,
+        index_name: &str,
+    ) -> Result<Option<Arc<dyn IndexDescription>>> {
+        let indices = self.describe_indices(None).await?;
+        Ok(indices.into_iter().find(|idx| idx.name() == index_name))
+    }
+
     /// Loads a specific index with the given index name.
     async fn load_scalar_index<'a, 'b>(
         &'a self,

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -291,10 +291,7 @@ pub trait DatasetIndexExt {
     async fn describe_index(
         &self,
         index_name: &str,
-    ) -> Result<Option<Arc<dyn IndexDescription>>> {
-        let indices = self.describe_indices(None).await?;
-        Ok(indices.into_iter().find(|idx| idx.name() == index_name))
-    }
+    ) -> Result<Option<Arc<dyn IndexDescription>>>;
 
     /// Loads a specific index with the given index name.
     async fn load_scalar_index<'a, 'b>(

--- a/rust/lance/src/session/index_caches.rs
+++ b/rust/lance/src/session/index_caches.rs
@@ -103,6 +103,20 @@ impl CacheKey for IndexMetadataKey {
     }
 }
 
+#[derive(Debug)]
+pub struct IndexMetadataByNameKey<'a> {
+    pub version: u64,
+    pub name: &'a str,
+}
+
+impl CacheKey for IndexMetadataByNameKey<'_> {
+    type ValueType = Vec<IndexMetadata>;
+
+    fn key(&self) -> Cow<'_, str> {
+        Cow::Owned(format!("{}:{}", self.version, self.name))
+    }
+}
+
 pub struct ProstAny(pub Arc<prost_types::Any>);
 
 impl DeepSizeOf for ProstAny {


### PR DESCRIPTION
This pull request introduces a new "describe index" feature across the Rust, Java, and Python APIs, allowing users to retrieve detailed metadata and statistics about a specific index by name. The change includes the addition of a new `IndexDescription` class in Java, updates to the JNI and Rust layers to support the new API, and corresponding tests and documentation in all three languages.

The most important changes are:

**API Additions:**

* Added a `describeIndex(String indexName)` method to the Java `Dataset` class, which returns a new `IndexDescription` object containing metadata and statistics for a specific index. This is supported by a new native JNI method and Rust FFI implementation. [[1]](diffhunk://#diff-04a9577f49fc3c004aa755fb15f03deb8865ce55e997a64a7a27e03a9ea86e07R985-R1005) [[2]](diffhunk://#diff-b3c4207806ed8561d35f7940d9ad9d4535be8861b774165ff2bb69b7a54b1f79R2505-R2649)
* Introduced a `describe_index(self, index_name: str)` method to the Python `LanceDataset` class, providing similar functionality for Python users. [[1]](diffhunk://#diff-3c0e591b6a64801b9e3f92380ab99c1546e03faaa769b6de4b37af58d95c588cR672-R714) [[2]](diffhunk://#diff-31492cb9a22ac40a820049c18a44ac88f651a5d0d7115fc09386899ab95f0c10R2653-R2668)
* Added a `describe_index` method to the Rust `DatasetIndexExt` trait, enabling retrieval of a single index's metadata without loading the full index.

**New Data Structures:**

* Implemented a new `IndexDescription` class in Java to encapsulate index metadata (type, distance metric, indexed/unindexed row counts) with a builder pattern for construction.

**Testing and Validation:**

* Added comprehensive tests for the new describe index functionality in Rust, Java, and Python to ensure correct behavior and error handling when describing existing and non-existent indices. [[1]](diffhunk://#diff-5377e74fdf73c8319af865fbcccd11b1276644c6afde7e1853e9a0995c943edfR2467-R2546) [[2]](diffhunk://#diff-9ea36460f24d3b368f9b6ea9ae43f9b79515089fb911438720b17309922f1e51R367-R402) [[3]](diffhunk://#diff-a95edaddaa3a260e498c04e10f073261bdc529cd4f47b928ad80274754af0548R4197-R4239)

**Documentation and Imports:**

* Updated imports and documentation to reflect the new API and data structures in both Java and Python. [[1]](diffhunk://#diff-04a9577f49fc3c004aa755fb15f03deb8865ce55e997a64a7a27e03a9ea86e07R21) [[2]](diffhunk://#diff-9ea36460f24d3b368f9b6ea9ae43f9b79515089fb911438720b17309922f1e51R17)

These changes make it much easier for users to programmatically inspect the properties and coverage of individual indices in a Lance dataset.

Fixed: #5553 