### PR TITLE
feat: introduce semaphore-based scheduling backpressure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,10 +4915,12 @@ dependencies = [
  "lance-bitpacking",
  "lance-core",
  "lance-datagen",
+ "lance-linalg",
  "lance-testing",
  "log",
  "lz4",
  "num-traits",
+ "peak_alloc",
  "pprof",
  "proptest",
  "prost",
@@ -6517,6 +6519,12 @@ dependencies = [
  "digest",
  "hmac",
 ]
+
+[[package]]
+name = "peak_alloc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c4e8e2dd832fd76346468f822e4e600d30ba4e5aa545a128abf12cfae7ea3e"
 
 [[package]]
 name = "pem"

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -46,6 +46,7 @@ zstd = { version = "0.13", optional = true }
 [dev-dependencies]
 lance-testing.workspace = true
 lance-datagen.workspace = true
+lance-linalg.workspace = true
 arrow-ord.workspace = true
 rand.workspace = true
 rstest.workspace = true
@@ -53,6 +54,7 @@ test-log.workspace = true
 criterion = { workspace = true }
 rand_xoshiro = { workspace = true }
 proptest.workspace = true
+peak_alloc = "0.2"
 
 [build-dependencies]
 prost-build.workspace = true
@@ -82,6 +84,10 @@ harness = false
 
 [[bench]]
 name = "buffer"
+harness = false
+
+[[bench]]
+name = "decode_backpressure"
 harness = false
 
 [lints]

--- a/rust/lance-encoding/benches/decode_backpressure.rs
+++ b/rust/lance-encoding/benches/decode_backpressure.rs
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Benchmark comparing bounded vs unbounded decode channels.
+//!
+//! Measures:
+//! - Throughput (rows/sec) at different parallelism levels
+//! - Peak memory (bytes) at different parallelism levels
+//!
+//! Run with: cargo bench --bench decode_backpressure
+//! Results are printed as CSV for easy plotting.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow_array::{Array, Float32Array};
+use arrow_schema::{DataType, Field, Schema};
+use futures::StreamExt;
+use lance_arrow::FixedSizeListArrayExt;
+use lance_core::cache::LanceCache;
+use lance_encoding::{
+    decoder::{
+        schedule_and_decode, DecoderConfig, DecoderPlugins, FilterExpression, RequestedRows,
+        SchedulerDecoderConfig,
+    },
+    encoder::{default_encoding_strategy, encode_batch, EncodingOptions},
+    version::LanceFileVersion,
+    EncodingsIo,
+};
+use lance_linalg::distance::l2_distance_arrow_batch;
+use peak_alloc::PeakAlloc;
+
+#[global_allocator]
+static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+
+// Benchmark parameters
+const NUM_ROWS: u64 = 100_000;
+const DIMS: i32 = 1024;
+const BATCH_SIZE: u32 = 1024;
+const PARALLELISM_LEVELS: &[usize] = &[4];
+const WARMUP_ITERS: usize = 1;
+const BENCH_ITERS: usize = 2;
+// I/O latencies to simulate: local NVMe (0ms), various cloud latencies
+const IO_LATENCIES_MS: &[u64] = &[0, 1, 5, 50];
+
+/// A wrapper around BufferScheduler that clones data on each read
+/// and simulates storage latency.
+///
+/// The latency model simulates parallel I/O: multiple concurrent requests
+/// share the same latency window. We track the "last request time" and only
+/// add latency if enough time has passed since the last batch of requests.
+/// This models real cloud storage where parallel requests overlap.
+#[derive(Debug)]
+struct CloningIoScheduler {
+    inner: lance_encoding::BufferScheduler,
+    latency: Duration,
+    request_count: AtomicUsize,
+    range_count: AtomicUsize,
+    total_bytes: AtomicUsize,
+}
+
+impl CloningIoScheduler {
+    fn with_latency(data: bytes::Bytes, latency: Duration) -> Self {
+        Self {
+            inner: lance_encoding::BufferScheduler::new(data),
+            latency,
+            request_count: AtomicUsize::new(0),
+            range_count: AtomicUsize::new(0),
+            total_bytes: AtomicUsize::new(0),
+        }
+    }
+
+    fn request_count(&self) -> usize {
+        self.request_count.load(Ordering::Relaxed)
+    }
+
+    fn range_count(&self) -> usize {
+        self.range_count.load(Ordering::Relaxed)
+    }
+
+    fn total_bytes(&self) -> usize {
+        self.total_bytes.load(Ordering::Relaxed)
+    }
+}
+
+impl EncodingsIo for CloningIoScheduler {
+    fn submit_request(
+        &self,
+        ranges: Vec<std::ops::Range<u64>>,
+        priority: u64,
+    ) -> futures::future::BoxFuture<'static, lance_core::Result<Vec<bytes::Bytes>>> {
+        self.request_count.fetch_add(1, Ordering::Relaxed);
+        self.range_count.fetch_add(ranges.len(), Ordering::Relaxed);
+        let bytes_requested: u64 = ranges.iter().map(|r| r.end - r.start).sum();
+        self.total_bytes.fetch_add(bytes_requested as usize, Ordering::Relaxed);
+
+        let fut = self.inner.submit_request(ranges, priority);
+        let latency = self.latency;
+
+        Box::pin(async move {
+            // Simulate I/O latency. When multiple requests are awaited concurrently,
+            // these sleeps overlap naturally (async parallelism).
+            if !latency.is_zero() {
+                tokio::time::sleep(latency).await;
+            }
+            let buffers = fut.await?;
+
+            Ok(buffers
+                .into_iter()
+                .map(|b| bytes::Bytes::copy_from_slice(&b))
+                .collect())
+        })
+    }
+}
+
+/// Compute L2 distance between a query vector and all vectors in a batch.
+/// Uses SIMD-optimized implementation from lance-linalg.
+fn compute_l2_distances(
+    batch: &arrow_array::RecordBatch,
+    query: &Float32Array,
+) -> Arc<Float32Array> {
+    let vector_col = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<arrow_array::FixedSizeListArray>()
+        .unwrap();
+
+    l2_distance_arrow_batch(query, vector_col).unwrap()
+}
+
+/// Generate a batch of f32 vectors (similar to embedding vectors in KNN workloads)
+fn generate_vector_batch(num_rows: usize, dims: i32) -> arrow_array::RecordBatch {
+    use rand::{Rng, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
+    let values: Vec<f32> = (0..num_rows * dims as usize)
+        .map(|_| rng.random::<f32>())
+        .collect();
+
+    let values_array = arrow_array::Float32Array::from(values);
+    let list_array =
+        arrow_array::FixedSizeListArray::try_new_from_values(values_array, dims).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "vector",
+        DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dims),
+        false,
+    )]));
+
+    arrow_array::RecordBatch::try_new(schema, vec![Arc::new(list_array)]).unwrap()
+}
+
+/// Encoded test data shared across benchmarks
+struct EncodedData {
+    encoded: Arc<lance_encoding::encoder::EncodedBatch>,
+    query: Float32Array,
+}
+
+impl EncodedData {
+    fn new(rt: &tokio::runtime::Runtime) -> Self {
+        let data = generate_vector_batch(NUM_ROWS as usize, DIMS);
+        let lance_schema =
+            Arc::new(lance_core::datatypes::Schema::try_from(data.schema().as_ref()).unwrap());
+        let encoding_strategy = default_encoding_strategy(LanceFileVersion::V2_1);
+
+        let encoded = rt
+            .block_on(encode_batch(
+                &data,
+                lance_schema,
+                encoding_strategy.as_ref(),
+                &EncodingOptions::default(),
+            ))
+            .unwrap();
+
+        let query: Float32Array = {
+            use rand::{Rng, SeedableRng};
+            let mut rng = rand::rngs::StdRng::seed_from_u64(123);
+            (0..DIMS).map(|_| Some(rng.random::<f32>())).collect()
+        };
+
+        Self {
+            encoded: Arc::new(encoded),
+            query,
+        }
+    }
+}
+
+/// Timing stats for diagnostics
+#[derive(Default, Debug)]
+struct DecodeStats {
+    total_rows: usize,
+    decode_wait_ns: u64,
+    l2_compute_ns: u64,
+    batch_count: usize,
+    io_request_count: usize,
+    io_range_count: usize,
+    io_total_bytes: usize,
+}
+
+/// Run decode with specified configuration, return stats
+async fn run_decode(
+    encoded: &lance_encoding::encoder::EncodedBatch,
+    query: &Float32Array,
+    channel_capacity: Option<usize>,
+    parallelism: usize,
+    io_latency: Duration,
+) -> DecodeStats {
+    let io_scheduler = Arc::new(CloningIoScheduler::with_latency(encoded.data.clone(), io_latency));
+    let io_scheduler_ref = io_scheduler.clone();
+    let cache = Arc::new(LanceCache::no_cache());
+
+    let config = SchedulerDecoderConfig {
+        decoder_plugins: Arc::<DecoderPlugins>::default(),
+        batch_size: BATCH_SIZE,
+        io: io_scheduler,
+        cache,
+        decoder_config: DecoderConfig::default(),
+        decode_channel_capacity: channel_capacity,
+    };
+
+    let decode_stream = schedule_and_decode(
+        encoded.page_table.clone(),
+        RequestedRows::Ranges(vec![0..encoded.num_rows]),
+        FilterExpression::no_filter(),
+        encoded.top_level_columns.clone(),
+        encoded.schema.clone(),
+        config,
+    );
+
+    let mut stats = DecodeStats::default();
+    let mut all_distances: Vec<Arc<Float32Array>> = Vec::new();
+    let mut stream = std::pin::pin!(decode_stream.map(|task| task.task).buffered(parallelism));
+
+    while let Some(batch) = {
+        let t0 = Instant::now();
+        let b = stream.next().await;
+        stats.decode_wait_ns += t0.elapsed().as_nanos() as u64;
+        b
+    } {
+        let batch = batch.unwrap();
+        stats.total_rows += batch.num_rows();
+        stats.batch_count += 1;
+
+        let t0 = Instant::now();
+        let distances = compute_l2_distances(&batch, query);
+        stats.l2_compute_ns += t0.elapsed().as_nanos() as u64;
+
+        all_distances.push(distances);
+    }
+
+    std::hint::black_box(&all_distances);
+    stats.io_request_count = io_scheduler_ref.request_count();
+    stats.io_range_count = io_scheduler_ref.range_count();
+    stats.io_total_bytes = io_scheduler_ref.total_bytes();
+    stats
+}
+
+#[derive(Debug, Clone)]
+struct BenchResult {
+    mode: &'static str,
+    parallelism: usize,
+    io_latency_ms: u64,
+    throughput_rows_per_sec: f64,
+    peak_memory_bytes: usize,
+    decode_wait_ms: f64,
+    l2_compute_ms: f64,
+    io_request_count: usize,
+}
+
+fn run_single_benchmark(
+    rt: &tokio::runtime::Runtime,
+    test_data: &EncodedData,
+    mode: &'static str,
+    channel_capacity: Option<usize>,
+    parallelism: usize,
+    io_latency: Duration,
+) -> BenchResult {
+    // Warmup
+    for _ in 0..WARMUP_ITERS {
+        PEAK_ALLOC.reset_peak_usage();
+        rt.block_on(run_decode(
+            &test_data.encoded,
+            &test_data.query,
+            channel_capacity,
+            parallelism,
+            io_latency,
+        ));
+    }
+
+    // Benchmark iterations
+    let mut total_duration = Duration::ZERO;
+    let mut max_peak_memory = 0usize;
+    let mut total_decode_wait_ns = 0u64;
+    let mut total_l2_compute_ns = 0u64;
+    let mut last_stats = DecodeStats::default();
+
+    for _ in 0..BENCH_ITERS {
+        PEAK_ALLOC.reset_peak_usage();
+        let baseline = PEAK_ALLOC.current_usage();
+
+        let start = Instant::now();
+        let stats = rt.block_on(run_decode(
+            &test_data.encoded,
+            &test_data.query,
+            channel_capacity,
+            parallelism,
+            io_latency,
+        ));
+        let duration = start.elapsed();
+
+        let peak = PEAK_ALLOC.peak_usage();
+        let peak_delta = peak.saturating_sub(baseline);
+
+        total_duration += duration;
+        max_peak_memory = max_peak_memory.max(peak_delta);
+        total_decode_wait_ns += stats.decode_wait_ns;
+        total_l2_compute_ns += stats.l2_compute_ns;
+        last_stats = stats;
+
+        assert_eq!(last_stats.total_rows, NUM_ROWS as usize);
+    }
+
+    let avg_duration = total_duration / BENCH_ITERS as u32;
+    let throughput = NUM_ROWS as f64 / avg_duration.as_secs_f64();
+
+    BenchResult {
+        mode,
+        parallelism,
+        io_latency_ms: io_latency.as_millis() as u64,
+        throughput_rows_per_sec: throughput,
+        peak_memory_bytes: max_peak_memory,
+        decode_wait_ms: (total_decode_wait_ns as f64 / BENCH_ITERS as f64) / 1_000_000.0,
+        l2_compute_ms: (total_l2_compute_ns as f64 / BENCH_ITERS as f64) / 1_000_000.0,
+        io_request_count: last_stats.io_request_count,
+    }
+}
+
+fn main() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    eprintln!("Generating test data ({} rows, {} dims)...", NUM_ROWS, DIMS);
+    let test_data = EncodedData::new(&rt);
+    eprintln!("Test data ready. Running benchmarks...\n");
+
+    let mut results = Vec::new();
+
+    // Channel capacities to test: unbounded, and various fixed sizes
+    let channel_configs: &[(&str, Option<usize>)] = &[
+        ("unbounded", None),
+        ("bounded_c=2", Some(2)),
+        ("bounded_c=4", Some(4)),
+        ("bounded_c=8", Some(8)),
+        ("bounded_c=16", Some(16)),
+    ];
+
+    for &latency_ms in IO_LATENCIES_MS {
+        let latency = Duration::from_millis(latency_ms);
+        eprintln!("=== I/O Latency: {}ms ===", latency_ms);
+
+        for &p in PARALLELISM_LEVELS {
+            for &(mode, capacity) in channel_configs {
+                eprint!("  latency={:2}ms p={:2} {:14} ", latency_ms, p, mode);
+                let result = run_single_benchmark(&rt, &test_data, mode, capacity, p, latency);
+                eprintln!(
+                    "{:>7.0} rows/s, {:>5.1} MB, io_reqs={}",
+                    result.throughput_rows_per_sec,
+                    result.peak_memory_bytes as f64 / (1024.0 * 1024.0),
+                    result.io_request_count,
+                );
+                results.push(result);
+            }
+        }
+        eprintln!();
+    }
+
+    // Print CSV
+    eprintln!("--- CSV Output ---");
+    println!("io_latency_ms,mode,parallelism,throughput_rows_per_sec,peak_memory_mb,decode_wait_ms,l2_compute_ms,io_request_count");
+    for r in &results {
+        println!(
+            "{},{},{},{:.0},{:.1},{:.1},{:.1},{}",
+            r.io_latency_ms,
+            r.mode,
+            r.parallelism,
+            r.throughput_rows_per_sec,
+            r.peak_memory_bytes as f64 / (1024.0 * 1024.0),
+            r.decode_wait_ms,
+            r.l2_compute_ms,
+            r.io_request_count,
+        );
+    }
+}

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -213,7 +213,9 @@
 //!    relation to the way the data is stored.
 
 use std::collections::VecDeque;
