### PR TITLE
feat: clean up data files on failed writes

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -101,7 +101,7 @@ use self::fragment::FileFragment;
 use self::refs::Refs;
 use self::scanner::{DatasetRecordBatchStream, Scanner};
 use self::transaction::{Operation, Transaction, TransactionBuilder, UpdateMapEntry};
-use self::write::write_fragments_internal;
+use self::write::{cleanup_data_fragments, write_fragments_internal};
 use crate::dataset::branch_location::BranchLocation;
 use crate::dataset::cleanup::{CleanupPolicy, CleanupPolicyBuilder};
 use crate::dataset::refs::{BranchContents, BranchIdentifier, Branches, Tags};

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1264,6 +1264,8 @@ async fn rewrite_files(
 
     log::info!("Compaction task {}: file written", task_id);
 
+    // Wrap in an async block so `?` returns into `row_addrs_result` and we can
+    // run cleanup before propagating the error.
     let row_addrs_result: Result<Option<Vec<u8>>> = async {
         if let Some(row_ids_rx) = row_ids_rx {
             let captured_ids = row_ids_rx

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -4838,4 +4838,93 @@ mod tests {
             "rows deleted before compaction must not be resurrected; found {row_count}"
         );
     }
+
+    /// Returns the number of files in `<base_dir>/data/`.
+    fn count_data_files_in(base_dir: &str) -> usize {
+        let data_dir = std::path::Path::new(base_dir).join("data");
+        if !data_dir.exists() {
+            return 0;
+        }
+        std::fs::read_dir(data_dir)
+            .unwrap()
+            .filter(|e| e.as_ref().unwrap().path().is_file())
+            .count()
+    }
+
+    /// Site 2 in PR #6320: when `commit_compaction` fails to apply the commit
+    /// after `rewrite_files` has already written new data files, those files
+    /// must be cleaned up. We force the commit failure by injecting an error on
+    /// writes to the `_transactions/` directory.
+    #[tokio::test]
+    async fn test_commit_compaction_cleans_up_data_on_commit_failure() {
+        use crate::dataset::builder::DatasetBuilder;
+        use crate::utils::test::FailingProxyStore;
+        use lance_io::object_store::ObjectStoreParams;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let routed_uri = format!("file-object-store://{}", test_uri);
+
+        let data = sample_data();
+        let reader = RecordBatchIterator::new(vec![Ok(data.slice(0, 200))], data.schema());
+        Dataset::write(
+            reader,
+            &routed_uri,
+            Some(WriteParams {
+                max_rows_per_file: 100,
+                // Stable row IDs lets `commit_compaction` skip the
+                // `reserve_fragment_ids` pre-commit (which would otherwise fail
+                // *before* the new data files exist), isolating the failure to
+                // the `apply_commit` call we want to test.
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let baseline_files = count_data_files_in(test_uri);
+
+        let failing = Arc::new(FailingProxyStore::new());
+        // `commit_compaction` first calls `reserve_fragment_ids` (which writes a
+        // ReserveFragments transaction) and then calls `apply_commit` for the
+        // rewrite itself. Skip the first transaction write so the reserve
+        // succeeds, and fail the second so `apply_commit` errors out — that's
+        // the branch we want to exercise cleanup for.
+        failing.fail_after_n("put", "_transactions", 1, "injected commit failure");
+        failing.fail_after_n(
+            "put_multipart",
+            "_transactions",
+            1,
+            "injected commit failure",
+        );
+
+        let mut dataset = DatasetBuilder::from_uri(&routed_uri)
+            .with_read_params(crate::dataset::ReadParams {
+                store_options: Some(ObjectStoreParams {
+                    object_store_wrapper: Some(failing.clone()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .load()
+            .await
+            .unwrap();
+
+        let options = CompactionOptions {
+            target_rows_per_fragment: 1000,
+            ..Default::default()
+        };
+        let result = compact_files(&mut dataset, options, None).await;
+        assert!(
+            result.is_err(),
+            "Compaction should fail when transaction commit fails"
+        );
+
+        assert_eq!(
+            count_data_files_in(test_uri),
+            baseline_files,
+            "Compaction data files should be cleaned up when commit fails"
+        );
+    }
 }

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -4865,7 +4865,10 @@ mod tests {
 
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
-        let routed_uri = format!("file-object-store://{}", test_uri);
+        // Prefix `/` so Windows drive letters (e.g. `C:`) don't get parsed as
+        // the URL authority.
+        let path_prefix = if test_uri.starts_with('/') { "" } else { "/" };
+        let routed_uri = format!("file-object-store://{path_prefix}{test_uri}");
 
         let data = sample_data();
         let reader = RecordBatchIterator::new(vec![Ok(data.slice(0, 200))], data.schema());

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -93,7 +93,7 @@ use super::transaction::{
     Operation, RewriteGroup, RewrittenIndex, Transaction, TransactionBuilder,
 };
 use super::utils::make_rowid_capture_stream;
-use super::{WriteMode, WriteParams, write_fragments_internal};
+use super::{WriteMode, WriteParams, cleanup_data_fragments, write_fragments_internal};
 use crate::Dataset;
 use crate::Result;
 use crate::dataset::utils::CapturedRowIds;
@@ -1264,26 +1264,37 @@ async fn rewrite_files(
 
     log::info!("Compaction task {}: file written", task_id);
 
-    let row_addrs = if let Some(row_ids_rx) = row_ids_rx {
-        let captured_ids = row_ids_rx
-            .try_recv()
-            .map_err(|err| Error::internal(format!("Failed to receive row ids: {}", err)))?;
-        let row_addrs = captured_ids.row_addrs(None).into_owned();
-        let mut serialized = Vec::with_capacity(row_addrs.serialized_size());
-        row_addrs.serialize_into(&mut serialized)?;
-        Some(serialized)
-    } else {
-        if dataset.manifest.uses_stable_row_ids() {
-            log::info!("Compaction task {}: rechunking stable row ids", task_id);
-            rechunk_stable_row_ids(dataset.as_ref(), &mut new_fragments, &fragments).await?;
-            recalc_versions_for_rewritten_fragments(
-                dataset.as_ref(),
-                &mut new_fragments,
-                &fragments,
-            )
-            .await?;
+    let row_addrs_result: Result<Option<Vec<u8>>> = async {
+        if let Some(row_ids_rx) = row_ids_rx {
+            let captured_ids = row_ids_rx
+                .try_recv()
+                .map_err(|err| Error::internal(format!("Failed to receive row ids: {}", err)))?;
+            let row_addrs = captured_ids.row_addrs(None).into_owned();
+            let mut serialized = Vec::with_capacity(row_addrs.serialized_size());
+            row_addrs.serialize_into(&mut serialized)?;
+            Ok(Some(serialized))
+        } else {
+            if dataset.manifest.uses_stable_row_ids() {
+                log::info!("Compaction task {}: rechunking stable row ids", task_id);
+                rechunk_stable_row_ids(dataset.as_ref(), &mut new_fragments, &fragments).await?;
+                recalc_versions_for_rewritten_fragments(
+                    dataset.as_ref(),
+                    &mut new_fragments,
+                    &fragments,
+                )
+                .await?;
+            }
+            Ok(None)
         }
-        None
+    }
+    .await;
+
+    let row_addrs = match row_addrs_result {
+        Ok(v) => v,
+        Err(e) => {
+            cleanup_data_fragments(&dataset.object_store, &dataset.base, &new_fragments).await;
+            return Err(e);
+        }
     };
 
     metrics.files_removed = task
@@ -1605,6 +1616,13 @@ pub async fn commit_compaction(
         None
     };
 
+    // Collect new fragment paths before moving rewrite_groups into the transaction,
+    // so we can clean them up if the commit fails.
+    let all_new_fragments: Vec<Fragment> = rewrite_groups
+        .iter()
+        .flat_map(|g| g.new_fragments.iter().cloned())
+        .collect();
+
     let transaction = TransactionBuilder::new(
         // Use the version at which the compaction tasks were *planned*, not the
         // version of the dataset handle passed to this function.  In distributed
@@ -1623,9 +1641,13 @@ pub async fn commit_compaction(
     .transaction_properties(options.transaction_properties.clone())
     .build();
 
-    dataset
+    if let Err(e) = dataset
         .apply_commit(transaction, &Default::default(), &Default::default())
-        .await?;
+        .await
+    {
+        cleanup_data_fragments(&dataset.object_store, &dataset.base, &all_new_fragments).await;
+        return Err(e);
+    }
 
     Ok(metrics)
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -3409,4 +3409,51 @@ mod tests {
             "All data files (including completed ones) should be cleaned up on failure"
         );
     }
+
+    /// Verifies the external-base branch in `cleanup_data_fragments`: files with
+    /// `base_id == Some(_)` are skipped (logged but not deleted via the dataset's
+    /// object store), while same-fragment files with `base_id == None` are deleted.
+    #[tokio::test]
+    async fn test_cleanup_data_fragments_skips_external_base() {
+        use lance_core::utils::tempfile::TempStrDir;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let (object_store, base_dir) =
+            ObjectStore::from_uri_and_params(Default::default(), test_uri, &Default::default())
+                .await
+                .unwrap();
+
+        // Create a real local data file we expect to be cleaned up.
+        let data_dir = base_dir.child(DATA_DIR);
+        let local_filename = "local.lance";
+        let local_path = data_dir.child(local_filename);
+        object_store.put(&local_path, b"x").await.unwrap();
+        // Sanity check: file is on disk.
+        assert_eq!(count_data_files(test_uri), 1);
+
+        let mut external_file = DataFile::new_unstarted("external.lance", 2, 1);
+        external_file.base_id = Some(42);
+        let local_file = DataFile::new_unstarted(local_filename, 2, 1);
+        let fragments = vec![Fragment {
+            id: 0,
+            files: vec![external_file, local_file],
+            deletion_file: None,
+            row_id_meta: None,
+            physical_rows: Some(0),
+            created_at_version_meta: None,
+            last_updated_at_version_meta: None,
+        }];
+
+        cleanup_data_fragments(&object_store, &base_dir, &fragments).await;
+
+        // The local file should be removed; the external file is skipped without
+        // erroring (its base store isn't known here).
+        assert_eq!(
+            count_data_files(test_uri),
+            0,
+            "Local data file should be deleted by cleanup"
+        );
+    }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -648,12 +648,12 @@ pub(crate) async fn cleanup_data_fragments(
     base_dir: &Path,
     fragments: &[Fragment],
 ) {
-    let data_dir = base_dir.child(DATA_DIR);
+    let data_dir = base_dir.clone().join(DATA_DIR);
     let mut skipped_external = 0usize;
     for fragment in fragments {
         for file in &fragment.files {
             if file.base_id.is_none() {
-                let path = data_dir.child(file.path.as_str());
+                let path = data_dir.clone().join(file.path.as_str());
                 if let Err(e) = object_store.delete(&path).await {
                     log::warn!("Failed to clean up orphaned data file '{}': {}", path, e);
                 }
@@ -3401,9 +3401,9 @@ mod tests {
                 .unwrap();
 
         // Create a real local data file we expect to be cleaned up.
-        let data_dir = base_dir.child(DATA_DIR);
+        let data_dir = base_dir.clone().join(DATA_DIR);
         let local_filename = "local.lance";
-        let local_path = data_dir.child(local_filename);
+        let local_path = data_dir.clone().join(local_filename);
         object_store.put(&local_path, b"x").await.unwrap();
         // Sanity check: file is on disk.
         assert_eq!(count_data_files(test_uri), 1);

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -42,6 +42,8 @@ use crate::session::Session;
 use super::DATA_DIR;
 use super::fragment::write::generate_random_filename;
 use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
+
+pub use super::progress::{WriteProgressFn, WriteStats};
 use super::transaction::Transaction;
 use super::utils::SchemaAdapter;
 
@@ -52,7 +54,6 @@ pub mod merge_insert;
 mod retry;
 pub mod update;
 
-pub use super::progress::{WriteProgressFn, WriteStats};
 pub use commit::CommitBuilder;
 pub use delete::{DeleteBuilder, DeleteResult, UncommittedDelete};
 pub use insert::InsertBuilder;
@@ -217,13 +218,6 @@ pub struct WriteParams {
 
     pub progress: Arc<dyn WriteFragmentProgress>,
 
-    /// Optional callback invoked after each batch is written.
-    ///
-    /// Receives cumulative [`WriteStats`] so callers can render a progress bar
-    /// or compute throughput. The callback must be cheap and non-blocking;
-    /// spawn a task if you need async work.
-    pub write_progress: Option<WriteProgressFn>,
-
     /// If present, dataset will use this to update the latest version
     ///
     /// If not set, the default will be based on the object store.  Generally this will
@@ -327,7 +321,6 @@ impl Default for WriteParams {
             store_params: None,
             base_store_params: None,
             progress: Arc::new(NoopFragmentWriteProgress::new()),
-            write_progress: None,
             commit_handler: None,
             data_storage_version: None,
             enable_stable_row_ids: false,
@@ -521,7 +514,7 @@ pub async fn do_write_fragments(
     let source_store_params = params.store_params.clone().unwrap_or_default();
 
     let writer_generator = WriterGenerator::new(
-        object_store,
+        object_store.clone(),
         base_dir,
         schema,
         storage_version,
@@ -535,71 +528,154 @@ pub async fn do_write_fragments(
     );
     let mut writer: Option<Box<dyn GenericWriter>> = None;
     let mut num_rows_in_current_file = 0;
-    let mut fragments = Vec::new();
+    let mut fragments: Vec<Fragment> = Vec::new();
     let mut bytes_completed: u64 = 0;
     let mut rows_completed: u64 = 0;
     let mut files_written: u32 = 0;
-    while let Some(batch_chunk) = buffered_reader.next().await {
-        let batch_chunk = batch_chunk?;
 
-        if writer.is_none() {
-            let (new_writer, new_fragment) = writer_generator.new_writer().await?;
-            params.progress.begin(&new_fragment).await?;
-            writer = Some(new_writer);
-            fragments.push(new_fragment);
-        }
+    let loop_result: Result<()> = async {
+        while let Some(batch_chunk) = buffered_reader.next().await {
+            let batch_chunk = batch_chunk?;
 
-        writer.as_mut().unwrap().write(&batch_chunk).await?;
-        for batch in &batch_chunk {
-            num_rows_in_current_file += batch.num_rows() as u32;
-        }
+            if writer.is_none() {
+                let (new_writer, new_fragment) = writer_generator.new_writer().await?;
+                params.progress.begin(&new_fragment).await?;
+                writer = Some(new_writer);
+                fragments.push(new_fragment);
+            }
 
-        if let Some(cb) = &params.write_progress {
-            let current_bytes = writer.as_mut().unwrap().tell().await?;
-            cb.call(WriteStats {
-                bytes_written: bytes_completed + current_bytes,
-                rows_written: rows_completed + num_rows_in_current_file as u64,
-                files_written,
-            });
-        }
+            writer.as_mut().unwrap().write(&batch_chunk).await?;
+            for batch in &batch_chunk {
+                num_rows_in_current_file += batch.num_rows() as u32;
+            }
 
-        if num_rows_in_current_file >= params.max_rows_per_file as u32
-            || writer.as_mut().unwrap().tell().await? >= params.max_bytes_per_file as u64
-        {
-            let (num_rows, data_file) = writer.take().unwrap().finish().await?;
-            info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
-            debug_assert_eq!(num_rows, num_rows_in_current_file);
-            bytes_completed += data_file.file_size_bytes.get().map_or(0, |s| s.get());
-            rows_completed += num_rows as u64;
-            files_written += 1;
-            params.progress.complete(fragments.last().unwrap()).await?;
-            let last_fragment = fragments.last_mut().unwrap();
-            last_fragment.physical_rows = Some(num_rows as usize);
-            last_fragment.files.push(data_file);
-            num_rows_in_current_file = 0;
+            if let Some(cb) = &params.write_progress {
+                let current_bytes = writer.as_mut().unwrap().tell().await?;
+                cb.call(WriteStats {
+                    bytes_written: bytes_completed + current_bytes,
+                    rows_written: rows_completed + num_rows_in_current_file as u64,
+                    files_written,
+                });
+            }
+
+            if num_rows_in_current_file >= params.max_rows_per_file as u32
+                || writer.as_mut().unwrap().tell().await? >= params.max_bytes_per_file as u64
+            {
+                let (num_rows, data_file) = writer.take().unwrap().finish().await?;
+                info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
+                debug_assert_eq!(num_rows, num_rows_in_current_file);
+                bytes_completed += data_file.file_size_bytes.get().map_or(0, |s| s.get());
+                rows_completed += num_rows as u64;
+                files_written += 1;
+                let last_fragment = fragments.last_mut().unwrap();
+                last_fragment.physical_rows = Some(num_rows as usize);
+                last_fragment.files.push(data_file);
+                params.progress.complete(fragments.last().unwrap()).await?;
+                if let Some(cb) = &params.write_progress {
+                    cb.call(WriteStats {
+                        bytes_written: bytes_completed,
+                        rows_written: rows_completed,
+                        files_written,
+                    });
+                }
+                num_rows_in_current_file = 0;
+            }
         }
+        Ok(())
+    }
+    .await;
+
+    if let Err(e) = loop_result {
+        let in_progress_filename = writer
+            .as_ref()
+            .filter(|w| w.base_id().is_none())
+            .map(|w| w.path().to_owned());
+        drop(writer.take());
+        cleanup_data_fragments(&object_store, base_dir, &fragments).await;
+        if let Some(filename) = in_progress_filename {
+            let path = base_dir.child(DATA_DIR).child(filename.as_str());
+            if let Err(del_e) = object_store.delete(&path).await {
+                log::warn!(
+                    "Failed to clean up in-progress data file '{}': {}",
+                    path,
+                    del_e
+                );
+            }
+        }
+        return Err(e);
     }
 
     // Complete the final writer
-    if let Some(mut writer) = writer.take() {
-        let (num_rows, data_file) = writer.finish().await?;
-        info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
-        bytes_completed += data_file.file_size_bytes.get().map_or(0, |s| s.get());
-        rows_completed += num_rows as u64;
-        files_written += 1;
-        if let Some(cb) = &params.write_progress {
-            cb.call(WriteStats {
-                bytes_written: bytes_completed,
-                rows_written: rows_completed,
-                files_written,
-            });
+    if let Some(mut w) = writer.take() {
+        let in_progress_filename = if w.base_id().is_none() {
+            Some(w.path().to_owned())
+        } else {
+            None
+        };
+        match w.finish().await {
+            Ok((num_rows, data_file)) => {
+                info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
+                bytes_completed += data_file.file_size_bytes.get().map_or(0, |s| s.get());
+                rows_completed += num_rows as u64;
+                files_written += 1;
+                let last_fragment = fragments.last_mut().unwrap();
+                last_fragment.physical_rows = Some(num_rows as usize);
+                last_fragment.files.push(data_file);
+                if let Some(cb) = &params.write_progress {
+                    cb.call(WriteStats {
+                        bytes_written: bytes_completed,
+                        rows_written: rows_completed,
+                        files_written,
+                    });
+                }
+            }
+            Err(e) => {
+                cleanup_data_fragments(&object_store, base_dir, &fragments).await;
+                if let Some(filename) = in_progress_filename {
+                    let path = base_dir.child(DATA_DIR).child(filename.as_str());
+                    if let Err(del_e) = object_store.delete(&path).await {
+                        log::warn!(
+                            "Failed to clean up in-progress data file '{}': {}",
+                            path,
+                            del_e
+                        );
+                    }
+                }
+                return Err(e);
+            }
         }
-        let last_fragment = fragments.last_mut().unwrap();
-        last_fragment.physical_rows = Some(num_rows as usize);
-        last_fragment.files.push(data_file);
     }
 
     Ok(fragments)
+}
+
+/// Best-effort cleanup of data files for fragments that were written but not committed.
+///
+/// Only cleans up files in the dataset's default storage (base_id == None). Files
+/// written to external bases are skipped because we don't have their object stores here.
+pub(crate) async fn cleanup_data_fragments(
+    object_store: &ObjectStore,
+    base_dir: &Path,
+    fragments: &[Fragment],
+) {
+    let data_dir = base_dir.child(DATA_DIR);
+    for fragment in fragments {
+        for file in &fragment.files {
+            if file.base_id.is_none() {
+                let path = data_dir.child(file.path.as_str());
+                if let Err(e) = object_store.delete(&path).await {
+                    log::warn!("Failed to clean up orphaned data file '{}': {}", path, e);
+                }
+            } else {
+                log::warn!(
+                    "Unable to clean up orphaned data file '{}' in external base {}: \
+                     cleanup not supported for external bases",
+                    file.path,
+                    file.base_id.unwrap()
+                );
+            }
+        }
+    }
 }
 
 pub async fn validate_and_resolve_target_bases(
@@ -939,6 +1015,11 @@ pub trait GenericWriter: Send {
     async fn tell(&mut self) -> Result<u64>;
     /// Finish writing the file (flush the remaining data and write footer)
     async fn finish(&mut self) -> Result<(u32, DataFile)>;
+    /// Returns the relative filename (without directory) of the file being written.
+    fn path(&self) -> &str;
+    /// Returns the base ID if this writer is writing to an external base, or None
+    /// for the dataset's default storage.
+    fn base_id(&self) -> Option<u32>;
 }
 
 struct V1WriterAdapter<M>
@@ -972,6 +1053,12 @@ where
                 self.base_id,
             ),
         ))
+    }
+    fn path(&self) -> &str {
+        &self.path
+    }
+    fn base_id(&self) -> Option<u32> {
+        self.base_id
     }
 }
 
@@ -1028,6 +1115,12 @@ impl GenericWriter for V2WriterAdapter {
             self.base_id,
         );
         Ok((num_rows, data_file))
+    }
+    fn path(&self) -> &str {
+        &self.path
+    }
+    fn base_id(&self) -> Option<u32> {
+        self.base_id
     }
 }
 
@@ -1333,11 +1426,13 @@ async fn new_source_iter(
 
 struct SpillStreamIter {
     receiver: SpillReceiver,
-    _sender_handle: tokio::task::JoinHandle<SpillSender>,
+    #[allow(dead_code)] // Exists to keep the SpillSender alive
+    sender_handle: tokio::task::JoinHandle<SpillSender>,
     // This temp dir is used to store the spilled data. It is kept alive by
     // this struct. When this struct is dropped, the Drop implementation of
     // tempfile::TempDir will delete the temp dir.
-    _tmp_dir: TempDir,
+    #[allow(dead_code)] // Exists to keep the temp dir alive
+    tmp_dir: TempDir,
 }
 
 impl SpillStreamIter {
@@ -1381,8 +1476,8 @@ impl SpillStreamIter {
 
         Ok(Self {
             receiver,
-            _tmp_dir: tmp_dir,
-            _sender_handle: sender_handle,
+            tmp_dir,
+            sender_handle,
         })
     }
 }
@@ -3186,6 +3281,133 @@ mod tests {
             all_ids,
             vec![1, 2, 3, 4, 5, 6],
             "All data should be correctly written"
+        );
+    }
+
+    /// Returns the number of files in `<base_dir>/data/`.
+    fn count_data_files(base_dir: &str) -> usize {
+        let data_dir = std::path::Path::new(base_dir).join("data");
+        if !data_dir.exists() {
+            return 0;
+        }
+        std::fs::read_dir(data_dir)
+            .unwrap()
+            .filter(|e| e.as_ref().unwrap().path().is_file())
+            .count()
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_data_files_on_failed_write() {
+        use lance_core::utils::tempfile::TempStrDir;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let schema = Schema::try_from(arrow_schema.as_ref()).unwrap();
+
+        let (object_store, base_dir) =
+            ObjectStore::from_uri_and_params(Default::default(), test_uri, &Default::default())
+                .await
+                .unwrap();
+
+        let good_batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+
+        // Build a stream: one good batch, then an error.
+        let items: Vec<std::result::Result<RecordBatch, DataFusionError>> = vec![
+            Ok(good_batch.clone()),
+            Err(DataFusionError::External("injected failure".into())),
+        ];
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            arrow_schema.clone(),
+            futures::stream::iter(items),
+        ));
+
+        let result = do_write_fragments(
+            None,
+            object_store.clone(),
+            &base_dir,
+            &schema,
+            stream,
+            WriteParams::default(),
+            LanceFileVersion::V2_1,
+            None,
+        )
+        .await;
+
+        assert!(result.is_err(), "Expected write to fail");
+        assert_eq!(
+            count_data_files(test_uri),
+            0,
+            "All partial data files should be cleaned up on failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_data_files_on_failed_write_multi_file() {
+        // Verify cleanup when a failure occurs after one file has already been completed
+        // (i.e., max_rows_per_file causes a file boundary before the error).
+        use lance_core::utils::tempfile::TempStrDir;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let schema = Schema::try_from(arrow_schema.as_ref()).unwrap();
+
+        let (object_store, base_dir) =
+            ObjectStore::from_uri_and_params(Default::default(), test_uri, &Default::default())
+                .await
+                .unwrap();
+
+        // 3 rows per file; 2 good batches of 3 rows (fills one file), then error.
+        let good_batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let items: Vec<std::result::Result<RecordBatch, DataFusionError>> = vec![
+            Ok(good_batch.clone()),
+            Ok(good_batch.clone()),
+            Err(DataFusionError::External("injected failure".into())),
+        ];
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            arrow_schema.clone(),
+            futures::stream::iter(items),
+        ));
+
+        let result = do_write_fragments(
+            None,
+            object_store.clone(),
+            &base_dir,
+            &schema,
+            stream,
+            WriteParams {
+                max_rows_per_file: 3,
+                ..Default::default()
+            },
+            LanceFileVersion::V2_1,
+            None,
+        )
+        .await;
+
+        assert!(result.is_err(), "Expected write to fail");
+        assert_eq!(
+            count_data_files(test_uri),
+            0,
+            "All data files (including completed ones) should be cleaned up on failure"
         );
     }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -540,6 +540,8 @@ pub async fn do_write_fragments(
     let mut rows_completed: u64 = 0;
     let mut files_written: u32 = 0;
 
+    // Wrap the loop in an async block so `?` returns into `loop_result` and we
+    // can run cleanup before propagating the error.
     let loop_result: Result<()> = async {
         while let Some(batch_chunk) = buffered_reader.next().await {
             let batch_chunk = batch_chunk?;
@@ -643,14 +645,20 @@ pub async fn do_write_fragments(
 
 /// Best-effort cleanup of data files for fragments that were written but not committed.
 ///
-/// Only cleans up files in the dataset's default storage (base_id == None). Files
-/// written to external bases are skipped because we don't have their object stores here.
+/// Contract:
+/// - Errors from individual `delete` calls are logged and swallowed, never returned —
+///   callers should propagate the original write error.
+/// - Only files in the dataset's default storage (`base_id == None`) are deleted;
+///   files in external bases are skipped because we don't have their object stores here.
+/// - Safe to call with an empty slice.
+/// - Must be called before the fragments are committed, otherwise live data may be deleted.
 pub(crate) async fn cleanup_data_fragments(
     object_store: &ObjectStore,
     base_dir: &Path,
     fragments: &[Fragment],
 ) {
     let data_dir = base_dir.child(DATA_DIR);
+    let mut skipped_external = 0usize;
     for fragment in fragments {
         for file in &fragment.files {
             if file.base_id.is_none() {
@@ -659,14 +667,16 @@ pub(crate) async fn cleanup_data_fragments(
                     log::warn!("Failed to clean up orphaned data file '{}': {}", path, e);
                 }
             } else {
-                log::warn!(
-                    "Unable to clean up orphaned data file '{}' in external base {}: \
-                     cleanup not supported for external bases",
-                    file.path,
-                    file.base_id.unwrap()
-                );
+                skipped_external += 1;
             }
         }
+    }
+    if skipped_external > 0 {
+        log::warn!(
+            "Skipped cleanup of {} orphaned data file(s) in external bases: \
+             cleanup not supported for external bases",
+            skipped_external
+        );
     }
 }
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -597,25 +597,15 @@ pub async fn do_write_fragments(
     .await;
 
     if let Err(e) = loop_result {
-        let in_progress_path = writer
-            .as_ref()
-            .filter(|w| w.base_id().is_none())
-            .map(|w| w.path().to_owned());
-        // Drop the writer before deleting: closes any open file handle (some
-        // platforms can't delete open files) and aborts in-progress multipart
-        // uploads via `ObjectWriter::drop`.
+        // Drop the writer so its in-progress file is cleaned up (LocalWriter
+        // removes its temp file; ObjectWriter aborts the multipart upload).
         drop(writer.take());
-        cleanup_partial_write(&object_store, base_dir, &fragments, in_progress_path).await;
+        cleanup_data_fragments(&object_store, base_dir, &fragments).await;
         return Err(e);
     }
 
     // Complete the final writer
     if let Some(mut writer) = writer.take() {
-        let in_progress_path = if writer.base_id().is_none() {
-            Some(writer.path().to_owned())
-        } else {
-            None
-        };
         match writer.finish().await {
             Ok((num_rows, data_file)) => {
                 info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
@@ -634,7 +624,8 @@ pub async fn do_write_fragments(
                 }
             }
             Err(e) => {
-                cleanup_partial_write(&object_store, base_dir, &fragments, in_progress_path).await;
+                drop(writer);
+                cleanup_data_fragments(&object_store, base_dir, &fragments).await;
                 return Err(e);
             }
         }
@@ -677,23 +668,6 @@ pub(crate) async fn cleanup_data_fragments(
              cleanup not supported for external bases",
             skipped_external
         );
-    }
-}
-
-/// Best-effort cleanup of a partially-failed write: deletes all completed fragment
-/// data files plus an optional in-progress file that was never finished.
-async fn cleanup_partial_write(
-    object_store: &ObjectStore,
-    base_dir: &Path,
-    fragments: &[Fragment],
-    in_progress_filename: Option<String>,
-) {
-    cleanup_data_fragments(object_store, base_dir, fragments).await;
-    if let Some(filename) = in_progress_filename {
-        let path = base_dir.clone().join(DATA_DIR).join(filename.as_str());
-        if let Err(e) = object_store.delete(&path).await {
-            log::warn!("Failed to clean up in-progress data file '{}': {}", path, e);
-        }
     }
 }
 
@@ -1034,11 +1008,6 @@ pub trait GenericWriter: Send {
     async fn tell(&mut self) -> Result<u64>;
     /// Finish writing the file (flush the remaining data and write footer)
     async fn finish(&mut self) -> Result<(u32, DataFile)>;
-    /// Returns the relative filename (without directory) of the file being written.
-    fn path(&self) -> &str;
-    /// Returns the base ID if this writer is writing to an external base, or None
-    /// for the dataset's default storage.
-    fn base_id(&self) -> Option<u32>;
 }
 
 struct V1WriterAdapter<M>
@@ -1072,12 +1041,6 @@ where
                 self.base_id,
             ),
         ))
-    }
-    fn path(&self) -> &str {
-        &self.path
-    }
-    fn base_id(&self) -> Option<u32> {
-        self.base_id
     }
 }
 
@@ -1134,12 +1097,6 @@ impl GenericWriter for V2WriterAdapter {
             self.base_id,
         );
         Ok((num_rows, data_file))
-    }
-    fn path(&self) -> &str {
-        &self.path
-    }
-    fn base_id(&self) -> Option<u32> {
-        self.base_id
     }
 }
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -597,25 +597,15 @@ pub async fn do_write_fragments(
     .await;
 
     if let Err(e) = loop_result {
-        let in_progress_path = writer
-            .as_ref()
-            .filter(|w| w.base_id().is_none())
-            .map(|w| w.path().to_owned());
-        // Drop the writer before deleting: closes any open file handle (some
-        // platforms can't delete open files) and aborts in-progress multipart
-        // uploads via `ObjectWriter::drop`.
-        drop(writer.take());
-        cleanup_partial_write(&object_store, base_dir, &fragments, in_progress_path).await;
+        if let Some(w) = writer.take() {
+            w.abort().await;
+        }
+        cleanup_data_fragments(&object_store, base_dir, &fragments).await;
         return Err(e);
     }
 
     // Complete the final writer
     if let Some(mut writer) = writer.take() {
-        let in_progress_path = if writer.base_id().is_none() {
-            Some(writer.path().to_owned())
-        } else {
-            None
-        };
         match writer.finish().await {
             Ok((num_rows, data_file)) => {
                 info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
@@ -634,7 +624,8 @@ pub async fn do_write_fragments(
                 }
             }
             Err(e) => {
-                cleanup_partial_write(&object_store, base_dir, &fragments, in_progress_path).await;
+                writer.abort().await;
+                cleanup_data_fragments(&object_store, base_dir, &fragments).await;
                 return Err(e);
             }
         }
@@ -677,23 +668,6 @@ pub(crate) async fn cleanup_data_fragments(
              cleanup not supported for external bases",
             skipped_external
         );
-    }
-}
-
-/// Best-effort cleanup of a partially-failed write: deletes all completed fragment
-/// data files plus an optional in-progress file that was never finished.
-async fn cleanup_partial_write(
-    object_store: &ObjectStore,
-    base_dir: &Path,
-    fragments: &[Fragment],
-    in_progress_filename: Option<String>,
-) {
-    cleanup_data_fragments(object_store, base_dir, fragments).await;
-    if let Some(filename) = in_progress_filename {
-        let path = base_dir.child(DATA_DIR).child(filename.as_str());
-        if let Err(e) = object_store.delete(&path).await {
-            log::warn!("Failed to clean up in-progress data file '{}': {}", path, e);
-        }
     }
 }
 
@@ -1034,11 +1008,11 @@ pub trait GenericWriter: Send {
     async fn tell(&mut self) -> Result<u64>;
     /// Finish writing the file (flush the remaining data and write footer)
     async fn finish(&mut self) -> Result<(u32, DataFile)>;
-    /// Returns the relative filename (without directory) of the file being written.
-    fn path(&self) -> &str;
-    /// Returns the base ID if this writer is writing to an external base, or None
-    /// for the dataset's default storage.
-    fn base_id(&self) -> Option<u32>;
+    /// Abort writing: drop any open handle, abort any in-progress multipart
+    /// upload, and best-effort delete the partial file. Errors are logged and
+    /// swallowed. Files written to external bases are skipped (we don't have
+    /// access to their object stores).
+    async fn abort(self: Box<Self>);
 }
 
 struct V1WriterAdapter<M>
@@ -1048,6 +1022,8 @@ where
     writer: PreviousFileWriter<M>,
     path: String,
     base_id: Option<u32>,
+    object_store: ObjectStore,
+    full_path: Path,
 }
 
 #[async_trait::async_trait]
@@ -1073,11 +1049,15 @@ where
             ),
         ))
     }
-    fn path(&self) -> &str {
-        &self.path
-    }
-    fn base_id(&self) -> Option<u32> {
-        self.base_id
+    async fn abort(self: Box<Self>) {
+        let base_id = self.base_id;
+        let object_store = self.object_store.clone();
+        let full_path = self.full_path.clone();
+        // Drop the writer before deleting: closes any open file handle (some
+        // platforms can't delete open files) and aborts any in-progress
+        // multipart upload via `ObjectWriter::drop`.
+        drop(self);
+        delete_partial_file_if_local(base_id, object_store, full_path).await;
     }
 }
 
@@ -1086,6 +1066,8 @@ struct V2WriterAdapter {
     path: String,
     base_id: Option<u32>,
     preprocessor: Option<BlobPreprocessor>,
+    object_store: ObjectStore,
+    full_path: Path,
 }
 
 #[async_trait::async_trait]
@@ -1135,11 +1117,34 @@ impl GenericWriter for V2WriterAdapter {
         );
         Ok((num_rows, data_file))
     }
-    fn path(&self) -> &str {
-        &self.path
+    async fn abort(self: Box<Self>) {
+        let base_id = self.base_id;
+        let object_store = self.object_store.clone();
+        let full_path = self.full_path.clone();
+        // Drop the writer before deleting: closes any open file handle (some
+        // platforms can't delete open files) and aborts any in-progress
+        // multipart upload via `ObjectWriter::drop`.
+        drop(self);
+        delete_partial_file_if_local(base_id, object_store, full_path).await;
     }
-    fn base_id(&self) -> Option<u32> {
-        self.base_id
+}
+
+/// Best-effort delete of a partial data file. External-base files are skipped
+/// because we don't have access to their object stores here.
+async fn delete_partial_file_if_local(
+    base_id: Option<u32>,
+    object_store: ObjectStore,
+    full_path: Path,
+) {
+    if base_id.is_some() {
+        return;
+    }
+    if let Err(e) = object_store.delete(&full_path).await {
+        log::warn!(
+            "Failed to clean up in-progress data file '{}': {}",
+            full_path,
+            e
+        );
     }
 }
 
@@ -1214,6 +1219,8 @@ async fn open_writer_with_options(
             .await?,
             path: filename,
             base_id,
+            object_store: object_store.clone(),
+            full_path: full_path.clone(),
         })
     } else {
         let writer = object_store.create(&full_path).await?;
@@ -1247,6 +1254,8 @@ async fn open_writer_with_options(
             path: filename,
             base_id,
             preprocessor,
+            object_store: object_store.clone(),
+            full_path: full_path.clone(),
         };
         Box::new(writer_adapter) as Box<dyn GenericWriter>
     };

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -570,6 +570,8 @@ pub async fn do_write_fragments(
                 let last_fragment = fragments.last_mut().unwrap();
                 last_fragment.physical_rows = Some(num_rows as usize);
                 last_fragment.files.push(data_file);
+                // Notify after pushing the data file so it's tracked for cleanup
+                // if the callback fails.
                 params.progress.complete(fragments.last().unwrap()).await?;
                 if let Some(cb) = &params.write_progress {
                     cb.call(WriteStats {
@@ -586,28 +588,18 @@ pub async fn do_write_fragments(
     .await;
 
     if let Err(e) = loop_result {
-        let in_progress_filename = writer
+        let in_progress_path = writer
             .as_ref()
             .filter(|w| w.base_id().is_none())
             .map(|w| w.path().to_owned());
         drop(writer.take());
-        cleanup_data_fragments(&object_store, base_dir, &fragments).await;
-        if let Some(filename) = in_progress_filename {
-            let path = base_dir.child(DATA_DIR).child(filename.as_str());
-            if let Err(del_e) = object_store.delete(&path).await {
-                log::warn!(
-                    "Failed to clean up in-progress data file '{}': {}",
-                    path,
-                    del_e
-                );
-            }
-        }
+        cleanup_partial_write(&object_store, base_dir, &fragments, in_progress_path).await;
         return Err(e);
     }
 
     // Complete the final writer
     if let Some(mut w) = writer.take() {
-        let in_progress_filename = if w.base_id().is_none() {
+        let in_progress_path = if w.base_id().is_none() {
             Some(w.path().to_owned())
         } else {
             None
@@ -630,17 +622,7 @@ pub async fn do_write_fragments(
                 }
             }
             Err(e) => {
-                cleanup_data_fragments(&object_store, base_dir, &fragments).await;
-                if let Some(filename) = in_progress_filename {
-                    let path = base_dir.child(DATA_DIR).child(filename.as_str());
-                    if let Err(del_e) = object_store.delete(&path).await {
-                        log::warn!(
-                            "Failed to clean up in-progress data file '{}': {}",
-                            path,
-                            del_e
-                        );
-                    }
-                }
+                cleanup_partial_write(&object_store, base_dir, &fragments, in_progress_path).await;
                 return Err(e);
             }
         }
@@ -674,6 +656,23 @@ pub(crate) async fn cleanup_data_fragments(
                     file.base_id.unwrap()
                 );
             }
+        }
+    }
+}
+
+/// Best-effort cleanup of a partially-failed write: deletes all completed fragment
+/// data files plus an optional in-progress file that was never finished.
+async fn cleanup_partial_write(
+    object_store: &ObjectStore,
+    base_dir: &Path,
+    fragments: &[Fragment],
+    in_progress_filename: Option<String>,
+) {
+    cleanup_data_fragments(object_store, base_dir, fragments).await;
+    if let Some(filename) = in_progress_filename {
+        let path = base_dir.child(DATA_DIR).child(filename.as_str());
+        if let Err(e) = object_store.delete(&path).await {
+            log::warn!("Failed to clean up in-progress data file '{}': {}", path, e);
         }
     }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -42,8 +42,6 @@ use crate::session::Session;
 use super::DATA_DIR;
 use super::fragment::write::generate_random_filename;
 use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
-
-pub use super::progress::{WriteProgressFn, WriteStats};
 use super::transaction::Transaction;
 use super::utils::SchemaAdapter;
 
@@ -54,6 +52,7 @@ pub mod merge_insert;
 mod retry;
 pub mod update;
 
+pub use super::progress::{WriteProgressFn, WriteStats};
 pub use commit::CommitBuilder;
 pub use delete::{DeleteBuilder, DeleteResult, UncommittedDelete};
 pub use insert::InsertBuilder;
@@ -218,6 +217,13 @@ pub struct WriteParams {
 
     pub progress: Arc<dyn WriteFragmentProgress>,
 
+    /// Optional callback invoked after each batch is written.
+    ///
+    /// Receives cumulative [`WriteStats`] so callers can render a progress bar
+    /// or compute throughput. The callback must be cheap and non-blocking;
+    /// spawn a task if you need async work.
+    pub write_progress: Option<WriteProgressFn>,
+
     /// If present, dataset will use this to update the latest version
     ///
     /// If not set, the default will be based on the object store.  Generally this will
@@ -321,6 +327,7 @@ impl Default for WriteParams {
             store_params: None,
             base_store_params: None,
             progress: Arc::new(NoopFragmentWriteProgress::new()),
+            write_progress: None,
             commit_handler: None,
             data_storage_version: None,
             enable_stable_row_ids: false,
@@ -592,19 +599,22 @@ pub async fn do_write_fragments(
             .as_ref()
             .filter(|w| w.base_id().is_none())
             .map(|w| w.path().to_owned());
+        // Drop the writer before deleting: closes any open file handle (some
+        // platforms can't delete open files) and aborts in-progress multipart
+        // uploads via `ObjectWriter::drop`.
         drop(writer.take());
         cleanup_partial_write(&object_store, base_dir, &fragments, in_progress_path).await;
         return Err(e);
     }
 
     // Complete the final writer
-    if let Some(mut w) = writer.take() {
-        let in_progress_path = if w.base_id().is_none() {
-            Some(w.path().to_owned())
+    if let Some(mut writer) = writer.take() {
+        let in_progress_path = if writer.base_id().is_none() {
+            Some(writer.path().to_owned())
         } else {
             None
         };
-        match w.finish().await {
+        match writer.finish().await {
             Ok((num_rows, data_file)) => {
                 info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
                 bytes_completed += data_file.file_size_bytes.get().map_or(0, |s| s.get());
@@ -1425,13 +1435,11 @@ async fn new_source_iter(
 
 struct SpillStreamIter {
     receiver: SpillReceiver,
-    #[allow(dead_code)] // Exists to keep the SpillSender alive
-    sender_handle: tokio::task::JoinHandle<SpillSender>,
+    _sender_handle: tokio::task::JoinHandle<SpillSender>,
     // This temp dir is used to store the spilled data. It is kept alive by
     // this struct. When this struct is dropped, the Drop implementation of
     // tempfile::TempDir will delete the temp dir.
-    #[allow(dead_code)] // Exists to keep the temp dir alive
-    tmp_dir: TempDir,
+    _tmp_dir: TempDir,
 }
 
 impl SpillStreamIter {
@@ -1475,8 +1483,8 @@ impl SpillStreamIter {
 
         Ok(Self {
             receiver,
-            tmp_dir,
-            sender_handle,
+            _tmp_dir: tmp_dir,
+            _sender_handle: sender_handle,
         })
     }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -597,15 +597,25 @@ pub async fn do_write_fragments(
     .await;
 
     if let Err(e) = loop_result {
-        if let Some(w) = writer.take() {
-            w.abort().await;
-        }
-        cleanup_data_fragments(&object_store, base_dir, &fragments).await;
+        let in_progress_path = writer
+            .as_ref()
+            .filter(|w| w.base_id().is_none())
+            .map(|w| w.path().to_owned());
+        // Drop the writer before deleting: closes any open file handle (some
+        // platforms can't delete open files) and aborts in-progress multipart
+        // uploads via `ObjectWriter::drop`.
+        drop(writer.take());
+        cleanup_partial_write(&object_store, base_dir, &fragments, in_progress_path).await;
         return Err(e);
     }
 
     // Complete the final writer
     if let Some(mut writer) = writer.take() {
+        let in_progress_path = if writer.base_id().is_none() {
+            Some(writer.path().to_owned())
+        } else {
+            None
+        };
         match writer.finish().await {
             Ok((num_rows, data_file)) => {
                 info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
@@ -624,8 +634,7 @@ pub async fn do_write_fragments(
                 }
             }
             Err(e) => {
-                writer.abort().await;
-                cleanup_data_fragments(&object_store, base_dir, &fragments).await;
+                cleanup_partial_write(&object_store, base_dir, &fragments, in_progress_path).await;
                 return Err(e);
             }
         }
@@ -668,6 +677,23 @@ pub(crate) async fn cleanup_data_fragments(
              cleanup not supported for external bases",
             skipped_external
         );
+    }
+}
+
+/// Best-effort cleanup of a partially-failed write: deletes all completed fragment
+/// data files plus an optional in-progress file that was never finished.
+async fn cleanup_partial_write(
+    object_store: &ObjectStore,
+    base_dir: &Path,
+    fragments: &[Fragment],
+    in_progress_filename: Option<String>,
+) {
+    cleanup_data_fragments(object_store, base_dir, fragments).await;
+    if let Some(filename) = in_progress_filename {
+        let path = base_dir.clone().join(DATA_DIR).join(filename.as_str());
+        if let Err(e) = object_store.delete(&path).await {
+            log::warn!("Failed to clean up in-progress data file '{}': {}", path, e);
+        }
     }
 }
 
@@ -1008,11 +1034,11 @@ pub trait GenericWriter: Send {
     async fn tell(&mut self) -> Result<u64>;
     /// Finish writing the file (flush the remaining data and write footer)
     async fn finish(&mut self) -> Result<(u32, DataFile)>;
-    /// Abort writing: drop any open handle, abort any in-progress multipart
-    /// upload, and best-effort delete the partial file. Errors are logged and
-    /// swallowed. Files written to external bases are skipped (we don't have
-    /// access to their object stores).
-    async fn abort(self: Box<Self>);
+    /// Returns the relative filename (without directory) of the file being written.
+    fn path(&self) -> &str;
+    /// Returns the base ID if this writer is writing to an external base, or None
+    /// for the dataset's default storage.
+    fn base_id(&self) -> Option<u32>;
 }
 
 struct V1WriterAdapter<M>
@@ -1022,8 +1048,6 @@ where
     writer: PreviousFileWriter<M>,
     path: String,
     base_id: Option<u32>,
-    object_store: ObjectStore,
-    full_path: Path,
 }
 
 #[async_trait::async_trait]
@@ -1049,15 +1073,11 @@ where
             ),
         ))
     }
-    async fn abort(self: Box<Self>) {
-        let base_id = self.base_id;
-        let object_store = self.object_store.clone();
-        let full_path = self.full_path.clone();
-        // Drop the writer before deleting: closes any open file handle (some
-        // platforms can't delete open files) and aborts any in-progress
-        // multipart upload via `ObjectWriter::drop`.
-        drop(self);
-        delete_partial_file_if_local(base_id, object_store, full_path).await;
+    fn path(&self) -> &str {
+        &self.path
+    }
+    fn base_id(&self) -> Option<u32> {
+        self.base_id
     }
 }
 
@@ -1066,8 +1086,6 @@ struct V2WriterAdapter {
     path: String,
     base_id: Option<u32>,
     preprocessor: Option<BlobPreprocessor>,
-    object_store: ObjectStore,
-    full_path: Path,
 }
 
 #[async_trait::async_trait]
@@ -1117,34 +1135,11 @@ impl GenericWriter for V2WriterAdapter {
         );
         Ok((num_rows, data_file))
     }
-    async fn abort(self: Box<Self>) {
-        let base_id = self.base_id;
-        let object_store = self.object_store.clone();
-        let full_path = self.full_path.clone();
-        // Drop the writer before deleting: closes any open file handle (some
-        // platforms can't delete open files) and aborts any in-progress
-        // multipart upload via `ObjectWriter::drop`.
-        drop(self);
-        delete_partial_file_if_local(base_id, object_store, full_path).await;
+    fn path(&self) -> &str {
+        &self.path
     }
-}
-
-/// Best-effort delete of a partial data file. External-base files are skipped
-/// because we don't have access to their object stores here.
-async fn delete_partial_file_if_local(
-    base_id: Option<u32>,
-    object_store: ObjectStore,
-    full_path: Path,
-) {
-    if base_id.is_some() {
-        return;
-    }
-    if let Err(e) = object_store.delete(&full_path).await {
-        log::warn!(
-            "Failed to clean up in-progress data file '{}': {}",
-            full_path,
-            e
-        );
+    fn base_id(&self) -> Option<u32> {
+        self.base_id
     }
 }
 
@@ -1219,8 +1214,6 @@ async fn open_writer_with_options(
             .await?,
             path: filename,
             base_id,
-            object_store: object_store.clone(),
-            full_path: full_path.clone(),
         })
     } else {
         let writer = object_store.create(&full_path).await?;
@@ -1254,8 +1247,6 @@ async fn open_writer_with_options(
             path: filename,
             base_id,
             preprocessor,
-            object_store: object_store.clone(),
-            full_path: full_path.clone(),
         };
         Box::new(writer_adapter) as Box<dyn GenericWriter>
     };

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -9143,7 +9143,10 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
 
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
-        let routed_uri = format!("file-object-store://{}", test_uri);
+        // Prefix `/` so Windows drive letters (e.g. `C:`) don't get parsed as
+        // the URL authority.
+        let path_prefix = if test_uri.starts_with('/') { "" } else { "/" };
+        let routed_uri = format!("file-object-store://{path_prefix}{test_uri}");
 
         let batches = RecordBatchIterator::new([Ok(initial)], schema.clone());
         let mut dataset = Dataset::write(

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -9108,4 +9108,119 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
             assert_eq!(values.value(i), 888.0, "row {i} should have value_a=888.0");
         }
     }
+
+    fn count_data_files(base_dir: &str) -> usize {
+        let data_dir = std::path::Path::new(base_dir).join("data");
+        if !data_dir.exists() {
+            return 0;
+        }
+        std::fs::read_dir(data_dir)
+            .unwrap()
+            .filter(|e| e.as_ref().unwrap().path().is_file())
+            .count()
+    }
+
+    /// Site 3 in PR #6320: when `MergeInsertJob::apply_deletions` fails after
+    /// the new fragments have been written, the new data files must be cleaned up.
+    #[tokio::test]
+    async fn test_merge_insert_cleans_up_data_on_apply_deletions_failure() {
+        use crate::utils::test::FailingProxyStore;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let initial = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from_iter_values(0..30)),
+                Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+                    "foo", 30,
+                ))),
+            ],
+        )
+        .unwrap();
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let routed_uri = format!("file-object-store://{}", test_uri);
+
+        let batches = RecordBatchIterator::new([Ok(initial)], schema.clone());
+        let mut dataset = Dataset::write(
+            batches,
+            &routed_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                data_storage_version: Some(LanceFileVersion::V2_1),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Create a scalar index on the join key. This forces the merge insert
+        // to take the slow (non-fast) path, which is the path that has the
+        // post-write cleanup we want to exercise.
+        dataset
+            .create_index(
+                &["id"],
+                IndexType::Scalar,
+                None,
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+
+        let baseline_files = count_data_files(test_uri);
+        assert!(baseline_files > 0);
+
+        let failing = Arc::new(FailingProxyStore::new());
+        failing.fail_when("put", "_deletions", "injected deletions failure");
+        failing.fail_when("put_multipart", "_deletions", "injected deletions failure");
+
+        let dataset = DatasetBuilder::from_uri(&routed_uri)
+            .with_read_params(ReadParams {
+                store_options: Some(ObjectStoreParams {
+                    object_store_wrapper: Some(failing.clone()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .load()
+            .await
+            .unwrap();
+
+        // Update existing keys (5..15 already exist) to force the apply_deletions path.
+        let new_data = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from_iter_values(5..15)),
+                Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+                    "bar", 10,
+                ))),
+            ],
+        )
+        .unwrap();
+        let new_reader = Box::new(RecordBatchIterator::new([Ok(new_data)], schema.clone()));
+
+        let job = MergeInsertBuilder::try_new(Arc::new(dataset), vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap();
+
+        let result = job.execute_reader(new_reader).await;
+        assert!(
+            result.is_err(),
+            "Merge insert should fail when deletion-file write fails"
+        );
+
+        assert_eq!(
+            count_data_files(test_uri),
+            baseline_files,
+            "Newly written merge-insert data files should be cleaned up on apply_deletions failure"
+        );
+    }
 }

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -41,6 +41,7 @@ pub mod inserted_rows;
 use assign_action::merge_insert_action;
 use inserted_rows::KeyExistenceFilter;
 
+use super::cleanup_data_fragments;
 use super::retry::{RetryConfig, RetryExecutor, execute_with_retry};
 use super::{CommitBuilder, WriteParams, write_fragments_internal};
 use crate::dataset::rowids::get_row_id_index;
@@ -1775,8 +1776,19 @@ impl MergeInsertJob {
 
             let removed_row_addrs = RoaringTreemap::from_iter(removed_row_addr_vec.into_iter());
 
-            let (old_fragments, removed_fragment_ids) =
-                Self::apply_deletions(&self.dataset, &removed_row_addrs).await?;
+            let deletions_result = Self::apply_deletions(&self.dataset, &removed_row_addrs).await;
+            let (old_fragments, removed_fragment_ids) = match deletions_result {
+                Ok(v) => v,
+                Err(e) => {
+                    cleanup_data_fragments(
+                        &self.dataset.object_store,
+                        &self.dataset.base,
+                        &new_fragments,
+                    )
+                    .await;
+                    return Err(e);
+                }
+            };
 
             // Commit updated and new fragments
             let operation = Operation::Update {

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
+use super::cleanup_data_fragments;
 use super::retry::{RetryConfig, RetryExecutor, execute_with_retry};
 use super::{CommitBuilder, WriteParams, write_fragments_internal};
 use crate::dataset::rowids::get_row_id_index;
@@ -351,7 +352,19 @@ impl UpdateJob {
         // Apply deletions
         let row_id_index = get_row_id_index(&self.dataset).await?;
         let row_addrs = removed_row_ids.row_addrs(row_id_index.as_deref());
-        let (old_fragments, removed_fragment_ids) = self.apply_deletions(&row_addrs).await?;
+        let deletions_result = self.apply_deletions(&row_addrs).await;
+        let (old_fragments, removed_fragment_ids) = match deletions_result {
+            Ok(v) => v,
+            Err(e) => {
+                cleanup_data_fragments(
+                    &self.dataset.object_store,
+                    &self.dataset.base,
+                    &new_fragments,
+                )
+                .await;
+                return Err(e);
+            }
+        };
         let affected_rows = RowAddrTreeMap::from(row_addrs.as_ref().clone());
 
         let num_updated_rows = new_fragments

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -1593,4 +1593,95 @@ mod tests {
             }
         }
     }
+
+    fn count_data_files(base_dir: &str) -> usize {
+        let data_dir = std::path::Path::new(base_dir).join("data");
+        if !data_dir.exists() {
+            return 0;
+        }
+        std::fs::read_dir(data_dir)
+            .unwrap()
+            .filter(|e| e.as_ref().unwrap().path().is_file())
+            .count()
+    }
+
+    /// Site 4 in PR #6320: when `UpdateJob::apply_deletions` fails after the new
+    /// rewrite fragments have been written, those new data files must be cleaned up.
+    #[tokio::test]
+    async fn test_update_cleans_up_data_on_apply_deletions_failure() {
+        use crate::utils::test::FailingProxyStore;
+        use lance_io::object_store::ObjectStoreParams;
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from_iter_values(0..30)),
+                Arc::new(StringArray::from_iter_values(std::iter::repeat_n(
+                    "foo", 30,
+                ))),
+            ],
+        )
+        .unwrap();
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+        let routed_uri = format!("file-object-store://{}", test_uri);
+
+        let write_params = WriteParams {
+            max_rows_per_file: 10,
+            data_storage_version: Some(LanceFileVersion::V2_1),
+            ..Default::default()
+        };
+        let batches = RecordBatchIterator::new([Ok(batch)], schema.clone());
+        Dataset::write(batches, &routed_uri, Some(write_params))
+            .await
+            .unwrap();
+
+        let baseline_files = count_data_files(test_uri);
+        assert!(baseline_files > 0);
+
+        // Fail writes to `_deletions/`: this is where `apply_deletions` writes
+        // the new deletion file. The rewrite fragments (in `data/`) are written
+        // earlier and should be successfully created, then cleaned up on failure.
+        let failing = Arc::new(FailingProxyStore::new());
+        failing.fail_when("put", "_deletions", "injected deletions failure");
+        failing.fail_when("put_multipart", "_deletions", "injected deletions failure");
+
+        let dataset = DatasetBuilder::from_uri(&routed_uri)
+            .with_read_params(ReadParams {
+                store_options: Some(ObjectStoreParams {
+                    object_store_wrapper: Some(failing.clone()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .load()
+            .await
+            .unwrap();
+
+        let result = UpdateBuilder::new(Arc::new(dataset))
+            .update_where("id < 5")
+            .unwrap()
+            .set("name", "'bar'")
+            .unwrap()
+            .build()
+            .unwrap()
+            .execute()
+            .await;
+
+        assert!(
+            result.is_err(),
+            "Update should fail when deletion-file write fails"
+        );
+
+        assert_eq!(
+            count_data_files(test_uri),
+            baseline_files,
+            "Rewritten data files should be cleaned up on apply_deletions failure"
+        );
+    }
 }

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -1629,7 +1629,10 @@ mod tests {
 
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
-        let routed_uri = format!("file-object-store://{}", test_uri);
+        // Prefix `/` so Windows drive letters (e.g. `C:`) don't get parsed as
+        // the URL authority.
+        let path_prefix = if test_uri.starts_with('/') { "" } else { "/" };
+        let routed_uri = format!("file-object-store://{path_prefix}{test_uri}");
 
         let write_params = WriteParams {
             max_rows_per_file: 10,

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -21,8 +21,10 @@ use crate::dataset::WriteParams;
 use crate::dataset::fragment::write::FragmentCreateBuilder;
 use crate::dataset::transaction::Operation;
 
+mod failing_store;
 mod throttle_store;
 
+pub use failing_store::FailingProxyStore;
 pub use throttle_store::ThrottledStoreWrapper;
 
 /// A dataset generator that can generate random layouts. This is used to test

--- a/rust/lance/src/utils/test/failing_store.rs
+++ b/rust/lance/src/utils/test/failing_store.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Test helper that wraps an object store and injects failures for specific
+//! method/path combinations. Used to exercise cleanup paths in write code that
+//! handle storage failures after partial data files have been written.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use lance_core::utils::testing::{ProxyObjectStore, ProxyObjectStorePolicy};
+use lance_io::object_store::WrappingObjectStore;
+
+/// Wraps the object store so that calls matching a configured method+path
+/// substring return a synthetic error.
+#[derive(Debug)]
+pub struct FailingProxyStore {
+    policy: Arc<Mutex<ProxyObjectStorePolicy>>,
+}
+
+impl Default for FailingProxyStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FailingProxyStore {
+    pub fn new() -> Self {
+        Self {
+            policy: Arc::new(Mutex::new(ProxyObjectStorePolicy::new())),
+        }
+    }
+
+    /// Fail calls to `method` on paths containing `path_substr` only after
+    /// the first `skip` matching calls have passed through. Useful when an
+    /// earlier write to the same prefix must succeed (e.g. `reserve_fragment_ids`)
+    /// before we want a later write to fail.
+    pub fn fail_after_n(
+        &self,
+        method: &'static str,
+        path_substr: &'static str,
+        skip: usize,
+        error_message: &'static str,
+    ) {
+        let mut policy = self.policy.lock().unwrap();
+        let counter = Arc::new(AtomicUsize::new(0));
+        let policy_name = format!("fail_after_{}_{}_{}", method, path_substr, skip);
+        policy.set_before_policy(
+            Box::leak(policy_name.into_boxed_str()),
+            Arc::new(move |called_method, path| {
+                if called_method == method && path.as_ref().contains(path_substr) {
+                    let count = counter.fetch_add(1, Ordering::SeqCst);
+                    if count >= skip {
+                        return Err(object_store::Error::Generic {
+                            store: "FailingProxyStore",
+                            source: error_message.into(),
+                        }
+                        .into());
+                    }
+                }
+                Ok(())
+            }),
+        );
+    }
+
+    /// Fail every call to `method` whose path contains `path_substr` with a
+    /// generic store error carrying `error_message`.
+    pub fn fail_when(
+        &self,
+        method: &'static str,
+        path_substr: &'static str,
+        error_message: &'static str,
+    ) {
+        let mut policy = self.policy.lock().unwrap();
+        let policy_name = format!("fail_{}_{}", method, path_substr);
+        policy.set_before_policy(
+            Box::leak(policy_name.into_boxed_str()),
+            Arc::new(move |called_method, path| {
+                if called_method == method && path.as_ref().contains(path_substr) {
+                    Err(object_store::Error::Generic {
+                        store: "FailingProxyStore",
+                        source: error_message.into(),
+                    }
+                    .into())
+                } else {
+                    Ok(())
+                }
+            }),
+        );
+    }
+}
+
+impl WrappingObjectStore for FailingProxyStore {
+    fn wrap(
+        &self,
+        _storage_prefix: &str,
+        original: Arc<dyn object_store::ObjectStore>,
+    ) -> Arc<dyn object_store::ObjectStore> {
+        Arc::new(ProxyObjectStore::new(original, self.policy.clone()))
+    }
+}


### PR DESCRIPTION
Previously, if a write operation failed mid-stream, the data files already
written to storage were left as orphans until GC reclaimed them (7+ days by
default).

This adds best-effort cleanup at two levels:

1. `do_write_fragments`: on error in the write loop, deletes all data files
   it opened (both completed and in-progress). External-base files are
   skipped with a warning since their object store isn't available at
   cleanup time.

2. `update` / `merge_insert` `execute_impl`: if `apply_deletions` fails
   after data files were successfully written, cleans up those data files.

Every path we clean up was generated by a writer we opened in the same call,
stored in local-only data structures, so there is no risk of deleting
pre-existing files.

Fixes #6124

## Test plan

- [x] New test: single-file write failure cleans up partial data file
- [x] New test: multi-file write failure (file boundary crossed before error) cleans up all files
- [x] All 183 existing `dataset::write` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)