### PR TITLE
fix: lance error TooMuchWriteContention should be converted to a retryable namespace error.

### DIFF
--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -274,13 +274,15 @@ impl std::fmt::Debug for ManifestNamespace {
 fn convert_lance_commit_error(e: &LanceError, operation: &str, object_id: Option<&str>) -> Error {
     match e {
         // CommitConflict: version collision retries exhausted -> Throttled (safe to retry)
-        LanceError::CommitConflict { .. } => NamespaceError::Throttled {
-            message: format!("Too many concurrent writes, please retry later: {:?}", e),
+        // TooMuchWriteContention: RetryableCommitConflict (semantic conflict) retries exhausted -> Throttled (safe to retry)
+        LanceError::CommitConflict { .. } | LanceError::TooMuchWriteContention { .. } => {
+            NamespaceError::Throttled {
+                message: format!("Too many concurrent writes, please retry later: {:?}", e),
+            }
+            .into()
         }
-        .into(),
-        // TooMuchWriteContention: RetryableCommitConflict (semantic conflict) retries exhausted -> ConcurrentModification
         // IncompatibleTransaction: incompatible concurrent change -> ConcurrentModification
-        LanceError::TooMuchWriteContention { .. } | LanceError::IncompatibleTransaction { .. } => {
+        LanceError::IncompatibleTransaction { .. } => {
             let message = if let Some(id) = object_id {
                 format!(
                     "Object '{}' was concurrently modified by another operation: {:?}",


### PR DESCRIPTION
In semantics, I think TooMuchWriteContention should be converted to NamespaceError::Throttled. Because TooMuchWriteContention is caused by RetryableCommitConflict, which means too many concurrent commits and can be retried, just like CommitConflict.

Currently, TooMuchWriteContention and IncompatibleTransaction are both converted into NamespaceError::ConcurrentModification. Since RetryableCommitConflict should be retry and IncompatibleTransaction should not, the caller can't distinguish whether the ConcurrentModification error should be retried
