### PR TITLE
chore: use Uuid type for Transaction.uuid instead of String

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5146,6 +5146,7 @@ dependencies = [
  "tower",
  "tower-http 0.5.2",
  "url",
+ "uuid",
  "wiremock",
 ]
 

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -309,7 +309,7 @@ pub(crate) fn convert_to_java_transaction<'local>(
     env: &mut JNIEnv<'local>,
     transaction: Transaction,
 ) -> Result<JObject<'local>> {
-    let uuid = env.new_string(transaction.uuid)?;
+    let uuid = env.new_string(transaction.uuid.to_string())?;
     let tag = match transaction.tag {
         Some(tag) => JObject::from(env.new_string(tag)?),
         None => JObject::null(),
@@ -809,6 +809,8 @@ fn convert_to_rust_transaction(
             to_rust_map(env, &transaction_properties)
         },
     )?;
+    let uuid = Uuid::parse_str(&uuid)
+        .map_err(|e| Error::input_error(format!("Invalid transaction uuid: {e}")))?;
     Ok(TransactionBuilder::new(read_ver, op)
         .uuid(uuid)
         .tag(tag)

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -309,7 +309,7 @@ pub(crate) fn convert_to_java_transaction<'local>(
     env: &mut JNIEnv<'local>,
     transaction: Transaction,
 ) -> Result<JObject<'local>> {
