### PR TITLE
feat: support FTS query execution for LSM scanner

### DIFF
--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -323,6 +323,9 @@ pub struct FullTextSearchQuery {
     /// Increasing this value will reduce the recall and improve the performance
     /// 1.0 is the value that would give the best performance without recall loss
     pub wand_factor: Option<f32>,
+
+    /// Optional BM25 stats override for custom corpus-level statistics.
+    pub bm25_override: Option<Arc<inverted::scorer::BM25StatsOverride>>,
 }
 
 impl FullTextSearchQuery {
@@ -333,6 +336,7 @@ impl FullTextSearchQuery {
             query,
             limit: None,
             wand_factor: None,
+            bm25_override: None,
         }
     }
 
@@ -343,6 +347,7 @@ impl FullTextSearchQuery {
             query,
             limit: None,
             wand_factor: None,
+            bm25_override: None,
         }
     }
 
@@ -352,6 +357,7 @@ impl FullTextSearchQuery {
             query,
             limit: None,
             wand_factor: None,
+            bm25_override: None,
         }
     }
 
@@ -389,6 +395,7 @@ impl FullTextSearchQuery {
         FtsSearchParams::new()
             .with_limit(self.limit.map(|limit| limit as usize))
             .with_wand_factor(self.wand_factor.unwrap_or(1.0))
+            .with_bm25_override(self.bm25_override.clone())
     }
 }
 

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -9,7 +9,7 @@ pub mod json;
 mod merger;
 pub mod parser;
 pub mod query;
-mod scorer;
+pub mod scorer;
 pub mod tokenizer;
 mod wand;
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -55,7 +55,7 @@ use super::{
     },
     iter::PlainPostingListIterator,
     query::*,
