### PR TITLE
fix: track merge key in transaction for concurrent merge_insert conflict detection

### DIFF
--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -431,6 +431,7 @@ fn convert_to_java_operation_inner<'local>(
             fields_for_preserving_frag_bitmap,
             update_mode,
             inserted_rows_filter: _,
+            merge_key_field_ids: _,
         } => {
             let removed_ids: Vec<JLance<i64>> = removed_fragment_ids
                 .iter()
@@ -1030,6 +1031,7 @@ fn convert_to_rust_operation(
                 fields_for_preserving_frag_bitmap,
                 update_mode,
                 inserted_rows_filter: None,
+                merge_key_field_ids: vec![],
             }
         }
         "DataReplacement" => {

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -209,11 +209,9 @@ message Transaction {
   }
 
   // A filter for checking key existence in set of rows inserted by a merge insert operation.
-  // Only created when the merge insert's ON columns match the schema's unenforced primary key.
-  // The presence of this filter indicates strict primary key conflict detection should be used.
   // Can use either an exact set (for small row counts) or a Bloom filter (for large row counts).
   message KeyExistenceFilter {
-    // Field IDs of columns participating in the key (must match unenforced primary key).
+    // Field IDs of columns participating in the key.
     repeated int32 field_ids = 1;
     // The underlying data structure storing the key hashes.
     oneof data {
@@ -245,6 +243,11 @@ message Transaction {
     // Filter for checking existence of keys in newly inserted rows, used for conflict detection.
     // Only tracks keys from INSERT operations during merge insert, not updates.
     optional KeyExistenceFilter inserted_rows = 8;
+    // Field IDs of the columns used as the merge key (the ON columns in merge insert).
+    // When non-empty, this indicates a merge insert operation. Concurrent merge inserts
+    // with different merge keys are always treated as conflicts because their bloom
+    // filters are incompatible. Empty for non-merge-insert updates.
+    repeated int32 merge_key_field_ids = 9;
   }
 
   // The mode of update operation

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -233,6 +233,7 @@ impl FromPyObject<'_> for PyLance<Operation> {
                     fields_for_preserving_frag_bitmap,
                     update_mode,
                     inserted_rows_filter: None,
+                    merge_key_field_ids: vec![],
                 };
                 Ok(Self(op))
             }

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2889,6 +2889,7 @@ mod tests {
             fields_for_preserving_frag_bitmap: vec![],
             update_mode: Some(UpdateMode::RewriteColumns),
             inserted_rows_filter: None,
+            merge_key_field_ids: vec![],
         };
         let mut dataset1 = Dataset::commit(
             test_uri,
@@ -2962,6 +2963,7 @@ mod tests {
             fields_for_preserving_frag_bitmap: vec![],
             update_mode: Some(UpdateMode::RewriteColumns),
             inserted_rows_filter: None,
+            merge_key_field_ids: vec![],
         };
         let dataset2 = Dataset::commit(
             test_uri,

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -255,6 +255,10 @@ pub enum Operation {
         /// Optional filter for detecting conflicts on inserted row keys.
         /// Only tracks keys from INSERT operations during merge insert, not updates.
         inserted_rows_filter: Option<KeyExistenceFilter>,
+        /// Field IDs of the columns used as the merge key (the ON columns).
+        /// Non-empty for merge insert operations; empty for regular updates.
+        /// Concurrent merge inserts with different merge keys are incompatible.
+        merge_key_field_ids: Vec<i32>,
     },
 
     /// Project to a new schema. This only changes the schema, not the data.
@@ -454,6 +458,7 @@ impl PartialEq for Operation {
                     fields_for_preserving_frag_bitmap: a_fields_for_preserving_frag_bitmap,
                     update_mode: a_update_mode,
                     inserted_rows_filter: a_inserted_rows_filter,
+                    merge_key_field_ids: a_merge_key,
                 },
                 Self::Update {
                     removed_fragment_ids: b_removed,
@@ -464,6 +469,7 @@ impl PartialEq for Operation {
                     fields_for_preserving_frag_bitmap: b_fields_for_preserving_frag_bitmap,
                     update_mode: b_update_mode,
                     inserted_rows_filter: b_inserted_rows_filter,
+                    merge_key_field_ids: b_merge_key,
                 },
             ) => {
                 compare_vec(a_removed, b_removed)
@@ -477,6 +483,7 @@ impl PartialEq for Operation {
                     )
                     && a_update_mode == b_update_mode
                     && a_inserted_rows_filter == b_inserted_rows_filter
+                    && a_merge_key == b_merge_key
             }
             (Self::Project { schema: a }, Self::Project { schema: b }) => a == b,
             (
@@ -2889,6 +2896,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                 fields_for_preserving_frag_bitmap,
                 update_mode,
                 inserted_rows,
+                merge_key_field_ids,
             })) => Operation::Update {
                 removed_fragment_ids,
                 updated_fragments: updated_fragments
@@ -2913,6 +2921,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                 inserted_rows_filter: inserted_rows
                     .map(|ik| KeyExistenceFilter::try_from(&ik))
                     .transpose()?,
+                merge_key_field_ids,
             },
             Some(pb::transaction::Operation::Project(pb::transaction::Project { schema })) => {
                 Operation::Project {
@@ -3212,6 +3221,7 @@ impl From<&Transaction> for pb::Transaction {
                 fields_for_preserving_frag_bitmap,
                 update_mode,
                 inserted_rows_filter,
+                merge_key_field_ids,
             } => pb::transaction::Operation::Update(pb::transaction::Update {
                 removed_fragment_ids: removed_fragment_ids.clone(),
                 updated_fragments: updated_fragments
@@ -3233,6 +3243,7 @@ impl From<&Transaction> for pb::Transaction {
                     })
                     .unwrap_or(0),
                 inserted_rows: inserted_rows_filter.as_ref().map(|ik| ik.into()),
+                merge_key_field_ids: merge_key_field_ids.clone(),
             }),
             Operation::Project { schema } => {
                 pb::transaction::Operation::Project(pb::transaction::Project {

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -762,6 +762,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                merge_key_field_ids: vec![],
             },
             read_version: 1,
             tag: None,

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1590,6 +1590,7 @@ impl MergeInsertJob {
                 fields_for_preserving_frag_bitmap: vec![], // in-place update do not affect preserving frag bitmap
                 update_mode: Some(RewriteColumns),
                 inserted_rows_filter: None, // not implemented for v1
+                merge_key_field_ids: vec![],
             };
             // We have rewritten the fragments, not just the deletion files, so
             // we can't use affected rows here.
@@ -1665,6 +1666,7 @@ impl MergeInsertJob {
                     .collect(),
                 update_mode: Some(RewriteRows),
                 inserted_rows_filter: None, // not implemented for v1
+                merge_key_field_ids: vec![],
             };
 
             let affected_rows = Some(RowAddrTreeMap::from(removed_row_addrs));

--- a/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
@@ -284,6 +284,7 @@ impl ExecutionPlan for DeleteOnlyMergeInsertExec {
                     .collect(),
                 update_mode: None,
                 inserted_rows_filter: None, // Delete-only operations don't insert rows
+                merge_key_field_ids: vec![],
             };
 
             let transaction = Transaction::new(dataset.manifest.version, operation, None);

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -187,9 +187,8 @@ pub struct FullSchemaMergeInsertExec {
     transaction: Arc<Mutex<Option<Transaction>>>,
     affected_rows: Arc<Mutex<Option<RoaringTreemap>>>,
     inserted_rows_filter: Arc<Mutex<Option<KeyExistenceFilter>>>,
-    /// Whether the ON columns match the schema's unenforced primary key.
-    /// If true, inserted_rows_filter will be included in the transaction for conflict detection.
-    is_primary_key: bool,
+    /// Field IDs of the ON columns, used as merge_key_field_ids in the transaction.
+    merge_key_field_ids: Vec<i32>,
 }
 
 impl FullSchemaMergeInsertExec {
@@ -206,19 +205,12 @@ impl FullSchemaMergeInsertExec {
             Boundedness::Bounded,
         );
 
-        // Check if ON columns match the schema's unenforced primary key
-        let field_ids: Vec<i32> = params
+        // Get field IDs for the ON columns to track the merge key in the transaction.
+        let merge_key_field_ids: Vec<i32> = params
             .on
             .iter()
             .filter_map(|name| dataset.schema().field(name).map(|f| f.id))
             .collect();
-        let pk_field_ids: Vec<i32> = dataset
-            .schema()
-            .unenforced_primary_key()
-            .iter()
-            .map(|f| f.id)
-            .collect();
-        let is_primary_key = !pk_field_ids.is_empty() && field_ids == pk_field_ids;
 
         Ok(Self {
             input,
@@ -230,7 +222,7 @@ impl FullSchemaMergeInsertExec {
             transaction: Arc::new(Mutex::new(None)),
             affected_rows: Arc::new(Mutex::new(None)),
             inserted_rows_filter: Arc::new(Mutex::new(None)),
-            is_primary_key,
+            merge_key_field_ids,
         })
     }
 
@@ -785,7 +777,7 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
             transaction: self.transaction.clone(),
             affected_rows: self.affected_rows.clone(),
             inserted_rows_filter: self.inserted_rows_filter.clone(),
-            is_primary_key: self.is_primary_key,
+            merge_key_field_ids: self.merge_key_field_ids.clone(),
         }))
     }
 
@@ -851,7 +843,7 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
         let affected_rows_holder = self.affected_rows.clone();
         let inserted_rows_filter_holder = self.inserted_rows_filter.clone();
         let merged_generations = self.params.merged_generations.clone();
-        let is_primary_key = self.is_primary_key;
+        let merge_key_field_ids = self.merge_key_field_ids.clone();
         let updating_row_ids = {
             let state = merge_state.lock().unwrap();
             state.updating_row_ids.clone()
@@ -904,13 +896,11 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
             let merge_state =
                 Mutex::into_inner(merge_state).expect("MergeState lock should be available");
             let delete_row_addrs_clone = merge_state.delete_row_addrs;
-            let inserted_rows_filter = if is_primary_key {
-                Some(KeyExistenceFilter::from_bloom_filter(
-                    &merge_state.inserted_rows_filter,
-                ))
-            } else {
-                None
-            };
+            // Always include the bloom filter for conflict detection.
+            // The merge key is tracked separately in merge_key_field_ids.
+            let inserted_rows_filter = Some(KeyExistenceFilter::from_bloom_filter(
+                &merge_state.inserted_rows_filter,
+            ));
 
             let (updated_fragments, removed_fragment_ids) =
                 apply_deletions(&dataset, &delete_row_addrs_clone).await?;
@@ -930,6 +920,7 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
                     .collect(),
                 update_mode: Some(RewriteRows),
                 inserted_rows_filter: inserted_rows_filter.clone(),
+                merge_key_field_ids: merge_key_field_ids.clone(),
             };
 
             // Step 5: Create and store the transaction

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -392,6 +392,7 @@ impl UpdateJob {
             fields_for_preserving_frag_bitmap,
             update_mode: Some(RewriteRows),
             inserted_rows_filter: None,
+            merge_key_field_ids: vec![],
         };
 
         let transaction = Transaction::new(dataset.manifest.version, operation, None);

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -355,20 +355,35 @@ impl<'a> TransactionRebase<'a> {
         if let Operation::Update {
             inserted_rows_filter: self_inserted_rows_filter,
             merged_generations: self_merged_generations,
+            merge_key_field_ids: self_merge_key,
             ..
         } = &self.transaction.operation
         {
             if let Operation::Update {
                 inserted_rows_filter: other_inserted_rows_filter,
+                merge_key_field_ids: other_merge_key,
                 ..
             } = &other_transaction.operation
             {
-                // The presence of inserted_rows_filter means this is a primary key operation
-                // and strict conflict detection should be applied.
+                // Check merge key compatibility first.
+                // If both transactions are merge inserts (non-empty merge_key_field_ids),
+                // they must use the same merge key for their bloom filters to be comparable.
+                let both_are_merge_inserts =
+                    !self_merge_key.is_empty() && !other_merge_key.is_empty();
+                if both_are_merge_inserts && self_merge_key != other_merge_key {
+                    // Different merge keys — bloom filters are incompatible.
+                    return Err(self.retryable_conflict_err(
+                        other_transaction,
+                        other_version,
+                        location!(),
+                    ));
+                }
+
+                // Check inserted rows for overlap using bloom filters.
                 match (self_inserted_rows_filter, other_inserted_rows_filter) {
                     (Some(self_keys), Some(other_keys)) => {
                         if self_keys.field_ids != other_keys.field_ids {
-                            // Different key columns - can't verify conflicts
+                            // Different key columns in bloom filter — can't compare.
                             return Err(self.retryable_conflict_err(
                                 other_transaction,
                                 other_version,
@@ -396,17 +411,17 @@ impl<'a> TransactionRebase<'a> {
                             ));
                         }
                     }
-                    (Some(_), None) => {
-                        // Current transaction has primary key conflict detection but
-                        // the already committed transaction doesn't have a filter.
-                        // We can't determine what rows were inserted by the other
-                        // transaction, so we must fail to be safe.
+                    (Some(_), None) | (None, Some(_)) => {
+                        // One transaction has a bloom filter and the other doesn't.
+                        // We can't determine whether the untracked transaction's
+                        // inserts overlap, so we must treat this as a conflict.
                         return Err(self.retryable_conflict_err(
                             other_transaction,
                             other_version,
                             location!(),
                         ));
                     }
+                    // Neither transaction tracks inserts — backward-compatible case.
                     _ => {}
                 }
             }
@@ -1905,6 +1920,7 @@ mod tests {
             fields_for_preserving_frag_bitmap: vec![],
             update_mode: None,
             inserted_rows_filter: None,
+            merge_key_field_ids: vec![],
         };
         let transaction = Transaction::new_from_version(1, operation);
         let other_operations = [
@@ -1917,6 +1933,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                merge_key_field_ids: vec![],
             },
             Operation::Delete {
                 deleted_fragment_ids: vec![3],
@@ -1932,6 +1949,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                merge_key_field_ids: vec![],
             },
         ];
         let other_transactions = other_operations.map(|op| Transaction::new_from_version(2, op));
@@ -2034,6 +2052,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                merge_key_field_ids: vec![],
             },
             Operation::Delete {
                 updated_fragments: vec![apply_deletion(&[1], &mut fragment, &dataset).await],
@@ -2049,6 +2068,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                merge_key_field_ids: vec![],
             },
         ];
         let transactions =
@@ -2171,6 +2191,7 @@ mod tests {
                     fields_for_preserving_frag_bitmap: vec![],
                     update_mode: None,
                     inserted_rows_filter: None,
+                    merge_key_field_ids: vec![],
                 },
             ),
             (
@@ -2184,6 +2205,7 @@ mod tests {
                     fields_for_preserving_frag_bitmap: vec![],
                     update_mode: None,
                     inserted_rows_filter: None,
+                    merge_key_field_ids: vec![],
                 },
             ),
             (
@@ -2343,6 +2365,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                merge_key_field_ids: vec![],
             },
             create_update_config_for_test(
                 Some(HashMap::from_iter(vec![(
@@ -2549,6 +2572,7 @@ mod tests {
                     fields_for_preserving_frag_bitmap: vec![],
                     update_mode: None,
                     inserted_rows_filter: None,
+                    merge_key_field_ids: vec![],
                 },
                 [
                     Compatible,    // append
@@ -2973,6 +2997,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                merge_key_field_ids: vec![],
             },
         ];
 
@@ -3625,5 +3650,259 @@ mod tests {
         );
 
         assert_eq!(dataset_v2.count_rows(None).await.unwrap(), 5);
+    }
+
+    // =========================================================================
+    // Tests for merge_key_field_ids conflict detection
+    // =========================================================================
+
+    use crate::dataset::write::merge_insert::inserted_rows::{
+        KeyExistenceFilter, KeyExistenceFilterBuilder, KeyValue,
+    };
+
+    /// Build a KeyExistenceFilter with a single UInt32 key.
+    fn make_bloom_filter(field_id: i32, key: u32) -> KeyExistenceFilter {
+        let mut builder = KeyExistenceFilterBuilder::new(vec![field_id]);
+        builder.insert(KeyValue::UInt64(key as u64)).unwrap();
+        KeyExistenceFilter::from_bloom_filter(&builder)
+    }
+
+    #[test]
+    fn test_different_merge_keys_should_conflict() {
+        let filter_on_id = make_bloom_filter(0, 100);
+        let filter_on_name = make_bloom_filter(1, 200);
+
+        let to_commit_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(10)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: Some(filter_on_id),
+            merge_key_field_ids: vec![0], // merge on field 0 ("id")
+        };
+        let to_commit_txn = Transaction::new(0, to_commit_op.clone(), None);
+
+        let committed_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(20)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: Some(filter_on_name),
+            merge_key_field_ids: vec![1], // merge on field 1 ("name")
+        };
+        let committed_txn = Transaction::new(0, committed_op, None);
+
+        let mut rebase = TransactionRebase {
+            transaction: to_commit_txn,
+            initial_fragments: HashMap::new(),
+            modified_fragment_ids: modified_fragment_ids(&to_commit_op).collect::<HashSet<_>>(),
+            affected_rows: None,
+            conflicting_frag_reuse_indices: Vec::new(),
+            conflicting_mem_wal_merged_gens: Vec::new(),
+        };
+
+        let result = rebase.check_txn(&committed_txn, 1);
+        assert!(
+            matches!(result, Err(Error::RetryableCommitConflict { .. })),
+            "Different merge keys should conflict. Got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_same_merge_key_disjoint_bloom_filters_should_not_conflict() {
+        let filter1 = make_bloom_filter(0, 100);
+        let filter2 = make_bloom_filter(0, 200);
+
+        let to_commit_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(10)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: Some(filter1),
+            merge_key_field_ids: vec![0],
+        };
+        let to_commit_txn = Transaction::new(0, to_commit_op.clone(), None);
+
+        let committed_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(20)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: Some(filter2),
+            merge_key_field_ids: vec![0],
+        };
+        let committed_txn = Transaction::new(0, committed_op, None);
+
+        let mut rebase = TransactionRebase {
+            transaction: to_commit_txn,
+            initial_fragments: HashMap::new(),
+            modified_fragment_ids: modified_fragment_ids(&to_commit_op).collect::<HashSet<_>>(),
+            affected_rows: None,
+            conflicting_frag_reuse_indices: Vec::new(),
+            conflicting_mem_wal_merged_gens: Vec::new(),
+        };
+
+        let result = rebase.check_txn(&committed_txn, 1);
+        assert!(
+            result.is_ok(),
+            "Same merge key with disjoint bloom filters should not conflict. Got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_same_merge_key_overlapping_bloom_filters_should_conflict() {
+        let filter1 = make_bloom_filter(0, 100);
+        let filter2 = make_bloom_filter(0, 100);
+
+        let to_commit_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(10)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: Some(filter1),
+            merge_key_field_ids: vec![0],
+        };
+        let to_commit_txn = Transaction::new(0, to_commit_op.clone(), None);
+
+        let committed_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(20)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: Some(filter2),
+            merge_key_field_ids: vec![0],
+        };
+        let committed_txn = Transaction::new(0, committed_op, None);
+
+        let mut rebase = TransactionRebase {
+            transaction: to_commit_txn,
+            initial_fragments: HashMap::new(),
+            modified_fragment_ids: modified_fragment_ids(&to_commit_op).collect::<HashSet<_>>(),
+            affected_rows: None,
+            conflicting_frag_reuse_indices: Vec::new(),
+            conflicting_mem_wal_merged_gens: Vec::new(),
+        };
+
+        let result = rebase.check_txn(&committed_txn, 1);
+        assert!(
+            matches!(result, Err(Error::RetryableCommitConflict { .. })),
+            "Same merge key with overlapping bloom filters should conflict. Got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_merge_insert_vs_non_merge_update_with_bloom_filter_should_conflict() {
+        let filter = make_bloom_filter(0, 100);
+
+        // Merge insert (has merge_key_field_ids and bloom filter)
+        let to_commit_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(10)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: Some(filter),
+            merge_key_field_ids: vec![0],
+        };
+        let to_commit_txn = Transaction::new(0, to_commit_op.clone(), None);
+
+        // Regular update (no merge key, no bloom filter)
+        let committed_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(20)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: None,
+            merge_key_field_ids: vec![],
+        };
+        let committed_txn = Transaction::new(0, committed_op, None);
+
+        let mut rebase = TransactionRebase {
+            transaction: to_commit_txn,
+            initial_fragments: HashMap::new(),
+            modified_fragment_ids: modified_fragment_ids(&to_commit_op).collect::<HashSet<_>>(),
+            affected_rows: None,
+            conflicting_frag_reuse_indices: Vec::new(),
+            conflicting_mem_wal_merged_gens: Vec::new(),
+        };
+
+        let result = rebase.check_txn(&committed_txn, 1);
+        assert!(
+            matches!(result, Err(Error::RetryableCommitConflict { .. })),
+            "(Some, None) bloom filter asymmetry should conflict. Got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_non_merge_updates_both_none_should_not_conflict() {
+        // Both are regular updates with no bloom filters and no merge keys
+        let to_commit_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(10)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: None,
+            merge_key_field_ids: vec![],
+        };
+        let to_commit_txn = Transaction::new(0, to_commit_op.clone(), None);
+
+        let committed_op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![Fragment::new(20)],
+            fields_modified: vec![],
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: None,
+            inserted_rows_filter: None,
+            merge_key_field_ids: vec![],
+        };
+        let committed_txn = Transaction::new(0, committed_op, None);
+
+        let mut rebase = TransactionRebase {
+            transaction: to_commit_txn,
+            initial_fragments: HashMap::new(),
+            modified_fragment_ids: modified_fragment_ids(&to_commit_op).collect::<HashSet<_>>(),
+            affected_rows: None,
+            conflicting_frag_reuse_indices: Vec::new(),
+            conflicting_mem_wal_merged_gens: Vec::new(),
+        };
+
+        let result = rebase.check_txn(&committed_txn, 1);
+        assert!(
+            result.is_ok(),
+            "(None, None) should not conflict for backward compat. Got: {:?}",
+            result
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes lancedb/lancedb#2463, #4585
Supersedes #6018 (addresses reviewer feedback from @jackye1995)

Concurrent `merge_insert` operations that insert the same new key silently
produce duplicate rows when the schema lacks `unenforced-primary-key` metadata.
Per [review feedback](https://github.com/lance-format/lance/pull/6018#issuecomment-), the right
fix is to **track the merge key in the transaction model** rather than relying
solely on the presence of a bloom filter.

## Changes

### Spec change: `transaction.proto`

Add `repeated int32 merge_key_field_ids = 9` to the `Update` message. When
non-empty, this indicates the transaction is a merge insert and records which
columns were used as the merge key (the ON columns). This enables conflict
resolution to detect incompatible concurrent merge inserts even before checking
bloom filters.

Update `KeyExistenceFilter` comments to remove the requirement that field IDs
must match an unenforced primary key — they now represent the merge key.

### Conflict resolution

1. **Different merge keys → conflict**: If two concurrent merge inserts use
   different ON columns (e.g., one merges on `id`, another on `name`), their
   bloom filters are incompatible and cannot be compared. This is now detected
   via `merge_key_field_ids` and treated as a retryable conflict.

2. **Same merge key → bloom filter check**: If the merge keys match, the
   existing bloom filter intersection check determines whether the inserted
   rows overlap.

3. **Asymmetric bloom filters → conflict**: `(Some, None)` and `(None, Some)`
   are both conservatively treated as conflicts (fixes the original bug where
   `(None, Some)` fell through silently).

4. **Backward compatible**: Empty `merge_key_field_ids` means "not a merge
   insert" — the existing `(None, None)` fall-through is preserved for older
   transactions and regular updates.

### Always emit bloom filter

The bloom filter is now always included for merge insert operations, regardless
of whether the schema has `unenforced-primary-key` metadata. The `is_primary_key`
gate has been removed.

## Note on spec change process

Per @jackye1995's [comment](https://github.com/lance-format/lance/pull/6018#issuecomment-),
this adds a new field to `transaction.proto` which is a spec change. Happy to
create a separate discussion for a community vote if needed (similar to
[#5485](https://github.com/lance-format/lance/discussions/5485)).

The change is backward compatible: older writers produce empty
`merge_key_field_ids` which is handled correctly by the new conflict resolver.

## Test plan

- [x] Unit tests for merge key conflict detection (5 new tests):
  - Different merge keys → conflict
  - Same key, disjoint bloom filters → OK
  - Same key, overlapping bloom filters → conflict
  - Merge insert vs non-merge update (asymmetric bloom) → conflict
  - Both non-merge updates (None, None) → OK (backward compat)
- [x] All 40 existing conflict resolver tests pass
- [x] All 122 existing merge_insert tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean