### PR TITLE
feat: support sql as external manifest store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,8 +516,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -578,7 +578,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.5",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -605,8 +605,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.124.0"
+version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744c09d75dfec039a05cf8e117c995ded3b0baffa6eb83f3ed7075a01d8d8947"
+checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -632,9 +632,8 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -646,6 +645,7 @@ dependencies = [
  "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.2",
+ "http-body 0.4.6",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
@@ -664,8 +664,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -688,8 +688,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -712,8 +712,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.5",
+ "aws-smithy-json 0.62.4",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -736,7 +736,7 @@ checksum = "37411f8e0f4bea0c3ca0958ce7f18f6439db24d555dbd809787262cd00926aa9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.5",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -764,11 +764,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.5"
+version = "0.63.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180dddf5ef0f52a2f99e2fada10e16ea610e507ef6148a42bdc4d5867596aa00"
+checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.62.6",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.5"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d619373d490ad70966994801bc126846afaa0d1ee920697a031f0cf63f2568e7"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -842,6 +842,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
 version = "0.62.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
@@ -875,7 +884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ccf7f6eba8b2dcf8ce9b74806c6c185659c311665c4bf8d6e71ebd454db6bf"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.5",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -1634,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -1649,14 +1658,13 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
-version = "1.9.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
  "digest 0.10.7",
  "rustversion",
- "spin 0.10.0",
 ]
 
 [[package]]
@@ -2788,6 +2796,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,6 +3032,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,8 +3167,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-io"
-version = "0.3.32"
+name = "futures-intrusive"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
@@ -3516,6 +3541,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -5058,6 +5085,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "sqlx",
  "tokio",
  "tracing",
  "url",
@@ -5316,11 +5344,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -8315,6 +8343,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -9280,6 +9311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-blocks"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9308,6 +9345,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -9491,6 +9534,12 @@ checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,8 +516,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http 0.63.5",
- "aws-smithy-json 0.62.4",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -578,7 +578,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.5",
+ "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -605,8 +605,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.5",
- "aws-smithy-json 0.62.4",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.119.0"
+version = "1.124.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+checksum = "744c09d75dfec039a05cf8e117c995ded3b0baffa6eb83f3ed7075a01d8d8947"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -632,8 +632,9 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json 0.61.9",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -645,7 +646,6 @@ dependencies = [
  "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.2",
- "http-body 0.4.6",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
@@ -664,8 +664,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.5",
- "aws-smithy-json 0.62.4",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -688,8 +688,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.5",
- "aws-smithy-json 0.62.4",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -712,8 +712,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.5",
- "aws-smithy-json 0.62.4",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -736,7 +736,7 @@ checksum = "37411f8e0f4bea0c3ca0958ce7f18f6439db24d555dbd809787262cd00926aa9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.5",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -764,11 +764,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.12"
+version = "0.64.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+checksum = "180dddf5ef0f52a2f99e2fada10e16ea610e507ef6148a42bdc4d5867596aa00"
 dependencies = [
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -796,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.6"
+version = "0.63.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+checksum = "d619373d490ad70966994801bc126846afaa0d1ee920697a031f0cf63f2568e7"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -842,15 +842,6 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-json"
 version = "0.62.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
@@ -884,7 +875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ccf7f6eba8b2dcf8ce9b74806c6c185659c311665c4bf8d6e71ebd454db6bf"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.63.5",
+ "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -1116,6 +1107,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitpacking"
@@ -1643,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.4.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -1658,13 +1652,14 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
  "digest 0.10.7",
  "rustversion",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -2849,6 +2844,9 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -2940,6 +2938,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if 1.0.4",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3169,6 +3178,17 @@ dependencies = [
 [[package]]
 name = "futures-intrusive"
 version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
@@ -3564,6 +3584,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heapify"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,6 +3673,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,6 +3697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5224,7 +5271,10 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
+ "bitflags 2.13.0",
  "libc",
+ "plain",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -5234,6 +5284,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40fe164dbd47ea0c20e78a121c980ef673326905f1d4fba55e3645a20ef6717f"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5344,11 +5405,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -6367,7 +6428,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -6641,6 +6702,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -7193,6 +7260,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags 2.13.0",
 ]
@@ -8283,6 +8359,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -8400,6 +8479,196 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.118",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.13.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.13.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8447,6 +8716,17 @@ name = "str_stack"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -9528,18 +9808,18 @@ dependencies = [
 
 [[package]]
 name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
 ]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -9671,6 +9951,16 @@ dependencies = [
 
 [[package]]
 name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
@@ -9678,7 +9968,7 @@ dependencies = [
  "libc",
  "libredox",
  "objc2-system-configuration",
- "wasite",
+ "wasite 1.0.2",
  "web-sys",
 ]
 
@@ -9827,6 +10117,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -9859,6 +10158,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -9905,6 +10219,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -9917,6 +10237,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -9926,6 +10252,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9953,6 +10285,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -9962,6 +10300,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9977,6 +10321,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -9986,6 +10336,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10220,7 +10576,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "whoami",
+ "whoami 2.1.2",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,6 @@ serde = { version = "^1" }
 serde_json = { version = "1" }
 semver = "1.0"
 serial_test = "3"
-slatedb = "0.3"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "any", "postgres", "mysql", "sqlite"] }
 snafu = "0.9"
 strum = "0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,8 @@ serde = { version = "^1" }
 serde_json = { version = "1" }
 semver = "1.0"
 serial_test = "3"
+slatedb = "0.3"
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "any", "postgres", "mysql", "sqlite"] }
 snafu = "0.9"
 strum = "0.26"
 lindera = { version = "3.0.7" }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -2665,6 +2665,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dtor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,6 +2712,9 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -2770,7 +2779,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "home",
  "windows-sys 0.48.0",
 ]
@@ -3368,6 +3377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heapify"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,6 +3442,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,6 +3466,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3570,7 +3606,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -4758,7 +4794,10 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
+ "bitflags 2.13.0",
  "libc",
+ "plain",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -4768,6 +4807,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40fe164dbd47ea0c20e78a121c980ef673326905f1d4fba55e3645a20ef6717f"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5667,7 +5717,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -5948,6 +5998,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -6326,6 +6382,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -6465,6 +6522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6594,7 +6660,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.11.0",
 ]
 
 [[package]]
@@ -6615,7 +6681,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.11.0",
 ]
 
 [[package]]
@@ -6638,7 +6704,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "windows-sys 0.61.2",
 ]
@@ -6743,7 +6809,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -7331,6 +7397,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -7457,6 +7534,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -7548,6 +7628,196 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.118",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.13.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.13.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7588,6 +7858,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68df56303396bcfb639455b3c166804aeb7994005010aab5e9e8a1277b8871d"
 dependencies = [
  "serde_json",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -8507,18 +8788,18 @@ dependencies = [
 
 [[package]]
 name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
 ]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -8632,11 +8913,30 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite 0.1.0",
 ]
 
 [[package]]
@@ -8648,7 +8948,7 @@ dependencies = [
  "libc",
  "libredox",
  "objc2-system-configuration",
- "wasite",
+ "wasite 1.0.2",
  "web-sys",
 ]
 
@@ -8799,6 +9099,15 @@ dependencies = [
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.6",
@@ -8878,6 +9187,12 @@ checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -9209,7 +9524,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "whoami",
+ "whoami 2.1.2",
  "winapi",
 ]
 

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1047,6 +1047,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitpacking"
@@ -1552,6 +1555,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32c"
@@ -2747,6 +2765,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,6 +2852,17 @@ name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -2920,6 +2960,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3294,6 +3345,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -4591,6 +4644,7 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
+ "sqlx",
  "tokio",
  "tracing",
  "url",
@@ -7458,6 +7512,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -8277,6 +8334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-blocks"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8296,6 +8359,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -8376,6 +8445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8438,6 +8513,12 @@ checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -8716,7 +8797,7 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
@@ -8739,6 +8820,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -8797,6 +8893,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8806,6 +8908,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8833,6 +8941,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8842,6 +8956,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8857,6 +8977,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8866,6 +8992,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -37,6 +37,7 @@ half = { version = "2.5", default-features = false, features = [
 lance = { path = "../rust/lance", features = [
     "goosefs",
     "dynamodb",
+    "sql_store",
     "substrait",
 ] }
 lance-arrow = { path = "../rust/lance-arrow" }

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -319,7 +319,8 @@ impl Default for ObjectStoreRegistry {
         {
             let aws = Arc::new(aws::AwsStoreProvider);
             providers.insert("s3".into(), aws.clone());
-            providers.insert("s3+ddb".into(), aws);
+            providers.insert("s3+ddb".into(), aws.clone());
+            providers.insert("s3+sql".into(), aws);
         }
         #[cfg(feature = "azure")]
         {

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -25,6 +25,7 @@ arrow-schema.workspace = true
 async-trait.workspace = true
 aws-credential-types = { workspace = true, optional = true }
 aws-sdk-dynamodb = { workspace = true, optional = true, default-features = false, features = ["default-https-client", "rt-tokio"] }
+sqlx = { workspace = true, optional = true }
 byteorder.workspace = true
 bytes.workspace = true
 chrono.workspace = true
@@ -60,6 +61,7 @@ protobuf-src = { version = "2.1", optional = true }
 
 [features]
 dynamodb = ["dep:aws-sdk-dynamodb", "dep:aws-credential-types", "lance-io/aws"]
+sql_store = ["dep:sqlx"]
 protoc = ["dep:protobuf-src"]
 
 [package.metadata.docs.rs]

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -1161,14 +1161,12 @@ pub async fn commit_handler_from_url(
         )),
         #[cfg(feature = "sql_store")]
         "s3+sql" => {
-            let (conn_str, table_name, bucket_name, pool_config) = parse_sql_url_params(&url)?;
-            let store = sql::SqlExternalManifestStore::new_external_store(
-                &conn_str,
-                &table_name,
-                &bucket_name,
-                pool_config,
-            )
-            .await?;
+            let storage_options = options
+                .as_ref()
+                .and_then(|o| o.storage_options().cloned())
+                .unwrap_or_default();
+            let params = parse_sql_url_params(&url, &storage_options)?;
+            let store = sql::SqlExternalManifestStore::new_external_store(params).await?;
             Ok(Arc::new(external_manifest::ExternalManifestCommitHandler {
                 external_manifest_store: store,
             }))
@@ -1186,35 +1184,41 @@ fn get_dynamodb_endpoint(storage_options: &StorageOptions) -> Option<String> {
     }
 }
 
-/// Parse SQL-related query parameters from an `s3+sql://` URL.
-///
-/// URL format: `s3+sql://{bucket}/{path}?sqlConnStr={db_url}[&sqlTableName=...][&sqlMaxConnections=...][&...]`
-///
-/// Returns `(conn_str, table_name, bucket_name, SqlPoolConfig)`.
 #[cfg(feature = "sql_store")]
-fn parse_sql_url_params(url: &Url) -> Result<(String, String, String, sql::SqlPoolConfig)> {
-    let params: std::collections::HashMap<String, String> =
-        url.query_pairs().into_owned().collect();
+fn parse_sql_url_params(
+    url: &Url,
+    storage_options: &std::collections::HashMap<String, String>,
+) -> Result<sql::SqlStoreParams> {
+    use std::collections::HashMap;
 
-    let conn_str = params
-        .get("sqlConnStr")
+    let lower_opts: HashMap<String, &str> = storage_options
+        .iter()
+        .map(|(k, v)| (k.to_lowercase(), v.as_str()))
+        .collect();
+
+    let url_params: HashMap<String, String> = url.query_pairs().into_owned().collect();
+
+    let conn_str = lower_opts
+        .get("sql_conn_str")
+        .map(|s| s.to_string())
+        .or_else(|| std::env::var("LANCE_SQL_CONN_STR").ok())
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
             Error::invalid_input(
-                "`s3+sql://` scheme requires a non-empty `sqlConnStr` query parameter",
+                "`s3+sql://` scheme requires a non-empty `sql_conn_str` in \
+                 storage_options or the `LANCE_SQL_CONN_STR` environment variable",
             )
-        })?
-        .clone();
+        })?;
 
-    let table_name = match params.get("sqlTableName") {
-        Some(t) if t.is_empty() => {
-            return Err(Error::invalid_input(
-                "`sqlTableName` must not be empty if specified",
-            ));
-        }
-        Some(t) => t.clone(),
-        None => "external_manifest".to_string(),
-    };
+    let table_name = url_params
+        .get("sqlTableName")
+        .cloned()
+        .unwrap_or_else(|| "external_manifest".to_string());
+    if table_name.is_empty() {
+        return Err(Error::invalid_input(
+            "`sqlTableName` must not be empty if specified",
+        ));
+    }
 
     let bucket_name = url
         .host_str()
@@ -1224,38 +1228,43 @@ fn parse_sql_url_params(url: &Url) -> Result<(String, String, String, sql::SqlPo
         })?
         .to_string();
 
