### PR TITLE
perf: WAND and BM25 read optimizations

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::{
     cmp::{Reverse, min},
@@ -41,8 +42,20 @@ use lance_core::utils::mask::{RowAddrMask, RowAddrTreeMap};
 use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_cpu};
 use lance_core::utils::tracing::{IO_TYPE_LOAD_SCALAR_PART, TRACE_IO_EVENTS};
 use lance_core::{Error, ROW_ID, ROW_ID_FIELD, Result};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use roaring::RoaringBitmap;
 use std::sync::LazyLock;
+
+/// Dedicated rayon pool for BM25 search, sized to match Lance's CPU budget.
+/// This avoids using the global rayon pool which doesn't respect
+/// LANCE_CPU_THREADS / LANCE_IO_CORE_RESERVATION.
+static SEARCH_THREAD_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(|| {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(get_num_compute_intensive_cpus())
+        .thread_name(|i| format!("lance-search-{}", i))
+        .build()
+        .expect("Failed to create search thread pool")
+});
 use tokio::task::spawn_blocking;
 use tracing::{info, instrument};
 
@@ -112,15 +125,6 @@ static ROW_ID_SCHEMA: LazyLock<SchemaRef> =
 struct PartitionCandidates {
     tokens_by_position: Vec<String>,
     candidates: Vec<DocCandidate>,
-}
-
-impl PartitionCandidates {
-    fn empty() -> Self {
-        Self {
-            tokens_by_position: Vec::new(),
-            candidates: Vec::new(),
-        }
-    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
@@ -258,52 +262,95 @@ impl InvertedIndex {
         }
         let mask = prefilter.mask();
 
-        let mut candidates = BinaryHeap::new();
-        let parts = self
+        // Phase 1: Load all posting lists in parallel on tokio (async I/O)
+        let load_futs = self
             .partitions
             .iter()
             .map(|part| {
                 let part = part.clone();
                 let tokens = tokens.clone();
                 let params = params.clone();
-                let mask = mask.clone();
                 let metrics = metrics.clone();
                 async move {
                     let postings = part
                         .load_posting_lists(tokens.as_ref(), params.as_ref(), metrics.as_ref())
                         .await?;
                     if postings.is_empty() {
-                        return Result::Ok(PartitionCandidates::empty());
+                        return Result::Ok(None);
                     }
                     let mut tokens_by_position = vec![String::new(); postings.len()];
                     for posting in &postings {
                         let idx = posting.term_index() as usize;
                         tokens_by_position[idx] = posting.token().to_owned();
                     }
-                    let params = params.clone();
-                    let mask = mask.clone();
-                    let metrics = metrics.clone();
-                    spawn_cpu(move || {
-                        let candidates = part.bm25_search(
-                            params.as_ref(),
-                            operator,
-                            mask,
-                            postings,
-                            metrics.as_ref(),
-                        )?;
-                        Ok(PartitionCandidates {
-                            tokens_by_position,
-                            candidates,
-                        })
-                    })
-                    .await
+                    Ok(Some((part, postings, tokens_by_position)))
                 }
             })
             .collect::<Vec<_>>();
-        let mut parts = stream::iter(parts).buffer_unordered(get_num_compute_intensive_cpus());
-        let scorer = IndexBM25Scorer::new(self.partitions.iter().map(|part| part.as_ref()));
+        let loaded: Vec<_> = stream::iter(load_futs)
+            .buffer_unordered(get_num_compute_intensive_cpus())
+            .try_filter_map(|opt| async move { Ok(opt) })
+            .try_collect()
+            .await?;
+
+        if loaded.is_empty() {
+            return Ok((Vec::new(), Vec::new()));
+        }
+
+        // Phase 2: Run all bm25_search calls in a single spawn_cpu.
+        // For multiple partitions, use rayon work-stealing for CPU parallelism
+        // (single cross-runtime hop instead of per-partition spawn_cpu).
+        // For a single partition, skip rayon overhead entirely.
+        let all_results: Vec<PartitionCandidates> = if loaded.len() == 1 {
+            let (part, postings, tokens_by_position) = loaded.into_iter().next().unwrap();
+            let params_cpu = params.clone();
+            let metrics_cpu = metrics.clone();
+            spawn_cpu(move || -> Result<Vec<PartitionCandidates>> {
+                let candidates = part.bm25_search(
+                    params_cpu.as_ref(),
+                    operator,
+                    mask,
+                    postings,
+                    metrics_cpu.as_ref(),
+                )?;
+                Ok(vec![PartitionCandidates {
+                    tokens_by_position,
+                    candidates,
+                }])
+            })
+            .await?
+        } else {
+            let params_cpu = params.clone();
+            let mask_cpu = mask.clone();
+            let metrics_cpu = metrics.clone();
+            spawn_cpu(move || {
+                SEARCH_THREAD_POOL.install(|| {
+                    loaded
+                        .into_par_iter()
+                        .map(|(part, postings, tokens_by_position)| {
+                            let candidates = part.bm25_search(
+                                params_cpu.as_ref(),
+                                operator,
+                                mask_cpu.clone(),
+                                postings,
+                                metrics_cpu.as_ref(),
+                            )?;
+                            Ok(PartitionCandidates {
+                                tokens_by_position,
+                                candidates,
+                            })
+                        })
+                        .collect::<Result<Vec<_>>>()
+                })
+            })
+            .await?
+        };
+
+        // Phase 3: Cross-partition rescoring
+        let mut candidates = BinaryHeap::new();
+        let scorer = IndexBM25Scorer::new(self.partitions.iter().map(|part| part.as_ref()), &[]);
         let mut idf_cache: HashMap<String, f32> = HashMap::new();
-        while let Some(res) = parts.try_next().await? {
+        for res in all_results {
             if res.candidates.is_empty() {
                 continue;
             }
@@ -405,6 +452,10 @@ impl InvertedIndex {
                 inverted_list,
                 docs,
                 token_set_format: TokenSetFormat::Arrow,
+                stats: OnceLock::new(),
+                token_doc_freq_cache: std::sync::Mutex::new(HashMap::new()),
+                doc_freq_cache_hits: AtomicU64::new(0),
+                doc_freq_cache_misses: AtomicU64::new(0),
             })],
         }))
     }
