### PR TITLE
feat: add storage_options to BasePath

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -70,11 +70,21 @@ impl FromJObjectWithEnv<BasePath> for JObject<'_> {
         let name = env.get_optional_string_from_method(self, "getName")?;
         let path = env.get_string_from_method(self, "getPath")?;
         let is_dataset_root = env.get_boolean_from_method(self, "isDatasetRoot")?;
+        let storage_options_obj = env
+            .call_method(self, "getStorageOptions", "()Ljava/util/Map;", &[])?
+            .l()?;
+        let storage_options = if storage_options_obj.is_null() {
+            HashMap::new()
+        } else {
+            let map = JMap::from_env(env, &storage_options_obj)?;
+            to_rust_map(env, &map)?
+        };
         Ok(BasePath {
             id,
             name,
             path,
             is_dataset_root,
+            storage_options,
         })
     }
 }

--- a/java/src/main/java/org/lance/BasePath.java
+++ b/java/src/main/java/org/lance/BasePath.java
@@ -15,6 +15,9 @@ package org.lance;
 
 import com.google.common.base.MoreObjects;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 public final class BasePath {
@@ -22,12 +25,23 @@ public final class BasePath {
   private final Optional<String> name;
   private final String path;
   private final boolean isDatasetRoot;
+  private final Map<String, String> storageOptions;
 
   public BasePath(int id, Optional<String> name, String path, boolean isDatasetRoot) {
+    this(id, name, path, isDatasetRoot, Collections.emptyMap());
+  }
+
+  public BasePath(
+      int id,
+      Optional<String> name,
+      String path,
+      boolean isDatasetRoot,
+      Map<String, String> storageOptions) {
     this.id = id;
     this.name = name;
     this.path = path;
     this.isDatasetRoot = isDatasetRoot;
+    this.storageOptions = Collections.unmodifiableMap(new HashMap<>(storageOptions));
   }
 
   public int getId() {
@@ -46,6 +60,10 @@ public final class BasePath {
     return isDatasetRoot;
   }
 
+  public Map<String, String> getStorageOptions() {
+    return storageOptions;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -53,6 +71,7 @@ public final class BasePath {
         .add("name", name)
         .add("path", path)
         .add("isDatasetRoot", isDatasetRoot)
+        .add("storageOptions", storageOptions)
         .toString();
   }
 }

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -219,6 +219,10 @@ message BasePath {
   bool is_dataset_root = 3;
   // Note: This absolute path will be directly used by Path:parse(),
   string path = 4;
+  // Storage options relevant to identifying the base path. For example, azure_storage_account_name
+  // goes here. Credentials and options which don't affect the identity of the data being stored
+  // should not be placed here.
+  map<string, string> storage_options = 5;
 }
 
 // Auxiliary Data attached to a version.

--- a/python/python/tests/test_multi_base.py
+++ b/python/python/tests/test_multi_base.py
@@ -347,6 +347,32 @@ class TestMultiBase:
         result = dataset.to_table().to_pandas()
         assert len(result) == 100
 
+    def test_multi_base_storage_options_roundtrip(self):
+        """Test storage_options on DatasetBasePath are preserved in the manifest."""
+        initial_data = self.create_test_data(20)
+
+        dataset = lance.write_dataset(
+            initial_data,
+            self.primary_uri,
+            mode="create",
+            initial_bases=[
+                DatasetBasePath(
+                    self.path1_uri,
+                    name="path1",
+                    storage_options={"azure_storage_account_name": "account1"},
+                ),
+                DatasetBasePath(self.path2_uri, name="path2"),
+            ],
+            target_bases=["path1"],
+            max_rows_per_file=10,
+        )
+
+        base_paths = dataset._ds.base_paths()
+        path1_base = next(bp for bp in base_paths.values() if bp.name == "path1")
+        assert path1_base.storage_options == {
+            "azure_storage_account_name": "account1"
+        }
+
     def test_multi_base_target_by_path_uri(self):
         """Test using path URIs instead of names in target_bases."""
         # Create initial dataset with named bases

--- a/python/python/tests/test_multi_base.py
+++ b/python/python/tests/test_multi_base.py
@@ -369,9 +369,7 @@ class TestMultiBase:
 
         base_paths = dataset._ds.base_paths()
         path1_base = next(bp for bp in base_paths.values() if bp.name == "path1")
-        assert path1_base.storage_options == {
-            "azure_storage_account_name": "account1"
-        }
+        assert path1_base.storage_options == {"azure_storage_account_name": "account1"}
 
     def test_multi_base_target_by_path_uri(self):
         """Test using path URIs instead of names in target_bases."""

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -495,25 +495,34 @@ pub struct DatasetBasePath {
     pub path: String,
     #[pyo3(get)]
     pub is_dataset_root: bool,
+    #[pyo3(get)]
+    pub storage_options: HashMap<String, String>,
 }
 
 #[pymethods]
 impl DatasetBasePath {
     #[new]
-    #[pyo3(signature = (path, name = None, is_dataset_root = false, id = None))]
-    fn new(path: String, name: Option<String>, is_dataset_root: bool, id: Option<u32>) -> Self {
+    #[pyo3(signature = (path, name = None, is_dataset_root = false, id = None, storage_options = None))]
+    fn new(
+        path: String,
+        name: Option<String>,
+        is_dataset_root: bool,
+        id: Option<u32>,
+        storage_options: Option<HashMap<String, String>>,
+    ) -> Self {
         Self {
             id: id.unwrap_or(0),
             name,
             path,
             is_dataset_root,
+            storage_options: storage_options.unwrap_or_default(),
         }
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "DatasetBasePath(id={}, name={:?}, path={}, is_dataset_root={})",
-            self.id, self.name, self.path, self.is_dataset_root
+            "DatasetBasePath(id={}, name={:?}, path={}, is_dataset_root={}, storage_options={:?})",
+            self.id, self.name, self.path, self.is_dataset_root, self.storage_options
         )
     }
 }
@@ -525,6 +534,7 @@ impl From<BasePath> for DatasetBasePath {
             name: base_path.name,
             path: base_path.path,
             is_dataset_root: base_path.is_dataset_root,
+            storage_options: base_path.storage_options,
         }
     }
 }
@@ -537,6 +547,7 @@ impl From<DatasetBasePath> for BasePath {
             py_base_path.name,
             py_base_path.is_dataset_root,
         )
+        .with_storage_options(py_base_path.storage_options)
     }
 }
 

