### PR TITLE
fix: add panic-catching infrastructure and fix error propagation in Java JNI layer

### DIFF
--- a/java/lance-jni/src/blocking_scanner.rs
+++ b/java/lance-jni/src/blocking_scanner.rs
@@ -319,7 +319,7 @@ fn inner_create_scanner<'local>(
         let key_array = env.get_vec_f32_from_method(&java_obj, "getKey")?;
         let key = Float32Array::from(key_array);
         let k = env.get_int_as_usize_from_method(&java_obj, "getK")?;
-        let _ = scanner.nearest(&column, &key, k);
+        scanner.nearest(&column, &key, k)?;
 
         let minimum_nprobes = env.get_int_as_usize_from_method(&java_obj, "getMinimumNprobes")?;
         scanner.minimum_nprobes(minimum_nprobes);

--- a/java/lance-jni/src/lib.rs
+++ b/java/lance-jni/src/lib.rs
@@ -39,6 +39,66 @@ macro_rules! ok_or_throw_with_return {
     };
 }
 
+/// Extracts a panic message from a `catch_unwind` error payload.
+pub fn panic_message(panic_info: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic_info.downcast_ref::<&str>() {
+        format!("Rust panic: {}", s)
+    } else if let Some(s) = panic_info.downcast_ref::<String>() {
+        format!("Rust panic: {}", s)
+    } else {
+        "Rust panic: <unknown>".to_string()
+    }
+}
+
+/// Wraps a JNI function body with `catch_unwind` to convert Rust panics into
+/// Java `RuntimeException`s. Use for functions returning `JObject`.
+#[macro_export]
+macro_rules! jni_entry {
+    ($env:expr, $body:expr) => {{
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $body));
+        match result {
+            Ok(val) => val,
+            Err(panic_info) => {
+                let msg = $crate::panic_message(&panic_info);
+                let _ = $env.throw_new("java/lang/RuntimeException", &msg);
+                JObject::null()
+            }
+        }
+    }};
+}
+
+/// Wraps a JNI function body with `catch_unwind` for void functions.
+#[macro_export]
+macro_rules! jni_entry_void {
+    ($env:expr, $body:expr) => {{
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $body));
+        match result {
+            Ok(val) => val,
+            Err(panic_info) => {
+                let msg = $crate::panic_message(&panic_info);
+                let _ = $env.throw_new("java/lang/RuntimeException", &msg);
+            }
+        }
+    }};
+}
+
+/// Wraps a JNI function body with `catch_unwind` for functions returning
+/// a custom default value (e.g., `jlong`, `jint`, `jbyteArray`).
+#[macro_export]
+macro_rules! jni_entry_with_return {
+    ($env:expr, $default:expr, $body:expr) => {{
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $body));
+        match result {
+            Ok(val) => val,
+            Err(panic_info) => {
+                let msg = $crate::panic_message(&panic_info);
+                let _ = $env.throw_new("java/lang/RuntimeException", &msg);
+                $default
+            }
+        }
+    }};
+}
+
 mod blocking_blob;
 mod blocking_dataset;
 mod blocking_scanner;
@@ -139,15 +199,35 @@ fn set_log_file_target(builder: &mut env_logger::Builder) {
 
 #[no_mangle]
 pub extern "system" fn Java_org_lance_JniLoader_initLanceLogger() {
-    let env = Env::new()
-        .filter_or("LANCE_LOG", "warn")
-        .write_style("LANCE_LOG_STYLE");
-    let mut log_builder = Builder::from_env(env);
-    set_timestamp_precision(&mut log_builder);
-    set_log_file_target(&mut log_builder);
-    let logger = Arc::new(log_builder.build());
-    let max_level = logger.filter();
-    log::set_boxed_logger(Box::new(logger.clone())).unwrap();
-    log::set_max_level(max_level);
-    // todo: add tracing
+    // This JNI function has no JNIEnv parameter, so we catch panics without
+    // throwing Java exceptions. The panic hook (installed below) will log the
+    // message.
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let env = Env::new()
+            .filter_or("LANCE_LOG", "warn")
+            .write_style("LANCE_LOG_STYLE");
+        let mut log_builder = Builder::from_env(env);
+        set_timestamp_precision(&mut log_builder);
+        set_log_file_target(&mut log_builder);
+        let logger = Arc::new(log_builder.build());
+        let max_level = logger.filter();
+        // Ignore error if logger was already set (e.g., called multiple times)
+        let _ = log::set_boxed_logger(Box::new(logger.clone()));
+        log::set_max_level(max_level);
+
+        std::panic::set_hook(Box::new(|info| {
+            let msg = if let Some(s) = info.payload().downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = info.payload().downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "<unknown>".to_string()
+            };
+            let location = info
+                .location()
+                .map(|l| format!(" at {}:{}:{}", l.file(), l.line(), l.column()))
+                .unwrap_or_default();
+            log::error!("Rust panic{}: {}", location, msg);
+        }));
+    }));
 }

