### PR TITLE
fix: define fragment ID as long in Java API

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -856,7 +856,7 @@ pub extern "system" fn Java_org_lance_Dataset_nativeCreateIndex<'local>(
     params_jobj: JObject<'local>,            // IndexParams
     replace_jobj: jboolean,                  // replace
     train_jobj: jboolean,                    // train
-    fragments_jobj: JObject<'local>,         // List<Integer>
+    fragments_jobj: JObject<'local>,         // Optional<List<Long>>
     index_uuid_jobj: JObject<'local>,        // String
     arrow_stream_addr_jobj: JObject<'local>, // Optional<Long>
 ) -> JObject<'local> {
@@ -888,7 +888,7 @@ fn inner_create_index<'local>(
     params_jobj: JObject<'local>,            // IndexParams
     replace_jobj: jboolean,                  // replace
     train_jobj: jboolean,                    // train
-    fragments_jobj: JObject<'local>,         // Optional<List<String>>
+    fragments_jobj: JObject<'local>,         // Optional<List<Long>>
     index_uuid_jobj: JObject<'local>,        // Optional<String>
     arrow_stream_addr_jobj: JObject<'local>, // Optional<Long>
 ) -> Result<JObject<'local>> {
@@ -899,7 +899,7 @@ fn inner_create_index<'local>(
     let replace = replace_jobj != 0;
     let train = train_jobj != 0;
     let fragment_ids = env
-        .get_ints_opt(&fragments_jobj)?
+        .get_longs_opt(&fragments_jobj)?
         .map(|vec| vec.into_iter().map(|i| i as u32).collect());
     let index_uuid = env.get_string_opt(&index_uuid_jobj)?;
     let arrow_stream_addr_opt = env.get_long_opt(&arrow_stream_addr_jobj)?;
@@ -1373,7 +1373,7 @@ fn inner_get_fragments<'local>(
 pub extern "system" fn Java_org_lance_Dataset_getFragmentNative<'a>(
     mut env: JNIEnv<'a>,
     jdataset: JObject,
-    fragment_id: jint,
+    fragment_id: jlong,
 ) -> JObject<'a> {
     ok_or_throw!(env, inner_get_fragment(&mut env, jdataset, fragment_id))
 }
@@ -1381,7 +1381,7 @@ pub extern "system" fn Java_org_lance_Dataset_getFragmentNative<'a>(
 fn inner_get_fragment<'local>(
     env: &mut JNIEnv<'local>,
     jdataset: JObject,
