### PR TITLE
feat(python): add target_partition_size param to train_ivf, deprecate num_partitions

### DIFF
--- a/python/python/lance/indices/builder.py
+++ b/python/python/lance/indices/builder.py
@@ -11,6 +11,7 @@ import pyarrow as pa
 
 from lance.indices.ivf import IvfModel
 from lance.indices.pq import PqModel
+from lance.util import _target_partition_size_to_num_partitions
 
 if TYPE_CHECKING:
     import torch
@@ -65,6 +66,7 @@ class IndicesBuilder:
         accelerator: Optional[Union[str, "torch.Device"]] = None,
         sample_rate: int = 256,
         max_iters: int = 50,
+        target_partition_size: Optional[int] = None,
     ) -> IvfModel:
         """
         Train IVF centroids for the given vector column.
@@ -83,7 +85,8 @@ class IndicesBuilder:
         Parameters
         ----------
 
-        num_partitions: int
+        num_partitions: int, optional
+            Deprecated. Use ``target_partition_size`` instead.
             The number of partitions to train.  Large values are more expensive to
             train and can lead to longer search times.  Smaller values could lead to
             overtraining, reduced recall, and require large nprobes values.  If not
@@ -105,9 +108,26 @@ class IndicesBuilder:
             some cases, k-means will not converge but will cycle between various
             possible minima.  In these cases we must terminate or run forever.  The
             max_iters parameter defines a cutoff at which we terminate training.
+        target_partition_size: int, optional
+            The target number of rows per partition.  If set, ``num_partitions`` will
+            be computed automatically as ``num_rows / target_partition_size`` (clamped
+            to [1, 4096]).  Mutually exclusive with ``num_partitions``.
         """
