### PR TITLE
fix(index): use exact scalar indices for filtered count_rows

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -80,6 +80,7 @@ pub mod optimize;
 pub mod progress;
 pub mod refs;
 pub(crate) mod rowids;
+mod scalar_count;
 pub mod scanner;
 mod schema_evolution;
 pub mod sql;
@@ -103,6 +104,7 @@ use self::write::write_fragments_internal;
 use crate::dataset::branch_location::BranchLocation;
 use crate::dataset::cleanup::{CleanupPolicy, CleanupPolicyBuilder};
 use crate::dataset::refs::{BranchContents, BranchIdentifier, Branches, Tags};
+use crate::dataset::scalar_count::try_count_rows_with_exact_scalar_index;
 use crate::dataset::sql::SqlQueryBuilder;
 use crate::datatypes::Schema;
 use crate::index::retain_supported_indices;
@@ -1361,6 +1363,10 @@ impl Dataset {
     pub async fn count_rows(&self, filter: Option<String>) -> Result<usize> {
         // TODO: consolidate the count_rows into Scanner plan.
         if let Some(filter) = filter {
+            if let Some(index_count) = try_count_rows_with_exact_scalar_index(self, &filter).await?
+            {
+                return Ok(index_count);
+            }
             let mut scanner = self.scan();
             scanner.filter(&filter)?;
             Ok(scanner

--- a/rust/lance/src/dataset/scalar_count.rs
+++ b/rust/lance/src/dataset/scalar_count.rs
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_schema::Schema as ArrowSchema;
+use futures::stream::{self, StreamExt, TryStreamExt};
+use lance_core::utils::mask::{RowAddrMask, RowAddrSelection, RowAddrTreeMap, RowSetOps};
+use lance_datafusion::planner::Planner;
+use lance_index::{metrics::NoOpMetricsCollector, scalar::expression::PlannerIndexExt};
+use lance_table::format::Fragment;
+
+use crate::dataset::{Dataset, fragment::FileFragment, rowids, scanner::ExprFilter};
+use crate::index::prefilter::DatasetPreFilter;
+use crate::index::{DatasetIndexInternalExt, coverage::fragments_covered_by_scalar_index_query};
+use crate::{Error, Result};
+
+pub(super) async fn try_count_rows_with_exact_scalar_index(
+    dataset: &Dataset,
+    filter: &str,
+) -> Result<Option<usize>> {
+    if dataset
+        .manifest
+        .fragments
+        .iter()
+        .any(|fragment| fragment.physical_rows.is_none())
+    {
+        return Ok(None);
+    }
+
+    let schema = dataset.schema();
+    let expr = ExprFilter::Sql(filter.to_owned()).to_datafusion(schema, schema)?;
+    let planner = Planner::new(Arc::new(ArrowSchema::from(schema)));
+    let index_info = dataset.scalar_index_info().await?;
+    let filter_plan = planner.create_filter_plan(expr, &index_info, true)?;
+
+    if !filter_plan.is_exact_index_search() {
+        return Ok(None);
+    }
+
+    let index_query = filter_plan
+        .index_query
+        .expect("exact scalar index search should always have an index query");
+    let covered_fragments = fragments_covered_by_scalar_index_query(dataset, &index_query).await?;
+
+    if dataset
+        .manifest
+        .fragments
+        .iter()
+        .any(|fragment| !covered_fragments.contains(fragment.id as u32))
+    {
+        return Ok(None);
+    }
+
+    let selected_fragments = dataset
+        .manifest
+        .fragments
+        .iter()
+        .filter(|fragment| covered_fragments.contains(fragment.id as u32))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let mask = match index_query.evaluate(dataset, &NoOpMetricsCollector).await? {
+        lance_index::scalar::expression::IndexExprResult::Exact(mask) => mask,
+        lance_index::scalar::expression::IndexExprResult::AtMost(_)
+        | lance_index::scalar::expression::IndexExprResult::AtLeast(_) => return Ok(None),
+    };
+
+    let deletion_mask = if let Some(deletion_mask_fut) =
+        DatasetPreFilter::create_deletion_mask(Arc::new(dataset.clone()), covered_fragments)
+    {
+        Some((*deletion_mask_fut.await?).clone())
+    } else {
+        None
+    };
+
+    Ok(Some(
+        count_rows_for_exact_mask(dataset, mask, deletion_mask.as_ref(), &selected_fragments)
+            .await?,
+    ))
+}
+
+async fn count_rows_for_exact_mask(
+    dataset: &Dataset,
+    mask: RowAddrMask,
+    deletion_mask: Option<&RowAddrMask>,
+    fragments: &[Fragment],
+) -> Result<usize> {
+    match mask {
+        RowAddrMask::AllowList(mut allow_list) => {
+            if let Some(deletion_mask) = deletion_mask {
+                match deletion_mask {
+                    RowAddrMask::AllowList(live_rows) => allow_list &= live_rows,
+                    RowAddrMask::BlockList(deleted_rows) => allow_list -= deleted_rows,
+                }
+            }
+            if dataset.manifest.uses_stable_row_ids() {
+                let fragment_ids = rowids::load_row_id_sequences(dataset, fragments)
+                    .map_ok(|(_, sequence)| RowAddrTreeMap::from(sequence.as_ref()))
+                    .try_fold(RowAddrTreeMap::new(), |mut acc, tree| async move {
+                        acc |= tree;
+                        Ok(acc)
+                    })
+                    .await?;
+                allow_list &= &fragment_ids;
+            } else {
+                allow_list.retain_fragments(fragments.iter().map(|fragment| fragment.id as u32));
+            }
+            count_selected_rows(dataset, &allow_list, fragments).await
+        }
+        RowAddrMask::BlockList(block_list) if block_list.is_empty() => match deletion_mask {
+            Some(RowAddrMask::AllowList(live_rows)) => {
+                count_selected_rows(dataset, live_rows, fragments).await
+            }
+            _ => count_rows_in_fragments(dataset, fragments).await,
+        },
+        RowAddrMask::BlockList(mut block_list) => {
+            if let Some(RowAddrMask::BlockList(deleted_rows)) = deletion_mask {
+                block_list -= deleted_rows;
+            }
+            if dataset.manifest.uses_stable_row_ids() {
+                let live_rows = match deletion_mask {
+                    Some(RowAddrMask::AllowList(live_rows)) => Some(live_rows),
+                    _ => None,
+                };
+                let sequences = rowids::load_row_id_sequences(dataset, fragments)
+                    .map_ok(|(_, sequence)| sequence)
+                    .try_collect::<Vec<_>>()
+                    .await?;
+                Ok(sequences
+                    .into_iter()
+                    .map(|sequence| {
+                        sequence
+                            .iter()
+                            .filter(|row_id| {
+                                live_rows.is_none_or(|live_rows| live_rows.contains(*row_id))
+                            })
+                            .filter(|row_id| !block_list.contains(*row_id))
+                            .count()
+                    })
+                    .sum())
+            } else {
+                let total_rows = count_rows_in_fragments(dataset, fragments).await?;
+                let blocked_rows = count_selected_rows(dataset, &block_list, fragments).await?;
+                Ok(total_rows - blocked_rows)
+            }
+        }
+    }
+}
+
+async fn count_rows_in_fragments(dataset: &Dataset, fragments: &[Fragment]) -> Result<usize> {
+    let dataset = Arc::new(dataset.clone());
+    stream::iter(fragments.iter().cloned())
+        .map(move |fragment| {
+            let dataset = dataset.clone();
+            async move { FileFragment::new(dataset, fragment).count_rows(None).await }
+        })
+        .buffer_unordered(16)
+        .try_fold(0_usize, |acc, count| async move { Ok(acc + count) })
+        .await
+}
+
+async fn count_selected_rows(
+    dataset: &Dataset,
+    row_addrs: &RowAddrTreeMap,
+    fragments: &[Fragment],
+) -> Result<usize> {
+    let fragment_map = fragments
+        .iter()
+        .cloned()
+        .map(|fragment| (fragment.id as u32, fragment))
+        .collect::<HashMap<_, _>>();
+    let full_fragment_ids = row_addrs
+        .iter()
+        .filter_map(|(fragment_id, selection)| match selection {
+            RowAddrSelection::Full => Some(*fragment_id),
+            RowAddrSelection::Partial(_) => None,
+        })
+        .collect::<Vec<_>>();
+    let dataset = Arc::new(dataset.clone());
+    let full_fragment_counts = stream::iter(full_fragment_ids)
+        .map(move |fragment_id| {
+            let dataset = dataset.clone();
+            let fragment = fragment_map.get(&fragment_id).cloned();
+            async move {
+                let fragment = fragment.ok_or_else(|| {
+                    Error::internal(format!(
+                        "Scalar index count referenced unknown fragment id {}",
+                        fragment_id
+                    ))
+                })?;
+                FileFragment::new(dataset, fragment)
+                    .count_rows(None)
+                    .await
+                    .map(|count| (fragment_id, count))
+            }
+        })
+        .buffer_unordered(16)
+        .try_collect::<HashMap<_, _>>()
+        .await?;
+
+    Ok(row_addrs
+        .iter()
+        .map(|(fragment_id, selection)| match selection {
+            RowAddrSelection::Full => full_fragment_counts[fragment_id],
+            RowAddrSelection::Partial(bitmap) => bitmap.len() as usize,
+        })
+        .sum())
+}

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -81,6 +81,7 @@ use super::Dataset;
 use crate::dataset::row_offsets_to_row_addresses;
 use crate::dataset::utils::SchemaAdapter;
 use crate::index::DatasetIndexInternalExt;
+use crate::index::coverage::fragments_covered_by_scalar_index_query;
 use crate::index::vector::utils::{
     default_distance_type_for, get_vector_dim, get_vector_type, validate_distance_type_for,
 };
@@ -3797,32 +3798,6 @@ impl Scanner {
         Ok(knn_node)
     }
 
-    #[async_recursion]
-    async fn fragments_covered_by_index_query(
-        &self,
-        index_expr: &ScalarIndexExpr,
-    ) -> Result<RoaringBitmap> {
-        match index_expr {
-            ScalarIndexExpr::And(lhs, rhs) => {
-                Ok(self.fragments_covered_by_index_query(lhs).await?
-                    & self.fragments_covered_by_index_query(rhs).await?)
-            }
-            ScalarIndexExpr::Or(lhs, rhs) => Ok(self.fragments_covered_by_index_query(lhs).await?
-                & self.fragments_covered_by_index_query(rhs).await?),
-            ScalarIndexExpr::Not(expr) => self.fragments_covered_by_index_query(expr).await,
-            ScalarIndexExpr::Query(search) => {
-                let idx = self
-                    .dataset
-                    .load_scalar_index(IndexCriteria::default().with_name(&search.index_name))
-                    .await?
-                    .expect("Index not found even though it must have been found earlier");
-                Ok(idx
-                    .fragment_bitmap
-                    .expect("scalar indices should always have a fragment bitmap"))
-            }
-        }
-    }
-
     /// Given an index query, split the fragments into two sets
     ///
     /// The first set is the relevant fragments, which are covered by ALL indices in the query
@@ -3835,7 +3810,8 @@ impl Scanner {
         index_expr: &ScalarIndexExpr,
         fragments: Arc<Vec<Fragment>>,
     ) -> Result<(Vec<Fragment>, Vec<Fragment>)> {
-        let covered_frags = self.fragments_covered_by_index_query(index_expr).await?;
+        let covered_frags =
+            fragments_covered_by_scalar_index_query(self.dataset.as_ref(), index_expr).await?;
         let mut relevant_frags = Vec::with_capacity(fragments.len());
         let mut missing_frags = Vec::with_capacity(fragments.len());
         for fragment in fragments.iter() {

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -9,6 +9,7 @@ use super::dataset_common::{create_file, require_send};
 use crate::dataset::WriteDestination;
 use crate::dataset::WriteMode::Overwrite;
 use crate::dataset::builder::DatasetBuilder;
+use crate::dataset::scalar_count::try_count_rows_with_exact_scalar_index;
 use crate::dataset::{ManifestWriteConfig, write_manifest_file};
 use crate::session::Session;
 use crate::{Dataset, Error, Result};
@@ -236,7 +237,7 @@ async fn test_create_and_fill_empty_dataset(
     ];
     write_params.mode = WriteMode::Append;
     let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-    Dataset::write(batches, &test_uri, Some(write_params))
+    Dataset::write(batches, &test_uri, Some(write_params.clone()))
         .await
         .unwrap();
 
@@ -1396,23 +1397,23 @@ async fn test_fast_count_rows(
     #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)]
     data_storage_version: LanceFileVersion,
 ) {
-    let test_uri = TempStrDir::default();
-
     let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
         "i",
         DataType::Int32,
         false,
     )]));
 
-    let batches: Vec<RecordBatch> = (0..20)
-        .map(|i| {
-            RecordBatch::try_new(
-                schema.clone(),
-                vec![Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20))],
-            )
-            .unwrap()
-        })
-        .collect();
+    let make_batches = || {
+        (0..20)
+            .map(|i| {
+                RecordBatch::try_new(
+                    schema.clone(),
+                    vec![Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20))],
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>()
+    };
 
     let write_params = WriteParams {
         max_rows_per_file: 40,
@@ -1420,19 +1421,65 @@ async fn test_fast_count_rows(
         data_storage_version: Some(data_storage_version),
         ..Default::default()
     };
-    let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-    Dataset::write(batches, &test_uri, Some(write_params))
+    let test_uri = TempStrDir::default();
+    let batches = RecordBatchIterator::new(make_batches().into_iter().map(Ok), schema.clone());
+    Dataset::write(batches, &test_uri, Some(write_params.clone()))
         .await
         .unwrap();
 
-    let dataset = Dataset::open(&test_uri).await.unwrap();
+    let mut dataset = Dataset::open(&test_uri).await.unwrap();
     dataset.validate().await.unwrap();
     assert_eq!(10, dataset.fragments().len());
     assert_eq!(400, dataset.count_rows(None).await.unwrap());
     assert_eq!(
+        None,
+        try_count_rows_with_exact_scalar_index(&dataset, "i < 200")
+            .await
+            .unwrap()
+    );
+    assert_eq!(
         200,
         dataset
             .count_rows(Some("i < 200".to_string()))
+            .await
+            .unwrap()
+    );
+
+    dataset
+        .create_index(
+            &["i"],
+            IndexType::Scalar,
+            Some("i_idx".to_string()),
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        Some(200),
+        try_count_rows_with_exact_scalar_index(&dataset, "i < 200")
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        200,
+        dataset
+            .count_rows(Some("i < 200".to_string()))
+            .await
+            .unwrap()
+    );
+
+    dataset.delete("i >= 250 AND i < 300").await.unwrap();
+    assert_eq!(
+        Some(150),
+        try_count_rows_with_exact_scalar_index(&dataset, "NOT (i < 200)")
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        150,
+        dataset
+            .count_rows(Some("NOT (i < 200)".to_string()))
             .await
             .unwrap()
     );

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -68,6 +68,7 @@ use vector::utils::get_vector_type;
 
 mod api;
 pub(crate) mod append;
+pub(crate) mod coverage;
 mod create;
 pub mod frag_reuse;
 pub mod mem_wal;

--- a/rust/lance/src/index/coverage.rs
+++ b/rust/lance/src/index/coverage.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use async_recursion::async_recursion;
+use lance_index::scalar::expression::ScalarIndexExpr;
+use roaring::RoaringBitmap;
+
+use crate::{Error, Result, dataset::Dataset, index::DatasetIndexExt};
+
+#[async_recursion]
+pub(crate) async fn fragments_covered_by_scalar_index_query(
+    dataset: &Dataset,
+    index_expr: &ScalarIndexExpr,
+) -> Result<RoaringBitmap> {
+    match index_expr {
+        ScalarIndexExpr::And(lhs, rhs) => Ok(fragments_covered_by_scalar_index_query(dataset, lhs)
+            .await?
+            & fragments_covered_by_scalar_index_query(dataset, rhs).await?),
+        ScalarIndexExpr::Or(lhs, rhs) => Ok(fragments_covered_by_scalar_index_query(dataset, lhs)
+            .await?
+            & fragments_covered_by_scalar_index_query(dataset, rhs).await?),
+        ScalarIndexExpr::Not(expr) => fragments_covered_by_scalar_index_query(dataset, expr).await,
+        ScalarIndexExpr::Query(search) => {
+            let indices = dataset
+                .load_indices_by_name(&search.index_name)
+                .await?
+                .into_iter()
+                .filter_map(|index| index.fragment_bitmap)
+                .collect::<Vec<_>>();
+            if indices.is_empty() {
+                return Err(Error::internal(format!(
+                    "No scalar index segments found for logical index '{}'",
+                    search.index_name
+                )));
+            }
+            Ok(indices
+                .into_iter()
+                .fold(RoaringBitmap::new(), |mut covered, bitmap| {
+                    covered |= bitmap;
+                    covered
+                }))
+        }
+    }
+}

--- a/rust/lance/src/index/coverage.rs
+++ b/rust/lance/src/index/coverage.rs
@@ -8,7 +8,7 @@ use roaring::RoaringBitmap;
 use crate::{Error, Result, dataset::Dataset, index::DatasetIndexExt};
 
 #[async_recursion]
-pub(crate) async fn fragments_covered_by_scalar_index_query(
+pub async fn fragments_covered_by_scalar_index_query(
     dataset: &Dataset,
     index_expr: &ScalarIndexExpr,
 ) -> Result<RoaringBitmap> {

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -7,11 +7,13 @@ use super::utils::{IndexMetrics, InstrumentedRecordBatchStreamAdapter};
 use crate::{
     Dataset,
     dataset::rowids::load_row_id_sequences,
-    index::{DatasetIndexExt, DatasetIndexInternalExt, prefilter::DatasetPreFilter},
+    index::{
+        DatasetIndexExt, DatasetIndexInternalExt,
+        coverage::fragments_covered_by_scalar_index_query, prefilter::DatasetPreFilter,
+    },
 };
 use arrow_array::{Array, RecordBatch, UInt64Array};
 use arrow_schema::{Schema, SchemaRef};
-use async_recursion::async_recursion;
 use async_trait::async_trait;
 use datafusion::{
     common::{Statistics, stats::Precision},
@@ -24,6 +26,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 use datafusion_physical_expr::EquivalenceProperties;
+use deepsize::DeepSizeOf;
 use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt, stream::BoxStream};
 use lance_core::utils::mask::RowSetOps;
 use lance_core::{
@@ -39,11 +42,12 @@ use lance_datafusion::{
         ExecutionPlanMetricsSetExt, SCALAR_INDEX_SEARCH_TIME_METRIC, SCALAR_INDEX_SER_TIME_METRIC,
     },
 };
+use lance_index::Index;
 use lance_index::{
-    IndexCriteria,
+    IndexCriteria, IndexType,
     metrics::MetricsCollector,
     scalar::{
-        SargableQuery, ScalarIndex,
+        SargableQuery, ScalarIndex, SearchResult,
         expression::{
             INDEX_EXPR_RESULT_SCHEMA, IndexExprResult, ScalarIndexExpr, ScalarIndexLoader,
             ScalarIndexSearch,
@@ -52,7 +56,159 @@ use lance_index::{
 };
 use lance_table::format::Fragment;
 use roaring::RoaringBitmap;
+use serde_json::json;
 use tracing::{debug_span, instrument};
+
+#[derive(Debug, DeepSizeOf)]
+struct LogicalScalarIndex {
+    segments: Vec<Arc<dyn ScalarIndex>>,
+    index_type: IndexType,
+}
+
+impl LogicalScalarIndex {
+    fn try_new(segments: Vec<Arc<dyn ScalarIndex>>) -> Result<Self> {
+        let Some(index_type) = segments.first().map(|segment| segment.index_type()) else {
+            return Err(Error::internal(
+                "Logical scalar index requires at least one segment".to_string(),
+            ));
+        };
+        if !segments
+            .iter()
+            .all(|segment| segment.index_type() == index_type)
+        {
+            return Err(Error::internal(
+                "Logical scalar index segments must all have the same index type".to_string(),
+            ));
+        }
+        Ok(Self {
+            segments,
+            index_type,
+        })
+    }
+
+    fn combine_search_results(results: &[SearchResult]) -> SearchResult {
+        use lance_core::utils::mask::NullableRowAddrSet;
+
+        let lower = NullableRowAddrSet::union_all(
+            &results
+                .iter()
+                .filter_map(|result| match result {
+                    SearchResult::Exact(rows) | SearchResult::AtLeast(rows) => Some(rows.clone()),
+                    SearchResult::AtMost(_) => None,
+                })
+                .collect::<Vec<_>>(),
+        );
+        let upper = results
+            .iter()
+            .map(|result| match result {
+                SearchResult::Exact(rows) | SearchResult::AtMost(rows) => Some(rows.clone()),
+                SearchResult::AtLeast(_) => None,
+            })
+            .collect::<Option<Vec<_>>>()
+            .map(|rows| NullableRowAddrSet::union_all(&rows));
+
+        match upper {
+            Some(upper) if lower == upper => SearchResult::Exact(upper),
+            Some(upper) => SearchResult::AtMost(upper),
+            None => SearchResult::AtLeast(lower),
+        }
+    }
+}
+
+#[async_trait]
+impl Index for LogicalScalarIndex {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn lance_index::vector::VectorIndex>> {
+        Err(Error::invalid_input(
+            "Logical scalar index cannot be used as a vector index".to_string(),
+        ))
+    }
+
+    fn statistics(&self) -> Result<serde_json::Value> {
+        Ok(json!({
+            "num_segments": self.segments.len(),
+            "segments": self.segments.iter().map(|segment| segment.statistics()).collect::<Result<Vec<_>>>()?,
+        }))
+    }
+
+    async fn prewarm(&self) -> Result<()> {
+        for segment in &self.segments {
+            segment.prewarm().await?;
+        }
+        Ok(())
+    }
+
+    fn index_type(&self) -> IndexType {
+        self.index_type
+    }
+
+    async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+        let mut fragments = RoaringBitmap::new();
+        for segment in &self.segments {
+            fragments |= segment.calculate_included_frags().await?;
+        }
+        Ok(fragments)
+    }
+}
+
+#[async_trait]
+impl ScalarIndex for LogicalScalarIndex {
+    async fn search(
+        &self,
+        query: &dyn lance_index::scalar::AnyQuery,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
+        let mut results = Vec::with_capacity(self.segments.len());
+        for segment in &self.segments {
+            results.push(segment.search(query, metrics).await?);
+        }
+        Ok(Self::combine_search_results(&results))
+    }
+
+    fn can_remap(&self) -> bool {
+        false
+    }
+
+    async fn remap(
+        &self,
+        _mapping: &std::collections::HashMap<u64, Option<u64>>,
+        _dest_store: &dyn lance_index::scalar::IndexStore,
+    ) -> Result<lance_index::scalar::CreatedIndex> {
+        Err(Error::not_supported(
+            "Logical scalar index is query-only".to_string(),
+        ))
+    }
+
+    async fn update(
+        &self,
+        _new_data: datafusion::execution::SendableRecordBatchStream,
+        _dest_store: &dyn lance_index::scalar::IndexStore,
+        _old_data_filter: Option<lance_index::scalar::OldIndexDataFilter>,
+    ) -> Result<lance_index::scalar::CreatedIndex> {
+        Err(Error::not_supported(
+            "Logical scalar index is query-only".to_string(),
+        ))
+    }
+
+    fn update_criteria(&self) -> lance_index::scalar::UpdateCriteria {
+        lance_index::scalar::UpdateCriteria::requires_old_data(
+            lance_index::scalar::registry::TrainingCriteria::new(
+                lance_index::scalar::registry::TrainingOrdering::None,
+            ),
+        )
+    }
+
+    fn derive_index_params(&self) -> Result<lance_index::scalar::ScalarIndexParams> {
+        self.segments[0].derive_index_params()
+    }
+}
 
 #[async_trait]
 impl ScalarIndexLoader for Dataset {
@@ -62,12 +218,27 @@ impl ScalarIndexLoader for Dataset {
         index_name: &str,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn ScalarIndex>> {
-        let idx = self
-            .load_scalar_index(IndexCriteria::default().with_name(index_name))
-            .await?
-            .ok_or_else(|| Error::internal(format!("Scanner created plan for index query on index {} for column {} but no usable index exists with that name", index_name, column)))?;
-        self.open_scalar_index(column, &idx.uuid.to_string(), metrics)
-            .await
+        let indices = self.load_indices_by_name(index_name).await?;
+        match indices.len() {
+            0 => Err(Error::internal(format!(
+                "Scanner created plan for index query on index {} for column {} but no usable index exists with that name",
+                index_name, column
+            ))),
+            1 => {
+                self.open_scalar_index(column, &indices[0].uuid.to_string(), metrics)
+                    .await
+            }
+            _ => {
+                let mut segments = Vec::with_capacity(indices.len());
+                for index in indices {
+                    segments.push(
+                        self.open_scalar_index(column, &index.uuid.to_string(), metrics)
+                            .await?,
+                    );
+                }
+                Ok(Arc::new(LogicalScalarIndex::try_new(segments)?) as Arc<dyn ScalarIndex>)
+            }
+        }
     }
 }
 
@@ -115,35 +286,6 @@ impl ScalarIndexExec {
         }
     }
 
-    #[async_recursion]
-    async fn fragments_covered_by_index_query(
-        index_expr: &ScalarIndexExpr,
-        dataset: &Dataset,
-    ) -> Result<RoaringBitmap> {
-        match index_expr {
-            ScalarIndexExpr::And(lhs, rhs) => {
-                Ok(Self::fragments_covered_by_index_query(lhs, dataset).await?
-                    & Self::fragments_covered_by_index_query(rhs, dataset).await?)
-            }
-            ScalarIndexExpr::Or(lhs, rhs) => {
-                Ok(Self::fragments_covered_by_index_query(lhs, dataset).await?
-                    & Self::fragments_covered_by_index_query(rhs, dataset).await?)
-            }
-            ScalarIndexExpr::Not(expr) => {
-                Self::fragments_covered_by_index_query(expr, dataset).await
-            }
-            ScalarIndexExpr::Query(search_key) => {
-                let idx = dataset
-                    .load_scalar_index(IndexCriteria::default().with_name(&search_key.index_name))
-                    .await?
-                    .expect("Index not found even though it must have been found earlier");
-                Ok(idx
-                    .fragment_bitmap
-                    .expect("scalar indices should always have a fragment bitmap"))
-            }
-        }
-    }
-
     async fn do_execute(
         expr: ScalarIndexExpr,
         dataset: Arc<Dataset>,
@@ -156,7 +298,7 @@ impl ScalarIndexExec {
             expr.evaluate(dataset.as_ref(), &metrics).await?
         };
         let fragments_covered_by_result =
-            Self::fragments_covered_by_index_query(&expr, dataset.as_ref()).await?;
+            fragments_covered_by_scalar_index_query(dataset.as_ref(), &expr).await?;
         {
             let ser_time = plan_metrics.new_time(SCALAR_INDEX_SER_TIME_METRIC, 0);
             let _timer = ser_time.timer();
@@ -731,32 +873,129 @@ impl ExecutionPlan for MaterializeIndexExec {
 
 #[cfg(test)]
 mod tests {
-    use std::{ops::Bound, sync::Arc};
+    use std::{any::Any, collections::HashMap, ops::Bound, sync::Arc};
 
     use crate::index::DatasetIndexExt;
     use arrow::datatypes::UInt64Type;
+    use async_trait::async_trait;
     use datafusion::{
         execution::TaskContext, physical_plan::ExecutionPlan, prelude::SessionConfig,
         scalar::ScalarValue,
     };
+    use deepsize::DeepSizeOf;
     use futures::TryStreamExt;
+    use lance_core::utils::mask::{RowAddrTreeMap, RowSetOps};
     use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::gen_batch;
     use lance_index::{
-        IndexType,
+        Index, IndexType,
+        metrics::{MetricsCollector, NoOpMetricsCollector},
         scalar::{
-            SargableQuery, ScalarIndexParams,
+            CreatedIndex, SargableQuery, ScalarIndex, ScalarIndexParams, SearchResult,
+            UpdateCriteria,
             expression::{ScalarIndexExpr, ScalarIndexSearch},
+            registry::{TrainingCriteria, TrainingOrdering},
         },
     };
+    use roaring::RoaringBitmap;
+    use serde_json::json;
 
     use crate::{
-        Dataset,
+        Dataset, Error, Result,
         io::exec::scalar_index::MaterializeIndexExec,
         utils::test::{DatagenExt, FragmentCount, FragmentRowCount, NoContextTestFixture},
     };
 
-    use super::{MapIndexExec, ScalarIndexExec};
+    use super::{LogicalScalarIndex, MapIndexExec, ScalarIndexExec};
+
+    #[derive(Debug, DeepSizeOf)]
+    struct StubScalarIndex {
+        row_addrs: RowAddrTreeMap,
+        index_type: IndexType,
+    }
+
+    #[async_trait]
+    impl Index for StubScalarIndex {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+            self
+        }
+
+        fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn lance_index::vector::VectorIndex>> {
+            Err(Error::invalid_input(
+                "Stub scalar index cannot be used as a vector index".to_string(),
+            ))
+        }
+
+        fn statistics(&self) -> Result<serde_json::Value> {
+            Ok(json!({ "num_rows": self.row_addrs.len() }))
+        }
+
+        async fn prewarm(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn index_type(&self) -> IndexType {
+            self.index_type
+        }
+
+        async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+            Ok(self
+                .row_addrs
+                .iter()
+                .map(|(fragment_id, _)| *fragment_id)
+                .collect())
+        }
+    }
+
+    #[async_trait]
+    impl ScalarIndex for StubScalarIndex {
+        async fn search(
+            &self,
+            _query: &dyn lance_index::scalar::AnyQuery,
+            _metrics: &dyn MetricsCollector,
+        ) -> Result<SearchResult> {
+            Ok(SearchResult::exact(self.row_addrs.clone()))
+        }
+
+        fn can_remap(&self) -> bool {
+            false
+        }
+
+        async fn remap(
+            &self,
+            _mapping: &HashMap<u64, Option<u64>>,
+            _dest_store: &dyn lance_index::scalar::IndexStore,
+        ) -> Result<CreatedIndex> {
+            Err(Error::not_supported(
+                "Stub scalar index cannot be remapped".to_string(),
+            ))
+        }
+
+        async fn update(
+            &self,
+            _new_data: datafusion::execution::SendableRecordBatchStream,
+            _dest_store: &dyn lance_index::scalar::IndexStore,
+            _old_data_filter: Option<lance_index::scalar::OldIndexDataFilter>,
+        ) -> Result<CreatedIndex> {
+            Err(Error::not_supported(
+                "Stub scalar index cannot be updated".to_string(),
+            ))
+        }
+
+        fn update_criteria(&self) -> UpdateCriteria {
+            UpdateCriteria::requires_old_data(TrainingCriteria::new(TrainingOrdering::None))
+        }
+
+        fn derive_index_params(&self) -> Result<ScalarIndexParams> {
+            Ok(ScalarIndexParams::for_builtin(
+                self.index_type.try_into().unwrap(),
+            ))
+        }
+    }
 
     struct TestFixture {
         dataset: Arc<Dataset>,
@@ -865,5 +1104,43 @@ mod tests {
         let plan =
             MaterializeIndexExec::new(arc_dasaset.clone(), query, arc_dasaset.fragments().clone());
         plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_logical_scalar_index_search_unions_all_segments() {
+        let logical_index = LogicalScalarIndex::try_new(vec![
+            Arc::new(StubScalarIndex {
+                row_addrs: [0_u64, 1_u64, (1_u64 << 32) | 3].into_iter().collect(),
+                index_type: IndexType::BTree,
+            }) as Arc<dyn ScalarIndex>,
+            Arc::new(StubScalarIndex {
+                row_addrs: [(2_u64 << 32) | 5, (3_u64 << 32) | 7].into_iter().collect(),
+                index_type: IndexType::BTree,
+            }) as Arc<dyn ScalarIndex>,
+        ])
+        .unwrap();
+
+        let result = logical_index
+            .search(&SargableQuery::IsNull(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        let SearchResult::Exact(row_addrs) = result else {
+            panic!("logical scalar index should preserve exact segment results");
+        };
+        let row_addrs = row_addrs.true_rows();
+
+        for row_addr in [
+            0_u64,
+            1_u64,
+            (1_u64 << 32) | 3,
+            (2_u64 << 32) | 5,
+            (3_u64 << 32) | 7,
+        ] {
+            assert!(
+                row_addrs.contains(row_addr),
+                "missing row address {row_addr}"
+            );
+        }
+        assert_eq!(row_addrs.len(), Some(5));
     }
 }


### PR DESCRIPTION
Fixes #2682.

## Summary

- add an exact scalar-index fast path for `Dataset::count_rows(Some(filter))`
- keep the existing scanner path as the fallback when the filter is not an exact index search
- load and query all physical segments for a logical scalar index name
- share scalar-index fragment coverage logic between count / scanner / exec paths

## Problem

`Dataset::count_rows(Some(filter))` always went through the scan-based count path, even when the filter could be satisfied exactly by a scalar index. That meant we still materialized row ids and counted them through the scanner.

There was also a correctness gap once a logical scalar index had multiple physical segments. Coverage checks could treat the logical index as fully covering the dataset, while query execution still loaded only one segment. In that state, an exact result could be treated as complete even though it only came from part of the logical index.

## Approach

This change adds a dedicated exact-count path for filtered `count_rows` and only uses it when the filter planner produces an exact scalar-index search with full fragment coverage and no refine step. Exact allow-list and block-list results are counted directly, with deletion masks handled explicitly.

To keep coverage checks and execution aligned, scalar-index loading now aggregates all segments for the same logical index name into a `LogicalScalarIndex` and unions their search results.

## Tests

- `cargo test -p lance test_fast_count_rows -- --nocapture`
- `cargo test -p lance test_logical_scalar_index_search_unions_all_segments -- --nocapture`
- `cargo test -p lance test_plans -- --nocapture`
