### PR TITLE
feat: add tag parameter to commit API

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3396,6 +3396,7 @@ class LanceDataset(pa.dataset.Dataset):
         *,
         commit_message: Optional[str] = None,
         enable_stable_row_ids: Optional[bool] = None,
+        tag: Optional[str] = None,
     ) -> LanceDataset:
         """Create a new version of dataset
 
@@ -3462,6 +3463,11 @@ class LanceDataset(pa.dataset.Dataset):
             row IDs assign each row a monotonically increasing id that persists
             across compaction and other maintenance operations.  This option is
             ignored for existing datasets.
+        tag: str, optional
+            If set, a tag with this name will be created pointing to the committed
+            version. The tag is created after the commit succeeds. If the tag
+            creation fails (e.g. because a tag with that name already exists),
+            the data will still be committed but an error will be raised.
 
         Returns
         -------
@@ -3532,6 +3538,7 @@ class LanceDataset(pa.dataset.Dataset):
                 detached=detached,
                 max_retries=max_retries,
                 enable_stable_row_ids=enable_stable_row_ids,
+                tag=tag,
             )
         elif isinstance(operation, LanceOperation.BaseOperation):
             new_ds = _Dataset.commit(
@@ -3546,6 +3553,7 @@ class LanceDataset(pa.dataset.Dataset):
                 max_retries=max_retries,
                 commit_message=commit_message,
                 enable_stable_row_ids=enable_stable_row_ids,
+                tag=tag,
             )
         else:
             raise TypeError(
@@ -5593,6 +5601,7 @@ def write_dataset(
     target_bases: Optional[List[str]] = None,
     namespace: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
+    tag: Optional[str] = None,
 ) -> LanceDataset:
     """Write a given data_obj to the given uri
 
