### PR TITLE
feat(python): add preprocessed_data and range_id for range-based BTree index

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2490,6 +2490,8 @@ class LanceDataset(pa.dataset.Dataset):
         train: bool = True,
         fragment_ids: Optional[List[int]] = None,
         index_uuid: Optional[str] = None,
+        preprocessed_data=None,
+        range_id: Optional[int] = None,
         **kwargs,
     ):
         """Create a scalar index on a column.
@@ -2758,11 +2760,15 @@ class LanceDataset(pa.dataset.Dataset):
         else:
             raise Exception("index_type must be str or IndexConfig")
 
-        # Add fragment_ids and index_uuid to kwargs if provided
+        # Add fragment_ids, index_uuid, preprocessed_data, range_id to kwargs
         if fragment_ids is not None:
             kwargs["fragment_ids"] = fragment_ids
         if index_uuid is not None:
             kwargs["index_uuid"] = index_uuid
+        if preprocessed_data is not None:
+            kwargs["preprocessed_data"] = preprocessed_data
+        if range_id is not None:
+            kwargs["range_id"] = range_id
 
         self._ds.create_index([column], index_type, name, replace, train, None, kwargs)
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1823,10 +1823,19 @@ impl Dataset {
 
         log::info!("Creating index: type={}", index_type);
         let params: Box<dyn IndexParams> = match index_type.as_str() {
-            "BTREE" => Box::new(ScalarIndexParams {
-                index_type: "btree".to_string(),
-                params: None,
-            }),
+            "BTREE" => {
+                let mut btree_params: Option<String> = None;
+                if let Some(kwargs) = kwargs {
+                    if let Some(range_id) = kwargs.get_item("range_id")? {
+                        let range_id: u32 = range_id.extract()?;
+                        btree_params = Some(format!("{{\"range_id\":{}}}", range_id));
+                    }
+                }
+                Box::new(ScalarIndexParams {
+                    index_type: "btree".to_string(),
+                    params: btree_params,
+                })
+            }
             "BITMAP" => Box::new(ScalarIndexParams {
                 index_type: "bitmap".to_string(),
                 params: None,
@@ -1962,7 +1971,29 @@ impl Dataset {
             None
         };
 
-        // Add fragment_ids and index_uuid support
+        // Extract preprocessed_data from kwargs
+        let preprocessed_data: Option<Box<dyn RecordBatchReader + Send>> =
+            if let Some(kwargs) = kwargs {
+                kwargs
+                    .get_item("preprocessed_data")?
+                    .and_then(|v| {
+                        if v.is_none() {
+                            None
+                        } else {
+                            Some(
+                                ArrowArrayStreamReader::from_pyarrow_bound(&v)
+                                    .map(|r| Box::new(r) as Box<dyn RecordBatchReader + Send>),
+                            )
+                        }
+                    })
+                    .transpose()?
+            } else {
+                None
+            };
+
+        let has_preprocessed_data = preprocessed_data.is_some();
+
+        // Add fragment_ids, index_uuid, and preprocessed_data support
         let has_fragment_ids = fragment_ids.is_some();
         if let Some(fragment_ids) = fragment_ids {
             builder = builder.fragments(fragment_ids);
@@ -1970,11 +2001,14 @@ impl Dataset {
         if let Some(index_uuid) = index_uuid {
             builder = builder.index_uuid(index_uuid);
         }
+        if let Some(preprocessed_data) = preprocessed_data {
+            builder = builder.preprocessed_data(preprocessed_data);
+        }
 
         use std::future::IntoFuture;
 
-        // Use execute_uncommitted if fragment_ids is provided, otherwise use execute
-        let index_metadata = if has_fragment_ids {
+        // Use execute_uncommitted if fragment_ids or preprocessed_data is provided
+        let index_metadata = if has_fragment_ids || has_preprocessed_data {
             // For fragment-level indexing, use execute_uncommitted
             let index_metadata = rt()
                 .block_on(None, builder.execute_uncommitted())?


### PR DESCRIPTION
## Summary

- Expose `preprocessed_data` and `range_id` parameters in pylance's `create_scalar_index` binding
- Extract `range_id` from kwargs and serialize into `ScalarIndexParams.params` JSON for BTREE
- Extract `preprocessed_data` from kwargs via `ArrowArrayStreamReader` and pass to index builder
- Use `execute_uncommitted` when `preprocessed_data` is provided (matching Java binding's `should_skip_commit` logic)
- Forward both params through Python `create_scalar_index`

This is a prerequisite for lance-ray's range-based sorted BTree index support (lance-format/lance-ray#92).

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo fmt` passes
- [x] Tested end-to-end via lance-ray sorted BTree tests (13/13 passing)

cc @jackye1995 @chenghao-guo

🤖 Generated with [Claude Code](https://claude.com/claude-code)