### PR TITLE
feat(namespace-dir): add alter table column operations (add/alter/drop)

### DIFF
--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -115,12 +115,14 @@ impl OpsMetrics {
 /// Build SQL expression list for the add_columns operation.
 /// Returns an explicit error when the expression is missing, instead of silently using an empty string.
 pub(crate) fn build_sql_expressions(
-    new_columns: &[lance_namespace::models::NewColumnTransform],
+    new_columns: &[lance_namespace::models::AddColumnsEntry],
 ) -> Result<Vec<(String, String)>> {
     new_columns
         .iter()
         .map(|col| {
-            let expression = col.expression.clone().ok_or_else(|| {
+            // expression is Option<Option<String>>: outer Option means whether the
+            // field is present, inner Option means whether the value is JSON null.
+            let expression = col.expression.clone().and_then(|opt| opt).ok_or_else(|| {
                 Error::invalid_input(format!(
                     "Expression is required for new column '{}'",
                     col.name
@@ -140,17 +142,22 @@ pub(crate) fn build_column_alterations(
         .iter()
         .map(|entry| {
             let mut alteration = lance::dataset::ColumnAlteration::new(entry.path.clone());
-            if let Some(rename) = &entry.rename {
+            // rename is Option<Option<String>>: flatten to get the actual rename value.
+            if let Some(Some(rename)) = &entry.rename {
                 alteration = alteration.rename(rename.clone());
             }
-            if let Some(nullable) = entry.nullable {
+            // nullable is Option<Option<bool>>: flatten to get the actual nullable value.
+            if let Some(Some(nullable)) = entry.nullable {
                 alteration = alteration.set_nullable(nullable);
             }
-            if !entry.data_type.is_null() {
-                let type_str = entry.data_type.as_str().ok_or_else(|| {
+            // data_type is Option<serde_json::Value>: only process when present and not null.
+            if let Some(data_type) = &entry.data_type
+                && !data_type.is_null()
+            {
+                let type_str = data_type.as_str().ok_or_else(|| {
                     Error::invalid_input(format!(
                         "data_type for column '{}' must be a JSON string, got: {}",
-                        entry.path, entry.data_type
+                        entry.path, data_type
                     ))
                 })?;
                 let json_type =
@@ -4634,7 +4641,10 @@ mod tests {
     };
     use lance_namespace::schema::convert_json_arrow_schema;
     use std::io::Cursor;
-    use std::sync::{Arc, atomic::AtomicUsize};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
     use url::Url;
 
     fn assert_plan_contains_all(plan: &str, expected_fragments: &[&str], context: &str) {
@@ -11129,6 +11139,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_alter_table_add_columns() {
+        use lance_namespace::models::{
+            AddColumnsEntry, AlterTableAddColumnsRequest, DescribeTableRequest,
+        };
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        // Create a table
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        // Add a new column
+        let mut new_col = AddColumnsEntry::new("doubled_id".to_string());
+        new_col.expression = Some(Some("id * 2".to_string()));
+        let mut add_request = AlterTableAddColumnsRequest::new(vec![new_col]);
+        add_request.id = Some(vec!["test_table".to_string()]);
+
+        let response = namespace
+            .alter_table_add_columns(add_request)
+            .await
+            .unwrap();
+        assert!(
+            response.version > 1,
+            "Version should increment after adding columns"
+        );
+
+        // Verify via describe_table
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["test_table".to_string()]);
+        describe_request.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_request).await.unwrap();
+        assert!(describe_response.schema.is_some());
+
+        let resp_schema = describe_response.schema.unwrap();
+        let field_names: Vec<&str> = resp_schema.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            field_names.contains(&"doubled_id"),
+            "Column 'doubled_id' should exist, got: {:?}",
+            field_names
+        );
+    }
+
+    #[tokio::test]
     async fn test_update_table_schema_metadata() {
         use lance_namespace::models::UpdateTableSchemaMetadataRequest;
 
@@ -11152,6 +11211,72 @@ mod tests {
         assert!(
             response.transaction_id.is_some(),
             "update_table_schema_metadata should return a transaction_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_add_columns_missing_id() {
+        use lance_namespace::models::{AddColumnsEntry, AlterTableAddColumnsRequest};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let new_col = AddColumnsEntry::new("col".to_string());
+        let request = AlterTableAddColumnsRequest::new(vec![new_col]);
+        let result = namespace.alter_table_add_columns(request).await;
+        assert!(result.is_err(), "Should fail when table ID is missing");
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_alter_columns_rename() {
+        use lance_namespace::models::{
+            AlterColumnsEntry, AlterTableAlterColumnsRequest, DescribeTableRequest,
+        };
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        // Create a table
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        // Rename "name" to "full_name"
+        let mut entry = AlterColumnsEntry::new("name".to_string());
+        entry.rename = Some(Some("full_name".to_string()));
+        let mut alter_request = AlterTableAlterColumnsRequest::new(vec![entry]);
+        alter_request.id = Some(vec!["test_table".to_string()]);
+
+        let response = namespace
+            .alter_table_alter_columns(alter_request)
+            .await
+            .unwrap();
+        assert!(
+            response.version > 1,
+            "Version should increment after altering columns"
+        );
+
+        // Verify the rename
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["test_table".to_string()]);
+        describe_request.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_request).await.unwrap();
+        assert!(describe_response.schema.is_some());
+
+        let resp_schema = describe_response.schema.unwrap();
+        let field_names: Vec<&str> = resp_schema.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            field_names.contains(&"full_name"),
+            "Column should be renamed to 'full_name', got: {:?}",
+            field_names
+        );
+        assert!(
+            !field_names.contains(&"name"),
+            "Old column 'name' should not exist, got: {:?}",
+            field_names
         );
     }
 
@@ -11203,6 +11328,68 @@ mod tests {
                 "refine_filter=id > Int32(1)",
             ],
             "Filtered explain plan should preserve late materialization and filter pushdown",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_alter_columns_missing_id() {
+        use lance_namespace::models::{AlterColumnsEntry, AlterTableAlterColumnsRequest};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let entry = AlterColumnsEntry::new("name".to_string());
+        let request = AlterTableAlterColumnsRequest::new(vec![entry]);
+        let result = namespace.alter_table_alter_columns(request).await;
+        assert!(result.is_err(), "Should fail when table ID is missing");
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_drop_columns() {
+        use lance_namespace::models::{AlterTableDropColumnsRequest, DescribeTableRequest};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        // Create a table
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        // Drop the "name" column
+        let mut drop_request = AlterTableDropColumnsRequest::new(vec!["name".to_string()]);
+        drop_request.id = Some(vec!["test_table".to_string()]);
+
+        let response = namespace
+            .alter_table_drop_columns(drop_request)
+            .await
+            .unwrap();
+        assert!(
+            response.version > 1,
+            "Version should increment after dropping columns"
+        );
+
+        // Verify column was dropped
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["test_table".to_string()]);
+        describe_request.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_request).await.unwrap();
+        assert!(describe_response.schema.is_some());
+
+        let resp_schema = describe_response.schema.unwrap();
+        let field_names: Vec<&str> = resp_schema.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            !field_names.contains(&"name"),
+            "Column 'name' should be dropped, got: {:?}",
+            field_names
+        );
+        assert!(
+            field_names.contains(&"id"),
+            "Column 'id' should still exist, got: {:?}",
+            field_names
         );
     }
 
@@ -12165,184 +12352,6 @@ mod tests {
             err
         );
     }
-
-    #[tokio::test]
-    async fn test_alter_table_add_columns() {
-        use lance_namespace::models::{
-            AlterTableAddColumnsRequest, DescribeTableRequest, NewColumnTransform,
-        };
-
-        let (namespace, _temp_dir) = create_test_namespace().await;
-
-        // Create a table
-        let schema = create_test_schema();
-        let ipc_data = create_test_ipc_data(&schema);
-        let mut create_request = CreateTableRequest::new();
-        create_request.id = Some(vec!["test_table".to_string()]);
-        namespace
-            .create_table(create_request, bytes::Bytes::from(ipc_data))
-            .await
-            .unwrap();
-
-        // Add a new column
-        let mut new_col = NewColumnTransform::new("doubled_id".to_string());
-        new_col.expression = Some("id * 2".to_string());
-        let mut add_request = AlterTableAddColumnsRequest::new(vec![new_col]);
-        add_request.id = Some(vec!["test_table".to_string()]);
-
-        let response = namespace
-            .alter_table_add_columns(add_request)
-            .await
-            .unwrap();
-        assert!(
-            response.version > 1,
-            "Version should increment after adding columns"
-        );
-
-        // Verify via describe_table
-        let mut describe_request = DescribeTableRequest::new();
-        describe_request.id = Some(vec!["test_table".to_string()]);
-        describe_request.load_detailed_metadata = Some(true);
-        let describe_response = namespace.describe_table(describe_request).await.unwrap();
-        assert!(describe_response.schema.is_some());
-
-        let resp_schema = describe_response.schema.unwrap();
-        let field_names: Vec<&str> = resp_schema.fields.iter().map(|f| f.name.as_str()).collect();
-        assert!(
-            field_names.contains(&"doubled_id"),
-            "Column 'doubled_id' should exist, got: {:?}",
-            field_names
-        );
-    }
-
-    #[tokio::test]
-    async fn test_alter_table_add_columns_missing_id() {
-        use lance_namespace::models::{AlterTableAddColumnsRequest, NewColumnTransform};
-
-        let (namespace, _temp_dir) = create_test_namespace().await;
-
-        let new_col = NewColumnTransform::new("col".to_string());
-        let request = AlterTableAddColumnsRequest::new(vec![new_col]);
-        let result = namespace.alter_table_add_columns(request).await;
-        assert!(result.is_err(), "Should fail when table ID is missing");
-    }
-
-    #[tokio::test]
-    async fn test_alter_table_alter_columns_rename() {
-        use lance_namespace::models::{
-            AlterColumnsEntry, AlterTableAlterColumnsRequest, DescribeTableRequest,
-        };
-
-        let (namespace, _temp_dir) = create_test_namespace().await;
-
-        // Create a table
-        let schema = create_test_schema();
-        let ipc_data = create_test_ipc_data(&schema);
-        let mut create_request = CreateTableRequest::new();
-        create_request.id = Some(vec!["test_table".to_string()]);
-        namespace
-            .create_table(create_request, bytes::Bytes::from(ipc_data))
-            .await
-            .unwrap();
-
-        // Rename "name" to "full_name"
-        let mut entry = AlterColumnsEntry::new("name".to_string(), serde_json::Value::Null);
-        entry.rename = Some("full_name".to_string());
-        let mut alter_request = AlterTableAlterColumnsRequest::new(vec![entry]);
-        alter_request.id = Some(vec!["test_table".to_string()]);
-
-        let response = namespace
-            .alter_table_alter_columns(alter_request)
-            .await
-            .unwrap();
-        assert!(
-            response.version > 1,
-            "Version should increment after altering columns"
-        );
-
-        // Verify the rename
-        let mut describe_request = DescribeTableRequest::new();
-        describe_request.id = Some(vec!["test_table".to_string()]);
-        describe_request.load_detailed_metadata = Some(true);
-        let describe_response = namespace.describe_table(describe_request).await.unwrap();
-        assert!(describe_response.schema.is_some());
-
-        let resp_schema = describe_response.schema.unwrap();
-        let field_names: Vec<&str> = resp_schema.fields.iter().map(|f| f.name.as_str()).collect();
-        assert!(
-            field_names.contains(&"full_name"),
-            "Column should be renamed to 'full_name', got: {:?}",
-            field_names
-        );
-        assert!(
-            !field_names.contains(&"name"),
-            "Old column 'name' should not exist, got: {:?}",
-            field_names
-        );
-    }
-
-    #[tokio::test]
-    async fn test_alter_table_alter_columns_missing_id() {
-        use lance_namespace::models::{AlterColumnsEntry, AlterTableAlterColumnsRequest};
-
-        let (namespace, _temp_dir) = create_test_namespace().await;
-
-        let entry = AlterColumnsEntry::new("name".to_string(), serde_json::Value::Null);
-        let request = AlterTableAlterColumnsRequest::new(vec![entry]);
-        let result = namespace.alter_table_alter_columns(request).await;
-        assert!(result.is_err(), "Should fail when table ID is missing");
-    }
-
-    #[tokio::test]
-    async fn test_alter_table_drop_columns() {
-        use lance_namespace::models::{AlterTableDropColumnsRequest, DescribeTableRequest};
-
-        let (namespace, _temp_dir) = create_test_namespace().await;
-
-        // Create a table
-        let schema = create_test_schema();
-        let ipc_data = create_test_ipc_data(&schema);
-        let mut create_request = CreateTableRequest::new();
-        create_request.id = Some(vec!["test_table".to_string()]);
-        namespace
-            .create_table(create_request, bytes::Bytes::from(ipc_data))
-            .await
-            .unwrap();
-
-        // Drop the "name" column
-        let mut drop_request = AlterTableDropColumnsRequest::new(vec!["name".to_string()]);
-        drop_request.id = Some(vec!["test_table".to_string()]);
-
-        let response = namespace
-            .alter_table_drop_columns(drop_request)
-            .await
-            .unwrap();
-        assert!(
-            response.version > 1,
-            "Version should increment after dropping columns"
-        );
-
-        // Verify column was dropped
-        let mut describe_request = DescribeTableRequest::new();
-        describe_request.id = Some(vec!["test_table".to_string()]);
-        describe_request.load_detailed_metadata = Some(true);
-        let describe_response = namespace.describe_table(describe_request).await.unwrap();
-        assert!(describe_response.schema.is_some());
-
-        let resp_schema = describe_response.schema.unwrap();
-        let field_names: Vec<&str> = resp_schema.fields.iter().map(|f| f.name.as_str()).collect();
-        assert!(
-            !field_names.contains(&"name"),
-            "Column 'name' should be dropped, got: {:?}",
-            field_names
-        );
-        assert!(
-            field_names.contains(&"id"),
-            "Column 'id' should still exist, got: {:?}",
-            field_names
-        );
-    }
-
     #[tokio::test]
     async fn test_alter_table_drop_columns_missing_id() {
         use lance_namespace::models::AlterTableDropColumnsRequest;

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -2948,12 +2948,31 @@ impl LanceNamespace for DirectoryNamespace {
         let table_name = Self::table_name_from_id(&request.id)?;
         let table_uri = self.table_full_uri(&table_name);
 
-        let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
-            Error::io_source(box_error(std::io::Error::other(format!(
-                "Failed to open dataset: {}",
-                e
-            ))))
-        })?;
+        // Check table existence and deregistration status before opening the dataset
+        let status = self.check_table_status(&table_name).await;
+        if !status.exists {
+            return Err(NamespaceError::TableNotFound {
+                message: table_name,
+            }
+            .into());
+        }
+        if status.is_deregistered {
+            return Err(NamespaceError::TableNotFound {
+                message: format!("Table is deregistered: {}", table_name),
+            }
+            .into());
+        }
+
+        let mut dataset = self
+            .configured_builder(&table_uri)
+            .load()
+            .await
+            .map_err(|e| {
+                Error::io_source(box_error(std::io::Error::other(format!(
+                    "Failed to open dataset: {}",
+                    e
+                ))))
+            })?;
 
         let sql_expressions = build_sql_expressions(&request.new_columns)?;
 
@@ -2986,12 +3005,31 @@ impl LanceNamespace for DirectoryNamespace {
         let table_name = Self::table_name_from_id(&request.id)?;
         let table_uri = self.table_full_uri(&table_name);
 
-        let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
-            Error::io_source(box_error(std::io::Error::other(format!(
-                "Failed to open dataset: {}",
-                e
-            ))))
-        })?;
+        // Check table existence and deregistration status before opening the dataset
+        let status = self.check_table_status(&table_name).await;
+        if !status.exists {
+            return Err(NamespaceError::TableNotFound {
+                message: table_name,
+            }
+            .into());
+        }
+        if status.is_deregistered {
+            return Err(NamespaceError::TableNotFound {
+                message: format!("Table is deregistered: {}", table_name),
+            }
+            .into());
+        }
+
+        let mut dataset = self
+            .configured_builder(&table_uri)
+            .load()
+            .await
+            .map_err(|e| {
+                Error::io_source(box_error(std::io::Error::other(format!(
+                    "Failed to open dataset: {}",
+                    e
+                ))))
+            })?;
 
         let alterations = build_column_alterations(&request.alterations)?;
 
@@ -3017,12 +3055,31 @@ impl LanceNamespace for DirectoryNamespace {
         let table_name = Self::table_name_from_id(&request.id)?;
         let table_uri = self.table_full_uri(&table_name);
 
-        let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
-            Error::io_source(box_error(std::io::Error::other(format!(
-                "Failed to open dataset: {}",
-                e
-            ))))
-        })?;
+        // Check table existence and deregistration status before opening the dataset
+        let status = self.check_table_status(&table_name).await;
+        if !status.exists {
+            return Err(NamespaceError::TableNotFound {
+                message: table_name,
+            }
+            .into());
+        }
+        if status.is_deregistered {
+            return Err(NamespaceError::TableNotFound {
+                message: format!("Table is deregistered: {}", table_name),
+            }
+            .into());
+        }
+
+        let mut dataset = self
+            .configured_builder(&table_uri)
+            .load()
+            .await
+            .map_err(|e| {
+                Error::io_source(box_error(std::io::Error::other(format!(
+                    "Failed to open dataset: {}",
+                    e
+                ))))
+            })?;
 
         let columns: Vec<&str> = request.columns.iter().map(|s| s.as_str()).collect();
         dataset.drop_columns(&columns).await.map_err(|e| {

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -4634,10 +4634,7 @@ mod tests {
     };
     use lance_namespace::schema::convert_json_arrow_schema;
     use std::io::Cursor;
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    };
+    use std::sync::{Arc, atomic::AtomicUsize};
     use url::Url;
 
     fn assert_plan_contains_all(plan: &str, expected_fragments: &[&str], context: &str) {
@@ -4664,6 +4661,7 @@ mod tests {
     }
 
     #[derive(Debug)]
+    #[allow(dead_code)]
     struct CountingFileStoreProvider {
         listing_count: Arc<AtomicUsize>,
     }
@@ -4699,6 +4697,7 @@ mod tests {
         }
     }
 
+    #[allow(dead_code)]
     fn file_object_store_uri(path: &str) -> String {
         let file_url = uri_to_url(path).unwrap();
         let mut url = Url::parse("file-object-store:///").unwrap();
@@ -4706,6 +4705,7 @@ mod tests {
         url.to_string()
     }
 
+    #[allow(dead_code)]
     fn build_listing_counting_session(listing_count: Arc<AtomicUsize>) -> Arc<Session> {
         let registry = Arc::new(ObjectStoreRegistry::default());
         registry.insert(

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -45,6 +45,8 @@ use std::sync::{Arc, Mutex};
 
 use crate::context::DynamicContextProvider;
 use lance_namespace::models::{
+    AlterTableAddColumnsRequest, AlterTableAddColumnsResponse, AlterTableAlterColumnsRequest,
+    AlterTableAlterColumnsResponse, AlterTableDropColumnsRequest, AlterTableDropColumnsResponse,
     AnalyzeTableQueryPlanRequest, BatchDeleteTableVersionsRequest,
     BatchDeleteTableVersionsResponse, BranchContents as ModelBranchContents, CountTableRowsRequest,
     CreateNamespaceRequest, CreateNamespaceResponse, CreateTableBranchRequest,
@@ -71,7 +73,7 @@ use lance_namespace::models::{
     UpdateTableTagResponse,
 };
 
-use lance_core::{Error, Result};
+use lance_core::{Error, Result, box_error};
 use lance_namespace::LanceNamespace;
 use lance_namespace::error::NamespaceError;
 use lance_namespace::schema::arrow_schema_to_json;
@@ -108,6 +110,63 @@ impl OpsMetrics {
             counters.clear();
         }
     }
+}
+
+/// Build SQL expression list for the add_columns operation.
+/// Returns an explicit error when the expression is missing, instead of silently using an empty string.
+pub(crate) fn build_sql_expressions(
+    new_columns: &[lance_namespace::models::NewColumnTransform],
+) -> Result<Vec<(String, String)>> {
+    new_columns
+        .iter()
+        .map(|col| {
+            let expression = col.expression.clone().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "Expression is required for new column '{}'",
+                    col.name
+                ))
+            })?;
+            Ok((col.name.clone(), expression))
+        })
+        .collect()
+}
+
+/// Build column alteration list for the alter_columns operation.
+/// Returns an explicit error when data_type conversion fails, instead of silently ignoring it.
+pub(crate) fn build_column_alterations(
+    alterations: &[lance_namespace::models::AlterColumnsEntry],
+) -> Result<Vec<lance::dataset::ColumnAlteration>> {
+    alterations
+        .iter()
+        .map(|entry| {
+            let mut alteration = lance::dataset::ColumnAlteration::new(entry.path.clone());
+            if let Some(rename) = &entry.rename {
+                alteration = alteration.rename(rename.clone());
+            }
+            if let Some(nullable) = entry.nullable {
+                alteration = alteration.set_nullable(nullable);
+            }
+            if !entry.data_type.is_null() {
+                let type_str = entry.data_type.as_str().ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "data_type for column '{}' must be a JSON string, got: {}",
+                        entry.path, entry.data_type
+                    ))
+                })?;
+                let json_type =
+                    lance_namespace::models::JsonArrowDataType::new(type_str.to_string());
+                let dt =
+                    lance_namespace::schema::convert_json_arrow_type(&json_type).map_err(|e| {
+                        Error::invalid_input(format!(
+                            "Failed to parse data_type '{}' for column '{}': {}",
+                            type_str, entry.path, e
+                        ))
+                    })?;
+                alteration = alteration.cast_to(dt);
+            }
+            Ok(alteration)
+        })
+        .collect()
 }
 
 /// Result of checking table status atomically.
@@ -2868,6 +2927,106 @@ impl LanceNamespace for DirectoryNamespace {
             location: Some(table_uri),
             ..Default::default()
         })
+    }
+
+    async fn alter_table_add_columns(
+        &self,
+        request: AlterTableAddColumnsRequest,
+    ) -> Result<AlterTableAddColumnsResponse> {
+        if let Some(ref manifest_ns) = self.manifest_ns {
+            return manifest_ns.alter_table_add_columns(request).await;
+        }
+
+        // Non-manifest mode: open Dataset directly via table URI and perform the operation
+        let table_name = Self::table_name_from_id(&request.id)?;
+        let table_uri = self.table_full_uri(&table_name);
+
+        let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
+            Error::io_source(box_error(std::io::Error::other(format!(
+                "Failed to open dataset: {}",
+                e
+            ))))
+        })?;
+
+        let sql_expressions = build_sql_expressions(&request.new_columns)?;
+
+        dataset
+            .add_columns(
+                lance::dataset::NewColumnTransform::SqlExpressions(sql_expressions),
+                None,
+                None,
+            )
+            .await
+            .map_err(|e| {
+                Error::io_source(box_error(std::io::Error::other(format!(
+                    "Failed to add columns: {}",
+                    e
+                ))))
+            })?;
+
+        let version = dataset.version().version as i64;
+        Ok(AlterTableAddColumnsResponse::new(version))
+    }
+
+    async fn alter_table_alter_columns(
+        &self,
+        request: AlterTableAlterColumnsRequest,
+    ) -> Result<AlterTableAlterColumnsResponse> {
+        if let Some(ref manifest_ns) = self.manifest_ns {
+            return manifest_ns.alter_table_alter_columns(request).await;
+        }
+
+        let table_name = Self::table_name_from_id(&request.id)?;
+        let table_uri = self.table_full_uri(&table_name);
+
+        let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
+            Error::io_source(box_error(std::io::Error::other(format!(
+                "Failed to open dataset: {}",
+                e
+            ))))
+        })?;
+
+        let alterations = build_column_alterations(&request.alterations)?;
+
+        dataset.alter_columns(&alterations).await.map_err(|e| {
+            Error::io_source(box_error(std::io::Error::other(format!(
+                "Failed to alter columns: {}",
+                e
+            ))))
+        })?;
+
+        let version = dataset.version().version as i64;
+        Ok(AlterTableAlterColumnsResponse::new(version))
+    }
+
+    async fn alter_table_drop_columns(
+        &self,
+        request: AlterTableDropColumnsRequest,
+    ) -> Result<AlterTableDropColumnsResponse> {
+        if let Some(ref manifest_ns) = self.manifest_ns {
+            return manifest_ns.alter_table_drop_columns(request).await;
+        }
+
+        let table_name = Self::table_name_from_id(&request.id)?;
+        let table_uri = self.table_full_uri(&table_name);
+
+        let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
+            Error::io_source(box_error(std::io::Error::other(format!(
+                "Failed to open dataset: {}",
+                e
+            ))))
+        })?;
+
+        let columns: Vec<&str> = request.columns.iter().map(|s| s.as_str()).collect();
+        dataset.drop_columns(&columns).await.map_err(|e| {
+            Error::io_source(box_error(std::io::Error::other(format!(
+                "Failed to drop columns: {}",
+                e
+            ))))
+        })?;
+
+        let version = dataset.version().version as i64;
+        Ok(AlterTableDropColumnsResponse::new(version))
     }
 
     async fn list_table_versions(
@@ -12005,5 +12164,205 @@ mod tests {
             "expected TableNotFound error, got: {}",
             err
         );
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_add_columns() {
+        use lance_namespace::models::{
+            AlterTableAddColumnsRequest, DescribeTableRequest, NewColumnTransform,
+        };
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        // Create a table
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        // Add a new column
+        let mut new_col = NewColumnTransform::new("doubled_id".to_string());
+        new_col.expression = Some("id * 2".to_string());
+        let mut add_request = AlterTableAddColumnsRequest::new(vec![new_col]);
+        add_request.id = Some(vec!["test_table".to_string()]);
+
+        let response = namespace
+            .alter_table_add_columns(add_request)
+            .await
+            .unwrap();
+        assert!(
+            response.version > 1,
+            "Version should increment after adding columns"
+        );
+
+        // Verify via describe_table
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["test_table".to_string()]);
+        describe_request.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_request).await.unwrap();
+        assert!(describe_response.schema.is_some());
+
+        let resp_schema = describe_response.schema.unwrap();
+        let field_names: Vec<&str> = resp_schema.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            field_names.contains(&"doubled_id"),
+            "Column 'doubled_id' should exist, got: {:?}",
+            field_names
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_add_columns_missing_id() {
+        use lance_namespace::models::{AlterTableAddColumnsRequest, NewColumnTransform};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let new_col = NewColumnTransform::new("col".to_string());
+        let request = AlterTableAddColumnsRequest::new(vec![new_col]);
+        let result = namespace.alter_table_add_columns(request).await;
+        assert!(result.is_err(), "Should fail when table ID is missing");
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_alter_columns_rename() {
+        use lance_namespace::models::{
+            AlterColumnsEntry, AlterTableAlterColumnsRequest, DescribeTableRequest,
+        };
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        // Create a table
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        // Rename "name" to "full_name"
+        let mut entry = AlterColumnsEntry::new("name".to_string(), serde_json::Value::Null);
+        entry.rename = Some("full_name".to_string());
+        let mut alter_request = AlterTableAlterColumnsRequest::new(vec![entry]);
+        alter_request.id = Some(vec!["test_table".to_string()]);
+
+        let response = namespace
+            .alter_table_alter_columns(alter_request)
+            .await
+            .unwrap();
+        assert!(
+            response.version > 1,
+            "Version should increment after altering columns"
+        );
+
+        // Verify the rename
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["test_table".to_string()]);
+        describe_request.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_request).await.unwrap();
+        assert!(describe_response.schema.is_some());
+
+        let resp_schema = describe_response.schema.unwrap();
+        let field_names: Vec<&str> = resp_schema.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            field_names.contains(&"full_name"),
+            "Column should be renamed to 'full_name', got: {:?}",
+            field_names
+        );
+        assert!(
+            !field_names.contains(&"name"),
+            "Old column 'name' should not exist, got: {:?}",
+            field_names
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_alter_columns_missing_id() {
+        use lance_namespace::models::{AlterColumnsEntry, AlterTableAlterColumnsRequest};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let entry = AlterColumnsEntry::new("name".to_string(), serde_json::Value::Null);
+        let request = AlterTableAlterColumnsRequest::new(vec![entry]);
+        let result = namespace.alter_table_alter_columns(request).await;
+        assert!(result.is_err(), "Should fail when table ID is missing");
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_drop_columns() {
+        use lance_namespace::models::{AlterTableDropColumnsRequest, DescribeTableRequest};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        // Create a table
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        // Drop the "name" column
+        let mut drop_request = AlterTableDropColumnsRequest::new(vec!["name".to_string()]);
+        drop_request.id = Some(vec!["test_table".to_string()]);
+
+        let response = namespace
+            .alter_table_drop_columns(drop_request)
+            .await
+            .unwrap();
+        assert!(
+            response.version > 1,
+            "Version should increment after dropping columns"
+        );
+
+        // Verify column was dropped
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["test_table".to_string()]);
+        describe_request.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_request).await.unwrap();
+        assert!(describe_response.schema.is_some());
+
+        let resp_schema = describe_response.schema.unwrap();
+        let field_names: Vec<&str> = resp_schema.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            !field_names.contains(&"name"),
+            "Column 'name' should be dropped, got: {:?}",
+            field_names
+        );
+        assert!(
+            field_names.contains(&"id"),
+            "Column 'id' should still exist, got: {:?}",
+            field_names
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_drop_columns_missing_id() {
+        use lance_namespace::models::AlterTableDropColumnsRequest;
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let request = AlterTableDropColumnsRequest::new(vec!["col".to_string()]);
+        let result = namespace.alter_table_drop_columns(request).await;
+        assert!(result.is_err(), "Should fail when table ID is missing");
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_drop_columns_nonexistent_table() {
+        use lance_namespace::models::AlterTableDropColumnsRequest;
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let mut request = AlterTableDropColumnsRequest::new(vec!["col".to_string()]);
+        request.id = Some(vec!["nonexistent".to_string()]);
+        let result = namespace.alter_table_drop_columns(request).await;
+        assert!(result.is_err(), "Should fail when table does not exist");
     }
 }

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -30,7 +30,7 @@ use lance::session::Session;
 use lance::{Dataset, dataset::scanner::Scanner};
 use lance_core::Error as LanceError;
 use lance_core::datatypes::LANCE_UNENFORCED_PRIMARY_KEY_POSITION;
-use lance_core::{Error, ROW_ID, Result};
+use lance_core::{Error, ROW_ID, Result, box_error};
 use lance_index::progress::noop_progress;
 use lance_index::registry::IndexPluginRegistry;
 use lance_index::scalar::lance_format::LanceIndexStore;

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -41,6 +41,8 @@ use lance_io::stream::RecordBatchStream as LanceRecordBatchStream;
 use lance_namespace::LanceNamespace;
 use lance_namespace::error::NamespaceError;
 use lance_namespace::models::{
+    AlterTableAddColumnsRequest, AlterTableAddColumnsResponse, AlterTableAlterColumnsRequest,
+    AlterTableAlterColumnsResponse, AlterTableDropColumnsRequest, AlterTableDropColumnsResponse,
     CreateNamespaceRequest, CreateNamespaceResponse, CreateTableRequest, CreateTableResponse,
     DeclareTableRequest, DeclareTableResponse, DeregisterTableRequest, DeregisterTableResponse,
     DescribeNamespaceRequest, DescribeNamespaceResponse, DescribeTableRequest,
@@ -3530,6 +3532,163 @@ impl LanceNamespace for ManifestNamespace {
             ..Default::default()
         })
     }
