### PR TITLE
fix: list columns fail in v2.0 blocking decode path

### DIFF
--- a/java/src/test/java/org/lance/FileReaderWriterTest.java
+++ b/java/src/test/java/org/lance/FileReaderWriterTest.java
@@ -26,6 +26,7 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.LargeVarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -41,6 +42,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -397,6 +399,117 @@ public class FileReaderWriterTest {
         }
       }
     }
+    allocator.close();
+  }
+
+  /**
+   * Write a file with col_a (int64) + col_b (list&lt;int32&gt;), then project only the list column
+   * and verify the data round-trips correctly. This mirrors the Rust test test_project_list_int32
+   * in lance-file/src/reader.rs.
+   */
+  @Test
+  void testProjectListInt32(@TempDir Path tempDir) throws Exception {
+    BufferAllocator allocator = new RootAllocator();
+
+    // Schema: col_a (int64) + col_b (list<int32>)
+    Field itemField = new Field("item", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Schema schema =
+        new Schema(
+            Arrays.asList(
+                Field.nullable("col_a", new ArrowType.Int(64, true)),
+                new Field(
+                    "col_b",
+                    FieldType.nullable(new ArrowType.List()),
+                    Collections.singletonList(itemField))));
+
+    int numRows = 20000;
+    int itemsPerRow = 500;
+
+    // Build the batch
+    VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+    root.allocateNew();
+
+    BigIntVector colA = (BigIntVector) root.getVector("col_a");
+    ListVector colB = (ListVector) root.getVector("col_b");
+
+    colA.allocateNew(numRows);
+    colB.allocateNew();
+
+    org.apache.arrow.vector.IntVector innerVector =
+        (org.apache.arrow.vector.IntVector) colB.getDataVector();
+    int innerIdx = 0;
+    for (int i = 0; i < numRows; i++) {
+      colA.setSafe(i, (long) i);
+      colB.startNewValue(i);
+      for (int j = 0; j < itemsPerRow; j++) {
+        innerVector.setSafe(innerIdx, i * 100 + j);
+        innerIdx++;
+      }
+      colB.endValue(i, itemsPerRow);
+    }
+    colA.setValueCount(numRows);
+    colB.setValueCount(numRows);
+    root.setRowCount(numRows);
+
+    // Write the file
+    String filePath = tempDir.resolve("list_project.lance").toString();
+    try (LanceFileWriter writer = LanceFileWriter.open(filePath, allocator, null)) {
+      writer.write(root);
+    }
+    root.close();
+
+    // Read back and verify with different projections
+    LanceFileReader reader = LanceFileReader.open(filePath, allocator);
+    assertEquals(numRows, reader.numRows());
+
+    // Case 1: project only col_b (the list column)
+    try (ArrowReader batches = reader.readAll(Collections.singletonList("col_b"), null, 512)) {
+      long totalRows = 0;
+      while (batches.loadNextBatch()) {
+        VectorSchemaRoot batch = batches.getVectorSchemaRoot();
+        assertEquals(1, batch.getSchema().getFields().size());
+        assertEquals("col_b", batch.getSchema().getFields().get(0).getName());
+
+        ListVector listVec = (ListVector) batch.getVector("col_b");
+        int batchOffset = (int) totalRows;
+        for (int i = 0; i < batch.getRowCount(); i++) {
+          int rowIdx = batchOffset + i;
+          List<?> listVal = listVec.getObject(i);
+          assertEquals(itemsPerRow, listVal.size(), "Row " + rowIdx + " list size mismatch");
+          for (int j = 0; j < itemsPerRow; j++) {
+            int expected = rowIdx * 100 + j;
+            assertEquals(expected, listVal.get(j), "Row " + rowIdx + " item " + j + " mismatch");
+          }
+        }
+        totalRows += batch.getRowCount();
+      }
+      assertEquals(numRows, totalRows);
+    }
+
+    // Case 2: project col_a + col_b
+    try (ArrowReader batches = reader.readAll(Arrays.asList("col_a", "col_b"), null, 512)) {
+      long totalRows = 0;
+      while (batches.loadNextBatch()) {
+        VectorSchemaRoot batch = batches.getVectorSchemaRoot();
+        assertEquals(2, batch.getSchema().getFields().size());
+
+        BigIntVector aVec = (BigIntVector) batch.getVector("col_a");
+        ListVector listVec = (ListVector) batch.getVector("col_b");
+        int batchOffset = (int) totalRows;
+        for (int i = 0; i < batch.getRowCount(); i++) {
+          int rowIdx = batchOffset + i;
+          assertEquals((long) rowIdx, aVec.get(i));
+          List<?> listVal = listVec.getObject(i);
+          assertEquals(itemsPerRow, listVal.size());
+          assertEquals(rowIdx * 100, listVal.get(0));
+          assertEquals(rowIdx * 100 + itemsPerRow - 1, listVal.get(itemsPerRow - 1));
+        }
+        totalRows += batch.getRowCount();
+      }
+      assertEquals(numRows, totalRows);
+    }
+
+    reader.close();
     allocator.close();
   }
 }

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1654,6 +1654,13 @@ impl<T: RootDecoderType> BatchDecodeIterator<T> {
                 let under_scheduled = desired_scheduled - actually_scheduled;
                 to_take -= under_scheduled;
             }
