### PR TITLE
fix: create index conflict with concurrent rewrite columns updates

### DIFF
--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -537,9 +537,60 @@ impl<'a> TransactionRebase<'a> {
                         Ok(())
                     }
                 }
-                // Although some of the rows we indexed may have been deleted / moved,
-                // row ids are still valid, so we allow this optimistically.
-                Operation::Delete { .. } | Operation::Update { .. } => Ok(()),
+                // Delete doesn't change row ids in remaining fragments, so the
+                // index entries for those fragments are still valid.
+                Operation::Delete { .. } => Ok(()),
+                // For Update with RewriteRows mode, the old fragment is removed
+                // and a new one created. effective_fragment_bitmap filters out the
+                // deleted fragment at query time, so stale index entries are harmless.
+                //
+                // For Update with RewriteColumns mode, column data is rewritten
+                // in-place (same fragment ID, same row IDs, different values).
+                // If the rewritten columns overlap with indexed fields AND the
+                // rewritten fragments are in the new index's bitmap, the index
+                // data is stale and we must retry.
+                Operation::Update {
+                    updated_fragments,
+                    fields_modified,
+                    update_mode,
+                    ..
+                } => {
+                    use crate::dataset::transaction::UpdateMode::RewriteColumns;
+                    let is_rewrite_columns = update_mode
+                        .as_ref()
+                        .is_some_and(|m| *m == RewriteColumns);
+
+                    if is_rewrite_columns && !fields_modified.is_empty() {
+                        let modified_set: std::collections::HashSet<&u32> =
+                            fields_modified.iter().collect();
+                        let index_covers_modified = new_indices.iter().any(|idx| {
+                            idx.fields.iter().any(|f| {
+                                modified_set.contains(&u32::try_from(*f).unwrap())
+                            })
+                        });
+                        if index_covers_modified {
+                            let rewritten_ids: std::collections::HashSet<u32> =
+                                updated_fragments.iter().map(|f| f.id as u32).collect();
+                            let bitmap_overlap = new_indices.iter().any(|idx| {
+                                match &idx.fragment_bitmap {
+                                    // None = unknown coverage; conservatively
+                                    // assume it overlaps.
+                                    None => true,
+                                    Some(bm) => {
+                                        bm.iter().any(|id| rewritten_ids.contains(&id))
+                                    }
+                                }
+                            });
+                            if bitmap_overlap {
+                                return Err(self.retryable_conflict_err(
+                                    other_transaction,
+                                    other_version,
+                                ));
+                            }
+                        }
+                    }
+                    Ok(())
+                }
                 // Merge, reserve, and project don't change row ids, so this should be fine.
                 Operation::Merge { .. } => Ok(()),
                 Operation::ReserveFragments { .. } => Ok(()),
