### PR TITLE
ci: add dev artifact builds for python and java

### DIFF
--- a/.github/workflows/dev-artifacts.yml
+++ b/.github/workflows/dev-artifacts.yml
@@ -1,0 +1,434 @@
+name: Build Dev Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to checkout (branch, tag, or SHA)"
+        required: false
+        default: "main"
+        type: string
+      build_python:
+        description: "Build Python dev artifacts"
+        required: true
+        default: true
+        type: boolean
+      build_java:
+        description: "Build Java dev artifacts"
+        required: true
+        default: true
+        type: boolean
+      debug:
+        description: "Keep debug symbols in Python wheels"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  python-linux:
+    if: ${{ inputs.build_python }}
+    timeout-minutes: 60
+    name: Python Linux 3.${{ matrix.python-minor-version }} ${{ matrix.config.platform }} manylinux${{ matrix.config.manylinux }}
+    strategy:
+      matrix:
+        python-minor-version: ["9"]
+        config:
+          - platform: x86_64
+            manylinux: "2_17"
+            extra_args: ""
+            runner: ubuntu-22.04
+          - platform: x86_64
+            manylinux: "2_28"
+            extra_args: "--features fp16kernels"
+            runner: ubuntu-22.04
+          - platform: aarch64
+            manylinux: "2_17"
+            extra_args: ""
+            runner: ubuntu-24.04-arm64-4x
+          - platform: aarch64
+            manylinux: "2_28"
+            extra_args: "--features fp16kernels"
+            runner: ubuntu-24.04-arm64-4x
+    runs-on: ${{ matrix.config.runner }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          lfs: true
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: 3.${{ matrix.python-minor-version }}
+      - name: Prepare dev build tree
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          BUILD_ROOT=$(python -c 'import tempfile; from pathlib import Path; print(Path(tempfile.mkdtemp(prefix="lance-dev-build-")).as_posix())')
+          DEV_VERSION=$(python ci/set_dev_build_version.py \
+            --source-root "$PWD" \
+            --build-root "$BUILD_ROOT" \
+            --language python \
+            --run-number "$GITHUB_RUN_NUMBER" \
+            --sha "$SHORT_SHA")
+          ARTIFACT_VERSION=${DEV_VERSION//+/__}
+          echo "SHORT_SHA=$SHORT_SHA" >> "$GITHUB_ENV"
+          echo "BUILD_ROOT=$BUILD_ROOT" >> "$GITHUB_ENV"
+          echo "DEV_VERSION=$DEV_VERSION" >> "$GITHUB_ENV"
+          echo "ARTIFACT_VERSION=$ARTIFACT_VERSION" >> "$GITHUB_ENV"
+      - name: Clean old wheels
+        shell: bash
+        run: |
+          rm -f "${BUILD_ROOT}/python/target/wheels"/pylance-*.whl || true
+      - name: Build x86_64 Manylinux2014 wheel
+        if: ${{ matrix.config.platform == 'x86_64' && matrix.config.manylinux == '2_17' }}
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
+        with:
+          command: build
+          working-directory: ${{ env.BUILD_ROOT }}/python
+          target: x86_64-unknown-linux-gnu
+          manylinux: ${{ matrix.config.manylinux }}
+          args: "--release ${{ (!inputs.debug) && '--strip' || '' }} ${{ matrix.config.extra_args }}"
+          maturin-version: "1.10.2"
+          before-script-linux: |
+            set -e
+            yum install -y openssl-devel \
+              && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$(uname -m).zip > /tmp/protoc.zip \
+              && unzip /tmp/protoc.zip -d /usr/local \
+              && rm /tmp/protoc.zip
+      - name: Build x86_64 Manylinux wheel
+        if: ${{ matrix.config.platform == 'x86_64' && matrix.config.manylinux != '2_17' }}
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
+        with:
+          command: build
+          working-directory: ${{ env.BUILD_ROOT }}/python
+          target: x86_64-unknown-linux-gnu
+          manylinux: ${{ matrix.config.manylinux }}
+          docker-options: |
+            -e CC=clang
+            -e CXX=clang++
+          args: "--release ${{ (!inputs.debug) && '--strip' || '' }} ${{ matrix.config.extra_args }}"
+          maturin-version: "1.10.2"
+          before-script-linux: |
+            set -e
+            yum install -y openssl-devel clang \
+              && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$(uname -m).zip > /tmp/protoc.zip \
+              && unzip /tmp/protoc.zip -d /usr/local \
+              && rm /tmp/protoc.zip
+      - name: Build Arm Manylinux wheel
+        if: ${{ matrix.config.platform == 'aarch64' }}
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
+        with:
+          command: build
+          working-directory: ${{ env.BUILD_ROOT }}/python
+          target: aarch64-unknown-linux-gnu
+          manylinux: ${{ matrix.config.manylinux }}
+          args: "--release ${{ (!inputs.debug) && '--strip' || '' }} ${{ matrix.config.extra_args }}"
+          maturin-version: "1.10.2"
+          before-script-linux: |
+            set -e
+            yum install -y openssl-devel clang \
+              && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip > /tmp/protoc.zip \
+              && unzip /tmp/protoc.zip -d /usr/local \
+              && rm /tmp/protoc.zip
+      - name: Upload wheels
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pylance-${{ env.ARTIFACT_VERSION }}-manylinux_${{ matrix.config.manylinux }}_${{ matrix.config.platform }}
+          path: ${{ env.BUILD_ROOT }}/python/target/wheels/*.whl
+          retention-days: 14
+
+  python-mac:
+    if: ${{ inputs.build_python }}
+    timeout-minutes: 60
+    runs-on: warp-macos-14-arm64-6x
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          lfs: true
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: 3.13
+      - name: Prepare dev build tree
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          BUILD_ROOT=$(python -c 'import tempfile; from pathlib import Path; print(Path(tempfile.mkdtemp(prefix="lance-dev-build-")).as_posix())')
+          DEV_VERSION=$(python ci/set_dev_build_version.py \
+            --source-root "$PWD" \
+            --build-root "$BUILD_ROOT" \
+            --language python \
+            --run-number "$GITHUB_RUN_NUMBER" \
+            --sha "$SHORT_SHA")
+          ARTIFACT_VERSION=${DEV_VERSION//+/__}
+          echo "BUILD_ROOT=$BUILD_ROOT" >> "$GITHUB_ENV"
+          echo "DEV_VERSION=$DEV_VERSION" >> "$GITHUB_ENV"
+          echo "ARTIFACT_VERSION=$ARTIFACT_VERSION" >> "$GITHUB_ENV"
+      - name: Install macos dependency
+        shell: bash
+        run: |
+          brew install protobuf
+      - name: Build wheel
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
+        with:
+          command: build
+          working-directory: ${{ env.BUILD_ROOT }}/python
+          args: "--release ${{ (!inputs.debug) && '--strip' || '' }} --target aarch64-apple-darwin --features fp16kernels"
+      - name: Upload wheel
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pylance-${{ env.ARTIFACT_VERSION }}-macosx_arm64
+          path: ${{ env.BUILD_ROOT }}/python/target/wheels/*.whl
+          retention-days: 14
+
+  python-windows:
+    if: ${{ inputs.build_python }}
+    timeout-minutes: 60
+    runs-on: windows-latest-4x
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          lfs: true
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: 3.9
+      - name: Prepare dev build tree
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          BUILD_ROOT=$(python -c 'import tempfile; from pathlib import Path; print(Path(tempfile.mkdtemp(prefix="lance-dev-build-")).as_posix())')
+          DEV_VERSION=$(python ci/set_dev_build_version.py \
+            --source-root "$PWD" \
+            --build-root "$BUILD_ROOT" \
+            --language python \
+            --run-number "$GITHUB_RUN_NUMBER" \
+            --sha "$SHORT_SHA")
+          ARTIFACT_VERSION=${DEV_VERSION//+/__}
+          echo "BUILD_ROOT=$BUILD_ROOT" >> "$GITHUB_ENV"
+          echo "DEV_VERSION=$DEV_VERSION" >> "$GITHUB_ENV"
+          echo "ARTIFACT_VERSION=$ARTIFACT_VERSION" >> "$GITHUB_ENV"
+      - name: Install Protoc v21.12
+        working-directory: C:\
+        run: |
+          New-Item -Path 'C:\protoc' -ItemType Directory
+          Set-Location C:\protoc
+          Invoke-WebRequest https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-win64.zip -OutFile C:\protoc\protoc.zip
+          7z x protoc.zip
+          Add-Content $env:GITHUB_PATH "C:\protoc\bin"
+        shell: powershell
+      - name: Build wheel
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
+        with:
+          command: build
+          working-directory: ${{ env.BUILD_ROOT }}/python
+          args: "--release ${{ (!inputs.debug) && '--strip' || '' }}"
+      - name: Upload wheel
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pylance-${{ env.ARTIFACT_VERSION }}-win_amd64
+          path: ${{ env.BUILD_ROOT }}/python/target/wheels/*.whl
+          retention-days: 14
+
+  java-linux-arm64:
+    if: ${{ inputs.build_java }}
+    name: Java Linux Arm64
+    runs-on: ubuntu-24.04-arm64-8x
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: "3.11"
+      - name: Prepare dev build tree
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          BUILD_ROOT=$(python -c 'import tempfile; from pathlib import Path; print(Path(tempfile.mkdtemp(prefix="lance-dev-build-")).as_posix())')
+          DEV_VERSION=$(python ci/set_dev_build_version.py \
+            --source-root "$PWD" \
+            --build-root "$BUILD_ROOT" \
+            --language java \
+            --run-number "$GITHUB_RUN_NUMBER" \
+            --sha "$SHORT_SHA")
+          echo "BUILD_ROOT=$BUILD_ROOT" >> "$GITHUB_ENV"
+          echo "DEV_VERSION=$DEV_VERSION" >> "$GITHUB_ENV"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Build Linux Arm64 native library
+        shell: bash
+        run: |
+          docker run --platform linux/arm64 -v "${BUILD_ROOT}:/workspace" -w /workspace debian:10 bash -c "
+            set -ex
+            echo 'deb http://archive.debian.org/debian/ buster main' > /etc/apt/sources.list
+            echo 'deb http://archive.debian.org/debian-security buster/updates main' >> /etc/apt/sources.list
+            echo 'deb http://archive.debian.org/debian/ buster-updates main' >> /etc/apt/sources.list
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --assume-yes \
+              apt-transport-https ca-certificates curl gpg bash less openssl libssl-dev pkg-config \
+              libsqlite3-dev libsqlite3-0 libreadline-dev git cmake dh-autoreconf clang g++ libc++-dev \
+              libc++abi-dev libprotobuf-dev libncurses5-dev libncursesw5-dev libudev-dev libhidapi-dev \
+              zip unzip
+            PROTOC_ZIP=protoc-3.15.0-linux-aarch_64.zip
+            curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/\$PROTOC_ZIP
+            unzip -o \$PROTOC_ZIP -d /usr/local
+            rm -f \$PROTOC_ZIP
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+            source \$HOME/.cargo/env
+            cd java/lance-jni
+            export CC=clang
+            export CXX=clang++
+            cargo build --release
+          "
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dev-liblance_jni_linux_arm64
+          path: ${{ env.BUILD_ROOT }}/java/lance-jni/target/release/liblance_jni.so
+          retention-days: 1
+          if-no-files-found: error
+
+  java-linux-x86:
+    if: ${{ inputs.build_java }}
+    name: Java Linux x86-64
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: "3.11"
+      - name: Prepare dev build tree
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          BUILD_ROOT=$(python -c 'import tempfile; from pathlib import Path; print(Path(tempfile.mkdtemp(prefix="lance-dev-build-")).as_posix())')
+          DEV_VERSION=$(python ci/set_dev_build_version.py \
+            --source-root "$PWD" \
+            --build-root "$BUILD_ROOT" \
+            --language java \
+            --run-number "$GITHUB_RUN_NUMBER" \
+            --sha "$SHORT_SHA")
+          echo "BUILD_ROOT=$BUILD_ROOT" >> "$GITHUB_ENV"
+          echo "DEV_VERSION=$DEV_VERSION" >> "$GITHUB_ENV"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Build Linux x86-64 native library
+        shell: bash
+        run: |
+          docker run --platform linux/amd64 -v "${BUILD_ROOT}:/workspace" -w /workspace debian:10 bash -c "
+            set -ex
+            echo 'deb http://archive.debian.org/debian/ buster main' > /etc/apt/sources.list
+            echo 'deb http://archive.debian.org/debian-security buster/updates main' >> /etc/apt/sources.list
+            echo 'deb http://archive.debian.org/debian/ buster-updates main' >> /etc/apt/sources.list
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --assume-yes \
+              apt-transport-https ca-certificates curl gpg bash less openssl libssl-dev pkg-config \
+              libsqlite3-dev libsqlite3-0 libreadline-dev git cmake dh-autoreconf clang g++ libc++-dev \
+              libc++abi-dev libprotobuf-dev libncurses5-dev libncursesw5-dev libudev-dev libhidapi-dev \
+              zip unzip
+            PROTOC_ZIP=protoc-3.15.0-linux-x86_64.zip
+            curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/\$PROTOC_ZIP
+            unzip -o \$PROTOC_ZIP -d /usr/local
+            rm -f \$PROTOC_ZIP
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+            source \$HOME/.cargo/env
+            cd java/lance-jni
+            export CC=clang
+            export CXX=clang++
+            cargo build --release
+          "
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dev-liblance_jni_linux_x86_64
+          path: ${{ env.BUILD_ROOT }}/java/lance-jni/target/release/liblance_jni.so
+          retention-days: 1
+          if-no-files-found: error
+
+  java-macos-arm64:
+    if: ${{ inputs.build_java }}
+    name: Java MacOS Arm64
+    runs-on: warp-macos-14-arm64-6x
+    timeout-minutes: 60
+    needs:
+      - java-linux-arm64
+      - java-linux-x86
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+        with:
+          python-version: "3.11"
+      - name: Prepare dev build tree
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          BUILD_ROOT=$(python -c 'import tempfile; from pathlib import Path; print(Path(tempfile.mkdtemp(prefix="lance-dev-build-")).as_posix())')
+          DEV_VERSION=$(python ci/set_dev_build_version.py \
+            --source-root "$PWD" \
+            --build-root "$BUILD_ROOT" \
+            --language java \
+            --run-number "$GITHUB_RUN_NUMBER" \
+            --sha "$SHORT_SHA")
+          ARTIFACT_VERSION=${DEV_VERSION//+/__}
+          echo "BUILD_ROOT=$BUILD_ROOT" >> "$GITHUB_ENV"
+          echo "DEV_VERSION=$DEV_VERSION" >> "$GITHUB_ENV"
+          echo "ARTIFACT_VERSION=$ARTIFACT_VERSION" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: ${{ env.BUILD_ROOT }}/java/lance-jni
+      - name: Set up Java 11
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: corretto
+          java-version: 11
+          cache: "maven"
+      - uses: Homebrew/actions/setup-homebrew@50b8c2ab4a835c38897ed2c56c293b07167c0b59 # master 2026-03-07
+      - name: Install dependencies
+        shell: bash
+        run: |
+          brew install protobuf
+      - name: Download Linux native libraries
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: dev-liblance_jni_linux_*
+          path: ${{ env.BUILD_ROOT }}/downloads
+      - name: Copy native libs
+        shell: bash
+        run: |
+          mkdir -p "${BUILD_ROOT}/java/target/classes/nativelib/linux-x86-64" "${BUILD_ROOT}/java/target/classes/nativelib/linux-aarch64"
+          cp "${BUILD_ROOT}/downloads/dev-liblance_jni_linux_x86_64/liblance_jni.so" "${BUILD_ROOT}/java/target/classes/nativelib/linux-x86-64/liblance_jni.so"
+          cp "${BUILD_ROOT}/downloads/dev-liblance_jni_linux_arm64/liblance_jni.so" "${BUILD_ROOT}/java/target/classes/nativelib/linux-aarch64/liblance_jni.so"
+      - name: Package Java artifacts
+        shell: bash
+        working-directory: ${{ env.BUILD_ROOT }}/java
+        run: |
+          ./mvnw --batch-mode -DskipTests -Drust.release.build=true package
+      - name: Upload Java artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: lance-java-${{ env.ARTIFACT_VERSION }}
+          path: |
+            ${{ env.BUILD_ROOT }}/java/target/*.jar
+          retention-days: 14
+

--- a/ci/set_dev_build_version.py
+++ b/ci/set_dev_build_version.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Create a temporary source tree with dev build versions applied."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from pathlib import Path
+
+
+PYTHON_VERSION_RE = re.compile(r'^version = "([^"]+)"$', re.MULTILINE)
+JAVA_VERSION_RE = re.compile(r"(<version>)([^<]+)(</version>)", re.MULTILINE)
+
+
+def normalize_base_version(version: str) -> str:
+    return version.split("-", 1)[0]
+
+
+def build_dev_version(base_version: str, run_number: str, sha: str, language: str) -> str:
+    if language == "python":
+        return f"{base_version}.dev{run_number}+g{sha}"
+    if language == "java":
+        return f"{base_version}-dev.{run_number}.g{sha}"
+    raise ValueError(f"Unsupported language: {language}")
+
+
+def copy_source_tree(source_root: Path, build_root: Path) -> None:
+    ignore = shutil.ignore_patterns(
+        ".git",
+        "target",
+        "test_data",
+        "__pycache__",
+        ".pytest_cache",
+    )
+    shutil.copytree(source_root, build_root, ignore=ignore, dirs_exist_ok=True)
+
+
+def read_root_version(source_root: Path) -> str:
+    cargo_toml = (source_root / "Cargo.toml").read_text()
+    match = PYTHON_VERSION_RE.search(cargo_toml)
+    if match is None:
+        raise ValueError("Could not find workspace version in Cargo.toml")
+    return match.group(1)
+
+
+def update_python_version(build_root: Path, version: str) -> None:
+    cargo_toml = build_root / "python" / "Cargo.toml"
+    content = cargo_toml.read_text()
+    match = PYTHON_VERSION_RE.search(content)
+    if match is None:
+        raise ValueError("Could not find python package version")
+    cargo_toml.write_text(PYTHON_VERSION_RE.sub(f'version = "{version}"', content, count=1))
+
+
+def update_java_version(build_root: Path, version: str) -> None:
+    pom_xml = build_root / "java" / "pom.xml"
+    content = pom_xml.read_text()
+    match = JAVA_VERSION_RE.search(content)
+    if match is None:
+        raise ValueError("Could not find java package version")
+    pom_xml.write_text(
+        JAVA_VERSION_RE.sub(lambda match: f"{match.group(1)}{version}{match.group(3)}", content, count=1)
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prepare a dev build source tree")
+    parser.add_argument("--source-root", required=True, type=Path)
+    parser.add_argument("--build-root", required=True, type=Path)
+    parser.add_argument("--language", required=True, choices=["python", "java"])
+    parser.add_argument("--run-number", required=True)
+    parser.add_argument("--sha", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    source_root = args.source_root.resolve()
+    build_root = args.build_root.resolve()
+
+    current_version = read_root_version(source_root)
+    base_version = normalize_base_version(current_version)
+    dev_version = build_dev_version(base_version, args.run_number, args.sha, args.language)
+
+    copy_source_tree(source_root, build_root)
+    if args.language == "python":
+        update_python_version(build_root, dev_version)
+    else:
+        update_java_version(build_root, dev_version)
+
+    print(dev_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/test_set_dev_build_version.py
+++ b/ci/test_set_dev_build_version.py
@@ -1,0 +1,82 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from ci.set_dev_build_version import (
+    build_dev_version,
+    copy_source_tree,
+    normalize_base_version,
+    read_root_version,
+    update_java_version,
+    update_python_version,
+)
+
+
+class SetDevBuildVersionTest(unittest.TestCase):
+    def test_normalize_base_version(self) -> None:
+        self.assertEqual(normalize_base_version("4.1.0-beta.0"), "4.1.0")
+        self.assertEqual(normalize_base_version("4.1.0-rc.2"), "4.1.0")
+        self.assertEqual(normalize_base_version("4.1.0"), "4.1.0")
+
+    def test_build_dev_version(self) -> None:
+        self.assertEqual(build_dev_version("4.1.0", "42", "abc1234", "python"), "4.1.0.dev42+gabc1234")
+        self.assertEqual(build_dev_version("4.1.0", "42", "abc1234", "java"), "4.1.0-dev.42.gabc1234")
+
+    def test_copy_and_update_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as source_dir_name, tempfile.TemporaryDirectory() as build_parent_name:
+            source_dir = Path(source_dir_name)
+            build_root = Path(build_parent_name) / "build"
+            build_root.mkdir()
+
+            (source_dir / "python").mkdir(parents=True)
+            (source_dir / "java").mkdir(parents=True)
+            (source_dir / ".git").mkdir()
+            (source_dir / "target").mkdir()
+
+            (source_dir / "Cargo.toml").write_text(
+                """
+[workspace.package]
+version = "4.1.0-beta.0"
+""".strip()
+            )
+            (source_dir / "python" / "Cargo.toml").write_text(
+                """
+[package]
+name = "pylance"
+version = "4.1.0-beta.0"
+""".strip()
+            )
+            (source_dir / "java" / "pom.xml").write_text(
+                """
+<project>
+  <artifactId>lance-core</artifactId>
+  <version>4.1.0-beta.0</version>
+  <dependencies>
+    <dependency>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+</project>
+""".strip()
+            )
+            (source_dir / "target" / "ignored.txt").write_text("ignored")
+
+            self.assertEqual(read_root_version(source_dir), "4.1.0-beta.0")
+
+            copy_source_tree(source_dir, build_root)
+            self.assertFalse((build_root / ".git").exists())
+            self.assertFalse((build_root / "target").exists())
+
+            update_python_version(build_root, "4.1.0.dev42+gabc1234")
+            update_java_version(build_root, "4.1.0-dev.42.gabc1234")
+
+            python_cargo = (build_root / "python" / "Cargo.toml").read_text()
+            java_pom = (build_root / "java" / "pom.xml").read_text()
+
+            self.assertIn('version = "4.1.0.dev42+gabc1234"', python_cargo)
+            self.assertIn("<version>4.1.0-dev.42.gabc1234</version>", java_pom)
+            self.assertIn("<version>1.0.0</version>", java_pom)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds a separate GitHub Actions workflow to build temporary Python and Java dev artifacts from any ref without touching the existing release state machine. The workflow builds in a temporary source copy, applies dev-only version overrides there, and uploads the resulting artifacts for testing.

This keeps the current beta / RC / stable flows unchanged while making it easier to validate branch-specific changes before release.