--- a/rust/lance-io/src/object_store/storage_options.rs
+++ b/rust/lance-io/src/object_store/storage_options.rs
@@ -218,7 +218,7 @@ impl StorageOptionsAccessor {
             initial_options: new_initial_options,
             provider: self.provider.clone(),
             cache: Arc::new(RwLock::new(None)),
-            refresh_offset: self.refresh_offset.clone(),
+            refresh_offset: self.refresh_offset,
         }
     }
 

--- a/rust/lance-io/src/object_store/storage_options.rs
+++ b/rust/lance-io/src/object_store/storage_options.rs
@@ -192,6 +192,17 @@ impl fmt::Debug for StorageOptionsAccessor {
     }
 }
 
+impl Default for StorageOptionsAccessor {
+    fn default() -> Self {
+        Self {
+            initial_options: None,
+            provider: None,
+            cache: Arc::new(RwLock::new(None)),
+            refresh_offset: Duration::from_millis(DEFAULT_REFRESH_OFFSET_MILLIS),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct CachedStorageOptions {
     options: HashMap<String, String>,
@@ -199,6 +210,18 @@ struct CachedStorageOptions {
 }
 
 impl StorageOptionsAccessor {
+    pub fn clone_with_new_initial_options(
+        &self,
+        new_initial_options: Option<HashMap<String, String>>,
+    ) -> Self {
+        Self {
+            initial_options: new_initial_options,
+            provider: self.provider.clone(),
+            cache: self.cache.clone(),
+            refresh_offset: self.refresh_offset.clone(),
+        }
+    }
+
     /// Extract refresh offset from storage options, or use default
     fn extract_refresh_offset(options: &HashMap<String, String>) -> Duration {
         options

--- a/rust/lance-io/src/object_store/storage_options.rs
+++ b/rust/lance-io/src/object_store/storage_options.rs
@@ -217,7 +217,7 @@ impl StorageOptionsAccessor {
         Self {
             initial_options: new_initial_options,
             provider: self.provider.clone(),
-            cache: self.cache.clone(),
+            cache: Arc::new(RwLock::new(None)),
             refresh_offset: self.refresh_offset.clone(),
         }
     }

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -12,6 +12,7 @@ use object_store::path::Path;
 use prost::Message;
 use prost_types::Timestamp;
 use std::collections::{BTreeMap, HashMap};
+use std::mem::size_of;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -558,6 +559,8 @@ pub struct BasePath {
     pub is_dataset_root: bool,
     /// The full URI string (e.g., "s3://bucket/path")
     pub path: String,
+    /// Storage options that are part of this base path's identity.
+    pub storage_options: HashMap<String, String>,
 }
 
 impl BasePath {
@@ -575,7 +578,22 @@ impl BasePath {
             name,
             is_dataset_root,
             path,
+            storage_options: HashMap::new(),
         }
+    }
+
+    /// Return a copy of this base path with identity-defining storage options attached.
+    pub fn with_storage_options(mut self, storage_options: HashMap<String, String>) -> Self {
+        self.storage_options = storage_options;
+        self
+    }
+
+    /// Returns true when both base paths refer to the same underlying storage location.
+    ///
+    /// The path alone is not always sufficient to identify a store. Some providers also
+    /// require storage options such as an account name.
+    pub fn matches_identity(&self, other: &Self) -> bool {
+        self.path == other.path && self.storage_options == other.storage_options
     }
 
     /// Extract the object store path from this BasePath's URI.
@@ -590,6 +608,7 @@ impl DeepSizeOf for BasePath {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
         self.name.deep_size_of_children(context)
             + self.path.deep_size_of_children(context) * 2
+            + self.storage_options.deep_size_of_children(context)
             + size_of::<bool>()
     }
 }
@@ -824,7 +843,7 @@ impl ProtoStruct for Manifest {
 
 impl From<pb::BasePath> for BasePath {
     fn from(p: pb::BasePath) -> Self {
-        Self::new(p.id, p.path, p.name, p.is_dataset_root)
+        Self::new(p.id, p.path, p.name, p.is_dataset_root).with_storage_options(p.storage_options)
     }
 }
 
@@ -835,6 +854,7 @@ impl From<BasePath> for pb::BasePath {
             name: p.name,
             is_dataset_root: p.is_dataset_root,
             path: p.path,
+            storage_options: p.storage_options,
         }
     }
 }
@@ -989,6 +1009,7 @@ impl From<&Manifest> for pb::Manifest {
                     name: base_path.name.clone(),
                     is_dataset_root: base_path.is_dataset_root,
                     path: base_path.path.clone(),
+                    storage_options: base_path.storage_options.clone(),
                 })
                 .collect(),
             transaction_section: m.transaction_section.map(|i| i as u64),

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -93,6 +93,7 @@ use self::fragment::FileFragment;
 use self::refs::Refs;
 use self::scanner::{DatasetRecordBatchStream, Scanner};
 use self::transaction::{Operation, Transaction, TransactionBuilder, UpdateMapEntry};
+use self::utils::object_store_params_for_base_path;
 use self::write::write_fragments_internal;
 use crate::dataset::branch_location::BranchLocation;
 use crate::dataset::cleanup::{CleanupPolicy, CleanupPolicyBuilder};
@@ -1676,14 +1677,14 @@ impl Dataset {
         let base_path = self.manifest.base_paths.get(&base_id).ok_or_else(|| {
             Error::invalid_input(format!("Dataset base path with ID {} not found", base_id))
         })?;
-
+        let store_params =
+            object_store_params_for_base_path(base_path, self.store_params.as_deref());
         let (store, _) = ObjectStore::from_uri_and_params(
             self.session.store_registry(),
             &base_path.path,
-            &self.store_params.as_deref().cloned().unwrap_or_default(),
+            store_params.as_ref(),
         )
         .await?;
-
         Ok(store)
     }
 

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -1352,6 +1352,7 @@ mod tests {
                         name: Some("blob_base".to_string()),
                         path: base_uri,
                         is_dataset_root,
+                        storage_options: Default::default(),
                     }]),
                     target_bases: Some(vec![1]),
                     ..Default::default()
@@ -1894,6 +1895,7 @@ mod tests {
                         name: Some("external".to_string()),
                         path: base_uri,
                         is_dataset_root: false,
+                        storage_options: Default::default(),
                     }]),
                     ..Default::default()
                 }),

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2228,14 +2228,17 @@ impl Transaction {
             // Validate and add new base paths to the manifest
             for new_base in new_bases {
                 // Check for conflicts with existing base paths
-                if let Some(existing_base) = manifest
-                    .base_paths
-                    .values()
-                    .find(|bp| bp.name == new_base.name || bp.path == new_base.path)
-                {
+                if let Some(existing_base) = manifest.base_paths.values().find(|bp| {
+                    (bp.name == new_base.name && bp.name.is_some()) || bp.matches_identity(new_base)
+                }) {
                     return Err(Error::invalid_input(format!(
-                        "Conflict detected: Base path with name '{:?}' or path '{}' already exists. Existing: name='{:?}', path='{}'",
-                        new_base.name, new_base.path, existing_base.name, existing_base.path
+                        "Conflict detected: base path already exists. New base: name='{:?}', path='{}', storage_options={:?}. Existing base: name='{:?}', path='{}', storage_options={:?}",
+                        new_base.name,
+                        new_base.path,
+                        new_base.storage_options,
+                        existing_base.name,
+                        existing_base.path,
+                        existing_base.storage_options
                     )));
                 }
 

--- a/rust/lance/src/dataset/utils.rs
+++ b/rust/lance/src/dataset/utils.rs
@@ -297,3 +297,71 @@ pub fn object_store_params_for_base_path<'a>(
     ));
     Cow::Owned(output_params)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::object_store_params_for_base_path;
+    use lance_io::object_store::{ObjectStoreParams, StorageOptionsAccessor};
+    use lance_table::format::BasePath;
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_object_store_params_for_base_path_borrows_without_base_storage_options() {
+        let input_params = ObjectStoreParams {
+            block_size: Some(1024),
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([("azure_storage_account_name".to_string(), "my-storage-account".to_string())]),
+            ))),
+            ..Default::default()
+        };
+        let base_path = BasePath::new(7, "az://container/path".to_string(), None, false);
+
+        let output_params = object_store_params_for_base_path(&base_path, Some(&input_params));
+
+        match output_params {
+            Cow::Borrowed(params) => assert_eq!(params, &input_params),
+            Cow::Owned(_) => panic!("expected borrowed params when base storage options are empty"),
+        }
+    }
+
+    #[test]
+    fn test_object_store_params_for_base_path_merges_base_specific_storage_options() {
+        let input_params = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([
+                    ("base1.azure_storage_account_key".to_string(), "mykey1".to_string()),
+                    ("base7.azure_storage_account_key".to_string(), "mykey7".to_string()),
+                ]),
+            ))),
+            ..Default::default()
+        };
+        let base_path = BasePath::new(7, "az://container/path".to_string(), None, false)
+            .with_storage_options(HashMap::from([
+                ("azure_storage_account_name".to_string(), "myaccount7".to_string()),
+            ]));
+
+        let output_params = object_store_params_for_base_path(&base_path, Some(&input_params));
+
+        let Cow::Owned(output_params) = output_params else {
+            panic!("expected owned params when storage options must be merged");
+        };
+        let storage_options = output_params
+            .storage_options()
+            .expect("merged params should contain storage options");
+        assert_eq!(
+            storage_options.get("base1.azure_storage_account_key"),
+            Some(&"mykey1".to_string())
+        );
+        assert_eq!(
+            storage_options.get("azure_storage_account_key"),
+            Some(&"mykey7".to_string())
+        );
+        assert_eq!(
+            storage_options.get("azure_storage_account_name"),
+            Some(&"myaccount7".to_string())
+        );
+        assert_eq!(3, storage_options.len());
+    }
+}

