### PR TITLE
fix: avoid _rowaddr schema collision in take_blobs on multi-fragment tables

### DIFF
--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -378,6 +378,13 @@ async fn do_take_rows(
 
         if builder.with_row_address {
             // inject `ROW_ADDR` column
+            // The unsorted path (above) always requests row addresses for reordering,
+            // so the batch may already contain a _rowaddr column. Remove it first
+            // to avoid a duplicate-column error, then add the correctly ordered one.
+            if batch.column_by_name(ROW_ADDR).is_some() {
+                let idx = batch.schema().index_of(ROW_ADDR).unwrap();
+                batch = batch.remove_column(idx);
+            }
             let row_addr_field =
                 ArrowField::new(ROW_ADDR, arrow::datatypes::DataType::UInt64, false);
             batch = batch.try_with_column(row_addr_field, row_addr_col)?;


### PR DESCRIPTION
## Summary

Fix `take_blobs(indices=...)` failing with `SchemaError: Can not append column _rowaddr` on multi-fragment tables.

Closes #6227

## Root Cause

In `do_take_rows` (`take.rs`), when row addresses are unsorted (multi-fragment case), the unsorted path **always** requests `_rowaddr` from fragment readers (hardcoded `true` at line 312) so it can reorder results. After reordering, when `builder.with_row_address` is also `true` (blob take always sets this), the code tries to add `_rowaddr` again via `try_with_column`, causing a duplicate column error.

Single-fragment tables don't hit this because row addresses are sorted/contiguous, taking a different code path that doesn't pre-add `_rowaddr`.

## Fix

Before adding `_rowaddr` at line 379, check if the column already exists and remove it first. This is safe because the unsorted path's `_rowaddr` was only needed for the reordering step which has already completed.

## Reproduction

```python
import lance, random

ds = lance.dataset("path/to/multi_fragment_table.lance")
indices = sorted(random.sample(range(ds.count_rows()), 10))
blobs = ds.take_blobs("my_blob_column", indices=indices)  # Previously failed
```

## Testing

Existing test `test_take_blobs_by_indices` in `rust/lance/src/dataset/blob.rs` already covers the multi-fragment case and would catch regressions.