@@ -3605,5 +3656,172 @@ mod tests {
         );
 
         assert_eq!(dataset_v2.count_rows(None).await.unwrap(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_create_index_vs_rewrite_columns_update() {
+        use crate::dataset::transaction::UpdateMode;
+        use io::commit::conflict_resolver::tests::{ConflictResult::*, modified_fragment_ids};
+        use lance_table::format::IndexMetadata;
+        use roaring::RoaringBitmap;
+        use uuid::Uuid;
+
+        let fragment0 = Fragment::new(0);
+        let fragment1 = Fragment::new(1);
+
+        let index_on_field_0 = IndexMetadata {
+            uuid: Uuid::new_v4(),
+            name: "test_index".to_string(),
+            fields: vec![0],
+            dataset_version: 1,
+            fragment_bitmap: Some(RoaringBitmap::from_iter([0u32])),
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+        };
+
+        let index_no_bitmap = IndexMetadata {
+            uuid: Uuid::new_v4(),
+            name: "test_index_no_bm".to_string(),
+            fields: vec![0],
+            dataset_version: 1,
+            fragment_bitmap: None,
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+        };
+
+        let cases = vec![
+            (
+                "RewriteColumns, overlapping fields, overlapping fragments -> Retryable",
+                Operation::CreateIndex {
+                    new_indices: vec![index_on_field_0.clone()],
+                    removed_indices: vec![],
+                },
+                Operation::Update {
+                    removed_fragment_ids: vec![],
+                    updated_fragments: vec![fragment0.clone()],
+                    new_fragments: vec![],
+                    fields_modified: vec![0],
+                    merged_generations: vec![],
+                    fields_for_preserving_frag_bitmap: vec![],
+                    update_mode: Some(UpdateMode::RewriteColumns),
+                    inserted_rows_filter: None,
+                },
+                Retryable,
+            ),
+            (
+                "RewriteColumns, non-overlapping fields -> Compatible",
+                Operation::CreateIndex {
+                    new_indices: vec![index_on_field_0.clone()],
+                    removed_indices: vec![],
+                },
+                Operation::Update {
+                    removed_fragment_ids: vec![],
+                    updated_fragments: vec![fragment0.clone()],
+                    new_fragments: vec![],
+                    fields_modified: vec![1],
+                    merged_generations: vec![],
+                    fields_for_preserving_frag_bitmap: vec![],
+                    update_mode: Some(UpdateMode::RewriteColumns),
+                    inserted_rows_filter: None,
+                },
+                Compatible,
+            ),
+            (
+                "RewriteColumns, overlapping fields, non-overlapping fragments -> Compatible",
+                Operation::CreateIndex {
+                    new_indices: vec![index_on_field_0.clone()],
+                    removed_indices: vec![],
+                },
+                Operation::Update {
+                    removed_fragment_ids: vec![],
+                    updated_fragments: vec![fragment1.clone()],
+                    new_fragments: vec![],
+                    fields_modified: vec![0],
+                    merged_generations: vec![],
+                    fields_for_preserving_frag_bitmap: vec![],
+                    update_mode: Some(UpdateMode::RewriteColumns),
+                    inserted_rows_filter: None,
+                },
+                Compatible,
+            ),
+            (
+                "RewriteColumns, overlapping fields, bitmap=None -> Retryable",
+                Operation::CreateIndex {
+                    new_indices: vec![index_no_bitmap],
+                    removed_indices: vec![],
+                },
+                Operation::Update {
+                    removed_fragment_ids: vec![],
+                    updated_fragments: vec![fragment0.clone()],
+                    new_fragments: vec![],
+                    fields_modified: vec![0],
+                    merged_generations: vec![],
+                    fields_for_preserving_frag_bitmap: vec![],
+                    update_mode: Some(UpdateMode::RewriteColumns),
+                    inserted_rows_filter: None,
+                },
+                Retryable,
+            ),
+            (
+                "RewriteRows, overlapping fields and fragments -> Compatible",
+                Operation::CreateIndex {
+                    new_indices: vec![index_on_field_0],
+                    removed_indices: vec![],
+                },
+                Operation::Update {
+                    removed_fragment_ids: vec![0],
+                    updated_fragments: vec![],
+                    new_fragments: vec![fragment1],
+                    fields_modified: vec![],
+                    merged_generations: vec![],
+                    fields_for_preserving_frag_bitmap: vec![],
+                    update_mode: Some(UpdateMode::RewriteRows),
+                    inserted_rows_filter: None,
+                },
+                Compatible,
+            ),
+        ];
+
+        for (description, op1, op2, expected) in cases {
+            let txn1 = Transaction::new(0, op1.clone(), None);
+            let txn2 = Transaction::new(0, op2.clone(), None);
+
+            let mut rebase = TransactionRebase {
+                transaction: txn1,
+                initial_fragments: HashMap::new(),
+                modified_fragment_ids: modified_fragment_ids(&op1).collect::<HashSet<_>>(),
+                affected_rows: None,
+                conflicting_frag_reuse_indices: Vec::new(),
+                conflicting_mem_wal_merged_gens: Vec::new(),
+            };
+
+            let result = rebase.check_txn(&txn2, 1);
+            match expected {
+                Compatible => {
+                    assert!(
+                        result.is_ok(),
+                        "{description}: expected Compatible but got {result:?}",
+                    );
+                }
+                NotCompatible => {
+                    assert!(
+                        matches!(result, Err(Error::CommitConflict { .. })),
+                        "{description}: expected NotCompatible but got {result:?}",
+                    );
+                }
+                Retryable => {
+                    assert!(
+                        matches!(result, Err(Error::RetryableCommitConflict { .. })),
+                        "{description}: expected Retryable but got {result:?}",
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What is this about?

 While running concurrently index optimization along with Dataset updates we've observed incorrect query results. As we dug deeper I believe we've identified the root cause - index corruption when `optimize_indices` (CreateIndex) races with a partial-column `MergeInsert` (Update with `RewriteColumns` mode).

I obviously don't have deep knowledge of Lance internals, so I'm happy to learn that actually our usage of APIs was problematic or that this bug fix is not really the right way to go about it.

## Investigation 

I've built independent (to our own code base) small reproducer and managed to figure out that the key thing to reproduce was making sure that updates to the dataset are **partial-column** updates i.e. we try to update with the `RecordBatch` that has less columns then our `Dataset`.  While doing such updates concurrently with ``optimize_indices`` calls, we've landed at situation where the index was corrupted (or more precisely - stale).

Repro example is basically something like:
 ```
  // 1. Create dataset with 15 columns, scalar Bitmap index on "my_status" column
  let dataset = Dataset::write(initial_batch, uri).await;
  dataset.create_index(&["my_status"], IndexType::Bitmap, ...).await;

  // 2. Concurrently:
  //    Thread A: register rows in 3 phases
  for row in rows {
      // Phase 1: full-schema upsert (my_status="bad", all 15 columns)
      merge_insert(dataset, full_schema_batch).await;       // → RewriteRows mode

      // Phase 2: partial-schema upsert (my_status="good", only 5 columns)
      merge_insert(dataset, partial_schema_batch).await;     // → RewriteColumns mode ← TRIGGER

      create_index(&["status"], replace=false).await;        // no-op, index exists
  }

  //    Thread B: maintenance loop
  for _ in 0..5 {
      compact_files(&mut dataset).await;
      optimize_indices(&mut dataset, merge=200).await;       // ← builds index from stale data
  }

  // 3. Final maintenance
  compact_files(&mut dataset).await;
  optimize_indices(&mut dataset).await;

  // 4. Verify
  assert_eq!(
      dataset.scan().filter("status = 'done'").count(),  // indexed scan — MISSES rows
      dataset.scan().count_where("status = 'done'"),     // full scan — correct
  );
```
 
## Root cause details

  When a `MergeInsert` updates fewer columns than the dataset schema, Lance takes the `RewriteColumns` path — rewriting column data files in-place within the same fragment (same
   fragment ID, same row IDs, different column values). If `optimize_indices` concurrently builds a new index from the pre-update data and commits it, `check_create_index_txn` unconditionally allows it with the comment "row ids are still valid." The resulting index has stale values for the rewritten columns.

  Since the fragment ID didn't change, `effective_fragment_bitmap` does not filter it out, and the stale index data is authoritative. Indexed scans return incorrect results while full scans return correct data.

  ## Fix

  When `CreateIndex` encounters a concurrent `Update` with `RewriteColumns` mode:
  - Check if the modified fields overlap with the new index's fields
  - Check if the rewritten fragments are in the index's `fragment_bitmap` (treating `None` as "covers everything")
  - If both: return a retryable conflict, forcing `optimize_indices` to re-read the updated data

  `RewriteRows` (full-column upsert) and `Delete` remain unconditionally allowed — they remove the old fragment entirely, so `effective_fragment_bitmap` naturally filters
  stale entries.

 ## Testing done
* new unit test
* repro example failure went from 80% (and more) to 0 failures
* our own internal codebase integration test failure rate went from 15-20% to 0.