--- a/rust/lance/src/dataset/utils.rs
+++ b/rust/lance/src/dataset/utils.rs
@@ -267,7 +267,7 @@ impl SchemaAdapter {
     }
 }
 
-pub(crate) fn object_store_params_for_base_path<'a>(
+pub fn object_store_params_for_base_path<'a>(
     base_path: &BasePath,
     input_params: Option<&'a ObjectStoreParams>,
 ) -> Cow<'a, ObjectStoreParams> {

--- a/rust/lance/src/dataset/utils.rs
+++ b/rust/lance/src/dataset/utils.rs
@@ -13,6 +13,8 @@ use lance_arrow::json::{
     is_arrow_json_field, is_json_field,
 };
 use lance_core::ROW_ID;
+use lance_io::object_store::ObjectStoreParams;
+use lance_table::format::BasePath;
 use lance_table::rowids::{RowIdIndex, RowIdSequence};
 use roaring::RoaringTreemap;
 use std::borrow::Cow;
@@ -263,4 +265,30 @@ impl SchemaAdapter {
             converted_stream,
         ))
     }
+}
+
+pub(crate) fn object_store_params_for_base_path<'a>(
+    base_path: &BasePath,
+    input_params: Option<&'a ObjectStoreParams>,
+) -> Cow<'a, ObjectStoreParams> {
+    if let Some(params) = input_params
+        && base_path.storage_options.is_empty()
+    {
+        return Cow::Borrowed(params);
+    }
+    let mut merged_storage_options = base_path.storage_options.clone();
+    let mut output_params = match input_params {
+        None => ObjectStoreParams::default(),
+        Some(params) => params.clone(),
+    };
+    if let Some(params_storage_options) = output_params.storage_options() {
+        for (k, v) in params_storage_options {
+            merged_storage_options.insert(k.into(), v.into());
+        }
+    }
+    let input_accessor = output_params.storage_options_accessor.unwrap_or_default();
+    output_params.storage_options_accessor = Some(Arc::new(
+        input_accessor.clone_with_new_initial_options(Some(merged_storage_options)),
+    ));
+    Cow::Owned(output_params)
 }

