### PR TITLE
feat(ci): support publishing wheels to custom PyPI index

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,6 +15,16 @@ on:
         required: false
         default: true
         type: boolean
+      custom_pypi_url:
+        description: "Custom PyPI index URL (e.g., Azure Artifacts). If set, uploads to this instead of default PyPI/Fury"
+        required: false
+        default: ""
+        type: string
+      custom_pypi_token:
+        description: "Access token for the custom PyPI index"
+        required: false
+        default: ""
+        type: string
   pull_request:
     branches:
       - main
@@ -93,6 +103,12 @@ jobs:
           pypi_token: ${{ secrets.PYPI_TOKEN }}
           fury_token: ${{ secrets.FURY_TOKEN }}
           repo: ${{ steps.handle_tag.outputs.repo }}
+      - uses: ./.github/workflows/upload_wheel
+        if: github.event_name == 'workflow_dispatch' && inputs.custom_pypi_url != ''
+        with:
+          repo: custom
+          custom_pypi_url: ${{ inputs.custom_pypi_url }}
+          custom_pypi_token: ${{ inputs.custom_pypi_token }}
   mac:
     timeout-minutes: 60
     runs-on: ${{ matrix.config.runner }}
@@ -144,6 +160,12 @@ jobs:
           pypi_token: ${{ secrets.PYPI_TOKEN }}
           fury_token: ${{ secrets.FURY_TOKEN }}
           repo: ${{ steps.handle_tag.outputs.repo }}
+      - uses: ./.github/workflows/upload_wheel
+        if: github.event_name == 'workflow_dispatch' && inputs.custom_pypi_url != ''
+        with:
+          repo: custom
+          custom_pypi_url: ${{ inputs.custom_pypi_url }}
+          custom_pypi_token: ${{ inputs.custom_pypi_token }}
   windows:
     timeout-minutes: 60
     runs-on: windows-latest-4x
@@ -191,6 +213,12 @@ jobs:
           pypi_token: ${{ secrets.PYPI_TOKEN }}
           fury_token: ${{ secrets.FURY_TOKEN }}
           repo: ${{ steps.handle_tag.outputs.repo }}
+      - uses: ./.github/workflows/upload_wheel
+        if: github.event_name == 'workflow_dispatch' && inputs.custom_pypi_url != ''
+        with:
+          repo: custom
+          custom_pypi_url: ${{ inputs.custom_pypi_url }}
+          custom_pypi_token: ${{ inputs.custom_pypi_token }}
   report-failure:
     name: Report Workflow Failure
     runs-on: ubuntu-latest

--- a/.github/workflows/upload_wheel/action.yml
+++ b/.github/workflows/upload_wheel/action.yml
@@ -13,13 +13,20 @@ inputs:
       - "pypi"
       - "testpypi"
       - "fury"
+      - "custom"
     default: "pypi"
   pypi_token:
-    required: true
+    required: false
     description: "release token for the repo"
   fury_token:
-    required: true
+    required: false
     description: "release token for the fury repo"
+  custom_pypi_url:
+    required: false
+    description: "Custom PyPI index URL (e.g., Azure Artifacts)"
+  custom_pypi_token:
+    required: false
+    description: "Access token for the custom PyPI index"
 
 runs:
   using: "composite"
@@ -35,11 +42,19 @@ runs:
     env:
       FURY_TOKEN: ${{ inputs.fury_token }}
       PYPI_TOKEN: ${{ inputs.pypi_token }}
+      CUSTOM_PYPI_URL: ${{ inputs.custom_pypi_url }}
+      CUSTOM_PYPI_TOKEN: ${{ inputs.custom_pypi_token }}
     run: |
-      if [ ${{ inputs.repo }} == "fury" ]; then
+      if [ "${{ inputs.repo }}" == "fury" ]; then
         WHEEL=$(ls target/wheels/pylance-*.whl 2> /dev/null | head -n 1)
         echo "Uploading $WHEEL to Fury"
         curl -f -F package=@$WHEEL https://$FURY_TOKEN@push.fury.io/lance-format/
+      elif [ "${{ inputs.repo }}" == "custom" ]; then
+        echo "Uploading to custom PyPI index: $CUSTOM_PYPI_URL"
+        twine upload --repository-url "$CUSTOM_PYPI_URL" \
+          --username __token__ \
+          --password "$CUSTOM_PYPI_TOKEN" \
+          target/wheels/pylance-*.whl
       else
         twine upload --repository ${{ inputs.repo }} \
           --username __token__ \


### PR DESCRIPTION
## Summary

- Add `custom_pypi_url` and `custom_pypi_token` workflow dispatch inputs to `pypi-publish.yml`
- Update `upload_wheel` action to support custom PyPI uploads via twine `--repository-url`
- Allow manual publishing of any released version to custom indexes like Azure Artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)