+use std::pin::Pin;
 use std::sync::{LazyLock, Once};
+use std::task::{Context, Poll};
 use std::{ops::Range, sync::Arc};
 
 use arrow_array::cast::AsArray;
@@ -222,7 +224,7 @@ use arrow_schema::{ArrowError, DataType, Field as ArrowField, Fields, Schema as 
 use bytes::Bytes;
 use futures::future::{maybe_done, BoxFuture, MaybeDone};
 use futures::stream::{self, BoxStream};
-use futures::{FutureExt, StreamExt};
+use futures::{FutureExt, Stream, StreamExt};
 use lance_arrow::DataTypeExt;
 use lance_core::cache::LanceCache;
 use lance_core::datatypes::{Field, Schema, BLOB_DESC_LANCE_FIELD};
@@ -231,6 +233,7 @@ use log::{debug, trace, warn};
 use snafu::location;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{self, unbounded_channel};
+use tokio::sync::Semaphore;
 
 use lance_core::error::LanceOptionExt;
 use lance_core::{ArrowResult, Error, Result};
@@ -1117,6 +1120,7 @@ impl DecodeBatchScheduler {
                 if !schedule_action(Ok(DecoderMessage {
                     scheduled_so_far: num_rows_scheduled,
                     decoders: next_scan_line.decoders,
+                    backpressure_permit: None,
                 })) {
                     // Decoder has disconnected
                     return;
@@ -1179,6 +1183,7 @@ impl DecodeBatchScheduler {
             if !schedule_action(Ok(DecoderMessage {
                 scheduled_so_far: num_rows_scheduled,
                 decoders: next_scan_line.decoders,
+                backpressure_permit: None,
             })) {
                 // Decoder has disconnected
                 return;
@@ -1331,6 +1336,11 @@ impl DecodeBatchScheduler {
 pub struct ReadBatchTask {
     pub task: BoxFuture<'static, Result<RecordBatch>>,
     pub num_rows: u32,
+    /// Backpressure permits held until this task completes.
+    /// When the task future is polled to completion, these permits are dropped,
+    /// releasing them back to the semaphore.
+    #[allow(dead_code)]
+    backpressure_permits: Vec<tokio::sync::OwnedSemaphorePermit>,
 }
 
 /// A stream that takes scheduled jobs and generates decode tasks from them.
@@ -1343,6 +1353,8 @@ pub struct BatchDecodeStream {
     rows_drained: u64,
     scheduler_exhausted: bool,
     emitted_batch_size_warning: Arc<Once>,
+    /// Permits collected from received messages, to be attached to the next batch task
+    pending_permits: Vec<tokio::sync::OwnedSemaphorePermit>,
 }
 
 impl BatchDecodeStream {
@@ -1370,6 +1382,30 @@ impl BatchDecodeStream {
             rows_drained: 0,
             scheduler_exhausted: false,
             emitted_batch_size_warning: Arc::new(Once::new()),
+            pending_permits: Vec::new(),
+        }
+    }
+
+    /// Create a new instance with a bounded channel for backpressure support.
+    ///
+    /// Using a bounded channel prevents unbounded memory growth when the decoder
+    /// cannot keep up with the scheduler.
+    pub fn new_bounded(
+        scheduled: mpsc::Receiver<Result<DecoderMessage>>,
+        rows_per_batch: u32,
+        num_rows: u64,
+        root_decoder: SimpleStructDecoder,
+    ) -> Self {
+        Self {
+            context: DecoderContext::new_bounded(scheduled),
+            root_decoder,
+            rows_remaining: num_rows,
+            rows_per_batch,
+            rows_scheduled: 0,
+            rows_drained: 0,
+            scheduler_exhausted: false,
+            emitted_batch_size_warning: Arc::new(Once::new()),
+            pending_permits: Vec::new(),
         }
     }
 
@@ -1394,6 +1430,10 @@ impl BatchDecodeStream {
                     self.rows_scheduled = scan_line.scheduled_so_far;
                     for message in scan_line.decoders {
                         self.accept_decoder(message.into_legacy())?;
+                    }
+                    // Collect backpressure permit to hold until batch task completes
+                    if let Some(permit) = scan_line.backpressure_permit {
+                        self.pending_permits.push(permit);
                     }
                 }
                 None => {
@@ -1458,10 +1498,14 @@ impl BatchDecodeStream {
     pub fn into_stream(self) -> BoxStream<'static, ReadBatchTask> {
         let stream = futures::stream::unfold(self, |mut slf| async move {
             let next_task = slf.next_batch_task().await;
+            // Take permits BEFORE creating the task so we can move them into the future
+            let permits = std::mem::take(&mut slf.pending_permits);
             let next_task = next_task.transpose().map(|next_task| {
                 let num_rows = next_task.as_ref().map(|t| t.num_rows).unwrap_or(0);
                 let emitted_batch_size_warning = slf.emitted_batch_size_warning.clone();
+                // Capture permits inside the async block so they're held until future completes
                 let task = async move {
+                    let _permits = permits; // Hold permits until this future completes
                     let next_task = next_task?;
                     // Real decode work happens inside into_batch, which can block the current
                     // thread for a long time. By spawning it as a new task, we allow Tokio's
@@ -1481,6 +1525,7 @@ impl BatchDecodeStream {
                 let next_task = ReadBatchTask {
                     task: task.boxed(),
                     num_rows: num_rows as u32,
+                    backpressure_permits: Vec::new(), // Permits are now inside the task future
                 };
                 (next_task, slf)
             })
@@ -1688,6 +1733,8 @@ pub struct StructuralBatchDecodeStream {
     rows_drained: u64,
     scheduler_exhausted: bool,
     emitted_batch_size_warning: Arc<Once>,
+    /// Permits collected from DecoderMessages, held until batch task completes.
+    pending_permits: Vec<tokio::sync::OwnedSemaphorePermit>,
 }
 
 impl StructuralBatchDecodeStream {
@@ -1715,6 +1762,30 @@ impl StructuralBatchDecodeStream {
             rows_drained: 0,
             scheduler_exhausted: false,
             emitted_batch_size_warning: Arc::new(Once::new()),
+            pending_permits: Vec::new(),
+        }
+    }
+
+    /// Create a new instance with a bounded channel for backpressure support.
+    ///
+    /// Using a bounded channel prevents unbounded memory growth when the decoder
+    /// cannot keep up with the scheduler.
+    pub fn new_bounded(
+        scheduled: mpsc::Receiver<Result<DecoderMessage>>,
+        rows_per_batch: u32,
+        num_rows: u64,
+        root_decoder: StructuralStructDecoder,
+    ) -> Self {
+        Self {
+            context: DecoderContext::new_bounded(scheduled),
+            root_decoder,
+            rows_remaining: num_rows,
+            rows_per_batch,
+            rows_scheduled: 0,
+            rows_drained: 0,
+            scheduler_exhausted: false,
+            emitted_batch_size_warning: Arc::new(Once::new()),
+            pending_permits: Vec::new(),
         }
     }
 
@@ -1726,8 +1797,12 @@ impl StructuralBatchDecodeStream {
             let next_message = self.context.source.recv().await;
             match next_message {
                 Some(scan_line) => {
-                    let scan_line = scan_line?;
+                    let mut scan_line = scan_line?;
                     self.rows_scheduled = scan_line.scheduled_so_far;
+                    // Collect backpressure permit to hold until batch task completes
+                    if let Some(permit) = scan_line.backpressure_permit.take() {
+                        self.pending_permits.push(permit);
+                    }
                     for message in scan_line.decoders {
                         let unloaded_page = message.into_structural();
                         let loaded_page = unloaded_page.0.await?;
@@ -1788,10 +1863,14 @@ impl StructuralBatchDecodeStream {
     pub fn into_stream(self) -> BoxStream<'static, ReadBatchTask> {
         let stream = futures::stream::unfold(self, |mut slf| async move {
             let next_task = slf.next_batch_task().await;
+            // Take permits BEFORE creating the task so we can move them into the future
+            let permits = std::mem::take(&mut slf.pending_permits);
             let next_task = next_task.transpose().map(|next_task| {
                 let num_rows = next_task.as_ref().map(|t| t.num_rows).unwrap_or(0);
                 let emitted_batch_size_warning = slf.emitted_batch_size_warning.clone();
+                // Capture permits inside the async block so they're held until future completes
                 let task = async move {
+                    let _permits = permits; // Hold permits until this future completes
                     let next_task = next_task?;
                     // Real decode work happens inside into_batch, which can block the current
                     // thread for a long time. By spawning it as a new task, we allow Tokio's
@@ -1811,6 +1890,7 @@ impl StructuralBatchDecodeStream {
                 let next_task = ReadBatchTask {
                     task: task.boxed(),
                     num_rows: num_rows as u32,
+                    backpressure_permits: Vec::new(), // Permits are now inside the task future
                 };
                 (next_task, slf)
             })
@@ -1858,6 +1938,13 @@ pub struct SchedulerDecoderConfig {
     pub cache: Arc<LanceCache>,
     /// Decoder configuration
     pub decoder_config: DecoderConfig,
+    /// Capacity of the decode channel between scheduler and decoder.
+    ///
+    /// If set to Some(n), a bounded channel of capacity n is used, providing
+    /// backpressure to prevent unbounded memory growth when the decoder can't
+    /// keep up with the scheduler. If None (default), an unbounded channel is
+    /// used for backward compatibility.
+    pub decode_channel_capacity: Option<usize>,
 }
 
 fn check_scheduler_on_drop(
@@ -1908,6 +1995,51 @@ pub fn create_decode_stream(
     }
 }
 
+/// Creates a decode stream with a bounded channel for backpressure support.
+///
+/// This is similar to `create_decode_stream` but uses a bounded channel receiver.
+/// When combined with `schedule_ranges_bounded`, this provides backpressure to
+/// prevent unbounded memory growth when the decoder cannot keep up with the scheduler.
+///
+/// # Arguments
+///
+/// * `schema` - The schema of the data to decode
+/// * `num_rows` - Total number of rows being decoded
+/// * `batch_size` - Number of rows per batch
+/// * `is_structural` - Whether to use structural decoding (for newer encodings)
+/// * `should_validate` - Whether to validate decoded data
+/// * `rx` - A bounded channel receiver for decoder messages
+pub fn create_decode_stream_bounded(
+    schema: &Schema,
+    num_rows: u64,
+    batch_size: u32,
+    is_structural: bool,
+    should_validate: bool,
+    rx: mpsc::Receiver<Result<DecoderMessage>>,
+) -> Result<BoxStream<'static, ReadBatchTask>> {
+    if is_structural {
+        let arrow_schema = ArrowSchema::from(schema);
+        let structural_decoder = StructuralStructDecoder::new(
+            arrow_schema.fields,
+            should_validate,
+            /*is_root=*/ true,
+        )?;
+        Ok(
+            StructuralBatchDecodeStream::new_bounded(rx, batch_size, num_rows, structural_decoder)
+                .into_stream(),
+        )
+    } else {
+        let arrow_schema = ArrowSchema::from(schema);
+        let root_fields = arrow_schema.fields;
+
+        let simple_struct_decoder = SimpleStructDecoder::new(root_fields, num_rows);
+        Ok(
+            BatchDecodeStream::new_bounded(rx, batch_size, num_rows, simple_struct_decoder)
+                .into_stream(),
+        )
+    }
+}
+
 /// Creates a iterator that decodes a set of messages in a blocking fashion
 ///
 /// See [`schedule_and_decode_blocking`] for more information.
@@ -1952,10 +2084,46 @@ fn create_scheduler_decoder(
     config: SchedulerDecoderConfig,
 ) -> Result<BoxStream<'static, ReadBatchTask>> {
     let num_rows = requested_rows.num_rows();
-
     let is_structural = column_infos[0].is_structural();
 
-    let (tx, rx) = mpsc::unbounded_channel();
+    // Use bounded channel if capacity is specified, otherwise use unbounded (legacy behavior)
+    if let Some(capacity) = config.decode_channel_capacity {
+        create_scheduler_decoder_bounded(
+            column_infos,
+            requested_rows,
+            filter,
+            column_indices,
+            target_schema,
+            config,
+            is_structural,
+            num_rows,
+            capacity,
+        )
+    } else {
+        create_scheduler_decoder_unbounded(
+            column_infos,
+            requested_rows,
+            filter,
+            column_indices,
+            target_schema,
+            config,
+            is_structural,
+            num_rows,
+        )
+    }
+}
+
+fn create_scheduler_decoder_unbounded(
+    column_infos: Vec<Arc<ColumnInfo>>,
+    requested_rows: RequestedRows,
+    filter: FilterExpression,
+    column_indices: Vec<u32>,
+    target_schema: Arc<Schema>,
+    config: SchedulerDecoderConfig,
+    is_structural: bool,
+    num_rows: u64,
+) -> Result<BoxStream<'static, ReadBatchTask>> {
+    let (tx, rx) = unbounded_channel();
 
     let decode_stream = create_decode_stream(
         &target_schema,
@@ -2001,6 +2169,191 @@ fn create_scheduler_decoder(
     Ok(check_scheduler_on_drop(decode_stream, scheduler_handle))
 }
 
+/// A wrapper around a decode stream that closes the backpressure semaphore when dropped.
+/// This ensures the scheduler task can exit cleanly when the decoder is done or dropped.
+struct BoundedDecodeStream {
+    inner: BoxStream<'static, ReadBatchTask>,
+    semaphore: Arc<Semaphore>,
+}
+
+impl Stream for BoundedDecodeStream {
+    type Item = ReadBatchTask;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+impl Drop for BoundedDecodeStream {
+    fn drop(&mut self) {
+        // Close the semaphore to unblock the scheduler if it's waiting for permits.
+        // This allows the scheduler task to exit cleanly.
+        self.semaphore.close();
+    }
+}
+
+fn create_scheduler_decoder_bounded(
+    column_infos: Vec<Arc<ColumnInfo>>,
+    requested_rows: RequestedRows,
+    filter: FilterExpression,
+    column_indices: Vec<u32>,
+    target_schema: Arc<Schema>,
+    config: SchedulerDecoderConfig,
+    is_structural: bool,
+    num_rows: u64,
+    channel_capacity: usize,
+) -> Result<BoxStream<'static, ReadBatchTask>> {
+    // Use semaphore-based backpressure instead of bounded channels.
+    // This approach:
+    // 1. Acquires a permit BEFORE scheduling I/O (pure async, no blocking)
+    // 2. Attaches the permit to the message (released when message is processed)
+    // 3. Uses an unbounded channel (simpler, no blocking send)
+    //
+    // Benefits over bounded channels:
+    // - No futex/condvar waits under concurrent load
+    // - Backpressure is async (semaphore.acquire().await) not blocking
+    // - Permits are released when messages are PROCESSED, not just received
+    //
+    // The semaphore is closed when the decode stream is dropped, which allows
+    // the scheduler to exit cleanly even if it's blocked waiting for permits.
+    let backpressure_semaphore = Arc::new(Semaphore::new(channel_capacity));
+    let scheduler_semaphore = backpressure_semaphore.clone();
+    let (tx, rx) = unbounded_channel();
+
+    let decode_stream = create_decode_stream(
+        &target_schema,
+        num_rows,
+        config.batch_size,
+        is_structural,
+        config.decoder_config.validate_on_decode,
+        rx,
+    )?;
+
+    let scheduler_handle = tokio::task::spawn(async move {
+        let mut decode_scheduler = match DecodeBatchScheduler::try_new(
+            target_schema.as_ref(),
+            &column_indices,
+            &column_infos,
+            &vec![],
+            num_rows,
+            config.decoder_plugins,
+            config.io.clone(),
+            config.cache,
+            &filter,
+            &config.decoder_config,
+        )
+        .await
+        {
+            Ok(scheduler) => scheduler,
+            Err(e) => {
+                let _ = tx.send(Err(e));
+                return;
+            }
+        };
+
+        // We acquire permits BEFORE scheduling I/O (not before sending) because scheduling
+        // fires I/O requests that load data into memory. Permits are released when the last
+        // message from each chunk is processed, limiting memory to: channel_capacity * chunk_size.
+        //
+        // We track scheduled_offset across chunks because schedule_ranges_to_vec resets
+        // scheduled_so_far to 0 on each call, but the decoder expects monotonically increasing values.
+        let mut scheduled_offset: u64 = 0;
+
+        // Helper closure to schedule ranges and send messages with permit attached to last
+        let mut schedule_chunk =
+            |decode_scheduler: &mut DecodeBatchScheduler,
+             ranges: &[std::ops::Range<u64>],
+             permit: tokio::sync::OwnedSemaphorePermit|
+             -> bool {
+                let messages = decode_scheduler
+                    .schedule_ranges_to_vec(ranges, &filter, config.io.clone(), None)
+                    .map(|msgs| msgs.into_iter().map(Ok).collect::<Vec<_>>())
+                    .unwrap_or_else(|e| vec![Err(e)]);
+
+                let msg_count = messages.len();
+                let mut permit_opt = Some(permit);
+                let mut chunk_max_scheduled: u64 = 0;
+
+                for (idx, msg) in messages.into_iter().enumerate() {
+                    let msg_permit = if idx == msg_count - 1 {
+                        permit_opt.take()
+                    } else {
+                        None
+                    };
+
+                    let msg_with_permit = msg.map(|m| {
+                        chunk_max_scheduled = chunk_max_scheduled.max(m.scheduled_so_far);
+                        DecoderMessage {
+                            scheduled_so_far: scheduled_offset + m.scheduled_so_far,
+                            decoders: m.decoders,
+                            backpressure_permit: msg_permit,
+                        }
+                    });
+
+                    if tx.send(msg_with_permit).is_err() {
+                        debug!("Scheduler aborting: receiver dropped");
+                        return false;
+                    }
+                }
+
+                scheduled_offset += chunk_max_scheduled;
+                true
+            };
+
+        match requested_rows {
+            RequestedRows::Ranges(ranges) => {
+                let batch_size = config.batch_size as u64;
+                for range in ranges {
+                    let mut start = range.start;
+                    while start < range.end {
+                        let end = (start + batch_size).min(range.end);
+                        let chunk_range = start..end;
+
+                        let permit = match scheduler_semaphore.clone().acquire_owned().await {
+                            Ok(p) => p,
+                            Err(_) => {
+                                debug!("Scheduler aborting: semaphore closed");
+                                return;
+                            }
+                        };
+
+                        if !schedule_chunk(&mut decode_scheduler, &[chunk_range], permit) {
+                            return;
+                        }
+                        start = end;
+                    }
+                }
+            }
+            RequestedRows::Indices(indices) => {
+                let chunk_size = config.batch_size as usize;
+                for chunk in indices.chunks(chunk_size) {
+                    let ranges = DecodeBatchScheduler::indices_to_ranges(chunk);
+
+                    let permit = match scheduler_semaphore.clone().acquire_owned().await {
+                        Ok(p) => p,
+                        Err(_) => {
+                            debug!("Scheduler aborting: semaphore closed");
+                            return;
+                        }
+                    };
+
+                    if !schedule_chunk(&mut decode_scheduler, &ranges, permit) {
+                        return;
+                    }
+                }
+            }
+        }
+    });
+
+    // Wrap the stream to close the semaphore when dropped
+    let bounded_stream = BoundedDecodeStream {
+        inner: check_scheduler_on_drop(decode_stream, scheduler_handle),
+        semaphore: backpressure_semaphore,
+    };
+
+    Ok(bounded_stream.boxed())
+}
+
 /// Launches a scheduler on a dedicated (spawned) task and creates a decoder to
 /// decode the scheduled data and returns the decoder as a stream of record batches.
 ///
@@ -2042,6 +2395,7 @@ pub fn schedule_and_decode(
         Err(e) => stream::once(std::future::ready(ReadBatchTask {
             num_rows: 0,
             task: std::future::ready(Err(e)).boxed(),
+            backpressure_permits: Vec::new(),
         }))
         .boxed(),
     }
@@ -2549,15 +2903,49 @@ impl MessageType {
 pub struct DecoderMessage {
     pub scheduled_so_far: u64,
     pub decoders: Vec<MessageType>,
+    /// Backpressure permit - when present, released when message is dropped (after processing).
+    /// This provides automatic backpressure: the scheduler acquires a permit before sending,
+    /// and the permit is released when the decoded batch is consumed.
+    #[allow(dead_code)]
+    pub backpressure_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+}
+
+/// A message receiver that can be either bounded or unbounded.
+///
+/// Using bounded channels provides backpressure to prevent unbounded memory
+/// growth when the decoder can't keep up with the scheduler.
+pub enum DecoderReceiver {
+    /// Unbounded channel - no backpressure, all messages queued immediately
+    Unbounded(mpsc::UnboundedReceiver<Result<DecoderMessage>>),
+    /// Bounded channel - provides backpressure when channel is full
+    Bounded(mpsc::Receiver<Result<DecoderMessage>>),
+}
+
+impl DecoderReceiver {
+    /// Receive the next message, awaiting if none available.
+    pub async fn recv(&mut self) -> Option<Result<DecoderMessage>> {
+        match self {
+            Self::Unbounded(rx) => rx.recv().await,
+            Self::Bounded(rx) => rx.recv().await,
+        }
+    }
 }
 
 pub struct DecoderContext {
-    source: mpsc::UnboundedReceiver<Result<DecoderMessage>>,
+    source: DecoderReceiver,
 }
 
 impl DecoderContext {
     pub fn new(source: mpsc::UnboundedReceiver<Result<DecoderMessage>>) -> Self {
-        Self { source }
+        Self {
+            source: DecoderReceiver::Unbounded(source),
+        }
+    }
+
+    pub fn new_bounded(source: mpsc::Receiver<Result<DecoderMessage>>) -> Self {
+        Self {
+            source: DecoderReceiver::Bounded(source),
+        }
     }
 }
 

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -335,6 +335,13 @@ pub struct FileReaderOptions {
     /// will be read in multiple chunks to control memory usage.
     /// Default: 8MB (DEFAULT_READ_CHUNK_SIZE)
     pub read_chunk_size: u64,
+    /// Capacity of the decode channel between scheduler and decoder.
+    ///
+    /// If set to Some(n), a bounded channel of capacity n is used, providing
+    /// backpressure to prevent unbounded memory growth when the decoder can't
+    /// keep up with the scheduler. If None (default), an unbounded channel is
+    /// used for backward compatibility.
+    pub decode_channel_capacity: Option<usize>,
 }
 
 impl Default for FileReaderOptions {
@@ -342,6 +349,7 @@ impl Default for FileReaderOptions {
         Self {
             decoder_config: DecoderConfig::default(),
             read_chunk_size: DEFAULT_READ_CHUNK_SIZE,
+            decode_channel_capacity: None,
         }
     }
 }
@@ -871,6 +879,7 @@ impl FileReader {
         projection: ReaderProjection,
         filter: FilterExpression,
         decoder_config: DecoderConfig,
+        decode_channel_capacity: Option<usize>,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
         debug!(
             "Reading range {:?} with batch_size {} from file with {} rows and {} columns into schema with {} columns",
@@ -887,6 +896,7 @@ impl FileReader {
             decoder_plugins,
             io,
             decoder_config,
+            decode_channel_capacity,
         };
 
         let requested_rows = RequestedRows::Ranges(vec![range]);
@@ -920,6 +930,7 @@ impl FileReader {
             projection,
             filter,
             self.options.decoder_config.clone(),
+            self.options.decode_channel_capacity,
         )
     }
 
@@ -934,6 +945,7 @@ impl FileReader {
         projection: ReaderProjection,
         filter: FilterExpression,
         decoder_config: DecoderConfig,
+        decode_channel_capacity: Option<usize>,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
         debug!(
             "Taking {} rows spread across range {}..{} with batch_size {} from columns {:?}",
@@ -950,6 +962,7 @@ impl FileReader {
             decoder_plugins,
             io,
             decoder_config,
+            decode_channel_capacity,
         };
 
         let requested_rows = RequestedRows::Indices(indices);
@@ -981,6 +994,7 @@ impl FileReader {
             projection,
             FilterExpression::no_filter(),
             self.options.decoder_config.clone(),
+            self.options.decode_channel_capacity,
         )
     }
 
@@ -995,6 +1009,7 @@ impl FileReader {
         projection: ReaderProjection,
         filter: FilterExpression,
         decoder_config: DecoderConfig,
+        decode_channel_capacity: Option<usize>,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
         let num_rows = ranges.iter().map(|r| r.end - r.start).sum::<u64>();
         debug!(
@@ -1013,6 +1028,7 @@ impl FileReader {
             decoder_plugins,
             io,
             decoder_config,
+            decode_channel_capacity,
         };
 
         let requested_rows = RequestedRows::Ranges(ranges);
@@ -1044,6 +1060,7 @@ impl FileReader {
             projection,
             filter,
             self.options.decoder_config.clone(),
+            self.options.decode_channel_capacity,
         )
     }
 
@@ -1197,6 +1214,7 @@ impl FileReader {
             decoder_plugins: self.decoder_plugins.clone(),
             io: self.scheduler.clone(),
             decoder_config: self.options.decoder_config.clone(),
+            decode_channel_capacity: self.options.decode_channel_capacity,
         };
 
         let requested_rows = RequestedRows::Indices(indices);
@@ -1236,6 +1254,7 @@ impl FileReader {
             decoder_plugins: self.decoder_plugins.clone(),
             io: self.scheduler.clone(),
             decoder_config: self.options.decoder_config.clone(),
+            decode_channel_capacity: self.options.decode_channel_capacity,
         };
 
         let requested_rows = RequestedRows::Ranges(ranges);
@@ -1275,6 +1294,7 @@ impl FileReader {
             decoder_plugins: self.decoder_plugins.clone(),
             io: self.scheduler.clone(),
             decoder_config: self.options.decoder_config.clone(),
+            decode_channel_capacity: self.options.decode_channel_capacity,
         };
 
         let requested_rows = RequestedRows::Ranges(vec![range]);

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -512,6 +512,14 @@ pub struct Scanner {
     /// Number of bytes to allow to queue up in the I/O buffer
     io_buffer_size: Option<u64>,
 
+    /// Capacity of the decode channel between scheduler and decoder.
+    ///
+    /// If set, a bounded channel of this capacity is used, providing
+    /// backpressure to prevent unbounded memory growth when the decoder can't
+    /// keep up with the scheduler. If None (default), an unbounded channel is
+    /// used for backward compatibility.
+    decode_channel_capacity: Option<usize>,
+
     limit: Option<i64>,
     offset: Option<i64>,
 
@@ -775,6 +783,7 @@ impl Scanner {
             batch_readahead: get_num_compute_intensive_cpus(),
             fragment_readahead: None,
             io_buffer_size: None,
+            decode_channel_capacity: None,
             limit: None,
             offset: None,
             ordering: None,
@@ -1078,6 +1087,19 @@ impl Scanner {
     /// This is only used if ``scan_in_order`` is set to false.
     pub fn fragment_readahead(&mut self, nfragments: usize) -> &mut Self {
         self.fragment_readahead = Some(nfragments);
+        self
+    }
+
+    /// Set the decode channel capacity.
+    ///
+    /// This controls the size of the bounded channel between the scheduler
+    /// and decoder. A smaller capacity limits memory usage but may reduce
+    /// throughput. If not set, an unbounded channel is used.
+    ///
+    /// This is particularly useful for KNN scans where decode tasks can
+    /// accumulate faster than they're consumed, causing memory growth.
+    pub fn decode_channel_capacity(&mut self, capacity: usize) -> &mut Self {
+        self.decode_channel_capacity = Some(capacity);
         self
     }
 
@@ -3521,6 +3543,7 @@ impl Scanner {
             batch_readahead: self.batch_readahead,
             fragment_readahead: self.fragment_readahead,
             io_buffer_size: self.get_io_buffer_size(),
+            decode_channel_capacity: self.decode_channel_capacity,
             with_row_id,
             with_row_address,
             with_row_last_updated_at_version,

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -34,6 +34,7 @@ use snafu::location;
 use tracing::Instrument;
 
 use crate::dataset::fragment::{FileFragment, FragReadConfig, FragmentReader};
+use lance_file::reader::FileReaderOptions;
 use crate::dataset::scanner::{
     BATCH_SIZE_FALLBACK, DEFAULT_FRAGMENT_READAHEAD, DEFAULT_IO_BUFFER_SIZE,
     LEGACY_DEFAULT_FRAGMENT_READAHEAD,
@@ -287,6 +288,10 @@ impl LanceStream {
                     Result<BoxStream<Result<BoxFuture<Result<RecordBatch>>>>>,
                 > = tokio::spawn(
                     (async move {
+                        let file_reader_options = FileReaderOptions {
+                            decode_channel_capacity: config.decode_channel_capacity,
+                            ..Default::default()
+                        };
                         let reader = open_file(
                             file_fragment.fragment,
                             project_schema,
@@ -296,7 +301,8 @@ impl LanceStream {
                                 .with_row_last_updated_at_version(
                                     config.with_row_last_updated_at_version,
                                 )
-                                .with_row_created_at_version(config.with_row_created_at_version),
+                                .with_row_created_at_version(config.with_row_created_at_version)
+                                .with_file_reader_options(file_reader_options),
                             config.with_make_deletions_null,
                             Some((scan_scheduler, priority as u32)),
                         )
@@ -376,8 +382,13 @@ impl LanceStream {
             .collect::<Vec<_>>();
 
         let batches = if config.ordered_output {
+            let file_reader_options = FileReaderOptions {
+                decode_channel_capacity: config.decode_channel_capacity,
+                ..Default::default()
+            };
             let readers = stream::iter(file_fragments)
                 .map(move |file_fragment| {
+                    let file_reader_options = file_reader_options.clone();
                     Ok(open_file(
                         file_fragment,
                         project_schema.clone(),
@@ -387,7 +398,8 @@ impl LanceStream {
                             .with_row_last_updated_at_version(
                                 config.with_row_last_updated_at_version,
                             )
-                            .with_row_created_at_version(config.with_row_created_at_version),
+                            .with_row_created_at_version(config.with_row_created_at_version)
+                            .with_file_reader_options(file_reader_options),
                         config.with_make_deletions_null,
                         None,
                     ))
@@ -409,8 +421,13 @@ impl LanceStream {
                 .stream_in_current_span()
                 .boxed()
         } else {
+            let file_reader_options = FileReaderOptions {
+                decode_channel_capacity: config.decode_channel_capacity,
+                ..Default::default()
+            };
             let readers = stream::iter(file_fragments)
                 .map(move |file_fragment| {
+                    let file_reader_options = file_reader_options.clone();
                     Ok(open_file(
                         file_fragment,
                         project_schema.clone(),
@@ -420,7 +437,8 @@ impl LanceStream {
                             .with_row_last_updated_at_version(
                                 config.with_row_last_updated_at_version,
                             )
-                            .with_row_created_at_version(config.with_row_created_at_version),
+                            .with_row_created_at_version(config.with_row_created_at_version)
+                            .with_file_reader_options(file_reader_options),
                         config.with_make_deletions_null,
                         None,
                     ))
@@ -497,6 +515,16 @@ pub struct LanceScanConfig {
     pub batch_readahead: usize,
     pub fragment_readahead: Option<usize>,
     pub io_buffer_size: u64,
+    /// Capacity of the decode channel between scheduler and decoder.
+    ///
+    /// If set to Some(n), a bounded channel of capacity n is used, providing
+    /// backpressure to prevent unbounded memory growth when the decoder can't
+    /// keep up with the scheduler. If None (default), an unbounded channel is
+    /// used for backward compatibility.
+    ///
+    /// Recommended value: 2-4 (matching batch_readahead) for memory-constrained
+    /// workloads like KNN scans.
+    pub decode_channel_capacity: Option<usize>,
     pub with_row_id: bool,
     pub with_row_address: bool,
     pub with_row_last_updated_at_version: bool,
@@ -514,6 +542,7 @@ impl Default for LanceScanConfig {
             batch_readahead: get_num_compute_intensive_cpus(),
             fragment_readahead: None,
             io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
+            decode_channel_capacity: None, // unbounded by default for backward compatibility
             with_row_id: false,
             with_row_address: false,
             with_row_last_updated_at_version: false,


### PR DESCRIPTION
Lance's read pipeline is split into independent scheduling and decoding loops, designed to maximize both IO and CPU parallelism.

When we schedule a range of rows to read, the scheduler breaks those ranges up into "scan lines" and issues requests against the storage backend at the maximum parallelism advertised by the backend. For each scan line, a message is sent over an unbounded mpsc channel to the decoder. The message includes futures that wrap the results of the column download operations.

Although requests against storage are limited by the advertised capabilities of the store, the limitation applies only to in-flight IO requests. There is nothing that stops results of completed IO requests from piling up in memory prior to decoding. This works fine when IO is slower than decoding, but if IO is significantly faster than decoding (for example, RAM or NVME-based storage, or particularly slow decoding tasks), we can eagerly accumulate a lot of downloaded data in memory a lot sooner than we need it.

This patch introduces a semaphore-based backpressure mechanism. Permits are required prior to scheduling and released after completion of the decoding futures, limiting the amount of work that can accumulate between the scheduler and the consumer.