--- a/rust/lance/src/dataset/utils.rs
+++ b/rust/lance/src/dataset/utils.rs
@@ -312,7 +312,10 @@ mod tests {
         let input_params = ObjectStoreParams {
             block_size: Some(1024),
             storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
-                HashMap::from([("azure_storage_account_name".to_string(), "my-storage-account".to_string())]),
+                HashMap::from([(
+                    "azure_storage_account_name".to_string(),
+                    "my-storage-account".to_string(),
+                )]),
             ))),
             ..Default::default()
         };
@@ -331,16 +334,23 @@ mod tests {
         let input_params = ObjectStoreParams {
             storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
                 HashMap::from([
-                    ("base1.azure_storage_account_key".to_string(), "mykey1".to_string()),
-                    ("base7.azure_storage_account_key".to_string(), "mykey7".to_string()),
+                    (
+                        "base1.azure_storage_account_key".to_string(),
+                        "mykey1".to_string(),
+                    ),
+                    (
+                        "base7.azure_storage_account_key".to_string(),
+                        "mykey7".to_string(),
+                    ),
                 ]),
             ))),
             ..Default::default()
         };
         let base_path = BasePath::new(7, "az://container/path".to_string(), None, false)
-            .with_storage_options(HashMap::from([
-                ("azure_storage_account_name".to_string(), "myaccount7".to_string()),
-            ]));
+            .with_storage_options(HashMap::from([(
+                "azure_storage_account_name".to_string(),
+                "myaccount7".to_string(),
+            )]));
 
         let output_params = object_store_params_for_base_path(&base_path, Some(&input_params));
 