-    scorer::{idf, IndexBM25Scorer, Scorer, B, K1},
+    scorer::{idf, BM25StatsOverride, IndexBM25Scorer, OverrideBM25Scorer, Scorer, B, K1},
 };
 use super::{
     builder::{InnerBuilder, PositionRecorder},
@@ -238,6 +238,21 @@ impl InvertedIndex {
         self.partitions.len()
     }
 
+    /// Read BM25 collection-level stats from this index without running a query.
+    ///
+    /// Returns `(num_docs, total_tokens, term_doc_freqs)` aggregated across
+    /// all partitions, using the same `IndexBM25Scorer` that `bm25_search` uses.
+    pub fn collection_stats(&self, terms: &[String]) -> (usize, u64, HashMap<String, usize>) {
+        let scorer = IndexBM25Scorer::new(self.partitions.iter().map(|p| p.as_ref()));
+        let num_docs = scorer.num_docs();
+        let total_tokens = scorer.total_tokens();
+        let term_doc_freqs: HashMap<String, usize> = terms
+            .iter()
+            .map(|t| (t.clone(), scorer.num_docs_containing_token(t)))
+            .collect();
+        (num_docs, total_tokens, term_doc_freqs)
+    }
+
     // search the documents that contain the query
     // return the row ids of the documents sorted by bm25 score
     // ref: https://en.wikipedia.org/wiki/Okapi_BM25
@@ -251,6 +266,35 @@ impl InvertedIndex {
         operator: Operator,
         prefilter: Arc<dyn PreFilter>,
         metrics: Arc<dyn MetricsCollector>,
+    ) -> Result<(Vec<u64>, Vec<f32>)> {
+        let scorer = IndexBM25Scorer::new(self.partitions.iter().map(|part| part.as_ref()));
+        self.bm25_search_internal(tokens, params, operator, prefilter, metrics, scorer)
+            .await
+    }
+
+    /// BM25 search using externally-provided global statistics.
+    pub async fn bm25_search_with_override(
+        &self,
+        tokens: Arc<Tokens>,
+        params: Arc<FtsSearchParams>,
+        operator: Operator,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+        override_stats: &BM25StatsOverride,
+    ) -> Result<(Vec<u64>, Vec<f32>)> {
+        let scorer = OverrideBM25Scorer::new(override_stats);
+        self.bm25_search_internal(tokens, params, operator, prefilter, metrics, scorer)
+            .await
+    }
+
+    async fn bm25_search_internal<S: Scorer>(
+        &self,
+        tokens: Arc<Tokens>,
+        params: Arc<FtsSearchParams>,
+        operator: Operator,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+        scorer: S,
     ) -> Result<(Vec<u64>, Vec<f32>)> {
         let limit = params.limit.unwrap_or(usize::MAX);
         if limit == 0 {
@@ -301,7 +345,6 @@ impl InvertedIndex {
             })
             .collect::<Vec<_>>();
         let mut parts = stream::iter(parts).buffer_unordered(get_num_compute_intensive_cpus());
-        let scorer = IndexBM25Scorer::new(self.partitions.iter().map(|part| part.as_ref()));
         let mut idf_cache: HashMap<String, f32> = HashMap::new();
         while let Some(res) = parts.try_next().await? {
             if res.candidates.is_empty() {

--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashSet;
+use std::sync::Arc;
+
 use crate::scalar::inverted::lance_tokenizer::DocType;
+use crate::scalar::inverted::scorer::BM25StatsOverride;
 use crate::scalar::inverted::tokenizer::lance_tokenizer::LanceTokenizer;
 use lance_core::{Error, Result};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
 use snafu::location;
-use std::collections::HashSet;
 
 #[derive(Debug, Clone)]
 pub struct FtsSearchParams {
@@ -20,6 +23,8 @@ pub struct FtsSearchParams {
     pub phrase_slop: Option<u32>,
     /// The number of beginning characters being unchanged for fuzzy matching.
     pub prefix_length: u32,
+    /// Optional BM25 stats override for custom corpus-level statistics.
+    pub bm25_override: Option<Arc<BM25StatsOverride>>,
 }
 
 impl FtsSearchParams {
@@ -31,6 +36,7 @@ impl FtsSearchParams {
             max_expansions: 50,
             phrase_slop: None,
             prefix_length: 0,
+            bm25_override: None,
         }
     }
 
@@ -61,6 +67,11 @@ impl FtsSearchParams {
 
     pub fn with_prefix_length(mut self, prefix_length: u32) -> Self {
         self.prefix_length = prefix_length;
+        self
+    }
+
+    pub fn with_bm25_override(mut self, bm25_override: Option<Arc<BM25StatsOverride>>) -> Self {
+        self.bm25_override = bm25_override;
         self
     }
 }

--- a/rust/lance-index/src/scalar/inverted/scorer.rs
+++ b/rust/lance-index/src/scalar/inverted/scorer.rs
@@ -131,6 +131,60 @@ impl Scorer for IndexBM25Scorer<'_> {
     }
 }
 
+/// Override BM25 stats for cross-generation scoring.
+///
+/// Contains the aggregated stats from all LSM generations so that
+/// a persistent index partition can produce globally-comparable scores.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BM25StatsOverride {
+    pub num_docs: usize,
+    pub total_tokens: u64,
+    /// term -> number of documents containing the term across all generations.
+    pub term_doc_freqs: HashMap<String, usize>,
+}
+
+/// BM25 scorer using externally-provided (global) statistics.
+///
+/// Same math as `IndexBM25Scorer`, but num_docs and term_doc_freqs
+/// come from the override rather than the local index partitions.
+pub struct OverrideBM25Scorer {
+    num_docs: usize,
+    avg_doc_length: f32,
+    term_doc_freqs: HashMap<String, usize>,
+}
+
+impl OverrideBM25Scorer {
+    pub fn new(override_stats: &BM25StatsOverride) -> Self {
+        let avg_doc_length = if override_stats.num_docs > 0 {
+            override_stats.total_tokens as f32 / override_stats.num_docs as f32
+        } else {
+            1.0
+        };
+        Self {
+            num_docs: override_stats.num_docs,
+            avg_doc_length,
+            term_doc_freqs: override_stats.term_doc_freqs.clone(),
+        }
+    }
+}
+
+impl Scorer for OverrideBM25Scorer {
+    fn query_weight(&self, token: &str) -> f32 {
+        let token_docs = self.term_doc_freqs.get(token).copied().unwrap_or(0);
+        if token_docs == 0 {
+            return 0.0;
+        }
+        idf(token_docs, self.num_docs)
+    }
+
+    fn doc_weight(&self, freq: u32, doc_tokens: u32) -> f32 {
+        let freq = freq as f32;
+        let doc_tokens = doc_tokens as f32;
+        let doc_norm = K1 * (1.0 - B + B * doc_tokens / self.avg_doc_length);
+        (K1 + 1.0) * freq / (freq + doc_norm)
+    }
+}
+
 #[inline]
 pub fn idf(token_docs: usize, num_docs: usize) -> f32 {
     let num_docs = num_docs as f32;

--- a/rust/lance/benches/mem_wal_read.rs
+++ b/rust/lance/benches/mem_wal_read.rs
@@ -63,6 +63,9 @@ use lance::dataset::mem_wal::scanner::{
 };
 use lance::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig, RegionWriterConfig};
 use lance::dataset::{Dataset, WriteParams};
+use lance_index::scalar::FullTextSearchQuery;
+use lance_index::scalar::InvertedIndexParams;
+use lance_index::{DatasetIndexExt, IndexType};
 use lance_linalg::distance::DistanceType;
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
@@ -1033,11 +1036,340 @@ fn bench_vector_search(c: &mut Criterion) {
     group.finish();
 }
 
+/// Sample text snippets for FTS benchmarking.
+const FTS_SAMPLE_TEXTS: &[&str] = &[
+    "The quick brown fox jumps over the lazy dog",
+    "Machine learning models require large datasets for training",
+    "Vector databases enable semantic search capabilities",
+    "Rust provides memory safety without garbage collection",
+    "Cloud native applications scale horizontally across regions",
+    "Data lakehouse combines warehouse and lake architecture benefits",
+    "Embeddings capture semantic meaning in high dimensional vector space",
+    "Columnar storage format optimizes analytical query performance",
+    "Neural networks learn hierarchical feature representations",
+    "Distributed systems handle concurrent requests efficiently",
+    "Natural language processing transforms text into structured data",
+    "Graph databases model relationships between connected entities",
+    "Streaming analytics processes real time event data continuously",
+    "Containerized microservices deploy independently at scale",
+    "Full text search indexes enable fast keyword matching queries",
+    "Object storage provides durable scalable blob persistence",
+];
+
+/// Create FTS schema: (id: Int64, text: Utf8)
+fn create_fts_schema() -> Arc<ArrowSchema> {
+    use std::collections::HashMap;
+
+    let mut id_metadata = HashMap::new();
+    id_metadata.insert(
+        "lance-schema:unenforced-primary-key".to_string(),
+        "true".to_string(),
+    );
+    let id_field = Field::new("id", DataType::Int64, false).with_metadata(id_metadata);
+
+    Arc::new(ArrowSchema::new(vec![
+        id_field,
+        Field::new("text", DataType::Utf8, true),
+    ]))
+}
+
+/// Create a batch with sequential IDs and cycling text content.
+fn create_fts_batch(schema: &ArrowSchema, start_id: i64, num_rows: usize) -> RecordBatch {
+    let ids: Vec<i64> = (start_id..start_id + num_rows as i64).collect();
+    let texts: Vec<String> = ids
+        .iter()
+        .map(|id| {
+            let base = FTS_SAMPLE_TEXTS[(*id as usize) % FTS_SAMPLE_TEXTS.len()];
+            format!("{} (row {})", base, id)
+        })
+        .collect();
+
+    RecordBatch::try_new(
+        Arc::new(schema.clone()),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(StringArray::from(texts)),
+        ],
+    )
+    .unwrap()
+}
+
+/// Setup context for FTS benchmarks.
+struct FtsBenchContext {
+    base_dataset: Arc<Dataset>,
+    lsm_dataset: Arc<Dataset>,
+    region_snapshots: Vec<RegionSnapshot>,
+    active_memtable: Option<(Uuid, ActiveMemTableRef)>,
+    total_rows: usize,
+    pk_columns: Vec<String>,
+}
+
+/// Create benchmark context for FTS search with:
+/// - Base table with FTS index (for baseline)
+/// - LSM dataset with FTS index + MemWAL maintained FTS index
+/// - 2 flushed MemTables + 1 active MemTable with text data
+async fn setup_fts_benchmark(
+    base_rows: usize,
+    memtable_rows: usize,
+    batch_size: usize,
+    dataset_prefix: &str,
+) -> FtsBenchContext {
+    let schema = create_fts_schema();
+    let pk_columns = vec!["id".to_string()];
+
+    let short_id = &Uuid::new_v4().to_string()[..8];
+    let prefix = dataset_prefix.trim_end_matches('/');
+
+    // Create base dataset with FTS index (for baseline comparison)
+    let base_uri = format!("{}/fts_base_{}", prefix, short_id);
+    let base_batches: Vec<RecordBatch> = (0..base_rows.div_ceil(batch_size))
+        .map(|i| {
+            let start = (i * batch_size) as i64;
+            let rows = batch_size.min(base_rows - i * batch_size);
+            create_fts_batch(&schema, start, rows)
+        })
+        .collect();
+
+    let reader = RecordBatchIterator::new(base_batches.into_iter().map(Ok), schema.clone());
+    let mut base_dataset = Dataset::write(reader, &base_uri, Some(WriteParams::default()))
+        .await
+        .unwrap();
+
+    let fts_params = InvertedIndexParams::default();
+    base_dataset
+        .create_index(
+            &["text"],
+            IndexType::Inverted,
+            Some("text_fts".to_string()),
+            &fts_params,
+            false,
+        )
+        .await
+        .unwrap();
+    let base_dataset = Arc::new(base_dataset);
+
+    // Create LSM dataset with FTS index + MemWAL
+    let lsm_uri = format!("{}/fts_lsm_{}", prefix, short_id);
+    let lsm_base_batches: Vec<RecordBatch> = (0..base_rows.div_ceil(batch_size))
+        .map(|i| {
+            let start = (i * batch_size) as i64;
+            let rows = batch_size.min(base_rows - i * batch_size);
+            create_fts_batch(&schema, start, rows)
+        })
+        .collect();
+
+    let reader = RecordBatchIterator::new(lsm_base_batches.into_iter().map(Ok), schema.clone());
+    let mut lsm_dataset = Dataset::write(reader, &lsm_uri, Some(WriteParams::default()))
+        .await
+        .unwrap();
+
+    let fts_params = InvertedIndexParams::default();
+    lsm_dataset
+        .create_index(
+            &["text"],
+            IndexType::Inverted,
+            Some("text_fts".to_string()),
+            &fts_params,
+            false,
+        )
+        .await
+        .unwrap();
+
+    lsm_dataset
+        .initialize_mem_wal(MemWalConfig {
+            region_spec: None,
+            maintained_indexes: vec!["text_fts".to_string()],
+        })
+        .await
+        .unwrap();
+
+    let lsm_dataset = Arc::new(lsm_dataset);
+
+    // Create RegionWriter
+    let region_id = Uuid::new_v4();
+    let config = RegionWriterConfig {
+        region_id,
+        region_spec_id: 0,
+        durable_write: false,
+        sync_indexed_write: false,
+        max_memtable_size: memtable_rows * 100,
+        max_memtable_rows: memtable_rows,
+        max_wal_flush_interval: Some(Duration::from_secs(60)),
+        ..RegionWriterConfig::default()
+    };
+
+    let writer = lsm_dataset
+        .as_ref()
+        .mem_wal_writer(region_id, config)
+        .await
+        .unwrap();
+
+    let is_cloud = dataset_prefix.starts_with("s3://")
+        || dataset_prefix.starts_with("gs://")
+        || dataset_prefix.starts_with("az://");
+    let flush_wait = if is_cloud {
+        Duration::from_secs(5)
+    } else {
+        Duration::from_millis(500)
+    };
+
+    // Write generation 1 (will be flushed)
+    let gen1_start = base_rows as i64;
+    for i in 0..memtable_rows.div_ceil(batch_size) {
+        let start = gen1_start + (i * batch_size) as i64;
+        let rows = batch_size.min(memtable_rows - i * batch_size);
+        let batch = create_fts_batch(&schema, start, rows);
+        writer.put(vec![batch]).await.unwrap();
+    }
+    tokio::time::sleep(flush_wait).await;
+
+    // Write generation 2 (will be flushed)
+    let gen2_start = gen1_start + memtable_rows as i64;
+    for i in 0..memtable_rows.div_ceil(batch_size) {
+        let start = gen2_start + (i * batch_size) as i64;
+        let rows = batch_size.min(memtable_rows - i * batch_size);
+        let batch = create_fts_batch(&schema, start, rows);
+        writer.put(vec![batch]).await.unwrap();
+    }
+    tokio::time::sleep(flush_wait).await;
+
+    // Write generation 3 (active memtable, not flushed)
+    let gen3_start = gen2_start + memtable_rows as i64;
+    let gen3_rows = memtable_rows / 2;
+    for i in 0..gen3_rows.div_ceil(batch_size) {
+        let start = gen3_start + (i * batch_size) as i64;
+        let rows = batch_size.min(gen3_rows - i * batch_size);
+        let batch = create_fts_batch(&schema, start, rows);
+        writer.put(vec![batch]).await.unwrap();
+    }
+
+    let manifest = writer.manifest().await.unwrap();
+    let active_memtable_ref = writer.active_memtable_ref().await;
+
+    let mut region_snapshot = RegionSnapshot::new(region_id);
+    if let Some(ref m) = manifest {
+        region_snapshot = region_snapshot.with_current_generation(m.current_generation);
+        for fg in &m.flushed_generations {
+            region_snapshot =
+                region_snapshot.with_flushed_generation(fg.generation, fg.path.clone());
+        }
+    }
+
+    let num_flushed = manifest
+        .as_ref()
+        .map(|m| m.flushed_generations.len())
+        .unwrap_or(0);
+
+    println!("FTS benchmark setup complete:");
+    println!("  Base table: {} rows (with FTS index)", base_rows);
+    println!("  Flushed MemTables: {} generations", num_flushed);
+    println!("  Active MemTable: {} rows", gen3_rows);
+    println!(
+        "  Total LSM rows: {}",
+        base_rows + memtable_rows * 2 + gen3_rows
+    );
+
+    std::mem::forget(writer);
+
+    FtsBenchContext {
+        base_dataset,
+        lsm_dataset,
+        region_snapshots: vec![region_snapshot],
+        active_memtable: Some((region_id, active_memtable_ref)),
+        total_rows: base_rows + memtable_rows * 2 + gen3_rows,
+        pk_columns,
+    }
+}
+
+/// Benchmark FTS search operations.
+fn bench_fts_search(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let base_rows = get_base_rows();
+    let memtable_rows = get_memtable_rows();
+    let batch_size = get_batch_size();
+    let sample_size = get_sample_size();
+    let dataset_prefix = get_dataset_prefix();
+
+    let ctx = rt.block_on(setup_fts_benchmark(
+        base_rows,
+        memtable_rows,
+        batch_size,
+        &dataset_prefix,
+    ));
+
+    let mut group = c.benchmark_group("LSM FTS Search");
+    group.throughput(Throughput::Elements(10));
+    group.sample_size(sample_size);
+
+    let label = format!("{}_total_rows", ctx.total_rows);
+    let k = 10;
+    let query_text = "machine learning";
+
+    // Baseline: FTS on base table only (persistent inverted index)
+    group.bench_with_input(BenchmarkId::new("BaseTable_FTS", &label), &(), |b, _| {
+        let dataset = ctx.base_dataset.clone();
+        b.to_async(&rt).iter(|| {
+            let dataset = dataset.clone();
+            async move {
+                let batches: Vec<RecordBatch> = dataset
+                    .scan()
+                    .full_text_search(FullTextSearchQuery::new(query_text.to_owned()))
+                    .unwrap()
+                    .limit(Some(k as i64), None)
+                    .unwrap()
+                    .try_into_stream()
+                    .await
+                    .unwrap()
+                    .try_collect()
+                    .await
+                    .unwrap();
+                let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+                assert!(total <= k);
+            }
+        });
+    });
+
+    // LSM FTS search: base table + flushed memtables + active memtable
+    if let Some((region_id, ref active_memtable)) = ctx.active_memtable {
+        group.bench_with_input(BenchmarkId::new("LSM_FTS", &label), &(), |b, _| {
+            let dataset = ctx.lsm_dataset.clone();
+            let region_snapshots = ctx.region_snapshots.clone();
+            let pk_columns = ctx.pk_columns.clone();
+            let active = active_memtable.clone();
+            b.to_async(&rt).iter(|| {
+                let dataset = dataset.clone();
+                let region_snapshots = region_snapshots.clone();
+                let pk_columns = pk_columns.clone();
+                let active = active.clone();
+                async move {
+                    let scanner = LsmScanner::new(dataset, region_snapshots, pk_columns)
+                        .with_active_memtable(region_id, active)
+                        .full_text_search("text", query_text)
+                        .limit(k, None);
+                    let batches: Vec<RecordBatch> = scanner
+                        .try_into_stream()
+                        .await
+                        .unwrap()
+                        .try_collect()
+                        .await
+                        .unwrap();
+                    let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+                    assert!(total <= k);
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
 fn all_benchmarks(c: &mut Criterion) {
     bench_scan(c);
     bench_scan_with_projection(c);
     bench_point_lookup(c);
     bench_vector_search(c);
+    bench_fts_search(c);
 }
 
 #[cfg(target_os = "linux")]

--- a/rust/lance/src/dataset/mem_wal/index/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/index/fts.rs
@@ -26,7 +26,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use arrow_array::RecordBatch;
 use crossbeam_skiplist::SkipMap;
@@ -38,6 +38,7 @@ use snafu::location;
 use tantivy::tokenizer::TokenStream;
 
 use super::RowPosition;
+use crate::dataset::mem_wal::scanner::bm25_stats::GlobalBM25Stats;
 
 /// Composite key for FTS index.
 ///
@@ -146,6 +147,9 @@ pub struct SearchOptions {
     pub wand_factor: f32,
     /// Maximum number of results to return. None means unlimited.
     pub limit: Option<usize>,
+    /// Optional BM25 stats override for custom corpus-level statistics.
+    /// When set, scoring uses these stats instead of the index's local stats.
+    pub bm25_override: Option<Arc<GlobalBM25Stats>>,
 }
 
 impl Default for SearchOptions {
@@ -153,6 +157,7 @@ impl Default for SearchOptions {
         Self {
             wand_factor: DEFAULT_WAND_FACTOR,
             limit: None,
+            bm25_override: None,
         }
     }
 }
@@ -176,6 +181,12 @@ impl SearchOptions {
     /// Set the maximum number of results to return.
     pub fn with_limit(mut self, limit: usize) -> Self {
         self.limit = Some(limit);
+        self
+    }
+
+    /// Set BM25 stats override for custom corpus-level statistics.
+    pub fn with_bm25_override(mut self, stats: Arc<GlobalBM25Stats>) -> Self {
+        self.bm25_override = Some(stats);
         self
     }
 }
@@ -842,9 +853,36 @@ impl FtsMemIndex {
         self.doc_count.load(Ordering::Relaxed) == 0
     }
 
+    /// Get total token count across all documents.
+    pub fn total_tokens(&self) -> usize {
+        self.total_tokens.load(Ordering::Relaxed)
+    }
+
+    /// Get document frequencies for the given terms.
+    pub fn term_doc_frequencies(&self, terms: &[String]) -> HashMap<String, usize> {
+        let mut result = HashMap::new();
+        for term in terms {
+            if let Some(entry) = self.doc_freq.get(term) {
+                result.insert(term.clone(), entry.value().load(Ordering::Relaxed));
+            }
+        }
+        result
+    }
+
     /// Get the column name.
     pub fn column_name(&self) -> &str {
         &self.column_name
+    }
+
+    /// Tokenize a query string using the index's tokenizer.
+    pub fn tokenize_query(&self, query: &str) -> Vec<String> {
+        let mut tokenizer = self.tokenizer.lock().unwrap();
+        let mut token_stream = tokenizer.token_stream_for_search(query);
+        let mut tokens = Vec::new();
+        while let Some(token) = token_stream.next() {
+            tokens.push(token.text.clone());
+        }
+        tokens
     }
 
     /// Expand a term to fuzzy matches within the specified edit distance.
@@ -1070,8 +1108,12 @@ impl FtsMemIndex {
         query: &FtsQueryExpr,
         options: SearchOptions,
     ) -> Vec<FtsEntry> {
-        // Execute the query to get all results
-        let mut results = self.search_query(query);
+        // Execute the query, using BM25 override stats if provided
+        let mut results = if let Some(ref stats) = options.bm25_override {
+            self.search_query_with_scorer(query, stats)
+        } else {
+            self.search_query(query)
+        };
 
         // Sort by score descending
         results.sort_by(|a, b| {
@@ -1106,6 +1148,365 @@ impl FtsMemIndex {
             results.truncate(limit);
         }
 
+        results
+    }
+
+    /// Execute a query using external BM25 statistics for scoring.
+    fn search_query_with_scorer(
+        &self,
+        query: &FtsQueryExpr,
+        stats: &GlobalBM25Stats,
+    ) -> Vec<FtsEntry> {
+        match query {
+            FtsQueryExpr::Match { query, boost } => {
+                let mut results = self.search_with_scorer(query, stats);
+                if *boost != 1.0 {
+                    for entry in &mut results {
+                        entry.score *= boost;
+                    }
+                }
+                results
+            }
+            FtsQueryExpr::Phrase { query, slop, boost } => {
+                let mut results = self.search_phrase_with_scorer(query, *slop, stats);
+                if *boost != 1.0 {
+                    for entry in &mut results {
+                        entry.score *= boost;
+                    }
+                }
+                results
+            }
+            FtsQueryExpr::Fuzzy {
+                query,
+                fuzziness,
+                max_expansions,
+                boost,
+            } => {
+                let mut results =
+                    self.search_fuzzy_with_scorer(query, *fuzziness, *max_expansions, stats);
+                if *boost != 1.0 {
+                    for entry in &mut results {
+                        entry.score *= boost;
+                    }
+                }
+                results
+            }
+            FtsQueryExpr::Boolean {
+                must,
+                should,
+                must_not,
+            } => self.search_boolean_with_scorer(must, should, must_not, stats),
+            FtsQueryExpr::Boost {
+                positive,
+                negative,
+                negative_boost,
+            } => {
+                self.search_boost_with_scorer(positive, negative.as_deref(), *negative_boost, stats)
+            }
+        }
+    }
+
+    /// Term search using external scorer for BM25 computation.
+    fn search_with_scorer(&self, term: &str, stats: &GlobalBM25Stats) -> Vec<FtsEntry> {
+        let tokens: Vec<String> = {
+            let mut tokenizer = self.tokenizer.lock().unwrap();
+            let mut token_stream = tokenizer.token_stream_for_search(term);
+            let mut tokens = Vec::new();
+            while let Some(token) = token_stream.next() {
+                tokens.push(token.text.clone());
+            }
+            tokens
+        };
+
+        let mut doc_term_info: HashMap<RowPosition, Vec<(u32, String)>> = HashMap::new();
+        for token in &tokens {
+            let df = self
+                .doc_freq
+                .get(token)
+                .map(|e| e.value().load(Ordering::Relaxed))
+                .unwrap_or(0);
+            if df == 0 {
+                continue;
+            }
+
+            let start = FtsKey {
+                token: token.clone(),
+                row_position: 0,
+            };
+            let end = FtsKey {
+                token: token.clone(),
+                row_position: u64::MAX,
+            };
+
+            for entry in self.postings.range(start..=end) {
+                doc_term_info
+                    .entry(entry.key().row_position)
+                    .or_default()
+                    .push((entry.value().frequency, token.clone()));
+            }
+        }
+
+        doc_term_info
+            .into_iter()
+            .map(|(row_position, term_infos)| {
+                let dl = self
+                    .doc_lengths
+                    .get(&row_position)
+                    .map(|e| *e.value())
+                    .unwrap_or(1);
+
+                let mut score: f32 = 0.0;
+                for (tf, token) in &term_infos {
+                    score += stats.score(token, *tf, dl);
+                }
+
+                FtsEntry {
+                    row_position,
+                    score,
+                }
+            })
+            .collect()
+    }
+
+    /// Phrase search using external scorer.
+    fn search_phrase_with_scorer(
+        &self,
+        phrase: &str,
+        slop: u32,
+        stats: &GlobalBM25Stats,
+    ) -> Vec<FtsEntry> {
+        let tokens: Vec<String> = {
+            let mut tokenizer = self.tokenizer.lock().unwrap();
+            let mut token_stream = tokenizer.token_stream_for_search(phrase);
+            let mut tokens = Vec::new();
+            while let Some(token) = token_stream.next() {
+                tokens.push(token.text.clone());
+            }
+            tokens
+        };
+
+        if tokens.is_empty() {
+            return vec![];
+        }
+        if tokens.len() == 1 {
+            return self.search_with_scorer(phrase, stats);
+        }
+
+        let mut token_postings: Vec<HashMap<RowPosition, PostingValue>> = Vec::new();
+        for token in &tokens {
+            let start = FtsKey {
+                token: token.clone(),
+                row_position: 0,
+            };
+            let end = FtsKey {
+                token: token.clone(),
+                row_position: u64::MAX,
+            };
+            let mut postings_for_token: HashMap<RowPosition, PostingValue> = HashMap::new();
+            for entry in self.postings.range(start..=end) {
+                postings_for_token.insert(entry.key().row_position, entry.value().clone());
+            }
+            token_postings.push(postings_for_token);
+        }
+
+        let first_token_docs: Vec<RowPosition> = token_postings[0].keys().copied().collect();
+        let mut matching_docs: Vec<FtsEntry> = Vec::new();
+
+        for row_position in first_token_docs {
+            let all_tokens_present = token_postings
+                .iter()
+                .all(|tp| tp.contains_key(&row_position));
+            if !all_tokens_present {
+                continue;
+            }
+
+            if self.check_phrase_positions(&token_postings, row_position, slop) {
+                let dl = self
+                    .doc_lengths
+                    .get(&row_position)
+                    .map(|e| *e.value())
+                    .unwrap_or(1);
+
+                let mut score: f32 = 0.0;
+                for (token_idx, token) in tokens.iter().enumerate() {
+                    let tf = token_postings[token_idx]
+                        .get(&row_position)
+                        .map(|p| p.frequency)
+                        .unwrap_or(1);
+                    score += stats.score(token, tf, dl);
+                }
+
+                matching_docs.push(FtsEntry {
+                    row_position,
+                    score,
+                });
+            }
+        }
+
+        matching_docs
+    }
+
+    /// Fuzzy search using external scorer.
+    fn search_fuzzy_with_scorer(
+        &self,
+        query: &str,
+        fuzziness: Option<u32>,
+        max_expansions: usize,
+        stats: &GlobalBM25Stats,
+    ) -> Vec<FtsEntry> {
+        let tokens: Vec<String> = {
+            let mut tokenizer = self.tokenizer.lock().unwrap();
+            let mut token_stream = tokenizer.token_stream_for_search(query);
+            let mut tokens = Vec::new();
+            while let Some(token) = token_stream.next() {
+                tokens.push(token.text.clone());
+            }
+            tokens
+        };
+
+        if tokens.is_empty() {
+            return vec![];
+        }
+
+        let mut doc_term_info: HashMap<RowPosition, Vec<(u32, String)>> = HashMap::new();
+        for token in &tokens {
+            let max_distance = fuzziness.unwrap_or_else(|| auto_fuzziness(token));
+            let expanded = self.expand_fuzzy(token, max_distance, max_expansions);
+
+            for (matched_term, _distance) in expanded {
+                let df = self
+                    .doc_freq
+                    .get(&matched_term)
+                    .map(|e| e.value().load(Ordering::Relaxed))
+                    .unwrap_or(0);
+                if df == 0 {
+                    continue;
+                }
+
+                let start = FtsKey {
+                    token: matched_term.clone(),
+                    row_position: 0,
+                };
+                let end = FtsKey {
+                    token: matched_term.clone(),
+                    row_position: u64::MAX,
+                };
+
+                for entry in self.postings.range(start..=end) {
+                    doc_term_info
+                        .entry(entry.key().row_position)
+                        .or_default()
+                        .push((entry.value().frequency, matched_term.clone()));
+                }
+            }
+        }
+
+        doc_term_info
+            .into_iter()
+            .map(|(row_position, term_infos)| {
+                let dl = self
+                    .doc_lengths
+                    .get(&row_position)
+                    .map(|e| *e.value())
+                    .unwrap_or(1);
+
+                let mut score: f32 = 0.0;
+                for (tf, token) in &term_infos {
+                    score += stats.score(token, *tf, dl);
+                }
+
+                FtsEntry {
+                    row_position,
+                    score,
+                }
+            })
+            .collect()
+    }
+
+    /// Boolean search using external scorer.
+    fn search_boolean_with_scorer(
+        &self,
+        must: &[FtsQueryExpr],
+        should: &[FtsQueryExpr],
+        must_not: &[FtsQueryExpr],
+        stats: &GlobalBM25Stats,
+    ) -> Vec<FtsEntry> {
+        let excluded: std::collections::HashSet<RowPosition> = must_not
+            .iter()
+            .flat_map(|q| self.search_query_with_scorer(q, stats))
+            .map(|e| e.row_position)
+            .collect();
+
+        let mut result_map: HashMap<RowPosition, f32> = if must.is_empty() {
+            let mut map = HashMap::new();
+            for q in should {
+                for entry in self.search_query_with_scorer(q, stats) {
+                    *map.entry(entry.row_position).or_default() += entry.score;
+                }
+            }
+            map
+        } else {
+            let first_results = self.search_query_with_scorer(&must[0], stats);
+            let mut map: HashMap<RowPosition, f32> = first_results
+                .into_iter()
+                .map(|e| (e.row_position, e.score))
+                .collect();
+
+            for q in must.iter().skip(1) {
+                let results = self.search_query_with_scorer(q, stats);
+                let result_set: HashMap<RowPosition, f32> = results
+                    .into_iter()
+                    .map(|e| (e.row_position, e.score))
+                    .collect();
+                map = map
+                    .into_iter()
+                    .filter_map(|(pos, score)| result_set.get(&pos).map(|s| (pos, score + s)))
+                    .collect();
+            }
+
+            if !should.is_empty() {
+                for q in should {
+                    for entry in self.search_query_with_scorer(q, stats) {
+                        if let Some(score) = map.get_mut(&entry.row_position) {
+                            *score += entry.score;
+                        }
+                    }
+                }
+            }
+            map
+        };
+
+        result_map.retain(|pos, _| !excluded.contains(pos));
+
+        result_map
+            .into_iter()
+            .map(|(row_position, score)| FtsEntry {
+                row_position,
+                score,
+            })
+            .collect()
+    }
+
+    /// Boost search using external scorer.
+    fn search_boost_with_scorer(
+        &self,
+        positive: &FtsQueryExpr,
+        negative: Option<&FtsQueryExpr>,
+        negative_boost: f32,
+        stats: &GlobalBM25Stats,
+    ) -> Vec<FtsEntry> {
+        let mut results = self.search_query_with_scorer(positive, stats);
+        let Some(neg_query) = negative else {
+            return results;
+        };
+        let negative_results = self.search_query_with_scorer(neg_query, stats);
+        let negative_positions: std::collections::HashSet<RowPosition> =
+            negative_results.iter().map(|e| e.row_position).collect();
+        for entry in &mut results {
+            if negative_positions.contains(&entry.row_position) {
+                entry.score *= negative_boost;
+            }
+        }
         results
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner.rs
@@ -36,5 +36,5 @@
 mod builder;
 mod exec;
 
-pub use builder::MemTableScanner;
-pub use exec::{BTreeIndexExec, FtsIndexExec, MemTableScanExec, VectorIndexExec};
+pub use builder::{FtsQuery, FtsQueryType, MemTableScanner};
+pub use exec::{BTreeIndexExec, FtsIndexExec, MemTableScanExec, VectorIndexExec, SCORE_COLUMN};

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
@@ -19,6 +19,7 @@ use lance_linalg::distance::DistanceType;
 use snafu::location;
 
 use super::exec::{BTreeIndexExec, FtsIndexExec, MemTableScanExec, VectorIndexExec};
+use crate::dataset::mem_wal::scanner::bm25_stats::DeferredBM25Stats;
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 
 /// Vector search query parameters.
@@ -94,6 +95,8 @@ pub struct FtsQuery {
     /// WAND factor for early termination (0.0 to 1.0).
     /// 1.0 = full recall (default), <1.0 = faster but may miss low-scoring results.
     pub wand_factor: f32,
+    /// Maximum number of results to return. None means unlimited.
+    pub limit: Option<usize>,
 }
 
 /// Default maximum number of fuzzy expansions.
@@ -111,6 +114,7 @@ impl FtsQuery {
                 query: query.into(),
             },
             wand_factor: DEFAULT_WAND_FACTOR,
+            limit: None,
         }
     }
 
@@ -123,6 +127,7 @@ impl FtsQuery {
                 slop,
             },
             wand_factor: DEFAULT_WAND_FACTOR,
+            limit: None,
         }
     }
 
@@ -141,6 +146,7 @@ impl FtsQuery {
                 must_not,
             },
             wand_factor: DEFAULT_WAND_FACTOR,
+            limit: None,
         }
     }
 
@@ -159,6 +165,7 @@ impl FtsQuery {
                 max_expansions: DEFAULT_MAX_EXPANSIONS,
             },
             wand_factor: DEFAULT_WAND_FACTOR,
+            limit: None,
         }
     }
 
@@ -176,6 +183,7 @@ impl FtsQuery {
                 max_expansions: DEFAULT_MAX_EXPANSIONS,
             },
             wand_factor: DEFAULT_WAND_FACTOR,
+            limit: None,
         }
     }
 
@@ -194,6 +202,7 @@ impl FtsQuery {
                 max_expansions,
             },
             wand_factor: DEFAULT_WAND_FACTOR,
+            limit: None,
         }
     }
 
