### PR TITLE
feat: parse Ref from version and version numbers

### DIFF
--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -234,7 +234,7 @@ impl DatasetBuilder {
 
     /// Sets `version` for the builder using a tag
     pub fn with_tag(mut self, tag: &str) -> Self {
-        self.version = Some(Ref::from(tag));
+        self.version = Some(Ref::Tag(tag.to_string()));
         self
     }
 

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -280,6 +280,13 @@ impl Tags<'_> {
                 message: format!("tag {} already exists", tag),
             });
         }
+
+        let branch_file = branch_contents_path(&root_location.path, tag);
+        if self.object_store().exists(&branch_file).await? {
+            return Err(Error::RefConflict {
+                message: format!("tag {} conflicts with existing branch", tag),
+            });
+        }
         let tag_contents = self.build_tag_content_by_ref(reference).await?;
 
         self.object_store()
@@ -314,6 +321,13 @@ impl Tags<'_> {
         if !self.object_store().exists(&tag_file).await? {
             return Err(Error::RefNotFound {
                 message: format!("tag {} does not exist", tag),
+            });
+        }
+
+        let branch_file = branch_contents_path(&root_location.path, tag);
+        if self.object_store().exists(&branch_file).await? {
+            return Err(Error::RefConflict {
+                message: format!("tag {} conflicts with existing branch", tag),
             });
         }
         let tag_contents = self.build_tag_content_by_ref(reference).await?;
@@ -452,6 +466,13 @@ impl Branches<'_> {
 
         let source_branch = source_branch.and_then(standardize_branch);
         let root_location = self.refs.root()?;