--- a/rust/lance/src/dataset/utils.rs
+++ b/rust/lance/src/dataset/utils.rs
@@ -281,9 +281,14 @@ pub fn object_store_params_for_base_path<'a>(
         None => ObjectStoreParams::default(),
         Some(params) => params.clone(),
     };
+    let base_path_prefix = format!("base{}.", base_path.id);
     if let Some(params_storage_options) = output_params.storage_options() {
         for (k, v) in params_storage_options {
-            merged_storage_options.insert(k.into(), v.into());
+            if let Some(stripped) = k.strip_prefix(&base_path_prefix) {
+                merged_storage_options.insert(stripped.into(), v.into());
+            } else {
+                merged_storage_options.insert(k.into(), v.into());
+            }
         }
     }
     let input_accessor = output_params.storage_options_accessor.unwrap_or_default();

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -43,7 +43,7 @@ use super::DATA_DIR;
 use super::fragment::write::generate_random_filename;
 use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
 use super::transaction::Transaction;
-use super::utils::SchemaAdapter;
+use super::utils::{SchemaAdapter, object_store_params_for_base_path};
 
 mod commit;
 pub mod delete;
@@ -508,19 +508,29 @@ pub async fn validate_and_resolve_target_bases(
         let mut resolved_ids = Vec::new();
         for reference in names_or_paths {
             let ref_str = reference.as_str();
-            let id = all_bases
+            let matching_ids = all_bases
                 .iter()
-                .find(|(_, base)| {
+                .filter(|(_, base)| {
                     base.name.as_ref().map(|n| n == ref_str).unwrap_or(false)
                         || base.path == ref_str
                 })
                 .map(|(&id, _)| id)
-                .ok_or_else(|| {
-                    Error::invalid_input(format!(
+                .collect::<Vec<_>>();
+            let id = match matching_ids.as_slice() {
+                [] => {
+                    return Err(Error::invalid_input(format!(
                         "Base reference '{}' not found in available bases",
                         ref_str
-                    ))
-                })?;
+                    )));
+                }
+                [id] => *id,
+                _ => {
+                    return Err(Error::invalid_input(format!(
+                        "Base reference '{}' is ambiguous across multiple base paths. Use a unique base name or base ID instead.",
+                        ref_str
+                    )));
+                }
+            };
 
             resolved_ids.push(id);
         }
@@ -547,11 +557,13 @@ pub async fn validate_and_resolve_target_bases(
                     target_base_id
                 ))
             })?;
