### PR TITLE
feat: add backtraces to internal errors to improve debugging

### DIFF
--- a/python/src/dataset/commit.rs
+++ b/python/src/dataset/commit.rs
@@ -15,10 +15,8 @@
 use std::fmt::Debug;
 use std::sync::LazyLock;
 
-use lance_table::io::commit::{CommitError, CommitLease, CommitLock};
-use snafu::location;
-
 use lance_core::Error;
+use lance_table::io::commit::{CommitError, CommitLease, CommitLock};
 
 use pyo3::{exceptions::PyIOError, prelude::*};
 
@@ -35,20 +33,20 @@ fn handle_error(py_err: PyErr, py: Python) -> CommitError {
     let conflict_err_type = match &*PY_CONFLICT_ERROR {
         Ok(err) => err.bind(py).get_type(),
         Err(import_error) => {
-            return CommitError::OtherError(Error::Internal {
-                message: format!("Error importing from pylance {}", import_error),
-                location: location!(),
-            })
+            return CommitError::OtherError(Error::internal(format!(
+                "Error importing from pylance {}",
+                import_error
+            )))
         }
     };
 
     if py_err.is_instance(py, &conflict_err_type) {
         CommitError::CommitConflict
     } else {
-        CommitError::OtherError(Error::Internal {
-            message: format!("Error from commit handler: {}", py_err),
-            location: location!(),
-        })
+        CommitError::OtherError(Error::internal(format!(
+            "Error from commit handler: {}",
+            py_err
+        )))
     }
 }
 

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -34,7 +34,6 @@ use pyo3::basic::CompareOp;
 use pyo3::types::PyTuple;
 use pyo3::{exceptions::*, types::PyDict};
 use pyo3::{intern, prelude::*};
-use snafu::location;
 
 use crate::dataset::{get_write_params, transforms_from_python, PyWriteDest};
 use crate::error::PythonErrorExt;
@@ -428,10 +427,7 @@ pub fn write_fragments(
     let get_fragments = |operation| match operation {
         Operation::Overwrite { fragments, .. } => Ok(fragments),
         Operation::Append { fragments, .. } => Ok(fragments),
-        _ => Err(Error::Internal {
-            message: "Unexpected operation".into(),
-            location: location!(),
-        }),
+        _ => Err(Error::internal("Unexpected operation")),
     };
     let fragments =
         get_fragments(written.operation).map_err(|err| PyRuntimeError::new_err(err.to_string()))?;

--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -12,7 +12,6 @@ use std::sync::{
 
 use futures::{Future, FutureExt};
 use moka::future::Cache;
-use snafu::location;
 
 use crate::Result;
 
@@ -251,10 +250,9 @@ impl LanceCache {
                 // The loader returned an error, retrieve it from the channel
                 match error_rx.await {
                     Ok(err) => Err(err),
-                    Err(_) => Err(crate::Error::Internal {
-                        message: "Failed to retrieve error from cache loader".into(),
-                        location: location!(),
-                    }),
+                    Err(_) => Err(crate::Error::internal(
+                        "Failed to receive error from cache loader",
+                    )),
                 }
             }
         }
@@ -449,10 +447,9 @@ impl WeakLanceCache {
                     // Init returned None, which means there was an error
                     match error_rx.await {
                         Ok(e) => Err(e),
-                        Err(_) => Err(crate::Error::Internal {
-                            message: "Failed to receive error from cache init function".to_string(),
-                            location: location!(),
-                        }),
+                        Err(_) => Err(crate::Error::internal(
+                            "Failed to receive error from cache init function",
+                        )),
                     }
                 }
             }

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -640,13 +640,10 @@ impl Schema {
         // Validate this addition does not create any duplicate field names
         let field_names = self.fields.iter().map(|f| &f.name).collect::<HashSet<_>>();
         if field_names.len() != self.fields.len() {
-            Err(Error::Internal {
-                message: format!(
-                    "Attempt to add fields [{:?}] would lead to duplicate field names",
-                    fields.iter().map(|f| f.name()).collect::<Vec<_>>()
-                ),
-                location: location!(),
-            })
+            Err(Error::internal(format!(
+                "Attempt to add fields [{:?}] would lead to duplicate field names",
+                fields.iter().map(|f| f.name()).collect::<Vec<_>>()
+            )))
         } else {
             Ok(())
         }

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -6,6 +6,10 @@ use snafu::{Location, Snafu};
 
 type BoxedError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+mod internal;
+
+pub use internal::InternalError;
+
 /// Allocates error on the heap and then places `e` into it.
 #[inline]
 pub fn box_error(e: impl std::error::Error + Send + Sync + 'static) -> BoxedError {
@@ -59,8 +63,8 @@ pub enum Error {
     },
     #[snafu(display("Too many concurrent writers. {message}, {location}"))]
     TooMuchWriteContention { message: String, location: Location },
-    #[snafu(display("Encountered internal error. Please file a bug report at https://github.com/lance-format/lance/issues. {message}, {location}"))]
-    Internal { message: String, location: Location },
+    #[snafu(transparent)]
+    Internal { source: InternalError },
     #[snafu(display("A prerequisite task failed: {message}, {location}"))]
     PrerequisiteFailed { message: String, location: Location },
     #[snafu(display("Unprocessable: {message}, {location}"))]
@@ -121,6 +125,16 @@ pub enum Error {
 }
 
 impl Error {
+    pub fn internal(message: impl Into<String>) -> Self {
+        let message: String = message.into();
+        Self::Internal {
+            source: InternalError {
+                message,
+                backtrace: std::backtrace::Backtrace::force_capture(),
+            },
+        }
+    }
+
     pub fn corrupt_file(
         path: object_store::path::Path,
         message: impl Into<String>,
@@ -176,11 +190,7 @@ pub trait LanceOptionExt<T> {
 impl<T> LanceOptionExt<T> for Option<T> {
     #[track_caller]
     fn expect_ok(self) -> Result<T> {
-        let location = std::panic::Location::caller().to_snafu_location();
-        self.ok_or_else(|| Error::Internal {
-            message: "Expected option to have value".to_string(),
-            location,
-        })
+        self.ok_or_else(|| Error::internal("Expected option to have value"))
     }
 }
 

--- a/rust/lance-core/src/error/internal.rs
+++ b/rust/lance-core/src/error/internal.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+#[derive(Debug)]
+pub struct InternalError {
+    pub message: String,
+    pub backtrace: std::backtrace::Backtrace,
+}
+
+impl std::error::Error for InternalError {}
+
+impl std::fmt::Display for InternalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "InternalError: Please file a bug report at https://github.com/lance-format/lance/issues."
+        )?;
+        write!(f, "{}\nBacktrace:\n{}", self.message, self.backtrace)
+    }
+}

--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -13,7 +13,6 @@ use deepsize::DeepSizeOf;
 use itertools::Itertools;
 use roaring::{MultiOps, RoaringBitmap, RoaringTreemap};
 
-use crate::error::ToSnafuLocation;
 use crate::{Error, Result};
 
 use super::address::RowAddress;
@@ -609,12 +608,9 @@ impl RowAddrTreeMap {
                 .peeking_take_while(|row_id| (row_id >> 32) as u32 == fragment_id)
                 .map(|row_id| row_id as u32);
             let Ok(bitmap) = RoaringBitmap::from_sorted_iter(next_bitmap_iter) else {
-                return Err(Error::Internal {
-                    message: "RowAddrTreeMap::from_sorted_iter called with non-sorted input"
-                        .to_string(),
-                    // Use the caller location since we aren't the one that got it out of order
-                    location: std::panic::Location::caller().to_snafu_location(),
-                });
+                return Err(Error::internal(
+                    "RowAddrTreeMap::from_sorted_iter called with non-sorted input",
+                ));
             };
             inner.insert(fragment_id, RowAddrSelection::Partial(bitmap));
         }

--- a/rust/lance-datafusion/src/projection.rs
+++ b/rust/lance-datafusion/src/projection.rs
@@ -443,10 +443,7 @@ impl ProjectionPlan {
         )?;
         let batches = stream.try_collect::<Vec<_>>().await?;
         if batches.len() != 1 {
-            Err(Error::Internal {
-                message: "Expected exactly one batch".to_string(),
-                location: location!(),
-            })
+            Err(Error::internal("Expected exactly one batch"))
         } else {
             Ok(batches.into_iter().next().unwrap())
         }

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -29,7 +29,6 @@ use arrow_buffer::{ArrowNativeType, BooleanBuffer, BooleanBufferBuilder, NullBuf
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::DataType;
 use lance_arrow::DataTypeExt;
-use snafu::location;
 
 use lance_core::{Error, Result};
 
@@ -652,10 +651,10 @@ impl StructDataBlock {
                 Ok(unsafe { builder.build_unchecked() })
             }
         } else {
-            Err(Error::Internal {
-                message: format!("Expected Struct, got {:?}", data_type),
-                location: location!(),
-            })
+            Err(Error::internal(format!(
+                "Expected Struct, got {:?}",
+                data_type
+            )))
         }
     }
 
@@ -734,13 +733,10 @@ impl DictionaryDataBlock {
             16 => self.decode_helper::<UInt16Type>(),
             32 => self.decode_helper::<UInt32Type>(),
             64 => self.decode_helper::<UInt64Type>(),
-            _ => Err(lance_core::Error::Internal {
-                message: format!(
-                    "Unsupported dictionary index bit width: {} bits",
-                    self.indices.bits_per_value
-                ),
-                location: location!(),
-            }),
+            _ => Err(lance_core::Error::internal(format!(
+                "Unsupported dictionary index bit width: {} bits",
+                self.indices.bits_per_value
+            ))),
         }
     }
 
@@ -834,10 +830,7 @@ impl DataBlock {
             Self::VariableWidth(inner) => inner.into_arrow(data_type, validate),
             Self::Struct(inner) => inner.into_arrow(data_type, validate),
             Self::Dictionary(inner) => inner.into_arrow(data_type, validate),
-            Self::Opaque(_) => Err(Error::Internal {
-                message: "Cannot convert OpaqueBlock to Arrow".to_string(),
-                location: location!(),
-            }),
+            Self::Opaque(_) => Err(Error::internal("Cannot convert OpaqueBlock to Arrow")),
         }
     }
 

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -2499,13 +2499,7 @@ impl NextDecodeTask {
                 }
                 Ok(batch)
             }