@@ -204,6 +213,12 @@ impl FtsQuery {
     /// - 0.0 = only return the absolute best match
     pub fn with_wand_factor(mut self, wand_factor: f32) -> Self {
         self.wand_factor = wand_factor.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Set the maximum number of results to return.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
         self
     }
 }
@@ -279,6 +294,8 @@ pub struct MemTableScanner {
     /// Whether to include _rowaddr column in output.
     /// Same value as _rowid but named for compatibility with LSM scanner.
     with_row_address: bool,
+    /// Deferred global BM25 stats for cross-generation FTS scoring.
+    deferred_bm25_stats: Option<DeferredBM25Stats>,
 }
 
 impl MemTableScanner {
@@ -311,6 +328,7 @@ impl MemTableScanner {
             batch_size: None,
             with_row_id: false,
             with_row_address: false,
+            deferred_bm25_stats: None,
         }
     }
 
@@ -350,6 +368,13 @@ impl MemTableScanner {
     pub fn with_row_address(&mut self) -> &mut Self {
         self.with_row_address = true;
         self
+    }
+
+    /// Set deferred global BM25 stats for cross-generation FTS scoring.
+    ///
+    /// The stats are resolved lazily at execution time via the `OnceCell`.
+    pub fn set_deferred_bm25_stats(&mut self, stats: Option<DeferredBM25Stats>) {
+        self.deferred_bm25_stats = stats;
     }
 
     /// Set a filter expression using SQL-like syntax.
@@ -612,6 +637,18 @@ impl MemTableScanner {
         self
     }
 
+    /// Set the maximum number of FTS results per source.
+    ///
+    /// Must be called after one of the `full_text_*` methods.
+    pub fn fts_limit(&mut self, limit: usize) -> &mut Self {
+        if let Some(ref mut q) = self.full_text_query {
+            q.limit = Some(limit);
+        } else {
+            log::warn!("fts_limit is not set because full_text_query has not been called yet");
+        }
+        self
+    }
+
     /// Enable or disable index usage.
     pub fn use_index(&mut self, use_index: bool) -> &mut Self {
         self.use_index = use_index;
@@ -849,7 +886,8 @@ impl MemTableScanner {
             projection_indices,
             self.base_output_schema(),
             self.with_row_id,
-        )?;
+        )?
+        .with_deferred_bm25_stats(self.deferred_bm25_stats.clone());
         self.apply_post_index_ops(Arc::new(index_exec)).await
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec.rs
@@ -15,6 +15,6 @@ mod scan;
 mod vector;
 
 pub use btree::BTreeIndexExec;
-pub use fts::FtsIndexExec;
+pub use fts::{FtsIndexExec, SCORE_COLUMN};
 pub use scan::{MemTableScanExec, ROW_ADDRESS_COLUMN};
 pub use vector::VectorIndexExec;

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
@@ -24,8 +24,9 @@ use futures::stream::{self, StreamExt};
 use lance_core::{Error, Result};
 use snafu::location;
 
-use super::super::builder::{FtsQuery, FtsQueryType, DEFAULT_WAND_FACTOR};
+use super::super::builder::{FtsQuery, FtsQueryType};
 use crate::dataset::mem_wal::index::{FtsQueryExpr, SearchOptions};
+use crate::dataset::mem_wal::scanner::bm25_stats::{DeferredBM25Stats, GlobalBM25Stats};
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 
 /// Score column name in output.
@@ -55,6 +56,9 @@ pub struct FtsIndexExec {
     max_visible_row: Option<u64>,
     /// Whether to include _rowid column (row position) in output.
     with_row_id: bool,
+    /// Deferred global BM25 stats for cross-generation scoring.
+    /// Resolved lazily at execution time to avoid blocking plan construction.
+    deferred_bm25_stats: Option<DeferredBM25Stats>,
 }
 
 impl Debug for FtsIndexExec {
@@ -158,235 +162,200 @@ impl FtsIndexExec {
             batch_ranges,
             max_visible_row,
             with_row_id,
+            deferred_bm25_stats: None,
         })
     }
 