+            let base_store_params =
+                object_store_params_for_base_path(base_path, Some(&store_params));
 
             let (target_object_store, extracted_path) = ObjectStore::from_uri_and_params(
                 store_registry.clone(),
                 &base_path.path,
-                &store_params,
+                &base_store_params,
             )
             .await?;
 
@@ -597,10 +609,12 @@ async fn append_external_initial_bases(
 ) -> Result<()> {
     if let Some(initial_bases) = initial_bases {
         for base_path in initial_bases {
+            let base_store_params =
+                object_store_params_for_base_path(base_path, Some(store_params));
             let (store, extracted_path) = ObjectStore::from_uri_and_params(
                 store_registry.clone(),
                 &base_path.path,
-                store_params,
+                &base_store_params,
             )
             .await?;
             append_external_base_candidate(
@@ -629,10 +643,12 @@ async fn build_external_base_resolver(
 
     if let Some(dataset) = dataset {
         for base_path in dataset.manifest.base_paths.values() {
+            let base_store_params =
+                object_store_params_for_base_path(base_path, Some(&store_params));
             let (store, extracted_path) = ObjectStore::from_uri_and_params(
                 store_registry.clone(),
                 &base_path.path,
-                &store_params,
+                &base_store_params,
             )
             .await?;
             append_external_base_candidate(
@@ -1871,24 +1887,28 @@ mod tests {
                     name: Some("bucket1".to_string()),
                     path: "s3://bucket1/path1".to_string(),
                     is_dataset_root: true,
+                    storage_options: Default::default(),
                 },
                 BasePath {
                     id: 2,
                     name: Some("bucket2".to_string()),
                     path: "s3://bucket2/path2".to_string(),
                     is_dataset_root: true,
+                    storage_options: Default::default(),
                 },
                 BasePath {
                     id: 3,
                     name: Some("azure-az-base".to_string()),
                     path: "az://container/path1".to_string(),
                     is_dataset_root: true,
+                    storage_options: Default::default(),
                 },
                 BasePath {
                     id: 4,
                     name: Some("azure-abfss-base".to_string()),
                     path: "abfss://filesystem@account.dfs.core.windows.net/path1".to_string(),
                     is_dataset_root: true,
+                    storage_options: Default::default(),
                 },
             ]),
             target_bases: Some(vec![1]), // Use ID 1 which corresponds to bucket1
@@ -1963,12 +1983,17 @@ mod tests {
                         name: Some("base1".to_string()),
                         path: base1_uri.clone(),
                         is_dataset_root: true,
+                        storage_options: HashMap::from([(
+                            "azure_storage_account_name".to_string(),
+                            "account1".to_string(),
+                        )]),
                     },
                     BasePath {
                         id: 2,
                         name: Some("base2".to_string()),
                         path: base2_uri.clone(),
                         is_dataset_root: true,
+                        storage_options: Default::default(),
                     },
                 ]),
                 target_bases: Some(vec![1]),
@@ -1996,6 +2021,16 @@ mod tests {
                 .base_paths
                 .values()
                 .any(|bp| bp.name == Some("base2".to_string()))
+        );
+        let base1 = dataset
+            .manifest
+            .base_paths
+            .values()
+            .find(|bp| bp.name == Some("base1".to_string()))
+            .expect("base1 should be registered in manifest");
+        assert_eq!(
+            base1.storage_options.get("azure_storage_account_name"),
+            Some(&"account1".to_string())
         );
 
         // Verify data was written to base1
@@ -2025,6 +2060,7 @@ mod tests {
                     name: Some("base1".to_string()),
                     path: base1_uri.clone(),
                     is_dataset_root: true,
+                    storage_options: Default::default(),
                 }]),
                 target_bases: Some(vec![1]),
                 target_base_names_or_paths: Some(vec!["base1".to_string()]),
@@ -2067,12 +2103,14 @@ mod tests {
                         name: Some("base1".to_string()),
                         path: base1_uri.clone(),
                         is_dataset_root: true,
+                        storage_options: Default::default(),
                     },
                     BasePath {
                         id: 2,
                         name: Some("base2".to_string()),
                         path: base2_uri.clone(),
                         is_dataset_root: true,
+                        storage_options: Default::default(),
                     },
                 ]),
                 target_bases: Some(vec![1]),