-    let mut config = sql::SqlPoolConfig::default();
+    let mut pool_config = sql::SqlPoolConfig::default();
 
-    if let Some(v) = params.get("sqlMaxConnections") {
-        config.max_connections = v
+    if let Some(v) = url_params.get("sqlMaxConnections") {
+        pool_config.max_connections = v
             .parse()
             .map_err(|_| Error::invalid_input(format!("invalid sqlMaxConnections value: {}", v)))?;
     }
-    if let Some(v) = params.get("sqlMinConnections") {
-        config.min_connections = v
+    if let Some(v) = url_params.get("sqlMinConnections") {
+        pool_config.min_connections = v
             .parse()
             .map_err(|_| Error::invalid_input(format!("invalid sqlMinConnections value: {}", v)))?;
     }
-    if let Some(v) = params.get("sqlAcquireTimeout") {
+    if let Some(v) = url_params.get("sqlAcquireTimeout") {
         let secs: u64 = v
             .parse()
             .map_err(|_| Error::invalid_input(format!("invalid sqlAcquireTimeout value: {}", v)))?;
-        config.acquire_timeout = std::time::Duration::from_secs(secs);
+        pool_config.acquire_timeout = std::time::Duration::from_secs(secs);
     }
-    if let Some(v) = params.get("sqlIdleTimeout") {
+    if let Some(v) = url_params.get("sqlIdleTimeout") {
         let secs: u64 = v
             .parse()
             .map_err(|_| Error::invalid_input(format!("invalid sqlIdleTimeout value: {}", v)))?;
-        config.idle_timeout = std::time::Duration::from_secs(secs);
+        pool_config.idle_timeout = std::time::Duration::from_secs(secs);
     }
-    if let Some(v) = params.get("sqlMaxLifetime") {
+    if let Some(v) = url_params.get("sqlMaxLifetime") {
         let secs: u64 = v
             .parse()
             .map_err(|_| Error::invalid_input(format!("invalid sqlMaxLifetime value: {}", v)))?;
-        config.max_lifetime = std::time::Duration::from_secs(secs);
+        pool_config.max_lifetime = std::time::Duration::from_secs(secs);
     }
 
-    Ok((conn_str, table_name, bucket_name, config))
+    Ok(sql::SqlStoreParams {
+        conn_str,
+        table_name,
+        bucket_name,
+        pool_config,
+    })
 }
 
 /// Errors that can occur when committing a manifest.

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -48,6 +48,8 @@ use url::Url;
 #[cfg(feature = "dynamodb")]
 pub mod dynamodb;
 pub mod external_manifest;
+#[cfg(feature = "sql_store")]
+pub mod sql;
 
 use lance_core::{Error, Result};
 use lance_io::object_store::{ObjectStore, ObjectStoreExt, ObjectStoreParams};
@@ -1153,6 +1155,24 @@ pub async fn commit_handler_from_url(
                 .await?,
             }))
         }
+        #[cfg(not(feature = "sql_store"))]
+        "s3+sql" => Err(Error::invalid_input(
+            "`s3+sql://` scheme requires `sql_store` feature to be enabled",
+        )),
+        #[cfg(feature = "sql_store")]
+        "s3+sql" => {
+            let (conn_str, table_name, bucket_name, pool_config) = parse_sql_url_params(&url)?;
+            let store = sql::SqlExternalManifestStore::new_external_store(
+                &conn_str,
+                &table_name,
+                &bucket_name,
+                pool_config,
+            )
+            .await?;
+            Ok(Arc::new(external_manifest::ExternalManifestCommitHandler {
+                external_manifest_store: store,
+            }))
+        }
         _ => Ok(Arc::new(UnsafeCommitHandler)),
     }
 }
@@ -1164,6 +1184,78 @@ fn get_dynamodb_endpoint(storage_options: &StorageOptions) -> Option<String> {
     } else {
         std::env::var("DYNAMODB_ENDPOINT").ok()
     }
+}
+
+/// Parse SQL-related query parameters from an `s3+sql://` URL.
+///
+/// URL format: `s3+sql://{bucket}/{path}?sqlConnStr={db_url}[&sqlTableName=...][&sqlMaxConnections=...][&...]`
+///
+/// Returns `(conn_str, table_name, bucket_name, SqlPoolConfig)`.
+#[cfg(feature = "sql_store")]
+fn parse_sql_url_params(url: &Url) -> Result<(String, String, String, sql::SqlPoolConfig)> {
+    let params: std::collections::HashMap<String, String> =
+        url.query_pairs().into_owned().collect();
+
+    let conn_str = params
+        .get("sqlConnStr")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            Error::invalid_input(
+                "`s3+sql://` scheme requires a non-empty `sqlConnStr` query parameter",
+            )
+        })?
+        .clone();
+
+    let table_name = match params.get("sqlTableName") {
+        Some(t) if t.is_empty() => {
+            return Err(Error::invalid_input(
+                "`sqlTableName` must not be empty if specified",
+            ));
+        }
+        Some(t) => t.clone(),
+        None => "external_manifest".to_string(),
+    };
+
+    let bucket_name = url
+        .host_str()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            Error::invalid_input("`s3+sql://` scheme requires a non-empty bucket name as host")
+        })?
+        .to_string();
+
+    let mut config = sql::SqlPoolConfig::default();
+
+    if let Some(v) = params.get("sqlMaxConnections") {
+        config.max_connections = v
+            .parse()
+            .map_err(|_| Error::invalid_input(format!("invalid sqlMaxConnections value: {}", v)))?;
+    }
+    if let Some(v) = params.get("sqlMinConnections") {
+        config.min_connections = v
+            .parse()
+            .map_err(|_| Error::invalid_input(format!("invalid sqlMinConnections value: {}", v)))?;
+    }
+    if let Some(v) = params.get("sqlAcquireTimeout") {
+        let secs: u64 = v
+            .parse()
+            .map_err(|_| Error::invalid_input(format!("invalid sqlAcquireTimeout value: {}", v)))?;
+        config.acquire_timeout = std::time::Duration::from_secs(secs);
+    }
+    if let Some(v) = params.get("sqlIdleTimeout") {
+        let secs: u64 = v
+            .parse()
+            .map_err(|_| Error::invalid_input(format!("invalid sqlIdleTimeout value: {}", v)))?;
+        config.idle_timeout = std::time::Duration::from_secs(secs);
+    }
+    if let Some(v) = params.get("sqlMaxLifetime") {
+        let secs: u64 = v
+            .parse()
+            .map_err(|_| Error::invalid_input(format!("invalid sqlMaxLifetime value: {}", v)))?;
+        config.max_lifetime = std::time::Duration::from_secs(secs);
+    }
+
+    Ok((conn_str, table_name, bucket_name, config))
 }
 
 /// Errors that can occur when committing a manifest.

