### PR TITLE
feat: support multiple index segments for FTS indices

### DIFF
--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -10,14 +10,16 @@ use std::{sync::Arc, time::Duration};
 use arrow_array::{LargeStringArray, RecordBatch, UInt64Array};
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use futures::stream;
+use futures::{TryStreamExt, stream};
 use itertools::Itertools;
 use lance_core::ROW_ID;
 use lance_core::cache::LanceCache;
 use lance_index::prefilter::NoFilter;
 use lance_index::scalar::inverted::lance_tokenizer::DocType;
 use lance_index::scalar::inverted::query::{FtsSearchParams, Operator, Tokens};
-use lance_index::scalar::inverted::{InvertedIndex, InvertedIndexBuilder};
+use lance_index::scalar::inverted::{
+    InvertedIndex, InvertedIndexBuilder, flat_bm25_search_stream, multi_index_bm25_search,
+};
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::{
     metrics::NoOpMetricsCollector, scalar::inverted::tokenizer::InvertedIndexParams,
@@ -233,6 +235,140 @@ fn bench_inverted(c: &mut Criterion) {
             }
         })
     });
+
+    // === Multi-segment search: 2 segments of HALF docs each vs 1 segment of TOTAL ===
+    // Measures the overhead introduced by coordinating across segment boundaries.
+    const HALF: usize = TOTAL / 2;
+    let batch_a = batch.slice(0, HALF);
+    let batch_b = batch.slice(HALF, HALF);
+
+    let seg_a_tempdir = tempfile::tempdir().unwrap();
+    let seg_b_tempdir = tempfile::tempdir().unwrap();
+    let seg_a_store = make_store(seg_a_tempdir.path());
+    let seg_b_store = make_store(seg_b_tempdir.path());
+
+    rt.block_on(async {
+        for (b, store) in [(&batch_a, &seg_a_store), (&batch_b, &seg_b_store)] {
+            let stream =
+                RecordBatchStreamAdapter::new(b.schema(), stream::iter(vec![Ok(b.clone())]));
+            let mut builder =
+                InvertedIndexBuilder::new(InvertedIndexParams::default().with_position(false));
+            builder
+                .update(Box::pin(stream), store.as_ref(), None)
+                .await
+                .unwrap();
+        }
+    });
+
+    let idx_a = rt
+        .block_on(InvertedIndex::load(
+            seg_a_store,
+            None,
+            &LanceCache::no_cache(),
+        ))
+        .unwrap();
+    let idx_b = rt
+        .block_on(InvertedIndex::load(
+            seg_b_store,
+            None,
+            &LanceCache::no_cache(),
+        ))
+        .unwrap();
+
+    let params_multi = FtsSearchParams::new().with_limit(Some(10));
+    let mut query_idx_multi = 0usize;
+
+    c.bench_function(
+        format!("multi_index_search_2_segs({HALF}+{HALF})").as_str(),
+        |b| {
+            b.to_async(&rt).iter(|| {
+                let query = queries[query_idx_multi % queries.len()].clone();
+                query_idx_multi = query_idx_multi.wrapping_add(1);
+                let idx_a = idx_a.clone();
+                let idx_b = idx_b.clone();
+                let params = params_multi.clone();
+                let no_filter = no_filter.clone();
+                async move {
+                    black_box(
+                        multi_index_bm25_search(
+                            &[idx_a.as_ref(), idx_b.as_ref()],
+                            query,
+                            params.into(),
+                            Operator::Or,
+                            no_filter,
+                            Arc::new(NoOpMetricsCollector),
+                        )
+                        .await
+                        .unwrap(),
+                    );
+                }
+            })
+        },
+    );
+
+    // === Flat (brute-force) search: simulates querying over unindexed rows ===
+    // Uses a smaller slice to keep iterations fast.
+    const FLAT_ROWS: usize = 50_000;
+    let flat_batch = batch.slice(0, FLAT_ROWS);
+    // The most common term in the Zipf vocabulary.
+    let flat_query = vocab[0].clone();
+
+    // Flat search with no indexed segment — pure brute-force BM25, no prior IDF stats.
+    c.bench_function(
+        format!("flat_bm25_search_no_index({FLAT_ROWS})").as_str(),
+        |b| {
+            b.to_async(&rt).iter(|| {
+                let flat_batch = flat_batch.clone();
+                let query = flat_query.clone();
+                async move {
+                    let stream = RecordBatchStreamAdapter::new(
+                        flat_batch.schema(),
+                        stream::iter(vec![Ok(flat_batch)]),
+                    );
+                    let result = flat_bm25_search_stream(
+                        Box::pin(stream),
+                        "doc".to_string(),
+                        query,
+                        &[],
+                        1024,
+                    )
+                    .await
+                    .unwrap();
+                    black_box(result.try_collect::<Vec<_>>().await.unwrap());
+                }
+            })
+        },
+    );
+
+    // Flat search with an existing indexed segment providing IDF stats.
+    // This is the code path triggered when some rows are indexed and some are not.
+    let flat_index = Arc::new(vec![(*invert_index).clone()]);
+    c.bench_function(
+        format!("flat_bm25_search_with_index({FLAT_ROWS})").as_str(),
+        |b| {
+            b.to_async(&rt).iter(|| {
+                let flat_batch = flat_batch.clone();
+                let flat_index = flat_index.clone();
+                let query = flat_query.clone();
+                async move {
+                    let stream = RecordBatchStreamAdapter::new(
+                        flat_batch.schema(),
+                        stream::iter(vec![Ok(flat_batch)]),
+                    );
+                    let result = flat_bm25_search_stream(
+                        Box::pin(stream),
+                        "doc".to_string(),
+                        query,
+                        flat_index.as_slice(),
+                        1024,
+                    )
+                    .await
+                    .unwrap();
+                    black_box(result.try_collect::<Vec<_>>().await.unwrap());
+                }
+            })
+        },
+    );
 }
 
 #[cfg(target_os = "linux")]

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -469,99 +469,7 @@ impl InvertedIndex {
         prefilter: Arc<dyn PreFilter>,
         metrics: Arc<dyn MetricsCollector>,
     ) -> Result<(Vec<u64>, Vec<f32>)> {
-        let limit = params.limit.unwrap_or(usize::MAX);
-        if limit == 0 {
-            return Ok((Vec::new(), Vec::new()));
-        }
-        let mask = prefilter.mask();
-
-        let mut candidates = BinaryHeap::new();
-        let parts = self
-            .partitions
-            .iter()
-            .map(|part| {
-                let part = part.clone();
-                let tokens = tokens.clone();
-                let params = params.clone();
-                let mask = mask.clone();
-                let metrics = metrics.clone();
-                async move {
-                    let postings = part
-                        .load_posting_lists(tokens.as_ref(), params.as_ref(), metrics.as_ref())
-                        .await?;
-                    if postings.is_empty() {
-                        return Result::Ok(PartitionCandidates::empty());
-                    }
-                    let mut tokens_by_position = vec![String::new(); postings.len()];
-                    for posting in &postings {
-                        let idx = posting.term_index() as usize;
-                        tokens_by_position[idx] = posting.token().to_owned();
-                    }
-                    let params = params.clone();
-                    let mask = mask.clone();
-                    let metrics = metrics.clone();
-                    spawn_cpu(move || {
-                        let candidates = part.bm25_search(
-                            params.as_ref(),
-                            operator,
-                            mask,
-                            postings,
-                            metrics.as_ref(),
-                        )?;
-                        Ok(PartitionCandidates {
-                            tokens_by_position,
-                            candidates,
-                        })
-                    })
-                    .await
-                }
-            })
-            .collect::<Vec<_>>();
-        let mut parts = stream::iter(parts).buffer_unordered(get_num_compute_intensive_cpus());
-        let scorer = IndexBM25Scorer::new(self.partitions.iter().map(|part| part.as_ref()));
-        let mut idf_cache: HashMap<String, f32> = HashMap::new();
-        while let Some(res) = parts.try_next().await? {
-            if res.candidates.is_empty() {
-                continue;
-            }
-            let mut idf_by_position = Vec::with_capacity(res.tokens_by_position.len());
-            for token in &res.tokens_by_position {
-                let idf_weight = match idf_cache.get(token) {
-                    Some(weight) => *weight,
-                    None => {
-                        let weight = scorer.query_weight(token);
-                        idf_cache.insert(token.clone(), weight);
-                        weight
-                    }
-                };
-                idf_by_position.push(idf_weight);
-            }
-            for DocCandidate {
-                row_id,
-                freqs,
-                doc_length,
-            } in res.candidates
-            {
-                let mut score = 0.0;
-                for (term_index, freq) in freqs.into_iter() {
-                    debug_assert!((term_index as usize) < idf_by_position.len());
-                    score +=
-                        idf_by_position[term_index as usize] * scorer.doc_weight(freq, doc_length);
-                }
-                if candidates.len() < limit {
-                    candidates.push(Reverse(ScoredDoc::new(row_id, score)));
-                } else if candidates.peek().unwrap().0.score.0 < score {
-                    candidates.pop();
-                    candidates.push(Reverse(ScoredDoc::new(row_id, score)));
-                }
-            }
-        }
-
-        Ok(candidates
-            .into_sorted_vec()
-            .into_iter()
-            .map(|Reverse(doc)| (doc.row_id, doc.score.0))
-            .unzip())
+        multi_index_bm25_search(&[self], tokens, params, operator, prefilter, metrics).await
     }
 
     async fn load_legacy_index(
@@ -3915,7 +3823,7 @@ async fn tokenize_and_count(
 /// In order to calculate BM25 scores we need to know token counts for the entire corpus.  We extract these from the
 /// counted input of the flat search combined with any counts recorded for the indexed portion.
 fn initialize_scorer(
-    index: &Option<InvertedIndex>,
+    indices: &[InvertedIndex],
     query_tokens: &Tokens,
     counted_input: &RecordBatch,
 ) -> MemBM25Scorer {
@@ -3923,8 +3831,12 @@ fn initialize_scorer(
     let mut num_docs = 0;
     let mut all_token_counts = vec![0; query_tokens.len()];
 
-    if let Some(index) = index {
-        let index_bm25_scorer = IndexBM25Scorer::new(index.partitions.iter().map(|p| p.as_ref()));
+    if !indices.is_empty() {
+        let all_partitions: Vec<_> = indices
+            .iter()
+            .flat_map(|idx| idx.partitions.iter().map(|p| p.as_ref()))
+            .collect();
+        let index_bm25_scorer = IndexBM25Scorer::new(all_partitions.into_iter());
         for (token_index, token) in query_tokens.into_iter().enumerate() {
             let token_nq = index_bm25_scorer.num_docs_containing_token(token);
             all_token_counts[token_index] = token_nq as u64;
@@ -4028,21 +3940,135 @@ fn flat_bm25_score(
     Ok(batch)
 }
 
+/// Search across multiple InvertedIndex segments with unified BM25 scoring.
+///
+/// Collects all partitions from all indices, creates a unified IndexBM25Scorer
+/// for cross-segment IDF reweighting, and returns merged top-k results.
+#[instrument(level = "debug", skip_all)]
+pub async fn multi_index_bm25_search(
+    indices: &[&InvertedIndex],
+    tokens: Arc<Tokens>,
+    params: Arc<FtsSearchParams>,
+    operator: Operator,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    let limit = params.limit.unwrap_or(usize::MAX);
+    if limit == 0 {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let mask = prefilter.mask();
+
+    // Collect all partitions from all indices
+    let all_partitions: Vec<Arc<InvertedPartition>> = indices
+        .iter()
+        .flat_map(|idx| idx.partitions.iter().cloned())
+        .collect();
+
+    let mut candidates = BinaryHeap::new();
+    let parts = all_partitions
+        .iter()
+        .map(|part| {
+            let part = part.clone();
+            let tokens = tokens.clone();
+            let params = params.clone();
+            let mask = mask.clone();
+            let metrics = metrics.clone();
+            async move {
+                let postings = part
+                    .load_posting_lists(tokens.as_ref(), params.as_ref(), metrics.as_ref())
+                    .await?;
+                if postings.is_empty() {
+                    return Result::Ok(PartitionCandidates::empty());
+                }
+                let mut tokens_by_position = vec![String::new(); postings.len()];
+                for posting in &postings {
+                    let idx = posting.term_index() as usize;
+                    tokens_by_position[idx] = posting.token().to_owned();
+                }
+                let params = params.clone();
+                let mask = mask.clone();
+                let metrics = metrics.clone();
+                spawn_cpu(move || {
+                    let candidates = part.bm25_search(
+                        params.as_ref(),
+                        operator,
+                        mask,
+                        postings,
+                        metrics.as_ref(),
+                    )?;
+                    Ok(PartitionCandidates {
+                        tokens_by_position,
+                        candidates,
+                    })
+                })
+                .await
+            }
+        })
+        .collect::<Vec<_>>();
+    let mut parts = stream::iter(parts).buffer_unordered(get_num_compute_intensive_cpus());
+    // Create unified scorer from all partitions across all indices
+    let scorer = IndexBM25Scorer::new(all_partitions.iter().map(|part| part.as_ref()));
+    let mut idf_cache: HashMap<String, f32> = HashMap::new();
+    while let Some(res) = parts.try_next().await? {
+        if res.candidates.is_empty() {
+            continue;
+        }
+        let mut idf_by_position = Vec::with_capacity(res.tokens_by_position.len());
+        for token in &res.tokens_by_position {
+            let idf_weight = match idf_cache.get(token) {
+                Some(weight) => *weight,
+                None => {
+                    let weight = scorer.query_weight(token);
+                    idf_cache.insert(token.clone(), weight);
+                    weight
+                }
+            };
+            idf_by_position.push(idf_weight);
+        }
+        for DocCandidate {
+            row_id,
+            freqs,
+            doc_length,
+        } in res.candidates
+        {
+            let mut score = 0.0;
+            for (term_index, freq) in freqs.into_iter() {
+                debug_assert!((term_index as usize) < idf_by_position.len());
+                score += idf_by_position[term_index as usize] * scorer.doc_weight(freq, doc_length);
+            }
+            if candidates.len() < limit {
+                candidates.push(Reverse(ScoredDoc::new(row_id, score)));
+            } else if candidates.peek().unwrap().0.score.0 < score {
+                candidates.pop();
+                candidates.push(Reverse(ScoredDoc::new(row_id, score)));
+            }
+        }
+    }
+
+    Ok(candidates
+        .into_sorted_vec()
+        .into_iter()
+        .map(|Reverse(doc)| (doc.row_id, doc.score.0))
+        .unzip())
+}
+
 pub async fn flat_bm25_search_stream(
     input: SendableRecordBatchStream,
     doc_col: String,
     query: String,
-    index: &Option<InvertedIndex>,
+    indices: &[InvertedIndex],
     target_batch_size: usize,
 ) -> DataFusionResult<SendableRecordBatchStream> {
-    let mut tokenizer = match index {
-        Some(index) => index.tokenizer(),
-        None => Box::new(TextTokenizer::new(
+    let mut tokenizer = if let Some(index) = indices.first() {
+        index.tokenizer()
+    } else {
+        Box::new(TextTokenizer::new(
             tantivy::tokenizer::TextAnalyzer::builder(
                 tantivy::tokenizer::SimpleTokenizer::default(),
             )
             .build(),
-        )),
+        ))
     };
     let query_tokens = Arc::new(collect_query_tokens(&query, &mut tokenizer));
 
@@ -4071,7 +4097,7 @@ pub async fn flat_bm25_search_stream(
         tokenize_and_count(chunked, tokenizer, query_tokens.clone(), doc_col_idx).await?;
 
     // Phase 3 - Calculate final scores (this is fairly cheap, probably don't need to parallelize)
-    let scorer = initialize_scorer(index, query_tokens.as_ref(), &counted_input);
+    let scorer = initialize_scorer(indices, query_tokens.as_ref(), &counted_input);
     let scores = flat_bm25_score(query_tokens.as_ref(), &counted_input, &scorer)?;
 
     // Finally we emit batches according to the target batch size

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -194,14 +194,12 @@ impl FromStr for InvertedListFormatVersion {
 
 #[derive(Debug)]
 struct PartitionCandidates {
-    tokens_by_position: Vec<String>,
     candidates: Vec<DocCandidate>,
 }
 
 impl PartitionCandidates {
     fn empty() -> Self {
         Self {
-            tokens_by_position: Vec::new(),
             candidates: Vec::new(),
         }
     }
@@ -940,7 +938,7 @@ impl InvertedPartition {
         let num_docs = self.docs.len();
         stream::iter(token_ids)
             .enumerate()
-            .map(|(position, (token_id, token))| async move {
+            .map(|(position, (token_id, _token))| async move {
                 let posting = self
                     .inverted_list
                     .posting_list(token_id, is_phrase_query, metrics)
@@ -949,7 +947,6 @@ impl InvertedPartition {
                 let query_weight = idf(posting.len(), num_docs);
 
                 Result::Ok(PostingIterator::with_query_weight(
-                    token,
                     token_id,
                     position as u32,
                     query_weight,
@@ -3981,11 +3978,6 @@ pub async fn multi_index_bm25_search(
                 if postings.is_empty() {
                     return Result::Ok(PartitionCandidates::empty());
                 }
-                let mut tokens_by_position = vec![String::new(); postings.len()];
-                for posting in &postings {
-                    let idx = posting.term_index() as usize;
-                    tokens_by_position[idx] = posting.token().to_owned();
-                }
                 let params = params.clone();
                 let mask = mask.clone();
                 let metrics = metrics.clone();
@@ -3997,34 +3989,23 @@ pub async fn multi_index_bm25_search(
                         postings,
                         metrics.as_ref(),
                     )?;
-                    Ok(PartitionCandidates {
-                        tokens_by_position,
-                        candidates,
-                    })
+                    Ok(PartitionCandidates { candidates })
                 })
                 .await
             }
         })
         .collect::<Vec<_>>();
     let mut parts = stream::iter(parts).buffer_unordered(get_num_compute_intensive_cpus());
-    // Create unified scorer from all partitions across all indices
+    // Create unified scorer from all partitions across all indices, then precompute
+    // IDF weights indexed by token position. All partitions use the same term_index
+    // mapping for the same query, so this can be done once before the streaming loop.
     let scorer = IndexBM25Scorer::new(all_partitions.iter().map(|part| part.as_ref()));
-    let mut idf_cache: HashMap<String, f32> = HashMap::new();
+    let idf_by_position: Vec<f32> = (0..tokens.len())
+        .map(|i| scorer.query_weight(tokens.get_token(i)))
+        .collect();
     while let Some(res) = parts.try_next().await? {
         if res.candidates.is_empty() {
             continue;
-        }
-        let mut idf_by_position = Vec::with_capacity(res.tokens_by_position.len());
-        for token in &res.tokens_by_position {
-            let idf_weight = match idf_cache.get(token) {
-                Some(weight) => *weight,
-                None => {
-                    let weight = scorer.query_weight(token);
-                    idf_cache.insert(token.clone(), weight);
-                    weight
-                }
-            };
-            idf_by_position.push(idf_weight);
         }
         for DocCandidate {
             row_id,

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -43,7 +43,6 @@ pub static FLAT_SEARCH_PERCENT_THRESHOLD: LazyLock<u64> = LazyLock::new(|| {
 });
 
 pub struct PostingIterator {
-    token: String,
     token_id: u32,
     position: u32,
     query_weight: f32,
@@ -195,18 +194,11 @@ impl PostingIterator {
     }
 
     #[cfg(test)]
-    pub(crate) fn new(
-        token: String,
-        token_id: u32,
-        position: u32,
-        list: PostingList,
-        num_doc: usize,
-    ) -> Self {
-        Self::with_query_weight(token, token_id, position, 1.0, list, num_doc)
+    pub(crate) fn new(token_id: u32, position: u32, list: PostingList, num_doc: usize) -> Self {
+        Self::with_query_weight(token_id, position, 1.0, list, num_doc)
     }
 
     pub(crate) fn with_query_weight(
-        token: String,
         token_id: u32,
         position: u32,
         query_weight: f32,
@@ -221,7 +213,6 @@ impl PostingIterator {
         let is_compressed = matches!(list, PostingList::Compressed(_));
 
         Self {
-            token,
             token_id,
             position,
             query_weight,
@@ -236,11 +227,6 @@ impl PostingIterator {
     #[inline]
     pub(crate) fn term_index(&self) -> u32 {
         self.position
-    }
-
-    #[inline]
-    pub(crate) fn token(&self) -> &str {
-        &self.token
     }
 
     #[inline]
@@ -1622,7 +1608,6 @@ mod tests {
         // when the pivot is greater than 0, and the first posting list is exhausted after shallow_next
         let postings = vec![
             PostingIterator::new(
-                String::from("test"),
                 0,
                 0,
                 generate_posting_list(
@@ -1634,7 +1619,6 @@ mod tests {
                 docs.len(),
             ),
             PostingIterator::new(
-                String::from("full"),
                 1,
                 1,
                 generate_posting_list(vec![BLOCK_SIZE as u32 + 2], 1.0, None, is_compressed),
@@ -1665,7 +1649,7 @@ mod tests {
 
         let doc_ids = (0..num_docs).collect::<Vec<_>>();
         let posting = generate_posting_list(doc_ids, 1.0, None, true);
-        let mut iter = PostingIterator::new(String::from("term"), 0, 0, posting, docs.len());
+        let mut iter = PostingIterator::new(0, 0, posting, docs.len());
 
         iter.next(10);
         assert_eq!(iter.doc().unwrap().doc_id(), 10);
@@ -1689,14 +1673,12 @@ mod tests {
 
         let postings = vec![
             PostingIterator::new(
-                String::from("full"),
                 0,
                 0,
                 generate_posting_list(large_posting_docs1, 1.0, Some(vec![0.5, 0.5]), true),
                 docs.len(),
             ),
             PostingIterator::new(
-                String::from("text"),
                 1,
                 1,
                 generate_posting_list(vec![0], 1.0, Some(vec![0.5]), true),
@@ -1726,7 +1708,6 @@ mod tests {
         docs.append(1, 1);
 
         let postings = vec![PostingIterator::with_query_weight(
-            String::from("term"),
             0,
             0,
             2.0,
@@ -1752,7 +1733,6 @@ mod tests {
 
         let postings = vec![
             PostingIterator::with_query_weight(
-                String::from("a"),
                 0,
                 0,
                 1.0,
@@ -1760,7 +1740,6 @@ mod tests {
                 docs.len(),
             ),
             PostingIterator::with_query_weight(
-                String::from("b"),
                 1,
                 1,
                 1.0,
@@ -1781,7 +1760,6 @@ mod tests {
         }
 
         let postings = vec![PostingIterator::with_query_weight(
-            String::from("term"),
             0,
             0,
             1.0,
@@ -1811,7 +1789,6 @@ mod tests {
 
         let postings = vec![
             PostingIterator::with_query_weight(
-                String::from("a"),
                 0,
                 0,
                 1.0,
@@ -1819,7 +1796,6 @@ mod tests {
                 docs.len(),
             ),
             PostingIterator::with_query_weight(
-                String::from("b"),
                 1,
                 1,
                 1.0,
@@ -1849,21 +1825,18 @@ mod tests {
 
         let postings = vec![
             PostingIterator::new(
-                String::from("a"),
                 0,
                 0,
                 generate_posting_list(vec![1, 10], 1.0, None, is_compressed),
                 docs.len(),
             ),
             PostingIterator::new(
-                String::from("b"),
                 1,
                 1,
                 generate_posting_list(vec![2, 10], 1.0, None, is_compressed),
                 docs.len(),
             ),
             PostingIterator::new(
-                String::from("c"),
                 2,
                 2,
                 generate_posting_list(vec![10], 1.0, None, is_compressed),
@@ -1888,7 +1861,6 @@ mod tests {
         }
 
         let posting = PostingIterator::with_query_weight(
-            String::from("term"),
             0,
             0,
             1.0,
@@ -1932,7 +1904,7 @@ mod tests {
             PostingList::Plain(_) => unreachable!("expected compressed posting list"),
         };
 
-        let posting = PostingIterator::new(String::from("test"), 0, 0, posting_list, 1);
+        let posting = PostingIterator::new(0, 0, posting_list, 1);
 
         let actual = posting.block_max_score();
         assert!(
@@ -1950,7 +1922,6 @@ mod tests {
         let token_b_positions = vec![vec![2_u32, 11]];
         let postings = vec![
             PostingIterator::new(
-                String::from("a"),
                 0,
                 0,
                 generate_posting_list_with_positions(
@@ -1962,7 +1933,6 @@ mod tests {
                 docs.len(),
             ),
             PostingIterator::new(
-                String::from("b"),
                 1,
                 1,
                 generate_posting_list_with_positions(
@@ -1974,7 +1944,6 @@ mod tests {
                 docs.len(),
             ),
             PostingIterator::new(
-                String::from("a"),
                 2,
                 2,
                 generate_posting_list_with_positions(
@@ -2001,7 +1970,6 @@ mod tests {
 
         let postings = vec![
             PostingIterator::new(
-                String::from("a"),
                 0,
                 0,
                 generate_posting_list_with_positions(
@@ -2013,7 +1981,6 @@ mod tests {
                 docs.len(),
             ),
             PostingIterator::new(
-                String::from("b"),
                 1,
                 1,
                 generate_posting_list_with_positions(

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -303,11 +303,13 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     // the builder only supports one source store.
                     let params = index.derive_index_params()?;
 
-                    // Collect all fragments to read from: merged segments + unindexed
+                    // Collect all fragments to read from: effective frags of merged
+                    // segments + unindexed. Use effective_old_frags (not frag_bitmap)
+                    // since frag_bitmap already includes unindexed fragment IDs.
                     let mut merge_frags: Vec<Fragment> = dataset
                         .fragments()
                         .iter()
-                        .filter(|f| frag_bitmap.contains(f.id as u32))
+                        .filter(|f| effective_old_frags.contains(f.id as u32))
                         .cloned()
                         .collect();
                     merge_frags.extend_from_slice(unindexed);

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -157,56 +157,40 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
     let index_type = indices[0].index_type();
     let (new_uuid, indices_merged, created_index) = match index_type {
         it if it.is_scalar() => {
-            // Use effective bitmap (intersected with existing dataset fragments)
-            // to avoid carrying stale data from pruned indices.
-            let effective_old_frags: RoaringBitmap = old_indices
-                .iter()
-                .filter_map(|idx| idx.effective_fragment_bitmap(&dataset.fragment_bitmap))
-                .fold(RoaringBitmap::new(), |mut acc, b| {
-                    acc |= &b;
-                    acc
-                });
-            let deleted_old_frags: RoaringBitmap = old_indices
-                .iter()
-                .filter_map(|idx| idx.deleted_fragment_bitmap(&dataset.fragment_bitmap))
-                .fold(RoaringBitmap::new(), |mut acc, b| {
-                    acc |= &b;
-                    acc
-                });
-            frag_bitmap |= &effective_old_frags;
+            let num_to_merge = options
+                .num_indices_to_merge
+                .unwrap_or(old_indices.len())
+                .min(old_indices.len());
 
-            let index = dataset
-                .open_scalar_index(
+            if num_to_merge == 0 {
+                // Append mode: build a new segment from only unindexed data.
+                // Existing segments are kept as-is.
+                if unindexed.is_empty() {
+                    return Ok(None);
+                }
+
+                let index = dataset
+                    .open_scalar_index(
+                        &field_path,
+                        &old_indices[0].uuid.to_string(),
+                        &NoOpMetricsCollector,
+                    )
+                    .await?;
+                let params = index.derive_index_params()?;
+                let update_criteria = index.update_criteria();
+
+                let new_data_stream = load_training_data(
+                    dataset.as_ref(),
                     &field_path,
-                    &old_indices[0].uuid.to_string(),
-                    &NoOpMetricsCollector,
+                    &update_criteria.data_criteria,
+                    Some(unindexed.to_vec()),
+                    true,
+                    None,
                 )
                 .await?;
 
-            let update_criteria = index.update_criteria();
-
-            let fragments = if update_criteria.requires_old_data {
-                None
-            } else {
-                Some(unindexed.to_vec())
-            };
-            let new_data_stream = load_training_data(
-                dataset.as_ref(),
-                &field_path,
-                &update_criteria.data_criteria,
-                fragments,
-                true,
-                None,
-            )
-            .await?;
-
-            let new_uuid = Uuid::new_v4();
-
-            let created_index = if effective_old_frags.is_empty() {
-                // Old data is fully stale (bitmap pruned to empty). Rebuild
-                // from scratch instead of merging stale entries.
-                let params = index.derive_index_params()?;
-                super::scalar::build_scalar_index(
+                let new_uuid = Uuid::new_v4();
+                let created_index = super::scalar::build_scalar_index(
                     dataset.as_ref(),
                     column.name.as_str(),
                     &new_uuid.to_string(),
@@ -216,32 +200,144 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     Some(new_data_stream),
                     Arc::new(NoopIndexBuildProgress),
                 )
-                .await?
-            } else {
-                let new_store =
-                    LanceIndexStore::from_dataset_for_new(&dataset, &new_uuid.to_string())?;
-                let old_data_filter = if dataset.manifest.uses_stable_row_ids() {
-                    // Stable row IDs are opaque IDs, so fragment-bit filtering on
-                    // (row_id >> 32) is invalid. Build an exact allow-list from retained
-                    // fragments' row-id sequences and use precise filtering.
-                    let valid_old_row_ids =
-                        build_stable_row_id_filter(dataset.as_ref(), &effective_old_frags).await?;
-                    Some(OldIndexDataFilter::RowIds(valid_old_row_ids))
-                } else {
-                    // Address-style row IDs encode fragment_id in high 32 bits.
-                    // Fragment bitmap filtering is valid and cheaper in this mode.
-                    Some(OldIndexDataFilter::Fragments {
-                        to_keep: effective_old_frags,
-                        to_remove: deleted_old_frags,
-                    })
-                };
-                index
-                    .update(new_data_stream, &new_store, old_data_filter)
-                    .await?
-            };
+                .await?;
 
-            // TODO: don't hard-code index version
-            Ok((new_uuid, 1, created_index))
+                // indices_merged = 0: no old segments removed
+                Ok((new_uuid, 0, created_index))
+            } else {
+                // Merge mode: merge the `num_to_merge` most recent segments
+                // plus any unindexed data into a single new segment.
+                let merge_start = old_indices.len() - num_to_merge;
+                let indices_to_merge = &old_indices[merge_start..];
+
+                let effective_old_frags: RoaringBitmap = indices_to_merge
+                    .iter()
+                    .filter_map(|idx| idx.effective_fragment_bitmap(&dataset.fragment_bitmap))
+                    .fold(RoaringBitmap::new(), |mut acc, b| {
+                        acc |= &b;
+                        acc
+                    });
+                let deleted_old_frags: RoaringBitmap = indices_to_merge
+                    .iter()
+                    .filter_map(|idx| idx.deleted_fragment_bitmap(&dataset.fragment_bitmap))
+                    .fold(RoaringBitmap::new(), |mut acc, b| {
+                        acc |= &b;
+                        acc
+                    });
+                frag_bitmap |= &effective_old_frags;
+
+                let index = dataset
+                    .open_scalar_index(
+                        &field_path,
+                        &indices_to_merge[0].uuid.to_string(),
+                        &NoOpMetricsCollector,
+                    )
+                    .await?;
+
+                let new_uuid = Uuid::new_v4();
+
+                let created_index = if effective_old_frags.is_empty() {
+                    // Old data is fully stale (bitmap pruned to empty). Rebuild
+                    // from scratch instead of merging stale entries.
+                    let params = index.derive_index_params()?;
+                    let update_criteria = index.update_criteria();
+
+                    let new_data_stream = load_training_data(
+                        dataset.as_ref(),
+                        &field_path,
+                        &update_criteria.data_criteria,
+                        Some(unindexed.to_vec()),
+                        true,
+                        None,
+                    )
+                    .await?;
+
+                    super::scalar::build_scalar_index(
+                        dataset.as_ref(),
+                        column.name.as_str(),
+                        &new_uuid.to_string(),
+                        &params,
+                        true,
+                        None,
+                        Some(new_data_stream),
+                        Arc::new(NoopIndexBuildProgress),
+                    )
+                    .await?
+                } else if num_to_merge == 1 {
+                    // Single-segment merge: use the existing update path
+                    // which carries forward old partitions efficiently.
+                    let update_criteria = index.update_criteria();
+                    let fragments = if update_criteria.requires_old_data {
+                        None
+                    } else {
+                        Some(unindexed.to_vec())
+                    };
+                    let new_data_stream = load_training_data(
+                        dataset.as_ref(),
+                        &field_path,
+                        &update_criteria.data_criteria,
+                        fragments,
+                        true,
+                        None,
+                    )
+                    .await?;
+
+                    let new_store =
+                        LanceIndexStore::from_dataset_for_new(&dataset, &new_uuid.to_string())?;
+                    let old_data_filter = if dataset.manifest.uses_stable_row_ids() {
+                        let valid_old_row_ids =
+                            build_stable_row_id_filter(dataset.as_ref(), &effective_old_frags)
+                                .await?;
+                        Some(OldIndexDataFilter::RowIds(valid_old_row_ids))
+                    } else {
+                        Some(OldIndexDataFilter::Fragments {
+                            to_keep: effective_old_frags,
+                            to_remove: deleted_old_frags,
+                        })
+                    };
+                    index
+                        .update(new_data_stream, &new_store, old_data_filter)
+                        .await?
+                } else {
+                    // Multi-segment merge (N > 1): rebuild from raw data since
+                    // the builder only supports one source store.
+                    let params = index.derive_index_params()?;
+
+                    // Collect all fragments to read from: merged segments + unindexed
+                    let mut merge_frags: Vec<Fragment> = dataset
+                        .fragments()
+                        .iter()
+                        .filter(|f| frag_bitmap.contains(f.id as u32))
+                        .cloned()
+                        .collect();
+                    merge_frags.extend_from_slice(unindexed);
+
+                    let update_criteria = index.update_criteria();
+                    let new_data_stream = load_training_data(
+                        dataset.as_ref(),
+                        &field_path,
+                        &update_criteria.data_criteria,
+                        Some(merge_frags),
+                        true,
+                        None,
+                    )
+                    .await?;
+
+                    super::scalar::build_scalar_index(
+                        dataset.as_ref(),
+                        column.name.as_str(),
+                        &new_uuid.to_string(),
+                        &params,
+                        true,
+                        None,
+                        Some(new_data_stream),
+                        Arc::new(NoopIndexBuildProgress),
+                    )
+                    .await?
+                };
+
+                Ok((new_uuid, num_to_merge, created_index))
+            }
         }
         it if it.is_vector() => {
             let new_data_stream = if unindexed.is_empty() {

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -39,15 +39,22 @@ use lance_index::scalar::inverted::{
 };
 use lance_index::{DatasetIndexExt, IndexCriteria};
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
+use lance_table::format::IndexMetadata;
 use tracing::instrument;
 
-/// Load all FTS index segments for a column and return them as InvertedIndex instances.
-/// Also returns the union of all deleted_fragments bitmaps across segments.
+/// Load all FTS index segments for a column.
+///
+/// Returns the opened indices, the union of their deleted_fragments bitmaps, and the
+/// metadata for all segments (needed by `build_prefilter` to cover all segments).
 async fn load_all_fts_segments(
     ds: &Dataset,
     column: &str,
     metrics: &dyn MetricsCollector,
-) -> DataFusionResult<(Vec<InvertedIndex>, roaring::RoaringBitmap)> {
+) -> DataFusionResult<(
+    Vec<InvertedIndex>,
+    roaring::RoaringBitmap,
+    Vec<IndexMetadata>,
+)> {
     let first_meta = ds
         .load_scalar_index(IndexCriteria::default().for_column(column).supports_fts())
         .await?
@@ -76,7 +83,7 @@ async fn load_all_fts_segments(
         all_deleted_fragments |= inverted_idx.deleted_fragments();
         indices.push(inverted_idx);
     }
-    Ok((indices, all_deleted_fragments))
+    Ok((indices, all_deleted_fragments, all_metas))
 }
 
 pub struct FtsIndexMetrics {
@@ -268,14 +275,9 @@ impl ExecutionPlan for MatchQueryExec {
         )))?;
         let stream = stream::once(async move {
             let _timer = metrics.baseline_metrics.elapsed_compute().timer();
-            let (indices, all_deleted_fragments) =
+            let (indices, all_deleted_fragments, all_metas) =
                 load_all_fts_segments(&ds, &column, &metrics.index_metrics).await?;
 
-            let all_metas = ds
-                .load_scalar_index(IndexCriteria::default().for_column(&column).supports_fts())
-                .await?
-                .into_iter()
-                .collect::<Vec<_>>();
             let mut pre_filter = build_prefilter(
                 context.clone(),
                 partition,
@@ -922,14 +924,9 @@ impl ExecutionPlan for PhraseQueryExec {
                 "column not set for PhraseQuery {}",
                 query.terms
             )))?;
-            let (indices, all_deleted_fragments) =
+            let (indices, all_deleted_fragments, all_metas) =
                 load_all_fts_segments(&ds, &column, &metrics.index_metrics).await?;
 
-            let all_metas = ds
-                .load_scalar_index(IndexCriteria::default().for_column(&column).supports_fts())
-                .await?
-                .into_iter()
-                .collect::<Vec<_>>();
             let mut pre_filter = build_prefilter(
                 context.clone(),
                 partition,

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -35,11 +35,49 @@ use lance_index::scalar::inverted::query::{
 };
 use lance_index::scalar::inverted::tokenizer::lance_tokenizer::TextTokenizer;
 use lance_index::scalar::inverted::{
-    FTS_SCHEMA, InvertedIndex, SCORE_COL, flat_bm25_search_stream,
+    FTS_SCHEMA, InvertedIndex, SCORE_COL, flat_bm25_search_stream, multi_index_bm25_search,
 };
 use lance_index::{DatasetIndexExt, IndexCriteria};
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
 use tracing::instrument;
+
+/// Load all FTS index segments for a column and return them as InvertedIndex instances.
+/// Also returns the union of all deleted_fragments bitmaps across segments.
+async fn load_all_fts_segments(
+    ds: &Dataset,
+    column: &str,
+    metrics: &dyn MetricsCollector,
+) -> DataFusionResult<(Vec<InvertedIndex>, roaring::RoaringBitmap)> {
+    let first_meta = ds
+        .load_scalar_index(IndexCriteria::default().for_column(column).supports_fts())
+        .await?
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("No Inverted index found for column {}", column))
+        })?;
+
+    let all_metas = ds.load_indices_by_name(&first_meta.name).await?;
+
+    let mut indices = Vec::with_capacity(all_metas.len());
+    let mut all_deleted_fragments = roaring::RoaringBitmap::new();
+    for meta in &all_metas {
+        let idx = ds
+            .open_generic_index(column, &meta.uuid.to_string(), metrics)
+            .await?;
+        let inverted_idx = idx
+            .as_any()
+            .downcast_ref::<InvertedIndex>()
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "Index for column {} is not an inverted index",
+                    column,
+                ))
+            })?
+            .clone();
+        all_deleted_fragments |= inverted_idx.deleted_fragments();
+        indices.push(inverted_idx);
+    }
+    Ok((indices, all_deleted_fragments))
+}
 
 pub struct FtsIndexMetrics {
     index_metrics: IndexMetrics,
@@ -230,54 +268,47 @@ impl ExecutionPlan for MatchQueryExec {
         )))?;
         let stream = stream::once(async move {
             let _timer = metrics.baseline_metrics.elapsed_compute().timer();
-            let index_meta = ds
+            let (indices, all_deleted_fragments) =
+                load_all_fts_segments(&ds, &column, &metrics.index_metrics).await?;
+
+            let all_metas = ds
                 .load_scalar_index(IndexCriteria::default().for_column(&column).supports_fts())
                 .await?
-                .ok_or(DataFusionError::Execution(format!(
-                    "No Inverted index found for column {}",
-                    column,
-                )))?;
-            let uuid = index_meta.uuid.to_string();
-            let index = ds
-                .open_generic_index(&column, &uuid, &metrics.index_metrics)
-                .await?;
-
+                .into_iter()
+                .collect::<Vec<_>>();
             let mut pre_filter = build_prefilter(
                 context.clone(),
                 partition,
                 &prefilter_source,
                 ds,
-                &[index_meta],
+                &all_metas,
             )?;
 
-            let inverted_idx = index
-                .as_any()
-                .downcast_ref::<InvertedIndex>()
-                .ok_or_else(|| {
-                    DataFusionError::Execution(format!(
-                        "Index for column {} is not an inverted index",
-                        column,
-                    ))
-                })?;
-            if !inverted_idx.deleted_fragments().is_empty() {
+            if !all_deleted_fragments.is_empty() {
                 Arc::get_mut(&mut pre_filter)
                     .expect("prefilter just created")
-                    .set_deleted_fragments(inverted_idx.deleted_fragments().clone());
+                    .set_deleted_fragments(all_deleted_fragments);
             }
-            metrics.record_parts_searched(inverted_idx.partition_count());
+            let total_partitions: usize = indices.iter().map(|i| i.partition_count()).sum();
+            metrics.record_parts_searched(total_partitions);
 
+            let first_idx = indices.first().ok_or_else(|| {
+                DataFusionError::Execution(
+                    format!("No Inverted index found for column {}", column,),
+                )
+            })?;
             let is_fuzzy = matches!(query.fuzziness, Some(n) if n != 0);
             let params = params
                 .with_fuzziness(query.fuzziness)
                 .with_max_expansions(query.max_expansions)
                 .with_prefix_length(query.prefix_length);
             let mut tokenizer = match is_fuzzy {
-                false => inverted_idx.tokenizer(),
+                false => first_idx.tokenizer(),
                 true => {
                     let tokenizer = tantivy::tokenizer::TextAnalyzer::from(
                         tantivy::tokenizer::SimpleTokenizer::default(),
                     );
-                    match inverted_idx.tokenizer().doc_type() {
+                    match first_idx.tokenizer().doc_type() {
                         DocType::Text => {
                             Box::new(TextTokenizer::new(tokenizer)) as Box<dyn LanceTokenizer>
                         }
@@ -290,16 +321,17 @@ impl ExecutionPlan for MatchQueryExec {
             let tokens = collect_query_tokens(&query.terms, &mut tokenizer);
 
             pre_filter.wait_for_ready().await?;
-            let (doc_ids, mut scores) = inverted_idx
-                .bm25_search(
-                    Arc::new(tokens),
-                    params.into(),
-                    query.operator,
-                    pre_filter,
-                    metrics.clone(),
-                )
-                .boxed()
-                .await?;
+            let index_refs: Vec<&InvertedIndex> = indices.iter().collect();
+            let (doc_ids, mut scores) = multi_index_bm25_search(
+                &index_refs,
+                Arc::new(tokens),
+                params.into(),
+                query.operator,
+                pre_filter,
+                metrics.clone(),
+            )
+            .boxed()
+            .await?;
             scores.iter_mut().for_each(|s| {
                 *s *= query.boost;
             });
@@ -674,28 +706,37 @@ impl ExecutionPlan for FlatMatchQueryExec {
             document_input(self.unindexed_input.execute(partition, context)?, &column)?;
 
         let stream = stream::once(async move {
-            let index_meta = ds
+            let indices = match ds
                 .load_scalar_index(IndexCriteria::default().for_column(&column).supports_fts())
-                .await?;
-            let inverted_idx = match index_meta {
-                Some(index_meta) => {
-                    let uuid = index_meta.uuid.to_string();
-                    let index = ds
-                        .open_generic_index(&column, &uuid, &metrics.index_metrics)
-                        .await?;
-                    index.as_any().downcast_ref::<InvertedIndex>().cloned()
+                .await?
+            {
+                Some(first_meta) => {
+                    let all_metas = ds.load_indices_by_name(&first_meta.name).await?;
+                    let mut indices = Vec::with_capacity(all_metas.len());
+                    for meta in &all_metas {
+                        let idx = ds
+                            .open_generic_index(
+                                &column,
+                                &meta.uuid.to_string(),
+                                &metrics.index_metrics,
+                            )
+                            .await?;
+                        if let Some(inv) = idx.as_any().downcast_ref::<InvertedIndex>() {
+                            indices.push(inv.clone());
+                        }
+                    }
+                    indices
                 }
-                None => None,
+                None => Vec::new(),
             };
-            if let Some(index) = inverted_idx.as_ref() {
-                metrics.record_parts_searched(index.partition_count());
-            }
+            let total_partitions: usize = indices.iter().map(|i| i.partition_count()).sum();
+            metrics.record_parts_searched(total_partitions);
 
             flat_bm25_search_stream(
                 unindexed_input,
                 column,
                 query.terms,
-                &inverted_idx,
+                &indices,
                 target_batch_size,
             )
             .await
@@ -881,56 +922,50 @@ impl ExecutionPlan for PhraseQueryExec {
                 "column not set for PhraseQuery {}",
                 query.terms
             )))?;
-            let index_meta = ds
+            let (indices, all_deleted_fragments) =
+                load_all_fts_segments(&ds, &column, &metrics.index_metrics).await?;
+
+            let all_metas = ds
                 .load_scalar_index(IndexCriteria::default().for_column(&column).supports_fts())
                 .await?
-                .ok_or(DataFusionError::Execution(format!(
-                    "No Inverted index found for column {}",
-                    column,
-                )))?;
-            let uuid = index_meta.uuid.to_string();
-            let index = ds
-                .open_generic_index(&column, &uuid, &metrics.index_metrics)
-                .await?;
-
+                .into_iter()
+                .collect::<Vec<_>>();
             let mut pre_filter = build_prefilter(
                 context.clone(),
                 partition,
                 &prefilter_source,
                 ds,
-                &[index_meta],
+                &all_metas,
             )?;
 
-            let index = index
-                .as_any()
-                .downcast_ref::<InvertedIndex>()
-                .ok_or_else(|| {
-                    DataFusionError::Execution(format!(
-                        "Index for column {} is not an inverted index",
-                        column,
-                    ))
-                })?;
-            if !index.deleted_fragments().is_empty() {
+            if !all_deleted_fragments.is_empty() {
                 Arc::get_mut(&mut pre_filter)
                     .expect("prefilter just created")
-                    .set_deleted_fragments(index.deleted_fragments().clone());
+                    .set_deleted_fragments(all_deleted_fragments);
             }
-            metrics.record_parts_searched(index.partition_count());
+            let total_partitions: usize = indices.iter().map(|i| i.partition_count()).sum();
+            metrics.record_parts_searched(total_partitions);
 
-            let mut tokenizer = index.tokenizer();
+            let first_idx = indices.first().ok_or_else(|| {
+                DataFusionError::Execution(
+                    format!("No Inverted index found for column {}", column,),
+                )
+            })?;
+            let mut tokenizer = first_idx.tokenizer();
             let tokens = collect_query_tokens(&query.terms, &mut tokenizer);
 
             pre_filter.wait_for_ready().await?;
-            let (doc_ids, scores) = index
-                .bm25_search(
-                    Arc::new(tokens),
-                    params.into(),
-                    lance_index::scalar::inverted::query::Operator::And,
-                    pre_filter,
-                    metrics.clone(),
-                )
-                .boxed()
-                .await?;
+            let index_refs: Vec<&InvertedIndex> = indices.iter().collect();
+            let (doc_ids, scores) = multi_index_bm25_search(
+                &index_refs,
+                Arc::new(tokens),
+                params.into(),
+                lance_index::scalar::inverted::query::Operator::And,
+                pre_filter,
+                metrics.clone(),
+            )
+            .boxed()
+            .await?;
             metrics.baseline_metrics.record_output(doc_ids.len());
             let batch = RecordBatch::try_new(
                 FTS_SCHEMA.clone(),

--- a/rust/lance/tests/query/inverted.rs
+++ b/rust/lance/tests/query/inverted.rs
@@ -3,10 +3,13 @@
 
 use std::sync::Arc;
 
-use arrow_array::{ArrayRef, Int32Array, RecordBatch, StringArray, UInt32Array};
+use arrow_array::{ArrayRef, Float32Array, Int32Array, RecordBatch, StringArray, UInt32Array};
 use lance::Dataset;
+use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::scanner::ColumnOrdering;
-use lance::dataset::{InsertBuilder, WriteParams};
+use lance::dataset::{InsertBuilder, WriteMode, WriteParams};
+use lance_core::utils::tempfile::TempStrDir;
+use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::query::{FtsQuery, PhraseQuery};
 use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
 use lance_index::{DatasetIndexExt, IndexType};
@@ -340,4 +343,493 @@ async fn test_fts_after_delete_with_stable_row_ids() {
     for id in result_ids.values().iter() {
         assert!(*id >= 5, "Deleted row id {} should not appear", id);
     }
+}
+
+// Helper: create a dataset with text data, split into initial + append batches.
+async fn make_fts_dataset_with_append(test_uri: &str, with_position: bool) -> Dataset {
+    let ids1: Vec<i32> = (0..10).collect();
+    let texts1 = vec![
+        "hello world",
+        "world hello",
+        "hello",
+        "lance database",
+        "search engine",
+        "hello lance",
+        "lance",
+        "database",
+        "world",
+        "hello world search",
+    ];
+
+    let batch1 = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(Int32Array::from(ids1)) as ArrayRef),
+        (
+            "text",
+            Arc::new(StringArray::from(
+                texts1.into_iter().map(Some).collect::<Vec<_>>(),
+            )) as ArrayRef,
+        ),
+    ])
+    .unwrap();
+
+    let mut ds = InsertBuilder::new(test_uri)
+        .execute(vec![batch1])
+        .await
+        .unwrap();
+
+    let params = base_inverted_params(with_position);
+    ds.create_index_builder(&["text"], IndexType::Inverted, &params)
+        .await
+        .unwrap();
+
+    // Append more data
+    let ids2: Vec<i32> = (10..20).collect();
+    let texts2 = vec![
+        "hello database",
+        "search world",
+        "lance search engine",
+        "hello hello hello",
+        "world world",
+        "database search",
+        "hello engine",
+        "lance world",
+        "search hello",
+        "engine database lance",
+    ];
+
+    let batch2 = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(Int32Array::from(ids2)) as ArrayRef),
+        (
+            "text",
+            Arc::new(StringArray::from(
+                texts2.into_iter().map(Some).collect::<Vec<_>>(),
+            )) as ArrayRef,
+        ),
+    ])
+    .unwrap();
+
+    let append_params = WriteParams {
+        mode: WriteMode::Append,
+        ..Default::default()
+    };
+    InsertBuilder::new(test_uri)
+        .with_params(&append_params)
+        .execute(vec![batch2])
+        .await
+        .unwrap();
+
+    DatasetBuilder::from_uri(test_uri).load().await.unwrap()
+}
+
+// Run FTS and return (row_ids, scores) sorted by row_id for deterministic comparison.
+async fn fts_results_sorted(ds: &Dataset, query: &str) -> Vec<(i32, f32)> {
+    let fts_query = FullTextSearchQuery::new(query.to_string())
+        .with_column("text".to_string())
+        .unwrap();
+    let mut scanner = ds.scan();
+    scanner.full_text_search(fts_query).unwrap();
+    scanner
+        .order_by(Some(vec![ColumnOrdering::asc_nulls_first(
+            "id".to_string(),
+        )]))
+        .unwrap();
+    let batch = scanner.try_into_batch().await.unwrap();
+    let ids = batch
+        .column_by_name("id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let scores = batch
+        .column_by_name("_score")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Float32Array>()
+        .unwrap();
+    ids.values()
+        .iter()
+        .zip(scores.values().iter())
+        .map(|(&id, &score)| (id, score))
+        .collect()
+}
+
+#[tokio::test]
+async fn test_fts_append_creates_separate_segment() {
+    let test_dir = TempStrDir::default();
+    let mut ds = make_fts_dataset_with_append(test_dir.as_str(), false).await;
+
+    let indices = ds.load_indices().await.unwrap();
+    let fts_idx_name = indices
+        .iter()
+        .find(|i| i.name.contains("text"))
+        .unwrap()
+        .name
+        .clone();
+
+    // Before optimize: only 1 segment
+    assert_eq!(
+        ds.load_indices_by_name(&fts_idx_name).await.unwrap().len(),
+        1
+    );
+
+    // Append mode: create a new segment without merging
+    ds.optimize_indices(&OptimizeOptions::append())
+        .await
+        .unwrap();
+    let ds = DatasetBuilder::from_uri(test_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+
+    // Should have 2 segments
+    let segments = ds.load_indices_by_name(&fts_idx_name).await.unwrap();
+    assert_eq!(segments.len(), 2, "Expected 2 FTS segments after append");
+
+    // Fragment bitmaps should be disjoint
+    let bm0 = segments[0].fragment_bitmap.as_ref().unwrap();
+    let bm1 = segments[1].fragment_bitmap.as_ref().unwrap();
+    assert!(
+        bm0.intersection_len(bm1) == 0,
+        "Segment fragment bitmaps should be disjoint"
+    );
+}
+
+#[tokio::test]
+async fn test_fts_multi_segment_score_equivalence() {
+    // Build single-segment index on full data
+    let single_dir = TempStrDir::default();
+    let mut ds_single = make_fts_dataset_with_append(single_dir.as_str(), false).await;
+
+    // Rebuild index on the whole dataset (single segment)
+    ds_single
+        .optimize_indices(&OptimizeOptions::default())
+        .await
+        .unwrap();
+    let ds_single = DatasetBuilder::from_uri(single_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+
+    // Build multi-segment index on same data
+    let multi_dir = TempStrDir::default();
+    let mut ds_multi = make_fts_dataset_with_append(multi_dir.as_str(), false).await;
+
+    // Append mode: create second segment
+    ds_multi
+        .optimize_indices(&OptimizeOptions::append())
+        .await
+        .unwrap();
+    let ds_multi = DatasetBuilder::from_uri(multi_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+
+    // Verify 2 segments
+    let indices = ds_multi.load_indices().await.unwrap();
+    let fts_name = indices
+        .iter()
+        .find(|i| i.name.contains("text"))
+        .unwrap()
+        .name
+        .clone();
+    let segments = ds_multi.load_indices_by_name(&fts_name).await.unwrap();
+    assert_eq!(segments.len(), 2);
+
+    // Compare results for multiple queries
+    for query in &["hello", "world", "lance", "database", "search", "engine"] {
+        let single_results = fts_results_sorted(&ds_single, query).await;
+        let multi_results = fts_results_sorted(&ds_multi, query).await;
+
+        assert_eq!(
+            single_results.len(),
+            multi_results.len(),
+            "Result count mismatch for query '{}'",
+            query
+        );
+
+        for (i, ((s_id, s_score), (m_id, m_score))) in
+            single_results.iter().zip(multi_results.iter()).enumerate()
+        {
+            assert_eq!(
+                s_id, m_id,
+                "ID mismatch at position {} for query '{}'",
+                i, query
+            );
+            assert!(
+                (s_score - m_score).abs() < 1e-5,
+                "Score mismatch at position {} for query '{}': single={}, multi={}",
+                i,
+                query,
+                s_score,
+                m_score,
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_fts_merge_combines_segments() {
+    let test_dir = TempStrDir::default();
+    let mut ds = make_fts_dataset_with_append(test_dir.as_str(), false).await;
+
+    // Create second segment
+    ds.optimize_indices(&OptimizeOptions::append())
+        .await
+        .unwrap();
+    let ds = DatasetBuilder::from_uri(test_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+
+    let indices = ds.load_indices().await.unwrap();
+    let fts_name = indices
+        .iter()
+        .find(|i| i.name.contains("text"))
+        .unwrap()
+        .name
+        .clone();
+    assert_eq!(ds.load_indices_by_name(&fts_name).await.unwrap().len(), 2);
+
+    // Query before merge
+    let before_merge = fts_results_sorted(&ds, "hello").await;
+
+    // Merge all segments
+    let mut ds = ds;
+    ds.optimize_indices(&OptimizeOptions::merge(2))
+        .await
+        .unwrap();
+    let ds = DatasetBuilder::from_uri(test_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+
+    // Should be back to 1 segment
+    let segments = ds.load_indices_by_name(&fts_name).await.unwrap();
+    assert_eq!(segments.len(), 1, "Expected 1 segment after merge(2)");
+
+    // Results should be the same
+    let after_merge = fts_results_sorted(&ds, "hello").await;
+    assert_eq!(
+        before_merge.len(),
+        after_merge.len(),
+        "Result count changed after merge"
+    );
+    for ((_, s1), (_, s2)) in before_merge.iter().zip(after_merge.iter()) {
+        assert!(
+            (s1 - s2).abs() < 1e-5,
+            "Scores changed after merge: {} vs {}",
+            s1,
+            s2,
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_fts_three_segments_partial_merge() {
+    let test_dir = TempStrDir::default();
+
+    // Create initial data
+    let batch1 = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(Int32Array::from(vec![0, 1, 2])) as ArrayRef),
+        (
+            "text",
+            Arc::new(StringArray::from(vec!["hello world", "lance db", "search"])) as ArrayRef,
+        ),
+    ])
+    .unwrap();
+
+    let mut ds = InsertBuilder::new(test_dir.as_str())
+        .execute(vec![batch1])
+        .await
+        .unwrap();
+
+    let params = base_inverted_params(false);
+    ds.create_index_builder(&["text"], IndexType::Inverted, &params)
+        .await
+        .unwrap();
+
+    // Append batch 2 and create segment
+    let batch2 = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(Int32Array::from(vec![3, 4, 5])) as ArrayRef),
+        (
+            "text",
+            Arc::new(StringArray::from(vec!["hello lance", "world search", "db"])) as ArrayRef,
+        ),
+    ])
+    .unwrap();
+    let append_params = WriteParams {
+        mode: WriteMode::Append,
+        ..Default::default()
+    };
+    InsertBuilder::new(test_dir.as_str())
+        .with_params(&append_params)
+        .execute(vec![batch2])
+        .await
+        .unwrap();
+    let mut ds = DatasetBuilder::from_uri(test_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+    ds.optimize_indices(&OptimizeOptions::append())
+        .await
+        .unwrap();
+
+    // Append batch 3 and create segment
+    let batch3 = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(Int32Array::from(vec![6, 7, 8])) as ArrayRef),
+        (
+            "text",
+            Arc::new(StringArray::from(vec![
+                "hello search",
+                "lance world",
+                "db engine",
+            ])) as ArrayRef,
+        ),
+    ])
+    .unwrap();
+    InsertBuilder::new(test_dir.as_str())
+        .with_params(&append_params)
+        .execute(vec![batch3])
+        .await
+        .unwrap();
+    let mut ds = DatasetBuilder::from_uri(test_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+    ds.optimize_indices(&OptimizeOptions::append())
+        .await
+        .unwrap();
+    let ds = DatasetBuilder::from_uri(test_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+
+    let indices = ds.load_indices().await.unwrap();
+    let fts_name = indices
+        .iter()
+        .find(|i| i.name.contains("text"))
+        .unwrap()
+        .name
+        .clone();
+    assert_eq!(ds.load_indices_by_name(&fts_name).await.unwrap().len(), 3);
+
+    // Query across 3 segments
+    let results_3seg = fts_results_sorted(&ds, "hello").await;
+    assert_eq!(results_3seg.len(), 3); // rows 0, 3, 6
+
+    // Partial merge: merge 2 most recent
+    let mut ds = ds;
+    ds.optimize_indices(&OptimizeOptions::merge(2))
+        .await
+        .unwrap();
+    let ds = DatasetBuilder::from_uri(test_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+
+    // Should now have 2 segments (original + merged)
+    let segments = ds.load_indices_by_name(&fts_name).await.unwrap();
+    assert_eq!(segments.len(), 2, "Expected 2 segments after merge(2)");
+
+    // Results should be the same
+    let results_2seg = fts_results_sorted(&ds, "hello").await;
+    assert_eq!(results_3seg.len(), results_2seg.len());
+}
+
+#[tokio::test]
+async fn test_fts_multi_segment_with_unindexed_data() {
+    let test_dir = TempStrDir::default();
+    let mut ds = make_fts_dataset_with_append(test_dir.as_str(), false).await;
+
+    // Create second segment
+    ds.optimize_indices(&OptimizeOptions::append())
+        .await
+        .unwrap();
+
+    // Append more data (stays unindexed)
+    let batch3 = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(Int32Array::from(vec![20, 21])) as ArrayRef),
+        (
+            "text",
+            Arc::new(StringArray::from(vec![
+                "hello unindexed",
+                "world unindexed",
+            ])) as ArrayRef,
+        ),
+    ])
+    .unwrap();
+    let append_params = WriteParams {
+        mode: WriteMode::Append,
+        ..Default::default()
+    };
+    InsertBuilder::new(test_dir.as_str())
+        .with_params(&append_params)
+        .execute(vec![batch3])
+        .await
+        .unwrap();
+    let ds = DatasetBuilder::from_uri(test_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+
+    // Query should include results from 2 segments + unindexed flat scan
+    let results = fts_results_sorted(&ds, "hello").await;
+    // Should find "hello" in indexed segments and in unindexed data
+    assert!(
+        results.iter().any(|(id, _)| *id == 20),
+        "Should find results in unindexed data"
+    );
+    assert!(
+        results.iter().any(|(id, _)| *id == 0),
+        "Should find results in first segment"
+    );
+    assert!(
+        results.iter().any(|(id, _)| *id == 10),
+        "Should find results in second segment"
+    );
+}
+
+#[tokio::test]
+async fn test_fts_multi_segment_phrase_query() {
+    let test_dir = TempStrDir::default();
+    let mut ds = make_fts_dataset_with_append(test_dir.as_str(), true).await;
+
+    // Create second segment (with positions)
+    ds.optimize_indices(&OptimizeOptions::append())
+        .await
+        .unwrap();
+    let ds = DatasetBuilder::from_uri(test_dir.as_str())
+        .load()
+        .await
+        .unwrap();
+
+    // Phrase query across 2 segments
+    let phrase_query =
+        PhraseQuery::new("hello world".to_string()).with_column(Some("text".to_string()));
+    let fts_query = FullTextSearchQuery::new_query(phrase_query.into());
+    let mut scanner = ds.scan();
+    scanner.full_text_search(fts_query).unwrap();
+    scanner
+        .order_by(Some(vec![ColumnOrdering::asc_nulls_first(
+            "id".to_string(),
+        )]))
+        .unwrap();
+    let batch = scanner.try_into_batch().await.unwrap();
+
+    // "hello world" appears at rows 0 and 9
+    let ids = batch
+        .column_by_name("id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let id_values: Vec<i32> = ids.values().to_vec();
+    assert!(
+        id_values.contains(&0),
+        "Should find 'hello world' in first segment"
+    );
+    assert!(
+        id_values.contains(&9),
+        "'hello world search' should match phrase 'hello world'"
+    );
 }


### PR DESCRIPTION
## Summary

- FTS indices now support multiple segments via `optimize_indices`, matching IVF_PQ vector index behavior
- `optimize_indices(append())` creates a new segment for unindexed data without rebuilding existing segments
- `optimize_indices(merge(N))` merges the N most recent segments into one
- All FTS query types (Match, Phrase, Boolean, Boost) search across all segments with unified cross-segment BM25 scoring (IDF reweighting), so multi-segment results are identical to single-segment

Previously, the scalar branch of `merge_indices` hardcoded `indices_merged = 1`, always merging everything into one index. Now it respects `OptimizeOptions::num_indices_to_merge`.

## Test plan

- [x] `test_fts_append_creates_separate_segment` — append creates 2 disjoint segments
- [x] `test_fts_multi_segment_score_equivalence` — identical BM25 scores for 6 queries across single vs multi-segment
- [x] `test_fts_merge_combines_segments` — merge(2) reduces 2→1 segment, results unchanged
- [x] `test_fts_three_segments_partial_merge` — 3 segments → merge(2) → 2 segments
- [x] `test_fts_multi_segment_with_unindexed_data` — 2 segments + unindexed flat scan
- [x] `test_fts_multi_segment_phrase_query` — phrase queries across segments
- [x] All existing inverted index tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)