+
+    /// Add columns to a table.
+    ///
+    /// Converts the API `NewColumnTransform` (SQL expressions) into Lance's
+    /// `NewColumnTransform::SqlExpressions` and delegates to `Dataset::add_columns`.
+    async fn alter_table_add_columns(
+        &self,
+        request: AlterTableAddColumnsRequest,
+    ) -> Result<AlterTableAddColumnsResponse> {
+        let table_id = request
+            .id
+            .as_ref()
+            .ok_or_else(|| Error::invalid_input_source("Table ID is required".into()))?;
+
+        if table_id.is_empty() {
+            return Err(Error::invalid_input_source(
+                "Table ID cannot be empty".into(),
+            ));
+        }
+
+        let object_id = Self::str_object_id(table_id);
+        let table_info = self.query_manifest_for_table(&object_id).boxed().await?;
+
+        match table_info {
+            Some(info) => {
+                let table_uri = Self::construct_full_uri(&self.root, &info.location)?;
+                let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
+                    Error::io_source(box_error(std::io::Error::other(format!(
+                        "Failed to open dataset: {}",
+                        e
+                    ))))
+                })?;
+
+                // Use shared helper to build SQL expressions, ensuring a clear error when expression is missing
+                let sql_expressions = super::build_sql_expressions(&request.new_columns)?;
+
+                dataset
+                    .add_columns(
+                        lance::dataset::NewColumnTransform::SqlExpressions(sql_expressions),
+                        None,
+                        None,
+                    )
+                    .await
+                    .map_err(|e| {
+                        Error::io_source(box_error(std::io::Error::other(format!(
+                            "Failed to add columns: {}",
+                            e
+                        ))))
+                    })?;
+
+                let version = dataset.version().version as i64;
+                Ok(AlterTableAddColumnsResponse::new(version))
+            }
+            None => Err(Error::namespace_source(
+                format!("Table '{}' not found", object_id).into(),
+            )),
+        }
+    }
+
+    /// Alter columns in a table (rename, change type, change nullability).
+    ///
+    /// Converts the API `AlterColumnsEntry` into Lance's `ColumnAlteration`
+    /// and delegates to `Dataset::alter_columns`.
+    async fn alter_table_alter_columns(
+        &self,
+        request: AlterTableAlterColumnsRequest,
+    ) -> Result<AlterTableAlterColumnsResponse> {
+        let table_id = request
+            .id
+            .as_ref()
+            .ok_or_else(|| Error::invalid_input_source("Table ID is required".into()))?;
+
+        if table_id.is_empty() {
+            return Err(Error::invalid_input_source(
+                "Table ID cannot be empty".into(),
+            ));
+        }
+
+        let object_id = Self::str_object_id(table_id);
+        let table_info = self.query_manifest_for_table(&object_id).boxed().await?;
+
+        match table_info {
+            Some(info) => {
+                let table_uri = Self::construct_full_uri(&self.root, &info.location)?;
+                let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
+                    Error::io_source(box_error(std::io::Error::other(format!(
+                        "Failed to open dataset: {}",
+                        e
+                    ))))
+                })?;
+
+                // Use shared helper to build column alterations, ensuring a clear error when data_type conversion fails
+                let alterations = super::build_column_alterations(&request.alterations)?;
+
+                dataset.alter_columns(&alterations).await.map_err(|e| {
+                    Error::io_source(box_error(std::io::Error::other(format!(
+                        "Failed to alter columns: {}",
+                        e
+                    ))))
+                })?;
+
+                let version = dataset.version().version as i64;
+                Ok(AlterTableAlterColumnsResponse::new(version))
+            }
+            None => Err(Error::namespace_source(
+                format!("Table '{}' not found", object_id).into(),
+            )),
+        }
+    }
+
+    /// Drop columns from a table.
+    ///
+    /// Delegates to `Dataset::drop_columns` with the column names from the request.
+    async fn alter_table_drop_columns(
+        &self,
+        request: AlterTableDropColumnsRequest,
+    ) -> Result<AlterTableDropColumnsResponse> {
+        let table_id = request
+            .id
+            .as_ref()
+            .ok_or_else(|| Error::invalid_input_source("Table ID is required".into()))?;
+
+        if table_id.is_empty() {
+            return Err(Error::invalid_input_source(
+                "Table ID cannot be empty".into(),
+            ));
+        }
+
+        let object_id = Self::str_object_id(table_id);
+        let table_info = self.query_manifest_for_table(&object_id).boxed().await?;
+
+        match table_info {
+            Some(info) => {
+                let table_uri = Self::construct_full_uri(&self.root, &info.location)?;
+                let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
+                    Error::io_source(box_error(std::io::Error::other(format!(
+                        "Failed to open dataset: {}",
+                        e
+                    ))))
+                })?;
+
+                let columns: Vec<&str> = request.columns.iter().map(|s| s.as_str()).collect();
+                dataset.drop_columns(&columns).await.map_err(|e| {
+                    Error::io_source(box_error(std::io::Error::other(format!(
+                        "Failed to drop columns: {}",
+                        e
+                    ))))
+                })?;
+
+                let version = dataset.version().version as i64;
+                Ok(AlterTableDropColumnsResponse::new(version))
+            }
+            None => Err(Error::namespace_source(
+                format!("Table '{}' not found", object_id).into(),
+            )),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -5376,5 +5535,298 @@ mod tests {
         let next = ManifestNamespace::apply_pagination(&mut n, Some("b".to_string()), Some(2));
         assert_eq!(n, names(&["c", "d"]));
         assert_eq!(next, Some("d".to_string()));
+    }
+
+    #[rstest]
+    #[case::with_optimization(true)]
+    #[case::without_optimization(false)]
+    #[tokio::test]
+    async fn test_alter_table_add_columns(#[case] inline_optimization: bool) {
+        use lance_namespace::models::{
+            AlterTableAddColumnsRequest, DescribeTableRequest, NewColumnTransform,
+        };
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let dir_namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .inline_optimization_enabled(inline_optimization)
+            .build()
+            .await
+            .unwrap();
+
+        // Create a table with id and name columns
+        let buffer = create_test_ipc_data();
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["test_table".to_string()]);
+        dir_namespace
+            .create_table(create_request, Bytes::from(buffer))
+            .await
+            .unwrap();
+
+        // Add a new column using SQL expression
+        let mut new_col = NewColumnTransform::new("doubled_id".to_string());
+        new_col.expression = Some("id * 2".to_string());
+        let mut add_request = AlterTableAddColumnsRequest::new(vec![new_col]);
+        add_request.id = Some(vec!["test_table".to_string()]);
+
+        let response = dir_namespace
+            .alter_table_add_columns(add_request)
+            .await
+            .unwrap();
+        // Version should have incremented
+        assert!(response.version > 1);
+
+        // Verify the column was added by describing the table with detailed metadata
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["test_table".to_string()]);
+        describe_request.load_detailed_metadata = Some(true);
+        let describe_response = dir_namespace
+            .describe_table(describe_request)
+            .await
+            .unwrap();
+        assert!(describe_response.schema.is_some());
+
+        let schema = describe_response.schema.unwrap();
+        let field_names: Vec<&str> = schema.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            field_names.contains(&"doubled_id"),
+            "Column 'doubled_id' should exist after add_columns, got: {:?}",
+            field_names
+        );
+    }
+
+    #[rstest]
+    #[case::with_optimization(true)]
+    #[case::without_optimization(false)]
+    #[tokio::test]
+    async fn test_alter_table_add_columns_missing_id(#[case] inline_optimization: bool) {
+        use lance_namespace::models::{AlterTableAddColumnsRequest, NewColumnTransform};
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let dir_namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .inline_optimization_enabled(inline_optimization)
+            .build()
+            .await
+            .unwrap();
+
+        // Request without ID should fail
+        let new_col = NewColumnTransform::new("col".to_string());
+        let request = AlterTableAddColumnsRequest::new(vec![new_col]);
+        let result = dir_namespace.alter_table_add_columns(request).await;
+        assert!(result.is_err(), "Should fail when table ID is missing");
+    }
+
+    #[rstest]
+    #[case::with_optimization(true)]
+    #[case::without_optimization(false)]
+    #[tokio::test]
+    async fn test_alter_table_add_columns_nonexistent_table(#[case] inline_optimization: bool) {
+        use lance_namespace::models::{AlterTableAddColumnsRequest, NewColumnTransform};
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let dir_namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .inline_optimization_enabled(inline_optimization)
+            .build()
+            .await
+            .unwrap();
+
+        // Request with non-existent table should fail
+        let new_col = NewColumnTransform::new("col".to_string());
+        let mut request = AlterTableAddColumnsRequest::new(vec![new_col]);
+        request.id = Some(vec!["nonexistent".to_string()]);
+        let result = dir_namespace.alter_table_add_columns(request).await;
+        assert!(result.is_err(), "Should fail when table does not exist");
+    }
+
+    #[rstest]
+    #[case::with_optimization(true)]
+    #[case::without_optimization(false)]
+    #[tokio::test]
+    async fn test_alter_table_alter_columns_rename(#[case] inline_optimization: bool) {
+        use lance_namespace::models::{
+            AlterColumnsEntry, AlterTableAlterColumnsRequest, DescribeTableRequest,
+        };
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let dir_namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .inline_optimization_enabled(inline_optimization)
+            .build()
+            .await
+            .unwrap();
+
+        // Create a table
+        let buffer = create_test_ipc_data();
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["test_table".to_string()]);
+        dir_namespace
+            .create_table(create_request, Bytes::from(buffer))
+            .await
+            .unwrap();
+
+        // Rename the "name" column to "full_name"
+        let mut entry = AlterColumnsEntry::new("name".to_string(), serde_json::Value::Null);
+        entry.rename = Some("full_name".to_string());
+        let mut alter_request = AlterTableAlterColumnsRequest::new(vec![entry]);
+        alter_request.id = Some(vec!["test_table".to_string()]);
+
+        let response = dir_namespace
+            .alter_table_alter_columns(alter_request)
+            .await
+            .unwrap();
+        assert!(response.version > 1);
+
+        // Verify the column was renamed
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["test_table".to_string()]);
+        describe_request.load_detailed_metadata = Some(true);
+        let describe_response = dir_namespace
+            .describe_table(describe_request)
+            .await
+            .unwrap();
+        assert!(describe_response.schema.is_some());
+
+        let schema = describe_response.schema.unwrap();
+        let field_names: Vec<&str> = schema.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            field_names.contains(&"full_name"),
+            "Column should be renamed to 'full_name', got: {:?}",
+            field_names
+        );
+        assert!(
+            !field_names.contains(&"name"),
+            "Old column name 'name' should no longer exist, got: {:?}",
+            field_names
+        );
+    }
+
+    #[rstest]
+    #[case::with_optimization(true)]
+    #[case::without_optimization(false)]
+    #[tokio::test]
+    async fn test_alter_table_alter_columns_missing_id(#[case] inline_optimization: bool) {
+        use lance_namespace::models::{AlterColumnsEntry, AlterTableAlterColumnsRequest};
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let dir_namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .inline_optimization_enabled(inline_optimization)
+            .build()
+            .await
+            .unwrap();
+
+        let entry = AlterColumnsEntry::new("name".to_string(), serde_json::Value::Null);
+        let request = AlterTableAlterColumnsRequest::new(vec![entry]);
+        let result = dir_namespace.alter_table_alter_columns(request).await;
+        assert!(result.is_err(), "Should fail when table ID is missing");
+    }
+
+    #[rstest]
+    #[case::with_optimization(true)]
+    #[case::without_optimization(false)]
+    #[tokio::test]
+    async fn test_alter_table_drop_columns(#[case] inline_optimization: bool) {
+        use lance_namespace::models::{AlterTableDropColumnsRequest, DescribeTableRequest};
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let dir_namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .inline_optimization_enabled(inline_optimization)
+            .build()
+            .await
+            .unwrap();
+
+        // Create a table with id and name columns
+        let buffer = create_test_ipc_data();
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["test_table".to_string()]);
+        dir_namespace
+            .create_table(create_request, Bytes::from(buffer))
+            .await
+            .unwrap();
+
+        // Drop the "name" column
+        let mut drop_request = AlterTableDropColumnsRequest::new(vec!["name".to_string()]);
+        drop_request.id = Some(vec!["test_table".to_string()]);
+
+        let response = dir_namespace
+            .alter_table_drop_columns(drop_request)
+            .await
+            .unwrap();
+        assert!(response.version > 1);
+
+        // Verify the column was dropped
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["test_table".to_string()]);
+        describe_request.load_detailed_metadata = Some(true);
+        let describe_response = dir_namespace
+            .describe_table(describe_request)
+            .await
+            .unwrap();
+        assert!(describe_response.schema.is_some());
+
+        let schema = describe_response.schema.unwrap();
+        let field_names: Vec<&str> = schema.fields.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            !field_names.contains(&"name"),
+            "Column 'name' should have been dropped, got: {:?}",
+            field_names
+        );
+        assert!(
+            field_names.contains(&"id"),
+            "Column 'id' should still exist, got: {:?}",
+            field_names
+        );
+    }
+
+    #[rstest]
+    #[case::with_optimization(true)]
+    #[case::without_optimization(false)]
+    #[tokio::test]
+    async fn test_alter_table_drop_columns_missing_id(#[case] inline_optimization: bool) {
+        use lance_namespace::models::AlterTableDropColumnsRequest;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let dir_namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .inline_optimization_enabled(inline_optimization)
+            .build()
+            .await
+            .unwrap();
+
+        let request = AlterTableDropColumnsRequest::new(vec!["col".to_string()]);
+        let result = dir_namespace.alter_table_drop_columns(request).await;
+        assert!(result.is_err(), "Should fail when table ID is missing");
+    }
+
+    #[rstest]
+    #[case::with_optimization(true)]
+    #[case::without_optimization(false)]
+    #[tokio::test]
+    async fn test_alter_table_drop_columns_nonexistent_table(#[case] inline_optimization: bool) {
+        use lance_namespace::models::AlterTableDropColumnsRequest;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let dir_namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .inline_optimization_enabled(inline_optimization)
+            .build()
+            .await
+            .unwrap();
+
+        let mut request = AlterTableDropColumnsRequest::new(vec!["col".to_string()]);
+        request.id = Some(vec!["nonexistent".to_string()]);
+        let result = dir_namespace.alter_table_drop_columns(request).await;
+        assert!(result.is_err(), "Should fail when table does not exist");
     }
 }

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -3535,7 +3535,7 @@ impl LanceNamespace for ManifestNamespace {
 
     /// Add columns to a table.
     ///
-    /// Converts the API `NewColumnTransform` (SQL expressions) into Lance's
+    /// Converts the API `AddColumnsEntry` (SQL expressions) into Lance's
     /// `NewColumnTransform::SqlExpressions` and delegates to `Dataset::add_columns`.
     async fn alter_table_add_columns(
         &self,
@@ -5543,7 +5543,7 @@ mod tests {
     #[tokio::test]
     async fn test_alter_table_add_columns(#[case] inline_optimization: bool) {
         use lance_namespace::models::{
-            AlterTableAddColumnsRequest, DescribeTableRequest, NewColumnTransform,
+            AddColumnsEntry, AlterTableAddColumnsRequest, DescribeTableRequest,
         };
 
         let temp_dir = TempStdDir::default();
@@ -5565,8 +5565,8 @@ mod tests {
             .unwrap();
 
         // Add a new column using SQL expression
-        let mut new_col = NewColumnTransform::new("doubled_id".to_string());
-        new_col.expression = Some("id * 2".to_string());
+        let mut new_col = AddColumnsEntry::new("doubled_id".to_string());
+        new_col.expression = Some(Some("id * 2".to_string()));
         let mut add_request = AlterTableAddColumnsRequest::new(vec![new_col]);
         add_request.id = Some(vec!["test_table".to_string()]);
 
@@ -5601,7 +5601,7 @@ mod tests {
     #[case::without_optimization(false)]
     #[tokio::test]
     async fn test_alter_table_add_columns_missing_id(#[case] inline_optimization: bool) {
-        use lance_namespace::models::{AlterTableAddColumnsRequest, NewColumnTransform};
+        use lance_namespace::models::{AddColumnsEntry, AlterTableAddColumnsRequest};
 
         let temp_dir = TempStdDir::default();
         let temp_path = temp_dir.to_str().unwrap();
@@ -5613,7 +5613,7 @@ mod tests {
             .unwrap();
 
         // Request without ID should fail
-        let new_col = NewColumnTransform::new("col".to_string());
+        let new_col = AddColumnsEntry::new("col".to_string());
         let request = AlterTableAddColumnsRequest::new(vec![new_col]);
         let result = dir_namespace.alter_table_add_columns(request).await;
         assert!(result.is_err(), "Should fail when table ID is missing");
@@ -5624,7 +5624,7 @@ mod tests {
     #[case::without_optimization(false)]
     #[tokio::test]
     async fn test_alter_table_add_columns_nonexistent_table(#[case] inline_optimization: bool) {
-        use lance_namespace::models::{AlterTableAddColumnsRequest, NewColumnTransform};
+        use lance_namespace::models::{AddColumnsEntry, AlterTableAddColumnsRequest};
 
         let temp_dir = TempStdDir::default();
         let temp_path = temp_dir.to_str().unwrap();
@@ -5636,7 +5636,7 @@ mod tests {
             .unwrap();
 
         // Request with non-existent table should fail
-        let new_col = NewColumnTransform::new("col".to_string());
+        let new_col = AddColumnsEntry::new("col".to_string());
         let mut request = AlterTableAddColumnsRequest::new(vec![new_col]);
         request.id = Some(vec!["nonexistent".to_string()]);
         let result = dir_namespace.alter_table_add_columns(request).await;
@@ -5671,8 +5671,8 @@ mod tests {
             .unwrap();
 
         // Rename the "name" column to "full_name"
-        let mut entry = AlterColumnsEntry::new("name".to_string(), serde_json::Value::Null);
-        entry.rename = Some("full_name".to_string());
+        let mut entry = AlterColumnsEntry::new("name".to_string());
+        entry.rename = Some(Some("full_name".to_string()));
         let mut alter_request = AlterTableAlterColumnsRequest::new(vec![entry]);
         alter_request.id = Some(vec!["test_table".to_string()]);
 
@@ -5722,7 +5722,7 @@ mod tests {
             .await
             .unwrap();
 
-        let entry = AlterColumnsEntry::new("name".to_string(), serde_json::Value::Null);
+        let entry = AlterColumnsEntry::new("name".to_string());
         let request = AlterTableAlterColumnsRequest::new(vec![entry]);
         let result = dir_namespace.alter_table_alter_columns(request).await;
         assert!(result.is_err(), "Should fail when table ID is missing");

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -3558,7 +3558,16 @@ impl LanceNamespace for ManifestNamespace {
         match table_info {
             Some(info) => {
                 let table_uri = Self::construct_full_uri(&self.root, &info.location)?;
-                let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
+                // Use DatasetBuilder with storage options to align with describe_table
+                // and to support custom storage backends (e.g. S3 with custom endpoints).
+                let mut builder = DatasetBuilder::from_uri(&table_uri);
+                if let Some(opts) = &self.storage_options {
+                    builder = builder.with_storage_options(opts.clone());
+                }
+                if let Some(session) = &self.session {
+                    builder = builder.with_session(session.clone());
+                }
+                let mut dataset = builder.load().await.map_err(|e| {
                     Error::io_source(box_error(std::io::Error::other(format!(
                         "Failed to open dataset: {}",
                         e
@@ -3576,18 +3585,16 @@ impl LanceNamespace for ManifestNamespace {
                     )
                     .await
                     .map_err(|e| {
-                        Error::io_source(box_error(std::io::Error::other(format!(
-                            "Failed to add columns: {}",
-                            e
-                        ))))
+                        // Surface specific commit/conflict errors (CommitConflict,
+                        // RetryableCommitConflict, IncompatibleTransaction, ...) rather than
+                        // collapsing every failure into a generic IO error.
+                        convert_lance_commit_error(&e, "add_columns", Some(&object_id))
                     })?;
 
                 let version = dataset.version().version as i64;
                 Ok(AlterTableAddColumnsResponse::new(version))
             }
-            None => Err(Error::namespace_source(
-                format!("Table '{}' not found", object_id).into(),
-            )),
+            None => Err(NamespaceError::TableNotFound { message: object_id }.into()),
         }
     }
 
@@ -3616,7 +3623,14 @@ impl LanceNamespace for ManifestNamespace {
         match table_info {
             Some(info) => {
                 let table_uri = Self::construct_full_uri(&self.root, &info.location)?;
-                let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
+                let mut builder = DatasetBuilder::from_uri(&table_uri);
+                if let Some(opts) = &self.storage_options {
+                    builder = builder.with_storage_options(opts.clone());
+                }
+                if let Some(session) = &self.session {
+                    builder = builder.with_session(session.clone());
+                }
+                let mut dataset = builder.load().await.map_err(|e| {
                     Error::io_source(box_error(std::io::Error::other(format!(
                         "Failed to open dataset: {}",
                         e
@@ -3627,18 +3641,13 @@ impl LanceNamespace for ManifestNamespace {
                 let alterations = super::build_column_alterations(&request.alterations)?;
 
                 dataset.alter_columns(&alterations).await.map_err(|e| {
-                    Error::io_source(box_error(std::io::Error::other(format!(
-                        "Failed to alter columns: {}",
-                        e
-                    ))))
+                    convert_lance_commit_error(&e, "alter_columns", Some(&object_id))
                 })?;
 
                 let version = dataset.version().version as i64;
                 Ok(AlterTableAlterColumnsResponse::new(version))
             }
-            None => Err(Error::namespace_source(
-                format!("Table '{}' not found", object_id).into(),
-            )),
+            None => Err(NamespaceError::TableNotFound { message: object_id }.into()),
         }
     }
 
@@ -3666,7 +3675,14 @@ impl LanceNamespace for ManifestNamespace {
         match table_info {
             Some(info) => {
                 let table_uri = Self::construct_full_uri(&self.root, &info.location)?;
-                let mut dataset = Dataset::open(&table_uri).await.map_err(|e| {
+                let mut builder = DatasetBuilder::from_uri(&table_uri);
+                if let Some(opts) = &self.storage_options {
+                    builder = builder.with_storage_options(opts.clone());
+                }
+                if let Some(session) = &self.session {
+                    builder = builder.with_session(session.clone());
+                }
+                let mut dataset = builder.load().await.map_err(|e| {
                     Error::io_source(box_error(std::io::Error::other(format!(
                         "Failed to open dataset: {}",
                         e
@@ -3675,18 +3691,13 @@ impl LanceNamespace for ManifestNamespace {
 
                 let columns: Vec<&str> = request.columns.iter().map(|s| s.as_str()).collect();
                 dataset.drop_columns(&columns).await.map_err(|e| {
-                    Error::io_source(box_error(std::io::Error::other(format!(
-                        "Failed to drop columns: {}",
-                        e
-                    ))))
+                    convert_lance_commit_error(&e, "drop_columns", Some(&object_id))
                 })?;
 
                 let version = dataset.version().version as i64;
                 Ok(AlterTableDropColumnsResponse::new(version))
             }
-            None => Err(Error::namespace_source(
-                format!("Table '{}' not found", object_id).into(),
-            )),
+            None => Err(NamespaceError::TableNotFound { message: object_id }.into()),
         }
     }
 }


### PR DESCRIPTION
close: #6274 

Implement the three DDL operations for altering table columns in both ManifestNamespace (manifest.rs) and DirectoryNamespace (dir.rs):

- alter_table_add_columns: Add new columns via SQL expressions
- alter_table_alter_columns: Rename, change type, or change nullability
- alter_table_drop_columns: Remove columns from a table

These methods were previously returning 'not implemented' errors. The implementation delegates to Lance Dataset's add_columns, alter_columns, and drop_columns APIs respectively.

Add comprehensive unit tests :

manifest.rs tests (12 tests, with/without optimization):
- test_alter_table_add_columns: add column via SQL expression, verify schema
- test_alter_table_add_columns_missing_id: error on missing table ID
- test_alter_table_add_columns_nonexistent_table: error on non-existent table
- test_alter_table_alter_columns_rename: rename column, verify schema change
- test_alter_table_alter_columns_missing_id: error on missing table ID
- test_alter_table_drop_columns: drop column, verify schema change
- test_alter_table_drop_columns_missing_id: error on missing table ID
- test_alter_table_drop_columns_nonexistent_table: error on non-existent table

dir.rs tests (8 tests):
- test_alter_table_add_columns: add column, verify schema
- test_alter_table_add_columns_missing_id: error on missing ID
- test_alter_table_alter_columns_rename: rename column, verify schema
- test_alter_table_alter_columns_missing_id: error on missing ID
- test_alter_table_drop_columns: drop column, verify schema
- test_alter_table_drop_columns_missing_id: error on missing ID
- test_alter_table_drop_columns_nonexistent_table: error on non-existent table