-            Err(e) => {
-                let e = Error::Internal {
-                    message: format!("Error decoding batch: {}", e),
-                    location: location!(),
-                };
-                Err(e)
-            }
+            Err(e) => Err(Error::internal(format!("Error decoding batch: {}", e))),
         }
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -90,11 +90,9 @@ impl BlobStructuralEncoder {
                     let encoded_page = encoded_page?;
 
                     let PageEncoding::Structural(inner_layout) = encoded_page.description else {
-                        return Err(Error::Internal {
-                            message: "Expected inner encoding to return structural layout"
-                                .to_string(),
-                            location: location!(),
-                        });
+                        return Err(Error::internal(
+                            "Expected inner encoding to return structural layout",
+                        ));
                     };
 
                     let wrapped = ProtobufUtils21::blob_layout(inner_layout, &def_meaning);

--- a/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
@@ -15,7 +15,6 @@ use arrow_schema::DataType;
 use futures::future::BoxFuture;
 use lance_arrow::deepcopy::deep_copy_nulls;
 use lance_core::{Error, Result};
-use snafu::location;
 
 use crate::{
     decoder::{
@@ -54,12 +53,9 @@ impl FieldEncoder for FixedSizeListStructuralEncoder {
         row_number: u64,
         num_rows: u64,
     ) -> Result<Vec<EncodeTask>> {
-        let fsl_arr = array
-            .as_fixed_size_list_opt()
-            .ok_or_else(|| Error::Internal {
-                message: "FixedSizeList encoder used for non-fixed-size-list data".to_string(),
-                location: location!(),
-            })?;
+        let fsl_arr = array.as_fixed_size_list_opt().ok_or_else(|| {
+            Error::internal("FixedSizeList encoder used for non-fixed-size-list data")
+        })?;
 
         let dimension = fsl_arr.value_length() as usize;
         let values = fsl_arr.values().clone();
@@ -210,10 +206,9 @@ impl StructuralFieldDecoder for StructuralFixedSizeListDecoder {
         let dimension = match &self.data_type {
             DataType::FixedSizeList(_, d) => *d as u64,
             _ => {
-                return Err(Error::Internal {
-                    message: "FixedSizeListDecoder has non-FSL data type".to_string(),
-                    location: location!(),
-                });
+                return Err(Error::internal(
+                    "FixedSizeListDecoder has non-FSL data type",
+                ));
             }
         };
         let child_task = self.child.drain(num_rows * dimension)?;
@@ -268,10 +263,9 @@ impl StructuralDecodeArrayTask for StructuralFixedSizeListDecodeTask {
                     repdef,
                 })
             }
-            _ => Err(Error::Internal {
-                message: "FixedSizeList decoder did not have a fixed-size list field".to_string(),
-                location: location!(),
-            }),
+            _ => Err(Error::internal(
+                "FixedSizeList decoder did not have a fixed-size list field",
+            )),
         }
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -605,13 +605,10 @@ impl DecodePageTask for DecodeMiniBlockTask {
                 instructions.preamble_action,
             );
             if item_range.end - item_range.start > chunk.items_in_chunk {
-                return Err(lance_core::Error::Internal {
-                    message: format!(
-                        "Item range {:?} is greater than chunk items in chunk {:?}",
-                        item_range, chunk.items_in_chunk
-                    ),
-                    location: location!(),
-                });
+                return Err(lance_core::Error::internal(format!(
+                    "Item range {:?} is greater than chunk items in chunk {:?}",
+                    item_range, chunk.items_in_chunk
+                )));
             }
 
             // Now we append the data to the output buffers
@@ -629,13 +626,10 @@ impl DecodePageTask for DecodeMiniBlockTask {
         if let Some(dictionary) = &self.dictionary_data {
             // Don't decode here, that happens later (if needed)
             let DataBlock::FixedWidth(indices) = data else {
-                return Err(lance_core::Error::Internal {
-                    message: format!(
-                        "Expected FixedWidth DataBlock for dictionary indices, got {:?}",
-                        data
-                    ),
-                    location: location!(),
-                });
+                return Err(lance_core::Error::internal(format!(
+                    "Expected FixedWidth DataBlock for dictionary indices, got {:?}",
+                    data
+                )));
             };
             data = DataBlock::Dictionary(DictionaryDataBlock::from_parts(
                 indices,
@@ -2023,10 +2017,9 @@ impl FullZipScheduler {
             PerValueDecompressor::Fixed(decompressor) => {
                 let bits_per_value = decompressor.bits_per_value();
                 if bits_per_value == 0 {
-                    return Err(lance_core::Error::Internal {
-                        message: "Invalid encoding: bits_per_value must be greater than 0".into(),
-                        location: location!(),
-                    });
+                    return Err(lance_core::Error::internal(
+                        "Invalid encoding: bits_per_value must be greater than 0",
+                    ));
                 }
                 if bits_per_value % 8 != 0 {
                     return Err(lance_core::Error::NotSupported {

--- a/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
@@ -140,23 +140,18 @@ impl DecodePageTask for BlobDescriptionDecodePageTask {
 
         // Need to extract out the repdef information
         let DataBlock::Struct(descriptions) = &decoded.data else {
-            return Err(Error::Internal {
-                message: "Expected struct data block for descriptions".into(),
-                location: location!(),
-            });
+            return Err(Error::internal(
+                "Expected struct data block for descriptions",
+            ));
         };
         let mut description_children = descriptions.children.iter();
         let DataBlock::FixedWidth(positions) = description_children.next().expect_ok()? else {
-            return Err(Error::Internal {
-                message: "Expected fixed width data block for positions".into(),
-                location: location!(),
-            });
+            return Err(Error::internal(
+                "Expected fixed width data block for positions",
+            ));
         };
         let DataBlock::FixedWidth(sizes) = description_children.next().expect_ok()? else {
-            return Err(Error::Internal {
-                message: "Expected fixed width data block for sizes".into(),
-                location: location!(),
-            });
+            return Err(Error::internal("Expected fixed width data block for sizes"));
         };
         let positions = positions.data.borrow_to_typed_slice::<u64>();
         let sizes = sizes.data.borrow_to_typed_slice::<u64>();

--- a/rust/lance-encoding/src/encodings/logical/primitive/dict.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/dict.rs
@@ -105,10 +105,10 @@ pub fn normalize_dict_nulls(array: Arc<dyn Array>) -> Result<Arc<dyn Array>> {
                 location: location!(),
             }),
         },
-        _ => Err(Error::Internal {
-            message: format!("Data type is not a dictionary: {}", array.data_type()),
-            location: location!(),
-        }),
+        _ => Err(Error::internal(format!(
+            "Data type is not a dictionary: {}",
+            array.data_type()
+        ))),
     }
 }
 

--- a/rust/lance-encoding/src/encodings/physical/block.rs
+++ b/rust/lance-encoding/src/encodings/physical/block.rs
@@ -186,10 +186,7 @@ mod zstd {
                         .map_err(|e| e.to_string())
                 })
                 .as_ref()
-                .map_err(|e| Error::Internal {
-                    message: format!("Failed to create zstd compressor: {}", e),
-                    location: location!(),
-                })
+                .map_err(|e| Error::internal(format!("Failed to create zstd compressor: {}", e)))
         }
 
         // https://datatracker.ietf.org/doc/html/rfc8878
@@ -262,10 +259,7 @@ mod zstd {
                 .lock()
                 .unwrap()
                 .compress_to_buffer(input_buf, &mut output_buf[start_pos..])
-                .map_err(|e| Error::Internal {
-                    message: format!("Zstd compression error: {}", e),
-                    location: location!(),
-                })?;
+                .map_err(|e| Error::internal(format!("Zstd compression error: {}", e)))?;
 
             output_buf.truncate(start_pos + compressed_size);
             Ok(())
@@ -318,10 +312,7 @@ mod lz4 {
                 true,
                 &mut output_buf[start_pos..],
             )
-            .map_err(|err| Error::Internal {
-                message: format!("LZ4 compression error: {}", err),
-                location: location!(),
-            })?;
+            .map_err(|err| Error::internal(format!("LZ4 compression error: {}", err)))?;
 
             // Truncate to actual size
             output_buf.truncate(start_pos + compressed_size);
@@ -332,10 +323,7 @@ mod lz4 {
             // When prepend_size is true, LZ4 stores the uncompressed size in the first 4 bytes
             // We can read this to know exactly how much space we need
             if input_buf.len() < 4 {
-                return Err(Error::Internal {
-                    message: "LZ4 compressed data too short".to_string(),
-                    location: location!(),
-                });
+                return Err(Error::internal("LZ4 compressed data too short"));
             }
 
             // Read the uncompressed size from the first 4 bytes (little-endian)
@@ -352,10 +340,7 @@ mod lz4 {
             // Now decompress directly into the buffer slice
             let decompressed_size =
                 ::lz4::block::decompress_to_buffer(input_buf, None, &mut output_buf[start_pos..])
-                    .map_err(|err| Error::Internal {
-                    message: format!("LZ4 decompression error: {}", err),
-                    location: location!(),
-                })?;
+                    .map_err(|err| Error::internal(format!("LZ4 decompression error: {}", err)))?;
 
             // Truncate to actual decompressed size (should be same as uncompressed_size)
             output_buf.truncate(start_pos + decompressed_size);
@@ -549,13 +534,10 @@ impl CompressedBufferEncoder {
 impl PerValueCompressor for CompressedBufferEncoder {
     fn compress(&self, data: DataBlock) -> Result<(PerValueDataBlock, CompressiveEncoding)> {
         let data_type = data.name();
-        let data = data.as_variable_width().ok_or(Error::Internal {
-            message: format!(
-                "Attempt to use CompressedBufferEncoder on data of type {}",
-                data_type
-            ),
-            location: location!(),
-        })?;
+        let data = data.as_variable_width().ok_or(Error::internal(format!(
+            "Attempt to use CompressedBufferEncoder on data of type {}",
+            data_type
+        )))?;
 
         let data_bytes = &data.data;
         let mut compressed = Vec::with_capacity(data_bytes.len());

--- a/rust/lance-encoding/src/previous/decoder.rs
+++ b/rust/lance-encoding/src/previous/decoder.rs
@@ -3,8 +3,6 @@
 
 use std::{collections::VecDeque, ops::Range};
 
-use snafu::location;
-
 use crate::decoder::{
     FilterExpression, NextDecodeTask, PriorityRange, ScheduledScanLine, SchedulerContext,
 };
@@ -106,13 +104,10 @@ pub trait LogicalPageDecoder: std::fmt::Debug + Send {
     /// The default implementation does not expect children and returns
     /// an error.
     fn accept_child(&mut self, _child: DecoderReady) -> Result<()> {
-        Err(Error::Internal {
-            message: format!(
-                "The decoder {:?} does not expect children but received a child",
-                self
-            ),
-            location: location!(),
-        })
+        Err(Error::internal(format!(
+            "The decoder {:?} does not expect children but received a child",
+            self
+        )))
     }
     /// Waits until at least `num_rows` have been loaded
     fn wait_for_loaded(&'_ mut self, loaded_need: u64) -> BoxFuture<'_, Result<()>>;

--- a/rust/lance-encoding/src/previous/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/primitive.rs
@@ -8,7 +8,6 @@ use arrow_buffer::bit_util;
 use arrow_schema::DataType;
 use futures::{future::BoxFuture, FutureExt};
 use log::trace;
-use snafu::location;
 
 use crate::decoder::{ColumnBuffers, PageBuffers};
 use crate::previous::decoder::{FieldScheduler, LogicalPageDecoder, SchedulingJob};
@@ -343,10 +342,7 @@ impl LogicalPageDecoder for PrimitiveFieldDecoder {
 
     fn drain(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
         if self.physical_decoder.as_ref().is_none() {
-            return Err(lance_core::Error::Internal {
-                message: format!("drain was called on primitive field decoder for data type {} on column {} but the decoder was never awaited", self.data_type, self.column_index),
-                location: location!(),
-            });
+            return Err(lance_core::Error::internal(format!("drain was called on primitive field decoder for data type {} on column {} but the decoder was never awaited", self.data_type, self.column_index)));
         }
 
         let rows_to_skip = self.rows_drained;
@@ -444,10 +440,10 @@ impl PrimitiveFieldEncoder {
         })
         .map(|res_res| {
             res_res.unwrap_or_else(|err| {
-                Err(Error::Internal {
-                    message: format!("Encoding task failed with error: {:?}", err),
-                    location: location!(),
-                })
+                Err(Error::internal(format!(
+                    "Encoding task failed with error: {:?}",
+                    err
+                )))
             })
         })
         .boxed())

--- a/rust/lance-encoding/src/previous/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/struct.rs
@@ -19,7 +19,6 @@ use arrow_schema::{DataType, Field, Fields};
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
 use lance_core::{Error, Result};
 use log::trace;
-use snafu::location;
 
 #[derive(Debug)]
 struct SchedulingJobWithStatus<'a> {
@@ -531,7 +530,7 @@ impl LogicalPageDecoder for SimpleStructDecoder {
                 .push_back(child.decoder);
         } else {
             // This decoder is intended for one of our children
-            let intended = self.children[child_idx as usize].scheduled.back_mut().ok_or_else(|| Error::Internal { message: format!("Decoder scheduled for child at index {} but we don't have any child at that index yet", child_idx), location: location!() })?;
+            let intended = self.children[child_idx as usize].scheduled.back_mut().ok_or_else(|| Error::internal(format!("Decoder scheduled for child at index {} but we don't have any child at that index yet", child_idx)))?;
             intended.accept_child(child)?;
         }
         Ok(())

--- a/rust/lance-file/src/previous/page_table.rs
+++ b/rust/lance-file/src/previous/page_table.rs
@@ -59,13 +59,10 @@ impl PageTable {
         num_batches: i32,
     ) -> Result<Self> {
         if max_field_id < min_field_id {
-            return Err(Error::Internal {
-                message: format!(
-                    "max_field_id {} is less than min_field_id {}",
-                    max_field_id, min_field_id
-                ),
-                location: location!(),
-            });
+            return Err(Error::internal(format!(
+                "max_field_id {} is less than min_field_id {}",
+                max_field_id, min_field_id
+            )));
         }
 
         let field_ids = min_field_id..=max_field_id;
@@ -291,7 +288,10 @@ mod tests {
         // Returns an error if max_field_id is less than min_field_id
         let res = PageTable::load(reader.as_ref(), res, 1, 0, 1).await;
         assert!(res.is_err());
-        assert!(matches!(res.unwrap_err(), Error::Internal { message, .. }
-                if message.contains("max_field_id 0 is less than min_field_id 1")));
+        let err = res.unwrap_err();
+        assert!(matches!(err, Error::Internal { .. }));
+        assert!(err
+            .to_string()
+            .contains("max_field_id 0 is less than min_field_id 1"));
     }
 }

--- a/rust/lance-file/src/previous/reader.rs
+++ b/rust/lance-file/src/previous/reader.rs
@@ -752,10 +752,9 @@ where
             positions.value(0).as_usize()..positions.value(range.end - range.start).as_usize(),
         ),
         ReadBatchParams::Ranges(_) => {
-            return Err(Error::Internal {
-                message: "ReadBatchParams::Ranges should not be used in v1 files".to_string(),
-                location: location!(),
-            })
+            return Err(Error::internal(
+                "ReadBatchParams::Ranges should not be used in v1 files",
+            ))
         }
         ReadBatchParams::RangeTo(RangeTo { end }) => {
             ReadBatchParams::from(..positions.value(*end).as_usize())

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -619,10 +619,9 @@ impl FileReader {
         let gbo_table =
             Self::decode_gbo_table(&tail_bytes, file_len, scheduler, &footer, file_version).await?;
         if gbo_table.is_empty() {
-            return Err(Error::Internal {
-                message: "File did not contain any global buffers, schema expected".to_string(),
-                location: location!(),
-            });
+            return Err(Error::internal(
+                "File did not contain any global buffers, schema expected",
+            ));
         }
         let schema_start = gbo_table[0].position;
         let schema_size = gbo_table[0].size;
@@ -1519,10 +1518,9 @@ impl EncodedBatchReaderExt for EncodedBatch {
             file_version,
         )?;
         if gbo_table.is_empty() {
-            return Err(Error::Internal {
-                message: "File did not contain any global buffers, schema expected".to_string(),
-                location: location!(),
-            });
+            return Err(Error::internal(
+                "File did not contain any global buffers, schema expected",
+            ));
         }
         let schema_start = gbo_table[0].position as usize;
         let schema_size = gbo_table[0].size as usize;

--- a/rust/lance-index/src/frag_reuse.rs
+++ b/rust/lance-index/src/frag_reuse.rs
@@ -370,9 +370,11 @@ impl Index for FragReuseIndex {
         let stats = FragReuseStatistics {
             num_versions: self.details.versions.len(),
         };
-        serde_json::to_value(stats).map_err(|e| Error::Internal {
-            message: format!("failed to serialize fragment reuse index statistics: {}", e),
-            location: location!(),
+        serde_json::to_value(stats).map_err(|e| {
+            Error::internal(format!(
+                "failed to serialize fragment reuse index statistics: {}",
+                e
+            ))
         })
     }
 

--- a/rust/lance-index/src/mem_wal.rs
+++ b/rust/lance-index/src/mem_wal.rs
@@ -272,9 +272,11 @@ impl Index for MemWalIndex {
             num_mem_wal: self.mem_wal_map.values().map(|m| m.len()).sum::<usize>() as u64,
             num_regions: self.mem_wal_map.len() as u64,
         };
-        serde_json::to_value(stats).map_err(|e| Error::Internal {
-            message: format!("failed to serialize MemWAL index statistics: {}", e),
-            location: location!(),
+        serde_json::to_value(stats).map_err(|e| {
+            Error::internal(format!(
+                "failed to serialize MemWAL index statistics: {}",
+                e
+            ))
         })
     }
 

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -216,10 +216,7 @@ impl BitmapIndex {
                 .column(0)
                 .as_any()
                 .downcast_ref::<BinaryArray>()
-                .ok_or_else(|| Error::Internal {
-                    message: "Invalid bitmap column type".to_string(),
-                    location: location!(),
-                })?;
+                .ok_or_else(|| Error::internal("Invalid bitmap column type"))?;
             let bitmap_bytes = binary_bitmaps.value(0);
             let mut bitmap = RowAddrTreeMap::deserialize_from(bitmap_bytes).unwrap();
 
@@ -277,10 +274,7 @@ impl BitmapIndex {
             .column(0)
             .as_any()
             .downcast_ref::<BinaryArray>()
-            .ok_or_else(|| Error::Internal {
-                message: "Invalid bitmap column type".to_string(),
-                location: location!(),
-            })?;
+            .ok_or_else(|| Error::internal("Invalid bitmap column type"))?;
         let bitmap_bytes = binary_bitmaps.value(0); // First (and only) row
         let mut bitmap = RowAddrTreeMap::deserialize_from(bitmap_bytes).unwrap();
 
@@ -386,9 +380,11 @@ impl Index for BitmapIndex {
         let stats = BitmapStatistics {
             num_bitmaps: self.index_map.len() + if !self.null_map.is_empty() { 1 } else { 0 },
         };
-        serde_json::to_value(stats).map_err(|e| Error::Internal {
-            message: format!("failed to serialize bitmap index statistics: {}", e),
-            location: location!(),
+        serde_json::to_value(stats).map_err(|e| {
+            Error::internal(format!(
+                "failed to serialize bitmap index statistics: {}",
+                e
+            ))
         })
     }
 
@@ -698,12 +694,8 @@ impl BitmapIndexPlugin {
         }
 
         // Finish file with metadata that allows lightweight statistics reads
-        let stats_json = serde_json::to_string(&BitmapStatistics { num_bitmaps }).map_err(|e| {
-            Error::Internal {
-                message: format!("failed to serialize bitmap statistics: {e}"),
-                location: location!(),
-            }
-        })?;
+        let stats_json = serde_json::to_string(&BitmapStatistics { num_bitmaps })
+            .map_err(|e| Error::internal(format!("failed to serialize bitmap statistics: {e}")))?;
         let mut metadata = HashMap::new();
         metadata.insert(INDEX_STATS_METADATA_KEY.to_string(), stats_json);
 
@@ -824,9 +816,8 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
     ) -> Result<Option<serde_json::Value>> {
         let reader = index_store.open_index_file(BITMAP_LOOKUP_NAME).await?;
         if let Some(value) = reader.schema().metadata.get(INDEX_STATS_METADATA_KEY) {
-            let stats = serde_json::from_str(value).map_err(|e| Error::Internal {
-                message: format!("failed to parse bitmap statistics metadata: {e}"),
-                location: location!(),
+            let stats = serde_json::from_str(value).map_err(|e| {
+                Error::internal(format!("failed to parse bitmap statistics metadata: {e}"))
             })?;
             Ok(Some(stats))
         } else {

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -902,13 +902,12 @@ impl LazyRangedIndexReader {
         &self,
         page_idx: u32,
     ) -> Result<(Arc<dyn IndexReader>, u32)> {
-        let (page_file_name, offset) =
-            self.ranges_to_files
-                .get(&page_idx)
-                .ok_or_else(|| Error::Internal {
-                    message: format!("Unexpected page index, index {} is out of range.", page_idx),
-                    location: location!(),
-                })?;
+        let (page_file_name, offset) = self.ranges_to_files.get(&page_idx).ok_or_else(|| {
+            Error::internal(format!(
+                "Unexpected page index, index {} is out of range.",
+                page_idx
+            ))
+        })?;
         let reader = self.get_reader(page_file_name).await?;
         Ok((reader.clone(), page_idx - *offset))
     }
@@ -1417,10 +1416,9 @@ impl Index for BTreeIndex {
                 .await;
 
             if !inserted {
-                return Err(Error::Internal {
-                    message: "Failed to prewarm index: cache is no longer available".to_string(),
-                    location: location!(),
-                });
+                return Err(Error::internal(
+                    "Failed to prewarm index: cache is no longer available",
+                ));
             }
         }
 
@@ -1607,20 +1605,12 @@ struct BatchStats {
 fn analyze_batch(batch: &RecordBatch) -> Result<BatchStats> {
     let values = batch.column_by_name(VALUE_COLUMN_NAME).expect_ok()?;
     if values.is_empty() {
-        return Err(Error::Internal {
-            message: "received an empty batch in btree training".to_string(),
-            location: location!(),
-        });
+        return Err(Error::internal("received an empty batch in btree training"));
     }
-    let min = ScalarValue::try_from_array(&values, 0).map_err(|e| Error::Internal {
-        message: format!("failed to get min value from batch: {}", e),
-        location: location!(),
-    })?;
-    let max =
-        ScalarValue::try_from_array(&values, values.len() - 1).map_err(|e| Error::Internal {
-            message: format!("failed to get max value from batch: {}", e),
-            location: location!(),
-        })?;
+    let min = ScalarValue::try_from_array(&values, 0)
+        .map_err(|e| Error::internal(format!("failed to get min value from batch: {}", e)))?;
+    let max = ScalarValue::try_from_array(&values, values.len() - 1)
+        .map_err(|e| Error::internal(format!("failed to get max value from batch: {}", e)))?;
 
     Ok(BatchStats {
         min,
@@ -1865,13 +1855,10 @@ async fn list_page_lookup_files(
     }
 
     if part_page_files.is_empty() || part_lookup_files.is_empty() {
-        return Err(Error::Internal {
-            message: format!(
-                "No partition metadata files found in index directory: {} (page_files: {}, lookup_files: {})",
-                index_dir, part_page_files.len(), part_lookup_files.len()
-            ),
-            location: location!(),
-        });
+        return Err(Error::internal(format!(
+            "No partition metadata files found in index directory: {} (page_files: {}, lookup_files: {})",
+            index_dir, part_page_files.len(), part_lookup_files.len()
+        )));
     }
 
     Ok((part_page_files, part_lookup_files))
@@ -1890,22 +1877,16 @@ async fn merge_metadata_files(
     batch_readhead: Option<usize>,
 ) -> Result<()> {
     if part_lookup_files.is_empty() || part_page_files.is_empty() {
-        return Err(Error::Internal {
-            message: "No partition files provided for merging".to_string(),
-            location: location!(),
-        });
+        return Err(Error::internal("No partition files provided for merging"));
     }
 
     // Step 1: Create lookup map for page files by partition ID
     if part_lookup_files.len() != part_page_files.len() {
-        return Err(Error::Internal {
-            message: format!(
-                "Number of partition lookup files ({}) does not match number of partition page files ({})",
-                part_lookup_files.len(),
-                part_page_files.len()
-            ),
-            location: location!(),
-        });
+        return Err(Error::internal(format!(
+            "Number of partition lookup files ({}) does not match number of partition page files ({})",
+            part_lookup_files.len(),
+            part_page_files.len()
+        )));
     }
     let mut page_files_map = HashMap::new();
     for page_file in part_page_files {
@@ -1917,13 +1898,10 @@ async fn merge_metadata_files(
     for lookup_file in part_lookup_files {
         let partition_id = extract_partition_id(lookup_file)?;
         if !page_files_map.contains_key(&partition_id) {
-            return Err(Error::Internal {
-                message: format!(
-                    "No corresponding page file found for lookup file: {} (partition_id: {})",
-                    lookup_file, partition_id
-                ),
-                location: location!(),
-            });
+            return Err(Error::internal(format!(
+                "No corresponding page file found for lookup file: {} (partition_id: {})",
+                lookup_file, partition_id
+            )));
         }
     }
 
@@ -2126,22 +2104,15 @@ async fn merge_pages_and_lookups(
 
 // Adjust local_page_idx_ in each look-up file to create a contiguous global_page_idx
 fn add_offset_to_page_idx(batch: &RecordBatch, offset: u32) -> Result<RecordBatch> {
-    let (page_idx_pos, _) =
-        batch
-            .schema()
-            .column_with_name("page_idx")
-            .ok_or_else(|| Error::Internal {
-                message: "Column 'page_idx' not found in RecordBatch schema".to_string(),
-                location: location!(),
-            })?;
+    let (page_idx_pos, _) = batch
+        .schema()
+        .column_with_name("page_idx")
+        .ok_or_else(|| Error::internal("Column 'page_idx' not found in RecordBatch schema"))?;
     let page_idx_array = batch
         .column(page_idx_pos)
         .as_any()
         .downcast_ref::<UInt32Array>()
-        .ok_or_else(|| Error::Internal {
-            message: "Failed to downcast 'page_idx' column to UInt32Array".to_string(),
-            location: location!(),
-        })?;
+        .ok_or_else(|| Error::internal("Failed to downcast 'page_idx' column to UInt32Array"))?;
     let offset_array = UInt32Array::from(vec![offset; page_idx_array.len()]);
     let new_page_idx_array_ref = add(page_idx_array, &offset_array)?;
     let mut new_columns = batch.columns().to_vec();
@@ -2177,14 +2148,13 @@ async fn merge_pages(
     let mut inputs: Vec<Arc<dyn ExecutionPlan>> = Vec::new();
     for lookup_file in part_lookup_files {
         let partition_id = extract_partition_id(lookup_file)?;
-        let page_file_name =
-            (*page_files_map
-                .get(&partition_id)
-                .ok_or_else(|| Error::Internal {
-                    message: format!("Page file not found for partition ID: {}", partition_id),
-                    location: location!(),
-                })?)
-            .clone();
+        let page_file_name = (*page_files_map.get(&partition_id).ok_or_else(|| {
+            Error::internal(format!(
+                "Page file not found for partition ID: {}",
+                partition_id
+            ))
+        })?)
+        .clone();
 
         let reader = store.open_index_file(&page_file_name).await?;
 
@@ -2270,23 +2240,25 @@ fn sort_files_by_partition_id(part_files: &[String]) -> Result<Vec<(u64, String)
 /// Expected format: "part_{partition_id}_{suffix}.lance"
 fn extract_partition_id(filename: &str) -> Result<u64> {
     if !filename.starts_with("part_") {
-        return Err(Error::Internal {
-            message: format!("Invalid partition file name format: {}", filename),
-            location: location!(),
-        });
+        return Err(Error::internal(format!(
+            "Invalid partition file name format: {}",
+            filename
+        )));
     }
 
     let parts: Vec<&str> = filename.split('_').collect();
     if parts.len() < 3 {
-        return Err(Error::Internal {
-            message: format!("Invalid partition file name format: {}", filename),
-            location: location!(),
-        });
+        return Err(Error::internal(format!(
+            "Invalid partition file name format: {}",
+            filename
+        )));
     }
 
-    parts[1].parse::<u64>().map_err(|_| Error::Internal {
-        message: format!("Failed to parse partition ID from filename: {}", filename),
-        location: location!(),
+    parts[1].parse::<u64>().map_err(|_| {
+        Error::internal(format!(
+            "Failed to parse partition ID from filename: {}",
+            filename
+        ))
     })
 }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1428,10 +1428,9 @@ impl PostingListReader {
                 .await;
 
             if !inserted {
-                return Err(Error::Internal {
-                    message: "Failed to prewarm index: cache is no longer available".to_string(),
-                    location: location!(),
-                });
+                return Err(Error::internal(
+                    "Failed to prewarm index: cache is no longer available",
+                ));
             }
         }
 

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -46,10 +46,9 @@ trait LabelListSubIndex: ScalarIndex + DeepSizeOf {
         let result = self.search(query, metrics).await?;
         match result {
             SearchResult::Exact(row_ids) => Ok(row_ids),
-            _ => Err(Error::Internal {
-                message: "Label list sub-index should return exact results".to_string(),
-                location: location!(),
-            }),
+            _ => Err(Error::internal(
+                "Label list sub-index should return exact results",
+            )),
         }
     }
 }

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -179,11 +179,8 @@ impl NGramPostingList {
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<Self> {
         let bitmap_bytes = batch.column(0).as_binary::<i32>().value(0);
-        let mut bitmap =
-            RoaringTreemap::deserialize_from(bitmap_bytes).map_err(|e| Error::Internal {
-                message: format!("Error deserializing ngram list: {}", e),
-                location: location!(),
-            })?;
+        let mut bitmap = RoaringTreemap::deserialize_from(bitmap_bytes)
+            .map_err(|e| Error::internal(format!("Error deserializing ngram list: {}", e)))?;
         if let Some(frag_reuse_index_ref) = frag_reuse_index.as_ref() {
             bitmap = frag_reuse_index_ref.remap_row_ids_roaring_tree_map(&bitmap);
         }
@@ -400,10 +397,8 @@ impl Index for NGramIndex {
         let ngram_stats = NGramStatistics {
             num_ngrams: self.tokens.len(),
         };
-        serde_json::to_value(ngram_stats).map_err(|e| Error::Internal {
-            message: format!("Error serializing statistics: {}", e),
-            location: location!(),
-        })
+        serde_json::to_value(ngram_stats)
+            .map_err(|e| Error::internal(format!("Error serializing statistics: {}", e)))
     }
 
     async fn prewarm(&self) -> Result<()> {
@@ -609,10 +604,8 @@ impl NGramIndexSpillState {
         let bitmaps = postings
             .into_iter()
             .map(|bytes| {
-                RoaringTreemap::deserialize_from(bytes.expect_ok()?).map_err(|e| Error::Internal {
-                    message: format!("Error deserializing ngram list: {}", e),
-                    location: location!(),
-                })
+                RoaringTreemap::deserialize_from(bytes.expect_ok()?)
+                    .map_err(|e| Error::internal(format!("Error deserializing ngram list: {}", e)))
             })
             .collect::<Result<Vec<_>>>()?;
 

--- a/rust/lance-index/src/scalar/rtree.rs
+++ b/rust/lance-index/src/scalar/rtree.rs
@@ -401,10 +401,8 @@ impl Index for RTreeIndex {
     }
 
     fn statistics(&self) -> Result<serde_json::Value> {
-        serde_json::to_value(self.metadata.clone()).map_err(|e| Error::Internal {
-            message: format!("Error serializing statistics: {}", e),
-            location: location!(),
-        })
+        serde_json::to_value(self.metadata.clone())
+            .map_err(|e| Error::internal(format!("Error serializing statistics: {}", e)))
     }
 
     async fn prewarm(&self) -> Result<()> {

--- a/rust/lance-io/src/encodings/plain.rs
+++ b/rust/lance-io/src/encodings/plain.rs
@@ -183,13 +183,10 @@ pub fn bytes_to_array(
     let layout = layout(data_type);
 
     if layout.buffers.len() != 1 {
-        return Err(Error::Internal {
-            message: format!(
-                "Can only convert datatypes that require one buffer, found {:?}",
-                data_type
-            ),
-            location: location!(),
-        });
+        return Err(Error::internal(format!(
+            "Can only convert datatypes that require one buffer, found {:?}",
+            data_type
+        )));
     }
 
     let buf: Buffer = if let BufferSpec::FixedWidth {

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -414,12 +414,10 @@ impl CredentialProvider for AwsCredentialAdapter {
                 token: creds.session_token().map(|s| s.to_string()),
             }))
         } else {
-            let refreshed_creds = Arc::new(self.inner.provide_credentials().await.map_err(
-                |e| Error::Internal {
-                    message: format!("Failed to get AWS credentials: {:?}", e),
-                    location: location!(),
-                },
-            )?);
+            let refreshed_creds =
+                Arc::new(self.inner.provide_credentials().await.map_err(|e| {
+                    Error::internal(format!("Failed to get AWS credentials: {:?}", e))
+                })?);
 
             self.cache
                 .write()

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -469,10 +469,9 @@ impl IoTask {
         self.to_read.end - self.to_read.start
     }
     fn cancel(self) {
-        (self.when_done)(Err(Error::Internal {
-            message: "Scheduler closed before I/O was completed".to_string(),
-            location: location!(),
-        }));
+        (self.when_done)(Err(Error::internal(
+            "Scheduler closed before I/O was completed",
+        )));
     }
 
     async fn run(self) {

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -885,10 +885,7 @@ impl TryFrom<pb::Manifest> for Manifest {
         if FLAG_STABLE_ROW_IDS & p.reader_feature_flags != 0
             && !fragments.iter().all(|frag| frag.row_id_meta.is_some())
         {
-            return Err(Error::Internal {
-                message: "All fragments must have row ids".into(),
-                location: location!(),
-            });
+            return Err(Error::internal("All fragments must have row ids"));
         }
 
         let data_storage_format = match p.data_format {
@@ -1042,12 +1039,11 @@ impl SelfDescribingFileReader for PreviousFileReader {
         cache: Option<&LanceCache>,
     ) -> Result<Self> {
         let metadata = Self::read_metadata(reader.as_ref(), cache).await?;
-        let manifest_position = metadata.manifest_position.ok_or(Error::Internal {
-            message: format!(
+        let manifest_position = metadata.manifest_position.ok_or_else(|| {
+            Error::internal(format!(
                 "Attempt to open file at {} as self-describing but it did not contain a manifest",
                 reader.path(),
-            ),
-            location: location!(),
+            ))
         })?;
         let mut manifest: Manifest = read_struct(reader.as_ref(), manifest_position).await?;
         if manifest.should_use_legacy_format() {

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -230,21 +230,15 @@ impl TryFrom<object_store::ObjectMeta> for ManifestLocation {
     type Error = Error;
 
     fn try_from(meta: object_store::ObjectMeta) -> Result<Self> {
-        let filename = meta.location.filename().ok_or_else(|| Error::Internal {
-            message: "ObjectMeta location does not have a filename".to_string(),
-            location: location!(),
-        })?;
-        let scheme =
-            ManifestNamingScheme::detect_scheme(filename).ok_or_else(|| Error::Internal {
-                message: format!("Invalid manifest filename: '{}'", filename),
-                location: location!(),
-            })?;
+        let filename = meta
+            .location
+            .filename()
+            .ok_or_else(|| Error::internal("ObjectMeta location does not have a filename"))?;
+        let scheme = ManifestNamingScheme::detect_scheme(filename)
+            .ok_or_else(|| Error::internal(format!("Invalid manifest filename: '{}'", filename)))?;
         let version = scheme
             .parse_version(filename)
-            .ok_or_else(|| Error::Internal {
-                message: format!("Invalid manifest filename: '{}'", filename),
-                location: location!(),
-            })?;
+            .ok_or_else(|| Error::internal(format!("Invalid manifest filename: '{}'", filename)))?;
         Ok(Self {
             version,
             path: meta.location,
@@ -329,14 +323,11 @@ async fn current_manifest_path(
 
             while let Some((entry_scheme, meta)) = valid_manifests.next().await.transpose()? {
                 if entry_scheme != scheme {
-                    return Err(Error::Internal {
-                        message: format!(
-                            "Found multiple manifest naming schemes in the same directory: {:?} and {:?}. \
-                             Use `migrate_manifest_paths_v2` to migrate the directory.",
-                            scheme, entry_scheme
-                        ),
-                        location: location!(),
-                    });
+                    return Err(Error::internal(format!(
+                        "Found multiple manifest naming schemes in the same directory: {:?} and {:?}. \
+                         Use `migrate_manifest_paths_v2` to migrate the directory.",
+                        scheme, entry_scheme
+                    )));
                 }
                 let version = entry_scheme
                     .parse_version(meta.location.filename().unwrap())
@@ -824,10 +815,7 @@ impl From<Error> for CommitError {
 impl From<CommitError> for Error {
     fn from(e: CommitError) -> Self {
         match e {
-            CommitError::CommitConflict => Self::Internal {
-                message: "Commit conflict".to_string(),
-                location: location!(),
-            },
+            CommitError::CommitConflict => Self::internal("Commit conflict"),
             CommitError::OtherError(e) => e,
         }
     }

--- a/rust/lance-table/src/rowids/version.rs
+++ b/rust/lance-table/src/rowids/version.rs
@@ -303,19 +303,17 @@ pub fn write_dataset_versions(sequence: &RowDatasetVersionSequence) -> Vec<u8> {
 
 /// Deserialize a dataset version sequence from bytes (following RowIdSequence pattern)
 pub fn read_dataset_versions(data: &[u8]) -> lance_core::Result<RowDatasetVersionSequence> {
-    let pb_sequence = pb::RowDatasetVersionSequence::decode(data).map_err(|e| Error::Internal {
-        message: format!("Failed to decode RowDatasetVersionSequence: {}", e),
-        location: location!(),
+    let pb_sequence = pb::RowDatasetVersionSequence::decode(data).map_err(|e| {
+        Error::internal(format!("Failed to decode RowDatasetVersionSequence: {}", e))
     })?;
 
     let segments = pb_sequence
         .runs
         .into_iter()
         .map(|pb_run| {
-            let positions_pb = pb_run.span.ok_or_else(|| Error::Internal {
-                message: "Missing positions in RowDatasetVersionRun".to_string(),
-                location: location!(),
-            })?;
+            let positions_pb = pb_run
+                .span
+                .ok_or_else(|| Error::internal("Missing positions in RowDatasetVersionRun"))?;
             let segment = U64Segment::try_from(positions_pb)?;
             Ok(RowDatasetVersionRun {
                 span: segment,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1701,13 +1701,10 @@ impl Dataset {
                 })?;
 
                 if !base_path.is_dataset_root {
-                    return Err(Error::Internal {
-                        message: format!(
-                            "base_path id {} is not a dataset root for deletion_file {:?}",
-                            base_id, deletion_file
-                        ),
-                        location: location!(),
-                    });
+                    return Err(Error::internal(format!(
+                        "base_path id {} is not a dataset root for deletion_file {:?}",
+                        base_id, deletion_file
+                    )));
                 }
                 base_path.extract_path(self.session.store_registry())
             }
@@ -2299,24 +2296,17 @@ impl Dataset {
         let mut file_paths: Vec<(String, Path)> = Vec::new();
         for fragment in self.manifest.fragments.iter() {
             if let Some(RowIdMeta::External(external_file)) = &fragment.row_id_meta {
-                return Err(Error::Internal {
-                    message: format!(
-                        "External row_id_meta is not supported yet. external file path: {}",
-                        external_file.path
-                    ),
-                    location: location!(),
-                });
+                return Err(Error::internal(format!(
+                    "External row_id_meta is not supported yet. external file path: {}",
+                    external_file.path
+                )));
             }
             for data_file in fragment.files.iter() {
                 let base_root = if let Some(base_id) = data_file.base_id {
                     let base_path =
-                        self.manifest
-                            .base_paths
-                            .get(&base_id)
-                            .ok_or_else(|| Error::Internal {
-                                message: format!("base_id {} not found", base_id),
-                                location: location!(),
-                            })?;
+                        self.manifest.base_paths.get(&base_id).ok_or_else(|| {
+                            Error::internal(format!("base_id {} not found", base_id))
+                        })?;
                     Path::parse(base_path.path.as_str())?
                 } else {
                     self.base.clone()
@@ -2329,13 +2319,9 @@ impl Dataset {
             if let Some(deletion_file) = &fragment.deletion_file {
                 let base_root = if let Some(base_id) = deletion_file.base_id {
                     let base_path =
-                        self.manifest
-                            .base_paths
-                            .get(&base_id)
-                            .ok_or_else(|| Error::Internal {
-                                message: format!("base_id {} not found", base_id),
-                                location: location!(),
-                            })?;
+                        self.manifest.base_paths.get(&base_id).ok_or_else(|| {
+                            Error::internal(format!("base_id {} not found", base_id))
+                        })?;
                     Path::parse(base_path.path.as_str())?
                 } else {
                     self.base.clone()
@@ -2356,14 +2342,11 @@ impl Dataset {
 
         for index in &indices {
             let base_root = if let Some(base_id) = index.base_id {
-                let base_path =
-                    self.manifest
-                        .base_paths
-                        .get(&base_id)
-                        .ok_or_else(|| Error::Internal {
-                            message: format!("base_id {} not found", base_id),
-                            location: location!(),
-                        })?;
+                let base_path = self
+                    .manifest
+                    .base_paths
+                    .get(&base_id)
+                    .ok_or_else(|| Error::internal(format!("base_id {} not found", base_id)))?;
                 Path::parse(base_path.path.as_str())?
             } else {
                 self.base.clone()
@@ -2495,13 +2478,10 @@ pub(crate) fn load_new_transactions(dataset: &Dataset) -> NewTransactionResult<'
                     )?;
                     let loaded =
                         Arc::new(dataset_version.read_transaction().await?.ok_or_else(|| {
-                            Error::Internal {
-                                message: format!(
-                                    "Dataset version {} does not have a transaction file",
-                                    manifest_copy.version
-                                ),
-                                location: location!(),
-                            }
+                            Error::internal(format!(
+                                "Dataset version {} does not have a transaction file",
+                                manifest_copy.version
+                            ))
                         })?);
                     dataset
                         .metadata_cache

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -717,19 +717,12 @@ async fn collect_blob_files_v2(
                 let blob_id = blob_ids.value(idx);
                 let size = sizes.value(idx);
                 let frag_id = RowAddress::from(*row_addr).fragment_id();
-                let frag =
-                    dataset
-                        .get_fragment(frag_id as usize)
-                        .ok_or_else(|| Error::Internal {
-                            message: "Fragment not found".to_string(),
-                            location: location!(),
-                        })?;
-                let data_file =
-                    frag.data_file_for_field(blob_field_id)
-                        .ok_or_else(|| Error::Internal {
-                            message: "Data file not found for blob field".to_string(),
-                            location: location!(),
-                        })?;
+                let frag = dataset
+                    .get_fragment(frag_id as usize)
+                    .ok_or_else(|| Error::internal("Fragment not found"))?;
+                let data_file = frag
+                    .data_file_for_field(blob_field_id)
+                    .ok_or_else(|| Error::internal("Data file not found for blob field"))?;
 
                 let data_file_key = data_file_key_from_path(data_file.path.as_str());
                 let path = blob_path(&dataset.data_dir(), data_file_key, blob_id);
@@ -740,19 +733,12 @@ async fn collect_blob_files_v2(
                 let size = sizes.value(idx);
                 let position = positions.value(idx);
                 let frag_id = RowAddress::from(*row_addr).fragment_id();
-                let frag =
-                    dataset
-                        .get_fragment(frag_id as usize)
-                        .ok_or_else(|| Error::Internal {
-                            message: "Fragment not found".to_string(),
-                            location: location!(),
-                        })?;
-                let data_file =
-                    frag.data_file_for_field(blob_field_id)
-                        .ok_or_else(|| Error::Internal {
-                            message: "Data file not found for blob field".to_string(),
-                            location: location!(),
-                        })?;
+                let frag = dataset
+                    .get_fragment(frag_id as usize)
+                    .ok_or_else(|| Error::internal("Fragment not found"))?;
+                let data_file = frag
+                    .data_file_for_field(blob_field_id)
+                    .ok_or_else(|| Error::internal("Data file not found for blob field"))?;
                 let data_file_key = data_file_key_from_path(data_file.path.as_str());
                 let path = blob_path(&dataset.data_dir(), data_file_key, blob_id);
                 files.push(BlobFile::new_packed(dataset.clone(), path, position, size));

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -750,7 +750,6 @@ mod tests {
     use lance_table::io::commit::RenameCommitHandler;
     use lance_testing::datagen::{some_batch, BatchGenerator, IncrementingInt32};
     use mock_instant::thread_local::MockClock;
-    use snafu::location;
 
     use super::*;
     use crate::blob::{blob_field, BlobArrayBuilder};
@@ -929,10 +928,7 @@ mod tests {
                 "block_commit",
                 Arc::new(|op, _| -> Result<()> {
                     if op.contains("copy") {
-                        return Err(Error::Internal {
-                            message: "Copy blocked".to_string(),
-                            location: location!(),
-                        });
+                        return Err(Error::internal("Copy blocked"));
                     }
                     Ok(())
                 }),
@@ -945,10 +941,7 @@ mod tests {
                 "block_delete_manifest",
                 Arc::new(|op, path| -> Result<()> {
                     if op.contains("delete") && path.extension() == Some("manifest") {
-                        Err(Error::Internal {
-                            message: "Delete manifest blocked".to_string(),
-                            location: location!(),
-                        })
+                        Err(Error::internal("Delete manifest blocked"))
                     } else {
                         Ok(())
                     }

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -237,10 +237,9 @@ impl GenericFileReader for V1Reader {
         _batch_size: u32,
         _projection: Arc<Schema>,
     ) -> Result<ReadBatchTaskStream> {
-        Err(Error::Internal {
-            message: "Attempt to perform FilteredRead on v1 files".to_string(),
-            location: location!(),
-        })
+        Err(Error::internal(
+            "Attempt to perform FilteredRead on v1 files",
+        ))
     }
 
     fn take_all_tasks(
@@ -1123,7 +1122,7 @@ impl FileFragment {
         if self.dataset.manifest.writer_version.is_some() && self.metadata.physical_rows.is_some() {
             Ok(self.metadata.physical_rows.unwrap())
         } else {
-            Err(Error::Internal { message: format!("The method fast_physical_rows was called on a fragment that does not have the physical row count in the metadata. Fragment id: {}", self.id()), location: location!() })
+            Err(Error::internal(format!("The method fast_physical_rows was called on a fragment that does not have the physical row count in the metadata. Fragment id: {}", self.id())))
         }
     }
 
@@ -1138,7 +1137,7 @@ impl FileFragment {
                 ..
             }) => Ok(*num_deleted),
             None => Ok(0),
-            _ => Err(Error::Internal { message: format!("The method fast_num_deletions was called on a fragment that does not have the deletion count in the metadata. Fragment id: {}", self.id()), location: location!() }),
+            _ => Err(Error::internal(format!("The method fast_num_deletions was called on a fragment that does not have the deletion count in the metadata. Fragment id: {}", self.id()))),
         }
     }
 
@@ -1178,12 +1177,11 @@ impl FileFragment {
         let reader = self
             .open_reader(some_file, None, &FragReadConfig::default())
             .await?
-            .ok_or_else(|| Error::Internal {
-                message: format!(
+            .ok_or_else(|| {
+                Error::internal(format!(
                     "The data file {} did not have any fields contained in the dataset schema",
                     some_file.path
-                ),
-                location: location!(),
+                ))
             })?;
 
         Ok(reader.len() as usize)
@@ -1824,15 +1822,12 @@ impl FileFragment {
                 .filter(|x| *x >= physical_rows as u32)
                 .take(5)
                 .collect();
-            return Err(Error::Internal {
-                message: format!(
-                    "Deletion vector includes rows that aren't in the fragment. \
+            return Err(Error::internal(format!(
+                "Deletion vector includes rows that aren't in the fragment. \
                 Num physical rows {}; Deletion vector length: {}; \
                 Examples: {:?}",
-                    physical_rows, dv_len, examples
-                ),
-                location: location!(),
-            });
+                physical_rows, dv_len, examples
+            )));
         }
 
         self.metadata.deletion_file = write_deletion_file(
@@ -2265,10 +2260,9 @@ impl FragmentReader {
                     .collect(),
             ),
             ReadBatchParams::Ranges(_) => {
-                return Err(Error::Internal {
-                    message: "ReadBatchParams::Ranges should not be used in v1 files".to_string(),
-                    location: location!(),
-                })
+                return Err(Error::internal(
+                    "ReadBatchParams::Ranges should not be used in v1 files",
+                ))
             }
             ReadBatchParams::RangeFull => {
                 ReadBatchParams::Range(batch_offset..(batch_offset + rows_in_batch))
@@ -2496,13 +2490,10 @@ impl FragmentReader {
         // Note that row ranges at this point are physical and not logical.
         for range in ranges.as_ref() {
             if range.end > total_num_rows as u64 {
-                return Err(Error::Internal {
-                    message: format!(
-                        "Invalid read of range {:?} for fragment {} with {} addressable rows",
-                        range, self.fragment_id, total_num_rows
-                    ),
-                    location: location!(),
-                });
+                return Err(Error::internal(format!(
+                    "Invalid read of range {:?} for fragment {} with {} addressable rows",
+                    range, self.fragment_id, total_num_rows
+                )));
             }
             num_requested_rows += range.end - range.start;
         }

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -20,7 +20,6 @@ use lance_index::DatasetIndexExt;
 use lance_table::format::pb::VectorIndexDetails;
 use lance_table::format::IndexMetadata;
 use serde::{Deserialize, Serialize};
-use snafu::location;
 
 use super::optimize::{IndexRemapper, IndexRemapperOptions};
 
@@ -84,13 +83,10 @@ impl IndexRemapper for DatasetIndexRemapper {
                                 let field = index.fields.first().unwrap();
                                 let field =
                                     self.dataset.schema().field_by_id(*field).ok_or_else(|| {
-                                        Error::Internal {
-                                            message: format!(
-                                                "Index {} references field {} which does not exist",
-                                                index.uuid, field
-                                            ),
-                                            location: location!(),
-                                        }
+                                        Error::internal(format!(
+                                            "Index {} references field {} which does not exist",
+                                            index.uuid, field
+                                        ))
                                     })?;
 
                                 if matches!(field.data_type(), DataType::FixedSizeList(..)) {

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -106,7 +106,6 @@ use lance_index::DatasetIndexExt;
 use lance_table::format::{Fragment, RowIdMeta};
 use roaring::{RoaringBitmap, RoaringTreemap};
 use serde::{Deserialize, Serialize};
-use snafu::location;
 use tracing::info;
 
 pub mod remapping;
@@ -799,10 +798,9 @@ async fn rewrite_files(
     log::info!("Compaction task {}: file written", task_id);
 
     let (row_id_map, changed_row_addrs) = if let Some(row_ids_rx) = row_ids_rx {
-        let captured_ids = row_ids_rx.try_recv().map_err(|err| Error::Internal {
-            message: format!("Failed to receive row ids: {}", err),
-            location: location!(),
-        })?;
+        let captured_ids = row_ids_rx
+            .try_recv()
+            .map_err(|err| Error::internal(format!("Failed to receive row ids: {}", err)))?;
         // This code path is only when we use address style ids.
         let row_addrs = captured_ids.row_addrs(None).into_owned();
 
@@ -953,9 +951,8 @@ async fn recalc_versions_for_rewritten_fragments(
 
         // Load created_at sequence (default to version 1 if missing)
         let mut created_at_seq = if let Some(version_meta) = &frag.created_at_version_meta {
-            version_meta.load_sequence().map_err(|e| Error::Internal {
-                message: format!("Failed to load created_at version sequence: {}", e),
-                location: location!(),
+            version_meta.load_sequence().map_err(|e| {
+                Error::internal(format!("Failed to load created_at version sequence: {}", e))
             })?
         } else {
             // Default: treat all rows as created at version 1
@@ -964,9 +961,11 @@ async fn recalc_versions_for_rewritten_fragments(
 
         // Load last_updated_at sequence (default to same as created_at sequence)
         let mut last_updated_seq = if let Some(version_meta) = &frag.last_updated_at_version_meta {
-            version_meta.load_sequence().map_err(|e| Error::Internal {
-                message: format!("Failed to load last_updated_at version sequence: {}", e),
-                location: location!(),
+            version_meta.load_sequence().map_err(|e| {
+                Error::internal(format!(
+                    "Failed to load last_updated_at version sequence: {}",
+                    e
+                ))
             })?
         } else {
             created_at_seq.clone()

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -10,7 +10,6 @@ use lance_table::{
     format::{Fragment, RowIdMeta},
     rowids::{read_row_ids, FragmentRowIdIndex, RowIdIndex, RowIdSequence},
 };
-use snafu::location;
 use std::sync::Arc;
 
 /// Load a row id sequence from the given dataset and fragment.
@@ -20,10 +19,7 @@ pub async fn load_row_id_sequence(
 ) -> Result<Arc<RowIdSequence>> {
     // Virtual path to prevent collisions in the cache.
     match &fragment.row_id_meta {
-        None => Err(Error::Internal {
-            message: "Missing row id meta".into(),
-            location: location!(),
-        }),
+        None => Err(Error::internal("Missing row id meta")),
         Some(RowIdMeta::Inline(data)) => {
             let data = data.clone();
             let key = RowIdSequenceKey {

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1458,12 +1458,11 @@ impl Scanner {
 
         if field_path.len() == 1 {
             // Simple top-level column
-            expressions::col(&field_path[0].name, arrow_schema).map_err(|e| Error::Internal {
-                message: format!(
+            expressions::col(&field_path[0].name, arrow_schema).map_err(|e| {
+                Error::internal(format!(
                     "Failed to create column expression for '{}': {}",
                     column_name, e
-                ),
-                location: location!(),
+                ))
             })
         } else {
             // Nested field - build a chain of GetFieldFunc calls
@@ -1481,12 +1480,11 @@ impl Scanner {
             // Convert logical to physical expression
             let df_schema = Arc::new(DFSchema::try_from(arrow_schema.clone())?);
             let execution_props = ExecutionProps::new().with_query_execution_start_time(Utc::now());
-            create_physical_expr(&expr, &df_schema, &execution_props).map_err(|e| Error::Internal {
-                message: format!(
+            create_physical_expr(&expr, &df_schema, &execution_props).map_err(|e| {
+                Error::internal(format!(
                     "Failed to create physical expression for nested field '{}': {}",
                     column_name, e
-                ),
-                location: location!(),
+                ))
             })
         }
     }
@@ -1589,11 +1587,10 @@ impl Scanner {
             let row_id_pos = output_expr
                 .iter()
                 .position(|(_, name)| name == ROW_ID)
-                .ok_or_else(|| Error::Internal {
-                    message:
-                        "user specified with_row_id but the _rowid column was not in the output"
-                            .to_string(),
-                    location: location!(),
+                .ok_or_else(|| {
+                    Error::internal(
+                        "user specified with_row_id but the _rowid column was not in the output",
+                    )
                 })?;
             if row_id_pos != output_expr.len() - 1 {
                 // Row id is not last column.  Need to rotate it to the last spot.
@@ -1603,12 +1600,14 @@ impl Scanner {
         }
 
         if self.legacy_with_row_addr {
-            let row_addr_pos = output_expr.iter().position(|(_, name)| name == ROW_ADDR).ok_or_else(|| {
-                Error::Internal {
-                    message: "user specified with_row_address but the _rowaddr column was not in the output".to_string(),
-                    location: location!(),
-                }
-            })?;
+            let row_addr_pos = output_expr
+                .iter()
+                .position(|(_, name)| name == ROW_ADDR)
+                .ok_or_else(|| {
+                    Error::internal(
+                        "user specified with_row_address but the _rowaddr column was not in the output",
+                    )
+                })?;
             if row_addr_pos != output_expr.len() - 1 {
                 // Row addr is not last column.  Need to rotate it to the last spot.
                 let row_addr_expr = output_expr.remove(row_addr_pos);

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -300,10 +300,7 @@ async fn do_take_rows(
 
         let returned_row_addr = one_batch
             .column_by_name(ROW_ADDR)
-            .ok_or_else(|| Error::Internal {
-                message: "_rowaddr column not found".into(),
-                location: location!(),
-            })?
+            .ok_or_else(|| Error::internal("_rowaddr column not found"))?
             .as_primitive::<UInt64Type>()
             .values();
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -1617,10 +1617,9 @@ impl Transaction {
                 if let Some(current_manifest) = current_manifest {
                     current_manifest.schema.clone()
                 } else {
-                    return Err(Error::Internal {
-                        message: "Cannot create a new dataset without a schema".to_string(),
-                        location: location!(),
-                    });
+                    return Err(Error::internal(
+                        "Cannot create a new dataset without a schema",
+                    ));
                 }
             }
         };
@@ -1656,20 +1655,18 @@ impl Transaction {
         let maybe_existing_fragments =
             current_manifest
                 .map(|m| m.fragments.as_ref())
-                .ok_or_else(|| Error::Internal {
-                    message: format!(
+                .ok_or_else(|| {
+                    Error::internal(format!(
                         "No current manifest was provided while building manifest for operation {}",
                         self.operation.name()
-                    ),
-                    location: location!(),
+                    ))
                 });
 
         match &self.operation {
             Operation::Clone { .. } => {
-                return Err(Error::Internal {
-                    message: "Clone operation should not enter build_manifest.".to_string(),
-                    location: location!(),
-                })
+                return Err(Error::internal(
+                    "Clone operation should not enter build_manifest.",
+                ))
             }
             Operation::Append { ref fragments } => {
                 final_fragments.extend(maybe_existing_fragments?.clone());
@@ -1861,12 +1858,11 @@ impl Transaction {
                                 lance_table::format::RowDatasetVersionMeta::from_sequence(
                                     &created_at_seq,
                                 )
-                                .map_err(|e| Error::Internal {
-                                    message: format!(
+                                .map_err(|e| {
+                                    Error::internal(format!(
                                         "Failed to create created_at version metadata: {}",
                                         e
-                                    ),
-                                    location: location!(),
+                                    ))
                                 })?,
                             );
 
@@ -2627,10 +2623,10 @@ impl Transaction {
         let mut pure_update_frag_ids = Vec::new();
 
         for fragment in fragments {
-            let physical_rows = fragment.physical_rows.ok_or_else(|| Error::Internal {
-                message: "Fragment does not have physical rows".into(),
-                location: location!(),
-            })? as u64;
+            let physical_rows = fragment
+                .physical_rows
+                .ok_or_else(|| Error::internal("Fragment does not have physical rows"))?
+                as u64;
 
             if let Some(row_id_meta) = &fragment.row_id_meta {
                 let existing_row_count = match row_id_meta {
@@ -2654,10 +2650,10 @@ impl Transaction {
 
     fn assign_row_ids(next_row_id: &mut u64, fragments: &mut [Fragment]) -> Result<()> {
         for fragment in fragments {
-            let physical_rows = fragment.physical_rows.ok_or_else(|| Error::Internal {
-                message: "Fragment does not have physical rows".into(),
-                location: location!(),
-            })? as u64;
+            let physical_rows = fragment
+                .physical_rows
+                .ok_or_else(|| Error::internal("Fragment does not have physical rows"))?
+                as u64;
 
             if fragment.row_id_meta.is_some() {
                 // we may meet merge insert case, it only has partial row ids.
@@ -2689,11 +2685,9 @@ impl Transaction {
                         let combined_sequence = match &fragment.row_id_meta {
                             Some(RowIdMeta::Inline(data)) => read_row_ids(data)?,
                             _ => {
-                                return Err(Error::Internal {
-                                    message: "Failed to deserialize existing row ID sequence"
-                                        .into(),
-                                    location: location!(),
-                                })
+                                return Err(Error::internal(
+                                    "Failed to deserialize existing row ID sequence",
+                                ))
                             }
                         };
 
@@ -2709,13 +2703,10 @@ impl Transaction {
                     }
                     Ordering::Greater => {
                         // More row IDs than physical rows - this shouldn't happen
-                        return Err(Error::Internal {
-                            message: format!(
-                                "Fragment has more row IDs ({}) than physical rows ({})",
-                                existing_row_count, physical_rows
-                            ),
-                            location: location!(),
-                        });
+                        return Err(Error::internal(format!(
+                            "Fragment has more row IDs ({}) than physical rows ({})",
+                            existing_row_count, physical_rows
+                        )));
                     }
                 }
             } else {
@@ -3039,10 +3030,9 @@ impl TryFrom<pb::Transaction> for Transaction {
                 new_bases: new_bases.into_iter().map(BasePath::from).collect(),
             },
             None => {
-                return Err(Error::Internal {
-                    message: "Transaction message did not contain an operation".to_string(),
-                    location: location!(),
-                });
+                return Err(Error::internal(
+                    "Transaction message did not contain an operation",
+                ));
             }
         };
         Ok(Self {
@@ -3843,8 +3833,10 @@ mod tests {
         let result = Transaction::assign_row_ids(&mut next_row_id, &mut fragments);
 
         assert!(result.is_err());
-        if let Err(Error::Internal { message, .. }) = result {
-            assert!(message.contains("more row IDs (60) than physical rows (50)"));
+        if let Err(Error::Internal { source }) = result {
+            assert!(source
+                .message
+                .contains("more row IDs (60) than physical rows (50)"));
         } else {
             panic!("Expected Internal error about excess row IDs");
         }
@@ -3924,8 +3916,10 @@ mod tests {
         let result = Transaction::assign_row_ids(&mut next_row_id, &mut fragments);
 
         assert!(result.is_err());
-        if let Err(Error::Internal { message, .. }) = result {
-            assert!(message.contains("Fragment does not have physical rows"));
+        if let Err(Error::Internal { source }) = result {
+            assert!(source
+                .message
+                .contains("Fragment does not have physical rows"));
         } else {
             panic!("Expected Internal error about missing physical rows");
         }

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -339,14 +339,11 @@ impl DeletionRestorer {
             // output should have the same fixed batch size (except the last batch)
             let is_last = self.is_exhausted();
             if batch.num_rows() != batch_size as usize && !is_last {
-                return Err(Error::Internal {
-                    message: format!(
-                        "Fragment Updater: batch size mismatch: {} != {}",
-                        batch.num_rows(),
-                        batch_size
-                    ),
-                    location: location!(),
-                });
+                return Err(Error::internal(format!(
+                    "Fragment Updater: batch size mismatch: {} != {}",
+                    batch.num_rows(),
+                    batch_size
+                )));
             }
         }
 

--- a/rust/lance/src/dataset/write/delete.rs
+++ b/rust/lance/src/dataset/write/delete.rs
@@ -14,7 +14,6 @@ use lance_core::utils::mask::RowAddrTreeMap;
 use lance_core::{Error, Result, ROW_ID};
 use lance_table::format::Fragment;
 use roaring::RoaringTreemap;
-use snafu::location;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -204,9 +203,8 @@ impl RetryExecutor for DeleteJob {
                 }
 
                 // Extract the row addresses from the receiver
-                let removed_row_ids = row_id_rx.try_recv().map_err(|err| Error::Internal {
-                    message: format!("Failed to receive row ids: {}", err),
-                    location: location!(),
+                let removed_row_ids = row_id_rx.try_recv().map_err(|err| {
+                    Error::internal(format!("Failed to receive row ids: {}", err))
                 })?;
                 let row_id_index = get_row_id_index(&self.dataset).await?;
                 let removed_row_addrs = removed_row_ids.row_addrs(row_id_index.as_deref());

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1197,17 +1197,14 @@ impl MergeInsertJob {
                             branch = ?dataset.manifest().branch,
                             "Non-existent fragment id returned from merge result",
                         );
-                        Error::Internal {
-                            message: format!(
-                                "Got non-existent fragment id from merge result: {} (uri={}, version={}, manifest={}, branch={})",
-                                frag_id,
-                                dataset.uri(),
-                                dataset.manifest().version,
-                                dataset.manifest_location().path,
-                                dataset.manifest().branch.as_deref().unwrap_or("main"),
-                            ),
-                            location: location!(),
-                        }
+                        Error::internal(format!(
+                            "Got non-existent fragment id from merge result: {} (uri={}, version={}, manifest={}, branch={})",
+                            frag_id,
+                            dataset.uri(),
+                            dataset.manifest().version,
+                            dataset.manifest_location().path,
+                            dataset.manifest().branch.as_deref().unwrap_or("main"),
+                        ))
                     })?;
                     let metadata = fragment.metadata.clone();
 
@@ -1232,10 +1229,10 @@ impl MergeInsertJob {
                     tasks.spawn(fut);
                 }
                 _ => {
-                    return Err(Error::Internal {
-                        message: format!("Got non-fragment id from merge result: {:?}", frag_id),
-                        location: location!(),
-                    });
+                    return Err(Error::internal(format!(
+                        "Got non-fragment id from merge result: {:?}",
+                        frag_id
+                    )));
                 }
             };
         }
@@ -1431,13 +1428,11 @@ impl MergeInsertJob {
             plan.as_any()
                 .downcast_ref::<exec::FullSchemaMergeInsertExec>()
         {
-            let stats = full_exec.merge_stats().ok_or_else(|| Error::Internal {
-                message: "Merge stats not available - execution may not have completed".into(),
-                location: location!(),
+            let stats = full_exec.merge_stats().ok_or_else(|| {
+                Error::internal("Merge stats not available - execution may not have completed")
             })?;
-            let transaction = full_exec.transaction().ok_or_else(|| Error::Internal {
-                message: "Transaction not available - execution may not have completed".into(),
-                location: location!(),
+            let transaction = full_exec.transaction().ok_or_else(|| {
+                Error::internal("Transaction not available - execution may not have completed")
             })?;
             let affected_rows = full_exec.affected_rows().map(RowAddrTreeMap::from);
             let inserted_rows_filter = full_exec.inserted_rows_filter();
@@ -1446,21 +1441,18 @@ impl MergeInsertJob {
             .as_any()
             .downcast_ref::<exec::DeleteOnlyMergeInsertExec>()
         {
-            let stats = delete_exec.merge_stats().ok_or_else(|| Error::Internal {
-                message: "Merge stats not available - execution may not have completed".into(),
-                location: location!(),
+            let stats = delete_exec.merge_stats().ok_or_else(|| {
+                Error::internal("Merge stats not available - execution may not have completed")
             })?;
-            let transaction = delete_exec.transaction().ok_or_else(|| Error::Internal {
-                message: "Transaction not available - execution may not have completed".into(),
-                location: location!(),
+            let transaction = delete_exec.transaction().ok_or_else(|| {
+                Error::internal("Transaction not available - execution may not have completed")
             })?;
             let affected_rows = delete_exec.affected_rows().map(RowAddrTreeMap::from);
             (stats, transaction, affected_rows, None)
         } else {
-            return Err(Error::Internal {
-                message: "Expected FullSchemaMergeInsertExec or DeleteOnlyMergeInsertExec".into(),
-                location: location!(),
-            });
+            return Err(Error::internal(
+                "Expected FullSchemaMergeInsertExec or DeleteOnlyMergeInsertExec",
+            ));
         };
 
         Ok((transaction, stats, affected_rows, inserted_rows_filter))
@@ -1620,12 +1612,11 @@ impl MergeInsertJob {
                     fragment_sizes,
                     true,
                 )
-                .map_err(|e| Error::Internal {
-                    message: format!(
+                .map_err(|e| {
+                    Error::internal(format!(
                         "Captured row ids not equal to number of rows written: {}",
                         e
-                    ),
-                    location: location!(),
+                    ))
                 })?;
 
                 for (fragment, sequence) in new_fragments.iter_mut().zip(sequences) {

--- a/rust/lance/src/dataset/write/merge_insert/assign_action.rs
+++ b/rust/lance/src/dataset/write/merge_insert/assign_action.rs
@@ -115,10 +115,9 @@ pub fn merge_insert_action(
                 cases.push((matched.and(condition), Action::UpdateAll.as_literal_expr()));
             } else {
                 // Fallback - this shouldn't happen in the fast path
-                return Err(crate::Error::Internal {
-                    message: "Schema required for UpdateIf parsing".into(),
-                    location: location!(),
-                });
+                return Err(crate::Error::internal(
+                    "Schema required for UpdateIf parsing",
+                ));
             }
         }
         WhenMatched::DoNothing => {}

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -22,7 +22,6 @@ use futures::{stream, StreamExt};
 use lance_core::{Error, ROW_ADDR, ROW_ID};
 use lance_table::format::RowIdMeta;
 use roaring::RoaringTreemap;
-use snafu::location;
 
 use crate::dataset::transaction::UpdateMode::RewriteRows;
 use crate::dataset::utils::CapturedRowIds;
@@ -886,12 +885,11 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
                     fragment_sizes,
                     true,
                 )
-                .map_err(|e| Error::Internal {
-                    message: format!(
+                .map_err(|e| {
+                    Error::internal(format!(
                         "Captured row ids not equal to number of rows written: {}",
                         e
-                    ),
-                    location: location!(),
+                    ))
                 })?;
 
                 for (fragment, sequence) in new_fragments.iter_mut().zip(sequences) {

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -284,10 +284,10 @@ impl UpdateJob {
 
         let expected_schema = self.dataset.schema().into();
         if schema.as_ref() != &expected_schema {
-            return Err(Error::Internal {
-                message: format!("Expected schema {:?} but got {:?}", expected_schema, schema),
-                location: location!(),
-            });
+            return Err(Error::internal(format!(
+                "Expected schema {:?} but got {:?}",
+                expected_schema, schema
+            )));
         }
 
         let updates_ref = self.updates.clone();
@@ -320,10 +320,9 @@ impl UpdateJob {
         )
         .await?;
 
-        let removed_row_ids = row_id_rx.try_recv().map_err(|err| Error::Internal {
-            message: format!("Failed to receive row ids: {}", err),
-            location: location!(),
-        })?;
+        let removed_row_ids = row_id_rx
+            .try_recv()
+            .map_err(|err| Error::internal(format!("Failed to receive row ids: {}", err)))?;
 
         if let Some(row_id_sequence) = removed_row_ids.row_id_sequence() {
             let fragment_sizes = new_fragments
@@ -334,12 +333,11 @@ impl UpdateJob {
                 fragment_sizes,
                 false,
             )
-            .map_err(|e| Error::Internal {
-                message: format!(
+            .map_err(|e| {
+                Error::internal(format!(
                     "Captured row ids not equal to number of rows written: {}",
                     e
-                ),
-                location: location!(),
+                ))
             })?;
             for (fragment, sequence) in new_fragments.iter_mut().zip(sequences) {
                 let serialized = lance_table::rowids::write_row_ids(&sequence);

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1000,11 +1000,11 @@ impl DatasetIndexExt for Dataset {
             .map(|frags| {
                 let mut sum = 0;
                 for frag in frags.iter() {
-                    sum += frag.num_rows().ok_or_else(|| Error::Internal {
-                        message: "Fragment should have row counts, please upgrade lance and \
-                                      trigger a single write to fix this"
-                            .to_string(),
-                        location: location!(),
+                    sum += frag.num_rows().ok_or_else(|| {
+                        Error::internal(
+                            "Fragment should have row counts, please upgrade lance and \
+                         trigger a single write to fix this",
+                        )
                     })?;
                 }
                 Ok(sum)
@@ -1029,8 +1029,9 @@ impl DatasetIndexExt for Dataset {
 
         let num_indexed_rows_per_delta = match res {
             Ok(rows) => rows,
-            Err(Error::Internal { message, .. })
-                if auto_migrate_corruption() && message.contains("trigger a single write") =>
+            Err(Error::Internal { source })
+                if auto_migrate_corruption()
+                    && source.message.contains("trigger a single write") =>
             {
                 return migrate_and_recompute(self, index_name).await;
             }
@@ -1044,13 +1045,10 @@ impl DatasetIndexExt for Dataset {
                     if auto_migrate_corruption() {
                         return migrate_and_recompute(self, index_name).await;
                     } else {
-                        return Err(Error::Internal {
-                            message:
-                                "Overlap in indexed fragments. Please upgrade to lance >= 0.23.0 \
-                                  and trigger a single write to fix this"
-                                    .to_string(),
-                            location: location!(),
-                        });
+                        return Err(Error::internal(
+                            "Overlap in indexed fragments. Please upgrade to lance >= 0.23.0 \
+                             and trigger a single write to fix this",
+                        ));
                     }
                 }
             }
@@ -1344,10 +1342,9 @@ impl DatasetIndexInternalExt for Dataset {
                         )
                         .await
                     }
-                    None => Err(Error::Internal {
-                        message: "Index proto was missing implementation field".into(),
-                        location: location!(),
-                    }),
+                    None => Err(Error::internal(
+                        "Index proto was missing implementation field",
+                    )),
                 }
             }
 
@@ -1643,11 +1640,10 @@ impl DatasetIndexInternalExt for Dataset {
             idx.fields.len() == 1 && !is_vector_index && (has_non_empty_bitmap || is_fts_index)
         }) {
             let field = index.fields[0];
-            let field = schema.field_by_id(field).ok_or_else(|| Error::Internal {
-                message: format!(
+            let field = schema.field_by_id(field).ok_or_else(|| {
+                Error::internal(format!(
                     "Index referenced a field with id {field} which did not exist in the schema"
-                ),
-                location: location!(),
+                ))
             })?;
 
             // Build the full field path for nested fields

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -344,10 +344,7 @@ impl<'a> CreateIndexBuilder<'a> {
                     .to_vector()
                     // this should never happen because we control the registration
                     // if this fails, the registration logic has a bug
-                    .ok_or(Error::Internal {
-                        message: "unable to cast index extension to vector".to_string(),
-                        location: location!(),
-                    })?;
+                    .ok_or(Error::internal("unable to cast index extension to vector"))?;
 
                 if train {
                     ext.create_index(self.dataset, column, &index_id.to_string(), self.params)

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -61,10 +61,7 @@ pub async fn find_latest_mem_wal_generation(
     if let Some(latest_mem_wal) = generations.values().last() {
         Ok(Some(latest_mem_wal.clone()))
     } else {
-        Err(Error::Internal {
-            message: format!("Encountered MemWAL index mapping that has a region with an empty list of generations: {}", region),
-            location: location!(),
-        })
+        Err(Error::internal(format!("Encountered MemWAL index mapping that has a region with an empty list of generations: {}", region)))
     }
 }
 
@@ -170,10 +167,7 @@ pub async fn advance_mem_wal_generation(
 
                 Ok((added_mem_wal, updated_mem_wal, removed_mem_wal))
             } else {
-                Err(Error::Internal {
-                    message: format!("Encountered MemWAL index mapping that has a region with an empty list of generations: {}", region),
-                    location: location!(),
-                })
+                Err(Error::internal(format!("Encountered MemWAL index mapping that has a region with an empty list of generations: {}", region)))
             }
         } else {
             if let Some(expected_owner_id) = expected_owner_id {

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -346,13 +346,13 @@ pub(crate) async fn infer_scalar_index_details(
     }
 
     let index_dir = dataset.indice_files_dir(index)?.child(uuid.clone());
-    let col = dataset.schema().field(column).ok_or(Error::Internal {
-        message: format!(
+    let col = dataset
+        .schema()
+        .field(column)
+        .ok_or(Error::internal(format!(
             "Index refers to column {} which does not exist in dataset schema",
             column
-        ),
-        location: location!(),
-    })?;
+        )))?;
 
     let bitmap_page_lookup = index_dir.child(BITMAP_LOOKUP_NAME);
     let inverted_list_lookup = index_dir.child(METADATA_FILE);

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -1417,10 +1417,7 @@ pub(crate) async fn open_vector_index_v2(
             {
                 ext.clone()
                     .to_vector()
-                    .ok_or(Error::Internal {
-                        message: "unable to cast index extension to vector".to_string(),
-                        location: location!(),
-                    })?
+                    .ok_or(Error::internal("unable to cast index extension to vector"))?
                     .load_index(dataset.clone(), column, uuid, reader)
                     .await?
             } else {

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -291,12 +291,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 let part = ivf_index
                     .load_partition(part_id, false, &NoOpMetricsCollector)
                     .await?;
-                let part = part.as_any().downcast_ref::<PartitionEntry<S, Q>>().ok_or(
-                    Error::Internal {
-                        message: "failed to downcast partition entry".to_string(),
-                        location: location!(),
-                    },
-                )?;
+                let part = part
+                    .as_any()
+                    .downcast_ref::<PartitionEntry<S, Q>>()
+                    .ok_or(Error::internal("failed to downcast partition entry"))?;
 
                 let storage = part.storage.remap(&mapping)?;
                 let index = part.index.remap(&mapping, &storage)?;

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -388,10 +388,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> Index for IVFIndex<S, 
                 serde_json::map::Map::new()
             };
         let mut store_stats = serde_json::to_value(self.storage.metadata())?;
-        let store_stats = store_stats.as_object_mut().ok_or(Error::Internal {
-            message: "failed to get storage metadata".to_string(),
-            location: location!(),
-        })?;
+        let store_stats = store_stats
+            .as_object_mut()
+            .ok_or(Error::internal("failed to get storage metadata"))?;
 
         sub_index_stats.append(store_stats);
         if S::name() == "FLAT" {
@@ -488,10 +487,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
             let part = part_entry
                 .as_any()
                 .downcast_ref::<PartitionEntry<S, Q>>()
-                .ok_or(Error::Internal {
-                    message: "failed to downcast partition entry".to_string(),
-                    location: location!(),
-                })?;
+                .ok_or(Error::internal("failed to downcast partition entry"))?;
             let batch = part.index.search(
                 query.key,
                 k,
@@ -539,10 +535,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
         let partition = partition
             .as_any()
             .downcast_ref::<PartitionEntry<S, Q>>()
-            .ok_or(Error::Internal {
-                message: "failed to downcast partition entry".to_string(),
-                location: location!(),
-            })?;
+            .ok_or(Error::internal("failed to downcast partition entry"))?;
         let store = &partition.storage;
         let schema = if with_vector {
             store.schema().clone()

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -335,13 +335,10 @@ fn check_storage_version(manifest: &mut Manifest) -> Result<()> {
         // match the file version.  As a result, we need to check and see if they are out
         // of sync.
         if let Some(actual_file_version) =
-            Fragment::try_infer_version(&manifest.fragments).map_err(|e| Error::Internal {
-                message: format!(
-                    "The dataset contains a mixture of file versions.  You will need to rollback to an earlier version: {}",
-                    e
-                ),
-                location: location!(),
-            })? {
+            Fragment::try_infer_version(&manifest.fragments).map_err(|e| Error::internal(format!(
+                "The dataset contains a mixture of file versions.  You will need to rollback to an earlier version: {}",
+                e
+            )))? {
                 if actual_file_version > data_storage_version {
                     log::warn!(
                         "Data storage version {} is less than the actual file version {}.  This has been automatically updated.",
@@ -356,14 +353,11 @@ fn check_storage_version(manifest: &mut Manifest) -> Result<()> {
         // match the data storage version.  This is a sanity assertion to prevent data corruption.
         if let Some(actual_file_version) = Fragment::try_infer_version(&manifest.fragments)? {
             if actual_file_version != data_storage_version {
-                return Err(Error::Internal {
-                    message: format!(
-                        "The operation added files with version {}.  However, the data storage version is {}.",
-                        actual_file_version,
-                        data_storage_version
-                    ),
-                    location: location!(),
-                });
+                return Err(Error::internal(format!(
+                    "The operation added files with version {}.  However, the data storage version is {}.",
+                    actual_file_version,
+                    data_storage_version
+                )));
             }
         }
     }
@@ -507,9 +501,8 @@ pub(crate) async fn migrate_fragments(
                             object_store
                                 .size(&dataset.base.child("data").child(file.path.clone()))
                                 .map_ok(|size| {
-                                    NonZero::new(size).ok_or_else(|| Error::Internal {
-                                        message: format!("File {} has size 0", file.path),
-                                        location: location!(),
+                                    NonZero::new(size).ok_or_else(|| {
+                                        Error::internal(format!("File {} has size 0", file.path))
                                     })
                                 })
                                 .await?
@@ -587,7 +580,7 @@ async fn migrate_indices(dataset: &Dataset, indices: &mut [IndexMetadata]) -> Re
                 && !is_system_index(index)
         {
             debug_assert_eq!(index.fields.len(), 1);
-            let idx_field = dataset.schema().field_by_id(index.fields[0]).ok_or_else(|| Error::Internal { message: format!("Index with uuid {} referred to field with id {} which did not exist in dataset", index.uuid, index.fields[0]), location: location!() })?;
+            let idx_field = dataset.schema().field_by_id(index.fields[0]).ok_or_else(|| Error::internal(format!("Index with uuid {} referred to field with id {} which did not exist in dataset", index.uuid, index.fields[0])))?;
             // We need to calculate the fragments covered by the index
             let idx = dataset
                 .open_generic_index(
@@ -851,7 +844,7 @@ pub(crate) async fn commit_transaction(
 
         target_version = dataset.manifest.version + 1;
         if is_detached_version(target_version) {
-            return Err(Error::Internal { message: "more than 2^65 versions have been created and so regular version numbers are appearing as 'detached' versions.".into(), location: location!() });
+            return Err(Error::internal("more than 2^65 versions have been created and so regular version numbers are appearing as 'detached' versions."));
         }
         // Build an up-to-date manifest from the transaction and current manifest
         let (mut manifest, mut indices) = match transaction.operation {

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1356,13 +1356,10 @@ impl<'a> TransactionRebase<'a> {
             }
 
             if committed.len() > 1 {
-                return Err(Error::Internal {
-                    message: format!(
-                        "Committing multiple MemWALs is not supported, but found committed: {:?}",
-                        committed
-                    ),
-                    location: location!(),
-                });
+                return Err(Error::internal(format!(
+                    "Committing multiple MemWALs is not supported, but found committed: {:?}",
+                    committed
+                )));
             }
 
             if to_commit.len() > 1 {
@@ -1567,10 +1564,7 @@ impl<'a> TransactionRebase<'a> {
                 })
             } else {
                 // We shouldn't hit this.
-                Err(crate::Error::Internal {
-                    message: "We have a transaction that needs to be rebased, but we don't have any affected rows.".into(),
-                    location: location!(),
-                })
+                Err(crate::Error::internal("We have a transaction that needs to be rebased, but we don't have any affected rows."))
             }
         } else {
             Ok(Transaction {
@@ -1752,10 +1746,7 @@ async fn initial_fragments_for_rebase(
 }
 
 fn wrong_operation_err(op: &Operation) -> Error {
-    Error::Internal {
-        message: format!("function called against a wrong operation: {}", op),
-        location: location!(),
-    }
+    Error::internal(format!("function called against a wrong operation: {}", op))
 }
 
 #[cfg(test)]

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -1526,11 +1526,9 @@ impl FilteredReadExec {
                 let mut evaluated_index = None;
                 if let Some(index_input) = index_input {
                     let mut index_search = index_input.execute(partition, context)?;
-                    let index_search_result =
-                        index_search.next().await.ok_or_else(|| Error::Internal {
-                            message: "Index search did not yield any results".to_string(),
-                            location: location!(),
-                        })??;
+                    let index_search_result = index_search.next().await.ok_or_else(|| {
+                        Error::internal("Index search did not yield any results")
+                    })??;
                     evaluated_index = Some(Arc::new(EvaluatedIndex::try_from_arrow(
                         &index_search_result,
                     )?));
@@ -1756,11 +1754,7 @@ impl ExecutionPlan for FilteredReadExec {
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         if children.len() > 1 {
             Err(DataFusionError::External(
-                Error::Internal {
-                    message: "A FilteredReadExec cannot have two children".to_string(),
-                    location: location!(),
-                }
-                .into(),
+                Error::internal("A FilteredReadExec cannot have two children").into(),
             ))
         } else {
             let index_input = children.into_iter().next();

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -539,14 +539,13 @@ impl FragmentScanner {
 
         let mut batch = batch
             .project_by_schema(&self.projection.as_ref().into())
-            .map_err(|err| Error::Internal {
-                message: format!(
+            .map_err(|err| {
+                Error::internal(format!(
                     "Failed to select schema {} from batch with schema {}\nInner error: {}",
                     self.projection,
                     batch.schema(),
                     err
-                ),
-                location: location!(),
+                ))
             })?;
 
         // Row id nor row address weren't part of the projection, so we need to

--- a/rust/lance/src/io/exec/rowids.rs
+++ b/rust/lance/src/io/exec/rowids.rs
@@ -24,7 +24,6 @@ use lance_core::{
     ROW_OFFSET_FIELD,
 };
 use lance_table::rowids::RowIdIndex;
-use snafu::location;
 
 use crate::dataset::rowids::get_row_id_index;
 use crate::utils::future::SharedPrerequisite;
@@ -356,18 +355,15 @@ impl AddRowOffsetExec {
         frag_id_to_offset: Arc<HashMap<u32, FragInfo>>,
     ) -> LanceResult<Self> {
         let input_schema = input.schema();
-        let row_addr_pos = input_schema
-            .index_of(ROW_ADDR)
-            .map_err(|_| LanceError::Internal {
-                message: format!("Input plan does not have a {} column", ROW_ADDR),
-                location: location!(),
-            })?;
+        let row_addr_pos = input_schema.index_of(ROW_ADDR).map_err(|_| {
+            LanceError::internal(format!("Input plan does not have a {} column", ROW_ADDR))
+        })?;
 
         if input_schema.field_with_name(ROW_OFFSET).is_ok() {
-            return Err(LanceError::Internal {
-                message: format!("Input plan already has a {} column", ROW_OFFSET),
-                location: location!(),
-            });
+            return Err(LanceError::internal(format!(
+                "Input plan already has a {} column",
+                ROW_OFFSET
+            )));
         }
 
         let mut fields = input.schema().fields().iter().cloned().collect::<Vec<_>>();
@@ -429,7 +425,7 @@ impl AddRowOffsetExec {
             if frag_id != last_frag_id {
                 last_frag_id = frag_id;
                 let Some(frag_info) = frag_id_to_offset.get(&frag_id) else {
-                    return Err(DataFusionError::External(Box::new(LanceError::Internal { message: format!("A row address referred to a fragment {} that wasn't in the frag_id_to_offset map", frag_id), location: location!() })));
+                    return Err(DataFusionError::External(Box::new(LanceError::internal(format!("A row address referred to a fragment {} that wasn't in the frag_id_to_offset map", frag_id)))));
                 };
                 last_frag_offset = frag_info.row_offset;
                 last_frag_delete_count = 0;

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -51,7 +51,6 @@ use lance_index::{
 };
 use lance_table::format::Fragment;
 use roaring::RoaringBitmap;
-use snafu::location;
 use tracing::{debug_span, instrument};
 
 #[async_trait]
@@ -65,10 +64,7 @@ impl ScalarIndexLoader for Dataset {
         let idx = self
             .load_scalar_index(IndexCriteria::default().with_name(index_name))
             .await?
-            .ok_or_else(|| Error::Internal {
-                message: format!("Scanner created plan for index query on index {} for column {} but no usable index exists with that name", index_name, column),
-                location: location!()
-            })?;
+            .ok_or_else(|| Error::internal(format!("Scanner created plan for index query on index {} for column {} but no usable index exists with that name", index_name, column)))?;
         self.open_scalar_index(column, &idx.uuid.to_string(), metrics)
             .await
     }

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -30,7 +30,6 @@ use lance_core::{Error, ROW_ADDR_FIELD, ROW_ID_FIELD};
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_table::format::Fragment;
 use log::debug;
-use snafu::location;
 use tracing::Instrument;
 
 use crate::dataset::fragment::{FileFragment, FragReadConfig, FragmentReader};
@@ -239,11 +238,9 @@ impl LanceStream {
                         .count_rows(None)
                         // count_rows should be a fast operation in v2 files
                         .now_or_never()
-                        .ok_or(Error::Internal {
-                            message: "Encountered fragment without row count metadata in v2 file"
-                                .to_string(),
-                            location: location!(),
-                        })??;
+                        .ok_or(Error::internal(
+                            "Encountered fragment without row count metadata in v2 file",
+                        ))??;
                     if rows_to_skip >= num_rows_in_frag as u64 {
                         rows_to_skip -= num_rows_in_frag as u64;
                     } else {

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -30,7 +30,6 @@ use lance_core::utils::futures::{Capacity, SharedStreamExt};
 use lance_core::utils::mask::{RowAddrMask, RowAddrTreeMap};
 use lance_core::{Result, ROW_ID};
 use lance_index::prefilter::FilterLoader;
-use snafu::location;
 
 use crate::index::prefilter::DatasetPreFilter;
 use crate::Dataset;
@@ -79,10 +78,7 @@ impl FilterLoader for FilteredRowIdsToPrefilter {
         let mut allow_list = RowAddrTreeMap::new();
         while let Some(batch) = self.0.next().await {
             let batch = batch?;
-            let row_ids = batch.column_by_name(ROW_ID).ok_or_else(|| Error::Internal {
-                message: "input batch missing row id column even though it is in the schema for the stream".into(),
-                location: location!(),
-            })?;
+            let row_ids = batch.column_by_name(ROW_ID).ok_or_else(|| Error::internal("input batch missing row id column even though it is in the schema for the stream"))?;
             let row_ids = row_ids
                 .as_any()
                 .downcast_ref::<UInt64Array>()
@@ -103,19 +99,15 @@ impl FilterLoader for SelectionVectorToPrefilter {
             .0
             .try_next()
             .await?
-            .ok_or_else(|| Error::Internal {
-                message: "Selection vector source for prefilter did not yield any batches".into(),
-                location: location!(),
+            .ok_or_else(|| {
+                Error::internal("Selection vector source for prefilter did not yield any batches")
             })
             .unwrap();
         RowAddrMask::from_arrow(batch["result"].as_binary_opt::<i32>().ok_or_else(|| {
-            Error::Internal {
-                message: format!(
-                    "Expected selection vector input to yield binary arrays but got {}",
-                    batch["result"].data_type()
-                ),
-                location: location!(),
-            }
+            Error::internal(format!(
+                "Expected selection vector input to yield binary arrays but got {}",
+                batch["result"].data_type()
+            ))
         })?)
     }
 }


### PR DESCRIPTION
## Summary

- `Error::Internal` now captures a backtrace instead of using snafu's `location!()` macro
- Introduces `Error::internal(message)` constructor that automatically captures the backtrace at the call site
- Migrated all 120+ usages across 63 files in 8 crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)