### PR TITLE
feat: add Dataset.sample() with optional seed for deterministic sampling

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1964,11 +1964,18 @@ pub extern "system" fn Java_org_lance_Dataset_nativeSample(
     mut env: JNIEnv,
     java_dataset: JObject,
     n: jlong,
-    columns_obj: JObject,       // List<String>
-    fragment_ids_obj: JObject,   // Optional<List<Integer>>
-    seed_obj: JObject,           // Optional<Long>
+    columns_obj: JObject,      // List<String>
+    fragment_ids_obj: JObject, // Optional<List<Integer>>
+    seed_obj: JObject,         // Optional<Long>
 ) -> jbyteArray {
-    match inner_sample(&mut env, java_dataset, n, columns_obj, fragment_ids_obj, seed_obj) {
+    match inner_sample(
+        &mut env,
+        java_dataset,
+        n,
+        columns_obj,
+        fragment_ids_obj,
+        seed_obj,
+    ) {
         Ok(byte_array) => byte_array,
         Err(e) => {
             let _ = env.throw_new("java/lang/RuntimeException", format!("{:?}", e));
@@ -1981,9 +1988,9 @@ fn inner_sample(
     env: &mut JNIEnv,
     java_dataset: JObject,
     n: jlong,
-    columns_obj: JObject,       // List<String>
-    fragment_ids_obj: JObject,   // Optional<List<Integer>>
-    seed_obj: JObject,           // Optional<Long>
+    columns_obj: JObject,      // List<String>
+    fragment_ids_obj: JObject, // Optional<List<Integer>>
+    seed_obj: JObject,         // Optional<Long>
 ) -> Result<jbyteArray> {
     let columns: Vec<String> = env.get_strings(&columns_obj)?;
     let fragment_ids: Option<Vec<i32>> = env.get_ints_opt(&fragment_ids_obj)?;

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1960,6 +1960,72 @@ fn inner_take(
 }
 
 #[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeSample(
+    mut env: JNIEnv,
+    java_dataset: JObject,
+    n: jlong,
+    columns_obj: JObject,       // List<String>
+    fragment_ids_obj: JObject,   // Optional<List<Integer>>
+    seed_obj: JObject,           // Optional<Long>
+) -> jbyteArray {
+    match inner_sample(&mut env, java_dataset, n, columns_obj, fragment_ids_obj, seed_obj) {
+        Ok(byte_array) => byte_array,
+        Err(e) => {
+            let _ = env.throw_new("java/lang/RuntimeException", format!("{:?}", e));
+            std::ptr::null_mut()
+        }
+    }
+}
+
+fn inner_sample(
+    env: &mut JNIEnv,
+    java_dataset: JObject,
+    n: jlong,
+    columns_obj: JObject,       // List<String>
+    fragment_ids_obj: JObject,   // Optional<List<Integer>>
+    seed_obj: JObject,           // Optional<Long>
+) -> Result<jbyteArray> {
+    let columns: Vec<String> = env.get_strings(&columns_obj)?;
+    let fragment_ids: Option<Vec<i32>> = env.get_ints_opt(&fragment_ids_obj)?;
+    let fragment_ids_u32: Option<Vec<u32>> =
+        fragment_ids.map(|ids| ids.iter().map(|&id| id as u32).collect());
+    let seed: Option<u64> = env.get_u64_opt(&seed_obj)?;
+
+    let result = {
+        let dataset_guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET) }?;
+        let dataset = &dataset_guard.inner;
+
+        let projection = dataset
+            .schema()
+            .project_preserve_system_columns(&columns)
+            .map_err(|e| Error::runtime_error(e.to_string()))?;
+
+        match RT.block_on(dataset.sample(
+            n as usize,
+            &projection,
+            fragment_ids_u32.as_deref(),
+            seed,
+        )) {
+            Ok(res) => res,
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+    };
+
+    let mut buffer = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut buffer, &result.schema())?;
+        writer.write(&result)?;
+        writer.finish()?;
+    }
+
+    let byte_array = env.byte_array_from_slice(&buffer)?;
+    Ok(**byte_array)
+}
+
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_org_lance_Dataset_nativeDelete(
     mut env: JNIEnv,
     java_dataset: JObject,

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -749,6 +749,80 @@ public class Dataset implements Closeable {
   private native byte[] nativeTake(List<Long> indices, List<String> columns);
 
   /**
+   * Randomly sample n rows from the dataset.
+   *
+   * <p>The returned rows are in row-id order (not random order), which allows the underlying take
+   * operation to use an efficient sorted code path.
+   *
+   * @param n the number of rows to sample
+   * @param columns the columns to include in the result
+   * @return an ArrowReader containing the sampled rows
+   * @throws IOException if an I/O error occurs
+   */
+  public ArrowReader sample(long n, List<String> columns) throws IOException {
+    return sample(n, columns, Optional.empty(), Optional.empty());
+  }
+
+  /**
+   * Randomly sample n rows from specific fragments of the dataset.
+   *
+   * <p>The returned rows are in row-id order (not random order), which allows the underlying take
+   * operation to use an efficient sorted code path.
+   *
+   * @param n the number of rows to sample
+   * @param columns the columns to include in the result
+   * @param fragmentIds optional list of fragment IDs to restrict sampling to
+   * @return an ArrowReader containing the sampled rows
+   * @throws IOException if an I/O error occurs
+   */
+  public ArrowReader sample(long n, List<String> columns, Optional<List<Integer>> fragmentIds)
+      throws IOException {
+    return sample(n, columns, fragmentIds, Optional.empty());
+  }
+
+  /**
+   * Randomly sample n rows from specific fragments of the dataset with an optional seed for
+   * deterministic sampling.
+   *
+   * <p>The returned rows are in row-id order (not random order), which allows the underlying take
+   * operation to use an efficient sorted code path.
+   *
+   * <p>When a seed is provided, the same seed with the same dataset state will always produce the
+   * same result, which is useful for reproducible ML training/validation splits.
+   *
+   * @param n the number of rows to sample
+   * @param columns the columns to include in the result
+   * @param fragmentIds optional list of fragment IDs to restrict sampling to
+   * @param seed optional random seed for deterministic sampling
+   * @return an ArrowReader containing the sampled rows
+   * @throws IOException if an I/O error occurs
+   */
+  public ArrowReader sample(
+      long n, List<String> columns, Optional<List<Integer>> fragmentIds, Optional<Long> seed)
+      throws IOException {
+    Preconditions.checkArgument(n > 0, "n must be greater than 0");
+    Preconditions.checkNotNull(columns, "columns cannot be null");
+    Preconditions.checkArgument(!columns.isEmpty(), "columns cannot be empty");
+    Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      byte[] arrowData = nativeSample(n, columns, fragmentIds, seed);
+      ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(arrowData);
+      ReadableByteChannel readChannel = Channels.newChannel(byteArrayInputStream);
+      return new ArrowStreamReader(readChannel, allocator) {
+        @Override
+        public void close() throws IOException {
+          super.close();
+          readChannel.close();
+          byteArrayInputStream.close();
+        }
+      };
+    }
+  }
+
+  private native byte[] nativeSample(
+      long n, List<String> columns, Optional<List<Integer>> fragmentIds, Optional<Long> seed);
+
+  /**
    * Delete rows of data by predicate.
    *
    * @param predicate the predicate to delete

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -840,6 +840,75 @@ public class DatasetTest {
   }
 
   @Test
+  void testSample(@TempDir Path tempDir) throws IOException {
+    String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
+    String datasetPath = tempDir.resolve(testMethodName).toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+
+      try (Dataset dataset2 = testDataset.write(1, 20)) {
+        // Sample without fragment filter
+        List<String> columns = Arrays.asList("id", "name");
+        try (ArrowReader reader = dataset2.sample(5, columns)) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertNotNull(result);
+          assertEquals(5, result.getRowCount());
+          assertEquals(2, result.getSchema().getFields().size());
+        }
+
+        // Sample with fragment filter
+        List<Fragment> fragments = dataset2.getFragments();
+        assertFalse(fragments.isEmpty());
+        List<Integer> fragmentIds =
+            fragments.stream().map(f -> f.getId()).collect(Collectors.toList());
+        try (ArrowReader reader = dataset2.sample(3, columns, Optional.of(fragmentIds))) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertNotNull(result);
+          assertEquals(3, result.getRowCount());
+        }
+
+        // Sample more than available rows returns all rows
+        try (ArrowReader reader = dataset2.sample(100, columns)) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertNotNull(result);
+          assertEquals(20, result.getRowCount());
+        }
+
+        // Deterministic sampling with seed: same seed produces same results
+        long seed = 42L;
+        List<Integer> firstSampleIds;
+        try (ArrowReader reader =
+            dataset2.sample(5, columns, Optional.empty(), Optional.of(seed))) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertEquals(5, result.getRowCount());
+          firstSampleIds = new ArrayList<>();
+          for (int i = 0; i < result.getRowCount(); i++) {
+            firstSampleIds.add((Integer) result.getVector("id").getObject(i));
+          }
+        }
+        List<Integer> secondSampleIds;
+        try (ArrowReader reader =
+            dataset2.sample(5, columns, Optional.empty(), Optional.of(seed))) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertEquals(5, result.getRowCount());
+          secondSampleIds = new ArrayList<>();
+          for (int i = 0; i < result.getRowCount(); i++) {
+            secondSampleIds.add((Integer) result.getVector("id").getObject(i));
+          }
+        }
+        assertEquals(firstSampleIds, secondSampleIds);
+      }
+    }
+  }
+
+  @Test
   void testCountRows(@TempDir Path tempDir) {
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     String datasetPath = tempDir.resolve(testMethodName).toString();

--- a/rust/lance/benches/take.rs
+++ b/rust/lance/benches/take.rs
@@ -376,7 +376,7 @@ fn bench_sample(c: &mut Criterion) {
                     let schema = schema.clone();
                     let dataset = dataset.clone();
                     async move {
-                        dataset.sample(sample_size, &schema, None).await.unwrap();
+                        dataset.sample(sample_size, &schema, None, None).await.unwrap();
                     }
                 })
             },

--- a/rust/lance/benches/take.rs
+++ b/rust/lance/benches/take.rs
@@ -376,7 +376,10 @@ fn bench_sample(c: &mut Criterion) {
                     let schema = schema.clone();
                     let dataset = dataset.clone();
                     async move {
-                        dataset.sample(sample_size, &schema, None, None).await.unwrap();
+                        dataset
+                            .sample(sample_size, &schema, None, None)
+                            .await
+                            .unwrap();
                     }
                 })
             },

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1509,15 +1509,17 @@ impl Dataset {
         fragment_ids: Option<&[u32]>,
         seed: Option<u64>,
     ) -> Result<RecordBatch> {
-        use rand::seq::IteratorRandom;
-        use rand::rngs::StdRng;
         use rand::SeedableRng;
+        use rand::rngs::StdRng;
+        use rand::seq::IteratorRandom;
 
         match fragment_ids {
             None => {
                 let num_rows = self.count_rows(None).await?;
                 let mut ids = match seed {
-                    Some(s) => (0..num_rows as u64).choose_multiple(&mut StdRng::seed_from_u64(s), n),
+                    Some(s) => {
+                        (0..num_rows as u64).choose_multiple(&mut StdRng::seed_from_u64(s), n)
+                    }
                     None => (0..num_rows as u64).choose_multiple(&mut rand::rng(), n),
                 };
                 ids.sort_unstable();

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1497,6 +1497,9 @@ impl Dataset {
     /// If `fragment_ids` is provided, sampling is limited to rows from those
     /// fragments in the current dataset version.
     ///
+    /// If `seed` is provided, the sampling is deterministic: the same seed
+    /// with the same dataset state will always produce the same result.
+    ///
     /// The returned rows are in row-id order (not random order), which allows
     /// the underlying take operation to use an efficient sorted code path.
     pub async fn sample(
@@ -1504,13 +1507,19 @@ impl Dataset {
         n: usize,
         projection: &Schema,
         fragment_ids: Option<&[u32]>,
+        seed: Option<u64>,
     ) -> Result<RecordBatch> {
         use rand::seq::IteratorRandom;
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
 
         match fragment_ids {
             None => {
                 let num_rows = self.count_rows(None).await?;
-                let mut ids = (0..num_rows as u64).choose_multiple(&mut rand::rng(), n);
+                let mut ids = match seed {
+                    Some(s) => (0..num_rows as u64).choose_multiple(&mut StdRng::seed_from_u64(s), n),
+                    None => (0..num_rows as u64).choose_multiple(&mut rand::rng(), n),
+                };
                 ids.sort_unstable();
                 self.take(&ids, projection.clone()).await
             }
@@ -1548,7 +1557,10 @@ impl Dataset {
                     .try_fold(0_u64, |acc, rows| async move { Ok(acc + rows as u64) })
                     .await?;
 
-                let mut offsets = (0..num_rows).choose_multiple(&mut rand::rng(), n);
+                let mut offsets = match seed {
+                    Some(s) => (0..num_rows).choose_multiple(&mut StdRng::seed_from_u64(s), n),
+                    None => (0..num_rows).choose_multiple(&mut rand::rng(), n),
+                };
                 offsets.sort_unstable();
 
                 let row_addrs = row_offsets_to_row_addresses(&selected_fragments, &offsets).await?;

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1504,7 +1504,10 @@ async fn test_sample_with_empty_fragment_ids_rejected(
     .unwrap();
 
     let projection = dataset.schema().project(&["i"]).unwrap();
-    let err = dataset.sample(1, &projection, Some(&[]), None).await.unwrap_err();
+    let err = dataset
+        .sample(1, &projection, Some(&[]), None)
+        .await
+        .unwrap_err();
 
     assert!(matches!(err, Error::InvalidInput { .. }));
     assert!(

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1465,7 +1465,7 @@ async fn test_sample_with_fragment_ids(
 
     let projection = dataset.schema().project(&["i"]).unwrap();
     let sampled = dataset
-        .sample(8, &projection, Some(&[0, 0, 2]))
+        .sample(8, &projection, Some(&[0, 0, 2]), None)
         .await
         .unwrap();
     let sampled_values = sampled
@@ -1504,7 +1504,7 @@ async fn test_sample_with_empty_fragment_ids_rejected(
     .unwrap();
 
     let projection = dataset.schema().project(&["i"]).unwrap();
-    let err = dataset.sample(1, &projection, Some(&[])).await.unwrap_err();
+    let err = dataset.sample(1, &projection, Some(&[]), None).await.unwrap_err();
 
     assert!(matches!(err, Error::InvalidInput { .. }));
     assert!(
@@ -1538,7 +1538,7 @@ async fn test_sample_with_unknown_fragment_ids_rejected(
 
     let projection = dataset.schema().project(&["i"]).unwrap();
     let err = dataset
-        .sample(1, &projection, Some(&[0, 999]))
+        .sample(1, &projection, Some(&[0, 999]), None)
         .await
         .unwrap_err();
 
@@ -1548,6 +1548,51 @@ async fn test_sample_with_unknown_fragment_ids_rejected(
             .contains("not part of the current dataset version")
     );
     assert!(err.to_string().contains("999"));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_sample_deterministic_with_seed(
+    #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)]
+    data_storage_version: LanceFileVersion,
+) {
+    let test_uri = TempStrDir::default();
+    let data = gen_batch()
+        .col("i", array::step::<Int32Type>())
+        .into_reader_rows(RowCount::from(100), BatchCount::from(1));
+    let dataset = Dataset::write(
+        data,
+        &test_uri,
+        Some(WriteParams {
+            max_rows_per_file: 50,
+            max_rows_per_group: 25,
+            data_storage_version: Some(data_storage_version),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let projection = dataset.schema().project(&["i"]).unwrap();
+    let seed = 42u64;
+
+    let first = dataset
+        .sample(10, &projection, None, Some(seed))
+        .await
+        .unwrap();
+    let second = dataset
+        .sample(10, &projection, None, Some(seed))
+        .await
+        .unwrap();
+
+    assert_eq!(first, second);
+
+    // Different seed should (very likely) produce different results
+    let third = dataset
+        .sample(10, &projection, None, Some(123))
+        .await
+        .unwrap();
+    assert_ne!(first, third);
 }
 
 #[rstest]

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -3360,7 +3360,7 @@ mod tests {
 
         // Sample 2048 random indices and then paste on a column of 9999999's
         let some_indices = ds
-            .sample(2048, &(&just_index_col).try_into().unwrap(), None)
+            .sample(2048, &(&just_index_col).try_into().unwrap(), None, None)
             .await
             .unwrap();
         let some_indices = some_indices.column(0).clone();

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -100,7 +100,7 @@ async fn estimate_multivector_vectors_per_row(
     let sample_batch_size = std::cmp::min(64, num_rows);
     for _ in 0..8 {
         let batch = dataset
-            .sample(sample_batch_size, &projection, fragments)
+            .sample(sample_batch_size, &projection, fragments, None)
             .await?;
         let array = get_column_from_batch(&batch, column)?;
         let list_array = array.as_list::<i32>();
@@ -438,7 +438,7 @@ async fn sample_training_data(
         if !is_nullable {
             let projection = dataset.schema().project(&[column])?;
             let batch = dataset
-                .sample(sample_size_hint, &projection, Some(fragment_ids))
+                .sample(sample_size_hint, &projection, Some(fragment_ids), None)
                 .await?;
             return vector_column_to_fsl(&batch, column);
         }


### PR DESCRIPTION
## Summary

- Add `Dataset.sample()` API to both Rust core and Java JNI for random row sampling
- Add optional `seed` parameter for deterministic sampling — same seed + same dataset state = same result
- Useful for reproducible ML training/validation splits

## Changes

- **`rust/lance/src/dataset.rs`**: Add `seed: Option<u64>` param to `Dataset::sample()`; use `StdRng::seed_from_u64` when seeded, `rand::rng()` otherwise
- **`rust/lance/src/dataset/tests/dataset_io.rs`**: Add `test_sample_deterministic_with_seed` verifying same seed = same result, different seed = different result
- **`rust/lance/src/index/vector/utils.rs`**, **`rust/lance/src/dataset/write/merge_insert.rs`**, **`rust/lance/benches/take.rs`**: Pass `None` for existing callers (backward compatible)
- **`java/lance-jni/src/blocking_dataset.rs`**: Add `nativeSample` JNI function
- **`java/src/main/java/org/lance/Dataset.java`**: Add `sample(n, columns)`, `sample(n, columns, fragmentIds)`, and `sample(n, columns, fragmentIds, seed)` overloads
- **`java/src/test/java/org/lance/DatasetTest.java`**: Test basic sampling, fragment-filtered sampling, over-sampling, and deterministic sampling with seed

## Test plan

- [ ] Rust: `test_sample_deterministic_with_seed` — same seed = identical `RecordBatch`, different seed = different result
- [ ] Rust: existing `test_sample_with_fragment_ids`, `test_sample_with_empty_fragment_ids_rejected`, `test_sample_with_unknown_fragment_ids_rejected` pass with `None` seed
- [ ] Java: `testSample` — basic sample, fragment-filtered sample, over-sample, deterministic seed verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)