@@ -672,7 +723,6 @@ impl ScalarIndex for InvertedIndex {
     }
 }
 
-#[derive(Debug, Clone, DeepSizeOf)]
 pub struct InvertedPartition {
     // 0 for legacy format
     id: u64,
@@ -681,6 +731,76 @@ pub struct InvertedPartition {
     pub(crate) inverted_list: Arc<PostingListReader>,
     pub(crate) docs: DocSet,
     token_set_format: TokenSetFormat,
+
+    /// Cached partition-level statistics for BM25 scoring.
+    /// Computed once on first access via OnceLock.
+    stats: OnceLock<PartitionStatsInner>,
+
+    /// Lazy per-token document frequency cache.
+    /// Avoids repeated FST lookups for the same token across queries.
+    /// Key: token string, Value: posting_len (number of documents containing the token).
+    token_doc_freq_cache: std::sync::Mutex<HashMap<String, usize>>,
+
+    /// Cache hit/miss counters for token_doc_freq lookups.
+    pub(crate) doc_freq_cache_hits: AtomicU64,
+    pub(crate) doc_freq_cache_misses: AtomicU64,
+}
+
+impl Debug for InvertedPartition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InvertedPartition")
+            .field("id", &self.id)
+            .field("tokens", &self.tokens)
+            .field("docs", &self.docs)
+            .field("token_set_format", &self.token_set_format)
+            .field(
+                "doc_freq_cache_size",
+                &self.token_doc_freq_cache.lock().unwrap().len(),
+            )
+            .field(
+                "doc_freq_cache_hits",
+                &self.doc_freq_cache_hits.load(Ordering::Relaxed),
+            )
+            .field(
+                "doc_freq_cache_misses",
+                &self.doc_freq_cache_misses.load(Ordering::Relaxed),
+            )
+            .finish()
+    }
+}
+
+impl Clone for InvertedPartition {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            store: self.store.clone(),
+            tokens: self.tokens.clone(),
+            inverted_list: self.inverted_list.clone(),
+            docs: self.docs.clone(),
+            token_set_format: self.token_set_format,
+            stats: OnceLock::new(),
+            token_doc_freq_cache: std::sync::Mutex::new(HashMap::new()),
+            doc_freq_cache_hits: AtomicU64::new(0),
+            doc_freq_cache_misses: AtomicU64::new(0),
+        }
+    }
+}
+
+impl DeepSizeOf for InvertedPartition {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.tokens.deep_size_of_children(context)
+            + self.inverted_list.deep_size_of_children(context)
+            + self.docs.deep_size_of_children(context)
+            + self.token_doc_freq_cache.lock().unwrap().len()
+                * (std::mem::size_of::<String>() + std::mem::size_of::<usize>())
+    }
+}
+
+/// Immutable partition-level statistics, computed once from DocSet.
+#[derive(Debug, Clone, Copy)]
+pub struct PartitionStatsInner {
+    pub num_docs: usize,
+    pub total_tokens: u64,
 }
 
 impl InvertedPartition {
@@ -731,11 +851,52 @@ impl InvertedPartition {
             inverted_list: Arc::new(inverted_list),
             docs,
             token_set_format,
+            stats: OnceLock::new(),
+            token_doc_freq_cache: std::sync::Mutex::new(HashMap::new()),
+            doc_freq_cache_hits: AtomicU64::new(0),
+            doc_freq_cache_misses: AtomicU64::new(0),
         })
     }
 
     fn map(&self, token: &str) -> Option<u32> {
         self.tokens.get(token)
+    }
+
+    /// Returns cached partition-level stats, computing on first call.
+    pub(crate) fn stats(&self) -> &PartitionStatsInner {
+        self.stats.get_or_init(|| {
+            let num_docs = self.docs.len();
+            let total_tokens = self.docs.total_tokens_num();
+            PartitionStatsInner {
+                num_docs,
+                total_tokens,
+            }
+        })
+    }
+
+    /// Returns the document frequency (posting_len) for a token, using a
+    /// lazy cache to avoid repeated FST lookups across queries.
+    pub(crate) fn doc_freq(&self, token: &str) -> usize {
+        // Fast path: check cache
+        {
+            let cache = self.token_doc_freq_cache.lock().unwrap();
+            if let Some(&freq) = cache.get(token) {
+                self.doc_freq_cache_hits.fetch_add(1, Ordering::Relaxed);
+                return freq;
+            }
+        }
+
+        // Slow path: FST lookup + cache insert
+        self.doc_freq_cache_misses.fetch_add(1, Ordering::Relaxed);
+        let freq = if let Some(token_id) = self.tokens.get(token) {
+            self.inverted_list.posting_len(token_id)
+        } else {
+            0
+        };
+
+        let mut cache = self.token_doc_freq_cache.lock().unwrap();
+        cache.insert(token.to_owned(), freq);
+        freq
     }
 
     pub fn expand_fuzzy(&self, tokens: &Tokens, params: &FtsSearchParams) -> Result<Tokens> {
@@ -842,7 +1003,8 @@ impl InvertedPartition {
         }
 
         // let local_metrics = LocalMetricsCollector::default();
-        let scorer = IndexBM25Scorer::new(std::iter::once(self));
+        let query_tokens: Vec<&str> = postings.iter().map(|p| p.token()).collect();
+        let scorer = IndexBM25Scorer::new(std::iter::once(self), &query_tokens);
         let mut wand = Wand::new(operator, postings.into_iter(), &self.docs, scorer);
         let hits = wand.search(params, mask, metrics)?;
         // local_metrics.dump_into(metrics);
@@ -1842,6 +2004,9 @@ pub struct CompressedPostingList {
     // that contains `BLOCK_SIZE` doc ids and then `BLOCK_SIZE` frequencies
     pub blocks: LargeBinaryArray,
     pub positions: Option<ListArray>,
+    // Pre-extracted block metadata to avoid Arrow array accessor overhead per call
+    block_least_doc_ids: Vec<u32>,
+    block_max_scores: Vec<f32>,
 }
 
 impl DeepSizeOf for CompressedPostingList {
@@ -1852,6 +2017,8 @@ impl DeepSizeOf for CompressedPostingList {
                 .as_ref()
                 .map(Array::get_buffer_memory_size)
                 .unwrap_or(0)
+            + self.block_least_doc_ids.capacity() * std::mem::size_of::<u32>()
+            + self.block_max_scores.capacity() * std::mem::size_of::<f32>()
     }
 }
 
@@ -1862,11 +2029,21 @@ impl CompressedPostingList {
         length: u32,
         positions: Option<ListArray>,
     ) -> Self {
+        let num_blocks = blocks.len();
+        let mut block_least_doc_ids = Vec::with_capacity(num_blocks);
+        let mut block_max_scores = Vec::with_capacity(num_blocks);
+        for i in 0..num_blocks {
+            let block = blocks.value(i);
+            block_max_scores.push(f32::from_le_bytes(block[0..4].try_into().unwrap()));
+            block_least_doc_ids.push(u32::from_le_bytes(block[4..8].try_into().unwrap()));
+        }
         Self {
             max_score,
             length,
             blocks,
             positions,
+            block_least_doc_ids,
+            block_max_scores,
         }
     }
 
@@ -1881,12 +2058,7 @@ impl CompressedPostingList {
             .column_by_name(POSITION_COL)
             .map(|col| col.as_list::<i32>().value(0).as_list::<i32>().clone());
 
-        Self {
-            max_score,
-            length,
-            blocks,
-            positions,
-        }
+        Self::new(blocks, max_score, length, positions)
     }
 
     pub fn iter(&self) -> CompressedPostingListIterator {
@@ -1897,14 +2069,14 @@ impl CompressedPostingList {
         )
     }
 
+    #[inline]
     pub fn block_max_score(&self, block_idx: usize) -> f32 {
-        let block = self.blocks.value(block_idx);
-        block[0..4].try_into().map(f32::from_le_bytes).unwrap()
+        self.block_max_scores[block_idx]
     }
 
+    #[inline]
     pub fn block_least_doc_id(&self, block_idx: usize) -> u32 {
-        let block = self.blocks.value(block_idx);
-        block[4..8].try_into().map(u32::from_le_bytes).unwrap()
+        self.block_least_doc_ids[block_idx]
     }
 }
 
