### PR TITLE
feat: compile-time feature-gated Rust backtrace for JNI error diagnostics

### DIFF
--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -20,6 +20,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
+backtrace = ["lance/backtrace", "lance-core/backtrace"]
 
 [dependencies]
 lance = { path = "../../rust/lance", features = ["substrait"] }

--- a/java/lance-jni/src/error.rs
+++ b/java/lance-jni/src/error.rs
@@ -181,29 +181,36 @@ impl std::fmt::Display for Error {
 
 impl From<LanceError> for Error {
     fn from(err: LanceError) -> Self {
+        let backtrace_suffix = err
+            .backtrace()
+            .map(|bt| format!("\n\nRust backtrace:\n{}", bt))
+            .unwrap_or_default();
+        let message = format!("{}{}", err, backtrace_suffix);
+
         match &err {
             LanceError::DatasetNotFound { .. }
             | LanceError::DatasetAlreadyExists { .. }
             | LanceError::CommitConflict { .. }
-            | LanceError::InvalidInput { .. } => Self::input_error(err.to_string()),
-            LanceError::IO { .. } => Self::io_error(err.to_string()),
-            LanceError::Timeout { .. } => Self::timeout_error(err.to_string()),
-            LanceError::NotSupported { .. } => Self::unsupported_error(err.to_string()),
-            LanceError::NotFound { .. } => Self::io_error(err.to_string()),
+            | LanceError::InvalidInput { .. } => Self::input_error(message),
+            LanceError::IO { .. } => Self::io_error(message),
+            LanceError::Timeout { .. } => Self::timeout_error(message),
+            LanceError::NotSupported { .. } => Self::unsupported_error(message),
+            LanceError::NotFound { .. } => Self::io_error(message),
             LanceError::Namespace { source, .. } => {
                 // Try to downcast to NamespaceError and get the error code
                 if let Some(ns_err) = source.downcast_ref::<NamespaceError>() {
-                    Self::namespace_error(ns_err.code().as_u32(), ns_err.to_string())
+                    let ns_message = format!("{}{}", ns_err, backtrace_suffix);
+                    Self::namespace_error(ns_err.code().as_u32(), ns_message)
                 } else {
                     log::warn!(
                         "Failed to downcast NamespaceError source, falling back to runtime error. \
                          This may indicate a version mismatch. Source type: {:?}",
                         source
                     );
-                    Self::runtime_error(err.to_string())
+                    Self::runtime_error(message)
                 }
             }
-            _ => Self::runtime_error(err.to_string()),
+            _ => Self::runtime_error(message),
         }
     }
 }
@@ -239,5 +246,106 @@ impl From<JniError> for Error {
 impl From<Utf8Error> for Error {
     fn from(err: Utf8Error) -> Self {
         Self::input_error(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper: extract the java_class from an Error via Display output
+    fn java_class(err: &Error) -> &JavaExceptionClass {
+        &err.java_class
+    }
+
+    #[test]
+    fn test_invalid_input_maps_to_illegal_argument() {
+        let lance_err = LanceError::invalid_input("bad input");
+        let jni_err: Error = lance_err.into();
+        assert_eq!(
+            *java_class(&jni_err),
+            JavaExceptionClass::IllegalArgumentException
+        );
+        assert!(jni_err.message.contains("bad input"));
+    }
+
+    #[test]
+    fn test_dataset_not_found_maps_to_illegal_argument() {
+        let lance_err = LanceError::dataset_not_found("my_dataset", "not found".to_string().into());
+        let jni_err: Error = lance_err.into();
+        assert_eq!(
+            *java_class(&jni_err),
+            JavaExceptionClass::IllegalArgumentException
+        );
+        assert!(jni_err.message.contains("my_dataset"));
+    }
+
+    #[test]
+    fn test_dataset_already_exists_maps_to_illegal_argument() {
+        let lance_err = LanceError::dataset_already_exists("my_dataset");
+        let jni_err: Error = lance_err.into();
+        assert_eq!(
+            *java_class(&jni_err),
+            JavaExceptionClass::IllegalArgumentException
+        );
+        assert!(jni_err.message.contains("my_dataset"));
+    }
+
+    #[test]
+    fn test_commit_conflict_maps_to_illegal_argument() {
+        let lance_err = LanceError::commit_conflict_source(42, "conflict".to_string().into());
+        let jni_err: Error = lance_err.into();
+        assert_eq!(
+            *java_class(&jni_err),
+            JavaExceptionClass::IllegalArgumentException
+        );
+    }
+
+    #[test]
+    fn test_io_maps_to_ioexception() {
+        let lance_err = LanceError::io("disk failure");
+        let jni_err: Error = lance_err.into();
+        assert_eq!(*java_class(&jni_err), JavaExceptionClass::IOException);
+        assert!(jni_err.message.contains("disk failure"));
+    }
+
+    #[test]
+    fn test_not_supported_maps_to_unsupported() {
+        let lance_err = LanceError::not_supported("nope");
+        let jni_err: Error = lance_err.into();
+        assert_eq!(
+            *java_class(&jni_err),
+            JavaExceptionClass::UnsupportedOperationException
+        );
+        assert!(jni_err.message.contains("nope"));
+    }
+
+    #[test]
+    fn test_not_found_maps_to_ioexception() {
+        let lance_err = LanceError::not_found("missing_uri");
+        let jni_err: Error = lance_err.into();
+        assert_eq!(*java_class(&jni_err), JavaExceptionClass::IOException);
+        assert!(jni_err.message.contains("missing_uri"));
+    }
+
+    #[test]
+    fn test_fallthrough_maps_to_runtime() {
+        let lance_err = LanceError::internal("internal oops");
+        let jni_err: Error = lance_err.into();
+        assert_eq!(*java_class(&jni_err), JavaExceptionClass::RuntimeException);
+        assert!(jni_err.message.contains("internal oops"));
+    }
+
+    #[test]
+    fn test_no_backtrace_suffix_when_backtrace_is_none() {
+        // Without the backtrace feature enabled in lance-core default tests,
+        // backtrace() returns None, so no suffix should be appended.
+        let lance_err = LanceError::io("clean message");
+        let jni_err: Error = lance_err.into();
+        assert!(
+            !jni_err.message.contains("Rust backtrace:"),
+            "Expected no backtrace suffix, got: {}",
+            jni_err.message
+        );
     }
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,6 +39,7 @@
         <spotless.scala.scalafmt.version>3.7.5</spotless.scala.scalafmt.version>
         <spotless.delimiter>package</spotless.delimiter>
         <rust.release.build>false</rust.release.build>
+        <rust.features></rust.features>
         <skip.build.jni>false</skip.build.jni>
         <shade.base>org.lance.shaded</shade.base>
         <spotless.license.header>
@@ -396,6 +397,9 @@
                                 <configuration>
                                     <path>lance-jni</path>
                                     <release>${rust.release.build}</release>
+                                    <features>
+                                        <feature>${rust.features}</feature>
+                                    </features>
                                     <!-- Copy native libraries to target/classes for runtime access -->
                                     <copyTo>${project.build.directory}/classes/nativelib</copyTo>
                                     <copyWithPlatformDir>true</copyWithPlatformDir>
@@ -409,6 +413,9 @@
                                 <configuration>
                                     <path>lance-jni</path>
                                     <release>${rust.release.build}</release>
+                                    <features>
+                                        <feature>${rust.features}</feature>
+                                    </features>
                                     <verbosity>-v</verbosity>
                                 </configuration>
                             </execution>

--- a/rust/lance-core/Cargo.toml
+++ b/rust/lance-core/Cargo.toml
@@ -55,6 +55,10 @@ proptest.workspace = true
 rstest.workspace = true
 
 [features]
+# Capture Rust backtraces in error types. When disabled (the default),
+# the backtrace field is zero-sized with no overhead. At runtime, capture
+# is still gated by RUST_BACKTRACE=1.
+backtrace = []
 datafusion = ["dep:datafusion-common", "dep:datafusion-sql"]
 
 [lints]

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -8,6 +8,52 @@ use snafu::{IntoError as _, Location, Snafu};
 
 type BoxedError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+#[cfg(feature = "backtrace")]
+mod backtrace_support {
+    use std::backtrace::Backtrace;
+
+    use snafu::{AsBacktrace, GenerateImplicitData};
+
+    #[derive(Debug)]
+    pub struct MaybeBacktrace(pub Option<Backtrace>);
+
+    impl GenerateImplicitData for MaybeBacktrace {
+        fn generate() -> Self {
+            Self(<Option<Backtrace>>::generate())
+        }
+    }
+
+    impl AsBacktrace for MaybeBacktrace {
+        fn as_backtrace(&self) -> Option<&Backtrace> {
+            self.0.as_ref()
+        }
+    }
+}
+
+#[cfg(not(feature = "backtrace"))]
+mod backtrace_support {
+    use std::backtrace::Backtrace;
+
+    use snafu::{AsBacktrace, GenerateImplicitData};
+
+    #[derive(Debug)]
+    pub struct MaybeBacktrace;
+
+    impl GenerateImplicitData for MaybeBacktrace {
+        fn generate() -> Self {
+            Self
+        }
+    }
+
+    impl AsBacktrace for MaybeBacktrace {
+        fn as_backtrace(&self) -> Option<&Backtrace> {
+            None
+        }
+    }
+}
+
+use backtrace_support::MaybeBacktrace;
+
 /// Error for when a requested field is not found in a schema.
 ///
 /// This error computes suggestions lazily (only when displayed) to avoid
@@ -81,18 +127,24 @@ pub enum Error {
         source: BoxedError,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Dataset already exists: {uri}, {location}"))]
     DatasetAlreadyExists {
         uri: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Append with different schema: {difference}, location: {location}"))]
     SchemaMismatch {
         difference: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Dataset at path {path} was not found: {source}, {location}"))]
     DatasetNotFound {
@@ -100,6 +152,8 @@ pub enum Error {
         source: BoxedError,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Encountered corrupt file {path}: {source}, {location}"))]
     CorruptFile {
@@ -107,13 +161,16 @@ pub enum Error {
         source: BoxedError,
         #[snafu(implicit)]
         location: Location,
-        // TODO: add backtrace?
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Not supported: {source}, {location}"))]
     NotSupported {
         source: BoxedError,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Commit conflict for version {version}: {source}, {location}"))]
     CommitConflict {
@@ -121,12 +178,16 @@ pub enum Error {
         source: BoxedError,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Incompatible transaction: {source}, {location}"))]
     IncompatibleTransaction {
         source: BoxedError,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Retryable commit conflict for version {version}: {source}, {location}"))]
     RetryableCommitConflict {
@@ -134,12 +195,16 @@ pub enum Error {
         source: BoxedError,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Too many concurrent writers. {message}, {location}"))]
     TooMuchWriteContention {
         message: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Operation timed out: {message}, {location}"))]
     Timeout {
@@ -154,54 +219,72 @@ pub enum Error {
         message: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("A prerequisite task failed: {message}, {location}"))]
     PrerequisiteFailed {
         message: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Unprocessable: {message}, {location}"))]
     Unprocessable {
         message: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("LanceError(Arrow): {message}, {location}"))]
     Arrow {
         message: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("LanceError(Schema): {message}, {location}"))]
     Schema {
         message: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Not found: {uri}, {location}"))]
     NotFound {
         uri: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("LanceError(IO): {source}, {location}"))]
     IO {
         source: BoxedError,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("LanceError(Index): {message}, {location}"))]
     Index {
         message: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Lance index not found: {identity}, {location}"))]
     IndexNotFound {
         identity: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Cannot infer storage location from: {message}"))]
     InvalidTableLocation { message: String },
@@ -212,18 +295,24 @@ pub enum Error {
         error: BoxedError,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Cloned error: {message}, {location}"))]
     Cloned {
         message: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Query Execution error: {message}, {location}"))]
     Execution {
         message: String,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Ref is invalid: {message}"))]
     InvalidRef { message: String },
@@ -242,12 +331,16 @@ pub enum Error {
         minor_version: u16,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     #[snafu(display("Namespace error: {source}, {location}"))]
     Namespace {
         source: BoxedError,
         #[snafu(implicit)]
         location: Location,
+        #[snafu(implicit)]
+        backtrace: MaybeBacktrace,
     },
     /// External error passed through from user code.
     ///
@@ -283,6 +376,65 @@ pub enum Error {
 }
 
 impl Error {
+    /// Returns the captured Rust backtrace, if available.
+    ///
+    /// Requires the `backtrace` feature to be enabled at compile time
+    /// and `RUST_BACKTRACE=1` at runtime.
+    #[cfg(feature = "backtrace")]
+    pub fn backtrace(&self) -> Option<&std::backtrace::Backtrace> {
+        match self {
+            Self::InvalidInput { backtrace, .. }
+            | Self::DatasetAlreadyExists { backtrace, .. }
+            | Self::SchemaMismatch { backtrace, .. }
+            | Self::DatasetNotFound { backtrace, .. }
+            | Self::CorruptFile { backtrace, .. }
+            | Self::NotSupported { backtrace, .. }
+            | Self::CommitConflict { backtrace, .. }
+            | Self::IncompatibleTransaction { backtrace, .. }
+            | Self::RetryableCommitConflict { backtrace, .. }
+            | Self::TooMuchWriteContention { backtrace, .. }
+            | Self::Internal { backtrace, .. }
+            | Self::PrerequisiteFailed { backtrace, .. }
+            | Self::Unprocessable { backtrace, .. }
+            | Self::Arrow { backtrace, .. }
+            | Self::Schema { backtrace, .. }
+            | Self::NotFound { backtrace, .. }
+            | Self::IO { backtrace, .. }
+            | Self::Index { backtrace, .. }
+            | Self::IndexNotFound { backtrace, .. }
+            | Self::Wrapped { backtrace, .. }
+            | Self::Cloned { backtrace, .. }
+            | Self::Execution { backtrace, .. }
+            | Self::VersionConflict { backtrace, .. }
+            | Self::Namespace { backtrace, .. } => {
+                use snafu::AsBacktrace;
+                backtrace.as_backtrace()
+            }
+            // Variants without a backtrace field — listed explicitly so that
+            // adding a new variant with a backtrace field triggers a compiler error.
+            Self::InvalidTableLocation { .. }
+            | Self::Stop
+            | Self::InvalidRef { .. }
+            | Self::RefConflict { .. }
+            | Self::RefNotFound { .. }
+            | Self::Cleanup { .. }
+            | Self::VersionNotFound { .. }
+            | Self::External { .. }
+            | Self::FieldNotFound { .. }
+            | Self::Timeout { .. }
+            | Self::DiskCapExceeded { .. }
+            | Self::Fenced { .. } => None,
+        }
+    }
+
+    /// Returns the captured Rust backtrace, if available.
+    ///
+    /// Always returns `None` when the `backtrace` feature is not enabled.
+    #[cfg(not(feature = "backtrace"))]
+    pub fn backtrace(&self) -> Option<&std::backtrace::Backtrace> {
+        None
+    }
+
     #[track_caller]
     pub fn corrupt_file(path: object_store::path::Path, message: impl Into<String>) -> Self {
         CorruptFileSnafu { path }.into_error(message.into().into())
@@ -1086,5 +1238,69 @@ mod test {
             }
             _ => panic!("Expected InvalidInput variant, got {:?}", recovered),
         }
+    }
+
+    #[test]
+    fn test_backtrace_accessor() {
+        // Verify that backtrace() returns the expected result based on feature state
+        let err = Error::io("test backtrace");
+        let bt = err.backtrace();
+        #[cfg(feature = "backtrace")]
+        {
+            // With the backtrace feature enabled, whether a backtrace is captured
+            // depends on the RUST_BACKTRACE env var at runtime. We just verify
+            // the accessor doesn't panic and returns a valid Option.
+            let _ = bt;
+        }
+        #[cfg(not(feature = "backtrace"))]
+        {
+            // Without the backtrace feature, this must always be None.
+            assert!(bt.is_none());
+        }
+    }
+
+    #[test]
+    fn test_backtrace_captured_when_feature_enabled() {
+        // Test that backtrace is actually captured when the feature is on and
+        // RUST_BACKTRACE=1 is set in the environment before the process starts.
+        //
+        // NOTE: std::backtrace::Backtrace caches the RUST_BACKTRACE env check,
+        // so set_var at runtime does not reliably enable capture. This test
+        // verifies the accessor works correctly in both cases:
+        // - If RUST_BACKTRACE=1 was set before the test binary started, we get Some.
+        // - If not, we get None (even with the feature on), which is expected.
+        #[cfg(feature = "backtrace")]
+        {
+            let err = Error::io("backtrace capture test");
+            if std::env::var("RUST_BACKTRACE").is_ok() {
+                assert!(
+                    err.backtrace().is_some(),
+                    "Expected a backtrace when RUST_BACKTRACE=1 and backtrace feature is enabled"
+                );
+            }
+            // When RUST_BACKTRACE is not set, backtrace() may return None even
+            // with the feature enabled — this is correct runtime gating behavior.
+        }
+        #[cfg(not(feature = "backtrace"))]
+        {
+            let err = Error::io("backtrace capture test");
+            assert!(err.backtrace().is_none());
+        }
+    }
+
+    #[test]
+    fn test_backtrace_returns_none_for_variants_without_location() {
+        let err = Error::InvalidTableLocation {
+            message: "test".to_string(),
+        };
+        assert!(err.backtrace().is_none());
+
+        let err = Error::InvalidRef {
+            message: "test".to_string(),
+        };
+        assert!(err.backtrace().is_none());
+
+        let err = Error::Stop;
+        assert!(err.backtrace().is_none());
     }
 }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -139,6 +139,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 
 [features]
 default = ["aws", "azure", "gcp", "oss", "huggingface", "tencent", "tos", "goosefs", "geo"]
+backtrace = ["lance-core/backtrace"]
 fp16kernels = ["lance-linalg/fp16kernels"]
 # Prevent dynamic linking of lzma, which comes from datafusion
 cli = ["dep:clap", "lzma-sys/static"]


### PR DESCRIPTION
No regression for release builds, Python layer also can reuse this mechanism

The overall design employs a two-tiered strategy of "compile-time switching + runtime gating":

1. **Compile-time switching:**  Two versions of the `MaybeBacktrace` type are defined through conditional compilation using `#[cfg(feature = "backtrace")]`, when the feature is disabled error size, layout, and runtime behavior are unchanged as before

2. **Runtime Gating:** With the `backtrace` feature enabled, actual backtrace capture is still controlled by the runtime environment variable `RUST_BACKTRACE=1`

3. **Java integration:** The transformation logic calls `err.backtrace()` to obtain an optional backtrace. If exists, it is  passed to the corresponding Java exception class. Users can enable this feature during Maven builds using `-Drust.features=backtrace`.