--- a/java/src/test/java/org/lance/VectorSearchTest.java
+++ b/java/src/test/java/org/lance/VectorSearchTest.java
@@ -13,7 +13,25 @@
  */
 package org.lance;
 
+import org.lance.ipc.LanceScanner;
+import org.lance.ipc.Query;
+import org.lance.ipc.ScanOptions;
+
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,189 +46,194 @@ import static org.junit.jupiter.api.Assertions.*;
 // An IVF-PQ index with 2 partitions is trained on this data
 public class VectorSearchTest {
 
-  // TODO: fix in https://github.com/lancedb/lance/issues/2956
+  @TempDir java.nio.file.Path tempDir;
 
-  // @Test
-  // void test_create_index() throws Exception {
-  //   try (TestVectorDataset testVectorDataset = new
-  // TestVectorDataset(tempDir.resolve("test_create_index"))) {
-  //     try (Dataset dataset = testVectorDataset.create()) {
-  //       testVectorDataset.createIndex(dataset);
-  //       List<String> indexes = dataset.listIndexes();
-  //       assertEquals(1, indexes.size());
-  //       assertEquals(TestVectorDataset.indexName, indexes.get(0));
-  //     }
-  //   }
-  // }
+  @Test
+  void test_create_index() throws Exception {
+    try (TestVectorDataset testVectorDataset =
+        new TestVectorDataset(tempDir.resolve("test_create_index"))) {
+      try (Dataset dataset = testVectorDataset.create()) {
+        testVectorDataset.createIndex(dataset);
+        List<String> indexes = dataset.listIndexes();
+        assertEquals(1, indexes.size());
+        assertEquals(TestVectorDataset.indexName, indexes.get(0));
+      }
+    }
+  }
 
-  // rust/lance-linalg/src/distance/l2.rs:256:5:
-  // 5assertion `left == right` failed
-  // Directly panic instead of throwing an exception
-  // @Test
-  // void search_invalid_vector() throws Exception {
-  //   try (TestVectorDataset testVectorDataset = new
-  // TestVectorDataset(tempDir.resolve("test_create_index"))) {
-  //     try (Dataset dataset = testVectorDataset.create()) {
-  //       float[] key = new float[30];
-  //       for (int i = 0; i < 30; i++) {
-  //         key[i] = (float) (i + 30);
-  //       }
-  //       ScanOptions options = new ScanOptions.Builder()
-  //           .nearest(new Query.Builder()
-  //               .setColumn(TestVectorDataset.vectorColumnName)
-  //               .setKey(key)
-  //               .setK(5)
-  //               .setUseIndex(false)
-  //               .build())
-  //           .build();
-  //       assertThrows(IllegalArgumentException.class, () -> {
-  //         try (Scanner scanner = dataset.newScan(options)) {
-  //           try (ArrowReader reader = scanner.scanBatches()) {
-  //           }
-  //         }
-  //       });
-  //     }
-  //   }
-  // }
+  // The Rust l2 distance function panics when vector dimensions don't match.
+  // With catch_unwind in place, this panic is now caught and converted to a
+  // RuntimeException instead of crashing the JVM.
+  @Test
+  void search_invalid_vector() throws Exception {
+    try (TestVectorDataset testVectorDataset =
+        new TestVectorDataset(tempDir.resolve("search_invalid_vector"))) {
+      try (Dataset dataset = testVectorDataset.create()) {
+        float[] key = new float[30];
+        for (int i = 0; i < 30; i++) {
+          key[i] = (float) (i + 30);
+        }
+        ScanOptions options =
+            new ScanOptions.Builder()
+                .nearest(
+                    new Query.Builder()
+                        .setColumn(TestVectorDataset.vectorColumnName)
+                        .setKey(key)
+                        .setK(5)
+                        .setUseIndex(false)
+                        .build())
+                .build();
+        assertThrows(
+            RuntimeException.class,
+            () -> {
+              try (LanceScanner scanner = dataset.newScan(options)) {
+                try (ArrowReader reader = scanner.scanBatches()) {}
+              }
+            });
+      }
+    }
+  }
 
-  // @ParameterizedTest
-  // @ValueSource(booleans = { false, true })
-  // void test_knn(boolean createVectorIndex) throws Exception {
-  //   try (TestVectorDataset testVectorDataset = new
-  // TestVectorDataset(tempDir.resolve("test_knn"))) {
-  //     try (Dataset dataset = testVectorDataset.create()) {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void test_knn(boolean createVectorIndex) throws Exception {
+    try (TestVectorDataset testVectorDataset = new TestVectorDataset(tempDir.resolve("test_knn"))) {
+      try (Dataset dataset = testVectorDataset.create()) {
 
-  //       if (createVectorIndex) {
-  //         testVectorDataset.createIndex(dataset);
-  //       }
-  //       float[] key = new float[32];
-  //       for (int i = 0; i < 32; i++) {
-  //         key[i] = (float) (i + 32);
-  //       }
-  //       ScanOptions options = new ScanOptions.Builder()
-  //           .nearest(new Query.Builder()
-  //               .setColumn(TestVectorDataset.vectorColumnName)
-  //               .setKey(key)
-  //               .setK(5)
-  //               .setUseIndex(false)
-  //               .build())
-  //           .build();
-  //       try (Scanner scanner = dataset.newScan(options)) {
-  //         try (ArrowReader reader = scanner.scanBatches()) {
-  //           VectorSchemaRoot root = reader.getVectorSchemaRoot();
-  //           System.out.println("Schema:");
-  //           assertTrue(reader.loadNextBatch(), "Expected at least one batch");
+        if (createVectorIndex) {
+          testVectorDataset.createIndex(dataset);
+        }
+        float[] key = new float[32];
+        for (int i = 0; i < 32; i++) {
+          key[i] = (float) (i + 32);
+        }
+        ScanOptions options =
+            new ScanOptions.Builder()
+                .nearest(
+                    new Query.Builder()
+                        .setColumn(TestVectorDataset.vectorColumnName)
+                        .setKey(key)
+                        .setK(5)
+                        .setUseIndex(false)
+                        .build())
+                .build();
+        try (LanceScanner scanner = dataset.newScan(options)) {
+          try (ArrowReader reader = scanner.scanBatches()) {
+            VectorSchemaRoot root = reader.getVectorSchemaRoot();
+            assertTrue(reader.loadNextBatch(), "Expected at least one batch");
 
-  //           assertEquals(5, root.getRowCount(), "Expected 5 results");
+            assertEquals(5, root.getRowCount(), "Expected 5 results");
 
-  //           assertEquals(4, root.getSchema().getFields().size(), "Expected 4 columns");
-  //           assertEquals("i", root.getSchema().getFields().get(0).getName());
-  //           assertEquals("s", root.getSchema().getFields().get(1).getName());
-  //           assertEquals(TestVectorDataset.vectorColumnName,
-  // root.getSchema().getFields().get(2).getName());
-  //           assertEquals("_distance", root.getSchema().getFields().get(3).getName());
+            assertEquals(4, root.getSchema().getFields().size(), "Expected 4 columns");
+            assertEquals("i", root.getSchema().getFields().get(0).getName());
+            assertEquals("s", root.getSchema().getFields().get(1).getName());
+            assertEquals(
+                TestVectorDataset.vectorColumnName, root.getSchema().getFields().get(2).getName());
+            assertEquals("_distance", root.getSchema().getFields().get(3).getName());
 
-  //           IntVector iVector = (IntVector) root.getVector("i");
-  //           Set<Integer> expectedI = new HashSet<>(Arrays.asList(1, 81, 161, 241, 321));
-  //           Set<Integer> actualI = new HashSet<>();
-  //           for (int i = 0; i < iVector.getValueCount(); i++) {
-  //             actualI.add(iVector.get(i));
-  //           }
-  //           assertEquals(expectedI, actualI, "Unexpected values in 'i' column");
+            IntVector iVector = (IntVector) root.getVector("i");
+            Set<Integer> expectedI = new HashSet<>(Arrays.asList(1, 81, 161, 241, 321));
+            Set<Integer> actualI = new HashSet<>();
+            for (int i = 0; i < iVector.getValueCount(); i++) {
+              actualI.add(iVector.get(i));
+            }
+            assertEquals(expectedI, actualI, "Unexpected values in 'i' column");
 
-  //           Float4Vector distanceVector = (Float4Vector) root.getVector("_distance");
-  //           float prevDistance = Float.NEGATIVE_INFINITY;
-  //           for (int i = 0; i < distanceVector.getValueCount(); i++) {
-  //             float distance = distanceVector.get(i);
-  //             assertTrue(distance >= prevDistance, "Distances should be in ascending order");
-  //             prevDistance = distance;
-  //           }
+            Float4Vector distanceVector = (Float4Vector) root.getVector("_distance");
+            float prevDistance = Float.NEGATIVE_INFINITY;
+            for (int i = 0; i < distanceVector.getValueCount(); i++) {
+              float distance = distanceVector.get(i);
+              assertTrue(distance >= prevDistance, "Distances should be in ascending order");
+              prevDistance = distance;
+            }
 
-  //           assertFalse(reader.loadNextBatch(), "Expected only one batch");
-  //         }
-  //       }
-  //     }
-  //   }
-  // }
+            assertFalse(reader.loadNextBatch(), "Expected only one batch");
+          }
+        }
+      }
+    }
+  }
 