@@ -5694,6 +5703,11 @@ def write_dataset(
     table_id : optional, List[str]
         The table identifier when using a namespace (e.g., ["my_table"]).
         Must be provided together with `namespace`. Cannot be used with `uri`.
+    tag : optional, str
+        If set, a tag with this name will be created pointing to the committed
+        version. The tag is created after the commit succeeds. If the tag
+        creation fails (e.g. because a tag with that name already exists),
+        the data will still be committed but an error will be raised.
 
     Notes
     -----
@@ -5843,6 +5857,7 @@ def write_dataset(
         "transaction_properties": merged_properties,
         "initial_bases": initial_bases,
         "target_bases": target_bases,
+        "tag": tag,
     }
 
     # Add storage_options_provider if created from namespace

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -571,6 +571,33 @@ def test_tag_order(tmp_path: Path):
     assert tags_default == tags_desc, "Default order should match descending order"
 
 
+def test_tag_on_write(tmp_path: Path):
+    table = pa.table({"a": [1, 2], "b": ["x", "y"]})
+    base_dir = tmp_path / "test"
+
+    # write_dataset with tag
+    ds = lance.write_dataset(table, base_dir, tag="v1")
+    assert ds.tags.get_version("v1") == 1
+
+    # append with tag
+    ds = lance.write_dataset(table, base_dir, mode="append", tag="v2")
+    assert ds.tags.get_version("v2") == 2
+
+    # commit API with tag
+    tab2 = pa.table({"a": [3, 4], "b": ["c", "d"]})
+    frag = lance.fragment.LanceFragment.create(base_dir, tab2)
+    operation = lance.LanceOperation.Append([frag])
+    ds = lance.LanceDataset.commit(base_dir, operation, read_version=2, tag="v3")
+    assert ds.tags.get_version("v3") == 3
+
+    # duplicate tag should raise error (but data is committed)
+    with pytest.raises(Exception, match="tag"):
+        lance.write_dataset(table, base_dir, mode="append", tag="v1")
+    # verify version 4 was still committed
+    ds = lance.dataset(base_dir)
+    assert ds.version == 4
+
+
 def test_sample(tmp_path: Path):
     table1 = pa.Table.from_pydict({"x": [0, 10, 20, 30, 40, 50], "y": range(6)})
     base_dir = tmp_path / "test"

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2110,7 +2110,7 @@ impl Dataset {
 
     #[allow(clippy::too_many_arguments)]
     #[staticmethod]
-    #[pyo3(signature = (dest, operation, read_version = None, commit_lock = None, storage_options = None, storage_options_provider = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, commit_message = None, enable_stable_row_ids = None))]
+    #[pyo3(signature = (dest, operation, read_version = None, commit_lock = None, storage_options = None, storage_options_provider = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, commit_message = None, enable_stable_row_ids = None, tag = None))]
     fn commit(
         dest: PyWriteDest,
         operation: PyLance<Operation>,
@@ -2123,6 +2123,7 @@ impl Dataset {
         max_retries: Option<u32>,
         commit_message: Option<String>,
         enable_stable_row_ids: Option<bool>,
+        tag: Option<String>,
     ) -> PyResult<Self> {
         let mut transaction = Transaction::new(read_version.unwrap_or_default(), operation.0, None);
 
@@ -2143,13 +2144,14 @@ impl Dataset {
             detached,
             max_retries,
             enable_stable_row_ids,
+            tag,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     #[allow(deprecated)]
     #[staticmethod]
-    #[pyo3(signature = (dest, transaction, commit_lock = None, storage_options = None, storage_options_provider = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, enable_stable_row_ids = None))]
+    #[pyo3(signature = (dest, transaction, commit_lock = None, storage_options = None, storage_options_provider = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, enable_stable_row_ids = None, tag = None))]
     fn commit_transaction(
         dest: PyWriteDest,
         transaction: PyLance<Transaction>,
@@ -2160,6 +2162,7 @@ impl Dataset {
         detached: Option<bool>,
         max_retries: Option<u32>,
         enable_stable_row_ids: Option<bool>,
+        tag: Option<String>,
     ) -> PyResult<Self> {
         let accessor = crate::storage_options::create_accessor_from_python(
             storage_options.clone(),
@@ -2187,7 +2190,8 @@ impl Dataset {
         let mut builder = CommitBuilder::new(dest.as_dest())
             .enable_v2_manifest_paths(enable_v2_manifest_paths.unwrap_or(true))
             .with_detached(detached.unwrap_or(false))
-            .with_max_retries(max_retries.unwrap_or(20));
+            .with_max_retries(max_retries.unwrap_or(20))
+            .with_tag(tag);
 
         if let Some(enable) = enable_stable_row_ids {
             builder = builder.use_stable_row_ids(enable);
@@ -3109,6 +3113,10 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
             if !target_bases_list.is_empty() {
                 p = p.with_target_base_names_or_paths(target_bases_list);
             }
+        }
+
+        if let Some(tag) = get_dict_opt::<String>(options, "tag")? {
+            p.tag = Some(tag);
         }
 
         // Handle properties

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -245,6 +245,10 @@ pub struct WriteParams {
     /// These will be resolved to IDs when the write operation executes.
     /// Resolution happens at builder execution time when dataset context is available.
     pub target_base_names_or_paths: Option<Vec<String>>,
+
+    /// If set, a tag with this name will be created pointing to the committed
+    /// version. The tag is created after a successful commit.
+    pub tag: Option<String>,
 }
 
 impl Default for WriteParams {
@@ -269,6 +273,7 @@ impl Default for WriteParams {
             initial_bases: None,
             target_bases: None,
             target_base_names_or_paths: None,
+            tag: None,
         }
     }
 }

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -48,6 +48,7 @@ pub struct CommitBuilder<'a> {
     commit_config: CommitConfig,
     affected_rows: Option<RowAddrTreeMap>,
     transaction_properties: Option<Arc<HashMap<String, String>>>,
+    tag: Option<String>,
 }
 
 impl<'a> CommitBuilder<'a> {
@@ -65,6 +66,7 @@ impl<'a> CommitBuilder<'a> {
             commit_config: Default::default(),
             affected_rows: None,
             transaction_properties: None,
+            tag: None,
         }
     }
 
@@ -178,6 +180,15 @@ impl<'a> CommitBuilder<'a> {
         transaction_properties: HashMap<String, String>,
     ) -> Self {
         self.transaction_properties = Some(Arc::new(transaction_properties));
+        self
+    }
+
+    /// If set, a tag with this name will be created pointing to the committed
+    /// version. The tag is created after the commit succeeds. If the tag
+    /// creation fails (e.g. because a tag with that name already exists),
+    /// the commit will still be persisted but an error will be returned.
+    pub fn with_tag(mut self, tag: Option<String>) -> Self {
+        self.tag = tag;
         self
     }
 
@@ -377,14 +388,14 @@ impl<'a> CommitBuilder<'a> {
 
         let fragment_bitmap = Arc::new(manifest.fragments.iter().map(|f| f.id as u32).collect());
 
-        match &self.dest {
-            WriteDestination::Dataset(dataset) => Ok(Dataset {
+        let dataset = match &self.dest {
+            WriteDestination::Dataset(dataset) => Dataset {
                 manifest: Arc::new(manifest),
                 manifest_location,
                 session,
                 fragment_bitmap,
                 ..dataset.as_ref().clone()
-            }),
+            },
             WriteDestination::Uri(uri) => {
                 let refs = Refs::new(
                     object_store.clone(),
@@ -396,7 +407,7 @@ impl<'a> CommitBuilder<'a> {
                     },
                 );
 
-                Ok(Dataset {
+                Dataset {
                     object_store,
                     base: base_path,
                     uri: uri.to_string(),
@@ -410,9 +421,26 @@ impl<'a> CommitBuilder<'a> {
                     metadata_cache,
                     file_reader_options: None,
                     store_params: self.store_params.clone().map(Box::new),
-                })
+                }
             }
+        };
+
+        if let Some(ref tag_name) = self.tag {
+            let version = dataset.manifest.version;
+            dataset
+                .tags()
+                .create(tag_name, version)
+                .await
+                .map_err(|e| Error::Internal {
+                    message: format!(
+                        "Commit successful (v{}) but tag '{}' creation failed: {}",
+                        version, tag_name, e
+                    ),
+                    location: location!(),
+                })?;
         }
+
+        Ok(dataset)
     }
 
     /// Commit a set of transactions as a single new version.
@@ -791,5 +819,55 @@ mod tests {
             matches!(transaction.operation, Operation::Append { fragments } if fragments == expected_fragments)
         );
         assert_eq!(transaction.read_version, 1);
+    }
+
+    #[tokio::test]
+    async fn test_commit_with_tag() {
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "i",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+        )
+        .unwrap();
+        let dataset = InsertBuilder::new("memory://test_tag")
+            .execute(vec![batch])
+            .await
+            .unwrap();
+        let dataset = Arc::new(dataset);
+
+        // Commit with a tag
+        let new_ds = CommitBuilder::new(dataset.clone())
+            .with_tag(Some("v1".to_string()))
+            .execute(sample_transaction(1))
+            .await
+            .unwrap();
+        assert_eq!(new_ds.manifest.version, 2);
+
+        // Verify tag exists and points to correct version
+        let tag_version = new_ds.tags().get_version("v1").await.unwrap();
+        assert_eq!(tag_version, 2);
+
+        // Commit without a tag still works (no regression)
+        let new_ds2 = CommitBuilder::new(Arc::new(new_ds))
+            .execute(sample_transaction(2))
+            .await
+            .unwrap();
+        assert_eq!(new_ds2.manifest.version, 3);
+
+        // Duplicate tag name should fail (data committed, but error raised)
+        let result = CommitBuilder::new(Arc::new(new_ds2))
+            .with_tag(Some("v1".to_string()))
+            .execute(sample_transaction(3))
+            .await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("tag"),
+            "Error should mention tag: {err_msg}"
+        );
     }
 }

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -122,7 +122,8 @@ impl<'a> InsertBuilder<'a> {
             .enable_v2_manifest_paths(context.params.enable_v2_manifest_paths)
             .with_commit_handler(context.commit_handler.clone())
             .with_object_store(context.object_store.clone())
-            .with_skip_auto_cleanup(context.params.skip_auto_cleanup);
+            .with_skip_auto_cleanup(context.params.skip_auto_cleanup)
+            .with_tag(context.params.tag.clone());
 
         if let Some(params) = context.params.store_params.as_ref() {
             commit_builder = commit_builder.with_store_params(params.clone());


### PR DESCRIPTION
## Summary

- Add a `tag` parameter to `CommitBuilder`, `WriteParams`, `write_dataset()`, and `LanceDataset.commit()` so users can create a tag in the same call as committing data
- The tag is created after the commit succeeds; if tag creation fails (e.g. duplicate name), the committed data is preserved but an error is returned
- Eliminates the need for a separate `dataset.tags().create()` call, closing the window where a version exists without its intended tag

## Test plan

- [x] Rust unit test: `test_commit_with_tag` in `commit.rs` — verifies tag creation, no-tag regression, and duplicate tag error
- [x] Python test: `test_tag_on_write` in `test_dataset.py` — verifies `write_dataset` with tag, append with tag, `LanceDataset.commit` with tag, and duplicate tag error handling
- [x] `cargo check --workspace --tests --benches` passes
- [x] `cargo clippy --all --tests -- -D warnings` passes
- [x] Existing `test_tag` and `test_tag_order` tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)