@@ -2144,6 +2182,7 @@ mod tests {
                     name: Some("base3".to_string()),
                     path: _base3_uri.clone(),
                     is_dataset_root: true,
+                    storage_options: Default::default(),
                 }]),
                 target_bases: Some(vec![1]),
                 ..Default::default()
@@ -2184,12 +2223,14 @@ mod tests {
                         name: Some("base1".to_string()),
                         path: base1_uri.clone(),
                         is_dataset_root: true,
+                        storage_options: Default::default(),
                     },
                     BasePath {
                         id: 2,
                         name: Some("base2".to_string()),
                         path: base2_uri.clone(),
                         is_dataset_root: true,
+                        storage_options: Default::default(),
                     },
                 ]),
                 target_bases: Some(vec![1]),
@@ -2267,6 +2308,7 @@ mod tests {
                     name: Some("base3".to_string()),
                     path: base3_uri,
                     is_dataset_root: true,
+                    storage_options: Default::default(),
                 }]),
                 target_bases: Some(vec![1]),
                 ..Default::default()
@@ -2315,12 +2357,14 @@ mod tests {
                         name: Some("base1".to_string()),
                         path: base1_uri.clone(),
                         is_dataset_root: true, // Files will go to base1/data/
+                        storage_options: Default::default(),
                     },
                     BasePath {
                         id: 2,
                         name: Some("base2".to_string()),
                         path: base2_uri.clone(),
                         is_dataset_root: false, // Files will go directly to base2/
+                        storage_options: Default::default(),
                     },
                 ]),
                 target_bases: Some(vec![1, 2]), // Write to both bases
@@ -2460,12 +2504,14 @@ mod tests {
                         name: Some("base1".to_string()),
                         path: base1_uri.clone(),
                         is_dataset_root: true,
+                        storage_options: Default::default(),
                     },
                     BasePath {
                         id: 2,
                         name: Some("base2".to_string()),
                         path: base2_uri.clone(),
                         is_dataset_root: true,
+                        storage_options: Default::default(),
                     },
                 ]),
                 target_base_names_or_paths: Some(vec!["base1".to_string()]), // Use name

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1221,8 +1221,8 @@ impl<'a> TransactionRebase<'a> {
                                 return Err(self
                                     .incompatible_conflict_err(other_transaction, other_version));
                             }