--- a/rust/lance-table/src/io/commit/sql.rs
+++ b/rust/lance-table/src/io/commit/sql.rs
@@ -1,0 +1,710 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! SQL-based external manifest store
+//!
+//! Uses sqlx with the `Any` driver to support PostgreSQL, MySQL, and SQLite.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use object_store::path::Path;
+use sqlx::any::{AnyPoolOptions, AnyRow};
+use sqlx::{AnyPool, Row};
+use tokio::sync::RwLock;
+use tracing::warn;
+
+use crate::io::commit::external_manifest::ExternalManifestStore;
+use lance_core::error::box_error;
+use lance_core::{Error, Result};
+
+use super::ManifestLocation;
+use super::external_manifest::detect_naming_scheme_from_path;
+
+/// Connection pool configuration for the SQL external manifest store.
+#[derive(Debug, Clone)]
+pub struct SqlPoolConfig {
+    /// Maximum number of connections in the pool. Default: 5.
+    pub max_connections: u32,
+    /// Minimum number of idle connections to maintain. Default: 1.
+    pub min_connections: u32,
+    /// Maximum time to wait for a connection from the pool. Default: 10s.
+    pub acquire_timeout: Duration,
+    /// Maximum idle time for a connection before it is closed. Default: 300s.
+    pub idle_timeout: Duration,
+    /// Maximum lifetime of a connection. Default: 1800s (30 min).
+    pub max_lifetime: Duration,
+}
+
+impl Default for SqlPoolConfig {
+    fn default() -> Self {
+        Self {
+            max_connections: 5,
+            min_connections: 1,
+            acquire_timeout: Duration::from_secs(10),
+            idle_timeout: Duration::from_secs(300),
+            max_lifetime: Duration::from_secs(1800),
+        }
+    }
+}
+
+/// An external manifest store backed by a SQL database (via sqlx).
+///
+/// When calling SqlExternalManifestStore::new_external_store()
+/// the table schema is checked. If the table does not exist,
+/// or the required columns are not present, an error is returned.
+///
+/// The table schema is expected as follows:
+/// bucket_name    -- VARCHAR(255) NOT NULL  (part of PRIMARY KEY)
+/// base_path      -- VARCHAR(255) NOT NULL  (part of PRIMARY KEY)
+/// version        -- BIGINT UNSIGNED NOT NULL  (part of PRIMARY KEY)
+/// manifest_uuid  -- VARCHAR(255) NOT NULL  (staging manifest uuid suffix)
+/// file_size      -- BIGINT UNSIGNED NOT NULL
+/// e_tag          -- VARCHAR(255) NOT NULL
+/// create_time    -- BIGINT UNSIGNED NOT NULL
+/// update_time    -- BIGINT UNSIGNED NOT NULL
+/// PRIMARY KEY (bucket_name, base_path, version)
+///
+/// Example DDL for MySQL:
+/// ```sql
+/// CREATE TABLE IF NOT EXISTS external_manifest (
+///     bucket_name   VARCHAR(255)    NOT NULL COMMENT 'object store bucket',
+///     base_path     VARCHAR(255)    NOT NULL COMMENT 'dataset path',
+///     version       BIGINT UNSIGNED NOT NULL COMMENT 'version number',
+///     manifest_uuid VARCHAR(255)    NOT NULL COMMENT 'staging manifest uuid',
+///     file_size     BIGINT UNSIGNED NOT NULL COMMENT 'file size',
+///     e_tag         VARCHAR(255)    NOT NULL COMMENT 'ETag checksum',
+///     create_time   BIGINT UNSIGNED NOT NULL COMMENT 'creation time',
+///     update_time   BIGINT UNSIGNED NOT NULL COMMENT 'update time',
+///     PRIMARY KEY (bucket_name, base_path, version)
+/// ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+///   COMMENT='external manifest';
+/// ```
+///
+/// Consistency: This store relies on the database's transaction semantics
+/// for read-after-write consistency.
+///
+/// Transaction Safety: Uses INSERT with primary key conflict detection to ensure
+/// only one writer can win per version.
+#[derive(Debug)]
+pub struct SqlExternalManifestStore {
+    pool: AnyPool,
+    table_name: String,
+    bucket_name: String,
+}
+
+/// Required columns that must exist in the table.
+const REQUIRED_COLUMNS: &[&str] = &[
+    "bucket_name",
+    "base_path",
+    "version",
+    "manifest_uuid",
+    "file_size",
+    "e_tag",
+    "create_time",
+    "update_time",
+];
+
+/// The identifier between the manifest base name and the uuid suffix.
+const MANIFEST_UUID_SEPARATOR: &str = ".manifest-";
+
+/// Validate that a SQL identifier (table name) contains only safe characters.
+///
+/// Accepts only ASCII letters, digits, and underscores (`[a-zA-Z0-9_]`).
+/// This prevents SQL injection via crafted table names.
+fn validate_sql_identifier(name: &str, param_name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(Error::invalid_input(format!(
+            "`{}` must not be empty",
+            param_name
+        )));
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(Error::invalid_input(format!(
+            "`{}` contains invalid characters: '{}'. \
+             Only ASCII letters, digits, and underscores are allowed.",
+            param_name, name
+        )));
+    }
+    Ok(())
+}
+
+impl SqlExternalManifestStore {
+    /// Create a new SQL-backed external manifest store.
+    ///
+    /// `database_url` should be a valid sqlx connection string, e.g.:
+    /// - `sqlite://lance_manifest.db`
+    /// - `postgres://user:pass@host/db`
+    /// - `mysql://user:pass@host/db`
+    ///
+    /// `bucket_name` is the object store bucket name, stored as part of the
+    /// primary key to support multi-bucket scenarios.
+    ///
+    /// `pool_config` controls connection pool sizing and timeouts.
+    ///
+    /// The table must already exist with the expected schema.
+    /// An error is returned if the table does not exist or is missing required columns.
+    pub async fn new_external_store(
+        database_url: &str,
+        table_name: &str,
+        bucket_name: &str,
+        pool_config: SqlPoolConfig,
+    ) -> Result<Arc<dyn ExternalManifestStore>> {
+        // Validate table_name to prevent SQL injection
+        validate_sql_identifier(table_name, "sqlTableName")?;
+
+        // Global pool cache keyed by database_url to reuse connections
+        static POOL_CACHE: std::sync::LazyLock<RwLock<HashMap<String, AnyPool>>> =
+            std::sync::LazyLock::new(|| RwLock::new(HashMap::new()));
+
+        // Cache already-checked tables to avoid repeated schema validation
+        static SANITY_CHECK_CACHE: std::sync::LazyLock<RwLock<HashSet<String>>> =
+            std::sync::LazyLock::new(|| RwLock::new(HashSet::new()));
+
+        sqlx::any::install_default_drivers();
+
+        // Reuse existing pool or create a new one.
+        // Fast path: check with a read lock first.
+        let pool = {
+            let cache = POOL_CACHE.read().await;
+            cache.get(database_url).cloned()
+        };
+        let pool = match pool {
+            Some(p) => p,
+            None => {
+                // Slow path: acquire write lock and double-check to avoid TOCTOU race.
+                let mut cache = POOL_CACHE.write().await;
+                if let Some(p) = cache.get(database_url) {
+                    p.clone()
+                } else {
+                    let p = AnyPoolOptions::new()
+                        .max_connections(pool_config.max_connections)
+                        .min_connections(pool_config.min_connections)
+                        .acquire_timeout(pool_config.acquire_timeout)
+                        .idle_timeout(pool_config.idle_timeout)
+                        .max_lifetime(pool_config.max_lifetime)
+                        .connect(database_url)
+                        .await
+                        .map_err(|e| Error::io_source(box_error(e)))?;
+                    cache.insert(database_url.to_string(), p.clone());
+                    p
+                }
+            }
+        };
+
+        let store = Arc::new(Self {
+            pool,
+            table_name: table_name.to_string(),
+            bucket_name: bucket_name.to_string(),
+        });
+
+        let cache_key = format!("{}:{}", database_url, table_name);
+        // already checked this table before, skip
+        if SANITY_CHECK_CACHE.read().await.contains(&cache_key) {
+            return Ok(store);
+        }
+
+        // Verify the table exists and has the required columns by issuing
+        // a lightweight query. This works across all SQL backends without
+        // needing backend-specific information_schema queries.
+        let check_sql = format!(
+            "SELECT {} FROM {} WHERE 1 = 0",
+            REQUIRED_COLUMNS.join(", "),
+            table_name
+        );
+        sqlx::query(&check_sql)
+            .execute(&store.pool)
+            .await
+            .map_err(|e| {
+                Error::io(format!(
+                    "sql table '{}' does not exist or is missing required columns ({}): {}",
+                    table_name,
+                    REQUIRED_COLUMNS.join(", "),
+                    e
+                ))
+            })?;
+
+        SANITY_CHECK_CACHE.write().await.insert(cache_key);
+
+        Ok(store)
+    }
+
+    /// Build the full manifest path from base_path, version, and manifest_uuid.
+    ///
+    /// Path rule: `{base_path}/_versions/{u64::MAX - version}.manifest[-uuid]`
+    fn build_manifest_path(base_path: &str, version: u64, manifest_uuid: &str) -> String {
+        let mut path = format!("{}/_versions/{}.manifest", base_path, u64::MAX - version);
+        if !manifest_uuid.is_empty() {
+            path.push('-');
+            path.push_str(manifest_uuid);
+        }
+        path
+    }
+
+    /// Extract the uuid suffix from a manifest path.
+    ///
+    /// If the path contains `.manifest-{uuid}`, returns the uuid part.
+    /// Otherwise, returns an empty string.
+    fn extract_uuid_from_path(manifest_path: &str) -> String {
+        if let Some(pos) = manifest_path.find(MANIFEST_UUID_SEPARATOR) {
+            manifest_path[pos + MANIFEST_UUID_SEPARATOR.len()..].to_string()
+        } else {
+            String::new()
+        }
+    }
+
+    fn now_timestamp() -> i64 {
+        chrono::Utc::now().timestamp()
+    }
+}
+
+fn sql_err(e: sqlx::Error) -> Error {
+    warn!(target: "lance::sql", "SQL error: {e:?}");
+    Error::io_source(box_error(e))
+}
+
+/// Extract a string column from a row.
+fn get_string(row: &AnyRow, col: &str) -> Result<String> {
+    row.try_get::<String, _>(col)
+        .map_err(|e| Error::io_source(box_error(e)))
+}
+
+/// Extract an i64 column and convert to u64.
+fn get_u64(row: &AnyRow, col: &str) -> Result<u64> {
+    row.try_get::<i64, _>(col)
+        .map(|v| v as u64)
+        .map_err(|e| Error::io_source(box_error(e)))
+}
+
+/// Extract an optional string column from a row.
+fn get_optional_string(row: &AnyRow, col: &str) -> Option<String> {
+    row.try_get::<String, _>(col).ok().filter(|s| !s.is_empty())
+}
+
+#[async_trait]
+impl ExternalManifestStore for SqlExternalManifestStore {
+    /// Get the manifest path for a given base_uri and version
+    async fn get(&self, base_uri: &str, version: u64) -> Result<String> {
+        let sql = format!(
+            "SELECT manifest_uuid FROM {} WHERE bucket_name = ? AND base_path = ? AND version = ?",
+            self.table_name
+        );
+        let row: AnyRow = sqlx::query(&sql)
+            .bind(&self.bucket_name)
+            .bind(base_uri)
+            .bind(version as i64)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| match e {
+                sqlx::Error::RowNotFound => Error::not_found(format!(
+                    "sql not found: bucket: {}; base_path: {}; version: {}",
+                    self.bucket_name, base_uri, version
+                )),
+                other => sql_err(other),
+            })?;
+
+        let manifest_uuid = get_string(&row, "manifest_uuid")?;
+        Ok(Self::build_manifest_path(base_uri, version, &manifest_uuid))
+    }
+
+    async fn get_manifest_location(
+        &self,
+        base_uri: &str,
+        version: u64,
+    ) -> Result<ManifestLocation> {
+        let sql = format!(
+            "SELECT manifest_uuid, file_size, e_tag FROM {} \
+             WHERE bucket_name = ? AND base_path = ? AND version = ?",
+            self.table_name
+        );
+        let row: AnyRow = sqlx::query(&sql)
+            .bind(&self.bucket_name)
+            .bind(base_uri)
+            .bind(version as i64)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| match e {
+                sqlx::Error::RowNotFound => Error::not_found(format!(
+                    "sql not found: bucket: {}; base_path: {}; version: {}",
+                    self.bucket_name, base_uri, version
+                )),
+                other => sql_err(other),
+            })?;
+
+        let manifest_uuid = get_string(&row, "manifest_uuid")?;
+        let full_path = Self::build_manifest_path(base_uri, version, &manifest_uuid);
+        let path = Path::from(full_path);
+        let size = Some(get_u64(&row, "file_size")?);
+        let e_tag = get_optional_string(&row, "e_tag");
+        let naming_scheme = detect_naming_scheme_from_path(&path)?;
+
+        Ok(ManifestLocation {
+            version,
+            path,
+            size,
+            naming_scheme,
+            e_tag,
+        })
+    }
+
+    /// Get the latest version of a dataset at the base_uri
+    async fn get_latest_version(&self, base_uri: &str) -> Result<Option<(u64, String)>> {
+        self.get_latest_manifest_location(base_uri)
+            .await
+            .map(|location| location.map(|loc| (loc.version, loc.path.to_string())))
+    }
+
+    async fn get_latest_manifest_location(
+        &self,
+        base_uri: &str,
+    ) -> Result<Option<ManifestLocation>> {
+        let sql = format!(
+            "SELECT version, manifest_uuid, file_size, e_tag FROM {} \
+             WHERE bucket_name = ? AND base_path = ? \
+             ORDER BY version DESC LIMIT 1",
+            self.table_name
+        );
+        let maybe_row: Option<AnyRow> = sqlx::query(&sql)
+            .bind(&self.bucket_name)
+            .bind(base_uri)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(sql_err)?;
+
+        match maybe_row {
+            Some(row) => {
+                let version = get_u64(&row, "version")?;
+                let manifest_uuid = get_string(&row, "manifest_uuid")?;
+                let full_path = Self::build_manifest_path(base_uri, version, &manifest_uuid);
+                let path = Path::from(full_path);
+                let size = Some(get_u64(&row, "file_size")?);
+                let e_tag = get_optional_string(&row, "e_tag");
+                let naming_scheme = detect_naming_scheme_from_path(&path)?;
+
+                Ok(Some(ManifestLocation {
+                    version,
+                    path,
+                    size,
+                    naming_scheme,
+                    e_tag,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Put the manifest path for a given base_uri and version.
+    /// Fails if the version already exists.
+    ///
+    /// Uses a transaction with a single INSERT — the PRIMARY KEY constraint
+    /// atomically rejects duplicates. No need to SELECT first.
+    async fn put_if_not_exists(
+        &self,
+        base_uri: &str,
+        version: u64,
+        path: &str,
+        size: u64,
+        e_tag: Option<String>,
+    ) -> Result<()> {
+        let manifest_uuid = Self::extract_uuid_from_path(path);
+        let now = Self::now_timestamp();
+
+        let mut tx = self.pool.begin().await.map_err(sql_err)?;
+
+        let sql = format!(
+            "INSERT INTO {} (bucket_name, base_path, version, manifest_uuid, file_size, e_tag, create_time, update_time) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            self.table_name
+        );
+        let res = sqlx::query(&sql)
+            .bind(&self.bucket_name)
+            .bind(base_uri)
+            .bind(version as i64)
+            .bind(&manifest_uuid)
+            .bind(size as i64)
+            .bind(e_tag.as_deref().unwrap_or(""))
+            .bind(now)
+            .bind(now)
+            .execute(&mut *tx)
+            .await;
+
+        match res {
+            Ok(_) => {
+                tx.commit().await.map_err(sql_err)?;
+                Ok(())
+            }
+            Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
+                tx.rollback().await.map_err(sql_err)?;
+                Err(Error::io(format!(
+                    "put_if_not_exists: version {} already exists for bucket: {}; base_path: {}",
+                    version, self.bucket_name, base_uri
+                )))
+            }
+            Err(e) => {
+                tx.rollback().await.map_err(sql_err)?;
+                Err(sql_err(e))
+            }
+        }
+    }
+
+    /// Put the manifest path for a given base_uri and version.
+    /// Fails if the version does NOT already exist.
+    ///
+    /// Uses a transaction with a single UPDATE WHERE — `rows_affected() == 0`
+    /// means the row doesn't exist. No need to SELECT first.
+    async fn put_if_exists(
+        &self,
+        base_uri: &str,
+        version: u64,
+        path: &str,
+        size: u64,
+        e_tag: Option<String>,
+    ) -> Result<()> {
+        let manifest_uuid = Self::extract_uuid_from_path(path);
+        let now = Self::now_timestamp();
+
+        let mut tx = self.pool.begin().await.map_err(sql_err)?;
+
+        let sql = format!(
+            "UPDATE {} SET manifest_uuid = ?, file_size = ?, e_tag = ?, update_time = ? \
+             WHERE bucket_name = ? AND base_path = ? AND version = ?",
+            self.table_name
+        );
+        let result = sqlx::query(&sql)
+            .bind(&manifest_uuid)
+            .bind(size as i64)
+            .bind(e_tag.as_deref().unwrap_or(""))
+            .bind(now)
+            .bind(&self.bucket_name)
+            .bind(base_uri)
+            .bind(version as i64)
+            .execute(&mut *tx)
+            .await
+            .map_err(sql_err)?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await.map_err(sql_err)?;
+            return Err(Error::not_found(format!(
+                "put_if_exists: version {} not found for bucket: {}; base_path: {}",
+                version, self.bucket_name, base_uri
+            )));
+        }
+
+        tx.commit().await.map_err(sql_err)?;
+        Ok(())
+    }
+
+    /// Delete all manifest information for the given base_uri
+    async fn delete(&self, base_uri: &str) -> Result<()> {
+        let sql = format!(
+            "DELETE FROM {} WHERE bucket_name = ? AND base_path = ?",
+            self.table_name
+        );
+        sqlx::query(&sql)
+            .bind(&self.bucket_name)
+            .bind(base_uri)
+            .execute(&self.pool)
+            .await
+            .map_err(sql_err)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_TABLE: &str = "external_manifest";
+    const TEST_BUCKET: &str = "test_bucket";
+    const TEST_BASE_URI: &str = "datasets/my_table";
+
+    /// Helper: create a fresh in-memory SQLite store with the required schema.
+    async fn create_test_store() -> Arc<dyn ExternalManifestStore> {
+        // Use a unique in-memory database for each test to avoid shared state.
+        // SQLite `:memory:` with a shared cache name keeps the DB alive across
+        // connections in the same pool.
+        let db_name = uuid::Uuid::new_v4().to_string().replace('-', "");
+        let url = format!("sqlite:file:{}?mode=memory&cache=shared", db_name);
+
+        sqlx::any::install_default_drivers();
+
+        let pool = AnyPoolOptions::new()
+            .max_connections(2)
+            .connect(&url)
+            .await
+            .expect("failed to connect to in-memory SQLite");
+
+        // Create the table with the expected schema.
+        sqlx::query(&format!(
+            "CREATE TABLE IF NOT EXISTS {} (
+                bucket_name   TEXT NOT NULL,
+                base_path     TEXT NOT NULL,
+                version       INTEGER NOT NULL,
+                manifest_uuid TEXT NOT NULL,
+                file_size     INTEGER NOT NULL,
+                e_tag         TEXT NOT NULL,
+                create_time   INTEGER NOT NULL,
+                update_time   INTEGER NOT NULL,
+                PRIMARY KEY (bucket_name, base_path, version)
+            )",
+            TEST_TABLE
+        ))
+        .execute(&pool)
+        .await
+        .expect("failed to create test table");
+
+        Arc::new(SqlExternalManifestStore {
+            pool,
+            table_name: TEST_TABLE.to_string(),
+            bucket_name: TEST_BUCKET.to_string(),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_put_if_not_exists_succeeds() {
+        let store = create_test_store().await;
+        let path = "datasets/my_table/_versions/18446744073709551614.manifest-abc123";
+        store
+            .put_if_not_exists(TEST_BASE_URI, 1, path, 1024, Some("etag1".into()))
+            .await
+            .expect("first put_if_not_exists should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_put_if_not_exists_duplicate_fails() {
+        let store = create_test_store().await;
+        let path = "datasets/my_table/_versions/18446744073709551614.manifest-abc123";
+        store
+            .put_if_not_exists(TEST_BASE_URI, 1, path, 1024, Some("etag1".into()))
+            .await
+            .expect("first insert should succeed");
+
+        let result = store
+            .put_if_not_exists(TEST_BASE_URI, 1, path, 2048, Some("etag2".into()))
+            .await;
+        assert!(result.is_err(), "duplicate version should fail");
+    }
+
+    #[tokio::test]
+    async fn test_put_if_exists_succeeds() {
+        let store = create_test_store().await;
+        let path1 = "datasets/my_table/_versions/18446744073709551614.manifest-staging1";
+        store
+            .put_if_not_exists(TEST_BASE_URI, 1, path1, 1024, Some("etag1".into()))
+            .await
+            .unwrap();
+
+        let path2 = "datasets/my_table/_versions/18446744073709551614.manifest-final1";
+        store
+            .put_if_exists(TEST_BASE_URI, 1, path2, 2048, Some("etag2".into()))
+            .await
+            .expect("put_if_exists on existing version should succeed");
+
+        // Verify the update took effect
+        let loc = store.get_manifest_location(TEST_BASE_URI, 1).await.unwrap();
+        assert_eq!(loc.size, Some(2048));
+        assert_eq!(loc.e_tag, Some("etag2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_put_if_exists_missing_fails() {
+        let store = create_test_store().await;
+        let path = "datasets/my_table/_versions/18446744073709551614.manifest-abc";
+        let result = store
+            .put_if_exists(TEST_BASE_URI, 1, path, 1024, Some("etag1".into()))
+            .await;
+        assert!(
+            result.is_err(),
+            "put_if_exists on non-existent version should fail"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_roundtrip() {
+        let store = create_test_store().await;
+        let path = "datasets/my_table/_versions/18446744073709551614.manifest-uuid1";
+        store
+            .put_if_not_exists(TEST_BASE_URI, 1, path, 512, Some("etag_a".into()))
+            .await
+            .unwrap();
+
+        let got_path = store.get(TEST_BASE_URI, 1).await.unwrap();
+        assert!(got_path.contains("uuid1"), "path should contain the uuid");
+    }
+
+    #[tokio::test]
+    async fn test_get_latest_version() {
+        let store = create_test_store().await;
+        // Insert v1 and v3 (skip v2)
+        let p1 = "datasets/my_table/_versions/18446744073709551614.manifest-a";
+        let p3 = "datasets/my_table/_versions/18446744073709551612.manifest-c";
+        store
+            .put_if_not_exists(TEST_BASE_URI, 1, p1, 100, None)
+            .await
+            .unwrap();
+        store
+            .put_if_not_exists(TEST_BASE_URI, 3, p3, 300, None)
+            .await
+            .unwrap();
+
+        let latest = store
+            .get_latest_version(TEST_BASE_URI)
+            .await
+            .unwrap()
+            .expect("should have a latest version");
+        assert_eq!(latest.0, 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_manifest_location_roundtrip() {
+        let store = create_test_store().await;
+        let path = "datasets/my_table/_versions/18446744073709551614.manifest-someuuid";
+        store
+            .put_if_not_exists(TEST_BASE_URI, 1, path, 4096, Some("my_etag".into()))
+            .await
+            .unwrap();
+
+        let loc = store.get_manifest_location(TEST_BASE_URI, 1).await.unwrap();
+        assert_eq!(loc.version, 1);
+        assert_eq!(loc.size, Some(4096));
+        assert_eq!(loc.e_tag, Some("my_etag".to_string()));
+        assert!(loc.path.as_ref().contains("someuuid"));
+    }
+
+    #[tokio::test]
+    async fn test_delete_clears_all_versions() {
+        let store = create_test_store().await;
+        let p1 = "datasets/my_table/_versions/18446744073709551614.manifest-a";
+        let p2 = "datasets/my_table/_versions/18446744073709551613.manifest-b";
+        store
+            .put_if_not_exists(TEST_BASE_URI, 1, p1, 100, None)
+            .await
+            .unwrap();
+        store
+            .put_if_not_exists(TEST_BASE_URI, 2, p2, 200, None)
+            .await
+            .unwrap();
+
+        store.delete(TEST_BASE_URI).await.unwrap();
+
+        let latest = store.get_latest_version(TEST_BASE_URI).await.unwrap();
+        assert!(latest.is_none(), "after delete, no versions should remain");
+    }
+
+    #[test]
+    fn test_validate_sql_identifier_rejects_injection() {
+        assert!(validate_sql_identifier("good_table_1", "sqlTableName").is_ok());
+        assert!(validate_sql_identifier("ExternalManifest", "sqlTableName").is_ok());
+
+        // SQL injection attempts
+        assert!(validate_sql_identifier("t; DROP TABLE t--", "sqlTableName").is_err());
+        assert!(validate_sql_identifier("table name", "sqlTableName").is_err());
+        assert!(validate_sql_identifier("table'name", "sqlTableName").is_err());
+        assert!(validate_sql_identifier("", "sqlTableName").is_err());
+        assert!(validate_sql_identifier("table.name", "sqlTableName").is_err());
+    }
+}

--- a/rust/lance-table/src/io/commit/sql.rs
+++ b/rust/lance-table/src/io/commit/sql.rs
@@ -24,18 +24,46 @@ use lance_core::{Error, Result};
 use super::ManifestLocation;
 use super::external_manifest::detect_naming_scheme_from_path;
 
-/// Connection pool configuration for the SQL external manifest store.
+fn placeholder(style: ParamStyle, n: usize) -> String {
+    match style {
+        ParamStyle::Numbered => format!("${n}"),
+        ParamStyle::Positional => "?".to_string(),
+    }
+}
+
+fn placeholders(style: ParamStyle, count: usize) -> String {
+    (1..=count)
+        .map(|i| placeholder(style, i))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// Parameter placeholder style used when rendering SQL statements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParamStyle {
+    /// `$1`, `$2`, … (PostgreSQL).
+    Numbered,
+    /// `?` (MySQL/MariaDB/SQLite).
+    Positional,
+}
+
+impl ParamStyle {
+    fn from_url(url: &str) -> Self {
+        let lower = url.to_ascii_lowercase();
+        if lower.starts_with("postgres:") || lower.starts_with("postgresql:") {
+            Self::Numbered
+        } else {
+            Self::Positional
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SqlPoolConfig {
-    /// Maximum number of connections in the pool. Default: 5.
     pub max_connections: u32,
-    /// Minimum number of idle connections to maintain. Default: 1.
     pub min_connections: u32,
-    /// Maximum time to wait for a connection from the pool. Default: 10s.
     pub acquire_timeout: Duration,
-    /// Maximum idle time for a connection before it is closed. Default: 300s.
     pub idle_timeout: Duration,
-    /// Maximum lifetime of a connection. Default: 1800s (30 min).
     pub max_lifetime: Duration,
 }
 
@@ -51,49 +79,42 @@ impl Default for SqlPoolConfig {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct SqlStoreParams {
+    /// sqlx connection string, e.g. `sqlite://lance.db`,
+    /// `postgres://user:pass@host/db`, or `mysql://user:pass@host/db`.
+    pub conn_str: String,
+    /// Table name that holds external manifest records.
+    pub table_name: String,
+    pub bucket_name: String,
+    pub pool_config: SqlPoolConfig,
+}
+
 /// An external manifest store backed by a SQL database (via sqlx).
 ///
-/// When calling SqlExternalManifestStore::new_external_store()
-/// the table schema is checked. If the table does not exist,
-/// or the required columns are not present, an error is returned.
+/// When calling [`SqlExternalManifestStore::new_external_store`] the table
+/// schema is checked. The table must already exist with the expected
+/// columns and a uniqueness constraint over `(bucket_name, base_path,
+/// version)`; otherwise an error is returned.
 ///
-/// The table schema is expected as follows:
-/// bucket_name    -- VARCHAR(255) NOT NULL  (part of PRIMARY KEY)
-/// base_path      -- VARCHAR(255) NOT NULL  (part of PRIMARY KEY)
-/// version        -- BIGINT UNSIGNED NOT NULL  (part of PRIMARY KEY)
-/// manifest_uuid  -- VARCHAR(255) NOT NULL  (staging manifest uuid suffix)
-/// file_size      -- BIGINT UNSIGNED NOT NULL
-/// e_tag          -- VARCHAR(255) NOT NULL
-/// create_time    -- BIGINT UNSIGNED NOT NULL
-/// update_time    -- BIGINT UNSIGNED NOT NULL
-/// PRIMARY KEY (bucket_name, base_path, version)
+/// The expected schema is:
 ///
-/// Example DDL for MySQL:
-/// ```sql
-/// CREATE TABLE IF NOT EXISTS external_manifest (
-///     bucket_name   VARCHAR(255)    NOT NULL COMMENT 'object store bucket',
-///     base_path     VARCHAR(255)    NOT NULL COMMENT 'dataset path',
-///     version       BIGINT UNSIGNED NOT NULL COMMENT 'version number',
-///     manifest_uuid VARCHAR(255)    NOT NULL COMMENT 'staging manifest uuid',
-///     file_size     BIGINT UNSIGNED NOT NULL COMMENT 'file size',
-///     e_tag         VARCHAR(255)    NOT NULL COMMENT 'ETag checksum',
-///     create_time   BIGINT UNSIGNED NOT NULL COMMENT 'creation time',
-///     update_time   BIGINT UNSIGNED NOT NULL COMMENT 'update time',
-///     PRIMARY KEY (bucket_name, base_path, version)
-/// ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-///   COMMENT='external manifest';
-/// ```
-///
-/// Consistency: This store relies on the database's transaction semantics
-/// for read-after-write consistency.
-///
-/// Transaction Safety: Uses INSERT with primary key conflict detection to ensure
-/// only one writer can win per version.
+/// | column          | type                    |
+/// |-----------------|-------------------------|
+/// | `bucket_name`   | `VARCHAR(255) NOT NULL` |
+/// | `base_path`     | `VARCHAR(255) NOT NULL` |
+/// | `version`       | `BIGINT NOT NULL`       |
+/// | `manifest_path` | `VARCHAR(512) NOT NULL` |
+/// | `file_size`     | `BIGINT NOT NULL`       |
+/// | `e_tag`         | `VARCHAR(255) NOT NULL` |
+/// | `create_time`   | `BIGINT NOT NULL`       |
+/// | `update_time`   | `BIGINT NOT NULL`       |
 #[derive(Debug)]
 pub struct SqlExternalManifestStore {
     pool: AnyPool,
     table_name: String,
     bucket_name: String,
+    param_style: ParamStyle,
 }
 
 /// Required columns that must exist in the table.
@@ -101,20 +122,13 @@ const REQUIRED_COLUMNS: &[&str] = &[
     "bucket_name",
     "base_path",
     "version",
-    "manifest_uuid",
+    "manifest_path",
     "file_size",
     "e_tag",
     "create_time",
     "update_time",
 ];
 
-/// The identifier between the manifest base name and the uuid suffix.
-const MANIFEST_UUID_SEPARATOR: &str = ".manifest-";
-
-/// Validate that a SQL identifier (table name) contains only safe characters.
-///
-/// Accepts only ASCII letters, digits, and underscores (`[a-zA-Z0-9_]`).
-/// This prevents SQL injection via crafted table names.
 fn validate_sql_identifier(name: &str, param_name: &str) -> Result<()> {
     if name.is_empty() {
         return Err(Error::invalid_input(format!(
@@ -133,51 +147,34 @@ fn validate_sql_identifier(name: &str, param_name: &str) -> Result<()> {
 }
 
 impl SqlExternalManifestStore {
-    /// Create a new SQL-backed external manifest store.
-    ///
-    /// `database_url` should be a valid sqlx connection string, e.g.:
-    /// - `sqlite://lance_manifest.db`
-    /// - `postgres://user:pass@host/db`
-    /// - `mysql://user:pass@host/db`
-    ///
-    /// `bucket_name` is the object store bucket name, stored as part of the
-    /// primary key to support multi-bucket scenarios.
-    ///
-    /// `pool_config` controls connection pool sizing and timeouts.
-    ///
-    /// The table must already exist with the expected schema.
-    /// An error is returned if the table does not exist or is missing required columns.
     pub async fn new_external_store(
-        database_url: &str,
-        table_name: &str,
-        bucket_name: &str,
-        pool_config: SqlPoolConfig,
+        params: SqlStoreParams,
     ) -> Result<Arc<dyn ExternalManifestStore>> {
-        // Validate table_name to prevent SQL injection
-        validate_sql_identifier(table_name, "sqlTableName")?;
+        let SqlStoreParams {
+            conn_str,
+            table_name,
+            bucket_name,
+            pool_config,
+        } = params;
+        validate_sql_identifier(&table_name, "sqlTableName")?;
 
         // Global pool cache keyed by database_url to reuse connections
         static POOL_CACHE: std::sync::LazyLock<RwLock<HashMap<String, AnyPool>>> =
             std::sync::LazyLock::new(|| RwLock::new(HashMap::new()));
-
-        // Cache already-checked tables to avoid repeated schema validation
         static SANITY_CHECK_CACHE: std::sync::LazyLock<RwLock<HashSet<String>>> =
             std::sync::LazyLock::new(|| RwLock::new(HashSet::new()));
 
         sqlx::any::install_default_drivers();
 
-        // Reuse existing pool or create a new one.
-        // Fast path: check with a read lock first.
         let pool = {
             let cache = POOL_CACHE.read().await;
-            cache.get(database_url).cloned()
+            cache.get(&conn_str).cloned()
         };
         let pool = match pool {
             Some(p) => p,
             None => {
-                // Slow path: acquire write lock and double-check to avoid TOCTOU race.
                 let mut cache = POOL_CACHE.write().await;
-                if let Some(p) = cache.get(database_url) {
+                if let Some(p) = cache.get(&conn_str) {
                     p.clone()
                 } else {
                     let p = AnyPoolOptions::new()
@@ -186,10 +183,10 @@ impl SqlExternalManifestStore {
                         .acquire_timeout(pool_config.acquire_timeout)
                         .idle_timeout(pool_config.idle_timeout)
                         .max_lifetime(pool_config.max_lifetime)
-                        .connect(database_url)
+                        .connect(&conn_str)
                         .await
-                        .map_err(|e| Error::io_source(box_error(e)))?;
-                    cache.insert(database_url.to_string(), p.clone());
+                        .map_err(|e| Error::io(format!("failed to connect to sql store: {e}")))?;
+                    cache.insert(conn_str.clone(), p.clone());
                     p
                 }
             }
@@ -197,100 +194,177 @@ impl SqlExternalManifestStore {
 
         let store = Arc::new(Self {
             pool,
-            table_name: table_name.to_string(),
-            bucket_name: bucket_name.to_string(),
+            table_name: table_name.clone(),
+            bucket_name,
+            param_style: ParamStyle::from_url(&conn_str),
         });
 
-        let cache_key = format!("{}:{}", database_url, table_name);
-        // already checked this table before, skip
-        if SANITY_CHECK_CACHE.read().await.contains(&cache_key) {
+        let sanity_key = format!("{conn_str}|{table_name}");
+        if SANITY_CHECK_CACHE.read().await.contains(&sanity_key) {
             return Ok(store);
         }
 
-        // Verify the table exists and has the required columns by issuing
-        // a lightweight query. This works across all SQL backends without
-        // needing backend-specific information_schema queries.
+        store.sanity_check().await?;
+        SANITY_CHECK_CACHE.write().await.insert(sanity_key);
+
+        Ok(store)
+    }
+
+    /// Verify the table has the required columns and a uniqueness constraint
+    /// over `(bucket_name, base_path, version)`.
+    async fn sanity_check(&self) -> Result<()> {
         let check_sql = format!(
             "SELECT {} FROM {} WHERE 1 = 0",
             REQUIRED_COLUMNS.join(", "),
-            table_name
+            self.table_name
         );
         sqlx::query(&check_sql)
-            .execute(&store.pool)
+            .execute(&self.pool)
             .await
             .map_err(|e| {
                 Error::io(format!(
                     "sql table '{}' does not exist or is missing required columns ({}): {}",
-                    table_name,
+                    self.table_name,
                     REQUIRED_COLUMNS.join(", "),
                     e
                 ))
             })?;
 
-        SANITY_CHECK_CACHE.write().await.insert(cache_key);
-
-        Ok(store)
+        self.probe_uniqueness().await
     }
 
-    /// Build the full manifest path from base_path, version, and manifest_uuid.
-    ///
-    /// Path rule: `{base_path}/_versions/{u64::MAX - version}.manifest[-uuid]`
-    fn build_manifest_path(base_path: &str, version: u64, manifest_uuid: &str) -> String {
-        let mut path = format!("{}/_versions/{}.manifest", base_path, u64::MAX - version);
-        if !manifest_uuid.is_empty() {
-            path.push('-');
-            path.push_str(manifest_uuid);
+    async fn probe_uniqueness(&self) -> Result<()> {
+        const SENTINEL: &str = "__lance_sql_probe__";
+        const V1: i64 = i64::MAX;
+        const V2: i64 = i64::MAX - 1;
+
+        let insert_sql = format!(
+            "INSERT INTO {} (bucket_name, base_path, version, manifest_path, \
+             file_size, e_tag, create_time, update_time) VALUES ({})",
+            self.table_name,
+            placeholders(self.param_style, 8),
+        );
+        let cleanup_sql = format!(
+            "DELETE FROM {} WHERE bucket_name = {} AND base_path = {}",
+            self.table_name,
+            placeholder(self.param_style, 1),
+            placeholder(self.param_style, 2),
+        );
+
+        let mut tx = self.pool.begin().await.map_err(sql_err)?;
+
+        // Clean up any leftover probe rows from a previous crashed run.
+        sqlx::query(&cleanup_sql)
+            .bind(SENTINEL)
+            .bind(SENTINEL)
+            .execute(&mut *tx)
+            .await
+            .map_err(sql_err)?;
+
+        let result = self
+            .run_uniqueness_probe(&mut tx, &insert_sql, SENTINEL, V1, V2)
+            .await;
+        let _ = tx.rollback().await;
+        result
+    }
+
+    async fn run_uniqueness_probe(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Any>,
+        insert_sql: &str,
+        sentinel: &str,
+        v1: i64,
+        v2: i64,
+    ) -> Result<()> {
+        Self::insert_probe_row(tx, insert_sql, sentinel, v1)
+            .await
+            .map_err(|e| self.probe_io_err("insert v1", e))?;
+
+        if let Err(e) = Self::insert_probe_row(tx, insert_sql, sentinel, v2).await {
+            return Err(match e {
+                sqlx::Error::Database(db) if db.is_unique_violation() => {
+                    Error::invalid_input(format!(
+                        "table '{}' has a UNIQUE constraint that does not include `version`; \
+                         inserting two rows with the same (bucket_name, base_path) but different \
+                         versions was rejected. The constraint must cover (bucket_name, base_path, version) \
+                         exactly, otherwise compare-and-swap semantics break.",
+                        self.table_name
+                    ))
+                }
+                other => self.probe_io_err("insert v2", other),
+            });
         }
-        path
-    }
 
-    /// Extract the uuid suffix from a manifest path.
-    ///
-    /// If the path contains `.manifest-{uuid}`, returns the uuid part.
-    /// Otherwise, returns an empty string.
-    fn extract_uuid_from_path(manifest_path: &str) -> String {
-        if let Some(pos) = manifest_path.find(MANIFEST_UUID_SEPARATOR) {
-            manifest_path[pos + MANIFEST_UUID_SEPARATOR.len()..].to_string()
-        } else {
-            String::new()
+        match Self::insert_probe_row(tx, insert_sql, sentinel, v1).await {
+            Err(sqlx::Error::Database(db)) if db.is_unique_violation() => Ok(()),
+            Ok(_) => Err(Error::invalid_input(format!(
+                "table '{}' is missing a UNIQUE/PRIMARY KEY constraint over \
+                 (bucket_name, base_path, version); duplicate inserts were accepted, \
+                 which would break compare-and-swap semantics",
+                self.table_name
+            ))),
+            Err(e) => Err(self.probe_io_err("duplicate insert", e)),
         }
     }
 
-    fn now_timestamp() -> i64 {
-        chrono::Utc::now().timestamp()
+    fn probe_io_err(&self, stage: &str, e: sqlx::Error) -> Error {
+        Error::io(format!(
+            "schema sanity probe failed ({}) for '{}': {}",
+            stage, self.table_name, e
+        ))
+    }
+
+    /// Insert a fixed-shape probe row used only by `probe_uniqueness`.
+    /// All non-key columns are filled with empty / zero placeholders.
+    async fn insert_probe_row(
+        tx: &mut sqlx::Transaction<'_, sqlx::Any>,
+        sql: &str,
+        sentinel: &str,
+        version: i64,
+    ) -> std::result::Result<sqlx::any::AnyQueryResult, sqlx::Error> {
+        sqlx::query(sql)
+            .bind(sentinel)
+            .bind(sentinel)
+            .bind(version)
+            .bind("")
+            .bind(0_i64)
+            .bind("")
+            .bind(0_i64)
+            .bind(0_i64)
+            .execute(&mut **tx)
+            .await
     }
 }
 
 fn sql_err(e: sqlx::Error) -> Error {
-    warn!(target: "lance::sql", "SQL error: {e:?}");
+    warn!(target: "lance::sql", "SQL error: {e}");
     Error::io_source(box_error(e))
 }
 
-/// Extract a string column from a row.
 fn get_string(row: &AnyRow, col: &str) -> Result<String> {
     row.try_get::<String, _>(col)
         .map_err(|e| Error::io_source(box_error(e)))
 }
 
-/// Extract an i64 column and convert to u64.
 fn get_u64(row: &AnyRow, col: &str) -> Result<u64> {
     row.try_get::<i64, _>(col)
         .map(|v| v as u64)
         .map_err(|e| Error::io_source(box_error(e)))
 }
 
-/// Extract an optional string column from a row.
 fn get_optional_string(row: &AnyRow, col: &str) -> Option<String> {
     row.try_get::<String, _>(col).ok().filter(|s| !s.is_empty())
 }
 
 #[async_trait]
 impl ExternalManifestStore for SqlExternalManifestStore {
-    /// Get the manifest path for a given base_uri and version
     async fn get(&self, base_uri: &str, version: u64) -> Result<String> {
         let sql = format!(
-            "SELECT manifest_uuid FROM {} WHERE bucket_name = ? AND base_path = ? AND version = ?",
-            self.table_name
+            "SELECT manifest_path FROM {} WHERE bucket_name = {} AND base_path = {} AND version = {}",
+            self.table_name,
+            placeholder(self.param_style, 1),
+            placeholder(self.param_style, 2),
+            placeholder(self.param_style, 3),
         );
         let row: AnyRow = sqlx::query(&sql)
             .bind(&self.bucket_name)
@@ -305,9 +379,7 @@ impl ExternalManifestStore for SqlExternalManifestStore {
                 )),
                 other => sql_err(other),
             })?;
-
-        let manifest_uuid = get_string(&row, "manifest_uuid")?;
-        Ok(Self::build_manifest_path(base_uri, version, &manifest_uuid))
+        get_string(&row, "manifest_path")
     }
 
     async fn get_manifest_location(
@@ -316,9 +388,12 @@ impl ExternalManifestStore for SqlExternalManifestStore {
         version: u64,
     ) -> Result<ManifestLocation> {
         let sql = format!(
-            "SELECT manifest_uuid, file_size, e_tag FROM {} \
-             WHERE bucket_name = ? AND base_path = ? AND version = ?",
-            self.table_name
+            "SELECT manifest_path, file_size, e_tag FROM {} \
+             WHERE bucket_name = {} AND base_path = {} AND version = {}",
+            self.table_name,
+            placeholder(self.param_style, 1),
+            placeholder(self.param_style, 2),
+            placeholder(self.param_style, 3),
         );
         let row: AnyRow = sqlx::query(&sql)
             .bind(&self.bucket_name)
@@ -334,8 +409,7 @@ impl ExternalManifestStore for SqlExternalManifestStore {
                 other => sql_err(other),
             })?;
 
-        let manifest_uuid = get_string(&row, "manifest_uuid")?;
-        let full_path = Self::build_manifest_path(base_uri, version, &manifest_uuid);
+        let full_path = get_string(&row, "manifest_path")?;
         let path = Path::from(full_path);
         let size = Some(get_u64(&row, "file_size")?);
         let e_tag = get_optional_string(&row, "e_tag");
@@ -350,7 +424,6 @@ impl ExternalManifestStore for SqlExternalManifestStore {
         })
     }
 
-    /// Get the latest version of a dataset at the base_uri
     async fn get_latest_version(&self, base_uri: &str) -> Result<Option<(u64, String)>> {
         self.get_latest_manifest_location(base_uri)
             .await
@@ -362,10 +435,12 @@ impl ExternalManifestStore for SqlExternalManifestStore {
         base_uri: &str,
     ) -> Result<Option<ManifestLocation>> {
         let sql = format!(
-            "SELECT version, manifest_uuid, file_size, e_tag FROM {} \
-             WHERE bucket_name = ? AND base_path = ? \
+            "SELECT version, manifest_path, file_size, e_tag FROM {} \
+             WHERE bucket_name = {} AND base_path = {} AND version >= 0 \
              ORDER BY version DESC LIMIT 1",
-            self.table_name
+            self.table_name,
+            placeholder(self.param_style, 1),
+            placeholder(self.param_style, 2),
         );
         let maybe_row: Option<AnyRow> = sqlx::query(&sql)
             .bind(&self.bucket_name)
@@ -377,8 +452,7 @@ impl ExternalManifestStore for SqlExternalManifestStore {
         match maybe_row {
             Some(row) => {
                 let version = get_u64(&row, "version")?;
-                let manifest_uuid = get_string(&row, "manifest_uuid")?;
-                let full_path = Self::build_manifest_path(base_uri, version, &manifest_uuid);
+                let full_path = get_string(&row, "manifest_path")?;
                 let path = Path::from(full_path);
                 let size = Some(get_u64(&row, "file_size")?);
                 let e_tag = get_optional_string(&row, "e_tag");
@@ -396,11 +470,6 @@ impl ExternalManifestStore for SqlExternalManifestStore {
         }
     }
 
-    /// Put the manifest path for a given base_uri and version.
-    /// Fails if the version already exists.
-    ///
-    /// Uses a transaction with a single INSERT — the PRIMARY KEY constraint
-    /// atomically rejects duplicates. No need to SELECT first.
     async fn put_if_not_exists(
         &self,
         base_uri: &str,
@@ -409,21 +478,22 @@ impl ExternalManifestStore for SqlExternalManifestStore {
         size: u64,
         e_tag: Option<String>,
     ) -> Result<()> {
-        let manifest_uuid = Self::extract_uuid_from_path(path);
-        let now = Self::now_timestamp();
+        let now = chrono::Utc::now().timestamp();
+
+        let sql = format!(
+            "INSERT INTO {} (bucket_name, base_path, version, manifest_path, file_size, e_tag, create_time, update_time) \
+             VALUES ({})",
+            self.table_name,
+            placeholders(self.param_style, 8),
+        );
 
         let mut tx = self.pool.begin().await.map_err(sql_err)?;
 
-        let sql = format!(
-            "INSERT INTO {} (bucket_name, base_path, version, manifest_uuid, file_size, e_tag, create_time, update_time) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            self.table_name
-        );
         let res = sqlx::query(&sql)
             .bind(&self.bucket_name)
             .bind(base_uri)
             .bind(version as i64)
-            .bind(&manifest_uuid)
+            .bind(path)
             .bind(size as i64)
             .bind(e_tag.as_deref().unwrap_or(""))
             .bind(now)
@@ -437,24 +507,19 @@ impl ExternalManifestStore for SqlExternalManifestStore {
                 Ok(())
             }
             Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
-                tx.rollback().await.map_err(sql_err)?;
-                Err(Error::io(format!(
+                let _ = tx.rollback().await;
+                Err(Error::invalid_input(format!(
                     "put_if_not_exists: version {} already exists for bucket: {}; base_path: {}",
                     version, self.bucket_name, base_uri
                 )))
             }
             Err(e) => {
-                tx.rollback().await.map_err(sql_err)?;
+                let _ = tx.rollback().await;
                 Err(sql_err(e))
             }
         }
     }
 
-    /// Put the manifest path for a given base_uri and version.
-    /// Fails if the version does NOT already exist.
-    ///
-    /// Uses a transaction with a single UPDATE WHERE — `rows_affected() == 0`
-    /// means the row doesn't exist. No need to SELECT first.
     async fn put_if_exists(
         &self,
         base_uri: &str,
@@ -463,18 +528,25 @@ impl ExternalManifestStore for SqlExternalManifestStore {
         size: u64,
         e_tag: Option<String>,
     ) -> Result<()> {
-        let manifest_uuid = Self::extract_uuid_from_path(path);
-        let now = Self::now_timestamp();
+        let now = chrono::Utc::now().timestamp();
+
+        let sql = format!(
+            "UPDATE {} SET manifest_path = {}, file_size = {}, e_tag = {}, update_time = {} \
+             WHERE bucket_name = {} AND base_path = {} AND version = {}",
+            self.table_name,
+            placeholder(self.param_style, 1),
+            placeholder(self.param_style, 2),
+            placeholder(self.param_style, 3),
+            placeholder(self.param_style, 4),
+            placeholder(self.param_style, 5),
+            placeholder(self.param_style, 6),
+            placeholder(self.param_style, 7),
+        );
 
         let mut tx = self.pool.begin().await.map_err(sql_err)?;
 
-        let sql = format!(
-            "UPDATE {} SET manifest_uuid = ?, file_size = ?, e_tag = ?, update_time = ? \
-             WHERE bucket_name = ? AND base_path = ? AND version = ?",
-            self.table_name
-        );
         let result = sqlx::query(&sql)
-            .bind(&manifest_uuid)
+            .bind(path)
             .bind(size as i64)
             .bind(e_tag.as_deref().unwrap_or(""))
             .bind(now)
@@ -486,7 +558,7 @@ impl ExternalManifestStore for SqlExternalManifestStore {
             .map_err(sql_err)?;
 
         if result.rows_affected() == 0 {
-            tx.rollback().await.map_err(sql_err)?;
+            let _ = tx.rollback().await;
             return Err(Error::not_found(format!(
                 "put_if_exists: version {} not found for bucket: {}; base_path: {}",
                 version, self.bucket_name, base_uri
@@ -497,19 +569,20 @@ impl ExternalManifestStore for SqlExternalManifestStore {
         Ok(())
     }
 
-    /// Delete all manifest information for the given base_uri
     async fn delete(&self, base_uri: &str) -> Result<()> {
         let sql = format!(
-            "DELETE FROM {} WHERE bucket_name = ? AND base_path = ?",
-            self.table_name
+            "DELETE FROM {} WHERE bucket_name = {} AND base_path = {}",
+            self.table_name,
+            placeholder(self.param_style, 1),
+            placeholder(self.param_style, 2),
         );
+
         sqlx::query(&sql)
             .bind(&self.bucket_name)
             .bind(base_uri)
             .execute(&self.pool)
             .await
             .map_err(sql_err)?;
-
         Ok(())
     }
 }
@@ -517,16 +590,16 @@ impl ExternalManifestStore for SqlExternalManifestStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::format::DETACHED_VERSION_MASK;
 
     const TEST_TABLE: &str = "external_manifest";
     const TEST_BUCKET: &str = "test_bucket";
     const TEST_BASE_URI: &str = "datasets/my_table";
 
-    /// Helper: create a fresh in-memory SQLite store with the required schema.
+    /// Create a fresh in-memory SQLite store with the required schema.
     async fn create_test_store() -> Arc<dyn ExternalManifestStore> {
-        // Use a unique in-memory database for each test to avoid shared state.
-        // SQLite `:memory:` with a shared cache name keeps the DB alive across
-        // connections in the same pool.
+        // A fresh shared-cache name keeps the DB isolated per test while
+        // still allowing multiple pool connections to see the same data.
         let db_name = uuid::Uuid::new_v4().to_string().replace('-', "");
         let url = format!("sqlite:file:{}?mode=memory&cache=shared", db_name);
 
@@ -538,13 +611,12 @@ mod tests {
             .await
             .expect("failed to connect to in-memory SQLite");
 
-        // Create the table with the expected schema.
         sqlx::query(&format!(
             "CREATE TABLE IF NOT EXISTS {} (
                 bucket_name   TEXT NOT NULL,
                 base_path     TEXT NOT NULL,
                 version       INTEGER NOT NULL,
-                manifest_uuid TEXT NOT NULL,
+                manifest_path TEXT NOT NULL,
                 file_size     INTEGER NOT NULL,
                 e_tag         TEXT NOT NULL,
                 create_time   INTEGER NOT NULL,
@@ -557,91 +629,113 @@ mod tests {
         .await
         .expect("failed to create test table");
 
-        Arc::new(SqlExternalManifestStore {
+        let store = Arc::new(SqlExternalManifestStore {
             pool,
             table_name: TEST_TABLE.to_string(),
             bucket_name: TEST_BUCKET.to_string(),
-        })
+            param_style: ParamStyle::from_url(&url),
+        });
+        store
+            .sanity_check()
+            .await
+            .expect("test schema must pass sanity check");
+        store
     }
 
     #[tokio::test]
     async fn test_put_if_not_exists_succeeds() {
         let store = create_test_store().await;
-        let path = "datasets/my_table/_versions/18446744073709551614.manifest-abc123";
+        let path = "datasets/my_table/_versions/00000000000000000001.manifest-abc123";
         store
             .put_if_not_exists(TEST_BASE_URI, 1, path, 1024, Some("etag1".into()))
             .await
-            .expect("first put_if_not_exists should succeed");
+            .unwrap();
     }
 
     #[tokio::test]
     async fn test_put_if_not_exists_duplicate_fails() {
         let store = create_test_store().await;
-        let path = "datasets/my_table/_versions/18446744073709551614.manifest-abc123";
+        let path = "datasets/my_table/_versions/00000000000000000001.manifest-abc123";
         store
             .put_if_not_exists(TEST_BASE_URI, 1, path, 1024, Some("etag1".into()))
             .await
-            .expect("first insert should succeed");
+            .unwrap();
 
         let result = store
             .put_if_not_exists(TEST_BASE_URI, 1, path, 2048, Some("etag2".into()))
             .await;
-        assert!(result.is_err(), "duplicate version should fail");
+        assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_put_if_exists_succeeds() {
         let store = create_test_store().await;
-        let path1 = "datasets/my_table/_versions/18446744073709551614.manifest-staging1";
+        let path1 = "datasets/my_table/_versions/00000000000000000001.manifest-staging1";
         store
             .put_if_not_exists(TEST_BASE_URI, 1, path1, 1024, Some("etag1".into()))
             .await
             .unwrap();
 
-        let path2 = "datasets/my_table/_versions/18446744073709551614.manifest-final1";
+        let path2 = "datasets/my_table/_versions/00000000000000000001.manifest";
         store
             .put_if_exists(TEST_BASE_URI, 1, path2, 2048, Some("etag2".into()))
             .await
-            .expect("put_if_exists on existing version should succeed");
+            .unwrap();
 
-        // Verify the update took effect
         let loc = store.get_manifest_location(TEST_BASE_URI, 1).await.unwrap();
         assert_eq!(loc.size, Some(2048));
         assert_eq!(loc.e_tag, Some("etag2".to_string()));
+        assert_eq!(loc.path.as_ref(), path2);
     }
 
     #[tokio::test]
     async fn test_put_if_exists_missing_fails() {
         let store = create_test_store().await;
-        let path = "datasets/my_table/_versions/18446744073709551614.manifest-abc";
+        let path = "datasets/my_table/_versions/00000000000000000001.manifest-abc";
         let result = store
             .put_if_exists(TEST_BASE_URI, 1, path, 1024, Some("etag1".into()))
             .await;
-        assert!(
-            result.is_err(),
-            "put_if_exists on non-existent version should fail"
-        );
+        assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn test_get_roundtrip() {
+    async fn test_get_roundtrip_v2() {
         let store = create_test_store().await;
-        let path = "datasets/my_table/_versions/18446744073709551614.manifest-uuid1";
+        let path = "datasets/my_table/_versions/00000000000000000001.manifest-uuid1";
         store
             .put_if_not_exists(TEST_BASE_URI, 1, path, 512, Some("etag_a".into()))
             .await
             .unwrap();
 
         let got_path = store.get(TEST_BASE_URI, 1).await.unwrap();
-        assert!(got_path.contains("uuid1"), "path should contain the uuid");
+        assert_eq!(got_path, path);
+    }
+
+    #[tokio::test]
+    async fn test_get_roundtrip_v1() {
+        // V1 path is `_versions/{version}.manifest` (not zero-padded).
+        let store = create_test_store().await;
+        let path = "datasets/my_table/_versions/1.manifest";
+        store
+            .put_if_not_exists(TEST_BASE_URI, 1, path, 512, Some("etag_a".into()))
+            .await
+            .unwrap();
+
+        let got_path = store.get(TEST_BASE_URI, 1).await.unwrap();
+        assert_eq!(got_path, path);
+
+        let loc = store.get_manifest_location(TEST_BASE_URI, 1).await.unwrap();
+        assert_eq!(
+            loc.naming_scheme,
+            crate::io::commit::ManifestNamingScheme::V1
+        );
     }
 
     #[tokio::test]
     async fn test_get_latest_version() {
         let store = create_test_store().await;
-        // Insert v1 and v3 (skip v2)
-        let p1 = "datasets/my_table/_versions/18446744073709551614.manifest-a";
-        let p3 = "datasets/my_table/_versions/18446744073709551612.manifest-c";
+        let p1 = "datasets/my_table/_versions/00000000000000000001.manifest-a";
+        let p3 = "datasets/my_table/_versions/00000000000000000003.manifest-c";
         store
             .put_if_not_exists(TEST_BASE_URI, 1, p1, 100, None)
             .await
@@ -655,14 +749,15 @@ mod tests {
             .get_latest_version(TEST_BASE_URI)
             .await
             .unwrap()
-            .expect("should have a latest version");
+            .unwrap();
         assert_eq!(latest.0, 3);
+        assert_eq!(latest.1, p3);
     }
 
     #[tokio::test]
     async fn test_get_manifest_location_roundtrip() {
         let store = create_test_store().await;
-        let path = "datasets/my_table/_versions/18446744073709551614.manifest-someuuid";
+        let path = "datasets/my_table/_versions/00000000000000000001.manifest-someuuid";
         store
             .put_if_not_exists(TEST_BASE_URI, 1, path, 4096, Some("my_etag".into()))
             .await
@@ -672,14 +767,14 @@ mod tests {
         assert_eq!(loc.version, 1);
         assert_eq!(loc.size, Some(4096));
         assert_eq!(loc.e_tag, Some("my_etag".to_string()));
-        assert!(loc.path.as_ref().contains("someuuid"));
+        assert_eq!(loc.path.as_ref(), path);
     }
 
     #[tokio::test]
     async fn test_delete_clears_all_versions() {
         let store = create_test_store().await;
-        let p1 = "datasets/my_table/_versions/18446744073709551614.manifest-a";
-        let p2 = "datasets/my_table/_versions/18446744073709551613.manifest-b";
+        let p1 = "datasets/my_table/_versions/00000000000000000001.manifest-a";
+        let p2 = "datasets/my_table/_versions/00000000000000000002.manifest-b";
         store
             .put_if_not_exists(TEST_BASE_URI, 1, p1, 100, None)
             .await
@@ -692,19 +787,239 @@ mod tests {
         store.delete(TEST_BASE_URI).await.unwrap();
 
         let latest = store.get_latest_version(TEST_BASE_URI).await.unwrap();
-        assert!(latest.is_none(), "after delete, no versions should remain");
+        assert!(latest.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_detached_version_roundtrip() {
+        // Detached versions (high bit set) must be stored and read back
+        // transparently — they exercise the u64 -> i64 -> u64 path through
+        // BIGINT columns.
+        let store = create_test_store().await;
+        let detached = DETACHED_VERSION_MASK | 7;
+        let path = format!("datasets/my_table/_versions/d{detached}.manifest");
+
+        store
+            .put_if_not_exists(TEST_BASE_URI, detached, &path, 100, Some("etag_d".into()))
+            .await
+            .unwrap();
+
+        assert_eq!(store.get(TEST_BASE_URI, detached).await.unwrap(), path);
+
+        let loc = store
+            .get_manifest_location(TEST_BASE_URI, detached)
+            .await
+            .unwrap();
+        assert_eq!(loc.version, detached);
+        assert_eq!(loc.path.to_string(), path);
+        assert_eq!(loc.size, Some(100));
+        assert_eq!(loc.e_tag.as_deref(), Some("etag_d"));
+    }
+
+    #[tokio::test]
+    async fn test_get_latest_ignores_detached() {
+        // get_latest_* must never return a detached version, even when its
+        // u64 value is numerically larger than every attached version.
+        let store = create_test_store().await;
+        let detached = DETACHED_VERSION_MASK | 7;
+
+        store
+            .put_if_not_exists(
+                TEST_BASE_URI,
+                1,
+                "datasets/my_table/_versions/1.manifest",
+                10,
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .put_if_not_exists(
+                TEST_BASE_URI,
+                2,
+                "datasets/my_table/_versions/2.manifest",
+                20,
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .put_if_not_exists(
+                TEST_BASE_URI,
+                detached,
+                &format!("datasets/my_table/_versions/d{detached}.manifest"),
+                30,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let latest = store.get_latest_version(TEST_BASE_URI).await.unwrap();
+        assert_eq!(latest.map(|(v, _)| v), Some(2));
+    }
+
+    #[tokio::test]
+    async fn test_sanity_rejects_no_constraint() {
+        let db_name = uuid::Uuid::new_v4().to_string().replace('-', "");
+        let url = format!("sqlite:file:{}?mode=memory&cache=shared", db_name);
+        sqlx::any::install_default_drivers();
+        let pool = AnyPoolOptions::new().connect(&url).await.unwrap();
+        sqlx::query(
+            "CREATE TABLE no_unique (
+                bucket_name   TEXT NOT NULL,
+                base_path     TEXT NOT NULL,
+                version       INTEGER NOT NULL,
+                manifest_path TEXT NOT NULL,
+                file_size     INTEGER NOT NULL,
+                e_tag         TEXT NOT NULL,
+                create_time   INTEGER NOT NULL,
+                update_time   INTEGER NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let store = SqlExternalManifestStore {
+            pool,
+            table_name: "no_unique".to_string(),
+            bucket_name: TEST_BUCKET.to_string(),
+            param_style: ParamStyle::from_url(&url),
+        };
+        let err = store.sanity_check().await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("UNIQUE") || msg.contains("PRIMARY KEY"),
+            "error must mention the missing constraint, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sanity_accepts_unique_index() {
+        // A table without PRIMARY KEY but with a UNIQUE INDEX over the
+        // CAS-relevant columns must pass — `probe_uniqueness` checks the
+        // unique constraint behaviorally, not the specific DDL form.
+        let db_name = uuid::Uuid::new_v4().to_string().replace('-', "");
+        let url = format!("sqlite:file:{}?mode=memory&cache=shared", db_name);
+        sqlx::any::install_default_drivers();
+        let pool = AnyPoolOptions::new().connect(&url).await.unwrap();
+        sqlx::query(
+            "CREATE TABLE unique_idx_only (
+                bucket_name   TEXT NOT NULL,
+                base_path     TEXT NOT NULL,
+                version       INTEGER NOT NULL,
+                manifest_path TEXT NOT NULL,
+                file_size     INTEGER NOT NULL,
+                e_tag         TEXT NOT NULL,
+                create_time   INTEGER NOT NULL,
+                update_time   INTEGER NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE UNIQUE INDEX uq_unique_idx_only \
+             ON unique_idx_only (bucket_name, base_path, version)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let store = SqlExternalManifestStore {
+            pool,
+            table_name: "unique_idx_only".to_string(),
+            bucket_name: TEST_BUCKET.to_string(),
+            param_style: ParamStyle::from_url(&url),
+        };
+        store
+            .sanity_check()
+            .await
+            .expect("unique index over the CAS columns must satisfy sanity check");
+    }
+
+    #[tokio::test]
+    async fn test_sanity_rejects_partial_constraint() {
+        // A UNIQUE constraint that does not cover `version` must be rejected
+        // — duplicates on (bucket, base, vN) would not collide and CAS would
+        // silently corrupt data.
+        let db_name = uuid::Uuid::new_v4().to_string().replace('-', "");
+        let url = format!("sqlite:file:{}?mode=memory&cache=shared", db_name);
+        sqlx::any::install_default_drivers();
+        let pool = AnyPoolOptions::new().connect(&url).await.unwrap();
+        sqlx::query(
+            "CREATE TABLE partial_unique (
+                bucket_name   TEXT NOT NULL,
+                base_path     TEXT NOT NULL,
+                version       INTEGER NOT NULL,
+                manifest_path TEXT NOT NULL,
+                file_size     INTEGER NOT NULL,
+                e_tag         TEXT NOT NULL,
+                create_time   INTEGER NOT NULL,
+                update_time   INTEGER NOT NULL,
+                UNIQUE (bucket_name, base_path)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let store = SqlExternalManifestStore {
+            pool,
+            table_name: "partial_unique".to_string(),
+            bucket_name: TEST_BUCKET.to_string(),
+            param_style: ParamStyle::from_url(&url),
+        };
+        // The first probe insert will already violate the (bucket, base)
+        // unique constraint because the cleanup happens in the same tx;
+        // either way the probe must surface this as an error rather than
+        // silently passing.
+        let err = store.sanity_check().await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("UNIQUE")
+                || msg.contains("PRIMARY KEY")
+                || msg.contains("schema sanity probe failed"),
+            "error must signal the constraint problem, got: {msg}"
+        );
     }
 
     #[test]
-    fn test_validate_sql_identifier_rejects_injection() {
+    fn test_validate_identifier_rejects_injection() {
         assert!(validate_sql_identifier("good_table_1", "sqlTableName").is_ok());
         assert!(validate_sql_identifier("ExternalManifest", "sqlTableName").is_ok());
 
-        // SQL injection attempts
         assert!(validate_sql_identifier("t; DROP TABLE t--", "sqlTableName").is_err());
         assert!(validate_sql_identifier("table name", "sqlTableName").is_err());
         assert!(validate_sql_identifier("table'name", "sqlTableName").is_err());
         assert!(validate_sql_identifier("", "sqlTableName").is_err());
         assert!(validate_sql_identifier("table.name", "sqlTableName").is_err());
+    }
+
+    #[test]
+    fn test_placeholder_style() {
+        assert_eq!(placeholder(ParamStyle::Positional, 1), "?");
+        assert_eq!(placeholder(ParamStyle::Positional, 3), "?");
+        assert_eq!(placeholder(ParamStyle::Numbered, 1), "$1");
+        assert_eq!(placeholder(ParamStyle::Numbered, 7), "$7");
+        assert_eq!(placeholders(ParamStyle::Numbered, 3), "$1, $2, $3");
+        assert_eq!(placeholders(ParamStyle::Positional, 3), "?, ?, ?");
+    }
+
+    #[test]
+    fn test_param_style_from_url() {
+        assert_eq!(
+            ParamStyle::from_url("postgres://h/db"),
+            ParamStyle::Numbered
+        );
+        assert_eq!(
+            ParamStyle::from_url("postgresql://h/db"),
+            ParamStyle::Numbered
+        );
+        assert_eq!(ParamStyle::from_url("mysql://h/db"), ParamStyle::Positional);
+        assert_eq!(
+            ParamStyle::from_url("sqlite://lance.db"),
+            ParamStyle::Positional
+        );
     }
 }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -144,6 +144,7 @@ fp16kernels = ["lance-linalg/fp16kernels"]
 cli = ["dep:clap", "lzma-sys/static"]
 dynamodb = ["lance-table/dynamodb", "dep:aws-sdk-dynamodb"]
 dynamodb_tests = ["dynamodb"]
+sql_store = ["lance-table/sql_store"]
 substrait = ["lance-datafusion/substrait"]
 protoc = [
     "dep:protobuf-src",

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -1503,6 +1503,10 @@ async fn resolve_commit_handler(
                 Err(Error::invalid_input(
                     "`s3+ddb://` scheme and custom commit handler are mutually exclusive",
                 ))
+            } else if uri.starts_with("s3+sql") {
+                Err(Error::invalid_input(
+                    "`s3+sql://` scheme and custom commit handler are mutually exclusive",
+                ))
             } else {
                 Ok(commit_handler)
             }


### PR DESCRIPTION
## Description
### 🔍 Related Issue
- Fixes: [#5751](https://github.com/lance-format/lance/issues/5751)
- Fixes:[#5573](https://github.com/lance-format/lance/issues/5573)

### 📝 Background & Motivation
Certain object storage systems lack support for the `put-if-not-exist` semantics, which prevents direct guarantees of transaction atomicity. This pull request introduces a standard SQL-based `ExternalManifest` solution to address this limitation, leveraging `ExternalManifest` to ensure transaction atomicity.

### Core Implementation

#### 1. New URL Scheme: `s3+sql://`

```
s3+sql://{bucket}/{path}[?sqlTableName=...&sqlMaxConnections=...&...]
```

- Routes through `SqlExternalManifestStore` automatically.
- Mutually exclusive with a custom `commit_handler` — passing both is
  rejected at write time.

Supported drivers (via `sqlx` `any` runtime):

| Scheme       | Database   |
|--------------|------------|
| `postgres://`, `postgresql://` | PostgreSQL |
| `mysql://`   | MySQL / MariaDB |
| `sqlite://`  | SQLite (local file or `:memory:`) |


##### URI query parameters 

| URL query key       | Description                              | Default             |
|---------------------|------------------------------------------|---------------------|
| `sqlTableName`      | Manifest table name                      | `external_manifest` |
| `sqlMaxConnections` | Max pool connections                     | `5`                 |
| `sqlMinConnections` | Min idle pool connections                | `1`                 |
| `sqlAcquireTimeout` | Acquire timeout (seconds)                | `10`                |
| `sqlIdleTimeout`    | Idle connection timeout (seconds)        | `300`               |
| `sqlMaxLifetime`    | Max connection lifetime (seconds)        | `1800`              |

`sqlTableName` is validated as an ASCII identifier (`[A-Za-z0-9_]+`) to
prevent SQL injection through the dynamically-substituted table name.

##### `storage_options` / environment 

| Key (storage_options)  | Env var               | Description                                |
|------------------------|-----------------------|--------------------------------------------|
| `sql_conn_str`         | `LANCE_SQL_CONN_STR`  | Database connection URL (**required**)     |

Precedence: `storage_options` > environment variable.

#### 3. Expected Table Schema

Users must create the table with this exact column set and a uniqueness
constraint covering `(bucket_name, base_path, version)`:

| Column          | Type                    |
|-----------------|-------------------------|
| `bucket_name`   | `VARCHAR(255) NOT NULL` |
| `base_path`     | `VARCHAR(255) NOT NULL` |
| `version`       | `BIGINT NOT NULL`       |
| `manifest_path` | `VARCHAR(512) NOT NULL` |
| `file_size`     | `BIGINT NOT NULL`       |
| `e_tag`         | `VARCHAR(255) NOT NULL` |
| `create_time`   | `BIGINT NOT NULL`       |
| `update_time`   | `BIGINT NOT NULL`       |

Example row:

| Field           | Value                                |
|-----------------|--------------------------------------|
| `bucket_name`   | `hsq-test-1253960454`                |
| `base_path`     | `test/lance_sql_store`                        |
| `version`       | `33`                                 |
| `manifest_path` | `test/lance_sql_store/_versions/18446744073709551614.manifest`              |
| `file_size`     | `3487`                               |
| `e_tag`         | `"df2eb24e6b1142d2cd6ce7b6d41800ec"` |
| `create_time`   | `1782296148`                         |
| `update_time`   | `1782296148`                         |