@@ -3073,7 +3245,10 @@ fn initialize_scorer(
     let mut all_token_counts = vec![0; query_tokens.len()];
 
     if let Some(index) = index {
-        let index_bm25_scorer = IndexBM25Scorer::new(index.partitions.iter().map(|p| p.as_ref()));
+        // Pass &[] — this scorer is only used for num_docs_containing_token(),
+        // total_tokens(), and num_docs(). IDF cache is not needed here.
+        let index_bm25_scorer =
+            IndexBM25Scorer::new(index.partitions.iter().map(|p| p.as_ref()), &[]);
         for (token_index, token) in query_tokens.into_iter().enumerate() {
             let token_nq = index_bm25_scorer.num_docs_containing_token(token);
             all_token_counts[token_index] = token_nq as u64;

--- a/rust/lance-index/src/scalar/inverted/scorer.rs
+++ b/rust/lance-index/src/scalar/inverted/scorer.rs
@@ -79,22 +79,41 @@ pub struct IndexBM25Scorer<'a> {
     num_docs: usize,
     total_tokens: u64,
     avg_doc_length: f32,
+    idf_cache: HashMap<String, f32>,
 }
 
 impl<'a> IndexBM25Scorer<'a> {
-    pub fn new(partitions: impl Iterator<Item = &'a InvertedPartition>) -> Self {
+    pub fn new(
+        partitions: impl Iterator<Item = &'a InvertedPartition>,
+        query_tokens: &[&str],
+    ) -> Self {
         let partitions = partitions.collect::<Vec<_>>();
-        let num_docs = partitions.iter().map(|p| p.docs.len()).sum();
-        let total_tokens = partitions
-            .iter()
-            .map(|part| part.docs.total_tokens_num())
-            .sum::<u64>();
-        let avgdl = total_tokens as f32 / num_docs as f32;
+
+        // Use cached partition stats — O(n_partitions) addition, no DocSet access
+        let num_docs: usize = partitions.iter().map(|p| p.stats().num_docs).sum();
+        let total_tokens: u64 = partitions.iter().map(|p| p.stats().total_tokens).sum();
+        let avgdl = if num_docs > 0 {
+            total_tokens as f32 / num_docs as f32
+        } else {
+            0.0
+        };
+
+        // Build IDF cache using partition doc_freq cache (avoids FST lookups on
+        // repeated tokens across queries)
+        let mut idf_cache = HashMap::with_capacity(query_tokens.len());
+        for &token in query_tokens {
+            let n: usize = partitions.iter().map(|p| p.doc_freq(token)).sum();
+            if n > 0 {
+                idf_cache.insert(token.to_owned(), idf(n, num_docs));
+            }
+        }
+
         Self {
             partitions,
             num_docs,
             total_tokens,
             avg_doc_length: avgdl,
+            idf_cache,
         }
     }
 
@@ -107,21 +126,17 @@ impl<'a> IndexBM25Scorer<'a> {
     }
 
     pub fn num_docs_containing_token(&self, token: &str) -> usize {
-        self.partitions
-            .iter()
-            .map(|part| {
-                if let Some(token_id) = part.tokens.get(token) {
-                    part.inverted_list.posting_len(token_id)
-                } else {
-                    0
-                }
-            })
-            .sum()
+        self.partitions.iter().map(|p| p.doc_freq(token)).sum()
     }
 }
 
 impl Scorer for IndexBM25Scorer<'_> {
     fn query_weight(&self, token: &str) -> f32 {
+        // Fast path: use precomputed IDF from cache (O(1) HashMap lookup)
+        if let Some(&cached) = self.idf_cache.get(token) {
+            return cached;
+        }
+        // Fallback for tokens not in the cache (should not happen if constructed correctly)
         let token_docs = self.num_docs_containing_token(token);
         if token_docs == 0 {
             return 0.0;

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -52,6 +52,10 @@ pub struct PostingIterator {
 
     // for compressed posting list
     compressed: Option<UnsafeCell<CompressedState>>,
+
+    // Cached current doc_id to avoid repeated decompression in Ord comparisons.
+    // Set to TERMINATED_DOC_ID when the iterator is exhausted.
+    cached_doc_id: u64,
 }
 
 #[derive(Clone)]
@@ -90,13 +94,7 @@ impl CompressedState {
 impl Debug for PostingIterator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PostingIterator")
-            .field(
-                "doc",
-                &self
-                    .doc()
-                    .map(|doc| doc.doc_id())
-                    .unwrap_or(TERMINATED_DOC_ID),
-            )
+            .field("doc", &self.cached_doc_id)
             .field("approximate_upper_bound", &self.approximate_upper_bound)
             .field("token_id", &self.token_id)
             .finish()
@@ -119,23 +117,25 @@ impl PartialOrd for PostingIterator {
 
 impl Ord for PostingIterator {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match (self.doc(), other.doc()) {
-            (Some(doc1), Some(doc2)) => doc1
-                .cmp(&doc2)
-                .then(
-                    self.approximate_upper_bound
-                        .total_cmp(&other.approximate_upper_bound),
-                )
-                .then(self.token_id.cmp(&other.token_id))
-                .then(self.position.cmp(&other.position)),
-            (Some(_), None) => std::cmp::Ordering::Less,
-            (None, Some(_)) => std::cmp::Ordering::Greater,
-            (None, None) => self
-                .approximate_upper_bound
-                .total_cmp(&other.approximate_upper_bound)
-                .then(self.token_id.cmp(&other.token_id))
-                .then(self.position.cmp(&other.position)),
+        // Fast path: compare cached doc_ids directly (no decompression needed)
+        let a = self.cached_doc_id;
+        let b = other.cached_doc_id;
+        match (a == TERMINATED_DOC_ID, b == TERMINATED_DOC_ID) {
+            (true, true) => {}
+            (true, false) => return std::cmp::Ordering::Greater,
+            (false, true) => return std::cmp::Ordering::Less,
+            (false, false) => {
+                let ord = a.cmp(&b);
+                if ord != std::cmp::Ordering::Equal {
+                    return ord;
+                }
+            }
         }
+        // Tiebreak (rare): upper_bound -> token_id -> position
+        self.approximate_upper_bound
+            .total_cmp(&other.approximate_upper_bound)
+            .then(self.token_id.cmp(&other.token_id))
+            .then(self.position.cmp(&other.position))
     }
 }
 
@@ -176,6 +176,16 @@ impl PostingIterator {
 
         let is_compressed = matches!(list, PostingList::Compressed(_));
 
+        // Initialize cached_doc_id from the first element without decompression
+        let cached_doc_id = if list.is_empty() {
+            TERMINATED_DOC_ID
+        } else {
+            match &list {
+                PostingList::Compressed(cpl) => cpl.block_least_doc_id(0) as u64,
+                PostingList::Plain(pl) => pl.row_ids[0],
+            }
+        };
+
         Self {
             token,
             token_id,
@@ -185,6 +195,7 @@ impl PostingIterator {
             block_idx: 0,
             approximate_upper_bound,
             compressed: is_compressed.then(|| UnsafeCell::new(CompressedState::new())),
+            cached_doc_id,
         }
     }
 
@@ -205,7 +216,14 @@ impl PostingIterator {
 
     #[inline]
     fn empty(&self) -> bool {
-        self.index >= self.list.len()
+        self.cached_doc_id == TERMINATED_DOC_ID
+    }
+
+    /// Zero-cost accessor for the current doc id.
+    /// Uses the cached value — no decompression or block access.
+    #[inline]
+    fn current_doc_id(&self) -> u64 {
+        self.cached_doc_id
     }
 
     #[inline]
@@ -265,18 +283,28 @@ impl PostingIterator {
                     let new_offset = block_offset + offset_in_block;
                     if new_offset < compressed.doc_ids.len() {
                         self.index = block_idx * BLOCK_SIZE + new_offset;
+                        self.cached_doc_id = compressed.doc_ids[new_offset] as u64;
                         break;
                     }
                     if block_idx + 1 >= list.blocks.len() {
                         self.index = length;
+                        self.cached_doc_id = TERMINATED_DOC_ID;
                         break;
                     }
                     self.index = (block_idx + 1) * BLOCK_SIZE;
+                }
+                if self.index >= length {
+                    self.cached_doc_id = TERMINATED_DOC_ID;
                 }
                 self.block_idx = self.index / BLOCK_SIZE;
             }
             PostingList::Plain(ref list) => {
                 self.index += list.row_ids[self.index..].partition_point(|&id| id < least_id);
+                self.cached_doc_id = if self.index < list.row_ids.len() {
+                    list.row_ids[self.index]
+                } else {
+                    TERMINATED_DOC_ID
+                };
             }
         }
     }
@@ -539,7 +567,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
 
             max_pivot = 0;
             while max_pivot + 1 < self.postings.len()
-                && self.postings[max_pivot + 1].doc().map(|d| d.doc_id()) == Some(doc_id)
+                && self.postings[max_pivot + 1].current_doc_id() == doc_id
             {
                 max_pivot += 1;
             }
@@ -613,9 +641,8 @@ impl<'a, S: Scorer> Wand<'a, S> {
     // find the next doc candidate
     fn next(&mut self) -> Result<Option<(usize, DocInfo)>> {
         while let Some((pivot, max_pivot)) = self.find_pivot_term() {
-            let posting = &self.postings[pivot];
-            let doc = posting.doc().unwrap();
-            let doc_id = doc.doc_id();
+            // Use cached doc_id for control flow — avoids decompression
+            let doc_id = self.postings[pivot].current_doc_id();
 
             if !self.check_block_max(max_pivot, doc_id) {
                 // the current block max score is less than the threshold,
@@ -632,9 +659,8 @@ impl<'a, S: Scorer> Wand<'a, S> {
                 continue;
             }
 
-            // all the posting iterators preceding pivot have reached this doc id,
-            // this means the sum of upper bound of all terms is not less than the threshold,
-            // this document is a candidate, but we still need to check filters, positions, etc.
+            // Only decompress now — this doc is a real candidate
+            let doc = self.postings[pivot].doc().unwrap();
             return Ok(Some((max_pivot, doc)));
         }
         Ok(None)
@@ -672,12 +698,9 @@ impl<'a, S: Scorer> Wand<'a, S> {
         }
 
         for posting in self.postings[pivot + 1..].iter() {
-            let doc = posting
-                .doc()
-                .map(|d| d.doc_id())
-                .unwrap_or(TERMINATED_DOC_ID);
-            if doc < least_id {
-                least_id = doc;
+            let doc_id = posting.current_doc_id();
+            if doc_id < least_id {
+                least_id = doc_id;
             }
         }
 
@@ -708,9 +731,9 @@ impl<'a, S: Scorer> Wand<'a, S> {
         }
         let pivot = pivot?;
         let mut max_pivot = pivot;
-        let doc_id = self.postings[pivot].doc().unwrap().doc_id();
+        let doc_id = self.postings[pivot].current_doc_id();
         while max_pivot + 1 < self.postings.len()
-            && self.postings[max_pivot + 1].doc().unwrap().doc_id() == doc_id
+            && self.postings[max_pivot + 1].current_doc_id() == doc_id
         {
             max_pivot += 1;
         }
@@ -722,11 +745,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
     // so that we can move the posting iterator to the next doc id that is possible to be candidate
     fn move_term(&mut self, picked_term: usize, least_id: u64) {
         self.postings[picked_term].next(least_id);
-        let doc_id = self.postings[picked_term]
-            .doc()
-            .map(|d| d.doc_id())
-            .unwrap_or(TERMINATED_DOC_ID);
-        if doc_id == TERMINATED_DOC_ID {
+        if self.postings[picked_term].empty() {
             self.postings.swap_remove(picked_term);
         }
         self.bubble_up(picked_term);
@@ -735,19 +754,18 @@ impl<'a, S: Scorer> Wand<'a, S> {
     fn check_pivot_aligned(&mut self, pivot: usize, pivot_doc: u64) -> bool {
         for i in (0..=pivot).rev() {
             self.postings[i].next(pivot_doc);
-            let doc_id = self.postings[i]
-                .doc()
-                .map(|d| d.doc_id())
-                .unwrap_or(TERMINATED_DOC_ID);
+            let doc_id = self.postings[i].current_doc_id();
             if doc_id != pivot_doc {
                 if doc_id == TERMINATED_DOC_ID {
                     self.postings.swap_remove(i);
                 }
                 self.bubble_up(i);
                 return false;
-            } else {
-                self.bubble_up(i);
             }
+            // Skip bubble_up on success: all postings 0..=pivot will have
+            // doc_id == pivot_doc, maintaining doc_id ordering invariant.
+            // Tiebreaker order within same doc_id doesn't affect WAND correctness,
+            // and move_preceding() re-sorts after scoring anyway.
         }
         true
     }
@@ -759,7 +777,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
 
         let mut i = 0;
         while i < self.postings.len() {
-            if self.postings[i].doc().is_none() {
+            if self.postings[i].empty() {
                 self.postings.swap_remove(i);
             } else {
                 i += 1;
@@ -966,7 +984,7 @@ mod tests {
             ),
         ];
 
-        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let bm25 = IndexBM25Scorer::new(std::iter::empty(), &[]);
         let mut wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
         // This should trigger the bug when the second posting list becomes empty
         let result = wand
@@ -1028,7 +1046,7 @@ mod tests {
             ),
         ];
 
-        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let bm25 = IndexBM25Scorer::new(std::iter::empty(), &[]);
         let mut wand = Wand::new(Operator::Or, postings.into_iter(), &docs, bm25);
 
         // set a threshold that the sum of max scores can hit,


### PR DESCRIPTION

Optimize the FTS query hot path for lower CPU usage:
 - Inline BM25 scoring into WAND inner loop, pre-sort postings by df
 - Phase-split scheduler: async I/O loading then rayon CPU compute
 - Dedicated rayon thread pool sized to Lance CPU budget
 - Partition-level stats cache and per-token doc_freq cache

Benchmarking is WIP.