-                            // Check for path conflicts
-                            if new_base.path == committed_base.path {
+                            // Check for storage identity conflicts
+                            if new_base.matches_identity(committed_base) {
                                 return Err(self
                                     .incompatible_conflict_err(other_transaction, other_version));
                             }
@@ -2774,6 +2774,7 @@ mod tests {
                     path: "s3://bucket1/path1".to_string(),
                     name: Some("base1".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -2786,6 +2787,7 @@ mod tests {
                     path: "s3://bucket2/path2".to_string(),
                     name: Some("base2".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -2810,6 +2812,7 @@ mod tests {
                     path: "s3://bucket1/path1".to_string(),
                     name: Some("duplicate_name".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -2822,6 +2825,7 @@ mod tests {
                     path: "s3://bucket2/path2".to_string(),
                     name: Some("duplicate_name".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -2851,6 +2855,7 @@ mod tests {
                     path: "s3://bucket/duplicate_path".to_string(),
                     name: Some("base1".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -2863,6 +2868,7 @@ mod tests {
                     path: "s3://bucket/duplicate_path".to_string(),
                     name: Some("base2".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -2880,6 +2886,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_add_bases_same_path_different_storage_options_no_conflict() {
+        let dataset = test_dataset(10, 2).await;
+
+        let txn1 = Transaction::new_from_version(
+            1,
+            Operation::UpdateBases {
+                new_bases: vec![lance_table::format::BasePath {
+                    id: 1,
+                    path: "s3://bucket/shared_path".to_string(),
+                    name: Some("base1".to_string()),
+                    is_dataset_root: false,
+                    storage_options: HashMap::from([(
+                        "azure_storage_account_name".to_string(),
+                        "account_a".to_string(),
+                    )]),
+                }],
+            },
+        );
+
+        let txn2 = Transaction::new_from_version(
+            1,
+            Operation::UpdateBases {
+                new_bases: vec![lance_table::format::BasePath {
+                    id: 2,
+                    path: "s3://bucket/shared_path".to_string(),
+                    name: Some("base2".to_string()),
+                    is_dataset_root: false,
+                    storage_options: HashMap::from([(
+                        "azure_storage_account_name".to_string(),
+                        "account_b".to_string(),
+                    )]),
+                }],
+            },
+        );
+
+        let mut rebase = TransactionRebase::try_new(&dataset, txn1, None)
+            .await
+            .unwrap();
+        assert!(rebase.check_txn(&txn2, 2).is_ok());
+    }
+
+    #[tokio::test]
     async fn test_add_bases_id_conflict() {
         let dataset = test_dataset(10, 2).await;
 
@@ -2892,6 +2940,7 @@ mod tests {
                     path: "s3://bucket1/path1".to_string(),
                     name: Some("base1".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -2904,6 +2953,7 @@ mod tests {
                     path: "s3://bucket2/path2".to_string(),
                     name: Some("base2".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -2932,6 +2982,7 @@ mod tests {
                     path: "s3://bucket/path".to_string(),
                     name: Some("base1".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -2983,12 +3034,14 @@ mod tests {
                         path: "s3://bucket1/path1".to_string(),
                         name: Some("base1".to_string()),
                         is_dataset_root: false,
+                        storage_options: Default::default(),
                     },
                     lance_table::format::BasePath {
                         id: 2,
                         path: "s3://bucket2/path2".to_string(),
                         name: Some("base2".to_string()),
                         is_dataset_root: false,
+                        storage_options: Default::default(),
                     },
                 ],
             },
@@ -3003,6 +3056,7 @@ mod tests {
                     path: "s3://bucket1/path1".to_string(), // Same path as txn1's first base
                     name: Some("base3".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -3032,6 +3086,7 @@ mod tests {
                     path: "s3://bucket1/path1".to_string(),
                     name: None,
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -3044,6 +3099,7 @@ mod tests {
                     path: "s3://bucket2/path2".to_string(),
                     name: None,
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -3068,6 +3124,7 @@ mod tests {
                     path: "s3://bucket1/path1".to_string(),
                     name: Some("base1".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );
@@ -3080,6 +3137,7 @@ mod tests {
                     path: "s3://bucket2/path2".to_string(),
                     name: Some("base2".to_string()),
                     is_dataset_root: false,
+                    storage_options: Default::default(),
                 }],
             },
         );


### PR DESCRIPTION
For Azure, different storage accounts can have buckets (containers) of the same name. Also storage account is the unit of rate limit cap.

When expressed as base, today we try to match base based on the prefix, and that would mean it can only match 1 bucket but not the others if user defines multiple bases of the same buckets in different storage accounts.

This PR adds the ability to define storage_options as a part of the base definition.