+        if num_partitions is not None and target_partition_size is not None:
+            raise ValueError(
+                "num_partitions and target_partition_size are mutually exclusive. "
+                "Please specify only one of them."
+            )
+        if num_partitions is not None:
+            warnings.warn(
+                "num_partitions is deprecated, use target_partition_size instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         num_rows = self.dataset.count_rows()
-        num_partitions = self._determine_num_partitions(num_partitions, num_rows)
+        num_partitions = self._determine_num_partitions(
+            num_partitions, num_rows, target_partition_size
+        )
         self._verify_ivf_sample_rate(sample_rate, num_partitions, num_rows)
         distance_type = self._normalize_distance_type(distance_type)
         self._verify_ivf_params(num_partitions)
@@ -205,13 +225,14 @@ class IndicesBuilder:
 
     def prepare_global_ivf_pq(
         self,
-        num_partitions: Optional[int],
-        num_subvectors: Optional[int],
+        num_partitions: Optional[int] = None,
+        num_subvectors: Optional[int] = None,
         *,
         distance_type: str = "l2",
         accelerator: Optional[Union[str, "torch.Device"]] = None,
         sample_rate: int = 256,
         max_iters: int = 50,
+        target_partition_size: Optional[int] = None,
     ) -> dict:
         """
         Perform global training for IVF+PQ using existing CPU training paths and
@@ -238,6 +259,7 @@ class IndicesBuilder:
             accelerator=accelerator,  # None by default (CPU path)
             sample_rate=sample_rate,
             max_iters=max_iters,
+            target_partition_size=target_partition_size,
         )
 
         # Global PQ training using IVF residuals
@@ -453,10 +475,19 @@ class IndicesBuilder:
         else:
             raise ValueError("filenames must be a list of strings")
 
-    def _determine_num_partitions(self, num_partitions: Optional[int], num_rows: int):
-        if num_partitions is None:
-            return round(math.sqrt(num_rows))
-        return num_partitions
+    def _determine_num_partitions(
+        self,
+        num_partitions: Optional[int],
+        num_rows: int,
+        target_partition_size: Optional[int] = None,
+    ):
+        if num_partitions is not None:
+            return num_partitions
+        if target_partition_size is not None:
+            return _target_partition_size_to_num_partitions(
+                num_rows, target_partition_size
+            )
+        return round(math.sqrt(num_rows))
 
     def _normalize_pq_params(self, num_subvectors: int, dimension: int):
         if num_subvectors is None:

--- a/python/python/lance/util.py
+++ b/python/python/lance/util.py
@@ -253,5 +253,11 @@ def _target_partition_size_to_num_partitions(
 ) -> int:
     if target_partition_size is None:
         target_partition_size = 8192
+    if target_partition_size <= 0:
+        raise ValueError(
+            "target_partition_size must be a positive integer, "
+            f"got {target_partition_size}"
+        )
+    MAX_PARTITIONS = 4096
     num_partitions = num_rows // target_partition_size
-    return max(1, num_partitions, 4096)
+    return max(1, min(num_partitions, MAX_PARTITIONS))

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -126,10 +126,61 @@ def test_ivf_centroids_distance_type(tmpdir, rand_dataset):
 
 
 def test_num_partitions(rand_dataset):
-    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
-        sample_rate=16, num_partitions=10
-    )
+    with pytest.warns(DeprecationWarning, match="num_partitions is deprecated"):
+        ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
+            sample_rate=16, num_partitions=10
+        )
     assert ivf.num_partitions == 10
+
+
+def test_target_partition_size(rand_dataset):
+    # NUM_ROWS=30000, target_partition_size=10000 => 30000//10000 = 3 partitions
+    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
+        sample_rate=16, target_partition_size=10000
+    )
+    assert ivf.num_partitions == 3
+
+
+def test_target_partition_size_and_num_partitions_mutually_exclusive(rand_dataset):
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        IndicesBuilder(rand_dataset, "vectors").train_ivf(
+            sample_rate=16, num_partitions=10, target_partition_size=1000
+        )
+
+
+def test_target_partition_size_zero_raises(rand_dataset):
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        IndicesBuilder(rand_dataset, "vectors").train_ivf(
+            sample_rate=16, target_partition_size=0
+        )
+
+
+def test_target_partition_size_negative_raises(rand_dataset):
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        IndicesBuilder(rand_dataset, "vectors").train_ivf(
+            sample_rate=16, target_partition_size=-1
+        )
+
+
+def test_num_partitions_deprecation_warning(rand_dataset):
+    with pytest.warns(DeprecationWarning, match="num_partitions is deprecated"):
+        IndicesBuilder(rand_dataset, "vectors").train_ivf(
+            sample_rate=16, num_partitions=10
+        )
+
+
+def test_target_partition_size_clamp_upper(rand_dataset):
+    # target_partition_size=1 => 30000//1 = 30000, clamped to 4096
+    builder = IndicesBuilder(rand_dataset, "vectors")
+    num_partitions = builder._determine_num_partitions(None, 30000, 1)
+    assert num_partitions == 4096
+
+
+def test_target_partition_size_clamp_lower(rand_dataset):
+    # target_partition_size larger than num_rows => 30000//100000 = 0, clamped to 1
+    builder = IndicesBuilder(rand_dataset, "vectors")
+    num_partitions = builder._determine_num_partitions(None, 30000, 100000)
+    assert num_partitions == 1
 
 
 @pytest.fixture

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -2259,12 +2259,15 @@ def assert_distributed_vector_consistency(
     safe_sr_pq = num_rows // 256
     safe_sr = max(2, min(safe_sr_ivf, safe_sr_pq))
 
+    # Convert num_partitions to target_partition_size (num_partitions is deprecated)
+    tps = num_rows // nparts if nparts else None
+
     if index_type in {"IVF_PQ", "IVF_HNSW_PQ"}:
         preprocessed = builder.prepare_global_ivf_pq(
-            nparts,
-            nsub,
+            num_subvectors=nsub,
             distance_type=dist_type,
             sample_rate=safe_sr,
+            target_partition_size=tps,
         )
     elif (
         ("IVF_FLAT" in index_type)
@@ -2272,9 +2275,9 @@ def assert_distributed_vector_consistency(
         or ("IVF_HNSW_FLAT" in index_type)
     ):
         ivf_model = builder.train_ivf(
-            nparts,
             distance_type=dist_type,
             sample_rate=safe_sr,
+            target_partition_size=tps,
         )
         preprocessed = {"ivf_centroids": ivf_model.centroids}
 
@@ -2393,11 +2396,11 @@ def test_prepared_global_ivfpq_distributed_merge_and_search(tmp_path: Path):
     # Global preparation
     builder = IndicesBuilder(ds, "vector")
     preprocessed = builder.prepare_global_ivf_pq(
-        num_partitions=4,
         num_subvectors=4,
         distance_type="l2",
         sample_rate=3,
         max_iters=20,
+        target_partition_size=500,
     )
 
     # Distributed build using prepared centroids/codebook
@@ -2423,11 +2426,11 @@ def test_consistency_improves_with_preprocessed_centroids(tmp_path: Path):
 
     builder = IndicesBuilder(ds, "vector")
     pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
         num_subvectors=16,
         distance_type="l2",
         sample_rate=7,
         max_iters=20,
+        target_partition_size=500,
     )
 
     # Build single-machine index as ground truth target index
@@ -2488,11 +2491,11 @@ def test_metadata_merge_pq_success(tmp_path):
     node2 = [f.fragment_id for f in frags[mid:]]
     builder = IndicesBuilder(ds, "vector")
     pre = builder.prepare_global_ivf_pq(
-        num_partitions=8,
         num_subvectors=16,
         distance_type="l2",
         sample_rate=7,
         max_iters=20,
+        target_partition_size=250,
     )
     try:
         segments = _build_segments(
@@ -2527,11 +2530,11 @@ def test_distributed_workflow_merge_and_search(tmp_path):
     node2 = [f.fragment_id for f in frags[mid:]]
     builder = IndicesBuilder(ds, "vector")
     pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
         num_subvectors=4,
         distance_type="l2",
         sample_rate=7,
         max_iters=20,
+        target_partition_size=500,
     )
     try:
         segments = _build_segments(
@@ -2563,11 +2566,11 @@ def test_vector_merge_two_shards_success_flat(tmp_path):
     # Global preparation
     builder = IndicesBuilder(ds, "vector")
     preprocessed = builder.prepare_global_ivf_pq(
-        num_partitions=4,
         num_subvectors=4,
         distance_type="l2",
         sample_rate=3,
         max_iters=20,
+        target_partition_size=250,
     )
 
     segments = _build_segments(
@@ -2604,11 +2607,11 @@ def test_distributed_ivf_parameterized(tmp_path, index_type, num_sub_vectors):
     node2 = [f.fragment_id for f in frags[mid:]]
     builder = IndicesBuilder(ds, "vector")
     pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
         num_subvectors=num_sub_vectors,
         distance_type="l2",
         sample_rate=7,
         max_iters=20,
+        target_partition_size=500,
     )
 
     try:
@@ -2659,11 +2662,11 @@ def test_merge_two_shards_parameterized(tmp_path, index_type, num_sub_vectors):
     shard2 = [frags[1].fragment_id]
     builder = IndicesBuilder(ds, "vector")
     pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
         num_subvectors=num_sub_vectors,
         distance_type="l2",
         sample_rate=7,
         max_iters=20,
+        target_partition_size=500,
     )
 
     base_kwargs = {
@@ -2713,11 +2716,11 @@ def test_index_segment_builder_builds_vector_segments(tmp_path):
     assert len(frags) >= 2
     builder = IndicesBuilder(ds, "vector")
     preprocessed = builder.prepare_global_ivf_pq(
-        num_partitions=4,
         num_subvectors=4,
         distance_type="l2",
         sample_rate=7,
         max_iters=20,
+        target_partition_size=500,
     )
 
     segments = [
@@ -2756,10 +2759,10 @@ def test_distributed_ivf_pq_order_invariance(tmp_path: Path):
     # Global IVF+PQ training once; artifacts are reused across shard orders.
     builder = IndicesBuilder(ds, "vector")
     pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
         num_subvectors=16,
         distance_type="l2",
         sample_rate=7,
+        target_partition_size=500,
     )
 
     # Copy the dataset twice so index manifests do not clash and we can vary


### PR DESCRIPTION
close #6286 
- Add `target_partition_size` as the preferred way to specify IVF partitioning,
  consistent with the Rust `recommended_num_partitions` logic (clamped to [1, 4096]).
- Mark `num_partitions` as deprecated with a DeprecationWarning.
- Propagate the new param through `prepare_global_ivf_pq`.
- Make `num_partitions` and `target_partition_size` mutually exclusive.