### PR TITLE
feat: support manifest version hint

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -102,10 +102,12 @@ fn is_version_hint_sync_write() -> bool {
 }
 
 /// Check if version hint should use JSON format.
+/// Default is JSON format (more portable and debuggable).
+/// Set LANCE_VERSION_HINT_FORMAT=file_size to use file-size encoding.
 fn is_version_hint_json_format() -> bool {
     match std::env::var(VERSION_HINT_FORMAT_ENV_VAR) {
-        Ok(val) => val.to_lowercase() == "json",
-        Err(_) => false, // Default to file-size encoding
+        Ok(val) => val.to_lowercase() != "file_size",
+        Err(_) => true, // Default to JSON format
     }
 }
 
@@ -340,56 +342,16 @@ async fn current_manifest_path(
         return result;
     }
 
-    // Stagger start: give hint a head start to avoid connection contention
-    // When hint and listing start simultaneously, both slow down due to TCP/TLS contention
-    // By giving hint a head start, it can complete quickly (~4ms) before listing starts
-    let hint_head_start_ms = std::env::var("LANCE_HINT_HEAD_START_MS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(10u64);
-
-    let hint_future = read_version_hint_and_probe(object_store, base);
-    tokio::pin!(hint_future);
-
-    // Phase 1: Give hint a head start
-    let head_start = tokio::time::Duration::from_millis(hint_head_start_ms);
-    let hint_result = tokio::select! {
-        biased;
-        result = &mut hint_future => Some(result),
-        _ = tokio::time::sleep(head_start) => None,
-    };
-
-    // If hint completed during head start, use it
-    if let Some(Some(location)) = hint_result {
-        eprintln!(
-            "[LOAD] hint won (head start): {:?}, version={}",
-            start.elapsed(),
-            location.version
-        );
-        return Ok(location);
-    }
-
-    // If hint failed during head start, fall back to listing only
-    if let Some(None) = hint_result {
-        let result = resolve_version_from_listing(object_store, base).await;
-        eprintln!(
-            "[LOAD] hint failed, listing fallback: {:?}, version={}",
-            start.elapsed(),
-            result.as_ref().map(|l| l.version).unwrap_or(0)
-        );
-        return result;
-    }
-
-    // Phase 2: Hint didn't complete in head start, race with listing
-    eprintln!("[LOAD] hint head start timeout, starting race");
+    // Race hint-based and listing-based approaches
+    // Use tokio::select! to return whichever completes first
     tokio::select! {
         biased;
 
-        // Continue hint attempt
-        hint_result = hint_future => {
+        // Try hint-based approach first (biased because it's usually faster)
+        hint_result = read_version_hint_and_probe(object_store, base) => {
             if let Some(location) = hint_result {
                 eprintln!(
-                    "[LOAD] hint won (after race): {:?}, version={}",
+                    "[LOAD] hint won: {:?}, version={}",
                     start.elapsed(),
                     location.version
                 );

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -70,6 +70,23 @@ use {
 pub const VERSIONS_DIR: &str = "_versions";
 const MANIFEST_EXTENSION: &str = "manifest";
 const DETACHED_VERSION_PREFIX: &str = "d";
+/// File name for the version hint file.
+/// The file size in bytes indicates the latest version number.
+/// This enables O(1) latest version lookup via HEAD request on object stores
+/// where listing is not lexicographically ordered (e.g., S3 Express).
+const VERSION_HINT_FILE: &str = "latest_version_hint.bin";
+
+/// Environment variable to enable/disable version hint optimization.
+/// Set to "0" or "false" to disable, any other value (or unset) to enable.
+const VERSION_HINT_ENV_VAR: &str = "LANCE_USE_VERSION_HINT";
+
+/// Check if version hint optimization is enabled via environment variable.
+fn is_version_hint_enabled() -> bool {
+    match std::env::var(VERSION_HINT_ENV_VAR) {
+        Ok(val) => !matches!(val.to_lowercase().as_str(), "0" | "false" | "no" | "off"),
+        Err(_) => true, // Enabled by default
+    }
+}
 
 /// How manifest files should be named.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -255,17 +272,214 @@ impl TryFrom<object_store::ObjectMeta> for ManifestLocation {
     }
 }
 
-/// Get the latest manifest path
+/// Get the latest manifest path.
+///
+/// This function uses two strategies in parallel:
+/// 1. Version hint: HEAD request on hint file + probing higher versions
+/// 2. Listing: Traditional directory listing
+///
+/// The hint-based approach is significantly faster on all object stores:
+/// - S3 Express: ~10ms (HEAD) vs ~200ms+ (LIST at scale)
+/// - S3 Standard: ~20ms (HEAD + probe) vs ~200ms+ (LIST at scale)
+///
+/// Even with lexicographic ordering (V2 naming), LIST still requires a full
+/// request that takes hundreds of milliseconds, while HEAD is much faster.
+///
+/// The version hint optimization can be disabled by setting the environment
+/// variable `LANCE_USE_VERSION_HINT=0` (or "false", "no", "off").
 async fn current_manifest_path(
     object_store: &ObjectStore,
     base: &Path,
 ) -> Result<ManifestLocation> {
+    // Fast path for local filesystem
     if object_store.is_local() {
         if let Ok(Some(location)) = current_manifest_local(base) {
             return Ok(location);
         }
     }
 
+    // Check if version hint is disabled via environment variable
+    if !is_version_hint_enabled() {
+        return resolve_version_from_listing(object_store, base).await;
+    }
+
+    // Race hint-based and listing-based approaches
+    // Use tokio::select! to return whichever completes first
+    tokio::select! {
+        biased;
+
+        // Try hint-based approach first (biased because it's usually faster)
+        hint_result = read_version_hint_and_probe(object_store, base) => {
+            if let Some(location) = hint_result {
+                return Ok(location);
+            }
+            // Hint failed, fall back to listing
+            resolve_version_from_listing(object_store, base).await
+        }
+
+        // Listing approach as backup
+        list_result = resolve_version_from_listing(object_store, base) => {
+            list_result
+        }
+    }
+}
+
+// This is an optimized function that searches for the latest manifest. In
+// object_store, list operations lookup metadata for each file listed. This
+// method only gets the metadata for the found latest manifest.
+fn current_manifest_local(base: &Path) -> std::io::Result<Option<ManifestLocation>> {
+    let path = lance_io::local::to_local_path(&base.child(VERSIONS_DIR));
+    let entries = std::fs::read_dir(path)?;
+
+    let mut latest_entry: Option<(u64, DirEntry)> = None;
+
+    let mut scheme: Option<ManifestNamingScheme> = None;
+
+    for entry in entries {
+        let entry = entry?;
+        let filename_raw = entry.file_name();
+        let filename = filename_raw.to_string_lossy();
+
+        let Some(entry_scheme) = ManifestNamingScheme::detect_scheme(&filename) else {
+            // Need to ignore temporary files, such as
+            // .tmp_7.manifest_9c100374-3298-4537-afc6-f5ee7913666d
+            continue;
+        };
+
+        if let Some(scheme) = scheme {
+            if scheme != entry_scheme {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Found multiple manifest naming schemes in the same directory: {:?} and {:?}",
+                        scheme, entry_scheme
+                    ),
+                ));
+            }
+        } else {
+            scheme = Some(entry_scheme);
+        }
+
+        let Some(version) = entry_scheme.parse_version(&filename) else {
+            continue;
+        };
+
+        if let Some((latest_version, _)) = &latest_entry {
+            if version > *latest_version {
+                latest_entry = Some((version, entry));
+            }
+        } else {
+            latest_entry = Some((version, entry));
+        }
+    }
+
+    if let Some((version, entry)) = latest_entry {
+        let path = Path::from_filesystem_path(entry.path())
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
+        let metadata = entry.metadata()?;
+        Ok(Some(ManifestLocation {
+            version,
+            path,
+            size: Some(metadata.len()),
+            naming_scheme: scheme.unwrap(),
+            e_tag: Some(get_etag(&metadata)),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Get the path to the version hint file.
+fn version_hint_path(base: &Path) -> Path {
+    base.child(VERSIONS_DIR).child(VERSION_HINT_FILE)
+}
+
+/// Write the version hint file after a successful commit.
+///
+/// The file size in bytes indicates the latest version number.
+/// This write is optimistic and failures are logged but ignored,
+/// as the hint is only used to accelerate reads, not for correctness.
+pub async fn write_version_hint(object_store: &ObjectStore, base: &Path, version: u64) {
+    let hint_path = version_hint_path(base);
+    // Create a file with `version` bytes (all zeros)
+    let content = vec![0u8; version as usize];
+    if let Err(e) = object_store.put(&hint_path, content.as_slice()).await {
+        // Log but don't fail - the hint is optional for correctness
+        warn!(
+            "Failed to write version hint file for version {}: {}",
+            version, e
+        );
+    }
+}
+
+/// Read the version hint and probe for higher versions.
+///
+/// Returns the latest version found and its manifest path, or None if the hint
+/// file doesn't exist or an error occurred.
+///
+/// This function:
+/// 1. HEAD request on the hint file to get the version hint (file size)
+/// 2. Probes version+1, version+2, etc. with HEAD requests until not found
+/// 3. Returns the highest version found
+async fn read_version_hint_and_probe(
+    object_store: &ObjectStore,
+    base: &Path,
+) -> Option<ManifestLocation> {
+    let hint_path = version_hint_path(base);
+
+    // Get the hint version from file size
+    let hint_meta = object_store.inner.head(&hint_path).await.ok()?;
+    let mut current_version = hint_meta.size as u64;
+
+    // Try V2 scheme first (more likely for newer datasets)
+    let mut scheme = ManifestNamingScheme::V2;
+
+    // Verify the hinted version exists
+    let manifest_path = scheme.manifest_path(base, current_version);
+    let manifest_meta = match object_store.inner.head(&manifest_path).await {
+        Ok(meta) => Some(meta),
+        Err(ObjectStoreError::NotFound { .. }) => {
+            // Try V1 scheme
+            scheme = ManifestNamingScheme::V1;
+            let manifest_path = scheme.manifest_path(base, current_version);
+            object_store.inner.head(&manifest_path).await.ok()
+        }
+        Err(_) => None,
+    };
+
+    // If the hinted version doesn't exist, the hint is stale/invalid
+    let mut last_meta = manifest_meta?;
+
+    // Probe for higher versions
+    loop {
+        let next_version = current_version + 1;
+        let next_path = scheme.manifest_path(base, next_version);
+        match object_store.inner.head(&next_path).await {
+            Ok(meta) => {
+                current_version = next_version;
+                last_meta = meta;
+            }
+            Err(ObjectStoreError::NotFound { .. }) => break,
+            Err(_) => break,
+        }
+    }
+
+    Some(ManifestLocation {
+        version: current_version,
+        path: scheme.manifest_path(base, current_version),
+        size: Some(last_meta.size),
+        naming_scheme: scheme,
+        e_tag: last_meta.e_tag,
+    })
+}
+
+/// Resolve the latest version from listing.
+///
+/// This is the traditional approach that lists all manifests and finds the highest version.
+async fn resolve_version_from_listing(
+    object_store: &ObjectStore,
+    base: &Path,
+) -> Result<ManifestLocation> {
     let manifest_files = object_store.list(Some(base.child(VERSIONS_DIR)));
 
     let mut valid_manifests = manifest_files.try_filter_map(|res| {
@@ -358,71 +572,6 @@ async fn current_manifest_path(
             uri: base.child(VERSIONS_DIR).to_string(),
             location: location!(),
         }),
-    }
-}
-
-// This is an optimized function that searches for the latest manifest. In
-// object_store, list operations lookup metadata for each file listed. This
-// method only gets the metadata for the found latest manifest.
-fn current_manifest_local(base: &Path) -> std::io::Result<Option<ManifestLocation>> {
-    let path = lance_io::local::to_local_path(&base.child(VERSIONS_DIR));
-    let entries = std::fs::read_dir(path)?;
-
-    let mut latest_entry: Option<(u64, DirEntry)> = None;
-
-    let mut scheme: Option<ManifestNamingScheme> = None;
-
-    for entry in entries {
-        let entry = entry?;
-        let filename_raw = entry.file_name();
-        let filename = filename_raw.to_string_lossy();
-
-        let Some(entry_scheme) = ManifestNamingScheme::detect_scheme(&filename) else {
-            // Need to ignore temporary files, such as
-            // .tmp_7.manifest_9c100374-3298-4537-afc6-f5ee7913666d
-            continue;
-        };
-
-        if let Some(scheme) = scheme {
-            if scheme != entry_scheme {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "Found multiple manifest naming schemes in the same directory: {:?} and {:?}",
-                        scheme, entry_scheme
-                    ),
-                ));
-            }
-        } else {
-            scheme = Some(entry_scheme);
-        }
-
-        let Some(version) = entry_scheme.parse_version(&filename) else {
-            continue;
-        };
-
-        if let Some((latest_version, _)) = &latest_entry {
-            if version > *latest_version {
-                latest_entry = Some((version, entry));
-            }
-        } else {
-            latest_entry = Some((version, entry));
-        }
-    }
-
-    if let Some((version, entry)) = latest_entry {
-        let path = Path::from_filesystem_path(entry.path())
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
-        let metadata = entry.metadata()?;
-        Ok(Some(ManifestLocation {
-            version,
-            path,
-            size: Some(metadata.len()),
-            naming_scheme: scheme.unwrap(),
-            e_tag: Some(get_etag(&metadata)),
-        }))
-    } else {
-        Ok(None)
     }
 }
 
@@ -839,6 +988,9 @@ impl CommitHandler for UnsafeCommitHandler {
         let res =
             manifest_writer(object_store, manifest, indices, &version_path, transaction).await?;
 
+        // Write version hint (optimistic, failures are ignored)
+        write_version_hint(object_store, base_path, manifest.version).await;
+
         Ok(ManifestLocation {
             version: manifest.version,
             size: Some(res.size as u64),
@@ -922,6 +1074,10 @@ impl<T: CommitLock + Send + Sync> CommitHandler for T {
         lease.release(res.is_ok()).await?;
 
         let res = res?;
+
+        // Write version hint (optimistic, failures are ignored)
+        write_version_hint(object_store, base_path, manifest.version).await;
+
         Ok(ManifestLocation {
             version: manifest.version,
             size: Some(res.size as u64),
@@ -989,6 +1145,9 @@ impl CommitHandler for RenameCommitHandler {
             .await
         {
             Ok(_) => {
+                // Write version hint (optimistic, failures are ignored)
+                write_version_hint(object_store, base_path, manifest.version).await;
+
                 // Successfully committed
                 Ok(ManifestLocation {
                     version: manifest.version,
@@ -1064,6 +1223,9 @@ impl CommitHandler for ConditionalPutCommitHandler {
                 }
                 _ => CommitError::OtherError(err.into()),
             })?;
+
+        // Write version hint (optimistic, failures are ignored)
+        write_version_hint(object_store, base_path, manifest.version).await;
 
         Ok(ManifestLocation {
             version: manifest.version,
@@ -1242,5 +1404,117 @@ mod tests {
         assert_eq!(location.version, 11);
         assert_eq!(location.naming_scheme, naming_scheme);
         assert_eq!(location.path, naming_scheme.manifest_path(&base, 11));
+    }
+
+    #[tokio::test]
+    async fn test_write_version_hint() {
+        let object_store = ObjectStore::memory();
+        let base = Path::from("base");
+
+        // Write version hint for version 42
+        write_version_hint(&object_store, &base, 42).await;
+
+        // Verify the hint file exists with correct size
+        let hint_path = version_hint_path(&base);
+        let meta = object_store.inner.head(&hint_path).await.unwrap();
+        assert_eq!(meta.size, 42);
+
+        // Write version hint for version 100 (overwrites previous)
+        write_version_hint(&object_store, &base, 100).await;
+        let meta = object_store.inner.head(&hint_path).await.unwrap();
+        assert_eq!(meta.size, 100);
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    async fn test_read_version_hint_and_probe(
+        #[values(ManifestNamingScheme::V1, ManifestNamingScheme::V2)]
+        naming_scheme: ManifestNamingScheme,
+    ) {
+        let object_store = ObjectStore::memory();
+        let base = Path::from("base");
+
+        // No hint file - should return None
+        let result = read_version_hint_and_probe(&object_store, &base).await;
+        assert!(result.is_none());
+
+        // Create manifests for versions 1-5
+        for version in 1..=5 {
+            let path = naming_scheme.manifest_path(&base, version);
+            object_store.put(&path, b"".as_slice()).await.unwrap();
+        }
+
+        // Write hint pointing to version 3 (stale hint)
+        write_version_hint(&object_store, &base, 3).await;
+
+        // Should probe and find version 5
+        let location = read_version_hint_and_probe(&object_store, &base)
+            .await
+            .unwrap();
+        assert_eq!(location.version, 5);
+        assert_eq!(location.naming_scheme, naming_scheme);
+
+        // Update hint to current version
+        write_version_hint(&object_store, &base, 5).await;
+
+        // Should return version 5 directly
+        let location = read_version_hint_and_probe(&object_store, &base)
+            .await
+            .unwrap();
+        assert_eq!(location.version, 5);
+    }
+
+    #[tokio::test]
+    async fn test_current_manifest_path_with_hint_non_lexical() {
+        // Test that hint-based lookup works for non-lexicographic stores
+        let mut object_store = ObjectStore::memory();
+        object_store.list_is_lexically_ordered = false;
+        let object_store = Box::new(object_store);
+        let base = Path::from("base");
+        let naming_scheme = ManifestNamingScheme::V2;
+
+        // Create many manifest files (simulating S3 Express with many versions)
+        for version in 1..=100 {
+            let path = naming_scheme.manifest_path(&base, version);
+            object_store.put(&path, b"".as_slice()).await.unwrap();
+        }
+
+        // Write hint pointing to version 98 (slightly stale)
+        write_version_hint(&object_store, &base, 98).await;
+
+        // Should find version 100 (probing from 98)
+        let location = current_manifest_path(&object_store, &base).await.unwrap();
+        assert_eq!(location.version, 100);
+    }
+
+    #[tokio::test]
+    async fn test_version_hint_invalid_version() {
+        // Test behavior when hint points to non-existent version
+        let object_store = ObjectStore::memory();
+        let base = Path::from("base");
+        let naming_scheme = ManifestNamingScheme::V2;
+
+        // Create manifest for version 5 only
+        let path = naming_scheme.manifest_path(&base, 5);
+        object_store.put(&path, b"".as_slice()).await.unwrap();
+
+        // Write hint pointing to version 10 (invalid - doesn't exist)
+        write_version_hint(&object_store, &base, 10).await;
+
+        // Hint should be ignored, should fall back to listing
+        let mut object_store_clone = ObjectStore::memory();
+        object_store_clone.list_is_lexically_ordered = false;
+
+        // Copy the manifest to the new store
+        object_store_clone.put(&path, b"".as_slice()).await.unwrap();
+
+        // Write the invalid hint
+        write_version_hint(&object_store_clone, &base, 10).await;
+
+        // Should find version 5 via listing fallback
+        let location = current_manifest_path(&object_store_clone, &base)
+            .await
+            .unwrap();
+        assert_eq!(location.version, 5);
     }
 }

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -340,16 +340,56 @@ async fn current_manifest_path(
         return result;
     }
 
-    // Race hint-based and listing-based approaches
-    // Use tokio::select! to return whichever completes first
+    // Stagger start: give hint a head start to avoid connection contention
+    // When hint and listing start simultaneously, both slow down due to TCP/TLS contention
+    // By giving hint a head start, it can complete quickly (~4ms) before listing starts
+    let hint_head_start_ms = std::env::var("LANCE_HINT_HEAD_START_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(10u64);
+
+    let hint_future = read_version_hint_and_probe(object_store, base);
+    tokio::pin!(hint_future);
+
+    // Phase 1: Give hint a head start
+    let head_start = tokio::time::Duration::from_millis(hint_head_start_ms);
+    let hint_result = tokio::select! {
+        biased;
+        result = &mut hint_future => Some(result),
+        _ = tokio::time::sleep(head_start) => None,
+    };
+
+    // If hint completed during head start, use it
+    if let Some(Some(location)) = hint_result {
+        eprintln!(
+            "[LOAD] hint won (head start): {:?}, version={}",
+            start.elapsed(),
+            location.version
+        );
+        return Ok(location);
+    }
+
+    // If hint failed during head start, fall back to listing only
+    if let Some(None) = hint_result {
+        let result = resolve_version_from_listing(object_store, base).await;
+        eprintln!(
+            "[LOAD] hint failed, listing fallback: {:?}, version={}",
+            start.elapsed(),
+            result.as_ref().map(|l| l.version).unwrap_or(0)
+        );
+        return result;
+    }
+
+    // Phase 2: Hint didn't complete in head start, race with listing
+    eprintln!("[LOAD] hint head start timeout, starting race");
     tokio::select! {
         biased;
 
-        // Try hint-based approach first (biased because it's usually faster)
-        hint_result = read_version_hint_and_probe(object_store, base) => {
+        // Continue hint attempt
+        hint_result = hint_future => {
             if let Some(location) = hint_result {
                 eprintln!(
-                    "[LOAD] hint won: {:?}, version={}",
+                    "[LOAD] hint won (after race): {:?}, version={}",
                     start.elapsed(),
                     location.version
                 );

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -604,6 +604,158 @@ async fn read_version_hint_and_probe(
     })
 }
 
+/// Probe upward from hint_version to find the true latest version.
+///
+/// Returns (true_latest_version, naming_scheme, Vec of (version, ObjectMeta) for probed versions).
+/// The Vec contains metadata for all versions from hint_version to true_latest.
+async fn probe_versions_upward(
+    object_store: &ObjectStore,
+    base: &Path,
+    hint_version: u64,
+) -> Option<(
+    u64,
+    ManifestNamingScheme,
+    Vec<(u64, object_store::ObjectMeta)>,
+)> {
+    // Try V2 scheme first (more likely for newer datasets)
+    let mut scheme = ManifestNamingScheme::V2;
+
+    // Verify the hinted version exists
+    let manifest_path = scheme.manifest_path(base, hint_version);
+    let hint_meta = match object_store.inner.head(&manifest_path).await {
+        Ok(meta) => Some(meta),
+        Err(ObjectStoreError::NotFound { .. }) => {
+            // Try V1 scheme
+            scheme = ManifestNamingScheme::V1;
+            let manifest_path = scheme.manifest_path(base, hint_version);
+            object_store.inner.head(&manifest_path).await.ok()
+        }
+        Err(_) => None,
+    }?;
+
+    let mut probed_versions = vec![(hint_version, hint_meta)];
+    let mut current_version = hint_version;
+
+    // Probe for higher versions sequentially
+    loop {
+        let next_version = current_version + 1;
+        let next_path = scheme.manifest_path(base, next_version);
+        match object_store.inner.head(&next_path).await {
+            Ok(meta) => {
+                probed_versions.push((next_version, meta));
+                current_version = next_version;
+            }
+            Err(ObjectStoreError::NotFound { .. }) => break,
+            Err(_) => break,
+        }
+    }
+
+    Some((current_version, scheme, probed_versions))
+}
+
+/// List manifest locations since a given version using version hint optimization.
+///
+/// This is optimized for non-lexically ordered stores (e.g., S3 Express).
+/// Instead of listing all manifests, it:
+/// 1. Reads the version hint to get approximate latest
+/// 2. Probes upward from hint to find true latest
+/// 3. Parallel HEADs for versions between since_version and hint
+/// 4. Returns all found manifests in descending order
+async fn list_manifests_since_version_with_hint(
+    object_store: &ObjectStore,
+    base: &Path,
+    since_version: u64,
+) -> Option<Vec<ManifestLocation>> {
+    // Read version hint
+    let hint_version = read_version_from_hint(object_store, base).await?;
+
+    // If hint is not newer than since_version, no new manifests
+    if hint_version <= since_version {
+        // But there might be newer versions, so probe upward from since_version
+        let (_true_latest, scheme, probed) =
+            probe_versions_upward(object_store, base, since_version + 1).await?;
+
+        // Filter to only versions > since_version and convert to ManifestLocations
+        let locations: Vec<ManifestLocation> = probed
+            .into_iter()
+            .filter(|(v, _)| *v > since_version)
+            .map(|(version, meta)| ManifestLocation {
+                version,
+                path: scheme.manifest_path(base, version),
+                size: Some(meta.size),
+                naming_scheme: scheme,
+                e_tag: meta.e_tag,
+            })
+            .collect();
+
+        // Sort descending
+        let mut locations = locations;
+        locations.sort_by_key(|loc| std::cmp::Reverse(loc.version));
+        return Some(locations);
+    }
+
+    // Probe upward from hint to find true latest and collect metadata
+    let (_true_latest, scheme, probed_above_hint) =
+        probe_versions_upward(object_store, base, hint_version).await?;
+
+    // Now parallel HEAD for versions between since_version+1 and hint_version-1
+    // (we already have hint_version and above from probing)
+    let versions_to_head: Vec<u64> = ((since_version + 1)..hint_version).collect();
+
+    let head_futures: Vec<_> = versions_to_head
+        .iter()
+        .map(|&version| {
+            let path = scheme.manifest_path(base, version);
+            let store = &object_store.inner;
+            async move {
+                match store.head(&path).await {
+                    Ok(meta) => Some((version, meta)),
+                    Err(_) => None,
+                }
+            }
+        })
+        .collect();
+
+    // Execute all HEADs in parallel
+    let head_results: Vec<Option<(u64, object_store::ObjectMeta)>> =
+        futures::future::join_all(head_futures).await;
+
+    // Combine results: probed versions + parallel HEAD results
+    let mut all_locations: Vec<ManifestLocation> = Vec::new();
+
+    // Add probed versions (hint and above)
+    for (version, meta) in probed_above_hint {
+        if version > since_version {
+            all_locations.push(ManifestLocation {
+                version,
+                path: scheme.manifest_path(base, version),
+                size: Some(meta.size),
+                naming_scheme: scheme,
+                e_tag: meta.e_tag,
+            });
+        }
+    }
+
+    // Add parallel HEAD results
+    for result in head_results.into_iter().flatten() {
+        let (version, meta) = result;
+        if version > since_version {
+            all_locations.push(ManifestLocation {
+                version,
+                path: scheme.manifest_path(base, version),
+                size: Some(meta.size),
+                naming_scheme: scheme,
+                e_tag: meta.e_tag,
+            });
+        }
+    }
+
+    // Sort descending by version
+    all_locations.sort_by_key(|loc| std::cmp::Reverse(loc.version));
+
+    Some(all_locations)
+}
+
 /// Resolve the latest version from listing.
 ///
 /// This is the traditional approach that lists all manifests and finds the highest version.
@@ -820,6 +972,66 @@ pub trait CommitHandler: Debug + Send + Sync {
                 .try_flatten()
                 .boxed()
         }
+    }
+
+    /// List manifest locations since a given version, in descending order.
+    ///
+    /// This is optimized for finding new transactions during commit.
+    /// For non-lexically ordered stores (e.g., S3 Express), it uses the version
+    /// hint to avoid O(n) full listing.
+    ///
+    /// Returns manifests with version > since_version, sorted descending.
+    fn list_manifest_locations_since<'a>(
+        &self,
+        base_path: &Path,
+        object_store: &'a ObjectStore,
+        since_version: u64,
+    ) -> BoxStream<'a, Result<ManifestLocation>> {
+        // For lexically ordered stores, use the standard approach with early termination
+        if object_store.list_is_lexically_ordered {
+            return self
+                .list_manifest_locations(base_path, object_store, true)
+                .try_take_while(move |loc| future::ready(Ok(loc.version > since_version)))
+                .boxed();
+        }
+
+        // For non-lexically ordered stores, try version hint optimization if enabled
+        if !is_version_hint_enabled() {
+            // Fall back to full listing with filter
+            return self
+                .list_manifest_locations(base_path, object_store, true)
+                .try_take_while(move |loc| future::ready(Ok(loc.version > since_version)))
+                .boxed();
+        }
+
+        // Use version hint optimization
+        let base_path = base_path.clone();
+        let object_store_clone = object_store.clone();
+
+        futures::stream::once(async move {
+            let locations: Vec<ManifestLocation> = match list_manifests_since_version_with_hint(
+                &object_store_clone,
+                &base_path,
+                since_version,
+            )
+            .await
+            {
+                Some(locs) => locs,
+                None => {
+                    // Fall back to full listing if hint-based approach fails
+                    let underlying_stream = list_manifests(&base_path, &object_store_clone.inner);
+                    let mut locs = underlying_stream.try_collect::<Vec<_>>().await?;
+                    locs.retain(|loc| loc.version > since_version);
+                    locs.sort_by_key(|m| std::cmp::Reverse(m.version));
+                    locs
+                }
+            };
+            Ok::<_, Error>(futures::stream::iter(
+                locations.into_iter().map(Ok::<_, Error>),
+            ))
+        })
+        .try_flatten()
+        .boxed()
     }
 
     /// Commit a manifest.

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -98,22 +98,9 @@ const VERSION_HINT_FORMAT_ENV_VAR: &str = "LANCE_VERSION_HINT_FORMAT";
 /// When enabled, the load path will ONLY use hint+HEAD, no listing fallback race.
 const HINT_ONLY_ENV_VAR: &str = "LANCE_HINT_ONLY";
 
-/// Environment variable to enable connection warmup before load operations.
-/// Set to "1" or "true" to make a warmup HEAD request before hint/listing race.
-/// This reduces cold connection overhead from ~100ms to ~60ms for fresh sessions.
-const CONNECTION_WARMUP_ENV_VAR: &str = "LANCE_CONNECTION_WARMUP";
-
 /// Check if hint-only mode is enabled (no racing with listing).
 fn is_hint_only_mode() -> bool {
     match std::env::var(HINT_ONLY_ENV_VAR) {
-        Ok(val) => matches!(val.to_lowercase().as_str(), "1" | "true" | "yes" | "on"),
-        Err(_) => false,
-    }
-}
-
-/// Check if connection warmup is enabled.
-fn is_connection_warmup_enabled() -> bool {
-    match std::env::var(CONNECTION_WARMUP_ENV_VAR) {
         Ok(val) => matches!(val.to_lowercase().as_str(), "1" | "true" | "yes" | "on"),
         Err(_) => false,
     }
@@ -344,13 +331,10 @@ impl TryFrom<object_store::ObjectMeta> for ManifestLocation {
 ///
 /// The version hint optimization can be disabled by setting the environment
 /// variable `LANCE_USE_VERSION_HINT=0` (or "false", "no", "off").
-#[allow(clippy::print_stderr)]
 async fn current_manifest_path(
     object_store: &ObjectStore,
     base: &Path,
 ) -> Result<ManifestLocation> {
-    let start = std::time::Instant::now();
-
     // Fast path for local filesystem
     if object_store.is_local() {
         if let Ok(Some(location)) = current_manifest_local(base) {
@@ -360,45 +344,17 @@ async fn current_manifest_path(
 
     // Check if version hint is disabled via environment variable
     if !is_version_hint_enabled() {
-        let result = resolve_version_from_listing(object_store, base).await;
-        eprintln!(
-            "[LOAD] no hint, listing only: {:?}, version={}",
-            start.elapsed(),
-            result.as_ref().map(|l| l.version).unwrap_or(0)
-        );
-        return result;
-    }
-
-    // Connection warmup: make a cheap HEAD request to establish connection
-    // This reduces cold connection overhead from ~100ms to ~60ms for fresh sessions
-    if is_connection_warmup_enabled() {
-        let warmup_path = version_hint_path(base);
-        let warmup_start = std::time::Instant::now();
-        // Just make the request, ignore the result (we only care about warming up the connection)
-        let _ = object_store.inner.head(&warmup_path).await;
-        eprintln!("[WARMUP] connection warmed: {:?}", warmup_start.elapsed());
+        return resolve_version_from_listing(object_store, base).await;
     }
 
     // Hint-only mode: no racing, purely hint+HEAD approach
     // This is for debugging/benchmarking to isolate hint performance from racing overhead
     if is_hint_only_mode() {
-        eprintln!("[LOAD] hint-only mode enabled");
         if let Some(location) = read_version_hint_and_probe(object_store, base).await {
-            eprintln!(
-                "[LOAD] hint-only success: {:?}, version={}",
-                start.elapsed(),
-                location.version
-            );
             return Ok(location);
         }
         // Hint failed, fall back to listing (no racing)
-        let result = resolve_version_from_listing(object_store, base).await;
-        eprintln!(
-            "[LOAD] hint-only failed, listing fallback: {:?}, version={}",
-            start.elapsed(),
-            result.as_ref().map(|l| l.version).unwrap_or(0)
-        );
-        return result;
+        return resolve_version_from_listing(object_store, base).await;
     }
 
     // Race hint-based and listing-based approaches
@@ -409,30 +365,14 @@ async fn current_manifest_path(
         // Try hint-based approach first (biased because it's usually faster)
         hint_result = read_version_hint_and_probe(object_store, base) => {
             if let Some(location) = hint_result {
-                eprintln!(
-                    "[LOAD] hint won: {:?}, version={}",
-                    start.elapsed(),
-                    location.version
-                );
                 return Ok(location);
             }
             // Hint failed, fall back to listing
-            let result = resolve_version_from_listing(object_store, base).await;
-            eprintln!(
-                "[LOAD] hint failed, listing fallback: {:?}, version={}",
-                start.elapsed(),
-                result.as_ref().map(|l| l.version).unwrap_or(0)
-            );
-            result
+            resolve_version_from_listing(object_store, base).await
         }
 
         // Listing approach as backup
         list_result = resolve_version_from_listing(object_store, base) => {
-            eprintln!(
-                "[LOAD] listing won: {:?}, version={}",
-                start.elapsed(),
-                list_result.as_ref().map(|l| l.version).unwrap_or(0)
-            );
             list_result
         }
     }
@@ -593,42 +533,19 @@ pub async fn write_version_hint_blocking(object_store: &ObjectStore, base: &Path
 /// The format is determined by `LANCE_VERSION_HINT_FORMAT` env var:
 /// - "json": Reads from latest_version_hint.json
 /// - "file_size" (default): Reads from latest_version_hint.bin (file size = version)
-#[allow(clippy::print_stderr)]
 async fn read_version_from_hint(object_store: &ObjectStore, base: &Path) -> Option<u64> {
     let hint_path = version_hint_path(base);
-    let start = std::time::Instant::now();
 
     if is_version_hint_json_format() {
         // JSON format: read and parse the file content
         let bytes = object_store.inner.get(&hint_path).await.ok()?;
-        let get_time = start.elapsed();
         let bytes = bytes.bytes().await.ok()?;
         let text = std::str::from_utf8(&bytes).ok()?;
-        let version = parse_version_from_json(text);
-        eprintln!(
-            "[HINT_READ] json, get={:?}, total={:?}, version={:?}",
-            get_time,
-            start.elapsed(),
-            version
-        );
-        version
+        parse_version_from_json(text)
     } else {
         // File-size format: version = file size in bytes
-        eprintln!(
-            "[HINT_READ_START] file_size, path={}, at={:?}",
-            hint_path,
-            start.elapsed()
-        );
-        let head_start = std::time::Instant::now();
         let meta = object_store.inner.head(&hint_path).await.ok()?;
-        let version = meta.size as u64;
-        eprintln!(
-            "[HINT_READ] file_size, total={:?}, head_only={:?}, version={}",
-            start.elapsed(),
-            head_start.elapsed(),
-            version
-        );
-        Some(version)
+        Some(meta.size as u64)
     }
 }
 
@@ -663,116 +580,45 @@ fn parse_version_from_json(json: &str) -> Option<u64> {
 /// 1. Reads the hint file to get the version hint (file size or JSON content)
 /// 2. Probes version+1, version+2, etc. with HEAD requests until not found
 /// 3. Returns the highest version found
-#[allow(clippy::print_stderr)]
 async fn read_version_hint_and_probe(
     object_store: &ObjectStore,
     base: &Path,
 ) -> Option<ManifestLocation> {
-    let start = std::time::Instant::now();
-
     // Read version from hint file (format determined by env var)
     let mut current_version = read_version_from_hint(object_store, base).await?;
-    let hint_read_time = start.elapsed();
-    eprintln!(
-        "[HINT_READ_DONE] hint_read={:?}, version={}",
-        hint_read_time, current_version
-    );
 
     // Try V2 scheme first (more likely for newer datasets)
     let mut scheme = ManifestNamingScheme::V2;
 
     // Verify the hinted version exists
     let manifest_path = scheme.manifest_path(base, current_version);
-    let verify_start = std::time::Instant::now();
     let manifest_meta = match object_store.inner.head(&manifest_path).await {
-        Ok(meta) => {
-            eprintln!(
-                "[VERIFY_HEAD] v={}, found, {:?}",
-                current_version,
-                verify_start.elapsed()
-            );
-            Some(meta)
-        }
+        Ok(meta) => Some(meta),
         Err(ObjectStoreError::NotFound { .. }) => {
-            eprintln!(
-                "[VERIFY_HEAD] v={}, not_found_v2, {:?}",
-                current_version,
-                verify_start.elapsed()
-            );
             // Try V1 scheme
             scheme = ManifestNamingScheme::V1;
             let manifest_path = scheme.manifest_path(base, current_version);
-            let v1_start = std::time::Instant::now();
-            let result = object_store.inner.head(&manifest_path).await.ok();
-            eprintln!(
-                "[VERIFY_HEAD] v={}, v1_fallback={:?}, {:?}",
-                current_version,
-                result.is_some(),
-                v1_start.elapsed()
-            );
-            result
+            object_store.inner.head(&manifest_path).await.ok()
         }
-        Err(e) => {
-            eprintln!(
-                "[VERIFY_HEAD] v={}, error={:?}, {:?}",
-                current_version,
-                e,
-                verify_start.elapsed()
-            );
-            None
-        }
+        Err(_) => None,
     };
-    let verify_time = start.elapsed();
 
     // If the hinted version doesn't exist, the hint is stale/invalid
     let mut last_meta = manifest_meta?;
 
     // Probe for higher versions
-    let mut probe_count = 0;
-    let probe_start = std::time::Instant::now();
     loop {
         let next_version = current_version + 1;
         let next_path = scheme.manifest_path(base, next_version);
-        let head_start = std::time::Instant::now();
         match object_store.inner.head(&next_path).await {
             Ok(meta) => {
-                eprintln!(
-                    "[PROBE_HEAD] v={}, found, {:?}",
-                    next_version,
-                    head_start.elapsed()
-                );
                 current_version = next_version;
                 last_meta = meta;
-                probe_count += 1;
             }
-            Err(ObjectStoreError::NotFound { .. }) => {
-                eprintln!(
-                    "[PROBE_HEAD] v={}, not_found, {:?}",
-                    next_version,
-                    head_start.elapsed()
-                );
-                break;
-            }
-            Err(_) => {
-                eprintln!(
-                    "[PROBE_HEAD] v={}, error, {:?}",
-                    next_version,
-                    head_start.elapsed()
-                );
-                break;
-            }
+            Err(ObjectStoreError::NotFound { .. }) => break,
+            Err(_) => break,
         }
     }
-
-    eprintln!(
-        "[HINT_PROBE] hint_read={:?}, verify={:?}, probe={:?}, total={:?}, probe_count={}, version={}",
-        hint_read_time,
-        verify_time - hint_read_time,
-        probe_start.elapsed(),
-        start.elapsed(),
-        probe_count,
-        current_version
-    );
 
     Some(ManifestLocation {
         version: current_version,
@@ -943,13 +789,10 @@ async fn list_manifests_since_version_with_hint(
 /// Resolve the latest version from listing.
 ///
 /// This is the traditional approach that lists all manifests and finds the highest version.
-#[allow(clippy::print_stderr)]
 async fn resolve_version_from_listing(
     object_store: &ObjectStore,
     base: &Path,
 ) -> Result<ManifestLocation> {
-    eprintln!("[LIST_START] versions_dir={}", base.child(VERSIONS_DIR));
-    let list_start = std::time::Instant::now();
     let manifest_files = object_store.list(Some(base.child(VERSIONS_DIR)));
 
     let mut valid_manifests = manifest_files.try_filter_map(|res| {
@@ -962,7 +805,6 @@ async fn resolve_version_from_listing(
     });
 
     let first = valid_manifests.next().await.transpose()?;
-    let first_item_time = list_start.elapsed();
     match (first, object_store.list_is_lexically_ordered) {
         // If the first valid manifest we see is V2, we can assume that we are using
         // V2 naming scheme for all manifests.
@@ -995,12 +837,6 @@ async fn resolve_version_from_listing(
                 }
             }
 
-            eprintln!(
-                "[LIST] lexical, first_item={:?}, total={:?}, version={}",
-                first_item_time,
-                list_start.elapsed(),
-                version
-            );
             Ok(ManifestLocation {
                 version,
                 path: meta.location,
@@ -1017,10 +853,8 @@ async fn resolve_version_from_listing(
                 .unwrap();
             let mut current_meta = meta;
             let scheme = first_scheme;
-            let mut count = 1;
 
             while let Some((entry_scheme, meta)) = valid_manifests.next().await.transpose()? {
-                count += 1;
                 if entry_scheme != scheme {
                     return Err(Error::Internal {
                         message: format!(
@@ -1039,13 +873,6 @@ async fn resolve_version_from_listing(
                     current_meta = meta;
                 }
             }
-            eprintln!(
-                "[LIST] non-lexical, first_item={:?}, total={:?}, count={}, version={}",
-                first_item_time,
-                list_start.elapsed(),
-                count,
-                current_version
-            );
             Ok(ManifestLocation {
                 version: current_version,
                 path: current_meta.location,
@@ -1960,15 +1787,19 @@ mod tests {
         // Write version hint for version 42
         write_version_hint_blocking(&object_store, &base, 42).await;
 
-        // Verify the hint file exists with correct size
+        // Verify the hint file exists with correct JSON content (default format)
         let hint_path = version_hint_path(&base);
-        let meta = object_store.inner.head(&hint_path).await.unwrap();
-        assert_eq!(meta.size, 42);
+        let data = object_store.inner.get(&hint_path).await.unwrap();
+        let bytes = data.bytes().await.unwrap();
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert_eq!(parse_version_from_json(text), Some(42));
 
         // Write version hint for version 100 (overwrites previous)
         write_version_hint_blocking(&object_store, &base, 100).await;
-        let meta = object_store.inner.head(&hint_path).await.unwrap();
-        assert_eq!(meta.size, 100);
+        let data = object_store.inner.get(&hint_path).await.unwrap();
+        let bytes = data.bytes().await.unwrap();
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert_eq!(parse_version_from_json(text), Some(100));
     }
 
     #[tokio::test]

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -70,54 +70,10 @@ use {
 pub const VERSIONS_DIR: &str = "_versions";
 const MANIFEST_EXTENSION: &str = "manifest";
 const DETACHED_VERSION_PREFIX: &str = "d";
-/// File name for the version hint file (file-size encoding).
-/// The file size in bytes indicates the latest version number.
+/// File name for the JSON-based version hint file.
 /// This enables O(1) latest version lookup via HEAD request on object stores
 /// where listing is not lexicographically ordered (e.g., S3 Express).
-const VERSION_HINT_FILE: &str = "latest_version_hint.bin";
-
-/// File name for the JSON-based version hint file.
 const VERSION_HINT_JSON_FILE: &str = "latest_version_hint.json";
-
-/// Environment variable to enable/disable version hint optimization.
-/// Set to "0" or "false" to disable, any other value (or unset) to enable.
-const VERSION_HINT_ENV_VAR: &str = "LANCE_USE_VERSION_HINT";
-
-/// Environment variable to control version hint write mode.
-/// Set to "sync" to wait for the write to complete (adds latency but guarantees write).
-/// Set to "async" (default) to spawn a background task and return immediately.
-const VERSION_HINT_WRITE_MODE_ENV_VAR: &str = "LANCE_VERSION_HINT_WRITE_MODE";
-
-/// Environment variable to control version hint encoding format.
-/// Set to "json" to use JSON encoding (writes version number as JSON).
-/// Set to "file_size" (default) to use file-size encoding (file size = version number).
-const VERSION_HINT_FORMAT_ENV_VAR: &str = "LANCE_VERSION_HINT_FORMAT";
-
-/// Check if version hint writes should be synchronous (blocking).
-fn is_version_hint_sync_write() -> bool {
-    match std::env::var(VERSION_HINT_WRITE_MODE_ENV_VAR) {
-        Ok(val) => val.to_lowercase() == "sync",
-        Err(_) => false, // Default to async (fire-and-forget)
-    }
-}
-
-/// Check if version hint should use JSON format.
-/// Default is JSON format (more portable and debuggable).
-/// Set LANCE_VERSION_HINT_FORMAT=file_size to use file-size encoding.
-fn is_version_hint_json_format() -> bool {
-    match std::env::var(VERSION_HINT_FORMAT_ENV_VAR) {
-        Ok(val) => val.to_lowercase() != "file_size",
-        Err(_) => true, // Default to JSON format
-    }
-}
-
-/// Check if version hint optimization is enabled via environment variable.
-fn is_version_hint_enabled() -> bool {
-    match std::env::var(VERSION_HINT_ENV_VAR) {
-        Ok(val) => !matches!(val.to_lowercase().as_str(), "0" | "false" | "no" | "off"),
-        Err(_) => true, // Enabled by default
-    }
-}
 
 /// How manifest files should be named.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -315,9 +271,6 @@ impl TryFrom<object_store::ObjectMeta> for ManifestLocation {
 ///
 /// Even with lexicographic ordering (V2 naming), LIST still requires a full
 /// request that takes hundreds of milliseconds, while HEAD is much faster.
-///
-/// The version hint optimization can be disabled by setting the environment
-/// variable `LANCE_USE_VERSION_HINT=0` (or "false", "no", "off").
 async fn current_manifest_path(
     object_store: &ObjectStore,
     base: &Path,
@@ -327,11 +280,6 @@ async fn current_manifest_path(
         if let Ok(Some(location)) = current_manifest_local(base) {
             return Ok(location);
         }
-    }
-
-    // Check if version hint is disabled via environment variable
-    if !is_version_hint_enabled() {
-        return resolve_version_from_listing(object_store, base).await;
     }
 
     // Race hint-based and listing-based approaches
@@ -422,39 +370,27 @@ fn current_manifest_local(base: &Path) -> std::io::Result<Option<ManifestLocatio
 
 /// Get the path to the version hint file.
 fn version_hint_path(base: &Path) -> Path {
-    let filename = if is_version_hint_json_format() {
-        VERSION_HINT_JSON_FILE
-    } else {
-        VERSION_HINT_FILE
-    };
-    base.child(VERSIONS_DIR).child(filename)
+    base.child(VERSIONS_DIR).child(VERSION_HINT_JSON_FILE)
 }
 
 /// Write the version hint file after a successful commit.
 ///
-/// The encoding format depends on `LANCE_VERSION_HINT_FORMAT`:
-/// - "file_size" (default): File size in bytes indicates the version number
-/// - "json": JSON file containing `{"version": N}`
+/// The hint is written as a JSON file containing `{"version": N}`.
 ///
-/// The write mode depends on `LANCE_VERSION_HINT_WRITE_MODE`:
-/// - "async" (default): Spawns a background task and returns immediately (fire-and-forget)
-/// - "sync": Spawns a background task and waits for it to complete before returning
+/// When `sync_write` is true, blocks until the write completes.
+/// When `sync_write` is false (default), spawns a background task and returns immediately.
 ///
 /// This write is optimistic and failures are logged but ignored,
 /// as the hint is only used to accelerate reads, not for correctness.
-pub fn write_version_hint(object_store: &ObjectStore, base: &Path, version: u64) {
-    if !is_version_hint_enabled() {
-        return;
-    }
+pub fn write_version_hint(object_store: &ObjectStore, base: &Path, version: u64, sync_write: bool) {
     let hint_path = version_hint_path(base);
-    let use_json = is_version_hint_json_format();
     let object_store = object_store.clone();
 
     let handle = tokio::spawn(async move {
-        write_version_hint_inner(&object_store, &hint_path, version, use_json).await;
+        write_version_hint_inner(&object_store, &hint_path, version).await;
     });
 
-    if is_version_hint_sync_write() {
+    if sync_write {
         // Synchronous write - block until the spawned task completes
         // Use block_in_place to avoid blocking the async runtime
         let _ = tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(handle));
@@ -465,27 +401,12 @@ pub fn write_version_hint(object_store: &ObjectStore, base: &Path, version: u64)
 /// Async version of write_version_hint that can be awaited.
 /// Use this when you need to ensure the write completes before proceeding.
 pub async fn write_version_hint_async(object_store: &ObjectStore, base: &Path, version: u64) {
-    if !is_version_hint_enabled() {
-        return;
-    }
     let hint_path = version_hint_path(base);
-    let use_json = is_version_hint_json_format();
-    write_version_hint_inner(object_store, &hint_path, version, use_json).await;
+    write_version_hint_inner(object_store, &hint_path, version).await;
 }
 
-async fn write_version_hint_inner(
-    object_store: &ObjectStore,
-    hint_path: &Path,
-    version: u64,
-    use_json: bool,
-) {
-    let content = if use_json {
-        // JSON format: {"version": N}
-        format!("{{\"version\":{}}}", version).into_bytes()
-    } else {
-        // File-size format: file with `version` zero bytes
-        vec![0u8; version as usize]
-    };
+async fn write_version_hint_inner(object_store: &ObjectStore, hint_path: &Path, version: u64) {
+    let content = format!("{{\"version\":{}}}", version).into_bytes();
 
     if let Err(e) = object_store.put(hint_path, content.as_slice()).await {
         // Log but don't fail - the hint is optional for correctness
@@ -501,29 +422,18 @@ async fn write_version_hint_inner(
 #[cfg(test)]
 pub async fn write_version_hint_blocking(object_store: &ObjectStore, base: &Path, version: u64) {
     let hint_path = version_hint_path(base);
-    let use_json = is_version_hint_json_format();
-    write_version_hint_inner(object_store, &hint_path, version, use_json).await;
+    write_version_hint_inner(object_store, &hint_path, version).await;
 }
 
 /// Read the version from the hint file.
 ///
-/// The format is determined by `LANCE_VERSION_HINT_FORMAT` env var:
-/// - "json": Reads from latest_version_hint.json
-/// - "file_size" (default): Reads from latest_version_hint.bin (file size = version)
+/// The hint file is a JSON file containing `{"version": N}`.
 async fn read_version_from_hint(object_store: &ObjectStore, base: &Path) -> Option<u64> {
     let hint_path = version_hint_path(base);
-
-    if is_version_hint_json_format() {
-        // JSON format: read and parse the file content
-        let bytes = object_store.inner.get(&hint_path).await.ok()?;
-        let bytes = bytes.bytes().await.ok()?;
-        let text = std::str::from_utf8(&bytes).ok()?;
-        parse_version_from_json(text)
-    } else {
-        // File-size format: version = file size in bytes
-        let meta = object_store.inner.head(&hint_path).await.ok()?;
-        Some(meta.size as u64)
-    }
+    let bytes = object_store.inner.get(&hint_path).await.ok()?;
+    let bytes = bytes.bytes().await.ok()?;
+    let text = std::str::from_utf8(&bytes).ok()?;
+    parse_version_from_json(text)
 }
 
 /// Parse version number from JSON string like {"version": 123}
@@ -1002,16 +912,7 @@ pub trait CommitHandler: Debug + Send + Sync {
                 .boxed();
         }
 
-        // For non-lexically ordered stores, try version hint optimization if enabled
-        if !is_version_hint_enabled() {
-            // Fall back to full listing with filter
-            return self
-                .list_manifest_locations(base_path, object_store, true)
-                .try_take_while(move |loc| future::ready(Ok(loc.version > since_version)))
-                .boxed();
-        }
-
-        // Use version hint optimization
+        // Use version hint optimization for non-lexically ordered stores
         let base_path = base_path.clone();
         let object_store_clone = object_store.clone();
 
@@ -1045,6 +946,10 @@ pub trait CommitHandler: Debug + Send + Sync {
     ///
     /// This function should return an [CommitError::CommitConflict] if another
     /// transaction has already been committed to the path.
+    ///
+    /// The `sync_version_hint_write` parameter controls whether to wait for the
+    /// version hint write to complete before returning. When `true`, adds ~10ms
+    /// latency but guarantees the hint is available for immediate reads.
     async fn commit(
         &self,
         manifest: &mut Manifest,
@@ -1054,6 +959,7 @@ pub trait CommitHandler: Debug + Send + Sync {
         manifest_writer: ManifestWriter,
         naming_scheme: ManifestNamingScheme,
         transaction: Option<Transaction>,
+        sync_version_hint_write: bool,
     ) -> std::result::Result<ManifestLocation, CommitError>;
 
     /// Delete the recorded manifest information for a dataset at the base_path
@@ -1324,6 +1230,7 @@ impl CommitHandler for UnsafeCommitHandler {
         manifest_writer: ManifestWriter,
         naming_scheme: ManifestNamingScheme,
         transaction: Option<Transaction>,
+        sync_version_hint_write: bool,
     ) -> std::result::Result<ManifestLocation, CommitError> {
         // Log a one-time warning
         if !WARNED_ON_UNSAFE_COMMIT.load(std::sync::atomic::Ordering::Relaxed) {
@@ -1338,8 +1245,12 @@ impl CommitHandler for UnsafeCommitHandler {
         let res =
             manifest_writer(object_store, manifest, indices, &version_path, transaction).await?;
 
-        // Write version hint (fire-and-forget, spawned as background task)
-        write_version_hint(object_store, base_path, manifest.version);
+        write_version_hint(
+            object_store,
+            base_path,
+            manifest.version,
+            sync_version_hint_write,
+        );
 
         Ok(ManifestLocation {
             version: manifest.version,
@@ -1394,6 +1305,7 @@ impl<T: CommitLock + Send + Sync> CommitHandler for T {
         manifest_writer: ManifestWriter,
         naming_scheme: ManifestNamingScheme,
         transaction: Option<Transaction>,
+        sync_version_hint_write: bool,
     ) -> std::result::Result<ManifestLocation, CommitError> {
         let path = naming_scheme.manifest_path(base_path, manifest.version);
         // NOTE: once we have the lease we cannot use ? to return errors, since
@@ -1425,8 +1337,12 @@ impl<T: CommitLock + Send + Sync> CommitHandler for T {
 
         let res = res?;
 
-        // Write version hint (fire-and-forget, spawned as background task)
-        write_version_hint(object_store, base_path, manifest.version);
+        write_version_hint(
+            object_store,
+            base_path,
+            manifest.version,
+            sync_version_hint_write,
+        );
 
         Ok(ManifestLocation {
             version: manifest.version,
@@ -1449,6 +1365,7 @@ impl<T: CommitLock + Send + Sync> CommitHandler for Arc<T> {
         manifest_writer: ManifestWriter,
         naming_scheme: ManifestNamingScheme,
         transaction: Option<Transaction>,
+        sync_version_hint_write: bool,
     ) -> std::result::Result<ManifestLocation, CommitError> {
         self.as_ref()
             .commit(
@@ -1459,6 +1376,7 @@ impl<T: CommitLock + Send + Sync> CommitHandler for Arc<T> {
                 manifest_writer,
                 naming_scheme,
                 transaction,
+                sync_version_hint_write,
             )
             .await
     }
@@ -1480,6 +1398,7 @@ impl CommitHandler for RenameCommitHandler {
         manifest_writer: ManifestWriter,
         naming_scheme: ManifestNamingScheme,
         transaction: Option<Transaction>,
+        sync_version_hint_write: bool,
     ) -> std::result::Result<ManifestLocation, CommitError> {
         // Create a temporary object, then use `rename_if_not_exists` to commit.
         // If failed, clean up the temporary object.
@@ -1495,8 +1414,12 @@ impl CommitHandler for RenameCommitHandler {
             .await
         {
             Ok(_) => {
-                // Write version hint (fire-and-forget, spawned as background task)
-                write_version_hint(object_store, base_path, manifest.version);
+                write_version_hint(
+                    object_store,
+                    base_path,
+                    manifest.version,
+                    sync_version_hint_write,
+                );
 
                 // Successfully committed
                 Ok(ManifestLocation {
@@ -1541,6 +1464,7 @@ impl CommitHandler for ConditionalPutCommitHandler {
         manifest_writer: ManifestWriter,
         naming_scheme: ManifestNamingScheme,
         transaction: Option<Transaction>,
+        sync_version_hint_write: bool,
     ) -> std::result::Result<ManifestLocation, CommitError> {
         let path = naming_scheme.manifest_path(base_path, manifest.version);
 
@@ -1574,8 +1498,12 @@ impl CommitHandler for ConditionalPutCommitHandler {
                 _ => CommitError::OtherError(err.into()),
             })?;
 
-        // Write version hint (fire-and-forget, spawned as background task)
-        write_version_hint(object_store, base_path, manifest.version);
+        write_version_hint(
+            object_store,
+            base_path,
+            manifest.version,
+            sync_version_hint_write,
+        );
 
         Ok(ManifestLocation {
             version: manifest.version,
@@ -1597,6 +1525,15 @@ impl Debug for ConditionalPutCommitHandler {
 pub struct CommitConfig {
     pub num_retries: u32,
     pub skip_auto_cleanup: bool,
+    /// Whether to wait for the version hint write to complete before returning.
+    ///
+    /// When `true`, the commit will block until the version hint is written.
+    /// This adds ~10ms latency on S3 Express but guarantees the hint is available
+    /// for immediate reads.
+    ///
+    /// When `false` (default), the version hint is written asynchronously in the
+    /// background, allowing the commit to return immediately.
+    pub sync_version_hint_write: bool,
     // TODO: add isolation_level
 }
 
@@ -1605,6 +1542,7 @@ impl Default for CommitConfig {
         Self {
             num_retries: 20,
             skip_auto_cleanup: false,
+            sync_version_hint_write: false,
         }
     }
 }

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -98,9 +98,22 @@ const VERSION_HINT_FORMAT_ENV_VAR: &str = "LANCE_VERSION_HINT_FORMAT";
 /// When enabled, the load path will ONLY use hint+HEAD, no listing fallback race.
 const HINT_ONLY_ENV_VAR: &str = "LANCE_HINT_ONLY";
 
+/// Environment variable to enable connection warmup before load operations.
+/// Set to "1" or "true" to make a warmup HEAD request before hint/listing race.
+/// This reduces cold connection overhead from ~100ms to ~60ms for fresh sessions.
+const CONNECTION_WARMUP_ENV_VAR: &str = "LANCE_CONNECTION_WARMUP";
+
 /// Check if hint-only mode is enabled (no racing with listing).
 fn is_hint_only_mode() -> bool {
     match std::env::var(HINT_ONLY_ENV_VAR) {
+        Ok(val) => matches!(val.to_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+        Err(_) => false,
+    }
+}
+
+/// Check if connection warmup is enabled.
+fn is_connection_warmup_enabled() -> bool {
+    match std::env::var(CONNECTION_WARMUP_ENV_VAR) {
         Ok(val) => matches!(val.to_lowercase().as_str(), "1" | "true" | "yes" | "on"),
         Err(_) => false,
     }
@@ -354,6 +367,16 @@ async fn current_manifest_path(
             result.as_ref().map(|l| l.version).unwrap_or(0)
         );
         return result;
+    }
+
+    // Connection warmup: make a cheap HEAD request to establish connection
+    // This reduces cold connection overhead from ~100ms to ~60ms for fresh sessions
+    if is_connection_warmup_enabled() {
+        let warmup_path = version_hint_path(base);
+        let warmup_start = std::time::Instant::now();
+        // Just make the request, ignore the result (we only care about warming up the connection)
+        let _ = object_store.inner.head(&warmup_path).await;
+        eprintln!("[WARMUP] connection warmed: {:?}", warmup_start.elapsed());
     }
 
     // Hint-only mode: no racing, purely hint+HEAD approach

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -93,19 +93,6 @@ const VERSION_HINT_WRITE_MODE_ENV_VAR: &str = "LANCE_VERSION_HINT_WRITE_MODE";
 /// Set to "file_size" (default) to use file-size encoding (file size = version number).
 const VERSION_HINT_FORMAT_ENV_VAR: &str = "LANCE_VERSION_HINT_FORMAT";
 
-/// Environment variable to enable hint-only mode (no racing with listing).
-/// Set to "1" or "true" to enable hint-only mode for debugging/benchmarking.
-/// When enabled, the load path will ONLY use hint+HEAD, no listing fallback race.
-const HINT_ONLY_ENV_VAR: &str = "LANCE_HINT_ONLY";
-
-/// Check if hint-only mode is enabled (no racing with listing).
-fn is_hint_only_mode() -> bool {
-    match std::env::var(HINT_ONLY_ENV_VAR) {
-        Ok(val) => matches!(val.to_lowercase().as_str(), "1" | "true" | "yes" | "on"),
-        Err(_) => false,
-    }
-}
-
 /// Check if version hint writes should be synchronous (blocking).
 fn is_version_hint_sync_write() -> bool {
     match std::env::var(VERSION_HINT_WRITE_MODE_ENV_VAR) {
@@ -344,16 +331,6 @@ async fn current_manifest_path(
 
     // Check if version hint is disabled via environment variable
     if !is_version_hint_enabled() {
-        return resolve_version_from_listing(object_store, base).await;
-    }
-
-    // Hint-only mode: no racing, purely hint+HEAD approach
-    // This is for debugging/benchmarking to isolate hint performance from racing overhead
-    if is_hint_only_mode() {
-        if let Some(location) = read_version_hint_and_probe(object_store, base).await {
-            return Ok(location);
-        }
-        // Hint failed, fall back to listing (no racing)
         return resolve_version_from_listing(object_store, base).await;
     }
 

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -603,21 +603,33 @@ async fn read_version_hint_and_probe(
     // Read version from hint file (format determined by env var)
     let mut current_version = read_version_from_hint(object_store, base).await?;
     let hint_read_time = start.elapsed();
+    eprintln!("[HINT_READ_DONE] hint_read={:?}, version={}", hint_read_time, current_version);
 
     // Try V2 scheme first (more likely for newer datasets)
     let mut scheme = ManifestNamingScheme::V2;
 
     // Verify the hinted version exists
     let manifest_path = scheme.manifest_path(base, current_version);
+    let verify_start = std::time::Instant::now();
     let manifest_meta = match object_store.inner.head(&manifest_path).await {
-        Ok(meta) => Some(meta),
+        Ok(meta) => {
+            eprintln!("[VERIFY_HEAD] v={}, found, {:?}", current_version, verify_start.elapsed());
+            Some(meta)
+        }
         Err(ObjectStoreError::NotFound { .. }) => {
+            eprintln!("[VERIFY_HEAD] v={}, not_found_v2, {:?}", current_version, verify_start.elapsed());
             // Try V1 scheme
             scheme = ManifestNamingScheme::V1;
             let manifest_path = scheme.manifest_path(base, current_version);
-            object_store.inner.head(&manifest_path).await.ok()
+            let v1_start = std::time::Instant::now();
+            let result = object_store.inner.head(&manifest_path).await.ok();
+            eprintln!("[VERIFY_HEAD] v={}, v1_fallback={:?}, {:?}", current_version, result.is_some(), v1_start.elapsed());
+            result
         }
-        Err(_) => None,
+        Err(e) => {
+            eprintln!("[VERIFY_HEAD] v={}, error={:?}, {:?}", current_version, e, verify_start.elapsed());
+            None
+        }
     };
     let verify_time = start.elapsed();
 

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -320,6 +320,8 @@ async fn current_manifest_path(
     object_store: &ObjectStore,
     base: &Path,
 ) -> Result<ManifestLocation> {
+    let start = std::time::Instant::now();
+
     // Fast path for local filesystem
     if object_store.is_local() {
         if let Ok(Some(location)) = current_manifest_local(base) {
@@ -329,7 +331,13 @@ async fn current_manifest_path(
 
     // Check if version hint is disabled via environment variable
     if !is_version_hint_enabled() {
-        return resolve_version_from_listing(object_store, base).await;
+        let result = resolve_version_from_listing(object_store, base).await;
+        eprintln!(
+            "[LOAD] no hint, listing only: {:?}, version={}",
+            start.elapsed(),
+            result.as_ref().map(|l| l.version).unwrap_or(0)
+        );
+        return result;
     }
 
     // Race hint-based and listing-based approaches
@@ -340,14 +348,30 @@ async fn current_manifest_path(
         // Try hint-based approach first (biased because it's usually faster)
         hint_result = read_version_hint_and_probe(object_store, base) => {
             if let Some(location) = hint_result {
+                eprintln!(
+                    "[LOAD] hint won: {:?}, version={}",
+                    start.elapsed(),
+                    location.version
+                );
                 return Ok(location);
             }
             // Hint failed, fall back to listing
-            resolve_version_from_listing(object_store, base).await
+            let result = resolve_version_from_listing(object_store, base).await;
+            eprintln!(
+                "[LOAD] hint failed, listing fallback: {:?}, version={}",
+                start.elapsed(),
+                result.as_ref().map(|l| l.version).unwrap_or(0)
+            );
+            result
         }
 
         // Listing approach as backup
         list_result = resolve_version_from_listing(object_store, base) => {
+            eprintln!(
+                "[LOAD] listing won: {:?}, version={}",
+                start.elapsed(),
+                list_result.as_ref().map(|l| l.version).unwrap_or(0)
+            );
             list_result
         }
     }
@@ -510,17 +534,32 @@ pub async fn write_version_hint_blocking(object_store: &ObjectStore, base: &Path
 /// - "file_size" (default): Reads from latest_version_hint.bin (file size = version)
 async fn read_version_from_hint(object_store: &ObjectStore, base: &Path) -> Option<u64> {
     let hint_path = version_hint_path(base);
+    let start = std::time::Instant::now();
 
     if is_version_hint_json_format() {
         // JSON format: read and parse the file content
         let bytes = object_store.inner.get(&hint_path).await.ok()?;
+        let get_time = start.elapsed();
         let bytes = bytes.bytes().await.ok()?;
         let text = std::str::from_utf8(&bytes).ok()?;
-        parse_version_from_json(text)
+        let version = parse_version_from_json(text);
+        eprintln!(
+            "[HINT_READ] json, get={:?}, total={:?}, version={:?}",
+            get_time,
+            start.elapsed(),
+            version
+        );
+        version
     } else {
         // File-size format: version = file size in bytes
         let meta = object_store.inner.head(&hint_path).await.ok()?;
-        Some(meta.size as u64)
+        let version = meta.size as u64;
+        eprintln!(
+            "[HINT_READ] file_size, head={:?}, version={}",
+            start.elapsed(),
+            version
+        );
+        Some(version)
     }
 }
 
@@ -559,8 +598,11 @@ async fn read_version_hint_and_probe(
     object_store: &ObjectStore,
     base: &Path,
 ) -> Option<ManifestLocation> {
+    let start = std::time::Instant::now();
+
     // Read version from hint file (format determined by env var)
     let mut current_version = read_version_from_hint(object_store, base).await?;
+    let hint_read_time = start.elapsed();
 
     // Try V2 scheme first (more likely for newer datasets)
     let mut scheme = ManifestNamingScheme::V2;
@@ -577,23 +619,45 @@ async fn read_version_hint_and_probe(
         }
         Err(_) => None,
     };
+    let verify_time = start.elapsed();
 
     // If the hinted version doesn't exist, the hint is stale/invalid
     let mut last_meta = manifest_meta?;
 
     // Probe for higher versions
+    let mut probe_count = 0;
+    let probe_start = std::time::Instant::now();
     loop {
         let next_version = current_version + 1;
         let next_path = scheme.manifest_path(base, next_version);
+        let head_start = std::time::Instant::now();
         match object_store.inner.head(&next_path).await {
             Ok(meta) => {
+                eprintln!("[PROBE_HEAD] v={}, found, {:?}", next_version, head_start.elapsed());
                 current_version = next_version;
                 last_meta = meta;
+                probe_count += 1;
             }
-            Err(ObjectStoreError::NotFound { .. }) => break,
-            Err(_) => break,
+            Err(ObjectStoreError::NotFound { .. }) => {
+                eprintln!("[PROBE_HEAD] v={}, not_found, {:?}", next_version, head_start.elapsed());
+                break;
+            }
+            Err(_) => {
+                eprintln!("[PROBE_HEAD] v={}, error, {:?}", next_version, head_start.elapsed());
+                break;
+            }
         }
     }
+
+    eprintln!(
+        "[HINT_PROBE] hint_read={:?}, verify={:?}, probe={:?}, total={:?}, probe_count={}, version={}",
+        hint_read_time,
+        verify_time - hint_read_time,
+        probe_start.elapsed(),
+        start.elapsed(),
+        probe_count,
+        current_version
+    );
 
     Some(ManifestLocation {
         version: current_version,
@@ -768,6 +832,7 @@ async fn resolve_version_from_listing(
     object_store: &ObjectStore,
     base: &Path,
 ) -> Result<ManifestLocation> {
+    let list_start = std::time::Instant::now();
     let manifest_files = object_store.list(Some(base.child(VERSIONS_DIR)));
 
     let mut valid_manifests = manifest_files.try_filter_map(|res| {
@@ -780,6 +845,7 @@ async fn resolve_version_from_listing(
     });
 
     let first = valid_manifests.next().await.transpose()?;
+    let first_item_time = list_start.elapsed();
     match (first, object_store.list_is_lexically_ordered) {
         // If the first valid manifest we see is V2, we can assume that we are using
         // V2 naming scheme for all manifests.
@@ -812,6 +878,12 @@ async fn resolve_version_from_listing(
                 }
             }
 
+            eprintln!(
+                "[LIST] lexical, first_item={:?}, total={:?}, version={}",
+                first_item_time,
+                list_start.elapsed(),
+                version
+            );
             Ok(ManifestLocation {
                 version,
                 path: meta.location,
@@ -828,8 +900,10 @@ async fn resolve_version_from_listing(
                 .unwrap();
             let mut current_meta = meta;
             let scheme = first_scheme;
+            let mut count = 1;
 
             while let Some((entry_scheme, meta)) = valid_manifests.next().await.transpose()? {
+                count += 1;
                 if entry_scheme != scheme {
                     return Err(Error::Internal {
                         message: format!(
@@ -848,6 +922,13 @@ async fn resolve_version_from_listing(
                     current_meta = meta;
                 }
             }
+            eprintln!(
+                "[LIST] non-lexical, first_item={:?}, total={:?}, count={}, version={}",
+                first_item_time,
+                list_start.elapsed(),
+                count,
+                current_version
+            );
             Ok(ManifestLocation {
                 version: current_version,
                 path: current_meta.location,

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -552,6 +552,7 @@ async fn read_version_from_hint(object_store: &ObjectStore, base: &Path) -> Opti
         version
     } else {
         // File-size format: version = file size in bytes
+        eprintln!("[HINT_READ_START] file_size, path={}", hint_path);
         let meta = object_store.inner.head(&hint_path).await.ok()?;
         let version = meta.size as u64;
         eprintln!(
@@ -844,6 +845,7 @@ async fn resolve_version_from_listing(
     object_store: &ObjectStore,
     base: &Path,
 ) -> Result<ManifestLocation> {
+    eprintln!("[LIST_START] versions_dir={}", base.child(VERSIONS_DIR));
     let list_start = std::time::Instant::now();
     let manifest_files = object_store.list(Some(base.child(VERSIONS_DIR)));
 

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -93,6 +93,19 @@ const VERSION_HINT_WRITE_MODE_ENV_VAR: &str = "LANCE_VERSION_HINT_WRITE_MODE";
 /// Set to "file_size" (default) to use file-size encoding (file size = version number).
 const VERSION_HINT_FORMAT_ENV_VAR: &str = "LANCE_VERSION_HINT_FORMAT";
 
+/// Environment variable to enable hint-only mode (no racing with listing).
+/// Set to "1" or "true" to enable hint-only mode for debugging/benchmarking.
+/// When enabled, the load path will ONLY use hint+HEAD, no listing fallback race.
+const HINT_ONLY_ENV_VAR: &str = "LANCE_HINT_ONLY";
+
+/// Check if hint-only mode is enabled (no racing with listing).
+fn is_hint_only_mode() -> bool {
+    match std::env::var(HINT_ONLY_ENV_VAR) {
+        Ok(val) => matches!(val.to_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+        Err(_) => false,
+    }
+}
+
 /// Check if version hint writes should be synchronous (blocking).
 fn is_version_hint_sync_write() -> bool {
     match std::env::var(VERSION_HINT_WRITE_MODE_ENV_VAR) {
@@ -318,6 +331,7 @@ impl TryFrom<object_store::ObjectMeta> for ManifestLocation {
 ///
 /// The version hint optimization can be disabled by setting the environment
 /// variable `LANCE_USE_VERSION_HINT=0` (or "false", "no", "off").
+#[allow(clippy::print_stderr)]
 async fn current_manifest_path(
     object_store: &ObjectStore,
     base: &Path,
@@ -336,6 +350,28 @@ async fn current_manifest_path(
         let result = resolve_version_from_listing(object_store, base).await;
         eprintln!(
             "[LOAD] no hint, listing only: {:?}, version={}",
+            start.elapsed(),
+            result.as_ref().map(|l| l.version).unwrap_or(0)
+        );
+        return result;
+    }
+
+    // Hint-only mode: no racing, purely hint+HEAD approach
+    // This is for debugging/benchmarking to isolate hint performance from racing overhead
+    if is_hint_only_mode() {
+        eprintln!("[LOAD] hint-only mode enabled");
+        if let Some(location) = read_version_hint_and_probe(object_store, base).await {
+            eprintln!(
+                "[LOAD] hint-only success: {:?}, version={}",
+                start.elapsed(),
+                location.version
+            );
+            return Ok(location);
+        }
+        // Hint failed, fall back to listing (no racing)
+        let result = resolve_version_from_listing(object_store, base).await;
+        eprintln!(
+            "[LOAD] hint-only failed, listing fallback: {:?}, version={}",
             start.elapsed(),
             result.as_ref().map(|l| l.version).unwrap_or(0)
         );
@@ -534,6 +570,7 @@ pub async fn write_version_hint_blocking(object_store: &ObjectStore, base: &Path
 /// The format is determined by `LANCE_VERSION_HINT_FORMAT` env var:
 /// - "json": Reads from latest_version_hint.json
 /// - "file_size" (default): Reads from latest_version_hint.bin (file size = version)
+#[allow(clippy::print_stderr)]
 async fn read_version_from_hint(object_store: &ObjectStore, base: &Path) -> Option<u64> {
     let hint_path = version_hint_path(base);
     let start = std::time::Instant::now();
@@ -554,7 +591,11 @@ async fn read_version_from_hint(object_store: &ObjectStore, base: &Path) -> Opti
         version
     } else {
         // File-size format: version = file size in bytes
-        eprintln!("[HINT_READ_START] file_size, path={}, at={:?}", hint_path, start.elapsed());
+        eprintln!(
+            "[HINT_READ_START] file_size, path={}, at={:?}",
+            hint_path,
+            start.elapsed()
+        );
         let head_start = std::time::Instant::now();
         let meta = object_store.inner.head(&hint_path).await.ok()?;
         let version = meta.size as u64;
@@ -599,6 +640,7 @@ fn parse_version_from_json(json: &str) -> Option<u64> {
 /// 1. Reads the hint file to get the version hint (file size or JSON content)
 /// 2. Probes version+1, version+2, etc. with HEAD requests until not found
 /// 3. Returns the highest version found
+#[allow(clippy::print_stderr)]
 async fn read_version_hint_and_probe(
     object_store: &ObjectStore,
     base: &Path,
@@ -608,7 +650,10 @@ async fn read_version_hint_and_probe(
     // Read version from hint file (format determined by env var)
     let mut current_version = read_version_from_hint(object_store, base).await?;
     let hint_read_time = start.elapsed();
-    eprintln!("[HINT_READ_DONE] hint_read={:?}, version={}", hint_read_time, current_version);
+    eprintln!(
+        "[HINT_READ_DONE] hint_read={:?}, version={}",
+        hint_read_time, current_version
+    );
 
     // Try V2 scheme first (more likely for newer datasets)
     let mut scheme = ManifestNamingScheme::V2;
@@ -618,21 +663,39 @@ async fn read_version_hint_and_probe(
     let verify_start = std::time::Instant::now();
     let manifest_meta = match object_store.inner.head(&manifest_path).await {
         Ok(meta) => {
-            eprintln!("[VERIFY_HEAD] v={}, found, {:?}", current_version, verify_start.elapsed());
+            eprintln!(
+                "[VERIFY_HEAD] v={}, found, {:?}",
+                current_version,
+                verify_start.elapsed()
+            );
             Some(meta)
         }
         Err(ObjectStoreError::NotFound { .. }) => {
-            eprintln!("[VERIFY_HEAD] v={}, not_found_v2, {:?}", current_version, verify_start.elapsed());
+            eprintln!(
+                "[VERIFY_HEAD] v={}, not_found_v2, {:?}",
+                current_version,
+                verify_start.elapsed()
+            );
             // Try V1 scheme
             scheme = ManifestNamingScheme::V1;
             let manifest_path = scheme.manifest_path(base, current_version);
             let v1_start = std::time::Instant::now();
             let result = object_store.inner.head(&manifest_path).await.ok();
-            eprintln!("[VERIFY_HEAD] v={}, v1_fallback={:?}, {:?}", current_version, result.is_some(), v1_start.elapsed());
+            eprintln!(
+                "[VERIFY_HEAD] v={}, v1_fallback={:?}, {:?}",
+                current_version,
+                result.is_some(),
+                v1_start.elapsed()
+            );
             result
         }
         Err(e) => {
-            eprintln!("[VERIFY_HEAD] v={}, error={:?}, {:?}", current_version, e, verify_start.elapsed());
+            eprintln!(
+                "[VERIFY_HEAD] v={}, error={:?}, {:?}",
+                current_version,
+                e,
+                verify_start.elapsed()
+            );
             None
         }
     };
@@ -650,17 +713,29 @@ async fn read_version_hint_and_probe(
         let head_start = std::time::Instant::now();
         match object_store.inner.head(&next_path).await {
             Ok(meta) => {
-                eprintln!("[PROBE_HEAD] v={}, found, {:?}", next_version, head_start.elapsed());
+                eprintln!(
+                    "[PROBE_HEAD] v={}, found, {:?}",
+                    next_version,
+                    head_start.elapsed()
+                );
                 current_version = next_version;
                 last_meta = meta;
                 probe_count += 1;
             }
             Err(ObjectStoreError::NotFound { .. }) => {
-                eprintln!("[PROBE_HEAD] v={}, not_found, {:?}", next_version, head_start.elapsed());
+                eprintln!(
+                    "[PROBE_HEAD] v={}, not_found, {:?}",
+                    next_version,
+                    head_start.elapsed()
+                );
                 break;
             }
             Err(_) => {
-                eprintln!("[PROBE_HEAD] v={}, error, {:?}", next_version, head_start.elapsed());
+                eprintln!(
+                    "[PROBE_HEAD] v={}, error, {:?}",
+                    next_version,
+                    head_start.elapsed()
+                );
                 break;
             }
         }
@@ -845,6 +920,7 @@ async fn list_manifests_since_version_with_hint(
 /// Resolve the latest version from listing.
 ///
 /// This is the traditional approach that lists all manifests and finds the highest version.
+#[allow(clippy::print_stderr)]
 async fn resolve_version_from_listing(
     object_store: &ObjectStore,
     base: &Path,

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -70,15 +70,44 @@ use {
 pub const VERSIONS_DIR: &str = "_versions";
 const MANIFEST_EXTENSION: &str = "manifest";
 const DETACHED_VERSION_PREFIX: &str = "d";
-/// File name for the version hint file.
+/// File name for the version hint file (file-size encoding).
 /// The file size in bytes indicates the latest version number.
 /// This enables O(1) latest version lookup via HEAD request on object stores
 /// where listing is not lexicographically ordered (e.g., S3 Express).
 const VERSION_HINT_FILE: &str = "latest_version_hint.bin";
 
+/// File name for the JSON-based version hint file.
+const VERSION_HINT_JSON_FILE: &str = "latest_version_hint.json";
+
 /// Environment variable to enable/disable version hint optimization.
 /// Set to "0" or "false" to disable, any other value (or unset) to enable.
 const VERSION_HINT_ENV_VAR: &str = "LANCE_USE_VERSION_HINT";
+
+/// Environment variable to control version hint write mode.
+/// Set to "sync" to wait for the write to complete (adds latency but guarantees write).
+/// Set to "async" (default) to spawn a background task and return immediately.
+const VERSION_HINT_WRITE_MODE_ENV_VAR: &str = "LANCE_VERSION_HINT_WRITE_MODE";
+
+/// Environment variable to control version hint encoding format.
+/// Set to "json" to use JSON encoding (writes version number as JSON).
+/// Set to "file_size" (default) to use file-size encoding (file size = version number).
+const VERSION_HINT_FORMAT_ENV_VAR: &str = "LANCE_VERSION_HINT_FORMAT";
+
+/// Check if version hint writes should be synchronous (blocking).
+fn is_version_hint_sync_write() -> bool {
+    match std::env::var(VERSION_HINT_WRITE_MODE_ENV_VAR) {
+        Ok(val) => val.to_lowercase() == "sync",
+        Err(_) => false, // Default to async (fire-and-forget)
+    }
+}
+
+/// Check if version hint should use JSON format.
+fn is_version_hint_json_format() -> bool {
+    match std::env::var(VERSION_HINT_FORMAT_ENV_VAR) {
+        Ok(val) => val.to_lowercase() == "json",
+        Err(_) => false, // Default to file-size encoding
+    }
+}
 
 /// Check if version hint optimization is enabled via environment variable.
 fn is_version_hint_enabled() -> bool {
@@ -391,19 +420,72 @@ fn current_manifest_local(base: &Path) -> std::io::Result<Option<ManifestLocatio
 
 /// Get the path to the version hint file.
 fn version_hint_path(base: &Path) -> Path {
-    base.child(VERSIONS_DIR).child(VERSION_HINT_FILE)
+    let filename = if is_version_hint_json_format() {
+        VERSION_HINT_JSON_FILE
+    } else {
+        VERSION_HINT_FILE
+    };
+    base.child(VERSIONS_DIR).child(filename)
 }
 
 /// Write the version hint file after a successful commit.
 ///
-/// The file size in bytes indicates the latest version number.
+/// The encoding format depends on `LANCE_VERSION_HINT_FORMAT`:
+/// - "file_size" (default): File size in bytes indicates the version number
+/// - "json": JSON file containing `{"version": N}`
+///
+/// The write mode depends on `LANCE_VERSION_HINT_WRITE_MODE`:
+/// - "async" (default): Spawns a background task and returns immediately (fire-and-forget)
+/// - "sync": Spawns a background task and waits for it to complete before returning
+///
 /// This write is optimistic and failures are logged but ignored,
 /// as the hint is only used to accelerate reads, not for correctness.
-pub async fn write_version_hint(object_store: &ObjectStore, base: &Path, version: u64) {
+pub fn write_version_hint(object_store: &ObjectStore, base: &Path, version: u64) {
+    if !is_version_hint_enabled() {
+        return;
+    }
     let hint_path = version_hint_path(base);
-    // Create a file with `version` bytes (all zeros)
-    let content = vec![0u8; version as usize];
-    if let Err(e) = object_store.put(&hint_path, content.as_slice()).await {
+    let use_json = is_version_hint_json_format();
+    let object_store = object_store.clone();
+
+    let handle = tokio::spawn(async move {
+        write_version_hint_inner(&object_store, &hint_path, version, use_json).await;
+    });
+
+    if is_version_hint_sync_write() {
+        // Synchronous write - block until the spawned task completes
+        // Use block_in_place to avoid blocking the async runtime
+        let _ = tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(handle));
+    }
+    // Otherwise fire-and-forget: the spawned task runs in the background
+}
+
+/// Async version of write_version_hint that can be awaited.
+/// Use this when you need to ensure the write completes before proceeding.
+pub async fn write_version_hint_async(object_store: &ObjectStore, base: &Path, version: u64) {
+    if !is_version_hint_enabled() {
+        return;
+    }
+    let hint_path = version_hint_path(base);
+    let use_json = is_version_hint_json_format();
+    write_version_hint_inner(object_store, &hint_path, version, use_json).await;
+}
+
+async fn write_version_hint_inner(
+    object_store: &ObjectStore,
+    hint_path: &Path,
+    version: u64,
+    use_json: bool,
+) {
+    let content = if use_json {
+        // JSON format: {"version": N}
+        format!("{{\"version\":{}}}", version).into_bytes()
+    } else {
+        // File-size format: file with `version` zero bytes
+        vec![0u8; version as usize]
+    };
+
+    if let Err(e) = object_store.put(hint_path, content.as_slice()).await {
         // Log but don't fail - the hint is optional for correctness
         warn!(
             "Failed to write version hint file for version {}: {}",
@@ -412,24 +494,73 @@ pub async fn write_version_hint(object_store: &ObjectStore, base: &Path, version
     }
 }
 
+/// Blocking version of write_version_hint for tests.
+/// This waits for the write to complete before returning.
+#[cfg(test)]
+pub async fn write_version_hint_blocking(object_store: &ObjectStore, base: &Path, version: u64) {
+    let hint_path = version_hint_path(base);
+    let use_json = is_version_hint_json_format();
+    write_version_hint_inner(object_store, &hint_path, version, use_json).await;
+}
+
+/// Read the version from the hint file.
+///
+/// The format is determined by `LANCE_VERSION_HINT_FORMAT` env var:
+/// - "json": Reads from latest_version_hint.json
+/// - "file_size" (default): Reads from latest_version_hint.bin (file size = version)
+async fn read_version_from_hint(object_store: &ObjectStore, base: &Path) -> Option<u64> {
+    let hint_path = version_hint_path(base);
+
+    if is_version_hint_json_format() {
+        // JSON format: read and parse the file content
+        let bytes = object_store.inner.get(&hint_path).await.ok()?;
+        let bytes = bytes.bytes().await.ok()?;
+        let text = std::str::from_utf8(&bytes).ok()?;
+        parse_version_from_json(text)
+    } else {
+        // File-size format: version = file size in bytes
+        let meta = object_store.inner.head(&hint_path).await.ok()?;
+        Some(meta.size as u64)
+    }
+}
+
+/// Parse version number from JSON string like {"version": 123}
+fn parse_version_from_json(json: &str) -> Option<u64> {
+    // Simple parsing: find "version": and extract the number
+    let trimmed = json.trim();
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        // Look for "version" key
+        if let Some(idx) = trimmed.find("\"version\"") {
+            let after_key = &trimmed[idx + 9..]; // Skip "version"
+                                                 // Skip whitespace and colon
+            let after_colon = after_key.trim_start().strip_prefix(':')?;
+            let num_start = after_colon.trim_start();
+            // Extract digits
+            let num_end = num_start
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(num_start.len());
+            let num_str = &num_start[..num_end];
+            return num_str.parse().ok();
+        }
+    }
+    None
+}
+
 /// Read the version hint and probe for higher versions.
 ///
 /// Returns the latest version found and its manifest path, or None if the hint
 /// file doesn't exist or an error occurred.
 ///
 /// This function:
-/// 1. HEAD request on the hint file to get the version hint (file size)
+/// 1. Reads the hint file to get the version hint (file size or JSON content)
 /// 2. Probes version+1, version+2, etc. with HEAD requests until not found
 /// 3. Returns the highest version found
 async fn read_version_hint_and_probe(
     object_store: &ObjectStore,
     base: &Path,
 ) -> Option<ManifestLocation> {
-    let hint_path = version_hint_path(base);
-
-    // Get the hint version from file size
-    let hint_meta = object_store.inner.head(&hint_path).await.ok()?;
-    let mut current_version = hint_meta.size as u64;
+    // Read version from hint file (format determined by env var)
+    let mut current_version = read_version_from_hint(object_store, base).await?;
 
     // Try V2 scheme first (more likely for newer datasets)
     let mut scheme = ManifestNamingScheme::V2;
@@ -988,8 +1119,8 @@ impl CommitHandler for UnsafeCommitHandler {
         let res =
             manifest_writer(object_store, manifest, indices, &version_path, transaction).await?;
 
-        // Write version hint (optimistic, failures are ignored)
-        write_version_hint(object_store, base_path, manifest.version).await;
+        // Write version hint (fire-and-forget, spawned as background task)
+        write_version_hint(object_store, base_path, manifest.version);
 
         Ok(ManifestLocation {
             version: manifest.version,
@@ -1075,8 +1206,8 @@ impl<T: CommitLock + Send + Sync> CommitHandler for T {
 
         let res = res?;
 
-        // Write version hint (optimistic, failures are ignored)
-        write_version_hint(object_store, base_path, manifest.version).await;
+        // Write version hint (fire-and-forget, spawned as background task)
+        write_version_hint(object_store, base_path, manifest.version);
 
         Ok(ManifestLocation {
             version: manifest.version,
@@ -1145,8 +1276,8 @@ impl CommitHandler for RenameCommitHandler {
             .await
         {
             Ok(_) => {
-                // Write version hint (optimistic, failures are ignored)
-                write_version_hint(object_store, base_path, manifest.version).await;
+                // Write version hint (fire-and-forget, spawned as background task)
+                write_version_hint(object_store, base_path, manifest.version);
 
                 // Successfully committed
                 Ok(ManifestLocation {
@@ -1224,8 +1355,8 @@ impl CommitHandler for ConditionalPutCommitHandler {
                 _ => CommitError::OtherError(err.into()),
             })?;
 
-        // Write version hint (optimistic, failures are ignored)
-        write_version_hint(object_store, base_path, manifest.version).await;
+        // Write version hint (fire-and-forget, spawned as background task)
+        write_version_hint(object_store, base_path, manifest.version);
 
         Ok(ManifestLocation {
             version: manifest.version,
@@ -1412,7 +1543,7 @@ mod tests {
         let base = Path::from("base");
 
         // Write version hint for version 42
-        write_version_hint(&object_store, &base, 42).await;
+        write_version_hint_blocking(&object_store, &base, 42).await;
 
         // Verify the hint file exists with correct size
         let hint_path = version_hint_path(&base);
@@ -1420,7 +1551,7 @@ mod tests {
         assert_eq!(meta.size, 42);
 
         // Write version hint for version 100 (overwrites previous)
-        write_version_hint(&object_store, &base, 100).await;
+        write_version_hint_blocking(&object_store, &base, 100).await;
         let meta = object_store.inner.head(&hint_path).await.unwrap();
         assert_eq!(meta.size, 100);
     }
@@ -1445,7 +1576,7 @@ mod tests {
         }
 
         // Write hint pointing to version 3 (stale hint)
-        write_version_hint(&object_store, &base, 3).await;
+        write_version_hint_blocking(&object_store, &base, 3).await;
 
         // Should probe and find version 5
         let location = read_version_hint_and_probe(&object_store, &base)
@@ -1455,7 +1586,7 @@ mod tests {
         assert_eq!(location.naming_scheme, naming_scheme);
 
         // Update hint to current version
-        write_version_hint(&object_store, &base, 5).await;
+        write_version_hint_blocking(&object_store, &base, 5).await;
 
         // Should return version 5 directly
         let location = read_version_hint_and_probe(&object_store, &base)
@@ -1480,7 +1611,7 @@ mod tests {
         }
 
         // Write hint pointing to version 98 (slightly stale)
-        write_version_hint(&object_store, &base, 98).await;
+        write_version_hint_blocking(&object_store, &base, 98).await;
 
         // Should find version 100 (probing from 98)
         let location = current_manifest_path(&object_store, &base).await.unwrap();
@@ -1499,7 +1630,7 @@ mod tests {
         object_store.put(&path, b"".as_slice()).await.unwrap();
 
         // Write hint pointing to version 10 (invalid - doesn't exist)
-        write_version_hint(&object_store, &base, 10).await;
+        write_version_hint_blocking(&object_store, &base, 10).await;
 
         // Hint should be ignored, should fall back to listing
         let mut object_store_clone = ObjectStore::memory();
@@ -1509,12 +1640,28 @@ mod tests {
         object_store_clone.put(&path, b"".as_slice()).await.unwrap();
 
         // Write the invalid hint
-        write_version_hint(&object_store_clone, &base, 10).await;
+        write_version_hint_blocking(&object_store_clone, &base, 10).await;
 
         // Should find version 5 via listing fallback
         let location = current_manifest_path(&object_store_clone, &base)
             .await
             .unwrap();
         assert_eq!(location.version, 5);
+    }
+
+    #[test]
+    fn test_parse_version_from_json() {
+        // Valid JSON formats
+        assert_eq!(parse_version_from_json(r#"{"version":42}"#), Some(42));
+        assert_eq!(parse_version_from_json(r#"{"version": 42}"#), Some(42));
+        assert_eq!(parse_version_from_json(r#"{ "version" : 42 }"#), Some(42));
+        assert_eq!(parse_version_from_json(r#"{"version":12345}"#), Some(12345));
+        assert_eq!(parse_version_from_json(r#"{"version": 0}"#), Some(0));
+
+        // Invalid JSON formats
+        assert_eq!(parse_version_from_json("not json"), None);
+        assert_eq!(parse_version_from_json(r#"{"other":42}"#), None);
+        assert_eq!(parse_version_from_json(""), None);
+        assert_eq!(parse_version_from_json(r#"{"version":"abc"}"#), None);
     }
 }

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -669,29 +669,34 @@ async fn list_manifests_since_version_with_hint(
     // Read version hint
     let hint_version = read_version_from_hint(object_store, base).await?;
 
-    // If hint is not newer than since_version, no new manifests
+    // If hint is not newer than since_version, check if there are any new versions
     if hint_version <= since_version {
-        // But there might be newer versions, so probe upward from since_version
-        let (_true_latest, scheme, probed) =
-            probe_versions_upward(object_store, base, since_version + 1).await?;
+        // Try to probe upward from since_version+1, but if nothing exists, return empty
+        match probe_versions_upward(object_store, base, since_version + 1).await {
+            Some((_true_latest, scheme, probed)) => {
+                // Filter to only versions > since_version and convert to ManifestLocations
+                let mut locations: Vec<ManifestLocation> = probed
+                    .into_iter()
+                    .filter(|(v, _)| *v > since_version)
+                    .map(|(version, meta)| ManifestLocation {
+                        version,
+                        path: scheme.manifest_path(base, version),
+                        size: Some(meta.size),
+                        naming_scheme: scheme,
+                        e_tag: meta.e_tag,
+                    })
+                    .collect();
 
-        // Filter to only versions > since_version and convert to ManifestLocations
-        let locations: Vec<ManifestLocation> = probed
-            .into_iter()
-            .filter(|(v, _)| *v > since_version)
-            .map(|(version, meta)| ManifestLocation {
-                version,
-                path: scheme.manifest_path(base, version),
-                size: Some(meta.size),
-                naming_scheme: scheme,
-                e_tag: meta.e_tag,
-            })
-            .collect();
-
-        // Sort descending
-        let mut locations = locations;
-        locations.sort_by_key(|loc| std::cmp::Reverse(loc.version));
-        return Some(locations);
+                // Sort descending
+                locations.sort_by_key(|loc| std::cmp::Reverse(loc.version));
+                return Some(locations);
+            }
+            None => {
+                // No versions exist after since_version, return empty list
+                // This is the FAST PATH - no new transactions!
+                return Some(Vec::new());
+            }
+        }
     }
 
     // Probe upward from hint to find true latest and collect metadata

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -592,12 +592,14 @@ async fn read_version_from_hint(object_store: &ObjectStore, base: &Path) -> Opti
         version
     } else {
         // File-size format: version = file size in bytes
-        eprintln!("[HINT_READ_START] file_size, path={}", hint_path);
+        eprintln!("[HINT_READ_START] file_size, path={}, at={:?}", hint_path, start.elapsed());
+        let head_start = std::time::Instant::now();
         let meta = object_store.inner.head(&hint_path).await.ok()?;
         let version = meta.size as u64;
         eprintln!(
-            "[HINT_READ] file_size, head={:?}, version={}",
+            "[HINT_READ] file_size, total={:?}, head_only={:?}, version={}",
             start.elapsed(),
+            head_start.elapsed(),
             version
         );
         Some(version)

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -472,6 +472,7 @@ impl CommitHandler for ExternalManifestCommitHandler {
         manifest_writer: super::ManifestWriter,
         naming_scheme: ManifestNamingScheme,
         transaction: Option<Transaction>,
+        sync_version_hint_write: bool,
     ) -> std::result::Result<ManifestLocation, CommitError> {
         // path we get here is the path to the manifest we want to write
         // use object_store.base_path.as_ref() for getting the root of the dataset
@@ -498,8 +499,12 @@ impl CommitHandler for ExternalManifestCommitHandler {
 
         match result {
             Ok(location) => {
-                // Write version hint (fire-and-forget, spawned as background task)
-                write_version_hint(object_store, base_path, manifest.version);
+                write_version_hint(
+                    object_store,
+                    base_path,
+                    manifest.version,
+                    sync_version_hint_write,
+                );
                 Ok(location)
             }
             Err(_) => {

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -498,8 +498,8 @@ impl CommitHandler for ExternalManifestCommitHandler {
 
         match result {
             Ok(location) => {
-                // Write version hint (optimistic, failures are ignored)
-                write_version_hint(object_store, base_path, manifest.version).await;
+                // Write version hint (fire-and-forget, spawned as background task)
+                write_version_hint(object_store, base_path, manifest.version);
                 Ok(location)
             }
             Err(_) => {

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -20,8 +20,8 @@ use snafu::location;
 use tracing::info;
 
 use super::{
-    current_manifest_path, default_resolve_version, make_staging_manifest_path, ManifestLocation,
-    ManifestNamingScheme, MANIFEST_EXTENSION,
+    current_manifest_path, default_resolve_version, make_staging_manifest_path, write_version_hint,
+    ManifestLocation, ManifestNamingScheme, MANIFEST_EXTENSION,
 };
 use crate::format::{IndexMetadata, Manifest, Transaction};
 use crate::io::commit::{CommitError, CommitHandler};
@@ -497,7 +497,11 @@ impl CommitHandler for ExternalManifestCommitHandler {
             .await;
 
         match result {
-            Ok(location) => Ok(location),
+            Ok(location) => {
+                // Write version hint (optimistic, failures are ignored)
+                write_version_hint(object_store, base_path, manifest.version).await;
+                Ok(location)
+            }
             Err(_) => {
                 // delete the staging manifest
                 match object_store.inner.delete(&staging_path).await {

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -193,5 +193,9 @@ harness = false
 name = "manifest_commit"
 harness = false
 
+[[bench]]
+name = "object_store_bench"
+harness = false
+
 [lints]
 workspace = true

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -189,5 +189,9 @@ harness = false
 name = "mem_wal_read"
 harness = false
 
+[[bench]]
+name = "manifest_commit"
+harness = false
+
 [lints]
 workspace = true

--- a/rust/lance/benches/manifest_commit.rs
+++ b/rust/lance/benches/manifest_commit.rs
@@ -237,6 +237,10 @@ fn bench_manifest_commit(c: &mut Criterion) {
             })
         };
 
+        // Small delay to let fire-and-forget hint write complete
+        // This avoids the hint write from previous commit interfering with load measurement
+        std::thread::sleep(std::time::Duration::from_millis(10));
+
         // Measure load time
         let load_time = if direct_checkout {
             // Direct checkout: use checkout_version which bypasses listing

--- a/rust/lance/benches/manifest_commit.rs
+++ b/rust/lance/benches/manifest_commit.rs
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Benchmark for manifest commit performance with many small fragments.
+//!
+//! This benchmark tests how performance degrades as the number of small fragments
+//! grows. Each fragment contains only 10 rows, and we measure both:
+//! - Commit time (write + manifest update)
+//! - Dataset load time (opening the manifest)
+//!
+//! ## Running against S3
+//!
+//! ```bash
+//! export AWS_DEFAULT_REGION=us-east-1
+//! export DATASET_PREFIX=s3://your-bucket/bench/manifest_commit
+//! export NUM_ITERATIONS=100
+//! cargo bench --bench manifest_commit
+//! ```
+//!
+//! ## Running against local filesystem (with temp directory)
+//!
+//! ```bash
+//! cargo bench --bench manifest_commit
+//! ```
+//!
+//! ## Running against specific local directory
+//!
+//! ```bash
+//! export DATASET_PREFIX=/tmp/bench/manifest_commit
+//! export NUM_ITERATIONS=50
+//! cargo bench --bench manifest_commit
+//! ```
+//!
+//! ## Configuration
+//!
+//! - `DATASET_PREFIX`: Base URI for datasets (optional, e.g. s3://bucket/prefix or /tmp/bench). If not set, uses a temporary directory.
+//! - `NUM_ITERATIONS`: Number of small fragment writes to perform (default: 100).
+//! - `ROWS_PER_FRAGMENT`: Number of rows per fragment (default: 10).
+
+#![allow(clippy::print_stdout)]
+
+use arrow_array::{Int64Array, RecordBatch, RecordBatchIterator, StringArray};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use criterion::{criterion_group, criterion_main, Criterion};
+use lance::dataset::{Dataset, WriteMode, WriteParams};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::runtime::Runtime;
+use uuid::Uuid;
+
+const DEFAULT_ROWS_PER_FRAGMENT: usize = 10;
+const DEFAULT_NUM_ITERATIONS: usize = 100;
+
+fn get_rows_per_fragment() -> usize {
+    std::env::var("ROWS_PER_FRAGMENT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_ROWS_PER_FRAGMENT)
+}
+
+fn get_num_iterations() -> usize {
+    std::env::var("NUM_ITERATIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_NUM_ITERATIONS)
+}
+
+fn get_dataset_prefix() -> String {
+    std::env::var("DATASET_PREFIX").unwrap_or_else(|_| {
+        let temp_dir = std::env::temp_dir().join(format!("lance_bench_{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+        temp_dir.to_string_lossy().to_string()
+    })
+}
+
+fn get_storage_label(prefix: &str) -> &'static str {
+    if prefix.starts_with("s3://") {
+        "s3"
+    } else if prefix.starts_with("gs://") {
+        "gcs"
+    } else if prefix.starts_with("az://") {
+        "azure"
+    } else if prefix.starts_with("memory://") {
+        "memory"
+    } else {
+        "local"
+    }
+}
+
+async fn create_initial_dataset(uri: &str, rows_per_fragment: usize) -> Dataset {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]));
+
+    let batch = create_batch(schema.clone(), 0, rows_per_fragment);
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+
+    std::fs::remove_dir_all(uri).ok();
+
+    Dataset::write(reader, uri, None)
+        .await
+        .expect("failed to create initial dataset")
+}
+
+fn create_batch(schema: Arc<ArrowSchema>, start_id: usize, num_rows: usize) -> RecordBatch {
+    let ids = Int64Array::from_iter_values((start_id as i64)..((start_id + num_rows) as i64));
+    let names = StringArray::from_iter_values(
+        (start_id..(start_id + num_rows)).map(|i| format!("name_{}", i)),
+    );
+
+    RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names)])
+        .expect("failed to create batch")
+}
+
+fn linear_regression(x: &[f64], y: &[f64]) -> (f64, f64) {
+    let n = x.len() as f64;
+    let sum_x: f64 = x.iter().sum();
+    let sum_y: f64 = y.iter().sum();
+    let sum_xx: f64 = x.iter().map(|v| v * v).sum();
+    let sum_xy: f64 = x.iter().zip(y.iter()).map(|(a, b)| a * b).sum();
+
+    let slope = (n * sum_xy - sum_x * sum_y) / (n * sum_xx - sum_x * sum_x);
+    let intercept = (sum_y - slope * sum_x) / n;
+
+    (slope, intercept)
+}
+
+fn bench_manifest_commit(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("failed to build tokio runtime");
+
+    let dataset_prefix = get_dataset_prefix();
+    let num_iterations = get_num_iterations();
+    let rows_per_fragment = get_rows_per_fragment();
+    let storage_label = get_storage_label(&dataset_prefix);
+
+    let short_id = &Uuid::new_v4().to_string()[..8];
+    let uri = format!(
+        "{}/manifest_commit_{}",
+        dataset_prefix.trim_end_matches('/'),
+        short_id
+    );
+
+    println!("=== Manifest Commit Benchmark Setup ===");
+    println!("Storage: {} ({})", uri, storage_label);
+    println!("Rows per fragment: {}", rows_per_fragment);
+    println!("Number of iterations: {}", num_iterations);
+    println!("Total fragments (including initial): {}", num_iterations + 1);
+    println!();
+
+    runtime.block_on(create_initial_dataset(&uri, rows_per_fragment));
+
+    let mut write_latencies = Vec::with_capacity(num_iterations);
+    let mut load_latencies = Vec::with_capacity(num_iterations);
+
+    println!("Running write and load benchmarks...");
+    println!("fragments,write_ms,load_ms");
+
+    for i in 1..=num_iterations {
+        let num_fragments = i + 1;
+
+        let write_time = {
+            let uri_ref = uri.as_str();
+            runtime.block_on(async move {
+                let dataset = Dataset::open(uri_ref).await.expect("failed to open dataset");
+                let schema: Arc<ArrowSchema> = Arc::new((&dataset.schema().clone()).into());
+                let start_id = dataset.count_rows(None).await.unwrap() as usize;
+                let batch = create_batch(schema.clone(), start_id, rows_per_fragment);
+                let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+
+                let write_params = WriteParams {
+                    mode: WriteMode::Append,
+                    ..Default::default()
+                };
+
+                let start = Instant::now();
+                Dataset::write(reader, uri_ref, Some(write_params))
+                    .await
+                    .expect("failed to append");
+                start.elapsed()
+            })
+        };
+
+        let load_time = {
+            let uri_ref = uri.as_str();
+            runtime.block_on(async move {
+                let start = Instant::now();
+                let dataset = Dataset::open(uri_ref).await.expect("failed to open");
+                let elapsed = start.elapsed();
+
+                assert_eq!(
+                    dataset.manifest().fragments.len(),
+                    num_fragments,
+                    "Expected {} fragments",
+                    num_fragments
+                );
+                elapsed
+            })
+        };
+
+        write_latencies.push(write_time);
+        load_latencies.push(load_time);
+
+        println!(
+            "{},{:.2},{:.2}",
+            num_fragments,
+            write_time.as_secs_f64() * 1000.0,
+            load_time.as_secs_f64() * 1000.0
+        );
+    }
+
+    println!();
+    println!("=== Summary Statistics ===");
+
+    let avg_write: f64 = write_latencies.iter().map(|d| d.as_secs_f64()).sum::<f64>()
+        / write_latencies.len() as f64;
+    let avg_load: f64 = load_latencies.iter().map(|d| d.as_secs_f64()).sum::<f64>()
+        / load_latencies.len() as f64;
+
+    let min_write = write_latencies.iter().min().unwrap();
+    let max_write = write_latencies.iter().max().unwrap();
+    let min_load = load_latencies.iter().min().unwrap();
+    let max_load = load_latencies.iter().max().unwrap();
+
+    println!("Write latency: avg={:.2}ms, min={:.2}ms, max={:.2}ms",
+        avg_write * 1000.0, min_write.as_secs_f64() * 1000.0, max_write.as_secs_f64() * 1000.0);
+    println!("Load latency:  avg={:.2}ms, min={:.2}ms, max={:.2}ms",
+        avg_load * 1000.0, min_load.as_secs_f64() * 1000.0, max_load.as_secs_f64() * 1000.0);
+
+    let fragment_counts: Vec<f64> = (2..=(num_iterations + 1)).map(|x| x as f64).collect();
+    let write_ms: Vec<f64> = write_latencies.iter().map(|d| d.as_secs_f64() * 1000.0).collect();
+    let load_ms: Vec<f64> = load_latencies.iter().map(|d| d.as_secs_f64() * 1000.0).collect();
+
+    let (write_slope, write_intercept) = linear_regression(&fragment_counts, &write_ms);
+    let (load_slope, load_intercept) = linear_regression(&fragment_counts, &load_ms);
+
+    println!();
+    println!("=== Linear Regression Analysis ===");
+    println!("Write latency = {:.4}ms + {:.4}ms * fragments", write_intercept, write_slope);
+    println!("Load latency  = {:.4}ms + {:.4}ms * fragments", load_intercept, load_slope);
+    println!();
+    println!("Per-fragment overhead:");
+    println!("  Write: {:.4}ms per additional fragment", write_slope);
+    println!("  Load:  {:.4}ms per additional fragment", load_slope);
+
+    let first_10_avg_write = write_latencies.iter().take(10).map(|d| d.as_secs_f64()).sum::<f64>() / 10.0;
+    let last_10_avg_write = write_latencies.iter().rev().take(10).map(|d| d.as_secs_f64()).sum::<f64>() / 10.0;
+    let first_10_avg_load = load_latencies.iter().take(10).map(|d| d.as_secs_f64()).sum::<f64>() / 10.0;
+    let last_10_avg_load = load_latencies.iter().rev().take(10).map(|d| d.as_secs_f64()).sum::<f64>() / 10.0;
+
+    println!();
+    println!("First 10 iterations avg: write={:.2}ms, load={:.2}ms",
+        first_10_avg_write * 1000.0, first_10_avg_load * 1000.0);
+    println!("Last 10 iterations avg:  write={:.2}ms, load={:.2}ms",
+        last_10_avg_write * 1000.0, last_10_avg_load * 1000.0);
+    println!("Degradation ratio: write={:.2}x, load={:.2}x",
+        last_10_avg_write / first_10_avg_write,
+        last_10_avg_load / first_10_avg_load);
+
+    let mut group = c.benchmark_group("manifest_commit");
+
+    group.bench_function("avg_write_latency", |b| {
+        b.iter(|| std::time::Duration::from_secs_f64(avg_write))
+    });
+
+    group.bench_function("avg_load_latency", |b| {
+        b.iter(|| std::time::Duration::from_secs_f64(avg_load))
+    });
+
+    group.bench_function("write_slope_per_fragment", |b| {
+        b.iter(|| write_slope)
+    });
+
+    group.bench_function("load_slope_per_fragment", |b| {
+        b.iter(|| load_slope)
+    });
+
+    group.finish();
+
+    std::fs::remove_dir_all(&uri).ok();
+}
+
+criterion_group!(benches, bench_manifest_commit);
+criterion_main!(benches);

--- a/rust/lance/benches/manifest_commit.rs
+++ b/rust/lance/benches/manifest_commit.rs
@@ -6,13 +6,14 @@
 //! This benchmark tests how performance degrades as the number of small fragments
 //! grows. Each fragment contains only 10 rows, and we measure both:
 //! - Commit time (manifest write only, excludes fragment data writing)
-//! - Load time (manifest read from storage, no caching)
+//! - Load time (manifest read from storage, using checkout_latest with no caching)
 //!
 //! Key optimizations:
 //! - Uses shared session for commits to avoid re-reading old manifests
 //! - Disables auto-cleanup to avoid background cleanup overhead
 //! - Separates fragment writing from commit measurement
-//! - Uses fresh session (no cache) for load measurement to force actual storage read
+//! - Uses checkout_latest() with zero cache size to measure actual storage read
+//!   while reusing warm TCP/TLS connections
 //!
 //! ## Running against S3
 //!
@@ -42,9 +43,7 @@
 //! - `DATASET_PREFIX`: Base URI for datasets (optional, e.g. s3://bucket/prefix or /tmp/bench). If not set, uses a temporary directory.
 //! - `NUM_ITERATIONS`: Number of small fragment writes to perform (default: 100).
 //! - `ROWS_PER_FRAGMENT`: Number of rows per fragment (default: 10).
-//! - `DIRECT_CHECKOUT`: When "true", use checkout_version which bypasses listing. When "false" (default), use load() which includes listing.
 //! - `DELETE_DATASET`: When "true", delete the dataset after benchmark completes. When "false" (default), keep the dataset for inspection.
-//! - `WARM_SESSION`: When "true", use the same shared session for load() to test warm connection performance. When "false" (default), use fresh session for each load.
 
 #![allow(clippy::print_stdout)]
 
@@ -54,6 +53,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::{CommitBuilder, Dataset, InsertBuilder, WriteMode, WriteParams};
 use lance::session::Session;
+use lance_io::object_store::ObjectStoreRegistry;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::runtime::Runtime;
@@ -76,20 +76,8 @@ fn get_num_iterations() -> usize {
         .unwrap_or(DEFAULT_NUM_ITERATIONS)
 }
 
-fn get_direct_checkout() -> bool {
-    std::env::var("DIRECT_CHECKOUT")
-        .map(|s| s.to_lowercase() == "true")
-        .unwrap_or(false)
-}
-
 fn get_delete_dataset() -> bool {
     std::env::var("DELETE_DATASET")
-        .map(|s| s.to_lowercase() == "true")
-        .unwrap_or(false)
-}
-
-fn get_warm_session() -> bool {
-    std::env::var("WARM_SESSION")
         .map(|s| s.to_lowercase() == "true")
         .unwrap_or(false)
 }
@@ -158,9 +146,7 @@ fn bench_manifest_commit(c: &mut Criterion) {
     let dataset_prefix = get_dataset_prefix();
     let num_iterations = get_num_iterations();
     let rows_per_fragment = get_rows_per_fragment();
-    let direct_checkout = get_direct_checkout();
     let delete_dataset = get_delete_dataset();
-    let warm_session = get_warm_session();
     let storage_label = get_storage_label(&dataset_prefix);
 
     let short_id = &Uuid::new_v4().to_string()[..8];
@@ -178,35 +164,48 @@ fn bench_manifest_commit(c: &mut Criterion) {
         "Total fragments (including initial): {}",
         num_iterations + 1
     );
-    println!(
-        "Direct checkout: {} ({})",
-        direct_checkout,
-        if direct_checkout {
-            "checkout_version - bypasses listing"
-        } else {
-            "load() - includes listing"
-        }
-    );
     println!("Delete dataset: {}", delete_dataset);
-    println!(
-        "Warm session: {} ({})",
-        warm_session,
-        if warm_session {
-            "reuse session for load - tests warm connection"
-        } else {
-            "fresh session for load - tests cold start"
-        }
-    );
+    println!();
+    println!("Load method: checkout_latest() with zero cache size");
+    println!("  - Reuses warm TCP/TLS connections (shared ObjectStoreRegistry)");
+    println!("  - No manifest caching (zero cache size)");
+    println!("  - Measures actual storage read latency without cold start overhead");
     println!();
 
-    // Create a shared session to avoid re-opening old manifests
-    let session = Arc::new(Session::default());
+    // Create a shared ObjectStoreRegistry to reuse TCP/TLS connections
+    let shared_store_registry = Arc::new(ObjectStoreRegistry::default());
+
+    // Create a session with caching for commits (to avoid re-reading old manifests)
+    let commit_session = Arc::new(Session::new(
+        128 * 1024 * 1024, // index_cache_size
+        128 * 1024 * 1024, // metadata_cache_size
+        shared_store_registry.clone(),
+    ));
+
+    // Create a session with zero cache for load measurements
+    // This shares the ObjectStoreRegistry (warm connections) but has no manifest cache
+    let load_session = Arc::new(Session::new(
+        0, // index_cache_size = 0
+        0, // metadata_cache_size = 0
+        shared_store_registry,
+    ));
 
     let initial_dataset = runtime.block_on(create_initial_dataset(
         &uri,
         rows_per_fragment,
-        session.clone(),
+        commit_session.clone(),
     ));
+
+    // Create a load dataset that uses the zero-cache session
+    // This will be used to call checkout_latest() for load measurements
+    let uri_clone = uri.clone();
+    let mut load_dataset = runtime.block_on(async {
+        DatasetBuilder::from_uri(&uri_clone)
+            .with_session(load_session.clone())
+            .load()
+            .await
+            .expect("failed to load dataset for load measurements")
+    });
 
     // Keep a mutable dataset reference that we update after each commit
     let mut current_dataset = Arc::new(initial_dataset);
@@ -222,7 +221,7 @@ fn bench_manifest_commit(c: &mut Criterion) {
 
         let (commit_time, new_dataset) = {
             let dataset = current_dataset.clone();
-            let session_clone = session.clone();
+            let session_clone = commit_session.clone();
             runtime.block_on(async move {
                 let schema: Arc<ArrowSchema> = Arc::new((&dataset.schema().clone()).into());
                 let start_id = dataset.count_rows(None).await.unwrap() as usize;
@@ -258,53 +257,24 @@ fn bench_manifest_commit(c: &mut Criterion) {
         // This avoids the hint write from previous commit interfering with load measurement
         std::thread::sleep(std::time::Duration::from_millis(10));
 
-        // Measure load time
-        let load_time = if direct_checkout {
-            // Direct checkout: use checkout_version which bypasses listing
-            let dataset = current_dataset.clone();
-            let new_version = (i + 1) as u64;
-            runtime.block_on(async move {
-                let start = Instant::now();
-                let checked_out = dataset
-                    .checkout_version(new_version)
-                    .await
-                    .expect("failed to checkout");
-                let elapsed = start.elapsed();
+        // Measure load time using checkout_latest() with zero-cache session
+        // This reuses warm TCP/TLS connections but doesn't use cached manifests
+        let load_time = runtime.block_on(async {
+            let start = Instant::now();
+            load_dataset
+                .checkout_latest()
+                .await
+                .expect("failed to checkout latest");
+            let elapsed = start.elapsed();
 
-                assert_eq!(
-                    checked_out.manifest().fragments.len(),
-                    num_fragments,
-                    "Expected {} fragments",
-                    num_fragments
-                );
-                elapsed
-            })
-        } else {
-            // Load dataset
-            let uri_ref = uri.as_str();
-            let session_for_load = if warm_session {
-                Some(session.clone())
-            } else {
-                None
-            };
-            runtime.block_on(async move {
-                let start = Instant::now();
-                let mut builder = DatasetBuilder::from_uri(uri_ref);
-                if let Some(s) = session_for_load {
-                    builder = builder.with_session(s);
-                }
-                let dataset = builder.load().await.expect("failed to load");
-                let elapsed = start.elapsed();
-
-                assert_eq!(
-                    dataset.manifest().fragments.len(),
-                    num_fragments,
-                    "Expected {} fragments",
-                    num_fragments
-                );
-                elapsed
-            })
-        };
+            assert_eq!(
+                load_dataset.manifest().fragments.len(),
+                num_fragments,
+                "Expected {} fragments",
+                num_fragments
+            );
+            elapsed
+        });
 
         // Update current_dataset for next iteration
         current_dataset = new_dataset;

--- a/rust/lance/benches/manifest_commit.rs
+++ b/rust/lance/benches/manifest_commit.rs
@@ -145,19 +145,6 @@ fn create_batch(schema: Arc<ArrowSchema>, start_id: usize, num_rows: usize) -> R
         .expect("failed to create batch")
 }
 
-fn linear_regression(x: &[f64], y: &[f64]) -> (f64, f64) {
-    let n = x.len() as f64;
-    let sum_x: f64 = x.iter().sum();
-    let sum_y: f64 = y.iter().sum();
-    let sum_xx: f64 = x.iter().map(|v| v * v).sum();
-    let sum_xy: f64 = x.iter().zip(y.iter()).map(|(a, b)| a * b).sum();
-
-    let slope = (n * sum_xy - sum_x * sum_y) / (n * sum_xx - sum_x * sum_x);
-    let intercept = (sum_y - slope * sum_x) / n;
-
-    (slope, intercept)
-}
-
 fn bench_manifest_commit(c: &mut Criterion) {
     let runtime = Runtime::new().expect("failed to build tokio runtime");
 
@@ -335,34 +322,6 @@ fn bench_manifest_commit(c: &mut Criterion) {
         max_load.as_secs_f64() * 1000.0
     );
 
-    let fragment_counts: Vec<f64> = (2..=(num_iterations + 1)).map(|x| x as f64).collect();
-    let commit_ms: Vec<f64> = commit_latencies
-        .iter()
-        .map(|d| d.as_secs_f64() * 1000.0)
-        .collect();
-    let load_ms: Vec<f64> = load_latencies
-        .iter()
-        .map(|d| d.as_secs_f64() * 1000.0)
-        .collect();
-
-    let (commit_slope, commit_intercept) = linear_regression(&fragment_counts, &commit_ms);
-    let (load_slope, load_intercept) = linear_regression(&fragment_counts, &load_ms);
-
-    println!();
-    println!("=== Linear Regression Analysis ===");
-    println!(
-        "Commit latency = {:.4}ms + {:.4}ms * fragments",
-        commit_intercept, commit_slope
-    );
-    println!(
-        "Load latency   = {:.4}ms + {:.4}ms * fragments",
-        load_intercept, load_slope
-    );
-    println!();
-    println!("Per-fragment overhead:");
-    println!("  Commit: {:.4}ms per additional fragment", commit_slope);
-    println!("  Load:   {:.4}ms per additional fragment", load_slope);
-
     let first_10_avg_commit = commit_latencies
         .iter()
         .take(10)
@@ -416,10 +375,6 @@ fn bench_manifest_commit(c: &mut Criterion) {
     group.bench_function("avg_load_latency", |b| {
         b.iter(|| std::time::Duration::from_secs_f64(avg_load))
     });
-
-    group.bench_function("commit_slope_per_fragment", |b| b.iter(|| commit_slope));
-
-    group.bench_function("load_slope_per_fragment", |b| b.iter(|| load_slope));
 
     group.finish();
 

--- a/rust/lance/benches/manifest_commit.rs
+++ b/rust/lance/benches/manifest_commit.rs
@@ -5,8 +5,14 @@
 //!
 //! This benchmark tests how performance degrades as the number of small fragments
 //! grows. Each fragment contains only 10 rows, and we measure both:
-//! - Commit time (write + manifest update)
-//! - Dataset load time (opening the manifest)
+//! - Commit time (manifest write only, excludes fragment data writing)
+//! - Load time (manifest read from storage, no caching)
+//!
+//! Key optimizations:
+//! - Uses shared session for commits to avoid re-reading old manifests
+//! - Disables auto-cleanup to avoid background cleanup overhead
+//! - Separates fragment writing from commit measurement
+//! - Uses fresh session (no cache) for load measurement to force actual storage read
 //!
 //! ## Running against S3
 //!
@@ -36,13 +42,17 @@
 //! - `DATASET_PREFIX`: Base URI for datasets (optional, e.g. s3://bucket/prefix or /tmp/bench). If not set, uses a temporary directory.
 //! - `NUM_ITERATIONS`: Number of small fragment writes to perform (default: 100).
 //! - `ROWS_PER_FRAGMENT`: Number of rows per fragment (default: 10).
+//! - `DIRECT_CHECKOUT`: When "true", use checkout_version which bypasses listing. When "false" (default), use load() which includes listing.
+//! - `DELETE_DATASET`: When "true", delete the dataset after benchmark completes. When "false" (default), keep the dataset for inspection.
 
 #![allow(clippy::print_stdout)]
 
 use arrow_array::{Int64Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use criterion::{criterion_group, criterion_main, Criterion};
-use lance::dataset::{Dataset, WriteMode, WriteParams};
+use lance::dataset::builder::DatasetBuilder;
+use lance::dataset::{CommitBuilder, Dataset, InsertBuilder, WriteMode, WriteParams};
+use lance::session::Session;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::runtime::Runtime;
@@ -63,6 +73,18 @@ fn get_num_iterations() -> usize {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_NUM_ITERATIONS)
+}
+
+fn get_direct_checkout() -> bool {
+    std::env::var("DIRECT_CHECKOUT")
+        .map(|s| s.to_lowercase() == "true")
+        .unwrap_or(false)
+}
+
+fn get_delete_dataset() -> bool {
+    std::env::var("DELETE_DATASET")
+        .map(|s| s.to_lowercase() == "true")
+        .unwrap_or(false)
 }
 
 fn get_dataset_prefix() -> String {
@@ -87,7 +109,11 @@ fn get_storage_label(prefix: &str) -> &'static str {
     }
 }
 
-async fn create_initial_dataset(uri: &str, rows_per_fragment: usize) -> Dataset {
+async fn create_initial_dataset(
+    uri: &str,
+    rows_per_fragment: usize,
+    session: Arc<Session>,
+) -> Dataset {
     let schema = Arc::new(ArrowSchema::new(vec![
         Field::new("id", DataType::Int64, false),
         Field::new("name", DataType::Utf8, false),
@@ -98,7 +124,13 @@ async fn create_initial_dataset(uri: &str, rows_per_fragment: usize) -> Dataset 
 
     std::fs::remove_dir_all(uri).ok();
 
-    Dataset::write(reader, uri, None)
+    let params = WriteParams {
+        session: Some(session),
+        skip_auto_cleanup: true,
+        ..Default::default()
+    };
+
+    Dataset::write(reader, uri, Some(params))
         .await
         .expect("failed to create initial dataset")
 }
@@ -132,6 +164,8 @@ fn bench_manifest_commit(c: &mut Criterion) {
     let dataset_prefix = get_dataset_prefix();
     let num_iterations = get_num_iterations();
     let rows_per_fragment = get_rows_per_fragment();
+    let direct_checkout = get_direct_checkout();
+    let delete_dataset = get_delete_dataset();
     let storage_label = get_storage_label(&dataset_prefix);
 
     let short_id = &Uuid::new_v4().to_string()[..8];
@@ -145,47 +179,107 @@ fn bench_manifest_commit(c: &mut Criterion) {
     println!("Storage: {} ({})", uri, storage_label);
     println!("Rows per fragment: {}", rows_per_fragment);
     println!("Number of iterations: {}", num_iterations);
-    println!("Total fragments (including initial): {}", num_iterations + 1);
+    println!(
+        "Total fragments (including initial): {}",
+        num_iterations + 1
+    );
+    println!(
+        "Direct checkout: {} ({})",
+        direct_checkout,
+        if direct_checkout {
+            "checkout_version - bypasses listing"
+        } else {
+            "load() - includes listing"
+        }
+    );
+    println!("Delete dataset: {}", delete_dataset);
     println!();
 
-    runtime.block_on(create_initial_dataset(&uri, rows_per_fragment));
+    // Create a shared session to avoid re-opening old manifests
+    let session = Arc::new(Session::default());
 
-    let mut write_latencies = Vec::with_capacity(num_iterations);
+    let initial_dataset = runtime.block_on(create_initial_dataset(
+        &uri,
+        rows_per_fragment,
+        session.clone(),
+    ));
+
+    // Keep a mutable dataset reference that we update after each commit
+    let mut current_dataset = Arc::new(initial_dataset);
+
+    let mut commit_latencies = Vec::with_capacity(num_iterations);
     let mut load_latencies = Vec::with_capacity(num_iterations);
 
-    println!("Running write and load benchmarks...");
-    println!("fragments,write_ms,load_ms");
+    println!("Running commit and load benchmarks...");
+    println!("fragments,commit_ms,load_ms");
 
     for i in 1..=num_iterations {
         let num_fragments = i + 1;
 
-        let write_time = {
-            let uri_ref = uri.as_str();
+        let (commit_time, new_dataset) = {
+            let dataset = current_dataset.clone();
+            let session_clone = session.clone();
             runtime.block_on(async move {
-                let dataset = Dataset::open(uri_ref).await.expect("failed to open dataset");
                 let schema: Arc<ArrowSchema> = Arc::new((&dataset.schema().clone()).into());
                 let start_id = dataset.count_rows(None).await.unwrap() as usize;
                 let batch = create_batch(schema.clone(), start_id, rows_per_fragment);
-                let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
 
                 let write_params = WriteParams {
                     mode: WriteMode::Append,
+                    session: Some(session_clone.clone()),
+                    skip_auto_cleanup: true,
                     ..Default::default()
                 };
 
-                let start = Instant::now();
-                Dataset::write(reader, uri_ref, Some(write_params))
+                // Write fragments without committing (not measured)
+                let transaction = InsertBuilder::new(dataset.clone())
+                    .with_params(&write_params)
+                    .execute_uncommitted(vec![batch])
                     .await
-                    .expect("failed to append");
-                start.elapsed()
+                    .expect("failed to write fragment");
+
+                // Measure only the commit time
+                let start = Instant::now();
+                let new_ds = CommitBuilder::new(dataset)
+                    .with_session(session_clone)
+                    .with_skip_auto_cleanup(true)
+                    .execute(transaction)
+                    .await
+                    .expect("failed to commit");
+                (start.elapsed(), Arc::new(new_ds))
             })
         };
 
-        let load_time = {
+        // Measure load time
+        let load_time = if direct_checkout {
+            // Direct checkout: use checkout_version which bypasses listing
+            let dataset = current_dataset.clone();
+            let new_version = (i + 1) as u64;
+            runtime.block_on(async move {
+                let start = Instant::now();
+                let checked_out = dataset
+                    .checkout_version(new_version)
+                    .await
+                    .expect("failed to checkout");
+                let elapsed = start.elapsed();
+
+                assert_eq!(
+                    checked_out.manifest().fragments.len(),
+                    num_fragments,
+                    "Expected {} fragments",
+                    num_fragments
+                );
+                elapsed
+            })
+        } else {
+            // Load with listing: use load() without session to force actual storage read
             let uri_ref = uri.as_str();
             runtime.block_on(async move {
                 let start = Instant::now();
-                let dataset = Dataset::open(uri_ref).await.expect("failed to open");
+                let dataset = DatasetBuilder::from_uri(uri_ref)
+                    .load()
+                    .await
+                    .expect("failed to load");
                 let elapsed = start.elapsed();
 
                 assert_eq!(
@@ -198,13 +292,16 @@ fn bench_manifest_commit(c: &mut Criterion) {
             })
         };
 
-        write_latencies.push(write_time);
+        // Update current_dataset for next iteration
+        current_dataset = new_dataset;
+
+        commit_latencies.push(commit_time);
         load_latencies.push(load_time);
 
         println!(
             "{},{:.2},{:.2}",
             num_fragments,
-            write_time.as_secs_f64() * 1000.0,
+            commit_time.as_secs_f64() * 1000.0,
             load_time.as_secs_f64() * 1000.0
         );
     }
@@ -212,72 +309,126 @@ fn bench_manifest_commit(c: &mut Criterion) {
     println!();
     println!("=== Summary Statistics ===");
 
-    let avg_write: f64 = write_latencies.iter().map(|d| d.as_secs_f64()).sum::<f64>()
-        / write_latencies.len() as f64;
-    let avg_load: f64 = load_latencies.iter().map(|d| d.as_secs_f64()).sum::<f64>()
-        / load_latencies.len() as f64;
+    let avg_commit: f64 = commit_latencies
+        .iter()
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / commit_latencies.len() as f64;
+    let avg_load: f64 =
+        load_latencies.iter().map(|d| d.as_secs_f64()).sum::<f64>() / load_latencies.len() as f64;
 
-    let min_write = write_latencies.iter().min().unwrap();
-    let max_write = write_latencies.iter().max().unwrap();
+    let min_commit = commit_latencies.iter().min().unwrap();
+    let max_commit = commit_latencies.iter().max().unwrap();
     let min_load = load_latencies.iter().min().unwrap();
     let max_load = load_latencies.iter().max().unwrap();
 
-    println!("Write latency: avg={:.2}ms, min={:.2}ms, max={:.2}ms",
-        avg_write * 1000.0, min_write.as_secs_f64() * 1000.0, max_write.as_secs_f64() * 1000.0);
-    println!("Load latency:  avg={:.2}ms, min={:.2}ms, max={:.2}ms",
-        avg_load * 1000.0, min_load.as_secs_f64() * 1000.0, max_load.as_secs_f64() * 1000.0);
+    println!(
+        "Commit latency: avg={:.2}ms, min={:.2}ms, max={:.2}ms",
+        avg_commit * 1000.0,
+        min_commit.as_secs_f64() * 1000.0,
+        max_commit.as_secs_f64() * 1000.0
+    );
+    println!(
+        "Load latency:   avg={:.2}ms, min={:.2}ms, max={:.2}ms",
+        avg_load * 1000.0,
+        min_load.as_secs_f64() * 1000.0,
+        max_load.as_secs_f64() * 1000.0
+    );
 
     let fragment_counts: Vec<f64> = (2..=(num_iterations + 1)).map(|x| x as f64).collect();
-    let write_ms: Vec<f64> = write_latencies.iter().map(|d| d.as_secs_f64() * 1000.0).collect();
-    let load_ms: Vec<f64> = load_latencies.iter().map(|d| d.as_secs_f64() * 1000.0).collect();
+    let commit_ms: Vec<f64> = commit_latencies
+        .iter()
+        .map(|d| d.as_secs_f64() * 1000.0)
+        .collect();
+    let load_ms: Vec<f64> = load_latencies
+        .iter()
+        .map(|d| d.as_secs_f64() * 1000.0)
+        .collect();
 
-    let (write_slope, write_intercept) = linear_regression(&fragment_counts, &write_ms);
+    let (commit_slope, commit_intercept) = linear_regression(&fragment_counts, &commit_ms);
     let (load_slope, load_intercept) = linear_regression(&fragment_counts, &load_ms);
 
     println!();
     println!("=== Linear Regression Analysis ===");
-    println!("Write latency = {:.4}ms + {:.4}ms * fragments", write_intercept, write_slope);
-    println!("Load latency  = {:.4}ms + {:.4}ms * fragments", load_intercept, load_slope);
+    println!(
+        "Commit latency = {:.4}ms + {:.4}ms * fragments",
+        commit_intercept, commit_slope
+    );
+    println!(
+        "Load latency   = {:.4}ms + {:.4}ms * fragments",
+        load_intercept, load_slope
+    );
     println!();
     println!("Per-fragment overhead:");
-    println!("  Write: {:.4}ms per additional fragment", write_slope);
-    println!("  Load:  {:.4}ms per additional fragment", load_slope);
+    println!("  Commit: {:.4}ms per additional fragment", commit_slope);
+    println!("  Load:   {:.4}ms per additional fragment", load_slope);
 
-    let first_10_avg_write = write_latencies.iter().take(10).map(|d| d.as_secs_f64()).sum::<f64>() / 10.0;
-    let last_10_avg_write = write_latencies.iter().rev().take(10).map(|d| d.as_secs_f64()).sum::<f64>() / 10.0;
-    let first_10_avg_load = load_latencies.iter().take(10).map(|d| d.as_secs_f64()).sum::<f64>() / 10.0;
-    let last_10_avg_load = load_latencies.iter().rev().take(10).map(|d| d.as_secs_f64()).sum::<f64>() / 10.0;
+    let first_10_avg_commit = commit_latencies
+        .iter()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
+    let last_10_avg_commit = commit_latencies
+        .iter()
+        .rev()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
+    let first_10_avg_load = load_latencies
+        .iter()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
+    let last_10_avg_load = load_latencies
+        .iter()
+        .rev()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
 
     println!();
-    println!("First 10 iterations avg: write={:.2}ms, load={:.2}ms",
-        first_10_avg_write * 1000.0, first_10_avg_load * 1000.0);
-    println!("Last 10 iterations avg:  write={:.2}ms, load={:.2}ms",
-        last_10_avg_write * 1000.0, last_10_avg_load * 1000.0);
-    println!("Degradation ratio: write={:.2}x, load={:.2}x",
-        last_10_avg_write / first_10_avg_write,
-        last_10_avg_load / first_10_avg_load);
+    println!(
+        "First 10 iterations avg: commit={:.2}ms, load={:.2}ms",
+        first_10_avg_commit * 1000.0,
+        first_10_avg_load * 1000.0
+    );
+    println!(
+        "Last 10 iterations avg:  commit={:.2}ms, load={:.2}ms",
+        last_10_avg_commit * 1000.0,
+        last_10_avg_load * 1000.0
+    );
+    println!(
+        "Degradation ratio: commit={:.2}x, load={:.2}x",
+        last_10_avg_commit / first_10_avg_commit,
+        last_10_avg_load / first_10_avg_load
+    );
 
     let mut group = c.benchmark_group("manifest_commit");
 
-    group.bench_function("avg_write_latency", |b| {
-        b.iter(|| std::time::Duration::from_secs_f64(avg_write))
+    group.bench_function("avg_commit_latency", |b| {
+        b.iter(|| std::time::Duration::from_secs_f64(avg_commit))
     });
 
     group.bench_function("avg_load_latency", |b| {
         b.iter(|| std::time::Duration::from_secs_f64(avg_load))
     });
 
-    group.bench_function("write_slope_per_fragment", |b| {
-        b.iter(|| write_slope)
-    });
+    group.bench_function("commit_slope_per_fragment", |b| b.iter(|| commit_slope));
 
-    group.bench_function("load_slope_per_fragment", |b| {
-        b.iter(|| load_slope)
-    });
+    group.bench_function("load_slope_per_fragment", |b| b.iter(|| load_slope));
 
     group.finish();
 
-    std::fs::remove_dir_all(&uri).ok();
+    if delete_dataset {
+        std::fs::remove_dir_all(&uri).ok();
+        println!("Dataset deleted: {}", uri);
+    } else {
+        println!("Dataset preserved: {}", uri);
+    }
 }
 
 criterion_group!(benches, bench_manifest_commit);

--- a/rust/lance/benches/manifest_commit.rs
+++ b/rust/lance/benches/manifest_commit.rs
@@ -6,20 +6,18 @@
 //! This benchmark tests how performance degrades as the number of small fragments
 //! grows. Each fragment contains only 10 rows, and we measure both:
 //! - Commit time (manifest write only, excludes fragment data writing)
-//! - Load time (manifest read from storage, using checkout_latest with no caching)
+//! - Load time (manifest read from storage, using checkout_latest)
 //!
 //! Key optimizations:
-//! - Uses shared session for commits to avoid re-reading old manifests
+//! - Uses shared ObjectStoreRegistry to reuse TCP/TLS connections
 //! - Disables auto-cleanup to avoid background cleanup overhead
 //! - Separates fragment writing from commit measurement
-//! - Uses checkout_latest() with zero cache size to measure actual storage read
-//!   while reusing warm TCP/TLS connections
 //!
-//! ## Running against S3
+//! ## Running against S3 Express
 //!
 //! ```bash
-//! export AWS_DEFAULT_REGION=us-east-1
-//! export DATASET_PREFIX=s3://your-bucket/bench/manifest_commit
+//! export AWS_REGION=us-east-1
+//! export DATASET_PREFIX=s3://your-bucket--use1-az4--x-s3/bench/manifest_commit
 //! export NUM_ITERATIONS=100
 //! cargo bench --bench manifest_commit
 //! ```
@@ -30,20 +28,15 @@
 //! cargo bench --bench manifest_commit
 //! ```
 //!
-//! ## Running against specific local directory
-//!
-//! ```bash
-//! export DATASET_PREFIX=/tmp/bench/manifest_commit
-//! export NUM_ITERATIONS=50
-//! cargo bench --bench manifest_commit
-//! ```
-//!
 //! ## Configuration
 //!
-//! - `DATASET_PREFIX`: Base URI for datasets (optional, e.g. s3://bucket/prefix or /tmp/bench). If not set, uses a temporary directory.
+//! - `DATASET_PREFIX`: Base URI for datasets (e.g. s3://bucket/prefix or /tmp/bench).
+//!   If not set, uses a temporary directory.
 //! - `NUM_ITERATIONS`: Number of small fragment writes to perform (default: 100).
 //! - `ROWS_PER_FRAGMENT`: Number of rows per fragment (default: 10).
-//! - `DELETE_DATASET`: When "true", delete the dataset after benchmark completes. When "false" (default), keep the dataset for inspection.
+//! - `DELETE_DATASET`: When "true", delete the dataset after benchmark completes.
+//! - `ENABLE_CACHE`: When "true", enable manifest caching for load measurements.
+//!   Default is "false" to measure actual storage read latency.
 
 #![allow(clippy::print_stdout)]
 
@@ -53,8 +46,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::{CommitBuilder, Dataset, InsertBuilder, WriteMode, WriteParams};
 use lance::session::Session;
-use lance_io::object_store::{ObjectStoreRegistry, StorageOptionsAccessor};
-use std::collections::HashMap;
+use lance_io::object_store::ObjectStoreRegistry;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::runtime::Runtime;
@@ -83,6 +75,12 @@ fn get_delete_dataset() -> bool {
         .unwrap_or(false)
 }
 
+fn get_enable_cache() -> bool {
+    std::env::var("ENABLE_CACHE")
+        .map(|s| s.to_lowercase() == "true")
+        .unwrap_or(false)
+}
+
 fn get_dataset_prefix() -> String {
     std::env::var("DATASET_PREFIX").unwrap_or_else(|_| {
         let temp_dir = std::env::temp_dir().join(format!("lance_bench_{}", Uuid::new_v4()));
@@ -93,11 +91,7 @@ fn get_dataset_prefix() -> String {
 
 fn get_storage_label(prefix: &str) -> &'static str {
     if prefix.starts_with("s3://") {
-        if is_s3_express(prefix) {
-            "s3-express"
-        } else {
-            "s3"
-        }
+        "s3"
     } else if prefix.starts_with("gs://") {
         "gcs"
     } else if prefix.starts_with("az://") {
@@ -109,30 +103,10 @@ fn get_storage_label(prefix: &str) -> &'static str {
     }
 }
 
-fn is_s3_express(uri: &str) -> bool {
-    // S3 Express bucket names end with --<az>--x-s3
-    uri.contains("--x-s3")
-}
-
-fn get_storage_options(uri: &str) -> HashMap<String, String> {
-    let mut options = HashMap::new();
-    if is_s3_express(uri) {
-        options.insert("s3_express".to_string(), "true".to_string());
-        // S3 Express requires explicit region because GetBucketLocation API doesn't work
-        if let Ok(region) = std::env::var("AWS_DEFAULT_REGION") {
-            options.insert("region".to_string(), region);
-        } else if let Ok(region) = std::env::var("AWS_REGION") {
-            options.insert("region".to_string(), region);
-        }
-    }
-    options
-}
-
 async fn create_initial_dataset(
     uri: &str,
     rows_per_fragment: usize,
     session: Arc<Session>,
-    storage_options: HashMap<String, String>,
 ) -> Dataset {
     let schema = Arc::new(ArrowSchema::new(vec![
         Field::new("id", DataType::Int64, false),
@@ -144,21 +118,9 @@ async fn create_initial_dataset(
 
     std::fs::remove_dir_all(uri).ok();
 
-    let store_params = if storage_options.is_empty() {
-        None
-    } else {
-        Some(lance_io::object_store::ObjectStoreParams {
-            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
-                storage_options,
-            ))),
-            ..Default::default()
-        })
-    };
-
     let params = WriteParams {
         session: Some(session),
         skip_auto_cleanup: true,
-        store_params,
         ..Default::default()
     };
 
@@ -184,6 +146,7 @@ fn bench_manifest_commit(c: &mut Criterion) {
     let num_iterations = get_num_iterations();
     let rows_per_fragment = get_rows_per_fragment();
     let delete_dataset = get_delete_dataset();
+    let enable_cache = get_enable_cache();
     let storage_label = get_storage_label(&dataset_prefix);
 
     let short_id = &Uuid::new_v4().to_string()[..8];
@@ -202,58 +165,42 @@ fn bench_manifest_commit(c: &mut Criterion) {
         num_iterations + 1
     );
     println!("Delete dataset: {}", delete_dataset);
-    println!();
-    println!("Load method: checkout_latest() with zero cache size");
-    println!("  - Reuses warm TCP/TLS connections (shared ObjectStoreRegistry)");
-    println!("  - No manifest caching (zero cache size)");
-    println!("  - Measures actual storage read latency without cold start overhead");
+    println!(
+        "Cache enabled: {} ({})",
+        enable_cache,
+        if enable_cache {
+            "using default cache size"
+        } else {
+            "zero cache size - measures actual storage read"
+        }
+    );
     println!();
 
-    // Get storage options (e.g., s3_express=true for S3 Express buckets)
-    let storage_options = get_storage_options(&uri);
-    if !storage_options.is_empty() {
-        println!("Storage options: {:?}", storage_options);
-        println!();
-    }
-
-    // Create a shared ObjectStoreRegistry to reuse TCP/TLS connections
+    // Create a shared session for both commit and load operations
+    // When cache is disabled, use zero cache size to measure actual storage read latency
+    // When cache is enabled, use default cache sizes (6GB index, 1GB metadata)
     let shared_store_registry = Arc::new(ObjectStoreRegistry::default());
-
-    // Create a session with caching for commits (to avoid re-reading old manifests)
-    let commit_session = Arc::new(Session::new(
-        128 * 1024 * 1024, // index_cache_size
-        128 * 1024 * 1024, // metadata_cache_size
-        shared_store_registry.clone(),
-    ));
-
-    // Create a session with zero cache for load measurements
-    // This shares the ObjectStoreRegistry (warm connections) but has no manifest cache
-    let load_session = Arc::new(Session::new(
-        0, // index_cache_size = 0
-        0, // metadata_cache_size = 0
-        shared_store_registry,
-    ));
+    let session = if enable_cache {
+        Arc::new(Session::default())
+    } else {
+        Arc::new(Session::new(0, 0, shared_store_registry))
+    };
 
     let initial_dataset = runtime.block_on(create_initial_dataset(
         &uri,
         rows_per_fragment,
-        commit_session.clone(),
-        storage_options.clone(),
+        session.clone(),
     ));
 
-    // Create a load dataset that uses the zero-cache session
-    // This will be used to call checkout_latest() for load measurements
     let uri_clone = uri.clone();
     let mut load_dataset = runtime.block_on(async {
         DatasetBuilder::from_uri(&uri_clone)
-            .with_session(load_session.clone())
-            .with_storage_options(storage_options.clone())
+            .with_session(session.clone())
             .load()
             .await
             .expect("failed to load dataset for load measurements")
     });
 
-    // Keep a mutable dataset reference that we update after each commit
     let mut current_dataset = Arc::new(initial_dataset);
 
     let mut commit_latencies = Vec::with_capacity(num_iterations);
@@ -267,7 +214,7 @@ fn bench_manifest_commit(c: &mut Criterion) {
 
         let (commit_time, new_dataset) = {
             let dataset = current_dataset.clone();
-            let session_clone = commit_session.clone();
+            let session_clone = session.clone();
             runtime.block_on(async move {
                 let schema: Arc<ArrowSchema> = Arc::new((&dataset.schema().clone()).into());
                 let start_id = dataset.count_rows(None).await.unwrap() as usize;
@@ -280,14 +227,12 @@ fn bench_manifest_commit(c: &mut Criterion) {
                     ..Default::default()
                 };
 
-                // Write fragments without committing (not measured)
                 let transaction = InsertBuilder::new(dataset.clone())
                     .with_params(&write_params)
                     .execute_uncommitted(vec![batch])
                     .await
                     .expect("failed to write fragment");
 
-                // Measure only the commit time
                 let start = Instant::now();
                 let new_ds = CommitBuilder::new(dataset)
                     .with_session(session_clone)
@@ -300,11 +245,8 @@ fn bench_manifest_commit(c: &mut Criterion) {
         };
 
         // Small delay to let fire-and-forget hint write complete
-        // This avoids the hint write from previous commit interfering with load measurement
         std::thread::sleep(std::time::Duration::from_millis(10));
 
-        // Measure load time using checkout_latest() with zero-cache session
-        // This reuses warm TCP/TLS connections but doesn't use cached manifests
         let load_time = runtime.block_on(async {
             let start = Instant::now();
             load_dataset
@@ -322,7 +264,6 @@ fn bench_manifest_commit(c: &mut Criterion) {
             elapsed
         });
 
-        // Update current_dataset for next iteration
         current_dataset = new_dataset;
 
         commit_latencies.push(commit_time);

--- a/rust/lance/benches/manifest_commit.rs
+++ b/rust/lance/benches/manifest_commit.rs
@@ -118,6 +118,12 @@ fn get_storage_options(uri: &str) -> HashMap<String, String> {
     let mut options = HashMap::new();
     if is_s3_express(uri) {
         options.insert("s3_express".to_string(), "true".to_string());
+        // S3 Express requires explicit region because GetBucketLocation API doesn't work
+        if let Ok(region) = std::env::var("AWS_DEFAULT_REGION") {
+            options.insert("region".to_string(), region);
+        } else if let Ok(region) = std::env::var("AWS_REGION") {
+            options.insert("region".to_string(), region);
+        }
     }
     options
 }

--- a/rust/lance/benches/manifest_commit.rs
+++ b/rust/lance/benches/manifest_commit.rs
@@ -44,6 +44,7 @@
 //! - `ROWS_PER_FRAGMENT`: Number of rows per fragment (default: 10).
 //! - `DIRECT_CHECKOUT`: When "true", use checkout_version which bypasses listing. When "false" (default), use load() which includes listing.
 //! - `DELETE_DATASET`: When "true", delete the dataset after benchmark completes. When "false" (default), keep the dataset for inspection.
+//! - `WARM_SESSION`: When "true", use the same shared session for load() to test warm connection performance. When "false" (default), use fresh session for each load.
 
 #![allow(clippy::print_stdout)]
 
@@ -83,6 +84,12 @@ fn get_direct_checkout() -> bool {
 
 fn get_delete_dataset() -> bool {
     std::env::var("DELETE_DATASET")
+        .map(|s| s.to_lowercase() == "true")
+        .unwrap_or(false)
+}
+
+fn get_warm_session() -> bool {
+    std::env::var("WARM_SESSION")
         .map(|s| s.to_lowercase() == "true")
         .unwrap_or(false)
 }
@@ -153,6 +160,7 @@ fn bench_manifest_commit(c: &mut Criterion) {
     let rows_per_fragment = get_rows_per_fragment();
     let direct_checkout = get_direct_checkout();
     let delete_dataset = get_delete_dataset();
+    let warm_session = get_warm_session();
     let storage_label = get_storage_label(&dataset_prefix);
 
     let short_id = &Uuid::new_v4().to_string()[..8];
@@ -180,6 +188,15 @@ fn bench_manifest_commit(c: &mut Criterion) {
         }
     );
     println!("Delete dataset: {}", delete_dataset);
+    println!(
+        "Warm session: {} ({})",
+        warm_session,
+        if warm_session {
+            "reuse session for load - tests warm connection"
+        } else {
+            "fresh session for load - tests cold start"
+        }
+    );
     println!();
 
     // Create a shared session to avoid re-opening old manifests
@@ -263,14 +280,20 @@ fn bench_manifest_commit(c: &mut Criterion) {
                 elapsed
             })
         } else {
-            // Load with listing: use load() without session to force actual storage read
+            // Load dataset
             let uri_ref = uri.as_str();
+            let session_for_load = if warm_session {
+                Some(session.clone())
+            } else {
+                None
+            };
             runtime.block_on(async move {
                 let start = Instant::now();
-                let dataset = DatasetBuilder::from_uri(uri_ref)
-                    .load()
-                    .await
-                    .expect("failed to load");
+                let mut builder = DatasetBuilder::from_uri(uri_ref);
+                if let Some(s) = session_for_load {
+                    builder = builder.with_session(s);
+                }
+                let dataset = builder.load().await.expect("failed to load");
                 let elapsed = start.elapsed();
 
                 assert_eq!(

--- a/rust/lance/benches/manifest_commit.rs
+++ b/rust/lance/benches/manifest_commit.rs
@@ -53,7 +53,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::{CommitBuilder, Dataset, InsertBuilder, WriteMode, WriteParams};
 use lance::session::Session;
-use lance_io::object_store::ObjectStoreRegistry;
+use lance_io::object_store::{ObjectStoreRegistry, StorageOptionsAccessor};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::runtime::Runtime;
@@ -92,7 +93,11 @@ fn get_dataset_prefix() -> String {
 
 fn get_storage_label(prefix: &str) -> &'static str {
     if prefix.starts_with("s3://") {
-        "s3"
+        if is_s3_express(prefix) {
+            "s3-express"
+        } else {
+            "s3"
+        }
     } else if prefix.starts_with("gs://") {
         "gcs"
     } else if prefix.starts_with("az://") {
@@ -104,10 +109,24 @@ fn get_storage_label(prefix: &str) -> &'static str {
     }
 }
 
+fn is_s3_express(uri: &str) -> bool {
+    // S3 Express bucket names end with --<az>--x-s3
+    uri.contains("--x-s3")
+}
+
+fn get_storage_options(uri: &str) -> HashMap<String, String> {
+    let mut options = HashMap::new();
+    if is_s3_express(uri) {
+        options.insert("s3_express".to_string(), "true".to_string());
+    }
+    options
+}
+
 async fn create_initial_dataset(
     uri: &str,
     rows_per_fragment: usize,
     session: Arc<Session>,
+    storage_options: HashMap<String, String>,
 ) -> Dataset {
     let schema = Arc::new(ArrowSchema::new(vec![
         Field::new("id", DataType::Int64, false),
@@ -119,9 +138,21 @@ async fn create_initial_dataset(
 
     std::fs::remove_dir_all(uri).ok();
 
+    let store_params = if storage_options.is_empty() {
+        None
+    } else {
+        Some(lance_io::object_store::ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                storage_options,
+            ))),
+            ..Default::default()
+        })
+    };
+
     let params = WriteParams {
         session: Some(session),
         skip_auto_cleanup: true,
+        store_params,
         ..Default::default()
     };
 
@@ -172,6 +203,13 @@ fn bench_manifest_commit(c: &mut Criterion) {
     println!("  - Measures actual storage read latency without cold start overhead");
     println!();
 
+    // Get storage options (e.g., s3_express=true for S3 Express buckets)
+    let storage_options = get_storage_options(&uri);
+    if !storage_options.is_empty() {
+        println!("Storage options: {:?}", storage_options);
+        println!();
+    }
+
     // Create a shared ObjectStoreRegistry to reuse TCP/TLS connections
     let shared_store_registry = Arc::new(ObjectStoreRegistry::default());
 
@@ -194,6 +232,7 @@ fn bench_manifest_commit(c: &mut Criterion) {
         &uri,
         rows_per_fragment,
         commit_session.clone(),
+        storage_options.clone(),
     ));
 
     // Create a load dataset that uses the zero-cache session
@@ -202,6 +241,7 @@ fn bench_manifest_commit(c: &mut Criterion) {
     let mut load_dataset = runtime.block_on(async {
         DatasetBuilder::from_uri(&uri_clone)
             .with_session(load_session.clone())
+            .with_storage_options(storage_options.clone())
             .load()
             .await
             .expect("failed to load dataset for load measurements")

--- a/rust/lance/benches/object_store_bench.rs
+++ b/rust/lance/benches/object_store_bench.rs
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Direct object_store benchmark to isolate S3 vs S3 Express performance.
+//!
+//! This benchmark reads actual manifest files from a Lance dataset and measures:
+//! - PUT latency (write to _validate directory)
+//! - LIST first page latency (list with pagination)
+//! - LIST all latency (list entire directory)
+//! - GET latency (read back)
+//!
+//! ## Running against S3 Express
+//!
+//! ```bash
+//! export AWS_REGION=us-east-1
+//! export DATASET_URI=s3://jack-lancedb-devland-az6--use1-az6--x-s3/bench/manifest_commit_XXXX
+//! cargo bench --bench object_store_bench
+//! ```
+//!
+//! ## Running against S3 Standard
+//!
+//! ```bash
+//! export AWS_REGION=us-east-1
+//! export DATASET_URI=s3://jack-lancedb-devland-us-east-1/bench/manifest_commit_XXXX
+//! cargo bench --bench object_store_bench
+//! ```
+//!
+//! ## Configuration
+//!
+//! - `DATASET_URI`: URI to Lance dataset with _versions directory (required)
+//! - `AWS_REGION`: AWS region (required for S3)
+//! - `MAX_MANIFESTS`: Maximum number of manifests to test (default: all)
+
+#![allow(clippy::print_stdout)]
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures::{StreamExt, TryStreamExt};
+use object_store::aws::AmazonS3Builder;
+use object_store::path::Path;
+use object_store::{ObjectMeta, ObjectStore};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::runtime::Runtime;
+use url::Url;
+
+fn get_max_manifests() -> Option<usize> {
+    std::env::var("MAX_MANIFESTS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+}
+
+fn get_storage_label(uri: &str) -> &'static str {
+    if uri.contains("--x-s3") {
+        "s3express"
+    } else if uri.starts_with("s3://") {
+        "s3"
+    } else if uri.starts_with("gs://") {
+        "gcs"
+    } else {
+        "local"
+    }
+}
+
+async fn create_object_store(uri: &str) -> Arc<dyn ObjectStore> {
+    let url = Url::parse(uri).expect("Invalid URL");
+    let bucket = url.host_str().expect("No bucket in URL");
+
+    let mut builder = AmazonS3Builder::from_env().with_bucket_name(bucket);
+
+    if uri.contains("--x-s3") {
+        builder = builder.with_s3_express(true);
+    }
+
+    Arc::new(builder.build().expect("Failed to build S3 client"))
+}
+
+async fn list_manifests(store: &dyn ObjectStore, versions_path: &Path) -> Vec<ObjectMeta> {
+    let stream = store.list(Some(versions_path));
+    let mut objects: Vec<ObjectMeta> = stream
+        .try_collect()
+        .await
+        .expect("Failed to list manifests");
+
+    // Filter for .manifest files and sort by version number
+    objects.retain(|o| o.location.as_ref().ends_with(".manifest"));
+    objects.sort_by(|a, b| {
+        let version_a = extract_version(&a.location);
+        let version_b = extract_version(&b.location);
+        version_a.cmp(&version_b)
+    });
+
+    objects
+}
+
+fn extract_version(path: &Path) -> u64 {
+    let filename = path.filename().unwrap_or("");
+    filename
+        .strip_suffix(".manifest")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0)
+}
+
+async fn list_first_page(store: &dyn ObjectStore, path: &Path) -> usize {
+    // List with a small limit to simulate first page
+    let stream = store.list(Some(path));
+    let objects: Vec<ObjectMeta> = stream.try_collect().await.expect("Failed to list");
+    // We can't easily limit in object_store, so we just count
+    // The latency measurement captures the full list time
+    objects.len()
+}
+
+async fn list_all(store: &dyn ObjectStore, path: &Path) -> usize {
+    let stream = store.list(Some(path));
+    let objects: Vec<ObjectMeta> = stream.try_collect().await.expect("Failed to list");
+    objects.len()
+}
+
+fn bench_direct_s3(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("Failed to create runtime");
+
+    let dataset_uri = std::env::var("DATASET_URI").expect(
+        "DATASET_URI environment variable is required.\n\
+         Example: export DATASET_URI=s3://bucket/bench/manifest_commit_XXXX",
+    );
+
+    let storage_label = get_storage_label(&dataset_uri);
+    let max_manifests = get_max_manifests();
+
+    let url = Url::parse(&dataset_uri).expect("Invalid URL");
+    let base_path = url.path().trim_start_matches('/');
+
+    println!("=== Direct S3 Operations Benchmark ===");
+    println!("Dataset: {}", dataset_uri);
+    println!("Storage: {}", storage_label);
+    if let Some(max) = max_manifests {
+        println!("Max manifests: {}", max);
+    }
+    println!();
+
+    let store = runtime.block_on(create_object_store(&dataset_uri));
+
+    // List all manifests from _versions directory
+    let versions_path = Path::from(format!("{}/_versions", base_path));
+    let manifests = runtime.block_on(list_manifests(store.as_ref(), &versions_path));
+
+    let manifest_count = if let Some(max) = max_manifests {
+        manifests.len().min(max)
+    } else {
+        manifests.len()
+    };
+
+    println!(
+        "Found {} manifests, testing {}",
+        manifests.len(),
+        manifest_count
+    );
+    println!();
+
+    // Prepare validate directory path
+    let validate_path = Path::from(format!("{}/_validate", base_path));
+
+    // Clean up any existing _validate directory
+    runtime.block_on(async {
+        let stream = store.list(Some(&validate_path));
+        if let Ok(objects) = stream.try_collect::<Vec<_>>().await {
+            for obj in objects {
+                let _ = store.delete(&obj.location).await;
+            }
+        }
+    });
+
+    println!("version,size_bytes,put_ms,list_first_ms,list_all_ms,get_ms,validate_count");
+
+    let mut put_times = Vec::with_capacity(manifest_count);
+    let mut list_first_times = Vec::with_capacity(manifest_count);
+    let mut list_all_times = Vec::with_capacity(manifest_count);
+    let mut get_times = Vec::with_capacity(manifest_count);
+    let mut sizes = Vec::with_capacity(manifest_count);
+
+    for (i, manifest) in manifests.iter().take(manifest_count).enumerate() {
+        let version = extract_version(&manifest.location);
+        let size = manifest.size;
+
+        // Read the manifest
+        let data: Bytes = runtime.block_on(async {
+            let result = store
+                .get(&manifest.location)
+                .await
+                .expect("Failed to read manifest");
+            result.bytes().await.expect("Failed to get bytes")
+        });
+
+        // Write to _validate directory - measure PUT
+        let validate_file = Path::from(format!("{}/_validate/{}.manifest", base_path, version));
+        let put_time = runtime.block_on(async {
+            let start = Instant::now();
+            store
+                .put(&validate_file, data.clone().into())
+                .await
+                .expect("PUT failed");
+            start.elapsed()
+        });
+
+        // List _validate with first page simulation - measure LIST first page
+        // Since object_store doesn't have built-in pagination limit, we measure full list
+        // but in practice this represents the first page latency for small counts
+        let (list_first_time, _) = runtime.block_on(async {
+            let start = Instant::now();
+            let count = list_first_page(store.as_ref(), &validate_path).await;
+            (start.elapsed(), count)
+        });
+
+        // List _validate completely - measure LIST all
+        let (list_all_time, validate_count) = runtime.block_on(async {
+            let start = Instant::now();
+            let count = list_all(store.as_ref(), &validate_path).await;
+            (start.elapsed(), count)
+        });
+
+        // Read back from _validate - measure GET
+        let get_time = runtime.block_on(async {
+            let start = Instant::now();
+            let result = store.get(&validate_file).await.expect("GET failed");
+            let _bytes = result.bytes().await.expect("Failed to get bytes");
+            start.elapsed()
+        });
+
+        put_times.push(put_time);
+        list_first_times.push(list_first_time);
+        list_all_times.push(list_all_time);
+        get_times.push(get_time);
+        sizes.push(size);
+
+        println!(
+            "{},{},{:.2},{:.2},{:.2},{:.2},{}",
+            version,
+            size,
+            put_time.as_secs_f64() * 1000.0,
+            list_first_time.as_secs_f64() * 1000.0,
+            list_all_time.as_secs_f64() * 1000.0,
+            get_time.as_secs_f64() * 1000.0,
+            validate_count
+        );
+
+        // Progress indicator every 500 iterations
+        if (i + 1) % 500 == 0 {
+            eprintln!("Progress: {}/{}", i + 1, manifest_count);
+        }
+    }
+
+    // Summary statistics
+    println!();
+    println!("=== Summary Statistics ===");
+
+    let avg_put = put_times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / manifest_count as f64;
+    let avg_list_first = list_first_times
+        .iter()
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / manifest_count as f64;
+    let avg_list_all =
+        list_all_times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / manifest_count as f64;
+    let avg_get = get_times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / manifest_count as f64;
+
+    let min_put = put_times.iter().min().unwrap().as_secs_f64();
+    let min_list_first = list_first_times.iter().min().unwrap().as_secs_f64();
+    let min_list_all = list_all_times.iter().min().unwrap().as_secs_f64();
+    let min_get = get_times.iter().min().unwrap().as_secs_f64();
+
+    let max_put = put_times.iter().max().unwrap().as_secs_f64();
+    let max_list_first = list_first_times.iter().max().unwrap().as_secs_f64();
+    let max_list_all = list_all_times.iter().max().unwrap().as_secs_f64();
+    let max_get = get_times.iter().max().unwrap().as_secs_f64();
+
+    println!(
+        "PUT:        avg={:.2}ms, min={:.2}ms, max={:.2}ms",
+        avg_put * 1000.0,
+        min_put * 1000.0,
+        max_put * 1000.0
+    );
+    println!(
+        "LIST first: avg={:.2}ms, min={:.2}ms, max={:.2}ms",
+        avg_list_first * 1000.0,
+        min_list_first * 1000.0,
+        max_list_first * 1000.0
+    );
+    println!(
+        "LIST all:   avg={:.2}ms, min={:.2}ms, max={:.2}ms",
+        avg_list_all * 1000.0,
+        min_list_all * 1000.0,
+        max_list_all * 1000.0
+    );
+    println!(
+        "GET:        avg={:.2}ms, min={:.2}ms, max={:.2}ms",
+        avg_get * 1000.0,
+        min_get * 1000.0,
+        max_get * 1000.0
+    );
+
+    // Linear regression for LIST latency vs file count
+    let n = manifest_count as f64;
+    let file_counts: Vec<f64> = (1..=manifest_count).map(|x| x as f64).collect();
+    let list_all_ms: Vec<f64> = list_all_times
+        .iter()
+        .map(|d| d.as_secs_f64() * 1000.0)
+        .collect();
+
+    let sum_x: f64 = file_counts.iter().sum();
+    let sum_y: f64 = list_all_ms.iter().sum();
+    let sum_xx: f64 = file_counts.iter().map(|x| x * x).sum();
+    let sum_xy: f64 = file_counts
+        .iter()
+        .zip(list_all_ms.iter())
+        .map(|(x, y)| x * y)
+        .sum();
+
+    let list_slope = (n * sum_xy - sum_x * sum_y) / (n * sum_xx - sum_x * sum_x);
+    let list_intercept = (sum_y - list_slope * sum_x) / n;
+
+    println!();
+    println!("=== Linear Regression (LIST all vs file count) ===");
+    println!(
+        "LIST all = {:.2}ms + {:.4}ms × files",
+        list_intercept, list_slope
+    );
+    println!("Per-file overhead: {:.4}ms", list_slope);
+
+    // First 10 vs last 10 comparison
+    let first_10_put = put_times
+        .iter()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
+    let last_10_put = put_times
+        .iter()
+        .rev()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
+    let first_10_list = list_all_times
+        .iter()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
+    let last_10_list = list_all_times
+        .iter()
+        .rev()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
+    let first_10_get = get_times
+        .iter()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
+    let last_10_get = get_times
+        .iter()
+        .rev()
+        .take(10)
+        .map(|d| d.as_secs_f64())
+        .sum::<f64>()
+        / 10.0;
+
+    println!();
+    println!("=== First 10 vs Last 10 ===");
+    println!(
+        "PUT:      first={:.2}ms, last={:.2}ms, ratio={:.2}x",
+        first_10_put * 1000.0,
+        last_10_put * 1000.0,
+        last_10_put / first_10_put
+    );
+    println!(
+        "LIST all: first={:.2}ms, last={:.2}ms, ratio={:.2}x",
+        first_10_list * 1000.0,
+        last_10_list * 1000.0,
+        last_10_list / first_10_list
+    );
+    println!(
+        "GET:      first={:.2}ms, last={:.2}ms, ratio={:.2}x",
+        first_10_get * 1000.0,
+        last_10_get * 1000.0,
+        last_10_get / first_10_get
+    );
+
+    // Cleanup _validate directory
+    println!();
+    println!("Cleaning up _validate directory...");
+    runtime.block_on(async {
+        let stream = store.list(Some(&validate_path));
+        if let Ok(objects) = stream.try_collect::<Vec<_>>().await {
+            for obj in objects {
+                let _ = store.delete(&obj.location).await;
+            }
+        }
+    });
+    println!("Cleanup complete.");
+
+    // Criterion benchmarks for tracking
+    let mut group = c.benchmark_group(format!("direct_s3_{}", storage_label));
+
+    group.bench_function("avg_put_ms", |b| b.iter(|| avg_put * 1000.0));
+    group.bench_function("avg_list_all_ms", |b| b.iter(|| avg_list_all * 1000.0));
+    group.bench_function("avg_get_ms", |b| b.iter(|| avg_get * 1000.0));
+    group.bench_function("list_slope_ms_per_file", |b| b.iter(|| list_slope));
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_direct_s3);
+criterion_main!(benches);

--- a/rust/lance/benches/object_store_bench.rs
+++ b/rust/lance/benches/object_store_bench.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
 //! Direct object_store benchmark to isolate S3 vs S3 Express performance.
 //!
 //! This benchmark reads actual manifest files from a Lance dataset and measures:
@@ -31,11 +33,9 @@
 //! - `AWS_REGION`: AWS region (required for S3)
 //! - `MAX_MANIFESTS`: Maximum number of manifests to test (default: all)
 
-#![allow(clippy::print_stdout)]
-
 use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, Criterion};
-use futures::{StreamExt, TryStreamExt};
+use futures::TryStreamExt;
 use object_store::aws::AmazonS3Builder;
 use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore};

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2487,13 +2487,13 @@ pub(crate) fn load_new_transactions(dataset: &Dataset) -> NewTransactionResult<'
     // Re-use the same list call for getting the latest manifest and the metadata
     // for all manifests in between.
     let io_parallelism = dataset.object_store().io_parallelism();
-    let latest_version = dataset.manifest.version;
-    let locations = dataset
-        .commit_handler
-        .list_manifest_locations(&dataset.base, dataset.object_store(), true)
-        .try_take_while(move |location| {
-            futures::future::ready(Ok(location.version > latest_version))
-        });
+    let current_version = dataset.manifest.version;
+    // Use the optimized method that leverages version hint for non-lexical stores
+    let locations = dataset.commit_handler.list_manifest_locations_since(
+        &dataset.base,
+        dataset.object_store(),
+        current_version,
+    );
 
     // Will send the latest manifest via a channel.
     let (latest_tx, latest_rx) = tokio::sync::oneshot::channel();

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3069,6 +3069,7 @@ pub(crate) async fn write_manifest_file(
     config: &ManifestWriteConfig,
     naming_scheme: ManifestNamingScheme,
     mut transaction: Option<&Transaction>,
+    sync_version_hint_write: bool,
 ) -> std::result::Result<ManifestLocation, CommitError> {
     if config.auto_set_feature_flags {
         apply_feature_flags(
@@ -3091,6 +3092,7 @@ pub(crate) async fn write_manifest_file(
             write_manifest_file_to_path,
             naming_scheme,
             transaction.take().map(|tx| tx.into()),
+            sync_version_hint_write,
         )
         .await
 }

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -549,6 +549,7 @@ async fn test_write_manifest(
         },
         dataset.manifest_location.naming_scheme,
         None,
+        false,
     )
     .await
     .unwrap();

--- a/rust/lance/src/dataset/tests/dataset_transactions.rs
+++ b/rust/lance/src/dataset/tests/dataset_transactions.rs
@@ -368,6 +368,7 @@ async fn test_inline_transaction() {
         &ManifestWriteConfig::default(),
         ds.manifest_location.naming_scheme,
         None,
+        false,
     )
     .await
     .unwrap();

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -163,6 +163,19 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
+    /// Whether to wait for the version hint write to complete before returning.
+    ///
+    /// When `true`, the commit will block until the version hint is written.
+    /// This adds ~10ms latency on S3 Express but guarantees the hint is available
+    /// for immediate reads by other clients.
+    ///
+    /// When `false` (default), the version hint is written asynchronously in the
+    /// background, allowing the commit to return immediately.
+    pub fn with_sync_version_hint_write(mut self, sync_write: bool) -> Self {
+        self.commit_config.sync_version_hint_write = sync_write;
+        self
+    }
+
     /// Provide the set of row addresses that were deleted or updated. This is
     /// used to perform fast conflict resolution.
     pub fn with_affected_rows(mut self, affected_rows: RowAddrTreeMap) -> Self {
@@ -924,11 +937,6 @@ mod tests {
             write_iops,
             3,
             "write txn + manifest + version_hint"
-        );
-
-        println!(
-            "Commit with version hint optimization: elapsed={:?}, read_iops={}, write_iops={}",
-            elapsed, io_stats.read_iops, io_stats.write_iops
         );
     }
 }

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -816,4 +816,119 @@ mod tests {
         );
         assert_eq!(transaction.read_version, 1);
     }
+
+    /// Test that commit uses HEAD-based probing instead of LIST on non-lexically ordered stores.
+    ///
+    /// This test verifies the version hint optimization works correctly for commit operations
+    /// on stores like S3 Express where listing is not lexicographically ordered.
+    ///
+    /// The test creates a dataset with many versions and verifies that subsequent commits
+    /// use HEAD requests (O(k) where k = new versions) instead of full listing (O(n)).
+    #[tokio::test]
+    async fn test_commit_uses_version_hint_on_non_lexical_store() {
+        use lance_io::object_store::ObjectStoreParams;
+
+        // Create a throttled store that makes list calls VERY slow
+        // but HEAD calls fast
+        let throttled = Arc::new(ThrottledStoreWrapper {
+            config: ThrottleConfig {
+                // Make list operations very slow - 100ms per entry
+                wait_list_per_entry: Duration::from_millis(100),
+                // HEAD (get metadata) should be fast
+                wait_get_per_call: Duration::from_millis(1),
+                wait_put_per_call: Duration::from_millis(1),
+                ..Default::default()
+            },
+        });
+
+        let session = Arc::new(Session::default());
+        let write_params = WriteParams {
+            store_params: Some(ObjectStoreParams {
+                object_store_wrapper: Some(throttled),
+                // This is the key setting - simulate S3 Express behavior
+                list_is_lexically_ordered: Some(false),
+                ..Default::default()
+            }),
+            session: Some(session.clone()),
+            enable_v2_manifest_paths: true,
+            ..Default::default()
+        };
+
+        // Create initial dataset
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "i",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+        )
+        .unwrap();
+
+        let dataset = InsertBuilder::new("memory://test_version_hint")
+            .with_params(&write_params)
+            .execute(vec![batch])
+            .await
+            .unwrap();
+
+        // Create 50 more versions to simulate a dataset with many versions
+        let mut dataset = Arc::new(dataset);
+        for _ in 0..50 {
+            let new_ds = CommitBuilder::new(dataset.clone())
+                .execute(sample_transaction(dataset.manifest().version))
+                .await
+                .unwrap();
+            dataset = Arc::new(new_ds);
+        }
+
+        assert_eq!(dataset.manifest().version, 51);
+
+        // Reset IO stats
+        dataset.object_store().io_stats_incremental();
+
+        // Now do a commit and measure time
+        // If the optimization is working, this should be fast (using HEAD requests)
+        // If not working, this would be slow (100ms * 51 entries = 5.1 seconds)
+        let start = std::time::Instant::now();
+        let new_ds = CommitBuilder::new(dataset.clone())
+            .execute(sample_transaction(dataset.manifest().version))
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        // With 51 versions and 100ms per list entry, a full list would take ~5.1 seconds
+        // With HEAD-based probing, it should take < 500ms even with some overhead
+        // Use 2 seconds as a generous threshold to avoid flaky tests
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "Commit took {:?}, expected < 2s. This suggests list was used instead of HEAD-based probing.",
+            elapsed
+        );
+
+        let io_stats = new_ds.object_store().io_stats_incremental();
+
+        // The read_iops should be low - just HEAD requests for version hint + probing
+        // A full list would show many more read operations
+        // With version hint optimization: ~2-5 HEAD requests (hint + probe a few versions)
+        // Without optimization: 51+ list entries
+        assert!(
+            io_stats.read_iops < 10,
+            "read_iops = {}, expected < 10 (HEAD-based). High value suggests full listing was used.",
+            io_stats.read_iops
+        );
+
+        // Write should still be: txn file + manifest + version hint = 3
+        assert_io_eq!(
+            io_stats,
+            write_iops,
+            3,
+            "write txn + manifest + version_hint"
+        );
+
+        println!(
+            "Commit with version hint optimization: elapsed={:?}, read_iops={}, write_iops={}",
+            elapsed, io_stats.read_iops, io_stats.write_iops
+        );
+    }
 }

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -568,7 +568,13 @@ mod tests {
             // Should see 2 IOPs:
             // 1. Write the transaction files
             // 2. Write (conditional put) the manifest
-            assert_io_eq!(io_stats, write_iops, 2, "write txn + manifest, i = {}", i);
+            assert_io_eq!(
+                io_stats,
+                write_iops,
+                3,
+                "write txn + manifest + version_hint, i = {}",
+                i
+            );
         }
 
         // Commit transaction with URI and session
@@ -582,8 +588,19 @@ mod tests {
         // However, the dataset needs to be loaded and the read version checked out,
         // so an additional 4 IOPs are needed.
         let io_stats = dataset.object_store().io_stats_incremental();
-        assert_io_eq!(io_stats, read_iops, 5, "load dataset + check version");
-        assert_io_eq!(io_stats, write_iops, 2, "write txn + manifest");
+        // read_iops increased due to version hint probing (HEAD for hint + probing versions)
+        assert_io_eq!(
+            io_stats,
+            read_iops,
+            8,
+            "load dataset + check version + version hint probing"
+        );
+        assert_io_eq!(
+            io_stats,
+            write_iops,
+            3,
+            "write txn + manifest + version_hint"
+        );
 
         // Commit transaction with URI and new session. Re-use the store
         // registry so we see the same store.
@@ -598,7 +615,12 @@ mod tests {
 
         let io_stats = dataset.object_store().io_stats_incremental();
         assert_io_gt!(io_stats, read_iops, 10);
-        assert_io_eq!(io_stats, write_iops, 2, "write txn + manifest");
+        assert_io_eq!(
+            io_stats,
+            write_iops,
+            3,
+            "write txn + manifest + version_hint"
+        );
     }
 
     #[tokio::test]
@@ -636,13 +658,14 @@ mod tests {
         // Assert io requests
         let io_stats = new_ds.object_store().io_stats_incremental();
         // This could be zero, if we decided to be optimistic. However, that
-        // would mean two wasted write requests (txn + manifest) if there was
+        // would mean wasted write requests (txn + manifest) if there was
         // a conflict. We choose to be pessimistic for more consistent performance.
         assert_io_eq!(io_stats, read_iops, 1);
-        assert_io_eq!(io_stats, write_iops, 2);
+        // write txn + manifest + version_hint
+        assert_io_eq!(io_stats, write_iops, 3);
         // We can't write them in parallel. The transaction file must exist before
-        // we can write the manifest.
-        assert_io_eq!(io_stats, num_stages, 3);
+        // we can write the manifest. Version hint is async/fire-and-forget (spawned task).
+        assert_io_eq!(io_stats, num_stages, 4);
     }
 
     #[tokio::test]
@@ -711,7 +734,8 @@ mod tests {
         // of those. We should be able to read in 5 hops.
         if use_cache {
             assert_io_eq!(io_stats, read_iops, 1); // Just list versions
-            assert_io_eq!(io_stats, num_stages, 3);
+                                                   // num_stages increased by 1 due to async version hint write (fire-and-forget spawned task)
+            assert_io_eq!(io_stats, num_stages, 4);
         } else {
             // We need to read the other manifests and transactions.
 
@@ -722,7 +746,7 @@ mod tests {
             // and txs" may appear as 1 hop instead of 2.
             assert_io_lt!(io_stats, num_stages, 6);
         }
-        assert_io_eq!(io_stats, write_iops, 2); // txn + manifest
+        assert_io_eq!(io_stats, write_iops, 3); // txn + manifest + version_hint
     }
 
     #[tokio::test]

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -228,6 +228,7 @@ async fn do_commit_new_dataset(
         write_config,
         manifest_naming_scheme,
         Some(transaction),
+        false, // New datasets use async hint write by default
     )
     .await;
 
@@ -710,6 +711,7 @@ pub(crate) async fn do_commit_detached_transaction(
             write_config,
             ManifestNamingScheme::V2,
             Some(transaction),
+            commit_config.sync_version_hint_write,
         )
         .await;
 
@@ -907,6 +909,7 @@ pub(crate) async fn commit_transaction(
             write_config,
             manifest_naming_scheme,
             Some(&transaction),
+            commit_config.sync_version_hint_write,
         )
         .await;
 

--- a/rust/lance/src/io/commit/external_manifest.rs
+++ b/rust/lance/src/io/commit/external_manifest.rs
@@ -278,6 +278,20 @@ mod test {
                         .to_string_lossy()
                         .contains(".manifest#")
                 })
+                // Version hint files are expected
+                .filter(|entry| {
+                    let entry = entry.as_ref().unwrap();
+                    let name = entry.file_name();
+                    let name = name.to_string_lossy();
+                    !name.starts_with("latest_version_hint")
+                })
+                // Temporary files from concurrent file system operations
+                .filter(|entry| {
+                    let entry = entry.as_ref().unwrap();
+                    let name = entry.file_name();
+                    let name = name.to_string_lossy();
+                    !name.starts_with(".tmp")
+                })
                 .collect::<Vec<_>>();
             assert!(unexpected_entries.is_empty(), "{:?}", unexpected_entries);
         }
@@ -382,6 +396,13 @@ mod test {
                     .as_os_str()
                     .to_string_lossy()
                     .ends_with(".manifest")
+            })
+            // Version hint files are expected
+            .filter(|entry| {
+                let entry = entry.as_ref().unwrap();
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                !name.starts_with("latest_version_hint")
             })
             .collect::<Vec<_>>();
         assert!(unexpected_entries.is_empty(), "{:?}", unexpected_entries);


### PR DESCRIPTION
Based on benchmarking result in https://github.com/lance-format/lance/discussions/5947#discussioncomment-15905954

Currently I have only kept JSON format manifest hint support. The exact format to choose requires some further discussions.