-    let uuid = env.new_string(transaction.uuid.to_string())?;
+    let uuid = transaction.uuid.into_java(env)?;
     let tag = match transaction.tag {
         Some(tag) => JObject::from(env.new_string(tag)?),
         None => JObject::null(),
@@ -322,7 +322,7 @@ pub(crate) fn convert_to_java_transaction<'local>(
 
     let java_transaction = env.new_object(
         "org/lance/Transaction",
-        "(JLjava/lang/String;Lorg/lance/operation/Operation;Ljava/lang/String;Ljava/util/Map;)V",
+        "(JLjava/util/UUID;Lorg/lance/operation/Operation;Ljava/lang/String;Ljava/util/Map;)V",
         &[
             JValue::Long(transaction.read_version as i64),
             JValue::Object(&uuid),
@@ -785,7 +785,10 @@ fn convert_to_rust_transaction(
     dataset: Option<&mut BlockingDataset>,
 ) -> Result<Transaction> {
     let read_ver = env.get_u64_from_method(&java_transaction, "readVersion")?;
-    let uuid = env.get_string_from_method(&java_transaction, "uuid")?;
+    let uuid = env
+        .call_method(&java_transaction, "uuid", "()Ljava/util/UUID;", &[])?
+        .l()?
+        .extract_object(env)?;
     let op = env
         .call_method(
             &java_transaction,
@@ -809,8 +812,6 @@ fn convert_to_rust_transaction(
             to_rust_map(env, &transaction_properties)
         },
     )?;
-    let uuid = Uuid::parse_str(&uuid)
-        .map_err(|e| Error::input_error(format!("Invalid transaction uuid: {e}")))?;
     Ok(TransactionBuilder::new(read_ver, op)
         .uuid(uuid)
         .tag(tag)

--- a/java/src/main/java/org/lance/SourcedTransaction.java
+++ b/java/src/main/java/org/lance/SourcedTransaction.java
@@ -19,6 +19,7 @@ import org.apache.arrow.util.Preconditions;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * A convenience wrapper that pairs a {@link Transaction} with a {@link Dataset}, providing a simple
@@ -59,7 +60,7 @@ public class SourcedTransaction implements AutoCloseable {
   }
 
   /** Delegates to {@link Transaction#uuid()}. */
-  public String uuid() {
+  public UUID uuid() {
     return transaction.uuid();
   }
 

--- a/java/src/main/java/org/lance/Transaction.java
+++ b/java/src/main/java/org/lance/Transaction.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 public class Transaction implements AutoCloseable {
 
   private final long readVersion;
-  private final String uuid;
+  private final UUID uuid;
   private final Operation operation;
   private final Optional<String> tag;
   private final Optional<Map<String, String>> transactionProperties;
@@ -50,7 +50,7 @@ public class Transaction implements AutoCloseable {
    */
   private Transaction(
       long readVersion,
-      String uuid,
+      UUID uuid,
       Operation operation,
       String tag,
       Map<String, String> transactionProperties) {
@@ -69,14 +69,14 @@ public class Transaction implements AutoCloseable {
    * @param operation the operation to perform
    */
   public Transaction(long readVersion, Operation operation) {
-    this(readVersion, UUID.randomUUID().toString(), operation, null, null);
+    this(readVersion, UUID.randomUUID(), operation, null, null);
   }
 
   public long readVersion() {
     return readVersion;
   }
 
-  public String uuid() {
+  public UUID uuid() {
     return uuid;
   }
 
@@ -133,14 +133,14 @@ public class Transaction implements AutoCloseable {
 
   /** Builder for constructing {@link Transaction} instances. */
   public static class Builder {
-    private String uuid;
+    private UUID uuid;
     private long readVersion;
     private Operation operation;
     private String tag;
     private Map<String, String> transactionProperties;
 
     public Builder() {
-      this.uuid = UUID.randomUUID().toString();
+      this.uuid = UUID.randomUUID();
     }
 
     public Builder readVersion(long readVersion) {
@@ -148,7 +148,7 @@ public class Transaction implements AutoCloseable {
       return this;
     }
 
-    public Builder uuid(String uuid) {
+    public Builder uuid(UUID uuid) {
       this.uuid = uuid;
       return this;
     }

--- a/java/src/test/java/org/lance/TransactionTest.java
+++ b/java/src/test/java/org/lance/TransactionTest.java
@@ -175,7 +175,7 @@ public class TransactionTest {
       try (Dataset dataset = testDataset.createEmptyDataset()) {
         FragmentMetadata fragmentMeta = testDataset.createNewFragment(10);
 
-        String customUuid = "custom-uuid-12345";
+        String customUuid = "550e8400-e29b-41d4-a716-446655440000";
         try (Transaction txn =
             new Transaction.Builder()
                 .readVersion(dataset.version())

--- a/java/src/test/java/org/lance/TransactionTest.java
+++ b/java/src/test/java/org/lance/TransactionTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -175,7 +176,7 @@ public class TransactionTest {
       try (Dataset dataset = testDataset.createEmptyDataset()) {
         FragmentMetadata fragmentMeta = testDataset.createNewFragment(10);
 
-        String customUuid = "550e8400-e29b-41d4-a716-446655440000";
+        UUID customUuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
         try (Transaction txn =
             new Transaction.Builder()
                 .readVersion(dataset.version())

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4361,7 +4361,7 @@ class BulkCommitResult(TypedDict):
 class Transaction:
     read_version: int
     operation: LanceOperation.BaseOperation
-    uuid: str = dataclasses.field(default_factory=lambda: str(uuid.uuid4()))
+    uuid: uuid.UUID = dataclasses.field(default_factory=uuid.uuid4)
     transaction_properties: Optional[Dict[str, str]] = dataclasses.field(
         default_factory=dict
     )

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -5027,7 +5027,7 @@ def test_update_config_transaction(tmp_path: Path):
     )
 
     transaction = lance.Transaction(
-        read_version=ds.version, operation=update_config_op, uuid=str(uuid.uuid4())
+        read_version=ds.version, operation=update_config_op, uuid=uuid.uuid4()
     )
 
     # Commit transaction
@@ -5051,7 +5051,7 @@ def test_update_config_transaction(tmp_path: Path):
     )
 
     transaction2 = lance.Transaction(
-        read_version=ds_v2.version, operation=update_config_op2, uuid=str(uuid.uuid4())
+        read_version=ds_v2.version, operation=update_config_op2, uuid=uuid.uuid4()
     )
 
     ds_v3 = lance.LanceDataset.commit(tmp_path, transaction2)
@@ -5073,7 +5073,7 @@ def test_update_config_transaction(tmp_path: Path):
     )
 
     transaction3 = lance.Transaction(
-        read_version=ds_v3.version, operation=update_config_op3, uuid=str(uuid.uuid4())
+        read_version=ds_v3.version, operation=update_config_op3, uuid=uuid.uuid4()
     )
 
     ds_v4 = lance.LanceDataset.commit(tmp_path, transaction3)
@@ -5102,7 +5102,7 @@ def test_update_config_transaction(tmp_path: Path):
     )
 
     transaction4 = lance.Transaction(
-        read_version=ds_v4.version, operation=update_config_op4, uuid=str(uuid.uuid4())
+        read_version=ds_v4.version, operation=update_config_op4, uuid=uuid.uuid4()
     )
 
     ds_v5 = lance.LanceDataset.commit(tmp_path, transaction4)
@@ -5147,7 +5147,7 @@ def test_update_config_transaction(tmp_path: Path):
     transaction5 = lance.Transaction(
         read_version=ds_v6.version,  # Use the actual latest version
         operation=update_config_op5,
-        uuid=str(uuid.uuid4()),
+        uuid=uuid.uuid4(),
     )
 
     ds_v7 = lance.LanceDataset.commit(tmp_path, transaction5)

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -585,7 +585,8 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
 impl FromPyObject<'_> for PyLance<Transaction> {
     fn extract_bound(ob: &pyo3::Bound<'_, PyAny>) -> PyResult<Self> {
         let read_version = ob.getattr("read_version")?.extract()?;
-        let uuid = ob.getattr("uuid")?.extract()?;
+        let uuid_str: String = ob.getattr("uuid")?.extract()?;
+        let uuid = Uuid::parse_str(&uuid_str).map_err(|e| PyValueError::new_err(e.to_string()))?;
         let operation = ob.getattr("operation")?.extract::<PyLance<Operation>>()?.0;
         let transaction_properties = ob
             .getattr("transaction_properties")?
@@ -613,7 +614,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Transaction> {
             .expect("Failed to import lance module");
 
         let read_version = self.0.read_version;
-        let uuid = &self.0.uuid;
+        let uuid = self.0.uuid.hyphenated().to_string();
         let operation = PyLance(&self.0.operation).into_pyobject(py)?;
 
         let cls = namespace

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -585,7 +585,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
 impl FromPyObject<'_> for PyLance<Transaction> {
     fn extract_bound(ob: &pyo3::Bound<'_, PyAny>) -> PyResult<Self> {
         let read_version = ob.getattr("read_version")?.extract()?;
-        let uuid_str: String = ob.getattr("uuid")?.extract()?;
+        let uuid_str = ob.getattr("uuid")?.to_string();
         let uuid = Uuid::parse_str(&uuid_str).map_err(|e| PyValueError::new_err(e.to_string()))?;
         let operation = ob.getattr("operation")?.extract::<PyLance<Operation>>()?.0;
         let transaction_properties = ob
@@ -614,7 +614,9 @@ impl<'py> IntoPyObject<'py> for PyLance<&Transaction> {
             .expect("Failed to import lance module");
 
         let read_version = self.0.read_version;
-        let uuid = self.0.uuid.to_string();
+        let uuid_mod = py.import(intern!(py, "uuid"))?;
+        let uuid_cls = uuid_mod.getattr(intern!(py, "UUID"))?;
+        let uuid = uuid_cls.call1((self.0.uuid.to_string(),))?;
         let operation = PyLance(&self.0.operation).into_pyobject(py)?;
 
         let cls = namespace

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -614,7 +614,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Transaction> {
             .expect("Failed to import lance module");
 
         let read_version = self.0.read_version;
-        let uuid = self.0.uuid.hyphenated().to_string();
+        let uuid = self.0.uuid.to_string();
         let operation = PyLance(&self.0.operation).into_pyobject(py)?;
 
         let cls = namespace

--- a/rust/lance-namespace-impls/Cargo.toml
+++ b/rust/lance-namespace-impls/Cargo.toml
@@ -88,6 +88,7 @@ time = { version = "0.3", optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 tempfile.workspace = true
+uuid.workspace = true
 wiremock.workspace = true
 arrow = { workspace = true }
 arrow-ipc = { workspace = true }

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1079,10 +1079,7 @@ impl DirectoryNamespace {
             .as_ref()
             .map(|properties| (**properties).clone())
             .unwrap_or_default();
-        properties.insert(
-            "uuid".to_string(),
-            transaction.uuid.hyphenated().to_string(),
-        );
+        properties.insert("uuid".to_string(), transaction.uuid.to_string());
         properties.insert("version".to_string(), version.to_string());
         properties.insert(
             "read_version".to_string(),
@@ -1174,7 +1171,7 @@ impl DirectoryNamespace {
                         ),
                     })
                 })?
-                && transaction.uuid.hyphenated().to_string() == id
+                && transaction.uuid.to_string() == id
             {
                 return Ok((version.version, transaction));
             }
@@ -2494,7 +2491,7 @@ impl LanceNamespace for DirectoryNamespace {
                     ),
                 })
             })?
-            .map(|transaction| transaction.uuid.hyphenated().to_string());
+            .map(|transaction| transaction.uuid.to_string());
 
         Ok(CreateTableIndexResponse { transaction_id })
     }
@@ -2724,7 +2721,7 @@ impl LanceNamespace for DirectoryNamespace {
                     ),
                 })
             })?
-            .map(|transaction| transaction.uuid.hyphenated().to_string());
+            .map(|transaction| transaction.uuid.to_string());
 
         Ok(DropTableIndexResponse { transaction_id })
     }
@@ -2747,6 +2744,7 @@ mod tests {
     use lance_namespace::schema::convert_json_arrow_schema;
     use std::io::Cursor;
     use std::sync::Arc;
+    use uuid::Uuid;
 
     /// Helper to create a test DirectoryNamespace with a temporary directory
     async fn create_test_namespace() -> (DirectoryNamespace, TempStdDir) {
@@ -3067,12 +3065,12 @@ mod tests {
 
         let transaction_id = create_scalar_index(&namespace, "users", "users_id_idx").await;
         let dataset = open_dataset(&namespace, "users").await;
-        let expected_transaction_id = dataset
-            .read_transaction()
-            .await
-            .unwrap()
-            .map(|transaction| transaction.uuid.hyphenated().to_string());
-        assert_eq!(transaction_id, expected_transaction_id);
+        assert_eq!(
+            transaction_id
+                .as_deref()
+                .map(|s| Uuid::parse_str(s).unwrap()),
+            dataset.read_transaction().await.unwrap().map(|t| t.uuid)
+        );
         let indices = dataset.load_indices().await.unwrap();
         assert!(indices.iter().any(|index| index.name == "users_id_idx"));
     }
@@ -3096,12 +3094,12 @@ mod tests {
             .transaction_id;
 
         let dataset = open_dataset(&namespace, "vectors").await;
-        let expected_transaction_id = dataset
-            .read_transaction()
-            .await
-            .unwrap()
-            .map(|transaction| transaction.uuid.hyphenated().to_string());
-        assert_eq!(transaction_id, expected_transaction_id);
+        assert_eq!(
+            transaction_id
+                .as_deref()
+                .map(|s| Uuid::parse_str(s).unwrap()),
+            dataset.read_transaction().await.unwrap().map(|t| t.uuid)
+        );
         let indices = dataset.load_indices().await.unwrap();
         assert!(indices.iter().any(|index| index.name == "vector_idx"));
     }
@@ -3138,12 +3136,12 @@ mod tests {
         assert_eq!(users_id_idx.status, "SUCCEEDED");
 
         let dataset = open_dataset(&namespace, "users").await;
-        let expected_transaction_id = dataset
-            .read_transaction()
-            .await
-            .unwrap()
-            .map(|transaction| transaction.uuid.hyphenated().to_string());
-        assert_eq!(transaction_id, expected_transaction_id);
+        assert_eq!(
+            transaction_id
+                .as_deref()
+                .map(|s| Uuid::parse_str(s).unwrap()),
+            dataset.read_transaction().await.unwrap().map(|t| t.uuid)
+        );
         let indices = dataset.load_indices().await.unwrap();
         assert_eq!(
             indices
@@ -3204,12 +3202,12 @@ mod tests {
         assert_eq!(response.num_unindexed_rows, Some(0));
 
         let dataset = open_dataset(&namespace, "users").await;
-        let expected_transaction_id = dataset
-            .read_transaction()
-            .await
-            .unwrap()
-            .map(|transaction| transaction.uuid.hyphenated().to_string());
-        assert_eq!(transaction_id, expected_transaction_id);
+        assert_eq!(
+            transaction_id
+                .as_deref()
+                .map(|s| Uuid::parse_str(s).unwrap()),
+            dataset.read_transaction().await.unwrap().map(|t| t.uuid)
+        );
         let stats: serde_json::Value =
             serde_json::from_str(&dataset.index_statistics("users_id_idx").await.unwrap()).unwrap();
         assert_eq!(stats["index_type"], "BTree");
@@ -3228,10 +3226,10 @@ mod tests {
         let dataset = open_dataset(&namespace, "users").await;
         let latest_transaction = dataset.read_transaction().await.unwrap();
         assert_eq!(
-            transaction_id,
-            latest_transaction
-                .as_ref()
-                .map(|transaction| transaction.uuid.hyphenated().to_string())
+            transaction_id
+                .as_deref()
+                .map(|s| Uuid::parse_str(s).unwrap()),
+            latest_transaction.as_ref().map(|t| t.uuid)
         );
 
         if let Some(transaction_id) = transaction_id {
@@ -3285,18 +3283,22 @@ mod tests {
             .checkout_version(dataset.version().version - 1)
             .await
             .unwrap();
-        let previous_transaction_id = previous_dataset
-            .read_transaction()
-            .await
-            .unwrap()
-            .map(|transaction| transaction.uuid.hyphenated().to_string());
-        assert_eq!(create_transaction_id, previous_transaction_id);
-        let expected_drop_transaction_id = dataset
-            .read_transaction()
-            .await
-            .unwrap()
-            .map(|transaction| transaction.uuid.hyphenated().to_string());
-        assert_eq!(drop_transaction_id, expected_drop_transaction_id);
+        assert_eq!(
+            create_transaction_id
+                .as_deref()
+                .map(|s| Uuid::parse_str(s).unwrap()),
+            previous_dataset
+                .read_transaction()
+                .await
+                .unwrap()
+                .map(|t| t.uuid)
+        );
+        assert_eq!(
+            drop_transaction_id
+                .as_deref()
+                .map(|s| Uuid::parse_str(s).unwrap()),
+            dataset.read_transaction().await.unwrap().map(|t| t.uuid)
+        );
         let indices = dataset.load_indices().await.unwrap();
         assert!(!indices.iter().any(|index| index.name == "users_id_idx"));
 

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1079,7 +1079,10 @@ impl DirectoryNamespace {
             .as_ref()
             .map(|properties| (**properties).clone())
             .unwrap_or_default();
-        properties.insert("uuid".to_string(), transaction.uuid.clone());
+        properties.insert(
+            "uuid".to_string(),
+            transaction.uuid.hyphenated().to_string(),
+        );
         properties.insert("version".to_string(), version.to_string());
         properties.insert(
             "read_version".to_string(),
@@ -1171,7 +1174,7 @@ impl DirectoryNamespace {
                         ),
                     })
                 })?
-                && transaction.uuid == id
+                && transaction.uuid.hyphenated().to_string() == id
             {
                 return Ok((version.version, transaction));
             }
@@ -2491,7 +2494,7 @@ impl LanceNamespace for DirectoryNamespace {
                     ),
                 })
             })?
-            .map(|transaction| transaction.uuid);
+            .map(|transaction| transaction.uuid.hyphenated().to_string());
 
         Ok(CreateTableIndexResponse { transaction_id })
     }
@@ -2721,7 +2724,7 @@ impl LanceNamespace for DirectoryNamespace {
                     ),
                 })
             })?
-            .map(|transaction| transaction.uuid);
+            .map(|transaction| transaction.uuid.hyphenated().to_string());
 
         Ok(DropTableIndexResponse { transaction_id })
     }
@@ -3068,7 +3071,7 @@ mod tests {
             .read_transaction()
             .await
             .unwrap()
-            .map(|transaction| transaction.uuid);
+            .map(|transaction| transaction.uuid.hyphenated().to_string());
         assert_eq!(transaction_id, expected_transaction_id);
         let indices = dataset.load_indices().await.unwrap();
         assert!(indices.iter().any(|index| index.name == "users_id_idx"));
@@ -3097,7 +3100,7 @@ mod tests {
             .read_transaction()
             .await
             .unwrap()
-            .map(|transaction| transaction.uuid);
+            .map(|transaction| transaction.uuid.hyphenated().to_string());
         assert_eq!(transaction_id, expected_transaction_id);
         let indices = dataset.load_indices().await.unwrap();
         assert!(indices.iter().any(|index| index.name == "vector_idx"));
@@ -3139,7 +3142,7 @@ mod tests {
             .read_transaction()
             .await
             .unwrap()
-            .map(|transaction| transaction.uuid);
+            .map(|transaction| transaction.uuid.hyphenated().to_string());
         assert_eq!(transaction_id, expected_transaction_id);
         let indices = dataset.load_indices().await.unwrap();
         assert_eq!(
@@ -3205,7 +3208,7 @@ mod tests {
             .read_transaction()
             .await
             .unwrap()
-            .map(|transaction| transaction.uuid);
+            .map(|transaction| transaction.uuid.hyphenated().to_string());
         assert_eq!(transaction_id, expected_transaction_id);
         let stats: serde_json::Value =
             serde_json::from_str(&dataset.index_statistics("users_id_idx").await.unwrap()).unwrap();
@@ -3228,7 +3231,7 @@ mod tests {
             transaction_id,
             latest_transaction
                 .as_ref()
-                .map(|transaction| transaction.uuid.clone())
+                .map(|transaction| transaction.uuid.hyphenated().to_string())
         );
 
         if let Some(transaction_id) = transaction_id {
@@ -3286,13 +3289,13 @@ mod tests {
             .read_transaction()
             .await
             .unwrap()
-            .map(|transaction| transaction.uuid);
+            .map(|transaction| transaction.uuid.hyphenated().to_string());
         assert_eq!(create_transaction_id, previous_transaction_id);
         let expected_drop_transaction_id = dataset
             .read_transaction()
             .await
             .unwrap()
-            .map(|transaction| transaction.uuid);
+            .map(|transaction| transaction.uuid.hyphenated().to_string());
         assert_eq!(drop_transaction_id, expected_drop_transaction_id);
         let indices = dataset.load_indices().await.unwrap();
         assert!(!indices.iter().any(|index| index.name == "users_id_idx"));

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -3281,7 +3281,7 @@ impl From<&Transaction> for pb::Transaction {
             .unwrap_or_default();
         Self {
             read_version: value.read_version,
-            uuid: value.uuid.hyphenated().to_string(),
+            uuid: value.uuid.to_string(),
             operation: Some(operation),
             tag: value.tag.clone().unwrap_or("".to_string()),
             transaction_properties,

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -49,15 +49,25 @@ use uuid::Uuid;
 ///
 /// This contains enough information to be able to build the next manifest,
 /// given the current manifest.
-#[derive(Debug, Clone, DeepSizeOf, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Transaction {
     /// The version of the table this transaction is based off of. If this is
     /// the first transaction, this should be 0.
     pub read_version: u64,
-    pub uuid: String,
+    pub uuid: Uuid,
     pub operation: Operation,
     pub tag: Option<String>,
     pub transaction_properties: Option<Arc<HashMap<String, String>>>,
+}
+
+impl DeepSizeOf for Transaction {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        // Uuid is a fixed-size type with no heap allocation, so no children to count.
+        self.read_version.deep_size_of_children(context)
+            + self.operation.deep_size_of_children(context)
+            + self.tag.deep_size_of_children(context)
+            + self.transaction_properties.deep_size_of_children(context)
+    }
 }
 
 #[derive(Debug, Clone, DeepSizeOf, PartialEq)]
@@ -1393,7 +1403,7 @@ impl From<&pb::transaction::UpdateMap> for UpdateMap {
 pub struct TransactionBuilder {
     read_version: u64,
     // uuid is optional for builder since it can autogenerate
-    uuid: Option<String>,
+    uuid: Option<Uuid>,
     operation: Operation,
     tag: Option<String>,
     transaction_properties: Option<Arc<HashMap<String, String>>>,
@@ -1410,7 +1420,7 @@ impl TransactionBuilder {
         }
     }
 
-    pub fn uuid(mut self, uuid: String) -> Self {
+    pub fn uuid(mut self, uuid: Uuid) -> Self {
         self.uuid = Some(uuid);
         self
     }
@@ -1429,9 +1439,7 @@ impl TransactionBuilder {
     }
 
     pub fn build(self) -> Transaction {
-        let uuid = self
-            .uuid
-            .unwrap_or_else(|| Uuid::new_v4().hyphenated().to_string());
+        let uuid = self.uuid.unwrap_or_else(Uuid::new_v4);
         Transaction {
             read_version: self.read_version,
             uuid,
@@ -2994,9 +3002,11 @@ impl TryFrom<pb::Transaction> for Transaction {
                 ));
             }
         };
+        let uuid = Uuid::parse_str(&message.uuid)
+            .map_err(|e| Error::invalid_input(format!("Transaction uuid is not valid: {e}")))?;
         Ok(Self {
             read_version: message.read_version,
-            uuid: message.uuid.clone(),
+            uuid,
             operation,
             tag: if message.tag.is_empty() {
                 None
@@ -3271,7 +3281,7 @@ impl From<&Transaction> for pb::Transaction {
             .unwrap_or_default();
         Self {
             read_version: value.read_version,
-            uuid: value.uuid.clone(),
+            uuid: value.uuid.hyphenated().to_string(),
             operation: Some(operation),
             tag: value.tag.clone().unwrap_or("".to_string()),
             transaction_properties,

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -433,7 +433,7 @@ impl<'a> CommitBuilder<'a> {
         let read_version = transactions.iter().map(|t| t.read_version).min().unwrap();
 
         let merged = Transaction {
-            uuid: uuid::Uuid::new_v4().hyphenated().to_string(),
+            uuid: uuid::Uuid::new_v4(),
             operation: Operation::Append {
                 fragments: transactions
                     .iter()
@@ -503,7 +503,7 @@ mod tests {
 
     fn sample_transaction(read_version: u64) -> Transaction {
         Transaction {
-            uuid: uuid::Uuid::new_v4().hyphenated().to_string(),
+            uuid: uuid::Uuid::new_v4(),
             operation: Operation::Append {
                 fragments: vec![sample_fragment()],
             },
@@ -744,7 +744,7 @@ mod tests {
 
         // Attempting to commit update gives error
         let update_transaction = Transaction {
-            uuid: uuid::Uuid::new_v4().hyphenated().to_string(),
+            uuid: uuid::Uuid::new_v4(),
             operation: Operation::Update {
                 updated_fragments: vec![],
                 new_fragments: vec![],


### PR DESCRIPTION
Previously, `Transaction.uuid` was typed as `String` despite always holding a UUID value. This required `Uuid::new_v4().to_string()` at creation, `.clone()` at every use site, and no type-level guarantee about the format.

Change the field to `Uuid`:
- Parse from the proto `string` field in `TryFrom<pb::Transaction>` with `Uuid::parse_str`
- Serialize back with `.hyphenated().to_string()` in `From<&Transaction>`
- `TransactionBuilder::uuid` now accepts `Uuid` directly
- `DeepSizeOf` is now implemented manually since `uuid::Uuid` doesn't implement that trait (it's fixed-size, so `deep_size_of_children` is 0 for that field)
- Update call sites in `lance-namespace-impls` that exposed the uuid as a string via the API

Closes #6346