+
+        let tag_file = tag_path(&root_location.path, branch_name);
+        if self.object_store().exists(&tag_file).await? {
+            return Err(Error::RefConflict {
+                message: format!("branch {} conflicts with existing tag", branch_name),
+            });
+        }
         let branch_file = branch_contents_path(&root_location.path, branch_name);
         if self.object_store().exists(&branch_file).await? {
             return Err(Error::RefConflict {

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -25,7 +25,7 @@ use std::io::ErrorKind;
 pub const MAIN_BRANCH: &str = "main";
 
 /// Lance Ref
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Ref {
     // Version number points of the current branch
     VersionNumber(u64),
@@ -35,6 +35,65 @@ pub enum Ref {
     Version(Option<String>, Option<u64>),
     // Tag name points to the global version identifier, could be considered as an alias of specific global version
     Tag(String),
+}
+
+impl std::str::FromStr for Ref {
+    type Err = Error;
+
+    fn from_str(reference: &str) -> std::result::Result<Self, Self::Err> {
+        let reference = reference.trim();
+        if reference.is_empty() {
+            return Err(Error::InvalidRef {
+                message: "Ref cannot be empty".to_string(),
+            });
+        }
+
+        if let Some((branch, version)) = reference.split_once(':') {
+            if branch.is_empty() {
+                return Err(Error::InvalidRef {
+                    message: "Branch name cannot be empty".to_string(),
+                });
+            }
+
+            let branch = if branch == MAIN_BRANCH {
+                None
+            } else {
+                check_valid_branch(branch)?;
+                Some(branch.to_string())
+            };
+
+            let version = match version {
+                "" | "latest" => None,
+                v => {
+                    let v = v.parse::<u64>().map_err(|e| Error::InvalidRef {
+                        message: format!("Failed to parse version number '{}': {}", v, e),
+                    })?;
+                    Some(v)
+                }
+            };
+
+            return Ok(Self::Version(branch, version));
+        }
+
+        if reference == MAIN_BRANCH {
+            return Ok(Self::Version(None, None));
+        }
+
+        if reference.chars().all(|c| c.is_ascii_digit()) {
+            let v = reference.parse::<u64>().map_err(|e| Error::InvalidRef {
+                message: format!("Failed to parse version number '{}': {}", reference, e),
+            })?;
+            return Ok(Self::VersionNumber(v));
+        }
+
+        if reference.contains('/') {
+            check_valid_branch(reference)?;
+            return Ok(Self::Version(Some(reference.to_string()), None));
+        }
+
+        check_valid_tag(reference)?;
+        Ok(Self::Tag(reference.to_string()))
+    }
 }
 
 impl From<u64> for Ref {
@@ -792,6 +851,41 @@ mod tests {
     use datafusion::common::assert_contains;
 
     use rstest::rstest;
+
+    #[rstest]
+    fn test_parse_ref_ok(
+        #[values(
+            ("0", Ref::VersionNumber(0)),
+            ("42", Ref::VersionNumber(42)),
+            ("main", Ref::Version(None, None)),
+            ("main:", Ref::Version(None, None)),
+            ("main:latest", Ref::Version(None, None)),
+            ("main:10", Ref::Version(None, Some(10))),
+            ("feature/a", Ref::Version(Some("feature/a".to_string()), None)),
+            ("feature/a:", Ref::Version(Some("feature/a".to_string()), None)),
+            ("feature/a:latest", Ref::Version(Some("feature/a".to_string()), None)),
+            ("feature/a:10", Ref::Version(Some("feature/a".to_string()), Some(10))),
+            ("tag1", Ref::Tag("tag1".to_string()))
+    )]
+        (input, expected): (&str, Ref),
+    ) {
+        assert_eq!(input.parse::<Ref>().unwrap(), expected);
+    }
+
+    #[rstest]
+    fn test_parse_ref_err(
+        #[values(
+            "",
+            ":",
+            ":10",
+            "main:bad",
+            "/start-with-slash",
+            "feature//double-slash"
+        )]
+        input: &str,
+    ) {
+        assert!(input.parse::<Ref>().is_err());
+    }
 
     #[rstest]
     fn test_ok_ref(

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -86,7 +86,7 @@ impl From<&str> for Ref {
 
 impl From<String> for Ref {
     fn from(reference: String) -> Self {
-        Ref::from(reference.as_str())
+        Self::from(reference.as_str())
     }
 }
 

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -37,65 +37,6 @@ pub enum Ref {
     Tag(String),
 }
 
-impl std::str::FromStr for Ref {
-    type Err = Error;
-
-    fn from_str(reference: &str) -> std::result::Result<Self, Self::Err> {
-        let reference = reference.trim();
-        if reference.is_empty() {
-            return Err(Error::InvalidRef {
-                message: "Ref cannot be empty".to_string(),
-            });
-        }
-
-        if let Some((branch, version)) = reference.split_once(':') {
-            if branch.is_empty() {
-                return Err(Error::InvalidRef {
-                    message: "Branch name cannot be empty".to_string(),
-                });
-            }
-
-            let branch = if branch == MAIN_BRANCH {
-                None
-            } else {
-                check_valid_branch(branch)?;
-                Some(branch.to_string())
-            };
-
-            let version = match version {
-                "" | "latest" => None,
-                v => {
-                    let v = v.parse::<u64>().map_err(|e| Error::InvalidRef {
-                        message: format!("Failed to parse version number '{}': {}", v, e),
-                    })?;
-                    Some(v)
-                }
-            };
-
-            return Ok(Self::Version(branch, version));
-        }
-
-        if reference == MAIN_BRANCH {
-            return Ok(Self::Version(None, None));
-        }
-
-        if reference.chars().all(|c| c.is_ascii_digit()) {
-            let v = reference.parse::<u64>().map_err(|e| Error::InvalidRef {
-                message: format!("Failed to parse version number '{}': {}", reference, e),
-            })?;
-            return Ok(Self::VersionNumber(v));
-        }
-
-        if reference.contains('/') {
-            check_valid_branch(reference)?;
-            return Ok(Self::Version(Some(reference.to_string()), None));
-        }
-
-        check_valid_tag(reference)?;
-        Ok(Self::Tag(reference.to_string()))
-    }
-}
-
 impl From<u64> for Ref {
     fn from(reference: u64) -> Self {
         VersionNumber(reference)
@@ -104,7 +45,48 @@ impl From<u64> for Ref {
 
 impl From<&str> for Ref {
     fn from(reference: &str) -> Self {
+        let reference = reference.trim();
+        if let Some((branch, version)) = reference.split_once(':') {
+            if branch.is_empty() {
+                return Tag(reference.to_string());
+            }
+
+            let branch = if branch == MAIN_BRANCH {
+                None
+            } else if check_valid_branch(branch).is_ok() {
+                Some(branch.to_string())
+            } else {
+                return Tag(reference.to_string());
+            };
+
+            let version = match version {
+                "" | "latest" => None,
+                v => match v.parse::<u64>() {
+                    Ok(v) => Some(v),
+                    Err(_) => return Tag(reference.to_string()),
+                },
+            };
+
+            return Version(branch, version);
+        }
+
+        if reference == MAIN_BRANCH {
+            return Version(None, None);
+        }
+
+        if reference.chars().all(|c| c.is_ascii_digit()) {
+            if let Ok(v) = reference.parse::<u64>() {
+                return VersionNumber(v);
+            }
+        }
+
         Tag(reference.to_string())
+    }
+}
+
+impl From<String> for Ref {
+    fn from(reference: String) -> Self {
+        Ref::from(reference.as_str())
     }
 }
 
@@ -882,7 +864,6 @@ mod tests {
             ("main:", Ref::Version(None, None)),
             ("main:latest", Ref::Version(None, None)),
             ("main:10", Ref::Version(None, Some(10))),
-            ("feature/a", Ref::Version(Some("feature/a".to_string()), None)),
             ("feature/a:", Ref::Version(Some("feature/a".to_string()), None)),
             ("feature/a:latest", Ref::Version(Some("feature/a".to_string()), None)),
             ("feature/a:10", Ref::Version(Some("feature/a".to_string()), Some(10))),
@@ -890,22 +871,23 @@ mod tests {
     )]
         (input, expected): (&str, Ref),
     ) {
-        assert_eq!(input.parse::<Ref>().unwrap(), expected);
+        assert_eq!(Ref::from(input), expected);
     }
 
     #[rstest]
-    fn test_parse_ref_err(
+    fn test_ref_from_str_invalid_syntax_falls_back_to_tag(
         #[values(
             "",
             ":",
             ":10",
             "main:bad",
+            "feature/a",
             "/start-with-slash",
             "feature//double-slash"
         )]
         input: &str,
     ) {
-        assert!(input.parse::<Ref>().is_err());
+        assert_eq!(Ref::from(input), Ref::Tag(input.trim().to_string()));
     }
 
     #[rstest]

--- a/rust/lance/src/dataset/tests/dataset_versioning.rs
+++ b/rust/lance/src/dataset/tests/dataset_versioning.rs
@@ -366,6 +366,59 @@ async fn test_tag(
     assert_eq!(dataset.manifest.version, 1);
 }
 
+#[tokio::test]
+async fn test_tag_branch_name_conflict() {
+    let test_uri = TempStrDir::default();
+
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "i",
+        DataType::UInt32,
+        false,
+    )]));
+
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(UInt32Array::from_iter_values(0..10))],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![data].into_iter().map(Ok), schema);
+    let mut dataset = Dataset::write(reader, &test_uri, None).await.unwrap();
+
+    dataset
+        .create_branch("conflict", dataset.version().version, None)
+        .await
+        .unwrap();
+
+    let err = dataset
+        .tags()
+        .create("conflict", dataset.version().version)
+        .await
+        .err()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        err,
+        "Ref conflict error: tag conflict conflicts with existing branch"
+    );
+
+    dataset
+        .tags()
+        .create("tag_conflict", dataset.version().version)
+        .await
+        .unwrap();
+
+    let err = dataset
+        .create_branch("tag_conflict", dataset.version().version, None)
+        .await
+        .err()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        err,
+        "Ref conflict error: branch tag_conflict conflicts with existing tag"
+    );
+}
+
 #[rstest]
 #[tokio::test]
 async fn test_fragment_id_zero_not_reused() {


### PR DESCRIPTION
This PR allows users to parse a str into `Ref`.

For example:

```rust
("0", Ref::VersionNumber(0)),
("42", Ref::VersionNumber(42)),
("main", Ref::Version(None, None)),
("main:", Ref::Version(None, None)),
("main:latest", Ref::Version(None, None)),
("main:10", Ref::Version(None, Some(10))),
("feature/a", Ref::Version(Some("feature/a".to_string()), None)),
("feature/a:", Ref::Version(Some("feature/a".to_string()), None)),
("feature/a:latest", Ref::Version(Some("feature/a".to_string()), None)),
("feature/a:10", Ref::Version(Some("feature/a".to_string()), Some(10))),
("tag1", Ref::Tag("tag1".to_string()))
```

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**