-  // @Test
-  // void test_knn_with_new_data() throws Exception {
-  //   try (TestVectorDataset testVectorDataset = new
-  // TestVectorDataset(tempDir.resolve("test_knn_with_new_data"))) {
-  //     try (Dataset dataset = testVectorDataset.create()) {
-  //       testVectorDataset.createIndex(dataset);
-  //     }
+  @Test
+  void test_knn_with_new_data() throws Exception {
+    try (TestVectorDataset testVectorDataset =
+        new TestVectorDataset(tempDir.resolve("test_knn_with_new_data"))) {
+      try (Dataset dataset = testVectorDataset.create()) {
+        testVectorDataset.createIndex(dataset);
+      }
 
-  //     float[] key = new float[32];
-  //     Arrays.fill(key, 0.0f);
-  //     // Set k larger than the number of new rows
-  //     int k = 20;
+      float[] key = new float[32];
+      Arrays.fill(key, 0.0f);
+      // Set k larger than the number of new rows
+      int k = 20;
 
-  //     List<TestCase> cases = new ArrayList<>();
-  //     List<Optional<String>> filters = Arrays.asList(Optional.empty(), Optional.of("i > 100"));
-  //     List<Optional<Integer>> limits = Arrays.asList(Optional.empty(), Optional.of(10));
+      List<TestCase> cases = new ArrayList<>();
+      List<Optional<String>> filters = Arrays.asList(Optional.empty(), Optional.of("i > 100"));
+      List<Optional<Integer>> limits = Arrays.asList(Optional.empty(), Optional.of(10));
 
-  //     for (Optional<String> filter : filters) {
-  //       for (Optional<Integer> limit : limits) {
-  //         for (boolean useIndex : new boolean[] { true, false }) {
-  //           cases.add(new TestCase(filter, limit, useIndex));
-  //         }
-  //       }
-  //     }
+      for (Optional<String> filter : filters) {
+        for (Optional<Integer> limit : limits) {
+          for (boolean useIndex : new boolean[] {true, false}) {
+            cases.add(new TestCase(filter, limit, useIndex));
+          }
+        }
+      }
 
-  //     // Validate all cases
-  //     try (Dataset dataset = testVectorDataset.appendNewData()) {
-  //       for (TestCase testCase : cases) {
-  //         ScanOptions.Builder optionsBuilder = new ScanOptions.Builder()
-  //             .nearest(new Query.Builder()
-  //                 .setColumn(TestVectorDataset.vectorColumnName)
-  //                 .setKey(key)
-  //                 .setK(k)
-  //                 .setUseIndex(testCase.useIndex)
-  //                 .build());
+      // Validate all cases
+      try (Dataset dataset = testVectorDataset.appendNewData()) {
+        for (TestCase testCase : cases) {
+          ScanOptions.Builder optionsBuilder =
+              new ScanOptions.Builder()
+                  .nearest(
+                      new Query.Builder()
+                          .setColumn(TestVectorDataset.vectorColumnName)
+                          .setKey(key)
+                          .setK(k)
+                          .setUseIndex(testCase.useIndex)
+                          .build());
 
-  //         testCase.filter.ifPresent(optionsBuilder::filter);
-  //         testCase.limit.ifPresent(optionsBuilder::limit);
+          testCase.filter.ifPresent(optionsBuilder::filter);
+          testCase.limit.ifPresent(optionsBuilder::limit);
 
-  //         ScanOptions options = optionsBuilder.build();
+          ScanOptions options = optionsBuilder.build();
 
-  //         try (Scanner scanner = dataset.newScan(options)) {
-  //           try (ArrowReader reader = scanner.scanBatches()) {
-  //             VectorSchemaRoot root = reader.getVectorSchemaRoot();
-  //             assertTrue(reader.loadNextBatch(), "Expected at least one batch");
+          try (LanceScanner scanner = dataset.newScan(options)) {
+            try (ArrowReader reader = scanner.scanBatches()) {
+              VectorSchemaRoot root = reader.getVectorSchemaRoot();
+              assertTrue(reader.loadNextBatch(), "Expected at least one batch");
 
-  //             if (testCase.filter.isPresent()) {
-  //               int resultRows = root.getRowCount();
-  //               int expectedRows = testCase.limit.orElse(k);
-  //               assertTrue(resultRows <= expectedRows,
-  //                   "Expected less than or equal to " + expectedRows + " rows, got " +
-  // resultRows);
-  //             } else {
-  //               assertEquals(testCase.limit.orElse(k), root.getRowCount(),
-  //                   "Unexpected number of rows");
-  //             }
+              if (testCase.filter.isPresent()) {
+                int resultRows = root.getRowCount();
+                int expectedRows = testCase.limit.orElse(k);
+                assertTrue(
+                    resultRows <= expectedRows,
+                    "Expected less than or equal to " + expectedRows + " rows, got " + resultRows);
+              } else {
+                assertEquals(
+                    testCase.limit.orElse(k), root.getRowCount(), "Unexpected number of rows");
+              }
 
-  //             // Top one should be the first value of new data
-  //             IntVector iVector = (IntVector) root.getVector("i");
-  //             assertEquals(400, iVector.get(0), "First result should be the first value of new
-  // data");
+              // Top one should be the first value of new data
+              IntVector iVector = (IntVector) root.getVector("i");
+              assertEquals(
+                  400, iVector.get(0), "First result should be the first value of new data");
 
-  //             // Check if distances are in ascending order
-  //             Float4Vector distanceVector = (Float4Vector) root.getVector("_distance");
-  //             float prevDistance = Float.NEGATIVE_INFINITY;
-  //             for (int i = 0; i < distanceVector.getValueCount(); i++) {
-  //               float distance = distanceVector.get(i);
-  //               assertTrue(distance >= prevDistance, "Distances should be in ascending order");
-  //               prevDistance = distance;
-  //             }
+              // Check if distances are in ascending order
+              Float4Vector distanceVector = (Float4Vector) root.getVector("_distance");
+              float prevDistance = Float.NEGATIVE_INFINITY;
+              for (int i = 0; i < distanceVector.getValueCount(); i++) {
+                float distance = distanceVector.get(i);
+                assertTrue(distance >= prevDistance, "Distances should be in ascending order");
+                prevDistance = distance;
+              }
 
-  //             assertFalse(reader.loadNextBatch(), "Expected only one batch");
-  //           }
-  //         }
-  //       }
-  //     }
-  //   }
-  // }
+              assertFalse(reader.loadNextBatch(), "Expected only one batch");
+            }
+          }
+        }
+      }
+    }
+  }
 
   private static class TestCase {
     final Optional<String> filter;


### PR DESCRIPTION
- Add jni_entry! macros that wrap JNI function bodies with catch_unwind to convert Rust panics into Java RuntimeExceptions
- Install a panic hook in initLanceLogger() to log panic details with source location before they cross the FFI boundary
- Fix silent error suppression in scanner: propagate dimension mismatch error from nearest() instead of discarding it with `let _ =`
- Re-enable VectorSearchTest tests that were disabled due to #2956
- Add a test `search_invalid_vector` to VectorSearchTest to show that the jni_entry! macros work.

Part 1 of fix for #2956.