+        } else {
+            // All rows are scheduled but we still need to wait for data to be loaded.
+            // This is important for types with indirect I/O (e.g. List, Binary) where
+            // scheduling completes but item data may not yet be loaded.
+            let loaded_need = self.rows_drained + to_take.min(self.rows_per_batch as u64) - 1;
+            self.root_decoder
+                .wait(loaded_need, &self.wait_for_io_runtime)?;
         }
 
         if to_take == 0 {


### PR DESCRIPTION
  # Summary

  Reading List, LargeList, Binary, or LargeBinary columns via read_stream_projected_blocking (used by the Java JNI LanceFileReader) fails with:

  Caused by: java.io.IOException: LanceError(Internal):
    drain was called on primitive field decoder for data type Int32 on column 2
    but the decoder was never awaited,
    /app/rust/lance-encoding/src/previous/encodings/logical/primitive.rs:348:27

#  Full Rust-side error:

  thread 'tokio-runtime-worker' panicked at
    rust/lance-encoding/src/previous/encodings/logical/primitive.rs:348:27:

  Internal error: drain was called on primitive field decoder for data type Int32
  on column 4 but the decoder was never awaited

  Stack:
```
    lance_encoding::previous::encodings::logical::primitive::PrimitiveFieldDecoder::drain
    lance_encoding::previous::encodings::logical::list::ListPageDecoder::drain
    lance_encoding::previous::encodings::logical::struct::SimpleStructDecoder::drain
    lance_encoding::decoder::BatchDecodeIterator::next_batch_task
    lance_file::reader::FileReader::read_stream_projected_blocking
    lance_jni::file_reader::BlockingFileReader::open_stream
    Java_org_lance_file_LanceFileReader_readAllNative

```
  Schema:
  col_a: int64
  col_b: list<int32>

  Bug : BatchDecodeIterator skips wait when all rows are already scheduled.

  For list columns, all rows are marked as "scheduled" after the first schedule_ranges call (because the ListPageDecoder message is sent synchronously), even though the item data has not
   been loaded yet. Starting from the second batch, scheduled_need == 0, so wait_for_io() is skipped entirely. The subsequent drain then encounters PrimitiveFieldDecoder instances whose
  physical decoders were never awaited.

# Changes

  - list.rs: Replace tokio::spawn(indirect_schedule_task(...)) with an inline BoxFuture via .boxed(). This removes the dependency on a tokio runtime during scheduling and makes the indirect scheduling work in both async and blocking contexts. The ListPageDecoder.unloaded field type changes from JoinHandle to BoxFuture, and the JoinError handling in wait_for_loaded is simplified accordingly.
  - decoder.rs: Add an else branch in BatchDecodeIterator::next_batch_task to call self.root_decoder.wait(loaded_need, ...) even when scheduled_need == 0. This ensures that list item data is fully loaded before draining, regardless of the scheduling status.
  - reader.rs: Add test_project_list_int32 regression test covering projected reads of list<int32> columns on both V2_0 and V2_1 file formats.