-    fragment_id: jint,
+    fragment_id: jlong,
 ) -> Result<JObject<'local>> {
     let fragment = {
         let dataset =
@@ -2971,7 +2971,7 @@ pub extern "system" fn Java_org_lance_Dataset_nativeCountIndexedRows(
     java_dataset: JObject,
     jindex_name: JString,
     jfilter: JString,
-    jfragment_ids: JObject, // Optional<List<Integer>>
+    jfragment_ids: JObject, // Optional<List<Long>>
 ) -> jlong {
     ok_or_throw_with_return!(
         env,
@@ -2985,12 +2985,12 @@ fn inner_count_indexed_rows(
     java_dataset: JObject,
     _jindex_name: JString,
     jfilter: JString,
-    jfragment_ids: JObject, // Optional<List<Integer>>
+    jfragment_ids: JObject, // Optional<List<Long>>
 ) -> Result<i64> {
     let filter: String = jfilter.extract(env)?;
 
     // Extract optional fragment IDs
-    let fragment_ids: Option<Vec<u32>> = if env
+    let fragment_ids: Option<Vec<u64>> = if env
         .call_method(&jfragment_ids, "isPresent", "()Z", &[])?
         .z()?
     {
@@ -3001,8 +3001,8 @@ fn inner_count_indexed_rows(
         let mut ids = Vec::new();
         let mut iter = list.iter(env)?;
         while let Some(elem) = iter.next(env)? {
-            let int_val = env.call_method(&elem, "intValue", "()I", &[])?.i()?;
-            ids.push(int_val as u32);
+            let long_val = env.call_method(&elem, "longValue", "()J", &[])?.j()?;
+            ids.push(long_val as u64);
         }
         Some(ids)
     } else {
@@ -3036,7 +3036,7 @@ fn inner_count_indexed_rows(
                 let filtered_fragments: Vec<_> = inner
                     .get_fragments()
                     .into_iter()
-                    .filter(|f| frag_ids.contains(&(f.id() as u32)))
+                    .filter(|f| frag_ids.contains(&(f.id() as u64)))
                     .map(|f| f.metadata().clone())
                     .collect();
                 scanner.with_fragments(filtered_fragments);
@@ -3226,7 +3226,7 @@ fn inner_get_zonemap_stats<'local>(
         })?;
 
     for i in 0..record_batch.num_rows() {
-        let fragment_id = fragment_id_col.value(i) as i32;
+        let fragment_id = fragment_id_col.value(i) as i64;
         let zone_start = zone_start_col.value(i) as i64;
         let zone_length = zone_length_col.value(i) as i64;
         let null_count = null_count_col.value(i) as i64;
@@ -3244,9 +3244,9 @@ fn inner_get_zonemap_stats<'local>(
 
         let zone_stats = env.new_object(
             "org/lance/index/scalar/ZoneStats",
-            "(IJJLjava/lang/Comparable;Ljava/lang/Comparable;J)V",
+            "(JJJLjava/lang/Comparable;Ljava/lang/Comparable;J)V",
             &[
-                JValue::Int(fragment_id),
+                JValue::Long(fragment_id),
                 JValue::Long(zone_start),
                 JValue::Long(zone_length),
                 JValue::Object(&j_min),

--- a/java/lance-jni/src/blocking_scanner.rs
+++ b/java/lance-jni/src/blocking_scanner.rs
@@ -367,21 +367,21 @@ pub extern "system" fn Java_org_lance_ipc_LanceScanner_createScanner<'local>(
     mut env: JNIEnv<'local>,
     _reader: JObject<'local>,
     jdataset: JObject<'local>,
-    fragment_ids_obj: JObject<'local>, // Optional<List<Long>>
-    columns_obj: JObject<'local>,      // Optional<List<String>>
+    fragment_ids_obj: JObject<'local>,     // Optional<List<Long>>
+    columns_obj: JObject<'local>,          // Optional<List<String>>
     substrait_filter_obj: JObject<'local>, // Optional<ByteBuffer>
-    filter_obj: JObject<'local>,       // Optional<String>
-    batch_size_obj: JObject<'local>,   // Optional<Long>
-    limit_obj: JObject<'local>,        // Optional<Integer>
-    offset_obj: JObject<'local>,       // Optional<Integer>
-    query_obj: JObject<'local>,        // Optional<Query>
-    fts_query_obj: JObject<'local>,    // Optional<FullTextQuery>
-    prefilter: jboolean,               // boolean
-    with_row_id: jboolean,             // boolean
-    with_row_address: jboolean,        // boolean
-    batch_readahead: jint,             // int
-    column_orderings: JObject<'local>, // Optional<List<ColumnOrdering>>
-    use_scalar_index: jboolean,        // boolean
+    filter_obj: JObject<'local>,           // Optional<String>
+    batch_size_obj: JObject<'local>,       // Optional<Long>
+    limit_obj: JObject<'local>,            // Optional<Integer>
+    offset_obj: JObject<'local>,           // Optional<Integer>
+    query_obj: JObject<'local>,            // Optional<Query>
+    fts_query_obj: JObject<'local>,        // Optional<FullTextQuery>
+    prefilter: jboolean,                   // boolean
+    with_row_id: jboolean,                 // boolean
+    with_row_address: jboolean,            // boolean
+    batch_readahead: jint,                 // int
+    column_orderings: JObject<'local>,     // Optional<List<ColumnOrdering>>
+    use_scalar_index: jboolean,            // boolean
     substrait_aggregate_obj: JObject<'local>, // Optional<ByteBuffer>
 ) -> JObject<'local> {
     ok_or_throw!(

--- a/java/lance-jni/src/blocking_scanner.rs
+++ b/java/lance-jni/src/blocking_scanner.rs
@@ -231,7 +231,7 @@ pub(crate) fn build_scanner_with_options<'a>(
     let mut scanner = dataset.scan();
 
     // handle fragment_ids
-    let fragment_ids_opt = env.get_ints_opt(&options.fragment_ids_obj)?;
+    let fragment_ids_opt = env.get_longs_opt(&options.fragment_ids_obj)?;
     if let Some(fragment_ids) = fragment_ids_opt {
         let mut fragments = Vec::with_capacity(fragment_ids.len());
         for fragment_id in fragment_ids {
@@ -367,7 +367,7 @@ pub extern "system" fn Java_org_lance_ipc_LanceScanner_createScanner<'local>(
     mut env: JNIEnv<'local>,
     _reader: JObject<'local>,
     jdataset: JObject<'local>,
-    fragment_ids_obj: JObject<'local>, // Optional<List<Integer>>
+    fragment_ids_obj: JObject<'local>, // Optional<List<Long>>
     columns_obj: JObject<'local>,      // Optional<List<String>>
     substrait_filter_obj: JObject<'local>, // Optional<ByteBuffer>
     filter_obj: JObject<'local>,       // Optional<String>

--- a/java/lance-jni/src/ffi.rs
+++ b/java/lance-jni/src/ffi.rs
@@ -48,6 +48,9 @@ pub trait JNIEnvExt {
     /// Get Option<Vec<i32>> from Java Optional<List<Integer>>.
     fn get_ints_opt(&mut self, obj: &JObject) -> Result<Option<Vec<i32>>>;
 
+    /// Get Option<Vec<i64>> from Java Optional<List<Long>>.
+    fn get_longs_opt(&mut self, obj: &JObject) -> Result<Option<Vec<i64>>>;
+
     /// Get Option<i64> from Java Optional<Long>.
     fn get_long_opt(&mut self, obj: &JObject) -> Result<Option<i64>>;
 
@@ -225,6 +228,10 @@ impl JNIEnvExt for JNIEnv<'_> {
 
     fn get_ints_opt(&mut self, obj: &JObject) -> Result<Option<Vec<i32>>> {
         self.get_optional(obj, |env, java_list_obj| env.get_integers(&java_list_obj))
+    }
+
+    fn get_longs_opt(&mut self, obj: &JObject) -> Result<Option<Vec<i64>>> {
+        self.get_optional(obj, |env, java_list_obj| env.get_longs(&java_list_obj))
     }
 
     fn get_long_opt(&mut self, obj: &JObject) -> Result<Option<i64>> {

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -315,7 +315,7 @@ pub extern "system" fn Java_org_lance_Fragment_nativeDeleteRows<'a>(
     mut env: JNIEnv<'a>,
     _obj: JObject,
     jdataset: JObject,
-    fragment_id: jint,
+    fragment_id: jlong,
     row_indexes: JObject, // List<Integer>
 ) -> JObject<'a> {
     ok_or_throw!(
@@ -327,7 +327,7 @@ pub extern "system" fn Java_org_lance_Fragment_nativeDeleteRows<'a>(
 fn inner_delete_rows<'local>(
     env: &mut JNIEnv<'local>,
     jdataset: JObject,
-    fragment_id: jint,
+    fragment_id: jlong,
     row_indexes: JObject, // List<Integer>
 ) -> Result<JObject<'local>> {
     let fragment_id = fragment_id as usize;
@@ -494,7 +494,7 @@ const DELETE_FILE_CONSTRUCTOR_SIG: &str =
     "(JJLjava/lang/Long;Lorg/lance/fragment/DeletionFileType;Ljava/lang/Integer;)V";
 const DELETE_FILE_TYPE_CLASS: &str = "org/lance/fragment/DeletionFileType";
 const FRAGMENT_METADATA_CLASS: &str = "org/lance/FragmentMetadata";
-const FRAGMENT_METADATA_CONSTRUCTOR_SIG: &str = "(ILjava/util/List;Ljava/lang/Long;Lorg/lance/fragment/DeletionFile;Lorg/lance/fragment/RowIdMeta;)V";
+const FRAGMENT_METADATA_CONSTRUCTOR_SIG: &str = "(JLjava/util/List;Ljava/lang/Long;Lorg/lance/fragment/DeletionFile;Lorg/lance/fragment/RowIdMeta;)V";
 const ROW_ID_META_CLASS: &str = "org/lance/fragment/RowIdMeta";
 const ROW_ID_META_CONSTRUCTOR_SIG: &str = "(Ljava/lang/String;)V";
 const FRAGMENT_MERGE_RESULT_CLASS: &str = "org/lance/fragment/FragmentMergeResult";
@@ -629,7 +629,7 @@ impl IntoJava for &Fragment {
             FRAGMENT_METADATA_CLASS,
             FRAGMENT_METADATA_CONSTRUCTOR_SIG,
             &[
-                JValueGen::Int(self.id as i32),
+                JValueGen::Long(self.id as i64),
                 JValueGen::Object(&files),
                 JValueGen::Object(physical_rows),
                 JValueGen::Object(&deletion_file),
@@ -655,7 +655,7 @@ impl FromJObjectWithEnv<RowIdMeta> for JObject<'_> {
 
 impl FromJObjectWithEnv<Fragment> for JObject<'_> {
     fn extract_object(&self, env: &mut JNIEnv<'_>) -> Result<Fragment> {
-        let id = env.call_method(self, "getId", "()I", &[])?.i()? as u64;
+        let id = env.call_method(self, "getId", "()J", &[])?.j()? as u64;
         let file_objs = env
             .call_method(self, "getFiles", "()Ljava/util/List;", &[])?
             .l()?;

--- a/java/lance-jni/src/index.rs
+++ b/java/lance-jni/src/index.rs
@@ -77,7 +77,7 @@ impl IntoJava for &IndexMetadata {
             let array_list = env.new_object("java/util/ArrayList", "()V", &[])?;
             for frag_id in bitmap.iter() {
                 let id_obj =
-                    env.new_object("java/lang/Integer", "(I)V", &[JValue::Int(frag_id as i32)])?;
+                    env.new_object("java/lang/Long", "(J)V", &[JValue::Long(frag_id as i64)])?;
                 env.call_method(
                     &array_list,
                     "add",

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -173,7 +173,7 @@ impl FromJObjectWithEnv<IndexMetadata> for JObject<'_> {
 
         let fragment_bitmap: Option<RoaringBitmap> =
             env.get_optional_from_method(self, "fragments", |env, fragments_obj| {
-                let frag_ids = env.get_integers(&fragments_obj)?;
+                let frag_ids = env.get_longs(&fragments_obj)?;
                 let bitmap = frag_ids
                     .iter()
                     .map(|val| *val as u32)

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1002,7 +1002,7 @@ public class Dataset implements Closeable {
       IndexParams params,
       boolean replace,
       boolean train,
-      Optional<List<Integer>> fragments,
+      Optional<List<Long>> fragments,
       Optional<String> indexUUID,
       Optional<Long> arrowStreamMemoryAddress);
 
@@ -1125,8 +1125,7 @@ public class Dataset implements Closeable {
    * @param fragmentIds optional list of fragment IDs to restrict the count to
    * @return count of matching rows
    */
-  public long countIndexedRows(
-      String indexName, String filter, Optional<List<Integer>> fragmentIds) {
+  public long countIndexedRows(String indexName, String filter, Optional<List<Long>> fragmentIds) {
     try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
       Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
       Preconditions.checkArgument(
@@ -1138,7 +1137,7 @@ public class Dataset implements Closeable {
   }
 
   private native long nativeCountIndexedRows(
-      String indexName, String filter, Optional<List<Integer>> fragmentIds);
+      String indexName, String filter, Optional<List<Long>> fragmentIds);
 
   /**
    * Calculate the size of the dataset.
@@ -1547,12 +1546,12 @@ public class Dataset implements Closeable {
     }
   }
 
-  public Fragment getFragment(int fragmentId) {
+  public Fragment getFragment(long fragmentId) {
     FragmentMetadata metadata = getFragmentNative(fragmentId);
     return new Fragment(this, metadata);
   }
 
-  private native FragmentMetadata getFragmentNative(int fragmentId);
+  private native FragmentMetadata getFragmentNative(long fragmentId);
 
   /**
    * Returns a {@link Tags} instance for performing tag-related operations on the dataset.

--- a/java/src/main/java/org/lance/Fragment.java
+++ b/java/src/main/java/org/lance/Fragment.java
@@ -43,7 +43,7 @@ public class Fragment {
 
   private final FragmentMetadata fragmentMetadata;
 
-  public Fragment(Dataset dataset, int fragmentId) {
+  public Fragment(Dataset dataset, long fragmentId) {
     Preconditions.checkNotNull(dataset);
     this.dataset = dataset;
     this.fragmentMetadata = dataset.getFragment(fragmentId).fragmentMetadata;
@@ -116,11 +116,11 @@ public class Fragment {
   }
 
   private static native FragmentMetadata nativeDeleteRows(
-      Dataset dataset, int fragmentId, List<Integer> rowIndexes);
+      Dataset dataset, long fragmentId, List<Integer> rowIndexes);
 
   private native int countRowsNative(Dataset dataset, long fragmentId);
 
-  public int getId() {
+  public long getId() {
     return fragmentMetadata.getId();
   }
 

--- a/java/src/main/java/org/lance/FragmentMetadata.java
+++ b/java/src/main/java/org/lance/FragmentMetadata.java
@@ -26,14 +26,14 @@ import java.util.Objects;
 /** Metadata of a Fragment in the dataset. Matching to lance Fragment. */
 public class FragmentMetadata implements Serializable {
   private static final long serialVersionUID = -5886811251944130460L;
-  private final int id;
+  private final long id;
   private final List<DataFile> files;
   private final long physicalRows;
   private final DeletionFile deletionFile;
   private final RowIdMeta rowIdMeta;
 
   public FragmentMetadata(
-      int id,
+      long id,
       List<DataFile> files,
       Long physicalRows,
       DeletionFile deletionFile,
@@ -45,7 +45,7 @@ public class FragmentMetadata implements Serializable {
     this.rowIdMeta = rowIdMeta;
   }
 
-  public int getId() {
+  public long getId() {
     return id;
   }
 

--- a/java/src/main/java/org/lance/index/Index.java
+++ b/java/src/main/java/org/lance/index/Index.java
@@ -31,7 +31,7 @@ public class Index {
   private final List<Integer> fields;
   private final String name;
   private final long datasetVersion;
-  private final List<Integer> fragments;
+  private final List<Long> fragments;
   private final byte[] indexDetails;
   private final int indexVersion;
   private final Instant createdAt;
@@ -43,7 +43,7 @@ public class Index {
       List<Integer> fields,
       String name,
       long datasetVersion,
-      List<Integer> fragments,
+      List<Long> fragments,
       byte[] indexDetails,
       int indexVersion,
       Instant createdAt,
@@ -92,7 +92,7 @@ public class Index {
     return datasetVersion;
   }
 
-  public Optional<List<Integer>> fragments() {
+  public Optional<List<Long>> fragments() {
     return Optional.ofNullable(fragments);
   }
 
@@ -194,7 +194,7 @@ public class Index {
     private List<Integer> fields;
     private String name;
     private long datasetVersion;
-    private List<Integer> fragments;
+    private List<Long> fragments;
     private byte[] indexDetails;
     private int indexVersion;
     private Instant createdAt;
@@ -223,7 +223,7 @@ public class Index {
       return this;
     }
 
-    public Builder fragments(List<Integer> fragments) {
+    public Builder fragments(List<Long> fragments) {
       this.fragments = fragments;
       return this;
     }

--- a/java/src/main/java/org/lance/index/IndexOptions.java
+++ b/java/src/main/java/org/lance/index/IndexOptions.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 public class IndexOptions {
   private final boolean replace;
   private final boolean train;
-  private final List<Integer> fragmentIds;
+  private final List<Long> fragmentIds;
   private final String indexUUID;
   private final String indexName;
   private final List<String> columns;
@@ -38,7 +38,7 @@ public class IndexOptions {
       IndexParams indexParams,
       boolean replace,
       boolean train,
-      List<Integer> fragmentIds,
+      List<Long> fragmentIds,
       String indexUUID,
       ArrowArrayStream preprocessedData) {
     this.replace = replace;
@@ -56,7 +56,7 @@ public class IndexOptions {
     return Optional.ofNullable(indexUUID);
   }
 
-  public Optional<List<Integer>> getFragmentIds() {
+  public Optional<List<Long>> getFragmentIds() {
     return Optional.ofNullable(fragmentIds);
   }
 
@@ -97,7 +97,7 @@ public class IndexOptions {
   public static class Builder {
     private boolean replace = false;
     private boolean train = true;
-    private List<Integer> fragmentIds = null;
+    private List<Long> fragmentIds = null;
     private String indexUUID = null;
     private String indexName = null;
     private ArrowArrayStream preprocessedData = null;
@@ -140,7 +140,7 @@ public class IndexOptions {
      *
      * @param fragmentIds fragmentIds option
      */
-    public Builder withFragmentIds(List<Integer> fragmentIds) {
+    public Builder withFragmentIds(List<Long> fragmentIds) {
       this.fragmentIds = fragmentIds;
       return this;
     }

--- a/java/src/main/java/org/lance/index/scalar/ZoneStats.java
+++ b/java/src/main/java/org/lance/index/scalar/ZoneStats.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
 public class ZoneStats implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private final int fragmentId;
+  private final long fragmentId;
   private final long zoneStart;
   private final long zoneLength;
   private final Comparable<?> min;
@@ -50,7 +50,7 @@ public class ZoneStats implements Serializable {
    * @param nullCount the number of null values in the zone
    */
   public ZoneStats(
-      int fragmentId,
+      long fragmentId,
       long zoneStart,
       long zoneLength,
       Comparable<?> min,
@@ -65,7 +65,7 @@ public class ZoneStats implements Serializable {
   }
 
   /** Returns the fragment ID this zone belongs to. */
-  public int getFragmentId() {
+  public long getFragmentId() {
     return fragmentId;
   }
 

--- a/java/src/main/java/org/lance/ipc/AsyncScanner.java
+++ b/java/src/main/java/org/lance/ipc/AsyncScanner.java
@@ -86,7 +86,7 @@ public class AsyncScanner implements AutoCloseable {
 
   static native AsyncScanner createAsyncScanner(
       Dataset dataset,
-      Optional<List<Integer>> fragmentIds,
+      Optional<List<Long>> fragmentIds,
       Optional<List<String>> columns,
       Optional<ByteBuffer> substraitFilter,
       Optional<String> filter,

--- a/java/src/main/java/org/lance/ipc/LanceScanner.java
+++ b/java/src/main/java/org/lance/ipc/LanceScanner.java
@@ -84,7 +84,7 @@ public class LanceScanner implements org.apache.arrow.dataset.scanner.Scanner {
 
   static native LanceScanner createScanner(
       Dataset dataset,
-      Optional<List<Integer>> fragmentIds,
+      Optional<List<Long>> fragmentIds,
       Optional<List<String>> columns,
       Optional<ByteBuffer> substraitFilter,
       Optional<String> filter,

--- a/java/src/main/java/org/lance/ipc/ScanOptions.java
+++ b/java/src/main/java/org/lance/ipc/ScanOptions.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 /** Lance scan options. */
 public class ScanOptions {
-  private final Optional<List<Integer>> fragmentIds;
+  private final Optional<List<Long>> fragmentIds;
   private final Optional<Long> batchSize;
   private final Optional<List<String>> columns;
   private final Optional<String> filter;
@@ -61,7 +61,7 @@ public class ScanOptions {
    * @param substraitAggregate (Optional) Substrait aggregate expression for aggregate pushdown.
    */
   public ScanOptions(
-      Optional<List<Integer>> fragmentIds,
+      Optional<List<Long>> fragmentIds,
       Optional<Long> batchSize,
       Optional<List<String>> columns,
       Optional<String> filter,
@@ -103,7 +103,7 @@ public class ScanOptions {
    *
    * @return Optional containing the fragment ids if specified, otherwise empty.
    */
-  public Optional<List<Integer>> getFragmentIds() {
+  public Optional<List<Long>> getFragmentIds() {
     return fragmentIds;
   }
 
@@ -265,7 +265,7 @@ public class ScanOptions {
 
   /** Builder for constructing LanceScanOptions. */
   public static class Builder {
-    private Optional<List<Integer>> fragmentIds = Optional.empty();
+    private Optional<List<Long>> fragmentIds = Optional.empty();
     private Optional<Long> batchSize = Optional.empty();
     private Optional<List<String>> columns = Optional.empty();
     private Optional<String> filter = Optional.empty();
@@ -314,7 +314,7 @@ public class ScanOptions {
      * @param fragmentIds the id of the fragments to scan
      * @return Builder instance for method chaining.
      */
-    public Builder fragmentIds(List<Integer> fragmentIds) {
+    public Builder fragmentIds(List<Long> fragmentIds) {
       this.fragmentIds = Optional.of(fragmentIds);
       return this;
     }

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -1266,7 +1266,7 @@ public class DatasetTest {
                       .withRowId(true)
                       // load data in one batch
                       .batchSize(20)
-                      .fragmentIds(Arrays.asList(0, 1))
+                      .fragmentIds(Arrays.asList(0L, 1L))
                       .build());
 
           try (ArrowReader reader = scanner.scanBatches()) {
@@ -1809,8 +1809,8 @@ public class DatasetTest {
                   .findFirst()
                   .orElse(null);
           assertNotNull(idIndexBefore);
-          List<Integer> beforeFragments = idIndexBefore.fragments().orElse(Collections.emptyList());
-          assertTrue(beforeFragments.contains(0));
+          List<Long> beforeFragments = idIndexBefore.fragments().orElse(Collections.emptyList());
+          assertTrue(beforeFragments.contains(0L));
           assertEquals(1, beforeFragments.size());
         }
 
@@ -1826,10 +1826,10 @@ public class DatasetTest {
                   .findFirst()
                   .orElse(null);
           assertNotNull(idIndexAfter);
-          List<Integer> afterFragments = idIndexAfter.fragments().orElse(Collections.emptyList());
+          List<Long> afterFragments = idIndexAfter.fragments().orElse(Collections.emptyList());
 
-          assertTrue(afterFragments.contains(0));
-          assertTrue(afterFragments.contains(1));
+          assertTrue(afterFragments.contains(0L));
+          assertTrue(afterFragments.contains(1L));
           assertEquals(2, afterFragments.size());
         }
       }

--- a/java/src/test/java/org/lance/ScannerTest.java
+++ b/java/src/test/java/org/lance/ScannerTest.java
@@ -622,7 +622,7 @@ public class ScannerTest {
     }
   }
 
-  private void validScanResult(Dataset dataset, int fragmentId, int rowCount) throws Exception {
+  private void validScanResult(Dataset dataset, long fragmentId, int rowCount) throws Exception {
     try (Scanner scanner =
         dataset.newScan(
             new ScanOptions.Builder()

--- a/java/src/test/java/org/lance/TestUtils.java
+++ b/java/src/test/java/org/lance/TestUtils.java
@@ -295,7 +295,7 @@ public class TestUtils {
       assertNotNull(dataset);
       List<Fragment> fragments = dataset.getFragments();
       assertEquals(1, fragments.size());
-      assertEquals(0, fragments.get(0).getId());
+      assertEquals(0L, fragments.get(0).getId());
       assertEquals(9, fragments.get(0).countRows());
       assertEquals(schema, dataset.getSchema());
     }

--- a/java/src/test/java/org/lance/VectorSearchTest.java
+++ b/java/src/test/java/org/lance/VectorSearchTest.java
@@ -245,7 +245,7 @@ public class VectorSearchTest {
         if (createVectorIndex) {
           testVectorDataset.createIndex(dataset);
         }
-        List<Integer> fragmentIds = new ArrayList<>(Arrays.asList(3, 4));
+        List<Long> fragmentIds = new ArrayList<>(Arrays.asList(3L, 4L));
         float[] key = new float[32];
         for (int i = 0; i < 32; i++) {
           key[i] = (float) (i + 32);
@@ -307,7 +307,7 @@ public class VectorSearchTest {
       try (Dataset dataset = testVectorDataset.create()) {
         testVectorDataset.createIndex(dataset);
       }
-      List<Integer> fragmentIds = new ArrayList<>(Arrays.asList(3, 4));
+      List<Long> fragmentIds = new ArrayList<>(Arrays.asList(3L, 4L));
       float[] key = new float[32];
       for (int i = 0; i < 32; i++) {
         key[i] = (float) (i + 32);

--- a/java/src/test/java/org/lance/index/ZonemapStatsTest.java
+++ b/java/src/test/java/org/lance/index/ZonemapStatsTest.java
@@ -206,7 +206,7 @@ public class ZonemapStatsTest {
         assertNotNull(stats);
         assertFalse(stats.isEmpty());
 
-        Set<Integer> fragmentIds = new HashSet<>();
+        Set<Long> fragmentIds = new HashSet<>();
         for (ZoneStats z : stats) {
           fragmentIds.add(z.getFragmentId());
         }


### PR DESCRIPTION
The Java API currently defines the fragment ID as a 32-bit int, but the core library mostly treats it as a 64-bit int (or usize, which is generally 64-bits). This PR moves the fragment ID in Java to be a 64-bit int.

The fragment ID is currently set to uint64 for Fragment in table.proto, and as u64 in fragment.rs in lance-table. However, there are some inconsistencies, e.g. for Manifest in table.proto, the max_fragment_id is set as uint32. It is also cast as u32 in places when used in combination with row address.

Alternatively, we keep fragment ID as 32-bit and update to 32-bit where needed, though that might be restrictive.

This PR only updates the Java API though the inconsistencies in the core library should probably be addressed separately.