-    /// Find batch for a row position using binary search. O(log n).
-    #[inline]
-    fn find_batch(&self, row_pos: usize) -> Option<&BatchRange> {
-        // Binary search: find the batch where start <= row_pos < end
-        let idx = self.batch_ranges.partition_point(|b| b.end <= row_pos);
-        self.batch_ranges
-            .get(idx)
-            .filter(|b| row_pos >= b.start && row_pos < b.end)
+    /// Set deferred global BM25 stats for cross-generation scoring.
+    ///
+    /// The stats are resolved lazily at execution time. If the stats task
+    /// hasn't completed yet, the execution stream will await its result.
+    pub fn with_deferred_bm25_stats(mut self, stats: Option<DeferredBM25Stats>) -> Self {
+        self.deferred_bm25_stats = stats;
+        self
     }
+}
 
-    /// Query the index and return matching rows with BM25 scores.
-    fn query_index(&self) -> Vec<(u64, f32)> {
-        let Some(index) = self.indexes.get_fts_by_column(&self.query.column) else {
-            return vec![];
-        };
+/// Standalone query + materialization logic used by both sync and async execute paths.
+///
+/// Extracted from `FtsIndexExec` methods so it can be called from an async block
+/// (which cannot borrow `&self` across an `.await`).
+#[allow(clippy::too_many_arguments)]
+fn execute_fts_query(
+    batch_store: &Arc<BatchStore>,
+    indexes: &Arc<IndexStore>,
+    query: &FtsQuery,
+    max_visible_row: Option<u64>,
+    projection: Option<&[usize]>,
+    output_schema: &SchemaRef,
+    batch_ranges: &[BatchRange],
+    with_row_id: bool,
+    resolved_stats: Option<&GlobalBM25Stats>,
+) -> DataFusionResult<Vec<RecordBatch>> {
+    // Query the index
+    let results = query_fts_index(indexes, query, resolved_stats);
 
-        // Convert FtsQueryType to FtsQueryExpr
-        let query_expr = match &self.query.query_type {
-            FtsQueryType::Match { query } => FtsQueryExpr::match_query(query),
-            FtsQueryType::Phrase { query, slop } => FtsQueryExpr::phrase_with_slop(query, *slop),
-            FtsQueryType::Boolean {
-                must,
-                should,
-                must_not,
-            } => {
-                let mut builder = FtsQueryExpr::boolean();
-                for term in must {
-                    builder = builder.must(FtsQueryExpr::match_query(term));
-                }
-                for term in should {
-                    builder = builder.should(FtsQueryExpr::match_query(term));
-                }
-                for term in must_not {
-                    builder = builder.must_not(FtsQueryExpr::match_query(term));
-                }
-                builder.build()
-            }
-            FtsQueryType::Fuzzy {
-                query,
-                fuzziness,
-                max_expansions,
-            } => FtsQueryExpr::fuzzy_with_options(query, *fuzziness, *max_expansions),
-        };
-
-        // Search the index using the query expression
-        // Use search_with_options if wand_factor is set (< 1.0)
-        let entries = if self.query.wand_factor < DEFAULT_WAND_FACTOR {
-            let options = SearchOptions::new().with_wand_factor(self.query.wand_factor);
-            index.search_with_options(&query_expr, options)
-        } else {
-            index.search_query(&query_expr)
-        };
-
-        // Convert to (row_position, score) pairs
-        entries
-            .into_iter()
-            .map(|entry| (entry.row_position, entry.score))
-            .collect()
-    }
-
-    /// Filter results by MVCC visibility using max_row_position. O(n).
-    fn filter_by_visibility(&self, results: Vec<(u64, f32)>) -> Vec<(u64, f32)> {
-        let Some(max_visible) = self.max_visible_row else {
-            return vec![];
-        };
-        results
+    // Filter by visibility
+    let mut visible_results = match max_visible_row {
+        Some(max_visible) => results
             .into_iter()
             .filter(|&(pos, _)| pos <= max_visible)
-            .collect()
+            .collect(),
+        None => vec![],
+    };
+
+    // Sort by score descending
+    visible_results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Materialize rows
+    materialize_rows_sorted(
+        &visible_results,
+        batch_store,
+        batch_ranges,
+        projection,
+        output_schema,
+        with_row_id,
+    )
+}
+
+/// Query the FTS index and return (row_position, score) pairs.
+fn query_fts_index(
+    indexes: &Arc<IndexStore>,
+    query: &FtsQuery,
+    resolved_stats: Option<&GlobalBM25Stats>,
+) -> Vec<(u64, f32)> {
+    let Some(index) = indexes.get_fts_by_column(&query.column) else {
+        return vec![];
+    };
+
+    let query_expr = match &query.query_type {
+        FtsQueryType::Match { query } => FtsQueryExpr::match_query(query),
+        FtsQueryType::Phrase { query, slop } => FtsQueryExpr::phrase_with_slop(query, *slop),
+        FtsQueryType::Boolean {
+            must,
+            should,
+            must_not,
+        } => {
+            let mut builder = FtsQueryExpr::boolean();
+            for term in must {
+                builder = builder.must(FtsQueryExpr::match_query(term));
+            }
+            for term in should {
+                builder = builder.should(FtsQueryExpr::match_query(term));
+            }
+            for term in must_not {
+                builder = builder.must_not(FtsQueryExpr::match_query(term));
+            }
+            builder.build()
+        }
+        FtsQueryType::Fuzzy {
+            query,
+            fuzziness,
+            max_expansions,
+        } => FtsQueryExpr::fuzzy_with_options(query, *fuzziness, *max_expansions),
+    };
+
+    let mut options = SearchOptions::new().with_wand_factor(query.wand_factor);
+    if let Some(limit) = query.limit {
+        options = options.with_limit(limit);
+    }
+    if let Some(stats) = resolved_stats {
+        options = options.with_bm25_override(Arc::new(stats.clone()));
+    }
+    let entries = index.search_with_options(&query_expr, options);
+
+    entries
+        .into_iter()
+        .map(|entry| (entry.row_position, entry.score))
+        .collect()
+}
+
+/// Find batch for a row position using binary search. O(log n).
+#[inline]
+fn find_batch(batch_ranges: &[BatchRange], row_pos: usize) -> Option<&BatchRange> {
+    let idx = batch_ranges.partition_point(|b| b.end <= row_pos);
+    batch_ranges
+        .get(idx)
+        .filter(|b| row_pos >= b.start && row_pos < b.end)
+}
+
+/// Materialize rows from batch store preserving input order (for sorted results).
+fn materialize_rows_sorted(
+    results: &[(u64, f32)],
+    batch_store: &Arc<BatchStore>,
+    batch_ranges: &[BatchRange],
+    projection: Option<&[usize]>,
+    output_schema: &SchemaRef,
+    with_row_id: bool,
+) -> DataFusionResult<Vec<RecordBatch>> {
+    if results.is_empty() {
+        return Ok(vec![]);
     }
 
-    /// Materialize rows from batch store with score column (for unsorted results).
-    #[allow(dead_code)]
-    fn materialize_rows(&self, results: &[(u64, f32)]) -> DataFusionResult<Vec<RecordBatch>> {
-        if results.is_empty() {
-            return Ok(vec![]);
+    let mut all_scores: Vec<f32> = Vec::with_capacity(results.len());
+    let mut all_row_positions: Vec<u64> = Vec::with_capacity(results.len());
+    let mut all_columns: Vec<Vec<Arc<dyn arrow_array::Array>>> = Vec::new();
+
+    if let Some(stored) = batch_store.get(0) {
+        for _ in 0..stored.data.num_columns() {
+            all_columns.push(Vec::with_capacity(results.len()));
         }
-
-        // Group rows by batch using binary search on pre-computed ranges
-        // Track (row_in_batch, score, original_row_position)
-        let mut batches_data: std::collections::HashMap<usize, Vec<(usize, f32, u64)>> =
-            std::collections::HashMap::new();
-
-        for &(pos, score) in results {
-            if let Some(batch) = self.find_batch(pos as usize) {
-                batches_data.entry(batch.batch_id).or_default().push((
-                    pos as usize - batch.start,
-                    score,
-                    pos,
-                ));
-            }
-        }
-
-        let mut all_batches = Vec::new();
-
-        for (batch_id, rows_with_score) in batches_data {
-            if let Some(stored) = self.batch_store.get(batch_id) {
-                let rows: Vec<u32> = rows_with_score.iter().map(|&(r, _, _)| r as u32).collect();
-                let scores: Vec<f32> = rows_with_score.iter().map(|&(_, s, _)| s).collect();
-                let row_positions: Vec<u64> =
-                    rows_with_score.iter().map(|&(_, _, pos)| pos).collect();
-
-                let indices = UInt32Array::from(rows);
-
-                let mut columns: Vec<Arc<dyn arrow_array::Array>> = stored
-                    .data
-                    .columns()
-                    .iter()
-                    .map(|col| arrow_select::take::take(col.as_ref(), &indices, None).unwrap())
-                    .collect();
-
-                // Add score column
-                columns.push(Arc::new(Float32Array::from(scores)));
-
-                // Apply projection if needed (excluding score column which is always included)
-                let mut final_columns = if let Some(ref proj_indices) = self.projection {
-                    let mut projected: Vec<_> =
-                        proj_indices.iter().map(|&i| columns[i].clone()).collect();
-                    // Always include score as last column
-                    projected.push(columns.last().unwrap().clone());
-                    projected
-                } else {
-                    columns
-                };
-
-                // Add _rowid column if requested
-                if self.with_row_id {
-                    final_columns.push(Arc::new(UInt64Array::from(row_positions)));
-                }
-
-                let batch = RecordBatch::try_new(self.output_schema.clone(), final_columns)?;
-                all_batches.push(batch);
-            }
-        }
-
-        Ok(all_batches)
     }
 
-    /// Materialize rows from batch store preserving input order (for sorted results).
-    ///
-    /// This method processes results one at a time to preserve the score-sorted order,
-    /// then combines them into a single batch.
-    fn materialize_rows_sorted(
-        &self,
-        results: &[(u64, f32)],
-    ) -> DataFusionResult<Vec<RecordBatch>> {
-        if results.is_empty() {
-            return Ok(vec![]);
-        }
+    for &(pos, score) in results {
+        if let Some(batch_range) = find_batch(batch_ranges, pos as usize) {
+            if let Some(stored) = batch_store.get(batch_range.batch_id) {
+                let row_in_batch = (pos as usize - batch_range.start) as u32;
+                let indices = UInt32Array::from(vec![row_in_batch]);
 
-        // Process each result in order to preserve sorting
-        let mut all_rows: Vec<u32> = Vec::with_capacity(results.len());
-        let mut all_scores: Vec<f32> = Vec::with_capacity(results.len());
-        let mut all_row_positions: Vec<u64> = Vec::with_capacity(results.len());
-        let mut all_columns: Vec<Vec<Arc<dyn arrow_array::Array>>> = Vec::new();
-
-        // Initialize column vectors based on first batch's schema
-        let first_batch = self.batch_store.get(0);
-        if let Some(stored) = first_batch {
-            for _ in 0..stored.data.num_columns() {
-                all_columns.push(Vec::with_capacity(results.len()));
-            }
-        }
-
-        for &(pos, score) in results {
-            if let Some(batch_range) = self.find_batch(pos as usize) {
-                if let Some(stored) = self.batch_store.get(batch_range.batch_id) {
-                    let row_in_batch = (pos as usize - batch_range.start) as u32;
-                    let indices = UInt32Array::from(vec![row_in_batch]);
-
-                    // Take each column value
-                    for (col_idx, col) in stored.data.columns().iter().enumerate() {
-                        let taken = arrow_select::take::take(col.as_ref(), &indices, None).unwrap();
-                        if all_columns.len() <= col_idx {
-                            all_columns.push(Vec::new());
-                        }
-                        all_columns[col_idx].push(taken);
+                for (col_idx, col) in stored.data.columns().iter().enumerate() {
+                    let taken = arrow_select::take::take(col.as_ref(), &indices, None).unwrap();
+                    if all_columns.len() <= col_idx {
+                        all_columns.push(Vec::new());
                     }
-
-                    all_rows.push(row_in_batch);
-                    all_scores.push(score);
-                    all_row_positions.push(pos);
+                    all_columns[col_idx].push(taken);
                 }
+
+                all_scores.push(score);
+                all_row_positions.push(pos);
             }
         }
-
-        if all_scores.is_empty() {
-            return Ok(vec![]);
-        }
-
-        // Concatenate all column arrays
-        let mut final_columns: Vec<Arc<dyn arrow_array::Array>> = Vec::new();
-
-        for col_arrays in &all_columns {
-            if !col_arrays.is_empty() {
-                let refs: Vec<&dyn arrow_array::Array> =
-                    col_arrays.iter().map(|a| a.as_ref()).collect();
-                let concatenated = arrow_select::concat::concat(&refs)?;
-                final_columns.push(concatenated);
-            }
-        }
-
-        // Add score column
-        final_columns.push(Arc::new(Float32Array::from(all_scores)));
-
-        // Apply projection if needed
-        let mut projected_columns = if let Some(ref proj_indices) = self.projection {
-            let mut projected: Vec<_> = proj_indices
-                .iter()
-                .map(|&i| final_columns[i].clone())
-                .collect();
-            // Always include score as last column
-            projected.push(final_columns.last().unwrap().clone());
-            projected
-        } else {
-            final_columns
-        };
-
-        // Add _rowid column if requested
-        if self.with_row_id {
-            projected_columns.push(Arc::new(UInt64Array::from(all_row_positions)));
-        }
-
-        let batch = RecordBatch::try_new(self.output_schema.clone(), projected_columns)?;
-        Ok(vec![batch])
     }
+
+    if all_scores.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let mut final_columns: Vec<Arc<dyn arrow_array::Array>> = Vec::new();
+
+    for col_arrays in &all_columns {
+        if !col_arrays.is_empty() {
+            let refs: Vec<&dyn arrow_array::Array> =
+                col_arrays.iter().map(|a| a.as_ref()).collect();
+            let concatenated = arrow_select::concat::concat(&refs)?;
+            final_columns.push(concatenated);
+        }
+    }
+
+    final_columns.push(Arc::new(Float32Array::from(all_scores)));
+
+    let mut projected_columns = if let Some(proj_indices) = projection {
+        let mut projected: Vec<_> = proj_indices
+            .iter()
+            .map(|&i| final_columns[i].clone())
+            .collect();
+        projected.push(final_columns.last().unwrap().clone());
+        projected
+    } else {
+        final_columns
+    };
+
+    if with_row_id {
+        projected_columns.push(Arc::new(UInt64Array::from(all_row_positions)));
+    }
+
+    let batch = RecordBatch::try_new(output_schema.clone(), projected_columns)?;
+    Ok(vec![batch])
 }
 
 impl DisplayAs for FtsIndexExec {
@@ -444,22 +413,64 @@ impl ExecutionPlan for FtsIndexExec {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
-        // Query the index
-        let results = self.query_index();
+        if self.deferred_bm25_stats.is_none() {
+            // Fast path: no deferred stats, execute synchronously
+            let batches = execute_fts_query(
+                &self.batch_store,
+                &self.indexes,
+                &self.query,
+                self.max_visible_row,
+                self.projection.as_deref(),
+                &self.output_schema,
+                &self.batch_ranges,
+                self.with_row_id,
+                None,
+            )?;
+            let stream = stream::iter(batches.into_iter().map(Ok)).boxed();
+            return Ok(Box::pin(RecordBatchStreamAdapter::new(
+                self.output_schema.clone(),
+                stream,
+            )));
+        }
 
-        // Filter by visibility
-        let mut visible_results = self.filter_by_visibility(results);
+        // Deferred path: clone fields needed by the async block
+        let deferred_stats = self.deferred_bm25_stats.clone().unwrap();
+        let batch_store = self.batch_store.clone();
+        let indexes = self.indexes.clone();
+        let query = self.query.clone();
+        let max_visible_row = self.max_visible_row;
+        let projection = self.projection.clone();
+        let output_schema = self.output_schema.clone();
+        let batch_ranges = self.batch_ranges.clone();
+        let with_row_id = self.with_row_id;
 
-        // Sort by score descending (best matches first)
-        visible_results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        let output_schema_for_stream = output_schema.clone();
+        let fut = async move {
+            // Resolve deferred BM25 stats (may already be available)
+            let resolved = deferred_stats.await;
+            // Run the sync query/materialization logic
+            execute_fts_query(
+                &batch_store,
+                &indexes,
+                &query,
+                max_visible_row,
+                projection.as_deref(),
+                &output_schema,
+                &batch_ranges,
+                with_row_id,
+                Some(&resolved),
+            )
+        };
 
-        // Materialize the rows (preserving sort order)
-        let batches = self.materialize_rows_sorted(&visible_results)?;
-
-        let stream = stream::iter(batches.into_iter().map(Ok)).boxed();
+        let stream = futures::stream::once(fut)
+            .flat_map(|result| match result {
+                Ok(batches) => stream::iter(batches.into_iter().map(Ok)).boxed(),
+                Err(e) => stream::once(async move { Err(e) }).boxed(),
+            })
+            .boxed();
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
-            self.output_schema.clone(),
+            output_schema_for_stream,
             stream,
         )))
     }

--- a/rust/lance/src/dataset/mem_wal/scanner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner.rs
@@ -31,16 +31,20 @@
 //! let stream = scanner.try_into_stream().await?;
 //! ```
 
+pub mod bm25_stats;
 mod builder;
 mod collector;
 mod data_source;
 pub mod exec;
+mod fts_search;
 mod planner;
 mod point_lookup;
 mod vector_search;
 
+pub use bm25_stats::GlobalBM25Stats;
 pub use builder::LsmScanner;
 pub use collector::{ActiveMemTableRef, LsmDataSourceCollector};
 pub use data_source::{FlushedGeneration, LsmDataSource, LsmGeneration, RegionSnapshot};
+pub use fts_search::LsmFtsSearchPlanner;
 pub use point_lookup::LsmPointLookupPlanner;
 pub use vector_search::{LsmVectorSearchPlanner, DISTANCE_COLUMN};

--- a/rust/lance/src/dataset/mem_wal/scanner/bm25_stats.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/bm25_stats.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Global BM25 statistics for cross-generation FTS scoring.
+//!
+//! When searching across multiple LSM generations, each has its own corpus
+//! statistics. This module provides aggregated statistics so BM25 scores
+//! are comparable across generations.
+
+use std::collections::HashMap;
+
+use futures::future::BoxFuture;
+use lance_index::scalar::inverted::scorer::{idf, B, K1};
+
+/// A deferred handle to global BM25 stats that are being computed asynchronously.
+///
+/// Stats collection is spawned as a background task at plan time. Execution
+/// nodes `.await` the shared future when they need the stats (which may already
+/// be resolved by then). All consumers share the same computation — the
+/// underlying future runs at most once.
+pub type DeferredBM25Stats = futures::future::Shared<BoxFuture<'static, GlobalBM25Stats>>;
+
+/// Per-generation BM25 statistics, collected before aggregation.
+#[derive(Debug, Clone)]
+pub struct GenerationBM25Stats {
+    pub num_docs: usize,
+    pub total_tokens: u64,
+    /// term -> number of documents containing the term in this generation.
+    pub term_doc_freqs: HashMap<String, usize>,
+}
+
+impl GenerationBM25Stats {
+    pub fn new(num_docs: usize, total_tokens: u64, term_doc_freqs: HashMap<String, usize>) -> Self {
+        Self {
+            num_docs,
+            total_tokens,
+            term_doc_freqs,
+        }
+    }
+}
+
+/// Aggregated BM25 statistics across all LSM generations.
+///
+/// Used to produce comparable BM25 scores when searching across
+/// memtables and base table simultaneously.
+#[derive(Debug, Clone)]
+pub struct GlobalBM25Stats {
+    pub num_docs: usize,
+    pub total_tokens: u64,
+    pub avg_doc_length: f32,
+    /// term -> total number of documents containing the term across all generations.
+    pub term_doc_freqs: HashMap<String, usize>,
+}
+
+impl GlobalBM25Stats {
+    pub fn new(num_docs: usize, total_tokens: u64, term_doc_freqs: HashMap<String, usize>) -> Self {
+        let avg_doc_length = if num_docs > 0 {
+            total_tokens as f32 / num_docs as f32
+        } else {
+            1.0
+        };
+        Self {
+            num_docs,
+            total_tokens,
+            avg_doc_length,
+            term_doc_freqs,
+        }
+    }
+
+    /// Aggregate multiple per-generation stats into global stats.
+    pub fn aggregate(stats: &[GenerationBM25Stats]) -> Self {
+        let num_docs: usize = stats.iter().map(|s| s.num_docs).sum();
+        let total_tokens: u64 = stats.iter().map(|s| s.total_tokens).sum();
+        let mut term_doc_freqs: HashMap<String, usize> = HashMap::new();
+        for s in stats {
+            for (term, freq) in &s.term_doc_freqs {
+                *term_doc_freqs.entry(term.clone()).or_default() += freq;
+            }
+        }
+        Self::new(num_docs, total_tokens, term_doc_freqs)
+    }
+
+    /// Compute IDF for a token using global stats.
+    pub fn idf(&self, token: &str) -> f32 {
+        let token_docs = self.term_doc_freqs.get(token).copied().unwrap_or(0);
+        if token_docs == 0 {
+            return 0.0;
+        }
+        idf(token_docs, self.num_docs)
+    }
+
+    /// Compute BM25 score for a single term occurrence.
+    pub fn score(&self, token: &str, freq: u32, doc_length: u32) -> f32 {
+        let idf_val = self.idf(token);
+        if idf_val == 0.0 {
+            return 0.0;
+        }
+        let freq = freq as f32;
+        let doc_length = doc_length as f32;
+        let doc_norm = K1 * (1.0 - B + B * doc_length / self.avg_doc_length);
+        idf_val * (K1 + 1.0) * freq / (freq + doc_norm)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_global_bm25_stats_new() {
+        let mut term_freqs = HashMap::new();
+        term_freqs.insert("hello".to_string(), 5);
+        term_freqs.insert("world".to_string(), 3);
+
+        let stats = GlobalBM25Stats::new(10, 100, term_freqs);
+        assert_eq!(stats.num_docs, 10);
+        assert_eq!(stats.total_tokens, 100);
+        assert!((stats.avg_doc_length - 10.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_global_bm25_stats_empty() {
+        let stats = GlobalBM25Stats::new(0, 0, HashMap::new());
+        assert_eq!(stats.num_docs, 0);
+        assert!((stats.avg_doc_length - 1.0).abs() < f32::EPSILON);
+        assert_eq!(stats.idf("unknown"), 0.0);
+        assert_eq!(stats.score("unknown", 1, 10), 0.0);
+    }
+
+    #[test]
+    fn test_aggregate_stats() {
+        let gen1 = GenerationBM25Stats::new(
+            5,
+            50,
+            HashMap::from([("hello".to_string(), 3), ("world".to_string(), 2)]),
+        );
+        let gen2 = GenerationBM25Stats::new(
+            10,
+            120,
+            HashMap::from([("hello".to_string(), 4), ("rust".to_string(), 6)]),
+        );
+
+        let global = GlobalBM25Stats::aggregate(&[gen1, gen2]);
+        assert_eq!(global.num_docs, 15);
+        assert_eq!(global.total_tokens, 170);
+        assert_eq!(global.term_doc_freqs["hello"], 7);
+        assert_eq!(global.term_doc_freqs["world"], 2);
+        assert_eq!(global.term_doc_freqs["rust"], 6);
+    }
+
+    #[test]
+    fn test_idf_known_token() {
+        let stats = GlobalBM25Stats::new(10, 100, HashMap::from([("hello".to_string(), 3)]));
+        let idf_val = stats.idf("hello");
+        assert!(idf_val > 0.0);
+        // IDF = ln((10 - 3 + 0.5) / (3 + 0.5) + 1) = ln(7.5/3.5 + 1)
+        let expected = ((10.0 - 3.0 + 0.5) / (3.0 + 0.5) + 1.0_f32).ln();
+        assert!((idf_val - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_score_calculation() {
+        let stats = GlobalBM25Stats::new(10, 100, HashMap::from([("hello".to_string(), 3)]));
+        let score = stats.score("hello", 2, 10);
+        assert!(score > 0.0);
+
+        // Verify same result as manual BM25 calculation
+        let idf_val = stats.idf("hello");
+        let freq = 2.0_f32;
+        let doc_norm = K1 * (1.0 - B + B * 10.0 / 10.0);
+        let expected = idf_val * (K1 + 1.0) * freq / (freq + doc_norm);
+        assert!((score - expected).abs() < 1e-6);
+    }
+}

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -16,9 +16,12 @@ use lance_core::{Error, Result};
 use snafu::location;
 use uuid::Uuid;
 
+use super::bm25_stats::GlobalBM25Stats;
 use super::collector::{ActiveMemTableRef, LsmDataSourceCollector};
 use super::data_source::RegionSnapshot;
+use super::fts_search::LsmFtsSearchPlanner;
 use super::planner::LsmScanPlanner;
+use crate::dataset::mem_wal::memtable::scanner::FtsQuery;
 use crate::dataset::Dataset;
 
 /// Scanner for LSM tree data spanning base table, flushed MemTables, and active MemTable.
@@ -60,6 +63,10 @@ pub struct LsmScanner {
 
     // Primary key columns (required for deduplication)
     pk_columns: Vec<String>,
+
+    // Full-text search
+    fts_query: Option<FtsQuery>,
+    fts_global_stats: Option<GlobalBM25Stats>,
 }
 
 impl LsmScanner {
@@ -86,6 +93,8 @@ impl LsmScanner {
             with_row_address: false,
             with_memtable_gen: false,
             pk_columns,
+            fts_query: None,
+            fts_global_stats: None,
         }
     }
 
@@ -159,6 +168,27 @@ impl LsmScanner {
         self
     }
 
+    /// Enable full-text search with global BM25 scoring.
+    ///
+    /// Stats are aggregated across all LSM levels at plan time so that
+    /// BM25 scores are comparable across generations.
+    pub fn full_text_search(mut self, column: impl Into<String>, query: impl Into<String>) -> Self {
+        self.fts_query = Some(FtsQuery::match_query(column, query));
+        self
+    }
+
+    /// Enable full-text search with pre-computed global BM25 stats.
+    pub fn fts_with_global_stats(
+        mut self,
+        column: impl Into<String>,
+        query: impl Into<String>,
+        stats: GlobalBM25Stats,
+    ) -> Self {
+        self.fts_query = Some(FtsQuery::match_query(column, query));
+        self.fts_global_stats = Some(stats);
+        self
+    }
+
     /// Get the output schema.
     pub fn schema(&self) -> SchemaRef {
         // For now, return base schema. Full implementation would compute
@@ -172,8 +202,26 @@ impl LsmScanner {
     pub async fn create_plan(&self) -> Result<Arc<dyn ExecutionPlan>> {
         let collector = self.build_collector();
         let base_schema = self.schema();
-        let planner = LsmScanPlanner::new(collector, self.pk_columns.clone(), base_schema);
 
+        if let Some(ref fts_query) = self.fts_query {
+            let k = self.limit.unwrap_or(10);
+            let mut planner = LsmFtsSearchPlanner::new(
+                collector,
+                self.pk_columns.clone(),
+                base_schema,
+                fts_query.clone(),
+            );
+            if let Some(ref stats) = self.fts_global_stats {
+                planner = planner.with_global_stats(stats.clone());
+            }
+            let projection = self
+                .projection
+                .as_ref()
+                .map(|p| p.iter().map(|s| s.as_str().to_string()).collect::<Vec<_>>());
+            return planner.plan_search(k, projection.as_deref()).await;
+        }
+
+        let planner = LsmScanPlanner::new(collector, self.pk_columns.clone(), base_schema);
         planner
             .plan_scan(
                 self.projection.as_deref(),
@@ -247,6 +295,7 @@ impl std::fmt::Debug for LsmScanner {
             .field("limit", &self.limit)
             .field("offset", &self.offset)
             .field("pk_columns", &self.pk_columns)
+            .field("fts_query", &self.fts_query.is_some())
             .finish()
     }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/exec.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec.rs
@@ -17,9 +17,11 @@ mod coalesce_first;
 mod deduplicate;
 mod filter_stale;
 mod generation_tag;
+mod top_k;
 
 pub use bloom_guard::{compute_pk_hash_from_scalars, BloomFilterGuardExec};
 pub use coalesce_first::CoalesceFirstExec;
 pub use deduplicate::{DeduplicateExec, ROW_ADDRESS_COLUMN};
 pub use filter_stale::{FilterStaleExec, GenerationBloomFilter};
 pub use generation_tag::{MemtableGenTagExec, MEMTABLE_GEN_COLUMN};
+pub use top_k::TopKExec;

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/top_k.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/top_k.rs
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! TopKExec - Heap-based top-K selection by score.
+//!
+//! Replaces SortExec + GlobalLimitExec for FTS queries. Uses a min-heap
+//! of size K so that only top-K rows are retained. Rows below the heap's
+//! minimum score are discarded immediately (cross-source pruning).
+//!
+//! Complexity: O(N log K) vs O(N log N) for full sort.
+
+use std::any::Any;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::fmt;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow_array::{Float32Array, RecordBatch};
+use arrow_schema::SchemaRef;
+use datafusion::error::Result as DFResult;
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    SendableRecordBatchStream,
+};
+use futures::{Stream, StreamExt};
+
+/// Row reference for the min-heap: batch index + row index + score.
+#[derive(Clone)]
+struct ScoredRow {
+    batch_idx: usize,
+    row_idx: usize,
+    score: f32,
+}
+
+impl PartialEq for ScoredRow {
+    fn eq(&self, other: &Self) -> bool {
+        self.score == other.score
+    }
+}
+
+impl Eq for ScoredRow {}
+
+impl PartialOrd for ScoredRow {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ScoredRow {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.score
+            .partial_cmp(&other.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    }
+}
+
+/// Heap-based top-K selection by a score column.
+///
+/// Consumes all input rows, maintains a min-heap of size K, and outputs
+/// a single RecordBatch with the K highest-scoring rows in descending order.
+///
+/// This provides cross-source pruning: as the heap fills with high-scoring
+/// rows from one source, rows from other sources that score below the
+/// heap minimum are immediately discarded without any heap operations.
+#[derive(Debug)]
+pub struct TopKExec {
+    input: Arc<dyn ExecutionPlan>,
+    /// Number of top results to keep.
+    k: usize,
+    /// Name of the score column.
+    score_column: String,
+    schema: SchemaRef,
+    properties: PlanProperties,
+}
+
+impl TopKExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, k: usize, score_column: String) -> Self {
+        let schema = input.schema();
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new(schema.clone()),
+            Partitioning::UnknownPartitioning(1),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        );
+        Self {
+            input,
+            k,
+            score_column,
+            schema,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for TopKExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::Verbose
+            | DisplayFormatType::TreeRender => {
+                write!(f, "TopKExec: k={}, score={}", self.k, self.score_column)
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for TopKExec {
+    fn name(&self) -> &str {
+        "TopKExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(datafusion::error::DataFusionError::Internal(
+                "TopKExec requires exactly one child".to_string(),
+            ));
+        }
+        Ok(Arc::new(Self::new(
+            children[0].clone(),
+            self.k,
+            self.score_column.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let input_stream = self.input.execute(partition, context)?;
+
+        let score_idx = self.schema.index_of(&self.score_column).map_err(|_| {
+            datafusion::error::DataFusionError::Internal(format!(
+                "Score column '{}' not found in schema",
+                self.score_column
+            ))
+        })?;
+
+        Ok(Box::pin(TopKStream::new(
+            input_stream,
+            self.k,
+            score_idx,
+            self.schema.clone(),
+        )))
+    }
+}
+
+/// Stream that collects all input, selects top-K by score, and emits them sorted DESC.
+struct TopKStream {
+    /// Input stream.
+    input: SendableRecordBatchStream,
+    /// Number of top results to keep.
+    k: usize,
+    /// Column index for the score.
+    score_idx: usize,
+    /// Output schema.
+    schema: SchemaRef,
+    /// Accumulated input batches (for row gathering after selection).
+    batches: Vec<RecordBatch>,
+    /// Min-heap of size K (Reverse to make BinaryHeap a min-heap).
+    heap: BinaryHeap<Reverse<ScoredRow>>,
+    /// Current minimum score in the heap (for fast pruning).
+    min_score: f32,
+    /// Whether we've finished consuming input and emitted the result.
+    done: bool,
+}
+
+impl TopKStream {
+    fn new(
+        input: SendableRecordBatchStream,
+        k: usize,
+        score_idx: usize,
+        schema: SchemaRef,
+    ) -> Self {
+        Self {
+            input,
+            k,
+            score_idx,
+            schema,
+            batches: Vec::new(),
+            heap: BinaryHeap::with_capacity(k + 1),
+            min_score: f32::NEG_INFINITY,
+            done: false,
+        }
+    }
+
+    /// Process a batch: for each row, compete for a spot in the top-K heap.
+    fn process_batch(&mut self, batch: &RecordBatch) {
+        let batch_idx = self.batches.len() - 1;
+        let scores = batch
+            .column(self.score_idx)
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .expect("Score column must be Float32");
+
+        for row_idx in 0..batch.num_rows() {
+            let score = scores.value(row_idx);
+
+            // Cross-source pruning: skip rows that can't make top-K
+            if self.heap.len() >= self.k && score <= self.min_score {
+                continue;
+            }
+
+            let row = ScoredRow {
+                batch_idx,
+                row_idx,
+                score,
+            };
+
+            if self.heap.len() < self.k {
+                self.heap.push(Reverse(row));
+                if self.heap.len() == self.k {
+                    self.min_score = self.heap.peek().unwrap().0.score;
+                }
+            } else {
+                // Replace the minimum element
+                self.heap.pop();
+                self.heap.push(Reverse(row));
+                self.min_score = self.heap.peek().unwrap().0.score;
+            }
+        }
+    }
+
+    /// Drain the heap and gather rows from stored batches into a single output batch.
+    fn build_output(&mut self) -> DFResult<RecordBatch> {
+        if self.heap.is_empty() || self.batches.is_empty() {
+            return Ok(RecordBatch::new_empty(self.schema.clone()));
+        }
+
+        // Drain heap into sorted order (score DESC)
+        let mut winners: Vec<ScoredRow> = self.heap.drain().map(|r| r.0).collect();
+        winners.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Gather rows from stored batches
+        let num_cols = self.schema.fields().len();
+        let mut column_builders: Vec<Vec<Arc<dyn arrow_array::Array>>> = (0..num_cols)
+            .map(|_| Vec::with_capacity(winners.len()))
+            .collect();
+
+        for winner in &winners {
+            let batch = &self.batches[winner.batch_idx];
+            for (col_idx, builder) in column_builders.iter_mut().enumerate() {
+                builder.push(batch.column(col_idx).slice(winner.row_idx, 1));
+            }
+        }
+
+        // Concatenate sliced arrays for each column
+        let columns: Vec<Arc<dyn arrow_array::Array>> = column_builders
+            .into_iter()
+            .map(|slices| {
+                let refs: Vec<&dyn arrow_array::Array> =
+                    slices.iter().map(|a| a.as_ref()).collect();
+                arrow::compute::concat(&refs)
+                    .map_err(|e| datafusion::error::DataFusionError::ArrowError(Box::new(e), None))
+            })
+            .collect::<DFResult<Vec<_>>>()?;
+
+        RecordBatch::try_new(self.schema.clone(), columns)
+            .map_err(|e| datafusion::error::DataFusionError::ArrowError(Box::new(e), None))
+    }
+}
+
+impl Stream for TopKStream {
+    type Item = DFResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+
+        // Consume all input batches
+        loop {
+            match self.input.poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(batch))) => {
+                    if batch.num_rows() > 0 {
+                        self.batches.push(batch);
+                        // Process the batch we just pushed (it's the last one)
+                        let batch_ref = self.batches.last().unwrap().clone();
+                        self.process_batch(&batch_ref);
+                    }
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    self.done = true;
+                    return Poll::Ready(Some(Err(e)));
+                }
+                Poll::Ready(None) => {
+                    // All input consumed, build and emit output
+                    self.done = true;
+                    let result = self.build_output();
+                    return Poll::Ready(Some(result));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+impl datafusion::physical_plan::RecordBatchStream for TopKStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -1,0 +1,675 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! FTS search planner for LSM scanner.
+//!
+//! Provides full-text search across LSM levels with global BM25 scoring.
+//! Global BM25 stats are collected concurrently with plan construction via a
+//! shared future handle, so planning is not blocked on stats I/O.
+//! Flushed memtable datasets share the base dataset's `Session` to benefit
+//! from a common index cache.
+
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use datafusion::physical_plan::union::UnionExec;
+use datafusion::physical_plan::ExecutionPlan;
+use lance_core::Result;
+use lance_index::metrics::NoOpMetricsCollector;
+use lance_index::scalar::bloomfilter::sbbf::Sbbf;
+use lance_index::scalar::inverted::query::MatchQuery;
+use lance_index::scalar::inverted::scorer::BM25StatsOverride;
+use lance_index::scalar::inverted::InvertedIndex;
+use lance_index::scalar::FullTextSearchQuery;
+use lance_index::{DatasetIndexExt, IndexCriteria};
+
+use super::bm25_stats::{DeferredBM25Stats, GenerationBM25Stats, GlobalBM25Stats};
+use super::collector::LsmDataSourceCollector;
+use super::data_source::LsmDataSource;
+use super::exec::{FilterStaleExec, GenerationBloomFilter, MemtableGenTagExec, TopKExec};
+use crate::dataset::mem_wal::memtable::scanner::{
+    FtsQuery, FtsQueryType, MemTableScanner, SCORE_COLUMN,
+};
+use crate::index::DatasetIndexInternalExt;
+use crate::session::Session;
+
+/// Plans FTS queries over LSM data with global BM25 scoring.
+///
+/// FTS queries are executed across all LSM levels with global BM25 statistics
+/// aggregated at plan time so scores are comparable across generations.
+///
+/// Each source is given `limit=k` so its internal WAND can prune low-scoring
+/// documents. The results are merged via a heap-based `TopKExec` node that
+/// provides cross-source pruning: as better results accumulate, rows from
+/// any source that score below the k-th best are discarded immediately.
+///
+/// # Query Plan Structure
+///
+/// ```text
+/// TopKExec: k=K, score=_score
+///   FilterStaleExec: bloom_filters=[...]
+///     UnionExec
+///       MemtableGenTagExec: gen=N
+///         FtsExec (active memtable, limit=K, global BM25 stats)
+///       MemtableGenTagExec: gen=2
+///         FtsExec (flushed gen 2, limit=K, global BM25 stats)
+///       MemtableGenTagExec: gen=0
+///         FtsExec (base table, limit=K, global BM25 stats)
+/// ```
+pub struct LsmFtsSearchPlanner {
+    collector: LsmDataSourceCollector,
+    pk_columns: Vec<String>,
+    base_schema: SchemaRef,
+    bloom_filters: Vec<GenerationBloomFilter>,
+    fts_query: FtsQuery,
+    /// If set, use this as global stats instead of collecting from sources.
+    global_stats_override: Option<GlobalBM25Stats>,
+    /// Shared session for index/metadata caching across flushed dataset opens.
+    session: Arc<Session>,
+}
+
+impl LsmFtsSearchPlanner {
+    pub fn new(
+        collector: LsmDataSourceCollector,
+        pk_columns: Vec<String>,
+        base_schema: SchemaRef,
+        fts_query: FtsQuery,
+    ) -> Self {
+        let session = collector.base_table().session();
+        Self {
+            collector,
+            pk_columns,
+            base_schema,
+            bloom_filters: Vec::new(),
+            fts_query,
+            global_stats_override: None,
+            session,
+        }
+    }
+
+    /// Add a bloom filter for staleness detection.
+    pub fn with_bloom_filter(mut self, generation: u64, bloom_filter: Arc<Sbbf>) -> Self {
+        self.bloom_filters.push(GenerationBloomFilter {
+            generation,
+            bloom_filter,
+        });
+        self
+    }
+
+    /// Add multiple bloom filters.
+    pub fn with_bloom_filters(
+        mut self,
+        bloom_filters: impl IntoIterator<Item = (u64, Arc<Sbbf>)>,
+    ) -> Self {
+        for (gen, bf) in bloom_filters {
+            self.bloom_filters.push(GenerationBloomFilter {
+                generation: gen,
+                bloom_filter: bf,
+            });
+        }
+        self
+    }
+
+    /// Provide pre-computed global BM25 stats instead of collecting at plan time.
+    pub fn with_global_stats(mut self, stats: GlobalBM25Stats) -> Self {
+        self.global_stats_override = Some(stats);
+        self
+    }
+
+    /// Create the FTS search plan.
+    ///
+    /// Stats collection is kicked off concurrently via a shared future.
+    /// Active memtable plans resolve the stats lazily at execution time.
+    /// Persistent source plans await the stats (which may already be resolved).
+    pub async fn plan_search(
+        &self,
+        k: usize,
+        projection: Option<&[String]>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let sources = self.collector.collect()?;
+
+        if sources.is_empty() {
+            return self.empty_plan(projection);
+        }
+
+        // Create the deferred stats handle and spawn collection concurrently
+        let deferred_stats = self.spawn_stats_collection(&sources)?;
+
+        // Build per-source FTS plans
+        let mut fts_plans = Vec::new();
+        for source in &sources {
+            let generation = source.generation();
+            let fts = self
+                .build_fts_plan(source, &deferred_stats, projection, k)
+                .await?;
+            let tagged: Arc<dyn ExecutionPlan> = Arc::new(MemtableGenTagExec::new(fts, generation));
+            fts_plans.push(tagged);
+        }
+
+        // Assemble the plan
+        #[allow(deprecated)]
+        let union: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(fts_plans));
+
+        let filtered: Arc<dyn ExecutionPlan> = if !self.bloom_filters.is_empty() {
+            Arc::new(FilterStaleExec::new(
+                union,
+                self.pk_columns.clone(),
+                self.bloom_filters.clone(),
+            ))
+        } else {
+            union
+        };
+
+        let top_k: Arc<dyn ExecutionPlan> =
+            Arc::new(TopKExec::new(filtered, k, SCORE_COLUMN.to_string()));
+
+        Ok(top_k)
+    }
+
+    /// Spawn stats collection as a concurrent task, returning a deferred handle.
+    ///
+    /// If a global stats override is set, the future resolves immediately.
+    /// Otherwise, a background task collects stats from all sources and the
+    /// shared future resolves once the task completes.
+    fn spawn_stats_collection(&self, sources: &[LsmDataSource]) -> Result<DeferredBM25Stats> {
+        use futures::FutureExt;
+
+        if let Some(ref stats) = self.global_stats_override {
+            let stats = stats.clone();
+            return Ok(async move { stats }.boxed().shared());
+        }
+
+        // Gather the information needed by the background task.
+        // ActiveMemTable stats are collected synchronously (cheap in-memory reads).
+        let query_terms = self.extract_query_terms(sources)?;
+        let fts_column = self.fts_query.column.clone();
+        let session = self.session.clone();
+
+        let mut mem_stats = Vec::new();
+        let mut persistent_sources: Vec<String> = Vec::new();
+
+        for source in sources {
+            match source {
+                LsmDataSource::ActiveMemTable { index_store, .. } => {
+                    if let Some(fts_index) = index_store.get_fts_by_column(&fts_column) {
+                        mem_stats.push(GenerationBM25Stats::new(
+                            fts_index.doc_count(),
+                            fts_index.total_tokens() as u64,
+                            fts_index.term_doc_frequencies(&query_terms),
+                        ));
+                    }
+                }
+                LsmDataSource::BaseTable { dataset } => {
+                    persistent_sources.push(dataset.uri().to_string());
+                }
+                LsmDataSource::FlushedMemTable { path, .. } => {
+                    persistent_sources.push(path.clone());
+                }
+            }
+        }
+
+        let fut = async move {
+            let mut per_gen_stats = mem_stats;
+
+            for path in &persistent_sources {
+                let Ok(dataset) = crate::dataset::DatasetBuilder::from_uri(path)
+                    .with_session(session.clone())
+                    .load()
+                    .await
+                else {
+                    continue;
+                };
+                if let Ok(Some(stats)) =
+                    Self::load_fts_stats_from_dataset(&dataset, &fts_column, &query_terms).await
+                {
+                    per_gen_stats.push(stats);
+                }
+            }
+
+            GlobalBM25Stats::aggregate(&per_gen_stats)
+        }
+        .boxed()
+        .shared();
+
+        // Eagerly start computation in background so it runs concurrently
+        // with plan construction.
+        let eager = fut.clone();
+        tokio::spawn(async move {
+            eager.await;
+        });
+
+        Ok(fut)
+    }
+
+    /// Collect global BM25 stats from all sources for the query terms.
+    #[cfg(test)]
+    async fn collect_global_stats(&self, sources: &[LsmDataSource]) -> Result<GlobalBM25Stats> {
+        if sources.is_empty() {
+            return Ok(GlobalBM25Stats::aggregate(&[]));
+        }
+
+        let mut per_gen_stats = Vec::new();
+
+        let query_terms = self.extract_query_terms(sources)?;
+
+        for source in sources {
+            match source {
+                LsmDataSource::ActiveMemTable { index_store, .. } => {
+                    if let Some(fts_index) = index_store.get_fts_by_column(&self.fts_query.column) {
+                        let num_docs = fts_index.doc_count();
+                        let total_tokens = fts_index.total_tokens() as u64;
+                        let term_doc_freqs = fts_index.term_doc_frequencies(&query_terms);
+                        per_gen_stats.push(GenerationBM25Stats::new(
+                            num_docs,
+                            total_tokens,
+                            term_doc_freqs,
+                        ));
+                    }
+                }
+                LsmDataSource::BaseTable { dataset } => {
+                    if let Some(stats) = Self::load_fts_stats_from_dataset(
+                        dataset,
+                        &self.fts_query.column,
+                        &query_terms,
+                    )
+                    .await?
+                    {
+                        per_gen_stats.push(stats);
+                    }
+                }
+                LsmDataSource::FlushedMemTable { path, .. } => {
+                    let dataset = self.open_flushed_dataset(path).await?;
+                    if let Some(stats) = Self::load_fts_stats_from_dataset(
+                        &dataset,
+                        &self.fts_query.column,
+                        &query_terms,
+                    )
+                    .await?
+                    {
+                        per_gen_stats.push(stats);
+                    }
+                }
+            }
+        }
+
+        Ok(GlobalBM25Stats::aggregate(&per_gen_stats))
+    }
+
+    /// Load FTS collection stats from a persistent dataset's inverted index.
+    ///
+    /// Returns `None` if the dataset has no FTS index on the given column.
+    async fn load_fts_stats_from_dataset(
+        dataset: &crate::dataset::Dataset,
+        column: &str,
+        query_terms: &[String],
+    ) -> Result<Option<GenerationBM25Stats>> {
+        let index_meta = dataset
+            .load_scalar_index(IndexCriteria::default().for_column(column).supports_fts())
+            .await?;
+
+        let Some(index_meta) = index_meta else {
+            return Ok(None);
+        };
+
+        let uuid = index_meta.uuid.to_string();
+        let metrics = NoOpMetricsCollector;
+        let index = dataset.open_generic_index(column, &uuid, &metrics).await?;
+
+        let inverted_index = index
+            .as_any()
+            .downcast_ref::<InvertedIndex>()
+            .ok_or_else(|| lance_core::Error::Internal {
+                message: format!(
+                    "Expected InvertedIndex for column '{}', got different index type",
+                    column
+                ),
+                location: snafu::location!(),
+            })?;
+
+        let (num_docs, total_tokens, term_doc_freqs) = inverted_index.collection_stats(query_terms);
+
+        Ok(Some(GenerationBM25Stats::new(
+            num_docs,
+            total_tokens,
+            term_doc_freqs,
+        )))
+    }
+
+    /// Extract unique query terms for stats collection.
+    ///
+    /// Uses the tokenizer from the active memtable's FTS index. An FTS index
+    /// must always be present when an FTS query is issued.
+    fn extract_query_terms(&self, sources: &[LsmDataSource]) -> Result<Vec<String>> {
+        for source in sources {
+            if let LsmDataSource::ActiveMemTable { index_store, .. } = source {
+                if let Some(fts_index) = index_store.get_fts_by_column(&self.fts_query.column) {
+                    let query_str = self.query_text();
+                    return Ok(fts_index.tokenize_query(&query_str));
+                }
+            }
+        }
+        Err(lance_core::Error::Internal {
+            message: format!(
+                "No FTS index with tokenizer found for column '{}'",
+                self.fts_query.column
+            ),
+            location: snafu::location!(),
+        })
+    }
+
+    /// Extract the query text from the FtsQuery.
+    fn query_text(&self) -> String {
+        match &self.fts_query.query_type {
+            FtsQueryType::Match { query } => query.clone(),
+            FtsQueryType::Phrase { query, .. } => query.clone(),
+            FtsQueryType::Fuzzy { query, .. } => query.clone(),
+            FtsQueryType::Boolean {
+                must,
+                should,
+                must_not,
+            } => {
+                let mut terms = Vec::new();
+                terms.extend(must.iter().cloned());
+                terms.extend(should.iter().cloned());
+                terms.extend(must_not.iter().cloned());
+                terms.join(" ")
+            }
+        }
+    }
+
+    /// Build FTS plan for a single data source with per-source limit.
+    ///
+    /// Active memtable plans receive the deferred stats handle and resolve it
+    /// lazily at execution time. Persistent source plans await the stats here
+    /// (since `FtsSearchParams.bm25_override` is sync), but benefit from the
+    /// concurrent stats task that's already running.
+    async fn build_fts_plan(
+        &self,
+        source: &LsmDataSource,
+        deferred_stats: &DeferredBM25Stats,
+        projection: Option<&[String]>,
+        k: usize,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match source {
+            LsmDataSource::BaseTable { dataset } => {
+                let global_stats = deferred_stats.clone().await;
+                let bm25_override = Arc::new(BM25StatsOverride {
+                    num_docs: global_stats.num_docs,
+                    total_tokens: global_stats.total_tokens,
+                    term_doc_freqs: global_stats.term_doc_freqs.clone(),
+                });
+                let mut scanner = dataset.scan();
+                let cols = self.build_projection_for_fts(projection);
+                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                let fts_query = self.build_full_text_query(&bm25_override, k);
+                scanner.full_text_search(fts_query)?;
+                scanner.create_plan().await
+            }
+            LsmDataSource::FlushedMemTable { path, .. } => {
+                let global_stats = deferred_stats.clone().await;
+                let bm25_override = Arc::new(BM25StatsOverride {
+                    num_docs: global_stats.num_docs,
+                    total_tokens: global_stats.total_tokens,
+                    term_doc_freqs: global_stats.term_doc_freqs.clone(),
+                });
+                let dataset = self.open_flushed_dataset(path).await?;
+                let mut scanner = dataset.scan();
+                let cols = self.build_projection_for_fts(projection);
+                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                let fts_query = self.build_full_text_query(&bm25_override, k);
+                scanner.full_text_search(fts_query)?;
+                scanner.create_plan().await
+            }
+            LsmDataSource::ActiveMemTable {
+                batch_store,
+                index_store,
+                schema,
+                ..
+            } => {
+                let mut scanner =
+                    MemTableScanner::new(batch_store.clone(), index_store.clone(), schema.clone());
+                if let Some(cols) = projection {
+                    scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+                }
+                scanner.full_text_search(&self.fts_query.column, self.query_text().as_str());
+                scanner.fts_limit(k);
+                scanner.set_deferred_bm25_stats(Some(deferred_stats.clone()));
+                scanner.create_plan().await
+            }
+        }
+    }
+
+    /// Build a FullTextSearchQuery for the base Scanner with BM25 override and limit.
+    fn build_full_text_query(
+        &self,
+        bm25_override: &Arc<BM25StatsOverride>,
+        k: usize,
+    ) -> FullTextSearchQuery {
+        let match_query =
+            MatchQuery::new(self.query_text()).with_column(Some(self.fts_query.column.clone()));
+        let mut fts = FullTextSearchQuery::new_query(match_query.into());
+        fts.bm25_override = Some(bm25_override.clone());
+        fts.limit = Some(k as i64);
+        fts
+    }
+
+    /// Open a flushed memtable dataset with the shared session for index caching.
+    async fn open_flushed_dataset(&self, path: &str) -> Result<crate::dataset::Dataset> {
+        crate::dataset::DatasetBuilder::from_uri(path)
+            .with_session(self.session.clone())
+            .load()
+            .await
+    }
+
+    /// Build projection list for FTS ensuring required columns are included.
+    fn build_projection_for_fts(&self, projection: Option<&[String]>) -> Vec<String> {
+        let mut cols: Vec<String> = if let Some(p) = projection {
+            p.to_vec()
+        } else {
+            self.base_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect()
+        };
+
+        for pk in &self.pk_columns {
+            if !cols.contains(pk) {
+                cols.push(pk.clone());
+            }
+        }
+
+        cols
+    }
+
+    /// Create an empty execution plan.
+    fn empty_plan(&self, projection: Option<&[String]>) -> Result<Arc<dyn ExecutionPlan>> {
+        use datafusion::physical_plan::empty::EmptyExec;
+
+        let mut fields: Vec<Arc<Field>> = if let Some(cols) = projection {
+            cols.iter()
+                .filter_map(|name| {
+                    self.base_schema
+                        .field_with_name(name)
+                        .ok()
+                        .map(|f| Arc::new(f.clone()))
+                })
+                .collect()
+        } else {
+            self.base_schema.fields().iter().cloned().collect()
+        };
+
+        fields.push(Arc::new(Field::new(SCORE_COLUMN, DataType::Float32, false)));
+
+        let schema = Arc::new(Schema::new(fields));
+        Ok(Arc::new(EmptyExec::new(schema)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::dataset::mem_wal::memtable::scanner::FtsQuery;
+    use crate::dataset::mem_wal::scanner::collector::LsmDataSourceCollector;
+    use crate::dataset::{Dataset, WriteParams};
+    use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator, StringArray};
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+
+    fn create_fts_schema() -> Arc<ArrowSchema> {
+        let mut id_metadata = HashMap::new();
+        id_metadata.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        let id_field = Field::new("id", DataType::Int32, false).with_metadata(id_metadata);
+
+        Arc::new(ArrowSchema::new(vec![
+            id_field,
+            Field::new("text", DataType::Utf8, true),
+        ]))
+    }
+
+    fn create_test_batch(schema: &ArrowSchema, ids: &[i32], texts: &[&str]) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(ids.to_vec())),
+                Arc::new(StringArray::from(texts.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    async fn create_dataset(uri: &str, batches: Vec<RecordBatch>) -> Dataset {
+        let schema = batches[0].schema();
+        let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+        Dataset::write(reader, uri, Some(WriteParams::default()))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_fts_search_plan_structure() {
+        let schema = create_fts_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
+        let base_batch = create_test_batch(
+            &schema,
+            &[1, 2, 3],
+            &["hello world", "foo bar", "hello foo"],
+        );
+        let base_dataset = Arc::new(create_dataset(&base_uri, vec![base_batch]).await);
+
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]);
+
+        let fts_query = FtsQuery::match_query("text", "hello");
+        let planner =
+            LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema.clone(), fts_query);
+
+        let plan = planner.plan_search(10, None).await;
+        // Plan creation should succeed
+        assert!(plan.is_ok() || plan.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_projection_includes_pk() {
+        let schema = create_fts_schema();
+        let base_batch = create_test_batch(&schema, &[1], &["hello"]);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let uri = format!("{}/proj_test", temp_dir.path().to_str().unwrap());
+        let base_dataset = Arc::new(create_dataset(&uri, vec![base_batch]).await);
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]);
+
+        let fts_query = FtsQuery::match_query("text", "hello");
+        let planner =
+            LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema, fts_query);
+
+        let cols = planner.build_projection_for_fts(Some(&["text".to_string()]));
+        assert!(cols.contains(&"text".to_string()));
+        assert!(cols.contains(&"id".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_global_stats_from_persistent_index() {
+        use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+        use lance_index::scalar::inverted::InvertedIndexParams;
+        use lance_index::{DatasetIndexExt, IndexType};
+
+        let schema = create_fts_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let uri = format!("{}/persistent_stats", temp_dir.path().to_str().unwrap());
+
+        let batch = create_test_batch(
+            &schema,
+            &[1, 2, 3, 4, 5],
+            &[
+                "hello world",
+                "hello lance",
+                "foo bar baz",
+                "hello foo",
+                "world lance",
+            ],
+        );
+        let mut dataset = create_dataset(&uri, vec![batch]).await;
+
+        let params = InvertedIndexParams::default();
+        dataset
+            .create_index(&["text"], IndexType::Inverted, None, &params, true)
+            .await
+            .unwrap();
+
+        // Create an active memtable with FTS index (provides the tokenizer)
+        let batch_store = Arc::new(BatchStore::with_capacity(10));
+        let mut index_store = IndexStore::new();
+        index_store.add_fts("text_idx".to_string(), 1, "text".to_string());
+        let mem_batch = create_test_batch(&schema, &[100], &["hello test"]);
+        index_store.insert(&mem_batch, 0).unwrap();
+        batch_store.append(mem_batch).unwrap();
+        let index_store = Arc::new(index_store);
+
+        let base_dataset = Arc::new(dataset);
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]);
+
+        let fts_query = FtsQuery::match_query("text", "hello");
+        let planner =
+            LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema.clone(), fts_query);
+
+        // Build sources with both base table and active memtable
+        let mut sources = planner.collector.collect().unwrap();
+        sources.push(LsmDataSource::ActiveMemTable {
+            batch_store,
+            index_store,
+            schema,
+            region_id: uuid::Uuid::new_v4(),
+            generation: 1.into(),
+        });
+        let stats = planner.collect_global_stats(&sources).await.unwrap();
+
+        // 5 docs from persistent + 1 from memtable = 6
+        assert_eq!(stats.num_docs, 6);
+        assert!(stats.total_tokens > 0);
+        // "hello" appears in 3 persistent docs + 1 memtable doc = 4
+        assert_eq!(stats.term_doc_freqs.get("hello"), Some(&4));
+    }
+
+    #[tokio::test]
+    async fn test_global_stats_collection_empty() {
+        let sources: Vec<LsmDataSource> = vec![];
+        let schema = create_fts_schema();
+        let base_batch = create_test_batch(&schema, &[1], &["hello"]);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let uri = format!("{}/stats_test", temp_dir.path().to_str().unwrap());
+        let base_dataset = Arc::new(create_dataset(&uri, vec![base_batch]).await);
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]);
+
+        let fts_query = FtsQuery::match_query("text", "hello");
+        let planner =
+            LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema, fts_query);
+
+        let stats = planner.collect_global_stats(&sources).await.unwrap();
+        assert_eq!(stats.num_docs, 0);
+        assert_eq!(stats.total_tokens, 0);
+    }
+}

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -1052,8 +1052,13 @@ impl RegionWriter {
         )?;
 
         // Start background MemTable flush handler
-        let memtable_handler =
-            MemTableFlushHandler::new(state.clone(), flusher, epoch, stats.clone());
+        let memtable_handler = MemTableFlushHandler::new(
+            state.clone(),
+            flusher,
+            epoch,
+            stats.clone(),
+            index_configs.clone(),
+        );
         task_executor.add_handler(
             "memtable_flusher".to_string(),
             Box::new(memtable_handler),
@@ -1456,6 +1461,7 @@ struct MemTableFlushHandler {
     flusher: Arc<MemTableFlusher>,
     epoch: u64,
     stats: SharedWriteStats,
+    index_configs: Vec<MemIndexConfig>,
 }
 
 impl MemTableFlushHandler {
@@ -1464,12 +1470,14 @@ impl MemTableFlushHandler {
         flusher: Arc<MemTableFlusher>,
         epoch: u64,
         stats: SharedWriteStats,
+        index_configs: Vec<MemIndexConfig>,
     ) -> Self {
         Self {
             state,
             flusher,
             epoch,
             stats,
+            index_configs,
         }
     }
 }
@@ -1514,8 +1522,14 @@ impl MemTableFlushHandler {
                 .map_err(|e| Error::io(format!("WAL flush failed: {}", e), snafu::location!()))?;
         }
 
-        // Step 2: Flush the memtable to Lance storage
-        let result = self.flusher.flush(&memtable, self.epoch).await?;
+        // Step 2: Flush the memtable to Lance storage (with indexes if configured)
+        let result = if self.index_configs.is_empty() {
+            self.flusher.flush(&memtable, self.epoch).await?
+        } else {
+            self.flusher
+                .flush_with_indexes(&memtable, self.epoch, &self.index_configs)
+                .await?
+        };
 
         // Step 3: Signal completion and update backpressure tracking
         // Signal memtable flush completion for backpressure watchers

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1003,6 +1003,19 @@ impl Scanner {
         Ok(self)
     }
 
+    /// Set a BM25 stats override on the full-text search query.
+    ///
+    /// This is used by the LSM FTS planner to inject global BM25 statistics
+    /// so that scores are comparable across LSM generations.
+    pub fn set_fts_bm25_override(
+        &mut self,
+        bm25_override: Option<Arc<lance_index::scalar::inverted::scorer::BM25StatsOverride>>,
+    ) {
+        if let Some(ref mut query) = self.full_text_query {
+            query.bm25_override = bm25_override;
+        }
+    }
+
     /// Set a filter using a Substrait ExtendedExpression message
     ///
     /// The message must contain exactly one expression and that expression

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1835,6 +1835,7 @@ async fn test_json_inverted_fuzziness_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -1851,6 +1852,7 @@ async fn test_json_inverted_fuzziness_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -1869,6 +1871,7 @@ async fn test_json_inverted_fuzziness_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -1887,6 +1890,7 @@ async fn test_json_inverted_fuzziness_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -1905,6 +1909,7 @@ async fn test_json_inverted_fuzziness_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -1923,6 +1928,7 @@ async fn test_json_inverted_fuzziness_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -1964,6 +1970,7 @@ async fn test_json_inverted_match_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -1981,6 +1988,7 @@ async fn test_json_inverted_match_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -1998,6 +2006,7 @@ async fn test_json_inverted_match_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -2015,6 +2024,7 @@ async fn test_json_inverted_match_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -2080,6 +2090,7 @@ async fn test_json_inverted_flat_match_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -2119,6 +2130,7 @@ async fn test_json_inverted_phrase_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -2136,6 +2148,7 @@ async fn test_json_inverted_phrase_query() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -2178,6 +2191,7 @@ async fn test_json_inverted_multimatch_query() {
         }),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -2226,6 +2240,7 @@ async fn test_json_inverted_boolean_query() {
         }),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()
@@ -2498,6 +2513,7 @@ async fn test_auto_infer_lance_tokenizer() {
         ),
         limit: None,
         wand_factor: None,
+        bm25_override: None,
     };
     let batch = dataset
         .scan()

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -284,16 +284,32 @@ impl ExecutionPlan for MatchQueryExec {
             let tokens = collect_query_tokens(&query.terms, &mut tokenizer, None);
 
             pre_filter.wait_for_ready().await?;
-            let (doc_ids, mut scores) = inverted_idx
-                .bm25_search(
-                    Arc::new(tokens),
-                    params.into(),
-                    query.operator,
-                    pre_filter,
-                    metrics.clone(),
-                )
-                .boxed()
-                .await?;
+            let params: Arc<FtsSearchParams> = params.into();
+            let bm25_override = params.bm25_override.clone();
+            let (doc_ids, mut scores) = if let Some(ref override_stats) = bm25_override {
+                inverted_idx
+                    .bm25_search_with_override(
+                        Arc::new(tokens),
+                        params,
+                        query.operator,
+                        pre_filter,
+                        metrics.clone(),
+                        override_stats,
+                    )
+                    .boxed()
+                    .await?
+            } else {
+                inverted_idx
+                    .bm25_search(
+                        Arc::new(tokens),
+                        params,
+                        query.operator,
+                        pre_filter,
+                        metrics.clone(),
+                    )
+                    .boxed()
+                    .await?
+            };
             scores.iter_mut().for_each(|s| {
                 *s *= query.boost;
             });


### PR DESCRIPTION
Based on previous discussion, separate out FTS query plan since it requires global BM25. @jackye1995 please take a look

This will calculate global BM25 and then use the same scorer to rank across different inverted indexes, similar to how Lucene does it.