### PR TITLE
spec: add merge_key_field_ids to Update transaction message

### DIFF
--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -209,11 +209,9 @@ message Transaction {
   }
 
   // A filter for checking key existence in set of rows inserted by a merge insert operation.
-  // Only created when the merge insert's ON columns match the schema's unenforced primary key.
-  // The presence of this filter indicates strict primary key conflict detection should be used.
   // Can use either an exact set (for small row counts) or a Bloom filter (for large row counts).
   message KeyExistenceFilter {
-    // Field IDs of columns participating in the key (must match unenforced primary key).
+    // Field IDs of columns participating in the key.
     repeated int32 field_ids = 1;
     // The underlying data structure storing the key hashes.
     oneof data {
@@ -245,6 +243,11 @@ message Transaction {
     // Filter for checking existence of keys in newly inserted rows, used for conflict detection.
     // Only tracks keys from INSERT operations during merge insert, not updates.
     optional KeyExistenceFilter inserted_rows = 8;
+    // Field IDs of the columns used as the merge key (the ON columns in merge insert).
+    // When non-empty, this indicates a merge insert operation. Concurrent merge inserts
+    // with different merge keys are always treated as conflicts because their bloom
+    // filters are incompatible. Empty for non-merge-insert updates.
+    repeated int32 merge_key_field_ids = 9;
   }
 
   // The mode of update operation


### PR DESCRIPTION
## Summary

Refs: lancedb/lancedb#2463, #4585, #6018

Add `repeated int32 merge_key_field_ids = 9` to the `Update` message in
`transaction.proto`, per @jackye1995's
[feedback](https://github.com/lance-format/lance/pull/6018#issuecomment-)
that the merge key should be tracked in the transaction model.

## Motivation

Concurrent `merge_insert` operations can silently produce duplicate rows when
the schema lacks `unenforced-primary-key` metadata (#4585). To fix this
properly, conflict resolution needs to know which columns were used as the
merge key (the ON columns), so it can:

1. Detect when two concurrent merge inserts use **different** merge keys
   (incompatible bloom filters — must conflict)
2. Compare bloom filters when merge keys **match** (check for overlapping
   inserted rows)

Currently the merge key is only embedded inside `KeyExistenceFilter.field_ids`,
which is optional and was previously gated on the schema having PK metadata.
Promoting the merge key to a top-level field on `Update` makes the semantics
explicit and enables conflict detection independent of bloom filter presence.

## Changes

- Add `repeated int32 merge_key_field_ids = 9` to `Update` message
- Update `KeyExistenceFilter` comments to remove the PK-only restriction
- Backward compatible: empty for non-merge-insert updates and older writers

## Community vote

Per @jackye1995's suggestion, this is a spec change that may require a community
vote (similar to [#5485](https://github.com/lance-format/lance/discussions/5485)).
Happy to create a vote discussion if needed.

A companion implementation PR will follow once this spec change is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)