### PR TITLE
refactor!: add NamespaceClientTableContext for cached namespace info

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -400,6 +400,98 @@ pub extern "system" fn Java_org_lance_Dataset_drop<'local>(
     JObject::null()
 }
 
+///////////////////
+// Write Methods //
+///////////////////
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_createWithFfiSchema<'local>(
+    mut env: JNIEnv<'local>,
+    _obj: JObject,
+    arrow_schema_addr: jlong,
+    path: JString,
+    max_rows_per_file: JObject,
+    max_rows_per_group: JObject,
+    max_bytes_per_file: JObject,
+    mode: JObject,
+    enable_stable_row_ids: JObject,
+    data_storage_version: JObject,
+    enable_v2_manifest_paths: JObject,
+    storage_options_obj: JObject,
+    initial_bases: JObject,
+    target_bases: JObject,
+    allow_external_blob_outside_bases: JObject,
+    blob_pack_file_size_threshold: JObject,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_create_with_ffi_schema(
+            &mut env,
+            arrow_schema_addr,
+            path,
+            max_rows_per_file,
+            max_rows_per_group,
+            max_bytes_per_file,
+            mode,
+            enable_stable_row_ids,
+            data_storage_version,
+            enable_v2_manifest_paths,
+            storage_options_obj,
+            initial_bases,
+            target_bases,
+            allow_external_blob_outside_bases,
+            blob_pack_file_size_threshold,
+        )
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inner_create_with_ffi_schema<'local>(
+    env: &mut JNIEnv<'local>,
+    arrow_schema_addr: jlong,
+    path: JString,
+    max_rows_per_file: JObject,
+    max_rows_per_group: JObject,
+    max_bytes_per_file: JObject,
+    mode: JObject,
+    enable_stable_row_ids: JObject,
+    data_storage_version: JObject,
+    enable_v2_manifest_paths: JObject,
+    storage_options_obj: JObject,
+    initial_bases: JObject,
+    target_bases: JObject,
+    allow_external_blob_outside_bases: JObject,
+    blob_pack_file_size_threshold: JObject,
+) -> Result<JObject<'local>> {
+    use arrow::ffi::FFI_ArrowSchema;
+    use arrow_schema::Schema;
+    use std::iter::empty;
+
+    let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
+    let c_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema_ptr) };
+    let schema = Schema::try_from(&c_schema)?;
+
+    let reader = arrow::record_batch::RecordBatchIterator::new(empty(), Arc::new(schema));
+    create_dataset(
+        env,
+        path,
+        max_rows_per_file,
+        max_rows_per_group,
+        max_bytes_per_file,
+        mode,
+        enable_stable_row_ids,
+        data_storage_version,
+        enable_v2_manifest_paths,
+        storage_options_obj,
+        initial_bases,
+        target_bases,
+        allow_external_blob_outside_bases,
+        blob_pack_file_size_threshold,
+        reader,
+        None,
+        None,
+    )
+}
+
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_org_lance_Dataset_nativeMigrateManifestPathsV2(
     mut env: JNIEnv,

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -19,7 +19,6 @@ use arrow::ffi::FFI_ArrowSchema;
 use arrow::ffi_stream::ArrowArrayStreamReader;
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use arrow::ipc::writer::StreamWriter;
-use arrow::record_batch::RecordBatchIterator;
 use arrow_schema::DataType;
 use arrow_schema::Schema as ArrowSchema;
 use chrono::{DateTime, Utc};
@@ -57,7 +56,7 @@ use lance_table::io::commit::CommitHandler;
 use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 use std::collections::HashMap;
 use std::future::IntoFuture;
-use std::iter::empty;
+
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
@@ -149,9 +148,8 @@ impl BlockingDataset {
         session: Option<Arc<LanceSession>>,
         namespace: Option<Arc<dyn LanceNamespace>>,
         table_id: Option<Vec<String>>,
-        namespace_client_managed_versioning: bool,
+        ctx: Option<lance_namespace::NamespaceClientTableContext>,
     ) -> Result<Self> {
-        // Create storage options accessor from storage_options and provider
         let accessor = match (storage_options.is_empty(), storage_options_provider) {
             (false, Some(provider)) => Some(Arc::new(
                 lance::io::StorageOptionsAccessor::with_initial_and_provider(
@@ -191,8 +189,7 @@ impl BlockingDataset {
             builder = builder.with_serialized_manifest(serialized_manifest)?;
         }
 
-        // Set up namespace commit handler only if namespace manages versioning
-        if namespace_client_managed_versioning
+        if ctx.as_ref().is_some_and(|c| c.managed_versioning)
             && let (Some(namespace_client), Some(tid)) = (namespace, table_id)
         {
             let external_store = LanceNamespaceExternalManifestStore::new(namespace_client, tid);
@@ -398,91 +395,6 @@ impl BlockingDataset {
 // Write Methods //
 ///////////////////
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_org_lance_Dataset_createWithFfiSchema<'local>(
-    mut env: JNIEnv<'local>,
-    _obj: JObject,
-    arrow_schema_addr: jlong,
-    path: JString,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_stable_row_ids: JObject,    // Optional<Boolean>
-    data_storage_version: JObject,     // Optional<String>
-    enable_v2_manifest_paths: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
-    initial_bases: JObject,
-    target_bases: JObject,
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
-) -> JObject<'local> {
-    ok_or_throw!(
-        env,
-        inner_create_with_ffi_schema(
-            &mut env,
-            arrow_schema_addr,
-            path,
-            max_rows_per_file,
-            max_rows_per_group,
-            max_bytes_per_file,
-            mode,
-            enable_stable_row_ids,
-            data_storage_version,
-            enable_v2_manifest_paths,
-            storage_options_obj,
-            initial_bases,
-            target_bases,
-            allow_external_blob_outside_bases,
-            blob_pack_file_size_threshold,
-        )
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn inner_create_with_ffi_schema<'local>(
-    env: &mut JNIEnv<'local>,
-    arrow_schema_addr: jlong,
-    path: JString,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_stable_row_ids: JObject,    // Optional<Boolean>
-    data_storage_version: JObject,     // Optional<String>
-    enable_v2_manifest_paths: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
-    initial_bases: JObject,
-    target_bases: JObject,
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
-) -> Result<JObject<'local>> {
-    let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
-    let c_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema_ptr) };
-    let schema = Schema::try_from(&c_schema)?;
-
-    let reader = RecordBatchIterator::new(empty(), Arc::new(schema));
-    create_dataset(
-        env,
-        path,
-        max_rows_per_file,
-        max_rows_per_group,
-        max_bytes_per_file,
-        mode,
-        enable_stable_row_ids,
-        data_storage_version,
-        enable_v2_manifest_paths,
-        storage_options_obj,
-        initial_bases,
-        target_bases,
-        allow_external_blob_outside_bases,
-        blob_pack_file_size_threshold,
-        reader,
-        None,  // No namespace for schema-only creation
-        false, // No managed versioning for schema-only creation
-    )
-}
-
-#[unsafe(no_mangle)]
 pub extern "system" fn Java_org_lance_Dataset_drop<'local>(
     mut env: JNIEnv<'local>,
     _obj: JObject,
@@ -521,21 +433,21 @@ pub extern "system" fn Java_org_lance_Dataset_createWithFfiStream<'local>(
     _obj: JObject,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,                    // Optional<Integer>
-    max_rows_per_group: JObject,                   // Optional<Integer>
-    max_bytes_per_file: JObject,                   // Optional<Long>
-    mode: JObject,                                 // Optional<String>
-    enable_stable_row_ids: JObject,                // Optional<Boolean>
-    data_storage_version: JObject,                 // Optional<String>
-    enable_v2_manifest_paths: JObject,             // Optional<Boolean>
-    storage_options_obj: JObject,                  // Map<String, String>
-    initial_bases: JObject,                        // Optional<List<BasePath>>
-    target_bases: JObject,                         // Optional<List<String>>
-    allow_external_blob_outside_bases: JObject,    // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,        // Optional<Long>
-    namespace_obj: JObject,                        // LanceNamespace (can be null)
-    table_id_obj: JObject,                         // List<String> (can be null)
-    namespace_client_managed_versioning: jboolean, // Whether namespace manages versioning
+    max_rows_per_file: JObject,                  // Optional<Integer>
+    max_rows_per_group: JObject,                 // Optional<Integer>
+    max_bytes_per_file: JObject,                 // Optional<Long>
+    mode: JObject,                               // Optional<String>
+    enable_stable_row_ids: JObject,              // Optional<Boolean>
+    data_storage_version: JObject,               // Optional<String>
+    enable_v2_manifest_paths: JObject,           // Optional<Boolean>
+    storage_options_obj: JObject,                // Map<String, String>
+    initial_bases: JObject,                      // Optional<List<BasePath>>
+    target_bases: JObject,                       // Optional<List<String>>
+    allow_external_blob_outside_bases: JObject,  // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,      // Optional<Long>
+    namespace_obj: JObject,                      // LanceNamespace (can be null)
+    table_id_obj: JObject,                       // List<String> (can be null)
+    namespace_client_table_context_obj: JObject, // NamespaceClientTableContext (can be null)
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -557,7 +469,7 @@ pub extern "system" fn Java_org_lance_Dataset_createWithFfiStream<'local>(
             blob_pack_file_size_threshold,
             namespace_obj,
             table_id_obj,
-            namespace_client_managed_versioning != 0,
+            namespace_client_table_context_obj,
         )
     )
 }
@@ -567,27 +479,27 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,                 // Optional<Integer>
-    max_rows_per_group: JObject,                // Optional<Integer>
-    max_bytes_per_file: JObject,                // Optional<Long>
-    mode: JObject,                              // Optional<String>
-    enable_stable_row_ids: JObject,             // Optional<Boolean>
-    data_storage_version: JObject,              // Optional<String>
-    enable_v2_manifest_paths: JObject,          // Optional<Boolean>
-    storage_options_obj: JObject,               // Map<String, String>
-    initial_bases: JObject,                     // Optional<List<BasePath>>
-    target_bases: JObject,                      // Optional<List<String>>
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
-    namespace_obj: JObject,                     // LanceNamespace (can be null)
-    table_id_obj: JObject,                      // List<String> (can be null)
-    namespace_client_managed_versioning: bool,  // Whether namespace manages versioning
+    max_rows_per_file: JObject,
+    max_rows_per_group: JObject,
+    max_bytes_per_file: JObject,
+    mode: JObject,
+    enable_stable_row_ids: JObject,
+    data_storage_version: JObject,
+    enable_v2_manifest_paths: JObject,
+    storage_options_obj: JObject,
+    initial_bases: JObject,
+    target_bases: JObject,
+    allow_external_blob_outside_bases: JObject,
+    blob_pack_file_size_threshold: JObject,
+    namespace_obj: JObject,
+    table_id_obj: JObject,
+    namespace_client_table_context_obj: JObject,
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
 
-    // Create the namespace wrapper for commit handling (if provided)
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
+    let ctx = extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
 
     create_dataset(
         env,
@@ -606,14 +518,14 @@ fn inner_create_with_ffi_stream<'local>(
         blob_pack_file_size_threshold,
         reader,
         namespace_info,
-        namespace_client_managed_versioning,
+        ctx,
     )
 }
 
 /// Creates a dataset from a record batch reader.
 ///
 /// When `namespace_info` is provided, sets up the storage options provider for
-/// credential refresh. When `namespace_client_managed_versioning` is true, also sets up the
+/// credential refresh. When `ctx` has `managed_versioning`, also sets up the
 /// commit handler for namespace-managed versioning.
 #[allow(clippy::too_many_arguments)]
 fn create_dataset<'local>(
@@ -633,7 +545,7 @@ fn create_dataset<'local>(
     blob_pack_file_size_threshold: JObject,
     reader: impl RecordBatchReader + Send + 'static,
     namespace_info: Option<(Arc<dyn LanceNamespace>, Vec<String>)>,
-    namespace_client_managed_versioning: bool,
+    ctx: Option<lance_namespace::NamespaceClientTableContext>,
 ) -> Result<JObject<'local>> {
     let path_str = path.extract(env)?;
 
@@ -653,10 +565,8 @@ fn create_dataset<'local>(
         &blob_pack_file_size_threshold,
     )?;
 
-    // Set up namespace commit handler and storage options provider if namespace is provided
     if let Some((namespace, table_id)) = namespace_info {
-        // Set up commit handler only if namespace manages versioning
-        if namespace_client_managed_versioning {
+        if ctx.as_ref().is_some_and(|c| c.managed_versioning) {
             let external_store =
                 LanceNamespaceExternalManifestStore::new(namespace.clone(), table_id.clone());
             let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
@@ -665,21 +575,23 @@ fn create_dataset<'local>(
             write_params.commit_handler = Some(commit_handler);
         }
 
-        // Set up storage options provider for credential refresh
         let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
             LanceNamespaceStorageOptionsProvider::new(namespace, table_id),
         );
 
-        // Get existing storage options to combine with provider
-        let storage_options: HashMap<String, String> =
-            extract_storage_options(env, &storage_options_obj)?;
+        let initial_opts = ctx
+            .as_ref()
+            .and_then(|c| c.storage_options.clone())
+            .unwrap_or_else(|| {
+                extract_storage_options(env, &storage_options_obj).unwrap_or_default()
+            });
 
-        let accessor = if storage_options.is_empty() {
+        let accessor = if initial_opts.is_empty() {
             Arc::new(lance::io::StorageOptionsAccessor::with_provider(provider))
         } else {
             Arc::new(
                 lance::io::StorageOptionsAccessor::with_initial_and_provider(
-                    storage_options,
+                    initial_opts,
                     provider,
                 ),
             )
@@ -1220,12 +1132,12 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
     block_size_obj: JObject, // Optional<Integer>
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
-    storage_options_obj: JObject,                  // Map<String, String>
-    serialized_manifest: JObject,                  // Optional<ByteBuffer>
-    session_handle: jlong,                         // Session handle, 0 means no session
-    namespace_obj: JObject,                        // LanceNamespace object, null if no namespace
-    table_id_obj: JObject,                         // List<String>, null if no namespace
-    namespace_client_managed_versioning: jboolean, // Whether namespace manages versioning
+    storage_options_obj: JObject,                // Map<String, String>
+    serialized_manifest: JObject,                // Optional<ByteBuffer>
+    session_handle: jlong,                       // Session handle, 0 means no session
+    namespace_obj: JObject,                      // LanceNamespace object, null if no namespace
+    table_id_obj: JObject,                       // List<String>, null if no namespace
+    namespace_client_table_context_obj: JObject, // NamespaceClientTableContext (can be null)
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -1241,7 +1153,7 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
             session_handle,
             namespace_obj,
             table_id_obj,
-            namespace_client_managed_versioning != 0,
+            namespace_client_table_context_obj,
         )
     )
 }
@@ -1250,16 +1162,16 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
 fn inner_open_native<'local>(
     env: &mut JNIEnv<'local>,
     path: JString,
-    version_obj: JObject,    // Optional<Long>
-    block_size_obj: JObject, // Optional<Integer>
+    version_obj: JObject,
+    block_size_obj: JObject,
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
-    storage_options_obj: JObject,              // Map<String, String>
-    serialized_manifest: JObject,              // Optional<ByteBuffer>
-    session_handle: jlong,                     // Session handle, 0 means no session
-    namespace_obj: JObject,                    // LanceNamespace object, null if no namespace
-    table_id_obj: JObject,                     // List<String>, null if no namespace
-    namespace_client_managed_versioning: bool, // Whether namespace manages versioning
+    storage_options_obj: JObject,
+    serialized_manifest: JObject,
+    session_handle: jlong,
+    namespace_obj: JObject,
+    table_id_obj: JObject,
+    namespace_client_table_context_obj: JObject,
 ) -> Result<JObject<'local>> {
     let path_str: String = path.extract(env)?;
     let version = env.get_u64_opt(&version_obj)?;
@@ -1267,15 +1179,14 @@ fn inner_open_native<'local>(
     let jmap = JMap::from_env(env, &storage_options_obj)?;
     let storage_options = to_rust_map(env, &jmap)?;
 
-    // Extract namespace and table_id if provided (before get_bytes_opt which holds borrow)
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
     let (namespace, table_id) = match namespace_info {
         Some((ns, tid)) => (Some(ns), Some(tid)),
         None => (None, None),
     };
 
-    // When namespace is provided, automatically create a storage options provider
-    // for credential refresh
+    let ctx = extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
+
     let storage_options_provider_arc: Option<Arc<dyn StorageOptionsProvider>> =
         if let (Some(ns), Some(tid)) = (namespace.clone(), table_id.clone()) {
             Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(ns, tid)))
@@ -1284,8 +1195,6 @@ fn inner_open_native<'local>(
         };
 
     let serialized_manifest = env.get_bytes_opt(&serialized_manifest)?;
-
-    // Convert session handle to Arc<LanceSession> if provided
     let session = session_from_handle(session_handle);
 
     let dataset = BlockingDataset::open(
@@ -1300,7 +1209,7 @@ fn inner_open_native<'local>(
         session,
         namespace,
         table_id,
-        namespace_client_managed_versioning,
+        ctx,
     )?;
     dataset.into_java(env)
 }
@@ -1362,6 +1271,48 @@ pub(crate) fn extract_namespace_info(
 
     let table_id = env.get_strings(table_id_obj)?;
     Ok(Some((namespace_client, table_id)))
+}
+
+/// Extract a [`NamespaceClientTableContext`] from a Java
+/// `org.lance.NamespaceClientTableContext` object.
+///
+/// Returns `None` if the object is null.
+pub(crate) fn extract_namespace_client_table_context(
+    env: &mut JNIEnv,
+    ctx_obj: &JObject,
+) -> Result<Option<lance_namespace::NamespaceClientTableContext>> {
+    if ctx_obj.is_null() {
+        return Ok(None);
+    }
+    let location: String = env
+        .call_method(ctx_obj, "getLocation", "()Ljava/lang/String;", &[])?
+        .l()
+        .and_then(|obj| env.get_string(&JString::from(obj)).map(|s| s.into()))
+        .map_err(|e| Error::runtime_error(e.to_string()))?;
+
+    let managed_versioning: bool = env
+        .call_method(ctx_obj, "isManagedVersioning", "()Z", &[])?
+        .z()
+        .map_err(|e| Error::runtime_error(e.to_string()))?;
+
+    let storage_opts_obj = env
+        .call_method(ctx_obj, "getStorageOptions", "()Ljava/util/Map;", &[])?
+        .l()
+        .map_err(|e| Error::runtime_error(e.to_string()))?;
+
+    let storage_options = if storage_opts_obj.is_null() {
+        None
+    } else {
+        let jmap = JMap::from_env(env, &storage_opts_obj)?;
+        let map: HashMap<String, String> = to_rust_map(env, &jmap)?;
+        if map.is_empty() { None } else { Some(map) }
+    };
+
+    Ok(Some(lance_namespace::NamespaceClientTableContext {
+        location,
+        storage_options,
+        managed_versioning,
+    }))
 }
 
 #[unsafe(no_mangle)]

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -37,7 +37,6 @@ use lance::dataset::{
     Version, WriteParams,
 };
 use lance::index::DatasetIndexExt;
-use lance::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use lance::io::{ObjectStore, ObjectStoreParams};
 use lance::session::Session as LanceSession;
 use lance::table::format::IndexMetadata;
@@ -50,10 +49,8 @@ use lance_index::progress::noop_progress;
 use lance_index::scalar::btree::BTreeParameters;
 use lance_index::{IndexParams, IndexType};
 use lance_io::object_store::ObjectStoreRegistry;
-use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOptionsProvider};
 use lance_namespace::LanceNamespace;
 use lance_table::io::commit::CommitHandler;
-use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 use std::collections::HashMap;
 use std::future::IntoFuture;
 
@@ -137,33 +134,24 @@ impl BlockingDataset {
 
     #[allow(clippy::too_many_arguments)]
     pub fn open(
-        uri: &str,
+        uri: Option<&str>,
         version: Option<u64>,
         block_size: Option<i32>,
         index_cache_size_bytes: i64,
         metadata_cache_size_bytes: i64,
         storage_options: HashMap<String, String>,
         serialized_manifest: Option<&[u8]>,
-        storage_options_provider: Option<Arc<dyn StorageOptionsProvider>>,
         session: Option<Arc<LanceSession>>,
         namespace: Option<Arc<dyn LanceNamespace>>,
         table_id: Option<Vec<String>>,
         namespace_client_table_context: Option<lance_namespace::NamespaceClientTableContext>,
     ) -> Result<Self> {
-        let accessor = match (storage_options.is_empty(), storage_options_provider) {
-            (false, Some(provider)) => Some(Arc::new(
-                lance::io::StorageOptionsAccessor::with_initial_and_provider(
-                    storage_options,
-                    provider,
-                ),
-            )),
-            (false, None) => Some(Arc::new(
+        let accessor = if !storage_options.is_empty() {
+            Some(Arc::new(
                 lance::io::StorageOptionsAccessor::with_static_options(storage_options),
-            )),
-            (true, Some(provider)) => Some(Arc::new(
-                lance::io::StorageOptionsAccessor::with_provider(provider),
-            )),
-            (true, None) => None,
+            ))
+        } else {
+            None
         };
 
         let store_params = ObjectStoreParams {
@@ -179,7 +167,21 @@ impl BlockingDataset {
             ..Default::default()
         };
 
-        let mut builder = DatasetBuilder::from_uri(uri).with_read_params(params);
+        let mut builder = if let (Some(namespace_client), Some(tid)) = (namespace, table_id) {
+            RT.block_on(DatasetBuilder::from_namespace(
+                namespace_client,
+                tid,
+                namespace_client_table_context.as_ref(),
+            ))?
+        } else {
+            let uri = uri.ok_or_else(|| {
+                Error::input_error(
+                    "uri is required when namespace_client is not provided".to_string(),
+                )
+            })?;
+            DatasetBuilder::from_uri(uri)
+        };
+        builder = builder.with_read_params(params);
 
         if let Some(ver) = version {
             builder = builder.with_version(ver);
@@ -187,18 +189,6 @@ impl BlockingDataset {
 
         if let Some(serialized_manifest) = serialized_manifest {
             builder = builder.with_serialized_manifest(serialized_manifest)?;
-        }
-
-        if namespace_client_table_context
-            .as_ref()
-            .is_some_and(|c| c.managed_versioning)
-            && let (Some(namespace_client), Some(tid)) = (namespace, table_id)
-        {
-            let external_store = LanceNamespaceExternalManifestStore::new(namespace_client, tid);
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            builder = builder.with_commit_handler(commit_handler);
         }
 
         let inner = RT.block_on(builder.load())?;
@@ -527,9 +517,10 @@ fn inner_create_with_ffi_stream<'local>(
 
 /// Creates a dataset from a record batch reader.
 ///
-/// When `namespace_info` is provided, sets up the storage options provider for
-/// credential refresh. When `ctx` has `managed_versioning`, also sets up the
-/// commit handler for namespace-managed versioning.
+/// Creates a dataset from a record batch reader.
+///
+/// When `namespace_info` is provided, uses `write_into_namespace` which handles
+/// storage options provider and commit handler setup internally.
 #[allow(clippy::too_many_arguments)]
 fn create_dataset<'local>(
     env: &mut JNIEnv<'local>,
@@ -550,9 +541,7 @@ fn create_dataset<'local>(
     namespace_info: Option<(Arc<dyn LanceNamespace>, Vec<String>)>,
     namespace_client_table_context: Option<lance_namespace::NamespaceClientTableContext>,
 ) -> Result<JObject<'local>> {
-    let path_str = path.extract(env)?;
-
-    let mut write_params = extract_write_params(
+    let write_params = extract_write_params(
         env,
         &max_rows_per_file,
         &max_rows_per_group,
@@ -568,47 +557,19 @@ fn create_dataset<'local>(
         &blob_pack_file_size_threshold,
     )?;
 
-    if let Some((namespace, table_id)) = namespace_info {
-        if namespace_client_table_context
-            .as_ref()
-            .is_some_and(|c| c.managed_versioning)
-        {
-            let external_store =
-                LanceNamespaceExternalManifestStore::new(namespace.clone(), table_id.clone());
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            write_params.commit_handler = Some(commit_handler);
-        }
-
-        let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
-            LanceNamespaceStorageOptionsProvider::new(namespace, table_id),
-        );
-
-        let initial_opts = namespace_client_table_context
-            .as_ref()
-            .and_then(|c| c.storage_options.clone())
-            .unwrap_or_else(|| {
-                extract_storage_options(env, &storage_options_obj).unwrap_or_default()
-            });
-
-        let accessor = if initial_opts.is_empty() {
-            Arc::new(lance::io::StorageOptionsAccessor::with_provider(provider))
-        } else {
-            Arc::new(
-                lance::io::StorageOptionsAccessor::with_initial_and_provider(
-                    initial_opts,
-                    provider,
-                ),
-            )
-        };
-        write_params.store_params = Some(ObjectStoreParams {
-            storage_options_accessor: Some(accessor),
-            ..Default::default()
-        });
-    }
-
-    let dataset = BlockingDataset::write(reader, &path_str, Some(write_params))?;
+    let dataset = if let Some((namespace_client, table_id)) = namespace_info {
+        let inner = RT.block_on(Dataset::write_into_namespace(
+            reader,
+            namespace_client,
+            table_id,
+            namespace_client_table_context.as_ref(),
+            Some(write_params),
+        ))?;
+        BlockingDataset { inner }
+    } else {
+        let path_str = path.extract(env)?;
+        BlockingDataset::write(reader, &path_str, Some(write_params))?
+    };
     dataset.into_java(env)
 }
 
@@ -1194,25 +1155,17 @@ fn inner_open_native<'local>(
     let namespace_client_table_context =
         extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
 
-    let storage_options_provider_arc: Option<Arc<dyn StorageOptionsProvider>> =
-        if let (Some(ns), Some(tid)) = (namespace.clone(), table_id.clone()) {
-            Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(ns, tid)))
-        } else {
-            None
-        };
-
     let serialized_manifest = env.get_bytes_opt(&serialized_manifest)?;
     let session = session_from_handle(session_handle);
 
     let dataset = BlockingDataset::open(
-        &path_str,
+        Some(path_str.as_str()).filter(|s| !s.is_empty()),
         version,
         block_size,
         index_cache_size_bytes,
         metadata_cache_size_bytes,
         storage_options,
         serialized_manifest,
-        storage_options_provider_arc,
         session,
         namespace,
         table_id,

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1232,7 +1232,11 @@ fn inner_open_native<'local>(
     table_id_obj: JObject,
     namespace_client_table_context_obj: JObject,
 ) -> Result<JObject<'local>> {
-    let path_str: String = path.extract(env)?;
+    let path_str: Option<String> = if path.is_null() {
+        None
+    } else {
+        Some(path.extract(env)?)
+    };
     let version = env.get_u64_opt(&version_obj)?;
     let block_size = env.get_int_opt(&block_size_obj)?;
     let jmap = JMap::from_env(env, &storage_options_obj)?;
@@ -1251,7 +1255,7 @@ fn inner_open_native<'local>(
     let session = session_from_handle(session_handle);
 
     let dataset = BlockingDataset::open(
-        Some(path_str.as_str()).filter(|s| !s.is_empty()),
+        path_str.as_deref(),
         version,
         block_size,
         index_cache_size_bytes,

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -168,20 +168,32 @@ impl BlockingDataset {
         };
 
         let mut builder = if let (Some(namespace_client), Some(tid)) = (namespace, table_id) {
-            RT.block_on(DatasetBuilder::from_namespace(
+            // from_namespace sets up storage_options_accessor and commit_handler.
+            // Apply read params first on a temp builder so from_namespace's setup
+            // takes precedence (with_read_params overwrites store_options).
+            let mut b = RT.block_on(DatasetBuilder::from_namespace(
                 namespace_client,
                 tid,
                 namespace_client_table_context.as_ref(),
-            ))?
+            ))?;
+            b = b
+                .with_index_cache_size_bytes(params.index_cache_size_bytes)
+                .with_metadata_cache_size_bytes(params.metadata_cache_size_bytes);
+            if let Some(session) = params.session {
+                b = b.with_session(session);
+            }
+            if let Some(block_size) = block_size {
+                b = b.with_block_size(block_size as usize);
+            }
+            b
         } else {
             let uri = uri.ok_or_else(|| {
                 Error::input_error(
                     "uri is required when namespace_client is not provided".to_string(),
                 )
             })?;
-            DatasetBuilder::from_uri(uri)
+            DatasetBuilder::from_uri(uri).with_read_params(params)
         };
-        builder = builder.with_read_params(params);
 
         if let Some(ver) = version {
             builder = builder.with_version(ver);

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -148,7 +148,7 @@ impl BlockingDataset {
         session: Option<Arc<LanceSession>>,
         namespace: Option<Arc<dyn LanceNamespace>>,
         table_id: Option<Vec<String>>,
-        ctx: Option<lance_namespace::NamespaceClientTableContext>,
+        namespace_client_table_context: Option<lance_namespace::NamespaceClientTableContext>,
     ) -> Result<Self> {
         let accessor = match (storage_options.is_empty(), storage_options_provider) {
             (false, Some(provider)) => Some(Arc::new(
@@ -189,7 +189,9 @@ impl BlockingDataset {
             builder = builder.with_serialized_manifest(serialized_manifest)?;
         }
 
-        if ctx.as_ref().is_some_and(|c| c.managed_versioning)
+        if namespace_client_table_context
+            .as_ref()
+            .is_some_and(|c| c.managed_versioning)
             && let (Some(namespace_client), Some(tid)) = (namespace, table_id)
         {
             let external_store = LanceNamespaceExternalManifestStore::new(namespace_client, tid);
@@ -499,7 +501,8 @@ fn inner_create_with_ffi_stream<'local>(
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
 
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
-    let ctx = extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
 
     create_dataset(
         env,
@@ -518,7 +521,7 @@ fn inner_create_with_ffi_stream<'local>(
         blob_pack_file_size_threshold,
         reader,
         namespace_info,
-        ctx,
+        namespace_client_table_context,
     )
 }
 
@@ -545,7 +548,7 @@ fn create_dataset<'local>(
     blob_pack_file_size_threshold: JObject,
     reader: impl RecordBatchReader + Send + 'static,
     namespace_info: Option<(Arc<dyn LanceNamespace>, Vec<String>)>,
-    ctx: Option<lance_namespace::NamespaceClientTableContext>,
+    namespace_client_table_context: Option<lance_namespace::NamespaceClientTableContext>,
 ) -> Result<JObject<'local>> {
     let path_str = path.extract(env)?;
 
@@ -566,7 +569,10 @@ fn create_dataset<'local>(
     )?;
 
     if let Some((namespace, table_id)) = namespace_info {
-        if ctx.as_ref().is_some_and(|c| c.managed_versioning) {
+        if namespace_client_table_context
+            .as_ref()
+            .is_some_and(|c| c.managed_versioning)
+        {
             let external_store =
                 LanceNamespaceExternalManifestStore::new(namespace.clone(), table_id.clone());
             let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
@@ -579,7 +585,7 @@ fn create_dataset<'local>(
             LanceNamespaceStorageOptionsProvider::new(namespace, table_id),
         );
 
-        let initial_opts = ctx
+        let initial_opts = namespace_client_table_context
             .as_ref()
             .and_then(|c| c.storage_options.clone())
             .unwrap_or_else(|| {
@@ -1185,7 +1191,8 @@ fn inner_open_native<'local>(
         None => (None, None),
     };
 
-    let ctx = extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
 
     let storage_options_provider_arc: Option<Arc<dyn StorageOptionsProvider>> =
         if let (Some(ns), Some(tid)) = (namespace.clone(), table_id.clone()) {
@@ -1209,7 +1216,7 @@ fn inner_open_native<'local>(
         session,
         namespace,
         table_id,
-        ctx,
+        namespace_client_table_context,
     )?;
     dataset.into_java(env)
 }

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -756,8 +756,12 @@ fn inner_commit_to_dataset<'local>(
     )?;
 
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
-    let ctx = extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
-    let commit_handler = if ctx.as_ref().is_some_and(|c| c.managed_versioning) {
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
+    let commit_handler = if namespace_client_table_context
+        .as_ref()
+        .is_some_and(|c| c.managed_versioning)
+    {
         namespace_info.map(|(ns, tid)| {
             let external_store = LanceNamespaceExternalManifestStore::new(ns, tid);
             Arc::new(ExternalManifestCommitHandler {
@@ -1490,7 +1494,8 @@ fn inner_commit_to_uri<'local>(
 
     // Open the read dataset using the same storage options (and provider, if any) so that
     // `convert_to_rust_transaction` can derive schema/field ids based on the target dataset.
-    let ctx = extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
 
     let mut ds = BlockingDataset::open(
         &uri_str,
@@ -1504,7 +1509,7 @@ fn inner_commit_to_uri<'local>(
         None,
         open_namespace,
         open_table_id,
-        ctx.clone(),
+        namespace_client_table_context.clone(),
     )
     .ok();
 
@@ -1534,7 +1539,9 @@ fn inner_commit_to_uri<'local>(
         builder = builder.with_skip_auto_cleanup(true);
     }
 
-    if ctx.as_ref().is_some_and(|c| c.managed_versioning)
+    if namespace_client_table_context
+        .as_ref()
+        .is_some_and(|c| c.managed_versioning)
         && let Some((namespace_client, tid)) = namespace_info
     {
         let external_store = LanceNamespaceExternalManifestStore::new(namespace_client, tid);

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -4,7 +4,9 @@
 use crate::Error;
 use crate::JNIEnvExt;
 use crate::RT;
-use crate::blocking_dataset::{BlockingDataset, NATIVE_DATASET, extract_namespace_info};
+use crate::blocking_dataset::{
+    BlockingDataset, NATIVE_DATASET, extract_namespace_client_table_context, extract_namespace_info,
+};
 use crate::error::Result;
 use crate::traits::{
     FromJObjectWithEnv, FromJString, IntoJava, JLance, export_vec, import_vec_from_method,
@@ -624,7 +626,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
     skip_auto_cleanup: jboolean,
     namespace_obj: JObject,
     table_id_obj: JObject,
-    namespace_client_managed_versioning: jboolean,
+    namespace_client_table_context_obj: JObject,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -641,7 +643,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
             skip_auto_cleanup != 0,
             namespace_obj,
             table_id_obj,
-            namespace_client_managed_versioning != 0,
+            namespace_client_table_context_obj,
         )
     )
 }
@@ -660,7 +662,7 @@ fn inner_commit_to_dataset<'local>(
     skip_auto_cleanup: bool,
     namespace_obj: JObject,
     table_id_obj: JObject,
-    namespace_client_managed_versioning: bool,
+    namespace_client_table_context_obj: JObject,
 ) -> Result<JObject<'local>> {
     let write_param = if write_params_obj.is_null() {
         HashMap::new()
@@ -753,9 +755,9 @@ fn inner_commit_to_dataset<'local>(
         Some(&mut java_blocking_ds),
     )?;
 
-    // Set namespace commit handler only if namespace_client_managed_versioning is true
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
-    let commit_handler = if namespace_client_managed_versioning {
+    let ctx = extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
+    let commit_handler = if ctx.as_ref().is_some_and(|c| c.managed_versioning) {
         namespace_info.map(|(ns, tid)| {
             let external_store = LanceNamespaceExternalManifestStore::new(ns, tid);
             Arc::new(ExternalManifestCommitHandler {
@@ -1380,7 +1382,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
     storage_format_obj: JObject,
     max_retries: jint,
     skip_auto_cleanup: jboolean,
-    namespace_client_managed_versioning: jboolean,
+    namespace_client_table_context_obj: JObject,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -1398,7 +1400,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
             storage_format_obj,
             max_retries as u32,
             skip_auto_cleanup != 0,
-            namespace_client_managed_versioning != 0,
+            namespace_client_table_context_obj,
         )
     )
 }
@@ -1418,7 +1420,7 @@ fn inner_commit_to_uri<'local>(
     storage_format_obj: JObject,
     max_retries: u32,
     skip_auto_cleanup: bool,
-    namespace_client_managed_versioning: bool,
+    namespace_client_table_context_obj: JObject,
 ) -> Result<JObject<'local>> {
     let uri_str: String = uri.extract(env)?;
 
@@ -1488,6 +1490,8 @@ fn inner_commit_to_uri<'local>(
 
     // Open the read dataset using the same storage options (and provider, if any) so that
     // `convert_to_rust_transaction` can derive schema/field ids based on the target dataset.
+    let ctx = extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
+
     let mut ds = BlockingDataset::open(
         &uri_str,
         None,
@@ -1500,11 +1504,10 @@ fn inner_commit_to_uri<'local>(
         None,
         open_namespace,
         open_table_id,
-        namespace_client_managed_versioning,
+        ctx.clone(),
     )
     .ok();
 
-    // Convert Java transaction to Rust
     let allocator_ref = if allocator_obj.is_null() {
         None
     } else {
@@ -1513,7 +1516,6 @@ fn inner_commit_to_uri<'local>(
     let transaction =
         convert_to_rust_transaction(env, java_transaction, allocator_ref.as_ref(), ds.as_mut())?;
 
-    // Build CommitBuilder with URI
     let mut builder = CommitBuilder::new(&*uri_str)
         .with_store_params(store_params)
         .with_detached(detached)
@@ -1532,8 +1534,9 @@ fn inner_commit_to_uri<'local>(
         builder = builder.with_skip_auto_cleanup(true);
     }
 
-    // Set namespace commit handler only if namespace_client_managed_versioning is true
-    if namespace_client_managed_versioning && let Some((namespace_client, tid)) = namespace_info {
+    if ctx.as_ref().is_some_and(|c| c.managed_versioning)
+        && let Some((namespace_client, tid)) = namespace_info
+    {
         let external_store = LanceNamespaceExternalManifestStore::new(namespace_client, tid);
         let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
             external_manifest_store: Arc::new(external_store),

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -29,7 +29,6 @@ use lance::table::format::{Fragment, IndexMetadata};
 use lance_core::datatypes::Field;
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_file::version::LanceFileVersion;
-use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOptionsProvider};
 use lance_table::io::commit::CommitHandler;
 use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 use prost::Message;
@@ -1454,58 +1453,36 @@ fn inner_commit_to_uri<'local>(
         Some(parse_storage_format(&format_str)?)
     };
 
-    // Extract namespace info and create storage options provider if namespace is provided
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
-    let storage_options_provider: Option<Arc<dyn StorageOptionsProvider>> =
-        if let Some((ref ns, ref tid)) = namespace_info {
-            Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(
-                ns.clone(),
-                tid.clone(),
-            )))
-        } else {
-            None
-        };
-
-    // Keep a copy of initial options for opening the read dataset.
-    let initial_storage_options = write_param.clone();
-
-    let accessor = match (write_param.is_empty(), storage_options_provider.clone()) {
-        (false, Some(provider)) => Some(Arc::new(
-            lance::io::StorageOptionsAccessor::with_initial_and_provider(write_param, provider),
-        )),
-        (false, None) => Some(Arc::new(
-            lance::io::StorageOptionsAccessor::with_static_options(write_param),
-        )),
-        (true, Some(provider)) => Some(Arc::new(lance::io::StorageOptionsAccessor::with_provider(
-            provider,
-        ))),
-        (true, None) => None,
-    };
-
-    let store_params = ObjectStoreParams {
-        storage_options_accessor: accessor,
-        ..Default::default()
-    };
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
 
     let (open_namespace, open_table_id) = match &namespace_info {
         Some((namespace_client, tid)) => (Some(namespace_client.clone()), Some(tid.clone())),
         None => (None, None),
     };
 
-    // Open the read dataset using the same storage options (and provider, if any) so that
-    // `convert_to_rust_transaction` can derive schema/field ids based on the target dataset.
-    let namespace_client_table_context =
-        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
+    let accessor = if !write_param.is_empty() {
+        Some(Arc::new(
+            lance::io::StorageOptionsAccessor::with_static_options(write_param),
+        ))
+    } else {
+        None
+    };
+    let store_params = ObjectStoreParams {
+        storage_options_accessor: accessor,
+        ..Default::default()
+    };
 
+    // Open the read dataset so that convert_to_rust_transaction can derive schema/field ids.
     let mut ds = BlockingDataset::open(
-        &uri_str,
+        Some(&*uri_str),
         None,
         None,
         6 * 1024 * 1024,
         1024 * 1024,
-        initial_storage_options,
+        HashMap::new(),
         None,
-        storage_options_provider,
         None,
         open_namespace,
         open_table_id,

--- a/java/src/main/java/org/lance/CommitBuilder.java
+++ b/java/src/main/java/org/lance/CommitBuilder.java
@@ -66,7 +66,7 @@ public class CommitBuilder {
   private Map<String, String> writeParams;
   private LanceNamespace namespaceClient;
   private List<String> tableId;
-  private boolean namespaceClientManagedVersioning = false;
+  private NamespaceClientTableContext namespaceClientTableContext;
   private boolean enableV2ManifestPaths = true;
   private boolean detached = false;
   private Boolean useStableRowIds;
@@ -138,17 +138,14 @@ public class CommitBuilder {
   }
 
   /**
-   * Set whether namespace manages versioning.
+   * Sets a cached namespace context from a prior {@code describeTable} or {@code declareTable}
+   * call. Rust uses this to determine managed versioning and storage options.
    *
-   * <p>When true and namespaceClient/tableId are set, commits are routed through the namespace
-   * client's create_table_version API. This is typically set based on the managed_versioning field
-   * from describe_table or declare_table responses.
-   *
-   * @param namespaceClientManagedVersioning whether namespace manages versioning
+   * @param context the cached namespace context
    * @return this builder instance
    */
-  public CommitBuilder namespaceClientManagedVersioning(boolean namespaceClientManagedVersioning) {
-    this.namespaceClientManagedVersioning = namespaceClientManagedVersioning;
+  public CommitBuilder namespaceClientTableContext(NamespaceClientTableContext context) {
+    this.namespaceClientTableContext = context;
     return this;
   }
 
@@ -246,6 +243,7 @@ public class CommitBuilder {
    */
   public Dataset execute(Transaction transaction) {
     Preconditions.checkNotNull(transaction, "Transaction must not be null");
+
     if (dataset != null) {
       Dataset result =
           nativeCommitToDataset(
@@ -260,7 +258,7 @@ public class CommitBuilder {
               skipAutoCleanup,
               namespaceClient,
               tableId,
-              namespaceClientManagedVersioning);
+              namespaceClientTableContext);
       result.setAllocator(dataset.allocator());
       return result;
     }
@@ -279,7 +277,7 @@ public class CommitBuilder {
               storageFormat,
               maxRetries,
               skipAutoCleanup,
-              namespaceClientManagedVersioning);
+              namespaceClientTableContext);
       result.setAllocator(allocator);
       return result;
     }
@@ -298,7 +296,7 @@ public class CommitBuilder {
       boolean skipAutoCleanup,
       Object namespace,
       Object tableId,
-      boolean namespaceClientManagedVersioning);
+      NamespaceClientTableContext namespaceClientTableContext);
 
   private static native Dataset nativeCommitToUri(
       String uri,
@@ -313,5 +311,5 @@ public class CommitBuilder {
       String storageFormat,
       int maxRetries,
       boolean skipAutoCleanup,
-      boolean namespaceClientManagedVersioning);
+      NamespaceClientTableContext namespaceClientTableContext);
 }

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -288,7 +288,6 @@ public class Dataset implements Closeable {
       NamespaceClientTableContext namespaceClientTableContext) {
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(stream);
-    Preconditions.checkNotNull(path);
     Preconditions.checkNotNull(params);
     Dataset dataset =
         createWithFfiStream(

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -352,7 +352,6 @@ public class Dataset implements Closeable {
       LanceNamespace namespaceClient,
       List<String> tableId,
       NamespaceClientTableContext namespaceClientTableContext) {
-    Preconditions.checkNotNull(path);
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(options);
 

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -120,9 +120,12 @@ public class Dataset implements Closeable {
   /**
    * Creates an empty dataset with the given schema.
    *
-   * @deprecated Use {@link #write()} builder instead.
+   * @param allocator the buffer allocator
+   * @param path dataset uri
+   * @param schema dataset schema
+   * @param params write params
+   * @return Dataset
    */
-  @Deprecated
   public static Dataset create(
       BufferAllocator allocator, String path, Schema schema, WriteParams params) {
     Preconditions.checkNotNull(allocator);
@@ -168,54 +171,29 @@ public class Dataset implements Closeable {
       Optional<Boolean> allowExternalBlobOutsideBases,
       Optional<Long> blobPackFileSizeThreshold);
 
-  /**
-   * Create a dataset with given stream.
-   *
-   * @deprecated Use {@link #write()} builder instead.
-   */
-  @Deprecated
+  /** Create a dataset with given stream. */
   public static Dataset create(
       BufferAllocator allocator, ArrowArrayStream stream, String path, WriteParams params) {
     return create(allocator, stream, path, params, null, null, null);
   }
 
-  /**
-   * Open a dataset from the specified path.
-   *
-   * @deprecated Use {@link #open()} builder instead.
-   */
-  @Deprecated
+  /** Open a dataset from the specified path. */
   public static Dataset open(String path) {
     return open(
         new RootAllocator(Long.MAX_VALUE), true, path, new ReadOptions.Builder().build(), null);
   }
 
-  /**
-   * Open a dataset from the specified path with options.
-   *
-   * @deprecated Use {@link #open()} builder instead.
-   */
-  @Deprecated
+  /** Open a dataset from the specified path with options. */
   public static Dataset open(String path, ReadOptions options) {
     return open(new RootAllocator(Long.MAX_VALUE), true, path, options, null);
   }
 
-  /**
-   * Open a dataset from the specified path with allocator.
-   *
-   * @deprecated Use {@link #open()} builder instead.
-   */
-  @Deprecated
+  /** Open a dataset from the specified path with allocator. */
   public static Dataset open(String path, BufferAllocator allocator) {
     return open(allocator, path, new ReadOptions.Builder().build());
   }
 
-  /**
-   * Open a dataset from the specified path with allocator and options.
-   *
-   * @deprecated Use {@link #open()} builder instead.
-   */
-  @Deprecated
+  /** Open a dataset from the specified path with allocator and options. */
   public static Dataset open(BufferAllocator allocator, String path, ReadOptions options) {
     return open(allocator, false, path, options, null);
   }

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -118,92 +118,6 @@ public class Dataset implements Closeable {
   }
 
   /**
-   * Creates an empty dataset.
-   *
-   * @param allocator the buffer allocator
-   * @param path dataset uri
-   * @param schema dataset schema
-   * @param params write params
-   * @return Dataset
-   * @deprecated Use {@link #write()} builder instead. For example: {@code
-   *     Dataset.write().allocator(allocator).schema(schema).uri(path)
-   *     .mode(WriteMode.CREATE).execute()}
-   */
-  @Deprecated
-  public static Dataset create(
-      BufferAllocator allocator, String path, Schema schema, WriteParams params) {
-    Preconditions.checkNotNull(allocator);
-    Preconditions.checkNotNull(path);
-    Preconditions.checkNotNull(schema);
-    Preconditions.checkNotNull(params);
-    try (ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator)) {
-      Data.exportSchema(allocator, schema, null, arrowSchema);
-      Dataset dataset =
-          createWithFfiSchema(
-              arrowSchema.memoryAddress(),
-              path,
-              params.getMaxRowsPerFile(),
-              params.getMaxRowsPerGroup(),
-              params.getMaxBytesPerFile(),
-              params.getMode(),
-              params.getEnableStableRowIds(),
-              params.getDataStorageVersion(),
-              params.getEnableV2ManifestPaths(),
-              params.getStorageOptions(),
-              params.getInitialBases(),
-              params.getTargetBases(),
-              params.getAllowExternalBlobOutsideBases(),
-              params.getBlobPackFileSizeThreshold());
-      dataset.allocator = allocator;
-      return dataset;
-    }
-  }
-
-  /**
-   * Create a dataset with given stream.
-   *
-   * @param allocator buffer allocator
-   * @param stream arrow stream
-   * @param path dataset uri
-   * @param params write parameters
-   * @return Dataset
-   * @deprecated Use {@link #write()} builder instead. For example: {@code
-   *     Dataset.write().allocator(allocator).stream(stream).uri(path)
-   *     .mode(WriteMode.CREATE).execute()}
-   */
-  /**
-   * Create a dataset with given stream.
-   *
-   * @param allocator buffer allocator
-   * @param stream arrow stream
-   * @param path dataset uri
-   * @param params write parameters
-   * @return Dataset
-   * @deprecated Use {@link #write()} builder instead.
-   */
-  @Deprecated
-  public static Dataset create(
-      BufferAllocator allocator, ArrowArrayStream stream, String path, WriteParams params) {
-    return create(allocator, stream, path, params, null, null, false);
-  }
-
-  private static native Dataset createWithFfiSchema(
-      long arrowSchemaMemoryAddress,
-      String path,
-      Optional<Integer> maxRowsPerFile,
-      Optional<Integer> maxRowsPerGroup,
-      Optional<Long> maxBytesPerFile,
-      Optional<String> mode,
-      Optional<Boolean> enableStableRowIds,
-      Optional<String> dataStorageVersion,
-      Optional<Boolean> enableV2ManifestPaths,
-      Map<String, String> storageOptions,
-      Optional<List<BasePath>> initialBases,
-      Optional<List<String>> targetBases,
-      Optional<Boolean> allowExternalBlobOutsideBases,
-      Optional<Long> blobPackFileSizeThreshold);
-
-  /**
    * Creates a dataset from an FFI arrow stream.
    *
    * @param arrowStreamMemoryAddress memory address of the arrow stream
@@ -240,7 +154,7 @@ public class Dataset implements Closeable {
       Optional<Long> blobPackFileSizeThreshold,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning);
+      NamespaceClientTableContext namespaceClientTableContext);
 
   /**
    * Creates a dataset with optional namespace client support for managed versioning.
@@ -268,7 +182,7 @@ public class Dataset implements Closeable {
       WriteParams params,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning) {
+      NamespaceClientTableContext namespaceClientTableContext) {
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(stream);
     Preconditions.checkNotNull(path);
@@ -294,62 +208,6 @@ public class Dataset implements Closeable {
             namespaceClientManagedVersioning);
     dataset.allocator = allocator;
     return dataset;
-  }
-
-  /**
-   * Open a dataset from the specified path.
-   *
-   * @param path file path
-   * @return Dataset
-   * @deprecated Use {@link #open()} builder instead: {@code Dataset.open().uri(path).build()}
-   */
-  @Deprecated
-  public static Dataset open(String path) {
-    return open(
-        new RootAllocator(Long.MAX_VALUE), true, path, new ReadOptions.Builder().build(), null);
-  }
-
-  /**
-   * Open a dataset from the specified path.
-   *
-   * @param path file path
-   * @param options the open options
-   * @return Dataset
-   * @deprecated Use {@link #open()} builder instead: {@code
-   *     Dataset.open().uri(path).readOptions(options).build()}
-   */
-  @Deprecated
-  public static Dataset open(String path, ReadOptions options) {
-    return open(new RootAllocator(Long.MAX_VALUE), true, path, options, null);
-  }
-
-  /**
-   * Open a dataset from the specified path.
-   *
-   * @param path file path
-   * @param allocator Arrow buffer allocator
-   * @return Dataset
-   * @deprecated Use {@link #open()} builder instead: {@code
-   *     Dataset.open().allocator(allocator).uri(path).build()}
-   */
-  @Deprecated
-  public static Dataset open(String path, BufferAllocator allocator) {
-    return open(allocator, path, new ReadOptions.Builder().build());
-  }
-
-  /**
-   * Open a dataset from the specified path with additional options.
-   *
-   * @param allocator Arrow buffer allocator
-   * @param path file path
-   * @param options the open options
-   * @return Dataset
-   * @deprecated Use {@link #open()} builder instead: {@code
-   *     Dataset.open().allocator(allocator).uri(path).readOptions(options).build()}
-   */
-  @Deprecated
-  public static Dataset open(BufferAllocator allocator, String path, ReadOptions options) {
-    return open(allocator, false, path, options, null);
   }
 
   /**
@@ -391,7 +249,7 @@ public class Dataset implements Closeable {
       Session session,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning) {
+      NamespaceClientTableContext namespaceClientTableContext) {
     Preconditions.checkNotNull(path);
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(options);
@@ -437,7 +295,7 @@ public class Dataset implements Closeable {
       long sessionHandle,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning);
+      NamespaceClientTableContext namespaceClientTableContext);
 
   /**
    * Creates a builder for opening a dataset.

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -118,6 +118,109 @@ public class Dataset implements Closeable {
   }
 
   /**
+   * Creates an empty dataset with the given schema.
+   *
+   * @deprecated Use {@link #write()} builder instead.
+   */
+  @Deprecated
+  public static Dataset create(
+      BufferAllocator allocator, String path, Schema schema, WriteParams params) {
+    Preconditions.checkNotNull(allocator);
+    Preconditions.checkNotNull(path);
+    Preconditions.checkNotNull(schema);
+    Preconditions.checkNotNull(params);
+    try (ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator)) {
+      Data.exportSchema(allocator, schema, null, arrowSchema);
+      Dataset dataset =
+          createWithFfiSchema(
+              arrowSchema.memoryAddress(),
+              path,
+              params.getMaxRowsPerFile(),
+              params.getMaxRowsPerGroup(),
+              params.getMaxBytesPerFile(),
+              params.getMode(),
+              params.getEnableStableRowIds(),
+              params.getDataStorageVersion(),
+              params.getEnableV2ManifestPaths(),
+              params.getStorageOptions(),
+              params.getInitialBases(),
+              params.getTargetBases(),
+              params.getAllowExternalBlobOutsideBases(),
+              params.getBlobPackFileSizeThreshold());
+      dataset.allocator = allocator;
+      return dataset;
+    }
+  }
+
+  private static native Dataset createWithFfiSchema(
+      long arrowSchemaMemoryAddress,
+      String path,
+      Optional<Integer> maxRowsPerFile,
+      Optional<Integer> maxRowsPerGroup,
+      Optional<Long> maxBytesPerFile,
+      Optional<String> mode,
+      Optional<Boolean> enableStableRowIds,
+      Optional<String> dataStorageVersion,
+      Optional<Boolean> enableV2ManifestPaths,
+      Map<String, String> storageOptions,
+      Optional<List<BasePath>> initialBases,
+      Optional<List<String>> targetBases,
+      Optional<Boolean> allowExternalBlobOutsideBases,
+      Optional<Long> blobPackFileSizeThreshold);
+
+  /**
+   * Create a dataset with given stream.
+   *
+   * @deprecated Use {@link #write()} builder instead.
+   */
+  @Deprecated
+  public static Dataset create(
+      BufferAllocator allocator, ArrowArrayStream stream, String path, WriteParams params) {
+    return create(allocator, stream, path, params, null, null, null);
+  }
+
+  /**
+   * Open a dataset from the specified path.
+   *
+   * @deprecated Use {@link #open()} builder instead.
+   */
+  @Deprecated
+  public static Dataset open(String path) {
+    return open(
+        new RootAllocator(Long.MAX_VALUE), true, path, new ReadOptions.Builder().build(), null);
+  }
+
+  /**
+   * Open a dataset from the specified path with options.
+   *
+   * @deprecated Use {@link #open()} builder instead.
+   */
+  @Deprecated
+  public static Dataset open(String path, ReadOptions options) {
+    return open(new RootAllocator(Long.MAX_VALUE), true, path, options, null);
+  }
+
+  /**
+   * Open a dataset from the specified path with allocator.
+   *
+   * @deprecated Use {@link #open()} builder instead.
+   */
+  @Deprecated
+  public static Dataset open(String path, BufferAllocator allocator) {
+    return open(allocator, path, new ReadOptions.Builder().build());
+  }
+
+  /**
+   * Open a dataset from the specified path with allocator and options.
+   *
+   * @deprecated Use {@link #open()} builder instead.
+   */
+  @Deprecated
+  public static Dataset open(BufferAllocator allocator, String path, ReadOptions options) {
+    return open(allocator, false, path, options, null);
+  }
+
+  /**
    * Creates a dataset from an FFI arrow stream.
    *
    * @param arrowStreamMemoryAddress memory address of the arrow stream
@@ -160,8 +263,8 @@ public class Dataset implements Closeable {
    * Creates a dataset with optional namespace client support for managed versioning.
    *
    * <p>When namespaceClient and tableId are provided, the Rust side will automatically create a
-   * storage options provider for credential refresh. When namespaceClientManagedVersioning is true,
-   * the commit handler will use the namespace client's create_table_version method for version
+   * storage options provider for credential refresh. When namespaceClientTableContext is true, the
+   * commit handler will use the namespace client's create_table_version method for version
    * tracking.
    *
    * @param allocator buffer allocator
@@ -171,8 +274,8 @@ public class Dataset implements Closeable {
    * @param namespaceClient optional namespace client for managed versioning and credential refresh
    *     (can be null)
    * @param tableId optional table identifier within the namespace client (can be null)
-   * @param namespaceClientManagedVersioning whether namespace manages versioning (commits go
-   *     through namespace API)
+   * @param namespaceClientTableContext whether namespace manages versioning (commits go through
+   *     namespace API)
    * @return Dataset
    */
   static Dataset create(
@@ -205,7 +308,7 @@ public class Dataset implements Closeable {
             params.getBlobPackFileSizeThreshold(),
             namespaceClient,
             tableId,
-            namespaceClientManagedVersioning);
+            namespaceClientTableContext);
     dataset.allocator = allocator;
     return dataset;
   }
@@ -223,7 +326,7 @@ public class Dataset implements Closeable {
       String path,
       ReadOptions options,
       Session session) {
-    return open(allocator, selfManagedAllocator, path, options, session, null, null, false);
+    return open(allocator, selfManagedAllocator, path, options, session, null, null, null);
   }
 
   /**
@@ -237,8 +340,8 @@ public class Dataset implements Closeable {
    * @param namespaceClient the LanceNamespace to use for managed versioning and credential refresh
    *     (null if not using namespace client)
    * @param tableId table identifier (null if not using namespace client)
-   * @param namespaceClientManagedVersioning whether namespace manages versioning (commits go
-   *     through namespace API)
+   * @param namespaceClientTableContext whether namespace manages versioning (commits go through
+   *     namespace API)
    * @return Dataset
    */
   static Dataset open(
@@ -272,7 +375,7 @@ public class Dataset implements Closeable {
             sessionHandle,
             namespaceClient,
             tableId,
-            namespaceClientManagedVersioning);
+            namespaceClientTableContext);
     dataset.allocator = allocator;
     dataset.selfManagedAllocator = selfManagedAllocator;
     if (effectiveSession != null) {

--- a/java/src/main/java/org/lance/NamespaceClientTableContext.java
+++ b/java/src/main/java/org/lance/NamespaceClientTableContext.java
@@ -31,7 +31,8 @@ import java.util.Map;
  *
  * <pre>{@code
  * DescribeTableResponse response = namespaceClient.describeTable(request);
- * NamespaceClientTableContext namespaceClientTableContext = NamespaceClientTableContext.fromDescribeTableResponse(response);
+ * NamespaceClientTableContext namespaceClientTableContext =
+ *     NamespaceClientTableContext.fromDescribeTableResponse(response);
  *
  * Dataset dataset = Dataset.open()
  *     .namespaceClient(namespaceClient)

--- a/java/src/main/java/org/lance/NamespaceClientTableContext.java
+++ b/java/src/main/java/org/lance/NamespaceClientTableContext.java
@@ -31,12 +31,12 @@ import java.util.Map;
  *
  * <pre>{@code
  * DescribeTableResponse response = namespaceClient.describeTable(request);
- * NamespaceClientTableContext ctx = NamespaceClientTableContext.fromDescribeTableResponse(response);
+ * NamespaceClientTableContext namespaceClientTableContext = NamespaceClientTableContext.fromDescribeTableResponse(response);
  *
  * Dataset dataset = Dataset.open()
  *     .namespaceClient(namespaceClient)
  *     .tableId(tableId)
- *     .namespaceClientTableContext(ctx)
+ *     .namespaceClientTableContext(namespaceClientTableContext)
  *     .build();
  * }</pre>
  */

--- a/java/src/main/java/org/lance/NamespaceClientTableContext.java
+++ b/java/src/main/java/org/lance/NamespaceClientTableContext.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+import org.lance.namespace.model.DeclareTableResponse;
+import org.lance.namespace.model.DescribeTableResponse;
+
+import org.apache.arrow.util.Preconditions;
+
+import java.util.Map;
+
+/**
+ * Cached context from a namespace client's {@code describeTable} or {@code declareTable} response.
+ *
+ * <p>Contains only the resolved table metadata (location, storage options, managed-versioning
+ * flag). The namespace client and table ID are <b>not</b> part of this class — they are still
+ * passed separately.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * DescribeTableResponse response = namespaceClient.describeTable(request);
+ * NamespaceClientTableContext ctx = NamespaceClientTableContext.fromDescribeTableResponse(response);
+ *
+ * Dataset dataset = Dataset.open()
+ *     .namespaceClient(namespaceClient)
+ *     .tableId(tableId)
+ *     .namespaceClientTableContext(ctx)
+ *     .build();
+ * }</pre>
+ */
+public class NamespaceClientTableContext {
+
+  private final String location;
+  private final Map<String, String> storageOptions;
+  private final boolean managedVersioning;
+
+  /**
+   * Creates a new NamespaceClientTableContext.
+   *
+   * @param location the table's storage location (URI)
+   * @param storageOptions storage options returned by the namespace (e.g. temporary credentials),
+   *     may be null
+   * @param managedVersioning whether commits should go through the namespace's version API
+   */
+  public NamespaceClientTableContext(
+      String location, Map<String, String> storageOptions, boolean managedVersioning) {
+    Preconditions.checkNotNull(location, "location must not be null");
+    this.location = location;
+    this.storageOptions = storageOptions;
+    this.managedVersioning = managedVersioning;
+  }
+
+  /**
+   * Build a context from a {@link DescribeTableResponse}.
+   *
+   * @param response the describe table response
+   * @return a new NamespaceClientTableContext
+   * @throws IllegalArgumentException if the response does not contain a location
+   */
+  public static NamespaceClientTableContext fromDescribeTableResponse(
+      DescribeTableResponse response) {
+    String location = response.getLocation();
+    Preconditions.checkArgument(
+        location != null && !location.isEmpty(), "DescribeTableResponse missing location");
+    return new NamespaceClientTableContext(
+        location,
+        response.getStorageOptions(),
+        Boolean.TRUE.equals(response.getManagedVersioning()));
+  }
+
+  /**
+   * Build a context from a {@link DeclareTableResponse}.
+   *
+   * @param response the declare table response
+   * @return a new NamespaceClientTableContext
+   * @throws IllegalArgumentException if the response does not contain a location
+   */
+  public static NamespaceClientTableContext fromDeclareTableResponse(
+      DeclareTableResponse response) {
+    String location = response.getLocation();
+    Preconditions.checkArgument(
+        location != null && !location.isEmpty(), "DeclareTableResponse missing location");
+    return new NamespaceClientTableContext(
+        location,
+        response.getStorageOptions(),
+        Boolean.TRUE.equals(response.getManagedVersioning()));
+  }
+
+  /** Returns the table's storage location (URI). */
+  public String getLocation() {
+    return location;
+  }
+
+  /** Returns the storage options, or null if none were provided. */
+  public Map<String, String> getStorageOptions() {
+    return storageOptions;
+  }
+
+  /** Returns whether commits should go through the namespace's version API. */
+  public boolean isManagedVersioning() {
+    return managedVersioning;
+  }
+}

--- a/java/src/main/java/org/lance/OpenDatasetBuilder.java
+++ b/java/src/main/java/org/lance/OpenDatasetBuilder.java
@@ -21,9 +21,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Builder for opening a Dataset.
@@ -56,6 +54,7 @@ public class OpenDatasetBuilder {
   private String uri;
   private LanceNamespace namespaceClient;
   private List<String> tableId;
+  private NamespaceClientTableContext namespaceClientTableContext;
   private ReadOptions options = new ReadOptions.Builder().build();
   private Session session;
 
@@ -117,6 +116,21 @@ public class OpenDatasetBuilder {
   }
 
   /**
+   * Sets a cached namespace context from a prior {@code describeTable} or {@code declareTable}
+   * call. When provided, skips the namespace call and uses the cached location, storage options,
+   * and managed-versioning flag directly.
+   *
+   * <p>Cannot be used with {@code uri()} or {@code namespaceClient()}/{@code tableId()}.
+   *
+   * @param context the cached namespace context
+   * @return this builder instance
+   */
+  public OpenDatasetBuilder namespaceClientTableContext(NamespaceClientTableContext context) {
+    this.namespaceClientTableContext = context;
+    return this;
+  }
+
+  /**
    * Sets the read options.
    *
    * @param options Read options
@@ -155,44 +169,72 @@ public class OpenDatasetBuilder {
    * @throws IllegalArgumentException if required parameters are missing or invalid
    */
   public Dataset build() {
-    // Validate that exactly one of uri or namespaceClient+tableId is provided
     boolean hasUri = uri != null;
-    boolean hasNamespaceClient = namespaceClient != null && tableId != null;
+    boolean hasNamespaceClient = namespaceClient != null || tableId != null;
+    boolean hasContext = namespaceClientTableContext != null;
 
     if (hasUri && hasNamespaceClient) {
+      throw new IllegalArgumentException("Cannot specify both uri and namespaceClient+tableId.");
+    }
+    if (hasContext && !hasNamespaceClient) {
       throw new IllegalArgumentException(
-          "Cannot specify both uri and namespaceClient+tableId. Use one or the other.");
+          "namespaceClientTableContext requires namespaceClient and tableId.");
     }
     if (!hasUri && !hasNamespaceClient) {
-      if (namespaceClient != null) {
+      throw new IllegalArgumentException("Either uri or namespaceClient+tableId must be provided.");
+    }
+
+    if (hasNamespaceClient) {
+      if (namespaceClient == null) {
         throw new IllegalArgumentException(
-            "namespaceClient is set but tableId is missing. Both namespaceClient and tableId must"
-                + " be provided together.");
-      } else if (tableId != null) {
+            "tableId is set but namespaceClient is missing. Both must be provided together.");
+      }
+      if (tableId == null) {
         throw new IllegalArgumentException(
-            "tableId is set but namespaceClient is missing. Both namespaceClient and tableId must"
-                + " be provided together.");
-      } else {
-        throw new IllegalArgumentException(
-            "Either uri or namespaceClient+tableId must be provided.");
+            "namespaceClient is set but tableId is missing. Both must be provided together.");
       }
     }
 
     Preconditions.checkNotNull(options, "options must be set");
 
-    // Create allocator if not provided
     if (allocator == null) {
       allocator = new RootAllocator(Long.MAX_VALUE);
       selfManagedAllocator = true;
     }
 
-    // Handle namespace client-based opening
+    if (hasContext) {
+      return buildFromContext();
+    }
+
     if (hasNamespaceClient) {
       return buildFromNamespaceClient();
     }
 
-    // Handle URI-based opening
     return Dataset.open(allocator, selfManagedAllocator, uri, options, session);
+  }
+
+  private Dataset buildFromContext() {
+    NamespaceClientTableContext ctx = this.namespaceClientTableContext;
+
+    ReadOptions.Builder optionsBuilder =
+        new ReadOptions.Builder()
+            .setIndexCacheSizeBytes(options.getIndexCacheSizeBytes())
+            .setMetadataCacheSizeBytes(options.getMetadataCacheSizeBytes());
+
+    options.getVersion().ifPresent(optionsBuilder::setVersion);
+    options.getBlockSize().ifPresent(optionsBuilder::setBlockSize);
+    options.getSerializedManifest().ifPresent(optionsBuilder::setSerializedManifest);
+    optionsBuilder.setStorageOptions(options.getStorageOptions());
+
+    return Dataset.open(
+        allocator,
+        selfManagedAllocator,
+        ctx.getLocation(),
+        optionsBuilder.build(),
+        session,
+        namespaceClient,
+        tableId,
+        ctx);
   }
 
   private Dataset buildFromNamespaceClient() {
@@ -209,10 +251,8 @@ public class OpenDatasetBuilder {
       throw new IllegalArgumentException("Namespace client did not return a table location");
     }
 
-    // Check if namespace client manages versioning (commits go through namespace client API)
-    Boolean namespaceClientManagedVersioning = response.getManagedVersioning();
-
-    Map<String, String> namespaceStorageOptions = response.getStorageOptions();
+    NamespaceClientTableContext ctx =
+        NamespaceClientTableContext.fromDescribeTableResponse(response);
 
     ReadOptions.Builder optionsBuilder =
         new ReadOptions.Builder()
@@ -222,18 +262,8 @@ public class OpenDatasetBuilder {
     options.getVersion().ifPresent(optionsBuilder::setVersion);
     options.getBlockSize().ifPresent(optionsBuilder::setBlockSize);
     options.getSerializedManifest().ifPresent(optionsBuilder::setSerializedManifest);
+    optionsBuilder.setStorageOptions(options.getStorageOptions());
 
-    Map<String, String> storageOptions = new HashMap<>(options.getStorageOptions());
-    if (namespaceStorageOptions != null) {
-      storageOptions.putAll(namespaceStorageOptions);
-    }
-    optionsBuilder.setStorageOptions(storageOptions);
-
-    // Pass namespaceClient, tableId, and namespaceClientManagedVersioning to Rust
-    // The Rust side will:
-    // - Create a storage options provider when namespaceClient/tableId are non-null for credential
-    // refresh
-    // - Create an external manifest commit handler when namespaceClientManagedVersioning is true
     return Dataset.open(
         allocator,
         selfManagedAllocator,
@@ -242,6 +272,6 @@ public class OpenDatasetBuilder {
         session,
         namespaceClient,
         tableId,
-        Boolean.TRUE.equals(namespaceClientManagedVersioning));
+        ctx);
   }
 }

--- a/java/src/main/java/org/lance/OpenDatasetBuilder.java
+++ b/java/src/main/java/org/lance/OpenDatasetBuilder.java
@@ -214,7 +214,7 @@ public class OpenDatasetBuilder {
   }
 
   private Dataset buildFromContext() {
-    NamespaceClientTableContext ctx = this.namespaceClientTableContext;
+    NamespaceClientTableContext namespaceClientTableContext = this.namespaceClientTableContext;
 
     ReadOptions.Builder optionsBuilder =
         new ReadOptions.Builder()
@@ -229,12 +229,12 @@ public class OpenDatasetBuilder {
     return Dataset.open(
         allocator,
         selfManagedAllocator,
-        ctx.getLocation(),
+        namespaceClientTableContext.getLocation(),
         optionsBuilder.build(),
         session,
         namespaceClient,
         tableId,
-        ctx);
+        namespaceClientTableContext);
   }
 
   private Dataset buildFromNamespaceClient() {
@@ -251,7 +251,7 @@ public class OpenDatasetBuilder {
       throw new IllegalArgumentException("Namespace client did not return a table location");
     }
 
-    NamespaceClientTableContext ctx =
+    NamespaceClientTableContext namespaceClientTableContext =
         NamespaceClientTableContext.fromDescribeTableResponse(response);
 
     ReadOptions.Builder optionsBuilder =
@@ -272,6 +272,6 @@ public class OpenDatasetBuilder {
         session,
         namespaceClient,
         tableId,
-        ctx);
+        namespaceClientTableContext);
   }
 }

--- a/java/src/main/java/org/lance/OpenDatasetBuilder.java
+++ b/java/src/main/java/org/lance/OpenDatasetBuilder.java
@@ -14,8 +14,6 @@
 package org.lance;
 
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.model.DescribeTableRequest;
-import org.lance.namespace.model.DescribeTableResponse;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -202,10 +200,6 @@ public class OpenDatasetBuilder {
       selfManagedAllocator = true;
     }
 
-    if (hasContext) {
-      return buildFromContext();
-    }
-
     if (hasNamespaceClient) {
       return buildFromNamespaceClient();
     }
@@ -213,62 +207,12 @@ public class OpenDatasetBuilder {
     return Dataset.open(allocator, selfManagedAllocator, uri, options, session);
   }
 
-  private Dataset buildFromContext() {
-    NamespaceClientTableContext namespaceClientTableContext = this.namespaceClientTableContext;
-
-    ReadOptions.Builder optionsBuilder =
-        new ReadOptions.Builder()
-            .setIndexCacheSizeBytes(options.getIndexCacheSizeBytes())
-            .setMetadataCacheSizeBytes(options.getMetadataCacheSizeBytes());
-
-    options.getVersion().ifPresent(optionsBuilder::setVersion);
-    options.getBlockSize().ifPresent(optionsBuilder::setBlockSize);
-    options.getSerializedManifest().ifPresent(optionsBuilder::setSerializedManifest);
-    optionsBuilder.setStorageOptions(options.getStorageOptions());
-
-    return Dataset.open(
-        allocator,
-        selfManagedAllocator,
-        namespaceClientTableContext.getLocation(),
-        optionsBuilder.build(),
-        session,
-        namespaceClient,
-        tableId,
-        namespaceClientTableContext);
-  }
-
   private Dataset buildFromNamespaceClient() {
-    // Call describe_table to get location and storage options
-    DescribeTableRequest request = new DescribeTableRequest();
-    request.setId(tableId);
-    // Only set version if present
-    options.getVersion().ifPresent(v -> request.setVersion(Long.valueOf(v)));
-
-    DescribeTableResponse response = namespaceClient.describeTable(request);
-
-    String location = response.getLocation();
-    if (location == null || location.isEmpty()) {
-      throw new IllegalArgumentException("Namespace client did not return a table location");
-    }
-
-    NamespaceClientTableContext namespaceClientTableContext =
-        NamespaceClientTableContext.fromDescribeTableResponse(response);
-
-    ReadOptions.Builder optionsBuilder =
-        new ReadOptions.Builder()
-            .setIndexCacheSizeBytes(options.getIndexCacheSizeBytes())
-            .setMetadataCacheSizeBytes(options.getMetadataCacheSizeBytes());
-
-    options.getVersion().ifPresent(optionsBuilder::setVersion);
-    options.getBlockSize().ifPresent(optionsBuilder::setBlockSize);
-    options.getSerializedManifest().ifPresent(optionsBuilder::setSerializedManifest);
-    optionsBuilder.setStorageOptions(options.getStorageOptions());
-
     return Dataset.open(
         allocator,
         selfManagedAllocator,
-        location,
-        optionsBuilder.build(),
+        null,
+        options,
         session,
         namespaceClient,
         tableId,

--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -24,6 +24,7 @@ import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
 
@@ -67,10 +68,10 @@ public class WriteDatasetBuilder {
   private String uri;
   private LanceNamespace namespaceClient;
   private List<String> tableId;
+  private NamespaceClientTableContext namespaceClientTableContext;
   private WriteParams.WriteMode mode = WriteParams.WriteMode.CREATE;
   private Schema schema;
   private Map<String, String> storageOptions = new HashMap<>();
-  private boolean ignoreNamespaceStorageOptions = false;
   private Optional<Integer> maxRowsPerFile = Optional.empty();
   private Optional<Integer> maxRowsPerGroup = Optional.empty();
   private Optional<Long> maxBytesPerFile = Optional.empty();
@@ -171,6 +172,21 @@ public class WriteDatasetBuilder {
   }
 
   /**
+   * Sets a cached namespace context from a prior {@code describeTable} or {@code declareTable}
+   * call. When provided, skips the namespace call and uses the cached location, storage options,
+   * and managed-versioning flag directly.
+   *
+   * <p>Cannot be used with {@code uri()} or {@code namespaceClient()}/{@code tableId()}.
+   *
+   * @param context the cached namespace context
+   * @return this builder instance
+   */
+  public WriteDatasetBuilder namespaceClientTableContext(NamespaceClientTableContext context) {
+    this.namespaceClientTableContext = context;
+    return this;
+  }
+
+  /**
    * Sets the write mode.
    *
    * @param mode The write mode (CREATE, APPEND, or OVERWRITE)
@@ -203,19 +219,6 @@ public class WriteDatasetBuilder {
    */
   public WriteDatasetBuilder storageOptions(Map<String, String> storageOptions) {
     this.storageOptions = new HashMap<>(storageOptions);
-    return this;
-  }
-
-  /**
-   * Sets whether to ignore storage options from the namespace client's describeTable() or
-   * declareTable().
-   *
-   * @param ignoreNamespaceStorageOptions If true, storage options returned from namespace client
-   *     will be ignored
-   * @return this builder instance
-   */
-  public WriteDatasetBuilder ignoreNamespaceStorageOptions(boolean ignoreNamespaceStorageOptions) {
-    this.ignoreNamespaceStorageOptions = ignoreNamespaceStorageOptions;
     return this;
   }
 
@@ -334,33 +337,38 @@ public class WriteDatasetBuilder {
    * @throws IllegalArgumentException if required parameters are missing or invalid
    */
   public Dataset execute() {
-    // Auto-create allocator if not provided
     if (allocator == null) {
       allocator = new RootAllocator(Long.MAX_VALUE);
     }
 
-    // Validate that exactly one of uri or namespaceClient is provided
     boolean hasUri = uri != null;
-    boolean hasNamespaceClient = namespaceClient != null && tableId != null;
+    boolean hasNamespaceClient = namespaceClient != null || tableId != null;
+    boolean hasContext = namespaceClientTableContext != null;
 
     if (hasUri && hasNamespaceClient) {
       throw new IllegalArgumentException(
-          "Cannot specify both uri() and namespaceClient()+tableId(). Use one or the other.");
+          "Cannot specify both uri() and namespaceClient()+tableId().");
+    }
+    if (hasContext && !hasNamespaceClient) {
+      throw new IllegalArgumentException(
+          "namespaceClientTableContext() requires namespaceClient() and tableId().");
     }
     if (!hasUri && !hasNamespaceClient) {
-      if (namespaceClient != null) {
-        throw new IllegalArgumentException(
-            "namespaceClient() is set but tableId() is missing. Both must be provided together.");
-      } else if (tableId != null) {
+      throw new IllegalArgumentException(
+          "Either uri() or namespaceClient()+tableId() must be called.");
+    }
+
+    if (hasNamespaceClient) {
+      if (namespaceClient == null) {
         throw new IllegalArgumentException(
             "tableId() is set but namespaceClient() is missing. Both must be provided together.");
-      } else {
+      }
+      if (tableId == null) {
         throw new IllegalArgumentException(
-            "Either uri() or namespaceClient()+tableId() must be called.");
+            "namespaceClient() is set but tableId() is missing. Both must be provided together.");
       }
     }
 
-    // Validate data source - exactly one of reader, stream, or schema must be provided
     int dataSourceCount = 0;
     if (reader != null) dataSourceCount++;
     if (stream != null) dataSourceCount++;
@@ -376,21 +384,43 @@ public class WriteDatasetBuilder {
               + "Use only one of: reader(), stream(), or schema().");
     }
 
-    // Handle namespace client-based writing
+    if (hasContext) {
+      return executeWithContext();
+    }
+
     if (hasNamespaceClient) {
       return executeWithNamespaceClient();
     }
 
-    // Handle URI-based writing
     return executeWithUri();
+  }
+
+  private Dataset executeWithContext() {
+    NamespaceClientTableContext ctx = this.namespaceClientTableContext;
+
+    WriteParams.Builder paramsBuilder =
+        new WriteParams.Builder().withMode(mode).withStorageOptions(storageOptions);
+
+    maxRowsPerFile.ifPresent(paramsBuilder::withMaxRowsPerFile);
+    maxRowsPerGroup.ifPresent(paramsBuilder::withMaxRowsPerGroup);
+    maxBytesPerFile.ifPresent(paramsBuilder::withMaxBytesPerFile);
+    enableStableRowIds.ifPresent(paramsBuilder::withEnableStableRowIds);
+    dataStorageVersion.ifPresent(paramsBuilder::withDataStorageVersion);
+    initialBases.ifPresent(paramsBuilder::withInitialBases);
+    targetBases.ifPresent(paramsBuilder::withTargetBases);
+    allowExternalBlobOutsideBases.ifPresent(paramsBuilder::withAllowExternalBlobOutsideBases);
+    blobPackFileSizeThreshold.ifPresent(paramsBuilder::withBlobPackFileSizeThreshold);
+
+    WriteParams params = paramsBuilder.build();
+
+    return createDatasetWithStreamAndNamespaceClient(
+        ctx.getLocation(), params, namespaceClient, tableId, ctx);
   }
 
   private Dataset executeWithNamespaceClient() {
     String tableUri;
-    Map<String, String> namespaceStorageOptions = null;
-    boolean namespaceClientManagedVersioning = false;
+    NamespaceClientTableContext ctx;
 
-    // Mode-specific namespace client operations
     if (mode == WriteParams.WriteMode.CREATE) {
       DeclareTableRequest declareRequest = new DeclareTableRequest();
       declareRequest.setId(tableId);
@@ -401,12 +431,8 @@ public class WriteDatasetBuilder {
         throw new IllegalArgumentException("Namespace client did not return a table location");
       }
 
-      namespaceClientManagedVersioning =
-          Boolean.TRUE.equals(declareResponse.getManagedVersioning());
-      namespaceStorageOptions =
-          ignoreNamespaceStorageOptions ? null : declareResponse.getStorageOptions();
+      ctx = NamespaceClientTableContext.fromDeclareTableResponse(declareResponse);
     } else {
-      // For APPEND/OVERWRITE modes, call namespaceClient.describeTable()
       DescribeTableRequest request = new DescribeTableRequest();
       request.setId(tableId);
 
@@ -417,20 +443,11 @@ public class WriteDatasetBuilder {
         throw new IllegalArgumentException("Namespace client did not return a table location");
       }
 
-      namespaceStorageOptions = ignoreNamespaceStorageOptions ? null : response.getStorageOptions();
-      namespaceClientManagedVersioning = Boolean.TRUE.equals(response.getManagedVersioning());
+      ctx = NamespaceClientTableContext.fromDescribeTableResponse(response);
     }
 
-    // Merge storage options (namespace client options + user options, with namespace client taking
-    // precedence)
-    Map<String, String> mergedStorageOptions = new HashMap<>(storageOptions);
-    if (namespaceStorageOptions != null && !namespaceStorageOptions.isEmpty()) {
-      mergedStorageOptions.putAll(namespaceStorageOptions);
-    }
-
-    // Build WriteParams with merged storage options
     WriteParams.Builder paramsBuilder =
-        new WriteParams.Builder().withMode(mode).withStorageOptions(mergedStorageOptions);
+        new WriteParams.Builder().withMode(mode).withStorageOptions(storageOptions);
 
     maxRowsPerFile.ifPresent(paramsBuilder::withMaxRowsPerFile);
     maxRowsPerGroup.ifPresent(paramsBuilder::withMaxRowsPerGroup);
@@ -445,22 +462,8 @@ public class WriteDatasetBuilder {
 
     WriteParams params = paramsBuilder.build();
 
-    // Pass namespaceClient, tableId, and namespaceClientManagedVersioning to JNI
-    // Rust will automatically create a storage options provider when namespaceClient/tableId
-    // are non-null for credential refresh, and will create an external manifest commit handler
-    // when namespaceClientManagedVersioning is true
-    if (namespaceClientManagedVersioning) {
-      return createDatasetWithStreamAndNamespaceClient(
-          tableUri, params, namespaceClient, tableId, true);
-    } else {
-      // Even without managed versioning, pass namespaceClient for credential refresh
-      // when namespace client vends credentials (storage options was non-null)
-      if (!ignoreNamespaceStorageOptions && namespaceStorageOptions != null) {
-        return createDatasetWithStreamAndNamespaceClient(
-            tableUri, params, namespaceClient, tableId, false);
-      }
-      return createDatasetWithStream(tableUri, params);
-    }
+    return createDatasetWithStreamAndNamespaceClient(
+        tableUri, params, namespaceClient, tableId, ctx);
   }
 
   private Dataset executeWithUri() {
@@ -479,29 +482,7 @@ public class WriteDatasetBuilder {
 
     WriteParams params = paramsBuilder.build();
 
-    return createDatasetWithStream(uri, params);
-  }
-
-  private Dataset createDatasetWithStream(String path, WriteParams params) {
-    // If stream is directly provided, use it
-    if (stream != null) {
-      return Dataset.create(allocator, stream, path, params);
-    }
-
-    // If reader is provided, convert to stream
-    if (reader != null) {
-      try (ArrowArrayStream tempStream = ArrowArrayStream.allocateNew(allocator)) {
-        Data.exportArrayStream(allocator, reader, tempStream);
-        return Dataset.create(allocator, tempStream, path, params);
-      }
-    }
-
-    // If only schema is provided (empty table), use Dataset.create with schema
-    if (schema != null) {
-      return Dataset.create(allocator, path, schema, params);
-    }
-
-    throw new IllegalStateException("No data source provided");
+    return createDatasetWithStreamAndNamespaceClient(uri, params, null, null, null);
   }
 
   private Dataset createDatasetWithStreamAndNamespaceClient(
@@ -509,20 +490,12 @@ public class WriteDatasetBuilder {
       WriteParams params,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning) {
-    // If stream is directly provided, use it
+      NamespaceClientTableContext namespaceClientTableContext) {
     if (stream != null) {
       return Dataset.create(
-          allocator,
-          stream,
-          path,
-          params,
-          namespaceClient,
-          tableId,
-          namespaceClientManagedVersioning);
+          allocator, stream, path, params, namespaceClient, tableId, namespaceClientTableContext);
     }
 
-    // If reader is provided, convert to stream
     if (reader != null) {
       try (ArrowArrayStream tempStream = ArrowArrayStream.allocateNew(allocator)) {
         Data.exportArrayStream(allocator, reader, tempStream);
@@ -533,14 +506,23 @@ public class WriteDatasetBuilder {
             params,
             namespaceClient,
             tableId,
-            namespaceClientManagedVersioning);
+            namespaceClientTableContext);
       }
     }
 
-    // If only schema is provided (empty table), use Dataset.create with schema
-    // Note: Schema-only creation doesn't support namespace client-based commit handling
     if (schema != null) {
-      return Dataset.create(allocator, path, schema, params);
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+          ArrowArrayStream tempStream = ArrowArrayStream.allocateNew(allocator)) {
+        Data.exportArrayStream(allocator, root, tempStream);
+        return Dataset.create(
+            allocator,
+            tempStream,
+            path,
+            params,
+            namespaceClient,
+            tableId,
+            namespaceClientTableContext);
+      }
     }
 
     throw new IllegalStateException("No data source provided");

--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -21,7 +21,6 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.ipc.ArrowReader;
-import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.util.HashMap;
 import java.util.List;
@@ -65,7 +64,6 @@ public class WriteDatasetBuilder {
   private List<String> tableId;
   private NamespaceClientTableContext namespaceClientTableContext;
   private WriteParams.WriteMode mode = WriteParams.WriteMode.CREATE;
-  private Schema schema;
   private Map<String, String> storageOptions = new HashMap<>();
   private Optional<Integer> maxRowsPerFile = Optional.empty();
   private Optional<Integer> maxRowsPerGroup = Optional.empty();
@@ -190,19 +188,6 @@ public class WriteDatasetBuilder {
   public WriteDatasetBuilder mode(WriteParams.WriteMode mode) {
     Preconditions.checkNotNull(mode);
     this.mode = mode;
-    return this;
-  }
-
-  /**
-   * Sets the schema for the dataset.
-   *
-   * <p>If the reader and stream not provided, this is used to create an empty dataset
-   *
-   * @param schema The dataset schema
-   * @return this builder instance
-   */
-  public WriteDatasetBuilder schema(Schema schema) {
-    this.schema = schema;
     return this;
   }
 
@@ -364,19 +349,12 @@ public class WriteDatasetBuilder {
       }
     }
 
-    int dataSourceCount = 0;
-    if (reader != null) dataSourceCount++;
-    if (stream != null) dataSourceCount++;
-    if (schema != null && reader == null && stream == null) dataSourceCount++;
-
-    if (dataSourceCount == 0) {
-      throw new IllegalArgumentException(
-          "Must provide data via reader(), stream(), or schema() (for empty tables).");
+    if (reader == null && stream == null) {
+      throw new IllegalArgumentException("Must provide data via reader() or stream().");
     }
-    if (dataSourceCount > 1) {
+    if (reader != null && stream != null) {
       throw new IllegalArgumentException(
-          "Cannot specify multiple data sources. "
-              + "Use only one of: reader(), stream(), or schema().");
+          "Cannot specify both reader() and stream(). Use only one.");
     }
 
     if (hasNamespaceClient) {
@@ -448,10 +426,6 @@ public class WriteDatasetBuilder {
             tableId,
             namespaceClientTableContext);
       }
-    }
-
-    if (schema != null) {
-      return Dataset.create(allocator, path, schema, params);
     }
 
     throw new IllegalStateException("No data source provided");

--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -14,10 +14,6 @@
 package org.lance;
 
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.model.DeclareTableRequest;
-import org.lance.namespace.model.DeclareTableResponse;
-import org.lance.namespace.model.DescribeTableRequest;
-import org.lance.namespace.model.DescribeTableResponse;
 
 import org.apache.arrow.c.ArrowArrayStream;
 import org.apache.arrow.c.Data;
@@ -384,10 +380,6 @@ public class WriteDatasetBuilder {
               + "Use only one of: reader(), stream(), or schema().");
     }
 
-    if (hasContext) {
-      return executeWithContext();
-    }
-
     if (hasNamespaceClient) {
       return executeWithNamespaceClient();
     }
@@ -395,62 +387,7 @@ public class WriteDatasetBuilder {
     return executeWithUri();
   }
 
-  private Dataset executeWithContext() {
-    NamespaceClientTableContext namespaceClientTableContext = this.namespaceClientTableContext;
-
-    WriteParams.Builder paramsBuilder =
-        new WriteParams.Builder().withMode(mode).withStorageOptions(storageOptions);
-
-    maxRowsPerFile.ifPresent(paramsBuilder::withMaxRowsPerFile);
-    maxRowsPerGroup.ifPresent(paramsBuilder::withMaxRowsPerGroup);
-    maxBytesPerFile.ifPresent(paramsBuilder::withMaxBytesPerFile);
-    enableStableRowIds.ifPresent(paramsBuilder::withEnableStableRowIds);
-    dataStorageVersion.ifPresent(paramsBuilder::withDataStorageVersion);
-    initialBases.ifPresent(paramsBuilder::withInitialBases);
-    targetBases.ifPresent(paramsBuilder::withTargetBases);
-    allowExternalBlobOutsideBases.ifPresent(paramsBuilder::withAllowExternalBlobOutsideBases);
-    blobPackFileSizeThreshold.ifPresent(paramsBuilder::withBlobPackFileSizeThreshold);
-
-    WriteParams params = paramsBuilder.build();
-
-    return createDatasetWithStreamAndNamespaceClient(
-        namespaceClientTableContext.getLocation(),
-        params,
-        namespaceClient,
-        tableId,
-        namespaceClientTableContext);
-  }
-
   private Dataset executeWithNamespaceClient() {
-    String tableUri;
-    NamespaceClientTableContext namespaceClientTableContext;
-
-    if (mode == WriteParams.WriteMode.CREATE) {
-      DeclareTableRequest declareRequest = new DeclareTableRequest();
-      declareRequest.setId(tableId);
-      DeclareTableResponse declareResponse = namespaceClient.declareTable(declareRequest);
-
-      tableUri = declareResponse.getLocation();
-      if (tableUri == null || tableUri.isEmpty()) {
-        throw new IllegalArgumentException("Namespace client did not return a table location");
-      }
-
-      namespaceClientTableContext =
-          NamespaceClientTableContext.fromDeclareTableResponse(declareResponse);
-    } else {
-      DescribeTableRequest request = new DescribeTableRequest();
-      request.setId(tableId);
-
-      DescribeTableResponse response = namespaceClient.describeTable(request);
-
-      tableUri = response.getLocation();
-      if (tableUri == null || tableUri.isEmpty()) {
-        throw new IllegalArgumentException("Namespace client did not return a table location");
-      }
-
-      namespaceClientTableContext = NamespaceClientTableContext.fromDescribeTableResponse(response);
-    }
-
     WriteParams.Builder paramsBuilder =
         new WriteParams.Builder().withMode(mode).withStorageOptions(storageOptions);
 
@@ -459,7 +396,6 @@ public class WriteDatasetBuilder {
     maxBytesPerFile.ifPresent(paramsBuilder::withMaxBytesPerFile);
     enableStableRowIds.ifPresent(paramsBuilder::withEnableStableRowIds);
     dataStorageVersion.ifPresent(paramsBuilder::withDataStorageVersion);
-
     initialBases.ifPresent(paramsBuilder::withInitialBases);
     targetBases.ifPresent(paramsBuilder::withTargetBases);
     allowExternalBlobOutsideBases.ifPresent(paramsBuilder::withAllowExternalBlobOutsideBases);
@@ -468,7 +404,7 @@ public class WriteDatasetBuilder {
     WriteParams params = paramsBuilder.build();
 
     return createDatasetWithStreamAndNamespaceClient(
-        tableUri, params, namespaceClient, tableId, namespaceClientTableContext);
+        null, params, namespaceClient, tableId, namespaceClientTableContext);
   }
 
   private Dataset executeWithUri() {

--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -20,7 +20,6 @@ import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
-import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
 
@@ -452,18 +451,7 @@ public class WriteDatasetBuilder {
     }
 
     if (schema != null) {
-      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
-          ArrowArrayStream tempStream = ArrowArrayStream.allocateNew(allocator)) {
-        Data.exportArrayStream(allocator, root, tempStream);
-        return Dataset.create(
-            allocator,
-            tempStream,
-            path,
-            params,
-            namespaceClient,
-            tableId,
-            namespaceClientTableContext);
-      }
+      return Dataset.create(allocator, path, schema, new WriteParams.Builder().build());
     }
 
     throw new IllegalStateException("No data source provided");

--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -396,7 +396,7 @@ public class WriteDatasetBuilder {
   }
 
   private Dataset executeWithContext() {
-    NamespaceClientTableContext ctx = this.namespaceClientTableContext;
+    NamespaceClientTableContext namespaceClientTableContext = this.namespaceClientTableContext;
 
     WriteParams.Builder paramsBuilder =
         new WriteParams.Builder().withMode(mode).withStorageOptions(storageOptions);
@@ -414,12 +414,16 @@ public class WriteDatasetBuilder {
     WriteParams params = paramsBuilder.build();
 
     return createDatasetWithStreamAndNamespaceClient(
-        ctx.getLocation(), params, namespaceClient, tableId, ctx);
+        namespaceClientTableContext.getLocation(),
+        params,
+        namespaceClient,
+        tableId,
+        namespaceClientTableContext);
   }
 
   private Dataset executeWithNamespaceClient() {
     String tableUri;
-    NamespaceClientTableContext ctx;
+    NamespaceClientTableContext namespaceClientTableContext;
 
     if (mode == WriteParams.WriteMode.CREATE) {
       DeclareTableRequest declareRequest = new DeclareTableRequest();
@@ -431,7 +435,8 @@ public class WriteDatasetBuilder {
         throw new IllegalArgumentException("Namespace client did not return a table location");
       }
 
-      ctx = NamespaceClientTableContext.fromDeclareTableResponse(declareResponse);
+      namespaceClientTableContext =
+          NamespaceClientTableContext.fromDeclareTableResponse(declareResponse);
     } else {
       DescribeTableRequest request = new DescribeTableRequest();
       request.setId(tableId);
@@ -443,7 +448,7 @@ public class WriteDatasetBuilder {
         throw new IllegalArgumentException("Namespace client did not return a table location");
       }
 
-      ctx = NamespaceClientTableContext.fromDescribeTableResponse(response);
+      namespaceClientTableContext = NamespaceClientTableContext.fromDescribeTableResponse(response);
     }
 
     WriteParams.Builder paramsBuilder =
@@ -463,7 +468,7 @@ public class WriteDatasetBuilder {
     WriteParams params = paramsBuilder.build();
 
     return createDatasetWithStreamAndNamespaceClient(
-        tableUri, params, namespaceClient, tableId, ctx);
+        tableUri, params, namespaceClient, tableId, namespaceClientTableContext);
   }
 
   private Dataset executeWithUri() {

--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -451,7 +451,7 @@ public class WriteDatasetBuilder {
     }
 
     if (schema != null) {
-      return Dataset.create(allocator, path, schema, new WriteParams.Builder().build());
+      return Dataset.create(allocator, path, schema, params);
     }
 
     throw new IllegalStateException("No data source provided");

--- a/java/src/main/java/org/lance/WriteFragmentBuilder.java
+++ b/java/src/main/java/org/lance/WriteFragmentBuilder.java
@@ -49,6 +49,7 @@ public class WriteFragmentBuilder {
   private WriteParams.Builder writeParamsBuilder;
   private LanceNamespace namespaceClient;
   private List<String> tableId;
+  private NamespaceClientTableContext namespaceClientTableContext;
 
   WriteFragmentBuilder() {}
 
@@ -128,7 +129,7 @@ public class WriteFragmentBuilder {
    *
    * <p>When provided with `tableId`, a storage options provider will be created automatically to
    * refresh credentials via the namespace client. Must be provided together with `tableId`. The
-   * caller should provide initial/merged storage options via the `storageOptions` method.
+   * caller should provide storage options via the `storageOptions` method.
    *
    * @param namespaceClient the LanceNamespace client instance
    * @return this builder
@@ -148,6 +149,21 @@ public class WriteFragmentBuilder {
    */
   public WriteFragmentBuilder tableId(List<String> tableId) {
     this.tableId = tableId;
+    return this;
+  }
+
+  /**
+   * Sets a cached namespace context from a prior {@code describeTable} or {@code declareTable}
+   * call. When provided, the namespace client and table ID are extracted from the context, and
+   * storage options are merged.
+   *
+   * <p>Cannot be used with {@code namespaceClient()}/{@code tableId()}.
+   *
+   * @param context the cached namespace context
+   * @return this builder
+   */
+  public WriteFragmentBuilder namespaceClientTableContext(NamespaceClientTableContext context) {
+    this.namespaceClientTableContext = context;
     return this;
   }
 
@@ -231,11 +247,8 @@ public class WriteFragmentBuilder {
   public List<FragmentMetadata> execute() {
     validate();
 
-    // Build the write params
     WriteParams finalWriteParams = buildWriteParams();
 
-    // Pass namespaceClient and tableId to JNI - Rust will automatically create a
-    // storage options provider when these are non-null for credential refresh
     if (vectorSchemaRoot != null) {
       return Fragment.create(
           datasetUri, allocator, vectorSchemaRoot, finalWriteParams, namespaceClient, tableId);

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -133,14 +133,12 @@ public class DatasetTest {
 
       // Test LEGACY version
       String legacyPath = tempDir.resolve("legacy_version").toString();
+      WriteParams legacyParams =
+          new WriteParams.Builder()
+              .withDataStorageVersion(LanceConstants.FILE_FORMAT_VERSION_LEGACY)
+              .build();
       try (Dataset legacyDataset =
-          Dataset.write()
-              .allocator(allocator)
-              .uri(legacyPath)
-              .schema(testDataset.getSchema())
-              .mode(WriteParams.WriteMode.CREATE)
-              .dataStorageVersion(LanceConstants.FILE_FORMAT_VERSION_LEGACY)
-              .execute()) {
+          Dataset.create(allocator, legacyPath, testDataset.getSchema(), legacyParams)) {
         assertEquals(
             LanceConstants.FILE_FORMAT_VERSION_0_1, legacyDataset.getLanceFileFormatVersion());
       }

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -192,9 +192,7 @@ def dataset(
     has_context = namespace_client_table_context is not None
 
     if has_uri and has_namespace:
-        raise ValueError(
-            "Cannot specify both 'uri' and 'namespace_client'/'table_id'."
-        )
+        raise ValueError("Cannot specify both 'uri' and 'namespace_client'/'table_id'.")
     if has_uri and has_context:
         raise ValueError(
             "Cannot specify both 'uri' and 'namespace_client_table_context'."
@@ -205,9 +203,7 @@ def dataset(
             "'table_id' to be provided."
         )
     if not has_uri and not has_namespace:
-        raise ValueError(
-            "Must specify either 'uri' or 'namespace_client'+'table_id'."
-        )
+        raise ValueError("Must specify either 'uri' or 'namespace_client'+'table_id'.")
 
     if namespace_client is not None:
         if table_id is None:

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -33,11 +33,6 @@ from .lance import (
     bytes_read_counter,
     iops_counter,
 )
-from .namespace import (
-    DescribeTableRequest,
-    LanceNamespace,
-    NamespaceClientTableContext,
-)
 from .progress import IndexProgress
 from .schema import json_to_schema, schema_to_json
 from .util import sanitize_ts
@@ -48,6 +43,8 @@ if TYPE_CHECKING:
 
     from lance.commit import CommitLock
     from lance.dependencies import pandas as pd
+
+    from .namespace import LanceNamespace, NamespaceClientTableContext
 
     ts_types = Union[datetime, pd.Timestamp, str]
 

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -214,22 +214,6 @@ def dataset(
             raise ValueError(
                 "Both 'namespace_client' and 'table_id' must be provided together."
             )
-
-        if has_context:
-            uri = namespace_client_table_context.location
-        else:
-            from .namespace import DescribeTableResponse
-
-            request = DescribeTableRequest(id=table_id, version=version)
-            response = namespace_client.describe_table(request)
-            uri = response.location
-            if uri is None:
-                raise ValueError(
-                    "Namespace did not return a 'location' for the table"
-                )
-            namespace_client_table_context = (
-                NamespaceClientTableContext.from_describe_table_response(response)
-            )
     elif table_id is not None:
         raise ValueError(
             "Both 'namespace_client' and 'table_id' must be provided together."

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -36,6 +36,7 @@ from .lance import (
 from .namespace import (
     DescribeTableRequest,
     LanceNamespace,
+    NamespaceClientTableContext,
 )
 from .progress import IndexProgress
 from .schema import json_to_schema, schema_to_json
@@ -101,6 +102,7 @@ def dataset(
     session: Optional[Session] = None,
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
+    namespace_client_table_context: Optional[NamespaceClientTableContext] = None,
 ) -> LanceDataset:
     """
     Opens the Lance dataset from the address specified.
@@ -169,6 +171,12 @@ def dataset(
     table_id : optional, List[str]
         The table identifier when using a namespace (e.g., ["my_table"]).
         Must be provided together with `namespace_client`. Cannot be used with `uri`.
+    namespace_client_table_context : optional, NamespaceClientTableContext
+        A cached context from a prior ``describe_table`` or ``declare_table``
+        call.  When provided with ``namespace_client`` + ``table_id``, skips
+        the namespace call and uses the cached location, storage options, and
+        managed-versioning flag directly.  Cannot be used with ``uri``.
+        Must be used together with ``namespace_client`` and ``table_id``.
 
     Notes
     -----
@@ -179,51 +187,49 @@ def dataset(
     - Initial storage options from describe_table() will be merged with
       any provided `storage_options`
     """
-    # Validate that user provides either uri OR (namespace_client + table_id), not both
     has_uri = uri is not None
     has_namespace = namespace_client is not None or table_id is not None
+    has_context = namespace_client_table_context is not None
 
     if has_uri and has_namespace:
         raise ValueError(
-            "Cannot specify both 'uri' and 'namespace_client/table_id'. "
-            "Please provide either 'uri' or both 'namespace_client' and 'table_id'."
+            "Cannot specify both 'uri' and 'namespace_client'/'table_id'."
         )
-    elif not has_uri and not has_namespace:
+    if has_uri and has_context:
         raise ValueError(
-            "Must specify either 'uri' or both 'namespace_client' and 'table_id'."
+            "Cannot specify both 'uri' and 'namespace_client_table_context'."
+        )
+    if has_context and not has_namespace:
+        raise ValueError(
+            "'namespace_client_table_context' requires 'namespace_client' and "
+            "'table_id' to be provided."
+        )
+    if not has_uri and not has_namespace:
+        raise ValueError(
+            "Must specify either 'uri' or 'namespace_client'+'table_id'."
         )
 
-    # Handle namespace resolution in Python
-    namespace_client_managed_versioning = False
     if namespace_client is not None:
         if table_id is None:
             raise ValueError(
                 "Both 'namespace_client' and 'table_id' must be provided together."
             )
 
-        request = DescribeTableRequest(id=table_id, version=version)
-        response = namespace_client.describe_table(request)
+        if has_context:
+            uri = namespace_client_table_context.location
+        else:
+            from .namespace import DescribeTableResponse
 
-        uri = response.location
-        if uri is None:
-            raise ValueError("Namespace did not return a 'location' for the table")
-
-        # Check if namespace manages versioning (commits go through namespace API)
-        namespace_client_managed_versioning = (
-            getattr(response, "managed_versioning", None) is True
-        )
-
-        namespace_storage_options = response.storage_options
-
-        # Merge namespace storage options with user-provided options
-        # Namespace options take precedence
-        if namespace_storage_options is not None:
-            if storage_options is None:
-                storage_options = namespace_storage_options
-            else:
-                merged_options = dict(storage_options)
-                merged_options.update(namespace_storage_options)
-                storage_options = merged_options
+            request = DescribeTableRequest(id=table_id, version=version)
+            response = namespace_client.describe_table(request)
+            uri = response.location
+            if uri is None:
+                raise ValueError(
+                    "Namespace did not return a 'location' for the table"
+                )
+            namespace_client_table_context = (
+                NamespaceClientTableContext.from_describe_table_response(response)
+            )
     elif table_id is not None:
         raise ValueError(
             "Both 'namespace_client' and 'table_id' must be provided together."
@@ -243,7 +249,7 @@ def dataset(
         session=session,
         namespace_client=namespace_client,
         table_id=table_id,
-        namespace_client_managed_versioning=namespace_client_managed_versioning,
+        namespace_client_table_context=namespace_client_table_context,
     )
     if version is None and asof is not None:
         ts_cutoff = sanitize_ts(asof)
@@ -269,7 +275,7 @@ def dataset(
                 session=session,
                 namespace_client=namespace_client,
                 table_id=table_id,
-                namespace_client_managed_versioning=namespace_client_managed_versioning,
+                namespace_client_table_context=namespace_client_table_context,
             )
     else:
         return ds

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -76,7 +76,7 @@ from .util import _target_partition_size_to_num_partitions, td_to_micros
 if TYPE_CHECKING:
     from pyarrow._compute import Expression
 
-    from lance.namespace import LanceNamespace
+    from lance.namespace import LanceNamespace, NamespaceClientTableContext
 
     from .commit import CommitLock
     from .lance.indices import IndexDescription
@@ -565,13 +565,14 @@ class LanceDataset(pa.dataset.Dataset):
         session: Optional[Session] = None,
         namespace_client: Optional[Any] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_managed_versioning: bool = False,
+        namespace_client_table_context: Optional[
+            "NamespaceClientTableContext"
+        ] = None,
     ):
         uri = os.fspath(uri) if isinstance(uri, Path) else uri
         self._uri = uri
         self._storage_options = storage_options
 
-        # Handle deprecation warning for index_cache_size
         if index_cache_size is not None:
             warnings.warn(
                 "The 'index_cache_size' parameter is deprecated. "
@@ -581,13 +582,10 @@ class LanceDataset(pa.dataset.Dataset):
                 stacklevel=2,
             )
 
-        # Store namespace_client and table_id for credential refresh in file operations
         self._namespace_client = namespace_client
         self._table_id = table_id
-        self._namespace_client_managed_versioning = namespace_client_managed_versioning
+        self._namespace_client_table_context = namespace_client_table_context
 
-        # Storage options provider is automatically created in Rust when
-        # namespace_client and table_id are provided
         self._ds = _Dataset(
             uri,
             version,
@@ -603,7 +601,7 @@ class LanceDataset(pa.dataset.Dataset):
             session=session,
             namespace_client=namespace_client,
             table_id=table_id,
-            namespace_client_managed_versioning=namespace_client_managed_versioning,
+            namespace_client_table_context=namespace_client_table_context,
         )
         self._default_scan_options = default_scan_options
         self._read_params = read_params
@@ -670,7 +668,7 @@ class LanceDataset(pa.dataset.Dataset):
         self._read_params = read_params
         self._namespace_client = None
         self._table_id = None
-        self._namespace_client_managed_versioning = False
+        self._namespace_client_table_context = False
 
     def __copy__(self):
         ds = LanceDataset.__new__(LanceDataset)
@@ -678,8 +676,8 @@ class LanceDataset(pa.dataset.Dataset):
         ds._storage_options = self._storage_options
         ds._namespace_client = self._namespace_client
         ds._table_id = self._table_id
-        ds._namespace_client_managed_versioning = (
-            self._namespace_client_managed_versioning
+        ds._namespace_client_table_context = (
+            self._namespace_client_table_context
         )
         ds._ds = copy.copy(self._ds)
         ds._default_scan_options = self._default_scan_options
@@ -3850,7 +3848,9 @@ class LanceDataset(pa.dataset.Dataset):
         enable_stable_row_ids: Optional[bool] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_managed_versioning: bool = False,
+        namespace_client_table_context: Optional[
+            "NamespaceClientTableContext"
+        ] = None,
     ) -> LanceDataset:
         """Create a new version of dataset
 
@@ -3995,7 +3995,7 @@ class LanceDataset(pa.dataset.Dataset):
                 enable_stable_row_ids=enable_stable_row_ids,
                 namespace_client=namespace_client,
                 table_id=table_id,
-                namespace_client_managed_versioning=namespace_client_managed_versioning,
+                namespace_client_table_context=namespace_client_table_context,
             )
         elif isinstance(operation, LanceOperation.BaseOperation):
             new_ds = _Dataset.commit(
@@ -4011,7 +4011,7 @@ class LanceDataset(pa.dataset.Dataset):
                 enable_stable_row_ids=enable_stable_row_ids,
                 namespace_client=namespace_client,
                 table_id=table_id,
-                namespace_client_managed_versioning=namespace_client_managed_versioning,
+                namespace_client_table_context=namespace_client_table_context,
             )
         else:
             raise TypeError(
@@ -4023,7 +4023,7 @@ class LanceDataset(pa.dataset.Dataset):
         ds._storage_options = storage_options
         ds._namespace_client = namespace_client
         ds._table_id = table_id
-        ds._namespace_client_managed_versioning = namespace_client_managed_versioning
+        ds._namespace_client_table_context = namespace_client_table_context
         ds._ds = new_ds
         ds._uri = new_ds.uri
         ds._default_scan_options = None
@@ -6286,6 +6286,7 @@ def write_dataset(
     blob_pack_file_size_threshold: Optional[int] = None,
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
+    namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
 ) -> LanceDataset:
     """Write a given data_obj to the given uri
 
@@ -6401,6 +6402,12 @@ def write_dataset(
     table_id : optional, List[str]
         The table identifier when using a namespace (e.g., ["my_table"]).
         Must be provided together with `namespace_client`. Cannot be used with `uri`.
+    namespace_client_table_context : optional, NamespaceClientTableContext
+        A cached context from a prior ``describe_table`` or ``declare_table``
+        call.  When provided with ``namespace_client`` + ``table_id``, skips
+        the namespace call and uses the cached location, storage options, and
+        managed-versioning flag directly.  Cannot be used with ``uri``.
+        Must be used together with ``namespace_client`` and ``table_id``.
 
     Notes
     -----
@@ -6411,79 +6418,71 @@ def write_dataset(
     - Initial storage options from describe_table() will be merged with
       any provided `storage_options`
     """
-    # Validate that user provides either uri OR (namespace_client + table_id), not both
     has_uri = uri is not None
     has_namespace = namespace_client is not None or table_id is not None
+    has_context = namespace_client_table_context is not None
 
     if has_uri and has_namespace:
         raise ValueError(
-            "Cannot specify both 'uri' and 'namespace_client/table_id'. "
-            "Please provide either 'uri' or both 'namespace_client' and 'table_id'."
+            "Cannot specify both 'uri' and 'namespace_client'/'table_id'."
         )
-    elif not has_uri and not has_namespace:
+    if has_uri and has_context:
         raise ValueError(
-            "Must specify either 'uri' or both 'namespace_client' and 'table_id'."
+            "Cannot specify both 'uri' and 'namespace_client_table_context'."
+        )
+    if has_context and not has_namespace:
+        raise ValueError(
+            "'namespace_client_table_context' requires 'namespace_client' and "
+            "'table_id' to be provided."
+        )
+    if not has_uri and not has_namespace:
+        raise ValueError(
+            "Must specify either 'uri' or 'namespace_client'+'table_id'."
         )
 
-    # Handle namespace-based dataset writing
     if namespace_client is not None:
         if table_id is None:
             raise ValueError(
                 "Both 'namespace_client' and 'table_id' must be provided together."
             )
 
-        # Implement write_into_namespace logic in Python
-        # This follows the same pattern as the Rust implementation:
-        # - CREATE mode: calls namespace.declare_table()
-        # - APPEND/OVERWRITE mode: calls namespace.describe_table()
-        # - Both modes: create storage options provider and merge storage options
-
-        from .namespace import (
-            DeclareTableRequest,
-            DescribeTableRequest,
-        )
-
-        # Determine which namespace method to call based on mode
-        if mode == "create":
-            declare_request = DeclareTableRequest(id=table_id, location=None)
-            response = namespace_client.declare_table(declare_request)
-        elif mode in ("append", "overwrite"):
-            request = DescribeTableRequest(id=table_id, version=None)
-            response = namespace_client.describe_table(request)
+        if has_context:
+            uri = namespace_client_table_context.location
         else:
-            raise ValueError(f"Invalid mode: {mode}")
-
-        # Get table location from response
-        uri = response.location
-        if not uri:
-            raise ValueError(
-                f"Namespace did not return a table location in {mode} response"
+            from .namespace import (
+                DeclareTableRequest,
+                DescribeTableRequest,
             )
 
-        # Check if namespace manages versioning (commits go through namespace API)
-        namespace_client_managed_versioning = (
-            getattr(response, "managed_versioning", None) is True
-        )
-
-        # Use namespace storage options
-        namespace_storage_options = response.storage_options
-
-        # Merge namespace storage options with any existing options
-        # Namespace options take precedence (same as Rust implementation)
-        # Storage options provider will be created automatically in Rust
-        if namespace_storage_options is not None:
-            if storage_options is None:
-                storage_options = dict(namespace_storage_options)
+            if mode == "create":
+                declare_request = DeclareTableRequest(id=table_id, location=None)
+                response = namespace_client.declare_table(declare_request)
+            elif mode in ("append", "overwrite"):
+                request = DescribeTableRequest(id=table_id, version=None)
+                response = namespace_client.describe_table(request)
             else:
-                merged_options = dict(storage_options)
-                merged_options.update(namespace_storage_options)
-                storage_options = merged_options
+                raise ValueError(f"Invalid mode: {mode}")
+
+            uri = response.location
+            if not uri:
+                raise ValueError(
+                    f"Namespace did not return a table location in {mode} response"
+                )
+
+            from .namespace import NamespaceClientTableContext
+
+            if mode == "create":
+                namespace_client_table_context = (
+                    NamespaceClientTableContext.from_declare_table_response(response)
+                )
+            else:
+                namespace_client_table_context = (
+                    NamespaceClientTableContext.from_describe_table_response(response)
+                )
     elif table_id is not None:
         raise ValueError(
             "Both 'namespace_client' and 'table_id' must be provided together."
         )
-    else:
-        namespace_client_managed_versioning = False
 
     if use_legacy_format is not None:
         warnings.warn(
@@ -6528,9 +6527,7 @@ def write_dataset(
     if namespace_client is not None and table_id is not None:
         params["namespace_client"] = namespace_client
         params["table_id"] = table_id
-        params["namespace_client_managed_versioning"] = (
-            namespace_client_managed_versioning
-        )
+        params["namespace_client_table_context"] = namespace_client_table_context
 
     if commit_lock:
         if not callable(commit_lock):
@@ -6550,7 +6547,7 @@ def write_dataset(
     ds._storage_options = storage_options
     ds._namespace_client = namespace_client
     ds._table_id = table_id
-    ds._namespace_client_managed_versioning = namespace_client_managed_versioning
+    ds._namespace_client_table_context = namespace_client_table_context
     ds._ds = inner_ds
     ds._uri = inner_ds.uri
     ds._default_scan_options = None

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -565,9 +565,7 @@ class LanceDataset(pa.dataset.Dataset):
         session: Optional[Session] = None,
         namespace_client: Optional[Any] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_table_context: Optional[
-            "NamespaceClientTableContext"
-        ] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
     ):
         uri = os.fspath(uri) if isinstance(uri, Path) else uri
         self._storage_options = storage_options
@@ -677,9 +675,7 @@ class LanceDataset(pa.dataset.Dataset):
         ds._storage_options = self._storage_options
         ds._namespace_client = self._namespace_client
         ds._table_id = self._table_id
-        ds._namespace_client_table_context = (
-            self._namespace_client_table_context
-        )
+        ds._namespace_client_table_context = self._namespace_client_table_context
         ds._ds = copy.copy(self._ds)
         ds._default_scan_options = self._default_scan_options
         ds._read_params = self._read_params.copy() if self._read_params else None
@@ -3849,9 +3845,7 @@ class LanceDataset(pa.dataset.Dataset):
         enable_stable_row_ids: Optional[bool] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_table_context: Optional[
-            "NamespaceClientTableContext"
-        ] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
     ) -> LanceDataset:
         """Create a new version of dataset
 
@@ -6424,9 +6418,7 @@ def write_dataset(
     has_context = namespace_client_table_context is not None
 
     if has_uri and has_namespace:
-        raise ValueError(
-            "Cannot specify both 'uri' and 'namespace_client'/'table_id'."
-        )
+        raise ValueError("Cannot specify both 'uri' and 'namespace_client'/'table_id'.")
     if has_uri and has_context:
         raise ValueError(
             "Cannot specify both 'uri' and 'namespace_client_table_context'."
@@ -6437,9 +6429,7 @@ def write_dataset(
             "'table_id' to be provided."
         )
     if not has_uri and not has_namespace:
-        raise ValueError(
-            "Must specify either 'uri' or 'namespace_client'+'table_id'."
-        )
+        raise ValueError("Must specify either 'uri' or 'namespace_client'+'table_id'.")
 
     if namespace_client is not None:
         if table_id is None:

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -550,7 +550,7 @@ class LanceDataset(pa.dataset.Dataset):
 
     def __init__(
         self,
-        uri: Union[str, Path],
+        uri: Optional[Union[str, Path]] = None,
         version: Optional[int | str] = None,
         block_size: Optional[int] = None,
         index_cache_size: Optional[int] = None,
@@ -570,7 +570,6 @@ class LanceDataset(pa.dataset.Dataset):
         ] = None,
     ):
         uri = os.fspath(uri) if isinstance(uri, Path) else uri
-        self._uri = uri
         self._storage_options = storage_options
 
         if index_cache_size is not None:
@@ -603,6 +602,8 @@ class LanceDataset(pa.dataset.Dataset):
             table_id=table_id,
             namespace_client_table_context=namespace_client_table_context,
         )
+        self._uri = self._ds.uri
+        self._storage_options = storage_options
         self._default_scan_options = default_scan_options
         self._read_params = read_params
 
@@ -6445,40 +6446,6 @@ def write_dataset(
             raise ValueError(
                 "Both 'namespace_client' and 'table_id' must be provided together."
             )
-
-        if has_context:
-            uri = namespace_client_table_context.location
-        else:
-            from .namespace import (
-                DeclareTableRequest,
-                DescribeTableRequest,
-            )
-
-            if mode == "create":
-                declare_request = DeclareTableRequest(id=table_id, location=None)
-                response = namespace_client.declare_table(declare_request)
-            elif mode in ("append", "overwrite"):
-                request = DescribeTableRequest(id=table_id, version=None)
-                response = namespace_client.describe_table(request)
-            else:
-                raise ValueError(f"Invalid mode: {mode}")
-
-            uri = response.location
-            if not uri:
-                raise ValueError(
-                    f"Namespace did not return a table location in {mode} response"
-                )
-
-            from .namespace import NamespaceClientTableContext
-
-            if mode == "create":
-                namespace_client_table_context = (
-                    NamespaceClientTableContext.from_declare_table_response(response)
-                )
-            else:
-                namespace_client_table_context = (
-                    NamespaceClientTableContext.from_describe_table_response(response)
-                )
     elif table_id is not None:
         raise ValueError(
             "Both 'namespace_client' and 'table_id' must be provided together."
@@ -6538,7 +6505,7 @@ def write_dataset(
         uri = os.fspath(uri)
     elif isinstance(uri, LanceDataset):
         uri = uri._ds
-    elif not isinstance(uri, str):
+    elif uri is not None and not isinstance(uri, str):
         raise TypeError(f"dest must be a str, Path, or LanceDataset. Got {type(uri)}")
 
     inner_ds = _write_dataset(reader, uri, params)

--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -71,9 +71,7 @@ class LanceFileReader:
         *,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_table_context: Optional[
-            "NamespaceClientTableContext"
-        ] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
         _inner_reader: Optional[_LanceFileReader] = None,
     ):
         """
@@ -230,9 +228,7 @@ class LanceFileSession:
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_table_context: Optional[
-            "NamespaceClientTableContext"
-        ] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
     ):
         """
         Creates a new file session
@@ -410,9 +406,7 @@ class LanceFileWriter:
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_table_context: Optional[
-            "NamespaceClientTableContext"
-        ] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
         max_page_bytes: Optional[int] = None,
         _inner_writer: Optional[_LanceFileWriter] = None,
         **kwargs,

--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -25,7 +25,7 @@ from .lance import (
 )
 
 if TYPE_CHECKING:
-    from .namespace import LanceNamespace
+    from .namespace import LanceNamespace, NamespaceClientTableContext
 
 
 class ReaderResults:
@@ -71,6 +71,9 @@ class LanceFileReader:
         *,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional[
+            "NamespaceClientTableContext"
+        ] = None,
         _inner_reader: Optional[_LanceFileReader] = None,
     ):
         """
@@ -91,10 +94,15 @@ class LanceFileReader:
         table_id : optional, List[str]
             The table identifier within the namespace.
             Must be provided together with namespace_client.
+        namespace_client_table_context : optional, NamespaceClientTableContext
+            Cached context from a prior namespace call. When provided,
+            ``namespace_client`` and ``table_id`` are extracted from the
+            context. Cannot be used with ``namespace_client``/``table_id``.
         columns: list of str, default None
             List of column names to be fetched.
             All columns are fetched if None or unspecified.
         """
+
         if _inner_reader is not None:
             self._reader = _inner_reader
         else:
@@ -222,6 +230,9 @@ class LanceFileSession:
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional[
+            "NamespaceClientTableContext"
+        ] = None,
     ):
         """
         Creates a new file session
@@ -241,7 +252,12 @@ class LanceFileSession:
         table_id : optional, List[str]
             The table identifier within the namespace.
             Must be provided together with namespace_client.
+        namespace_client_table_context : optional, NamespaceClientTableContext
+            Cached context from a prior namespace call. When provided,
+            ``namespace_client`` and ``table_id`` are extracted from the
+            context. Cannot be used with ``namespace_client``/``table_id``.
         """
+
         if isinstance(base_path, Path):
             base_path = str(base_path)
         self._session = _LanceFileSession(
@@ -394,6 +410,9 @@ class LanceFileWriter:
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional[
+            "NamespaceClientTableContext"
+        ] = None,
         max_page_bytes: Optional[int] = None,
         _inner_writer: Optional[_LanceFileWriter] = None,
         **kwargs,
@@ -426,11 +445,16 @@ class LanceFileWriter:
         table_id : optional, List[str]
             The table identifier within the namespace.
             Must be provided together with namespace_client.
+        namespace_client_table_context : optional, NamespaceClientTableContext
+            Cached context from a prior namespace call. When provided,
+            ``namespace_client`` and ``table_id`` are extracted from the
+            context. Cannot be used with ``namespace_client``/``table_id``.
         max_page_bytes : optional, int
             The maximum size of a page in bytes, if a single array would create a
             page larger than this then it will be split into multiple pages. The
             default value is 32MB.
         """
+
         if _inner_writer is not None:
             self._writer = _inner_writer
         else:

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
         Transaction,
     )
     from .lance import LanceSchema
-    from .namespace import LanceNamespace
+    from .namespace import LanceNamespace, NamespaceClientTableContext
 
 
 DEFAULT_MAX_BYTES_PER_FILE = 90 * 1024 * 1024 * 1024
@@ -348,6 +348,9 @@ class LanceFragment(pa.dataset.Fragment):
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional[
+            "NamespaceClientTableContext"
+        ] = None,
     ) -> FragmentMetadata:
         """Create a :class:`FragmentMetadata` from the given data.
 
@@ -391,11 +394,14 @@ class LanceFragment(pa.dataset.Fragment):
             A namespace client for automatic credential refresh. When provided with
             `table_id`, a storage options provider will be created automatically to
             refresh credentials via the namespace. Must be provided together with
-            `table_id`. The caller should provide initial/merged storage options via
-            the `storage_options` parameter.
+            `table_id`.
         table_id : optional, List[str]
             The table identifier when using a namespace (e.g., ["my_table"]).
             Must be provided together with `namespace_client`.
+        namespace_client_table_context : optional, NamespaceClientTableContext
+            Cached context from a prior namespace call. When provided,
+            ``namespace_client`` and ``table_id`` are extracted from the
+            context. Cannot be used with ``namespace_client``/``table_id``.
 
         See Also
         --------
@@ -411,7 +417,6 @@ class LanceFragment(pa.dataset.Fragment):
         -------
         FragmentMetadata
         """
-        # Validate namespace_client and table_id are provided together
         if namespace_client is not None and table_id is None:
             raise ValueError(
                 "Both 'namespace_client' and 'table_id' must be provided together."
@@ -1008,6 +1013,9 @@ if TYPE_CHECKING:
         initial_bases: Optional[List["DatasetBasePath"]] = None,
         namespace_client: Optional[LanceNamespace] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional[
+            NamespaceClientTableContext
+        ] = None,
     ) -> Transaction: ...
 
     @overload
@@ -1030,6 +1038,9 @@ if TYPE_CHECKING:
         initial_bases: Optional[List["DatasetBasePath"]] = None,
         namespace_client: Optional[LanceNamespace] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional[
+            NamespaceClientTableContext
+        ] = None,
     ) -> List[FragmentMetadata]: ...
 
 
@@ -1052,6 +1063,7 @@ def write_fragments(
     initial_bases: Optional[List["DatasetBasePath"]] = None,
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
+    namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
 ) -> List[FragmentMetadata] | Transaction:
     """
     Write data into one or more fragments.
@@ -1136,6 +1148,10 @@ def write_fragments(
     table_id : optional, List[str]
         The table identifier when using a namespace (e.g., ["my_table"]).
         Must be provided together with `namespace_client`.
+    namespace_client_table_context : optional, NamespaceClientTableContext
+        Cached context from a prior namespace call. When provided,
+        ``namespace_client`` and ``table_id`` are extracted from the
+        context. Cannot be used with ``namespace_client``/``table_id``.
 
     Returns
     -------
@@ -1153,7 +1169,6 @@ def write_fragments(
     """
     from .dataset import LanceDataset
 
-    # Validate namespace_client and table_id are provided together
     if namespace_client is not None and table_id is None:
         raise ValueError(
             "Both 'namespace_client' and 'table_id' must be provided together."

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -348,9 +348,7 @@ class LanceFragment(pa.dataset.Fragment):
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_table_context: Optional[
-            "NamespaceClientTableContext"
-        ] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
     ) -> FragmentMetadata:
         """Create a :class:`FragmentMetadata` from the given data.
 
@@ -1013,9 +1011,7 @@ if TYPE_CHECKING:
         initial_bases: Optional[List["DatasetBasePath"]] = None,
         namespace_client: Optional[LanceNamespace] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_table_context: Optional[
-            NamespaceClientTableContext
-        ] = None,
+        namespace_client_table_context: Optional[NamespaceClientTableContext] = None,
     ) -> Transaction: ...
 
     @overload
@@ -1038,9 +1034,7 @@ if TYPE_CHECKING:
         initial_bases: Optional[List["DatasetBasePath"]] = None,
         namespace_client: Optional[LanceNamespace] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_table_context: Optional[
-            NamespaceClientTableContext
-        ] = None,
+        namespace_client_table_context: Optional[NamespaceClientTableContext] = None,
     ) -> List[FragmentMetadata]: ...
 
 

--- a/python/python/lance/namespace.py
+++ b/python/python/lance/namespace.py
@@ -106,10 +106,81 @@ except ImportError:
 
 __all__ = [
     "DirectoryNamespace",
+    "NamespaceClientTableContext",
     "RestNamespace",
     "RestAdapter",
     "DynamicContextProvider",
 ]
+
+
+# =============================================================================
+# Cached Table Context
+# =============================================================================
+
+
+class NamespaceClientTableContext:
+    """Cached context from a namespace client's ``describe_table`` or
+    ``declare_table`` response.
+
+    Contains only the resolved table metadata (location, storage options,
+    managed-versioning flag).  The namespace client and table ID are **not**
+    part of this class — they are still passed separately.
+
+    Parameters
+    ----------
+    location : str
+        The table's storage location (URI).
+    storage_options : Optional[Dict[str, str]]
+        Storage options returned by the namespace (e.g. temporary credentials).
+    managed_versioning : bool
+        Whether commits should go through the namespace's version API.
+    """
+
+    def __init__(
+        self,
+        location: str,
+        storage_options: Optional[Dict[str, str]] = None,
+        managed_versioning: bool = False,
+    ):
+        self.location = location
+        self.storage_options = storage_options
+        self.managed_versioning = managed_versioning
+
+    @classmethod
+    def from_describe_table_response(
+        cls,
+        response: DescribeTableResponse,
+    ) -> "NamespaceClientTableContext":
+        """Build a context from a ``DescribeTableResponse``.
+
+        Raises ``ValueError`` if the response does not contain a location.
+        """
+        location = response.location
+        if not location:
+            raise ValueError("DescribeTableResponse missing location")
+        return cls(
+            location=location,
+            storage_options=response.storage_options,
+            managed_versioning=getattr(response, "managed_versioning", None) is True,
+        )
+
+    @classmethod
+    def from_declare_table_response(
+        cls,
+        response: DeclareTableResponse,
+    ) -> "NamespaceClientTableContext":
+        """Build a context from a ``DeclareTableResponse``.
+
+        Raises ``ValueError`` if the response does not contain a location.
+        """
+        location = response.location
+        if not location:
+            raise ValueError("DeclareTableResponse missing location")
+        return cls(
+            location=location,
+            storage_options=response.storage_options,
+            managed_versioning=getattr(response, "managed_versioning", None) is True,
+        )
 
 
 # =============================================================================

--- a/python/python/lance/tf/data.py
+++ b/python/python/lance/tf/data.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from lance import LanceNamespace
+    from lance.namespace import NamespaceClientTableContext
 
 
 def arrow_data_type_to_tf(dt: pa.DataType) -> tf.DType:
@@ -144,6 +145,7 @@ def from_lance(
     namespace_client: Optional["LanceNamespace"] = None,
     table_id: Optional[List[str]] = None,
     ignore_namespace_table_storage_options: bool = False,
+    namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
 ) -> tf.data.Dataset:
     """Create a ``tf.data.Dataset`` from a Lance dataset.
 
@@ -174,6 +176,10 @@ def from_lance(
     ignore_namespace_table_storage_options : bool, default False
         When using ``namespace_client``/``table_id``, ignore storage options
         returned by the namespace.
+    namespace_client_table_context : optional, NamespaceClientTableContext
+        Cached context from a prior namespace call. When provided,
+        ``namespace_client`` and ``table_id`` are extracted from the
+        context. Cannot be used with ``namespace_client``/``table_id``.
 
     Examples
     --------
@@ -214,9 +220,14 @@ def from_lance(
 
     """
     if isinstance(dataset, LanceDataset):
-        if namespace_client is not None or table_id is not None:
+        if (
+            namespace_client is not None
+            or table_id is not None
+            or namespace_client_table_context is not None
+        ):
             raise ValueError(
-                "Cannot specify 'namespace_client' or 'table_id' when passing "
+                "Cannot specify 'namespace_client', 'table_id', or "
+                "'namespace_client_table_context' when passing "
                 "a LanceDataset instance"
             )
     else:
@@ -224,7 +235,7 @@ def from_lance(
             dataset,
             namespace_client=namespace_client,
             table_id=table_id,
-            ignore_namespace_table_storage_options=ignore_namespace_table_storage_options,
+            namespace_client_table_context=namespace_client_table_context,
         )
 
     if isinstance(fragments, tf.data.Dataset):

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -565,22 +565,37 @@ impl Dataset {
             let namespace_client_table_context = namespace_client_table_context
                 .map(|c| extract_namespace_client_table_context(c))
                 .transpose()?;
-            rt().block_on(
-                Some(py),
-                DatasetBuilder::from_namespace(
-                    ns_client,
-                    tid.clone(),
-                    namespace_client_table_context.as_ref(),
-                ),
-            )?
-            .map_err(|err| PyIOError::new_err(err.to_string()))?
+            let mut b = rt()
+                .block_on(
+                    Some(py),
+                    DatasetBuilder::from_namespace(
+                        ns_client,
+                        tid.clone(),
+                        namespace_client_table_context.as_ref(),
+                    ),
+                )?
+                .map_err(|err| PyIOError::new_err(err.to_string()))?
+                .with_index_cache_size_bytes(params.index_cache_size_bytes)
+                .with_metadata_cache_size_bytes(params.metadata_cache_size_bytes);
+            if let Some(session) = params.session {
+                b = b.with_session(session);
+            }
+            if params.file_reader_options.is_some() {
+                // file_reader_options doesn't have a public setter, apply via with_read_params
+                // but strip store_options to preserve the namespace accessor
+                let fro_params = ReadParams {
+                    file_reader_options: params.file_reader_options,
+                    ..Default::default()
+                };
+                b = b.with_read_params(fro_params);
+            }
+            b
         } else {
             let uri = uri.ok_or_else(|| {
                 PyValueError::new_err("uri is required when namespace_client is not provided")
             })?;
-            DatasetBuilder::from_uri(&uri)
+            DatasetBuilder::from_uri(&uri).with_read_params(params)
         };
-        builder = builder.with_read_params(params);
 
         if let Some(ver) = version {
             if let Ok(i) = ver.downcast::<PyInt>() {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -489,10 +489,10 @@ impl Dataset {
     #[allow(clippy::too_many_arguments)]
     #[allow(deprecated)]
     #[new]
-    #[pyo3(signature=(uri, version=None, block_size=None, index_cache_size=None, metadata_cache_size=None, commit_handler=None, storage_options=None, manifest=None, metadata_cache_size_bytes=None, index_cache_size_bytes=None, read_params=None, session=None, namespace_client=None, table_id=None, namespace_client_table_context=None))]
+    #[pyo3(signature=(uri=None, version=None, block_size=None, index_cache_size=None, metadata_cache_size=None, commit_handler=None, storage_options=None, manifest=None, metadata_cache_size_bytes=None, index_cache_size_bytes=None, read_params=None, session=None, namespace_client=None, table_id=None, namespace_client_table_context=None))]
     fn new(
         py: Python,
-        uri: String,
+        uri: Option<String>,
         version: Option<Bound<PyAny>>,
         block_size: Option<usize>,
         index_cache_size: Option<usize>,
@@ -561,7 +561,31 @@ impl Dataset {
             params.file_reader_options = Some(file_reader_options);
         }
 
-        let mut builder = DatasetBuilder::from_uri(&uri).with_read_params(params);
+        // Create builder: namespace path or URI path
+        let mut builder =
+            if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
+                let ns_client = extract_namespace_arc(py, ns_client)?;
+                let namespace_client_table_context = namespace_client_table_context
+                    .map(|c| extract_namespace_client_table_context(c))
+                    .transpose()?;
+                rt().block_on(
+                    Some(py),
+                    DatasetBuilder::from_namespace(
+                        ns_client,
+                        tid.clone(),
+                        namespace_client_table_context.as_ref(),
+                    ),
+                )?
+                .map_err(|err| PyIOError::new_err(err.to_string()))?
+            } else {
+                let uri = uri.ok_or_else(|| {
+                    PyValueError::new_err(
+                        "uri is required when namespace_client is not provided",
+                    )
+                })?;
+                DatasetBuilder::from_uri(&uri)
+            };
+        builder = builder.with_read_params(params);
 
         if let Some(ver) = version {
             if let Ok(i) = ver.downcast::<PyInt>() {
@@ -576,8 +600,6 @@ impl Dataset {
                 ));
             };
         }
-        // Save a copy of storage options for potential namespace-based credential refresh
-        let initial_storage_options = storage_options.clone();
 
         if let Some(mut storage_options) = storage_options {
             if let Some(user_agent) = storage_options.get_mut("user_agent") {
@@ -599,47 +621,16 @@ impl Dataset {
             builder = builder.with_session(session.inner.clone());
         }
 
-        // Set up namespace-based features if namespace_client and table_id are provided
-        if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
-            let ns_client = extract_namespace_arc(py, ns_client)?;
-            let namespace_client_table_context = namespace_client_table_context
-                .map(|c| extract_namespace_client_table_context(c))
-                .transpose()?;
-
-            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
-                LanceNamespaceStorageOptionsProvider::new(ns_client.clone(), tid.clone()),
-            );
-            let initial_opts = namespace_client_table_context
-                .as_ref()
-                .and_then(|c| c.storage_options.clone())
-                .or(initial_storage_options.clone())
-                .unwrap_or_default();
-            let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                initial_opts, provider,
-            ));
-            builder = builder.with_storage_options_accessor(accessor);
-
-            if namespace_client_table_context
-                .as_ref()
-                .is_some_and(|c| c.managed_versioning)
-            {
-                let external_store =
-                    LanceNamespaceExternalManifestStore::new(ns_client, tid.clone());
-                let commit_handler: Arc<dyn CommitHandler> =
-                    Arc::new(ExternalManifestCommitHandler {
-                        external_manifest_store: Arc::new(external_store),
-                    });
-                builder = builder.with_commit_handler(commit_handler);
-            }
-        }
-
         let dataset = rt().block_on(Some(py), builder.load())?;
 
         match dataset {
-            Ok(ds) => Ok(Self {
-                uri,
-                ds: Arc::new(ds),
-            }),
+            Ok(ds) => {
+                let resolved_uri = ds.uri().to_string();
+                Ok(Self {
+                    uri: resolved_uri,
+                    ds: Arc::new(ds),
+                })
+            }
             Err(err) => Err(PyValueError::new_err(err.to_string())),
         }
     }
@@ -3321,29 +3312,77 @@ impl Dataset {
 #[pyfunction(name = "_write_dataset")]
 pub fn write_dataset(
     reader: &Bound<'_, PyAny>,
-    dest: PyWriteDest,
+    dest: Option<PyWriteDest>,
     options: &Bound<'_, PyDict>,
 ) -> PyResult<Dataset> {
     let params = get_write_params(options)?;
     let py = options.py();
-    let ds = if reader.is_instance_of::<Scanner>() {
-        let scanner: Scanner = reader.extract()?;
-        let batches = rt()
-            .block_on(Some(py), scanner.to_reader())?
-            .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
-        rt().block_on(
-            Some(py),
-            LanceDataset::write(batches, dest.as_dest(), params),
-        )?
-        .map_err(|err| PyIOError::new_err(err.to_string()))?
+    let namespace_client_opt = get_dict_opt::<Bound<PyAny>>(options, "namespace_client")?;
+    let table_id_opt = get_dict_opt::<Vec<String>>(options, "table_id")?;
+    let namespace_client_table_context_opt =
+        get_dict_opt::<Bound<PyAny>>(options, "namespace_client_table_context")?;
+
+    let ds = if let (Some(ns_client), Some(table_id)) =
+        (namespace_client_opt.as_ref(), table_id_opt.as_ref())
+    {
+        let ns_client = extract_namespace_arc(py, ns_client)?;
+        let namespace_client_table_context = namespace_client_table_context_opt
+            .map(|c| extract_namespace_client_table_context(&c))
+            .transpose()?;
+
+        if reader.is_instance_of::<Scanner>() {
+            let scanner: Scanner = reader.extract()?;
+            let batches = rt()
+                .block_on(Some(py), scanner.to_reader())?
+                .map_err(|err| PyValueError::new_err(err.to_string()))?;
+            rt().block_on(
+                Some(py),
+                LanceDataset::write_into_namespace(
+                    batches,
+                    ns_client,
+                    table_id.clone(),
+                    namespace_client_table_context.as_ref(),
+                    params,
+                ),
+            )?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?
+        } else {
+            let batches = ArrowArrayStreamReader::from_pyarrow_bound(reader)?;
+            rt().block_on(
+                Some(py),
+                LanceDataset::write_into_namespace(
+                    batches,
+                    ns_client,
+                    table_id.clone(),
+                    namespace_client_table_context.as_ref(),
+                    params,
+                ),
+            )?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?
+        }
     } else {
-        let batches = ArrowArrayStreamReader::from_pyarrow_bound(reader)?;
-        rt().block_on(
-            Some(py),
-            LanceDataset::write(batches, dest.as_dest(), params),
-        )?
-        .map_err(|err| PyIOError::new_err(err.to_string()))?
+        let dest = dest.ok_or_else(|| {
+            PyValueError::new_err("dest is required when namespace_client is not provided")
+        })?;
+        if reader.is_instance_of::<Scanner>() {
+            let scanner: Scanner = reader.extract()?;
+            let batches = rt()
+                .block_on(Some(py), scanner.to_reader())?
+                .map_err(|err| PyValueError::new_err(err.to_string()))?;
+            rt().block_on(
+                Some(py),
+                LanceDataset::write(batches, dest.as_dest(), params),
+            )?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?
+        } else {
+            let batches = ArrowArrayStreamReader::from_pyarrow_bound(reader)?;
+            rt().block_on(
+                Some(py),
+                LanceDataset::write(batches, dest.as_dest(), params),
+            )?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?
+        }
     };
     Ok(Dataset {
         uri: ds.uri().to_string(),
@@ -3421,34 +3460,7 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
 
         let storage_options = get_dict_opt::<HashMap<String, String>>(options, "storage_options")?;
 
-        let namespace_client_opt = get_dict_opt::<Bound<PyAny>>(options, "namespace_client")?;
-        let table_id_opt = get_dict_opt::<Vec<String>>(options, "table_id")?;
-        let namespace_client_table_context_opt =
-            get_dict_opt::<Bound<PyAny>>(options, "namespace_client_table_context")?;
-        let namespace_client_table_context = namespace_client_table_context_opt
-            .map(|c| extract_namespace_client_table_context(&c))
-            .transpose()?;
-
-        if let (Some(ns_client), Some(table_id)) =
-            (namespace_client_opt.as_ref(), table_id_opt.as_ref())
-        {
-            let ns_client = extract_namespace_arc(options.py(), ns_client)?;
-            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
-                LanceNamespaceStorageOptionsProvider::new(ns_client, table_id.clone()),
-            );
-            let initial_opts = namespace_client_table_context
-                .as_ref()
-                .and_then(|c| c.storage_options.clone())
-                .or(storage_options.clone())
-                .unwrap_or_default();
-            let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                initial_opts, provider,
-            ));
-            p.store_params = Some(ObjectStoreParams {
-                storage_options_accessor: Some(accessor),
-                ..Default::default()
-            });
-        } else if let Some(so) = storage_options.clone() {
+        if let Some(so) = storage_options {
             let accessor = Arc::new(StorageOptionsAccessor::with_static_options(so));
             p.store_params = Some(ObjectStoreParams {
                 storage_options_accessor: Some(accessor),
@@ -3544,22 +3556,6 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
                 new_props.insert(key, value);
             }
             p.transaction_properties = Some(Arc::new(new_props));
-        }
-
-        if p.commit_handler.is_none()
-            && namespace_client_table_context
-                .as_ref()
-                .is_some_and(|c| c.managed_versioning)
-            && let (Some(ns_client), Some(table_id)) =
-                (namespace_client_opt.as_ref(), table_id_opt.as_ref())
-        {
-            let ns_client = extract_namespace_arc(options.py(), ns_client)?;
-            let external_store =
-                LanceNamespaceExternalManifestStore::new(ns_client, table_id.clone());
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            p.commit_handler = Some(commit_handler);
         }
 
         Some(p)

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -82,9 +82,7 @@ use lance_index::{
 use lance_index::{
     infer_system_index_type, metrics::NoOpMetricsCollector, scalar::inverted::query::Occur,
 };
-use lance_io::object_store::{
-    LanceNamespaceStorageOptionsProvider, ObjectStoreParams, StorageOptionsAccessor,
-};
+use lance_io::object_store::{ObjectStoreParams, StorageOptionsAccessor};
 use lance_linalg::distance::MetricType;
 use lance_table::format::{BasePath, Fragment, IndexMetadata};
 use lance_table::io::commit::CommitHandler;
@@ -562,29 +560,26 @@ impl Dataset {
         }
 
         // Create builder: namespace path or URI path
-        let mut builder =
-            if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
-                let ns_client = extract_namespace_arc(py, ns_client)?;
-                let namespace_client_table_context = namespace_client_table_context
-                    .map(|c| extract_namespace_client_table_context(c))
-                    .transpose()?;
-                rt().block_on(
-                    Some(py),
-                    DatasetBuilder::from_namespace(
-                        ns_client,
-                        tid.clone(),
-                        namespace_client_table_context.as_ref(),
-                    ),
-                )?
-                .map_err(|err| PyIOError::new_err(err.to_string()))?
-            } else {
-                let uri = uri.ok_or_else(|| {
-                    PyValueError::new_err(
-                        "uri is required when namespace_client is not provided",
-                    )
-                })?;
-                DatasetBuilder::from_uri(&uri)
-            };
+        let mut builder = if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
+            let ns_client = extract_namespace_arc(py, ns_client)?;
+            let namespace_client_table_context = namespace_client_table_context
+                .map(|c| extract_namespace_client_table_context(c))
+                .transpose()?;
+            rt().block_on(
+                Some(py),
+                DatasetBuilder::from_namespace(
+                    ns_client,
+                    tid.clone(),
+                    namespace_client_table_context.as_ref(),
+                ),
+            )?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?
+        } else {
+            let uri = uri.ok_or_else(|| {
+                PyValueError::new_err("uri is required when namespace_client is not provided")
+            })?;
+            DatasetBuilder::from_uri(&uri)
+        };
         builder = builder.with_read_params(params);
 
         if let Some(ver) = version {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -94,7 +94,7 @@ use crate::error::PythonErrorExt;
 use crate::file::object_store_from_uri_or_path;
 use crate::fragment::FileFragment;
 use crate::indices::{PyIndexConfig, PyIndexDescription};
-use crate::namespace::extract_namespace_arc;
+use crate::namespace::{extract_namespace_arc, extract_namespace_client_table_context};
 use crate::rt;
 use crate::scanner::ScanStatistics;
 use crate::schema::{LanceSchema, logical_schema_from_lance};
@@ -489,7 +489,7 @@ impl Dataset {
     #[allow(clippy::too_many_arguments)]
     #[allow(deprecated)]
     #[new]
-    #[pyo3(signature=(uri, version=None, block_size=None, index_cache_size=None, metadata_cache_size=None, commit_handler=None, storage_options=None, manifest=None, metadata_cache_size_bytes=None, index_cache_size_bytes=None, read_params=None, session=None, namespace_client=None, table_id=None, namespace_client_managed_versioning=false))]
+    #[pyo3(signature=(uri, version=None, block_size=None, index_cache_size=None, metadata_cache_size=None, commit_handler=None, storage_options=None, manifest=None, metadata_cache_size_bytes=None, index_cache_size_bytes=None, read_params=None, session=None, namespace_client=None, table_id=None, namespace_client_table_context=None))]
     fn new(
         py: Python,
         uri: String,
@@ -506,7 +506,7 @@ impl Dataset {
         session: Option<Session>,
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
-        namespace_client_managed_versioning: bool,
+        namespace_client_table_context: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         let mut params = ReadParams::default();
         if let Some(metadata_cache_size_bytes) = metadata_cache_size_bytes {
@@ -602,23 +602,25 @@ impl Dataset {
         // Set up namespace-based features if namespace_client and table_id are provided
         if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
             let ns_client = extract_namespace_arc(py, ns_client)?;
+            let ctx = namespace_client_table_context
+                .map(|c| extract_namespace_client_table_context(c))
+                .transpose()?;
 
-            // Auto-create storage options provider from namespace client
-            // when storage_options are present (meaning credentials came from namespace.describe_table)
-            if initial_storage_options.is_some() {
-                let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
-                    LanceNamespaceStorageOptionsProvider::new(ns_client.clone(), tid.clone()),
-                );
-                // Create accessor with initial options and provider for credential refresh
-                let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                    initial_storage_options.clone().unwrap_or_default(),
-                    provider,
-                ));
-                builder = builder.with_storage_options_accessor(accessor);
-            }
+            // Create storage options provider for credential refresh
+            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
+                LanceNamespaceStorageOptionsProvider::new(ns_client.clone(), tid.clone()),
+            );
+            let initial_opts = ctx
+                .as_ref()
+                .and_then(|c| c.storage_options.clone())
+                .or(initial_storage_options.clone())
+                .unwrap_or_default();
+            let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                initial_opts, provider,
+            ));
+            builder = builder.with_storage_options_accessor(accessor);
 
-            // Set up commit handler only if namespace manages versioning
-            if namespace_client_managed_versioning {
+            if ctx.as_ref().is_some_and(|c| c.managed_versioning) {
                 let external_store =
                     LanceNamespaceExternalManifestStore::new(ns_client, tid.clone());
                 let commit_handler: Arc<dyn CommitHandler> =
@@ -2235,7 +2237,7 @@ impl Dataset {
 
     #[allow(clippy::too_many_arguments)]
     #[staticmethod]
-    #[pyo3(signature = (dest, operation, read_version = None, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, commit_message = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_managed_versioning = false))]
+    #[pyo3(signature = (dest, operation, read_version = None, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, commit_message = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_table_context = None))]
     fn commit(
         dest: PyWriteDest,
         operation: PyLance<Operation>,
@@ -2249,7 +2251,7 @@ impl Dataset {
         enable_stable_row_ids: Option<bool>,
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
-        namespace_client_managed_versioning: bool,
+        namespace_client_table_context: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         let mut transaction = Transaction::new(read_version.unwrap_or_default(), operation.0, None);
 
@@ -2271,14 +2273,14 @@ impl Dataset {
             enable_stable_row_ids,
             namespace_client,
             table_id,
-            namespace_client_managed_versioning,
+            namespace_client_table_context,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     #[allow(deprecated)]
     #[staticmethod]
-    #[pyo3(signature = (dest, transaction, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_managed_versioning = false))]
+    #[pyo3(signature = (dest, transaction, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_table_context = None))]
     fn commit_transaction(
         dest: PyWriteDest,
         transaction: PyLance<Transaction>,
@@ -2290,7 +2292,7 @@ impl Dataset {
         enable_stable_row_ids: Option<bool>,
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
-        namespace_client_managed_versioning: bool,
+        namespace_client_table_context: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         let accessor =
             crate::storage_options::create_accessor_from_storage_options(storage_options.clone())?;
@@ -2304,21 +2306,20 @@ impl Dataset {
             None
         };
 
-        // Create commit_handler: prefer user-provided commit_lock, then namespace client-based handler
-        // (only if namespace_client_managed_versioning is true)
+        let ctx = namespace_client_table_context
+            .map(|c| extract_namespace_client_table_context(c))
+            .transpose()?;
+
         let commit_handler: Option<Arc<dyn CommitHandler>> =
             if let Some(commit_lock) = commit_lock.as_ref() {
-                // User provided a commit_lock
                 Some(
                     commit_lock
                         .into_py_any(commit_lock.py())
                         .map(|cl| Arc::new(PyCommitLock::new(cl)) as Arc<dyn CommitHandler>)?,
                 )
-            } else if namespace_client_managed_versioning
+            } else if ctx.as_ref().is_some_and(|c| c.managed_versioning)
                 && let (Some(ns_client), Some(tid)) = (namespace_client, table_id)
             {
-                // Create ExternalManifestCommitHandler from namespace client and table_id
-                // only when namespace manages versioning
                 let ns_client = extract_namespace_arc(ns_client.py(), ns_client)?;
                 let external_store = LanceNamespaceExternalManifestStore::new(ns_client, tid);
                 Some(Arc::new(ExternalManifestCommitHandler {
@@ -3416,34 +3417,38 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
 
         let storage_options = get_dict_opt::<HashMap<String, String>>(options, "storage_options")?;
 
-        // Extract namespace_client and table_id for storage options provider creation
         let namespace_client_opt = get_dict_opt::<Bound<PyAny>>(options, "namespace_client")?;
         let table_id_opt = get_dict_opt::<Vec<String>>(options, "table_id")?;
+        let ctx_opt = get_dict_opt::<Bound<PyAny>>(options, "namespace_client_table_context")?;
+        let ctx = ctx_opt
+            .map(|c| extract_namespace_client_table_context(&c))
+            .transpose()?;
 
-        if let Some(so) = storage_options.clone() {
-            // If namespace_client and table_id are provided, create storage options provider from them
-            if let (Some(ns_client), Some(table_id)) =
-                (namespace_client_opt.as_ref(), table_id_opt.as_ref())
-            {
-                let ns_client = extract_namespace_arc(options.py(), ns_client)?;
-                let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
-                    LanceNamespaceStorageOptionsProvider::new(ns_client, table_id.clone()),
-                );
-                let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                    so, provider,
-                ));
-                p.store_params = Some(ObjectStoreParams {
-                    storage_options_accessor: Some(accessor),
-                    ..Default::default()
-                });
-            } else {
-                // No namespace, just use storage options directly
-                let accessor = Arc::new(StorageOptionsAccessor::with_static_options(so));
-                p.store_params = Some(ObjectStoreParams {
-                    storage_options_accessor: Some(accessor),
-                    ..Default::default()
-                });
-            }
+        if let (Some(ns_client), Some(table_id)) =
+            (namespace_client_opt.as_ref(), table_id_opt.as_ref())
+        {
+            let ns_client = extract_namespace_arc(options.py(), ns_client)?;
+            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
+                LanceNamespaceStorageOptionsProvider::new(ns_client, table_id.clone()),
+            );
+            let initial_opts = ctx
+                .as_ref()
+                .and_then(|c| c.storage_options.clone())
+                .or(storage_options.clone())
+                .unwrap_or_default();
+            let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                initial_opts, provider,
+            ));
+            p.store_params = Some(ObjectStoreParams {
+                storage_options_accessor: Some(accessor),
+                ..Default::default()
+            });
+        } else if let Some(so) = storage_options.clone() {
+            let accessor = Arc::new(StorageOptionsAccessor::with_static_options(so));
+            p.store_params = Some(ObjectStoreParams {
+                storage_options_accessor: Some(accessor),
+                ..Default::default()
+            });
         }
 
         if let Some(enable_stable_row_ids) = get_dict_opt::<bool>(options, "enable_stable_row_ids")?
@@ -3536,12 +3541,8 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
             p.transaction_properties = Some(Arc::new(new_props));
         }
 
-        // Handle namespace_client and table_id for managed versioning (external manifest store)
-        // Only set if commit_handler is not already set by user and namespace_client_managed_versioning is true
-        let namespace_client_managed_versioning =
-            get_dict_opt::<bool>(options, "namespace_client_managed_versioning")?.unwrap_or(false);
         if p.commit_handler.is_none()
-            && namespace_client_managed_versioning
+            && ctx.as_ref().is_some_and(|c| c.managed_versioning)
             && let (Some(ns_client), Some(table_id)) =
                 (namespace_client_opt.as_ref(), table_id_opt.as_ref())
         {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -602,15 +602,14 @@ impl Dataset {
         // Set up namespace-based features if namespace_client and table_id are provided
         if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
             let ns_client = extract_namespace_arc(py, ns_client)?;
-            let ctx = namespace_client_table_context
+            let namespace_client_table_context = namespace_client_table_context
                 .map(|c| extract_namespace_client_table_context(c))
                 .transpose()?;
 
-            // Create storage options provider for credential refresh
             let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
                 LanceNamespaceStorageOptionsProvider::new(ns_client.clone(), tid.clone()),
             );
-            let initial_opts = ctx
+            let initial_opts = namespace_client_table_context
                 .as_ref()
                 .and_then(|c| c.storage_options.clone())
                 .or(initial_storage_options.clone())
@@ -620,7 +619,10 @@ impl Dataset {
             ));
             builder = builder.with_storage_options_accessor(accessor);
 
-            if ctx.as_ref().is_some_and(|c| c.managed_versioning) {
+            if namespace_client_table_context
+                .as_ref()
+                .is_some_and(|c| c.managed_versioning)
+            {
                 let external_store =
                     LanceNamespaceExternalManifestStore::new(ns_client, tid.clone());
                 let commit_handler: Arc<dyn CommitHandler> =
@@ -2306,7 +2308,7 @@ impl Dataset {
             None
         };
 
-        let ctx = namespace_client_table_context
+        let namespace_client_table_context = namespace_client_table_context
             .map(|c| extract_namespace_client_table_context(c))
             .transpose()?;
 
@@ -2317,7 +2319,9 @@ impl Dataset {
                         .into_py_any(commit_lock.py())
                         .map(|cl| Arc::new(PyCommitLock::new(cl)) as Arc<dyn CommitHandler>)?,
                 )
-            } else if ctx.as_ref().is_some_and(|c| c.managed_versioning)
+            } else if namespace_client_table_context
+                .as_ref()
+                .is_some_and(|c| c.managed_versioning)
                 && let (Some(ns_client), Some(tid)) = (namespace_client, table_id)
             {
                 let ns_client = extract_namespace_arc(ns_client.py(), ns_client)?;
@@ -3419,8 +3423,9 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
 
         let namespace_client_opt = get_dict_opt::<Bound<PyAny>>(options, "namespace_client")?;
         let table_id_opt = get_dict_opt::<Vec<String>>(options, "table_id")?;
-        let ctx_opt = get_dict_opt::<Bound<PyAny>>(options, "namespace_client_table_context")?;
-        let ctx = ctx_opt
+        let namespace_client_table_context_opt =
+            get_dict_opt::<Bound<PyAny>>(options, "namespace_client_table_context")?;
+        let namespace_client_table_context = namespace_client_table_context_opt
             .map(|c| extract_namespace_client_table_context(&c))
             .transpose()?;
 
@@ -3431,7 +3436,7 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
             let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
                 LanceNamespaceStorageOptionsProvider::new(ns_client, table_id.clone()),
             );
-            let initial_opts = ctx
+            let initial_opts = namespace_client_table_context
                 .as_ref()
                 .and_then(|c| c.storage_options.clone())
                 .or(storage_options.clone())
@@ -3542,7 +3547,9 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
         }
 
         if p.commit_handler.is_none()
-            && ctx.as_ref().is_some_and(|c| c.managed_versioning)
+            && namespace_client_table_context
+                .as_ref()
+                .is_some_and(|c| c.managed_versioning)
             && let (Some(ns_client), Some(table_id)) =
                 (namespace_client_opt.as_ref(), table_id_opt.as_ref())
         {

--- a/python/src/namespace.rs
+++ b/python/src/namespace.rs
@@ -1512,6 +1512,13 @@ impl LanceNamespaceTrait for PyLanceNamespace {
         call_py_method(self.py_namespace.clone(), "describe_table", request).await
     }
 
+    async fn declare_table(
+        &self,
+        request: lance_namespace::models::DeclareTableRequest,
+    ) -> lance_core::Result<lance_namespace::models::DeclareTableResponse> {
+        call_py_method(self.py_namespace.clone(), "declare_table", request).await
+    }
+
     async fn describe_table_version(
         &self,
         request: DescribeTableVersionRequest,

--- a/python/src/namespace.rs
+++ b/python/src/namespace.rs
@@ -1581,6 +1581,24 @@ pub fn extract_namespace_arc(
     PyLanceNamespace::create_arc(py, namespace_client)
 }
 
+/// Extract a [`NamespaceClientTableContext`] from a Python object.
+///
+/// Reads the `location`, `storage_options`, and `managed_versioning`
+/// attributes from the Python `NamespaceClientTableContext` instance.
+pub fn extract_namespace_client_table_context(
+    ctx: &Bound<'_, PyAny>,
+) -> PyResult<lance_namespace::NamespaceClientTableContext> {
+    let location: String = ctx.getattr("location")?.extract()?;
+    let storage_options: Option<HashMap<String, String>> =
+        ctx.getattr("storage_options")?.extract()?;
+    let managed_versioning: bool = ctx.getattr("managed_versioning")?.extract()?;
+    Ok(lance_namespace::NamespaceClientTableContext {
+        location,
+        storage_options,
+        managed_versioning,
+    })
+}
+
 /// Python wrapper for REST adapter server
 #[pyclass(name = "PyRestAdapter", module = "lance.lance")]
 pub struct PyRestAdapter {

--- a/rust/lance-namespace-datafusion/src/namespace_level.rs
+++ b/rust/lance-namespace-datafusion/src/namespace_level.rs
@@ -119,6 +119,7 @@ impl NamespaceLevel {
         DatasetBuilder::from_namespace(
             Arc::clone(&self.root),
             self.child_id(table_name.to_string()),
+            None,
         )
         .await?
         .load()

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -5718,7 +5718,7 @@ mod tests {
 
         let reader1 = RecordBatchIterator::new(vec![data1].into_iter().map(Ok), schema.clone());
         let dataset =
-            Dataset::write_into_namespace(reader1, namespace.clone(), table_id.clone(), None)
+            Dataset::write_into_namespace(reader1, namespace.clone(), table_id.clone(), None, None)
                 .await
                 .unwrap();
 
@@ -5745,6 +5745,7 @@ mod tests {
             reader2,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(params_append),
         )
         .await
@@ -5773,6 +5774,7 @@ mod tests {
             reader3,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(params_overwrite),
         )
         .await
@@ -6282,6 +6284,7 @@ mod tests {
             batches,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(write_params),
         )
         .await
@@ -6399,6 +6402,7 @@ mod tests {
             batches,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(write_params),
         )
         .await
@@ -6514,6 +6518,7 @@ mod tests {
             batches,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(write_params),
         )
         .await
@@ -6580,7 +6585,7 @@ mod tests {
 
         // Open the dataset using from_namespace to get proper object_store and paths
         let table_id = vec!["test_table".to_string()];
-        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone(), None)
             .await
             .unwrap()
             .load()
@@ -6693,7 +6698,7 @@ mod tests {
 
         // Open the dataset using from_namespace to get proper object_store and paths
         let table_id = vec!["test_table".to_string()];
-        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone(), None)
             .await
             .unwrap()
             .load()
@@ -7064,6 +7069,7 @@ mod tests {
                 batches,
                 ns.clone(),
                 table_id.clone(),
+                None,
                 Some(write_params),
             )
             .await
@@ -7097,7 +7103,7 @@ mod tests {
 
             // checkout_latest should call list_table_versions exactly once
             let initial_list_calls = tracking_ns.list_table_versions_calls();
-            let latest_dataset = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            let latest_dataset = DatasetBuilder::from_namespace(ns.clone(), table_id.clone(), None)
                 .await
                 .unwrap()
                 .load()
@@ -7112,7 +7118,7 @@ mod tests {
 
             // checkout to specific version should call describe_table_version exactly once
             let initial_describe_calls = tracking_ns.describe_table_version_calls();
-            let v1_dataset = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            let v1_dataset = DatasetBuilder::from_namespace(ns.clone(), table_id.clone(), None)
                 .await
                 .unwrap()
                 .with_version(1)
@@ -7179,6 +7185,7 @@ mod tests {
                 batches,
                 tracking_ns.clone(),
                 table_id.clone(),
+                None,
                 Some(write_params),
             )
             .await
@@ -7203,6 +7210,7 @@ mod tests {
                 batches,
                 tracking_ns.clone(),
                 table_id.clone(),
+                None,
                 Some(write_params),
             )
             .await
@@ -8056,7 +8064,7 @@ mod tests {
                 .unwrap();
 
             let table_id = vec![table_name.to_string()];
-            let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+            let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone(), None)
                 .await
                 .unwrap()
                 .load()

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -2802,10 +2802,15 @@ mod tests {
             .unwrap();
 
             let reader1 = RecordBatchIterator::new(vec![data1].into_iter().map(Ok), schema.clone());
-            let dataset =
-                Dataset::write_into_namespace(reader1, namespace.clone(), table_id.clone(), None)
-                    .await
-                    .unwrap();
+            let dataset = Dataset::write_into_namespace(
+                reader1,
+                namespace.clone(),
+                table_id.clone(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
 
             assert_eq!(dataset.count_rows(None).await.unwrap(), 3);
             assert_eq!(dataset.version().version, 1);
@@ -2830,6 +2835,7 @@ mod tests {
                 reader2,
                 namespace.clone(),
                 table_id.clone(),
+                None,
                 Some(params_append),
             )
             .await
@@ -2858,6 +2864,7 @@ mod tests {
                 reader3,
                 namespace.clone(),
                 table_id.clone(),
+                None,
                 Some(params_overwrite),
             )
             .await

--- a/rust/lance-namespace/src/context.rs
+++ b/rust/lance-namespace/src/context.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Cached table context from a namespace client.
+//!
+//! [`NamespaceClientTableContext`] holds the information that was returned by a
+//! prior `describe_table` or `declare_table` call (location, storage options,
+//! managed-versioning flag).
+//!
+//! Passing this struct avoids repeating the same parameters across every API
+//! entry-point and makes it explicit that the values are cached from a prior
+//! namespace call rather than user-provided overrides.  The namespace client
+//! and table ID are **not** part of this struct — they are still passed
+//! separately.
+
+use std::collections::HashMap;
+
+use lance_namespace_reqwest_client::models::{DeclareTableResponse, DescribeTableResponse};
+
+/// Cached context from a namespace client's `describe_table` or `declare_table`
+/// response.
+///
+/// Contains only the resolved table metadata (location, storage options,
+/// managed-versioning flag).  The namespace client and table ID remain
+/// separate parameters.
+#[derive(Debug, Clone)]
+pub struct NamespaceClientTableContext {
+    /// The table's storage location (URI).
+    pub location: String,
+    /// Storage options returned by the namespace (e.g. temporary credentials).
+    pub storage_options: Option<HashMap<String, String>>,
+    /// Whether commits should go through the namespace's version API.
+    pub managed_versioning: bool,
+}
+
+impl NamespaceClientTableContext {
+    /// Build a context from a `DescribeTableResponse`.
+    ///
+    /// Returns an error if the response does not contain a `location`.
+    pub fn from_describe_table_response(response: DescribeTableResponse) -> Result<Self, String> {
+        let location = response
+            .location
+            .ok_or("DescribeTableResponse missing location")?;
+        Ok(Self {
+            location,
+            storage_options: response.storage_options,
+            managed_versioning: response.managed_versioning == Some(true),
+        })
+    }
+
+    /// Build a context from a `DeclareTableResponse`.
+    ///
+    /// Returns an error if the response does not contain a `location`.
+    pub fn from_declare_table_response(response: DeclareTableResponse) -> Result<Self, String> {
+        let location = response
+            .location
+            .ok_or("DeclareTableResponse missing location")?;
+        Ok(Self {
+            location,
+            storage_options: response.storage_options,
+            managed_versioning: response.managed_versioning == Some(true),
+        })
+    }
+}

--- a/rust/lance-namespace/src/lib.rs
+++ b/rust/lance-namespace/src/lib.rs
@@ -15,11 +15,13 @@
 //! See [`error::ErrorCode`] for the list of error codes and
 //! [`error::NamespaceError`] for the error types.
 
+pub mod context;
 pub mod error;
 pub mod namespace;
 pub mod schema;
 
 // Re-export the trait at the crate root
+pub use context::NamespaceClientTableContext;
 pub use lance_core::{Error, Result};
 pub use namespace::LanceNamespace;
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -754,92 +754,56 @@ impl Dataset {
 
     /// Write into a namespace client-managed table with automatic credential vending.
     ///
-    /// For CREATE mode, calls declare_table() to initialize the table.
-    /// For other modes, calls describe_table() and opens dataset with namespace client credentials.
+    /// When `namespace_client_table_context` is `None`, calls `declare_table()`
+    /// (CREATE) or `describe_table()` (APPEND/OVERWRITE) to resolve table info.
+    /// When provided, uses the cached values directly.
     pub async fn write_into_namespace(
         batches: impl RecordBatchReader + Send + 'static,
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
+        namespace_client_table_context: Option<&NamespaceClientTableContext>,
         mut params: Option<WriteParams>,
     ) -> Result<Self> {
-        let write_params = params.take().unwrap_or_default();
+        let mut write_params = params.take().unwrap_or_default();
 
-        match write_params.mode {
-            WriteMode::Create => {
-                let declare_request = DeclareTableRequest {
-                    id: Some(table_id.clone()),
-                    ..Default::default()
+        let owned_context;
+        let namespace_client_table_context = match namespace_client_table_context {
+            Some(c) => c,
+            None => {
+                owned_context = match write_params.mode {
+                    WriteMode::Create => {
+                        let declare_request = DeclareTableRequest {
+                            id: Some(table_id.clone()),
+                            ..Default::default()
+                        };
+                        let response = namespace_client
+                            .declare_table(declare_request)
+                            .await
+                            .map_err(|e| Error::namespace_source(Box::new(e)))?;
+                        NamespaceClientTableContext::from_declare_table_response(response).map_err(
+                            |e| Error::namespace_source(Box::new(std::io::Error::other(e))),
+                        )?
+                    }
+                    WriteMode::Append | WriteMode::Overwrite => {
+                        let request = DescribeTableRequest {
+                            id: Some(table_id.clone()),
+                            ..Default::default()
+                        };
+                        let response = namespace_client
+                            .describe_table(request)
+                            .await
+                            .map_err(|e| Error::namespace_source(Box::new(e)))?;
+                        NamespaceClientTableContext::from_describe_table_response(response)
+                            .map_err(|e| {
+                                Error::namespace_source(Box::new(std::io::Error::other(e)))
+                            })?
+                    }
                 };
-                let response = namespace_client
-                    .declare_table(declare_request)
-                    .await
-                    .map_err(|e| Error::namespace_source(Box::new(e)))?;
-
-                let ctx = NamespaceClientTableContext::from_declare_table_response(response)
-                    .map_err(|e| Error::namespace_source(Box::new(std::io::Error::other(e))))?;
-
-                Self::write_with_namespace_context(
-                    batches,
-                    namespace_client,
-                    table_id,
-                    &ctx,
-                    write_params,
-                )
-                .await
+                &owned_context
             }
-            WriteMode::Append | WriteMode::Overwrite => {
-                let request = DescribeTableRequest {
-                    id: Some(table_id.clone()),
-                    ..Default::default()
-                };
-                let response = namespace_client
-                    .describe_table(request)
-                    .await
-                    .map_err(|e| Error::namespace_source(Box::new(e)))?;
+        };
 
-                let ctx = NamespaceClientTableContext::from_describe_table_response(response)
-                    .map_err(|e| Error::namespace_source(Box::new(std::io::Error::other(e))))?;
-
-                Self::write_with_namespace_context(
-                    batches,
-                    namespace_client,
-                    table_id,
-                    &ctx,
-                    write_params,
-                )
-                .await
-            }
-        }
-    }
-
-    /// Write into a namespace client-managed table using a cached
-    /// [`NamespaceClientTableContext`].
-    ///
-    /// Unlike [`write_into_namespace`](Self::write_into_namespace), this method
-    /// does **not** call `declare_table` or `describe_table` — it uses the
-    /// location, storage options, and managed-versioning flag already cached in
-    /// `ctx`.
-    pub async fn write_into_namespace_context(
-        batches: impl RecordBatchReader + Send + 'static,
-        namespace_client: Arc<dyn LanceNamespace>,
-        table_id: Vec<String>,
-        ctx: &NamespaceClientTableContext,
-        params: Option<WriteParams>,
-    ) -> Result<Self> {
-        let write_params = params.unwrap_or_default();
-        Self::write_with_namespace_context(batches, namespace_client, table_id, ctx, write_params)
-            .await
-    }
-
-    /// Shared implementation for writing with a [`NamespaceClientTableContext`].
-    async fn write_with_namespace_context(
-        batches: impl RecordBatchReader + Send + 'static,
-        namespace_client: Arc<dyn LanceNamespace>,
-        table_id: Vec<String>,
-        ctx: &NamespaceClientTableContext,
-        mut write_params: WriteParams,
-    ) -> Result<Self> {
-        if ctx.managed_versioning {
+        if namespace_client_table_context.managed_versioning {
             let external_store = LanceNamespaceExternalManifestStore::new(
                 namespace_client.clone(),
                 table_id.clone(),
@@ -850,7 +814,8 @@ impl Dataset {
             write_params.commit_handler = Some(commit_handler);
         }
 
-        if let Some(ref namespace_storage_options) = ctx.storage_options {
+        if let Some(ref namespace_storage_options) = namespace_client_table_context.storage_options
+        {
             let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
                 LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
             );
@@ -876,10 +841,16 @@ impl Dataset {
 
         match write_params.mode {
             WriteMode::Create => {
-                Self::write(batches, ctx.location.as_str(), Some(write_params)).await
+                Self::write(
+                    batches,
+                    namespace_client_table_context.location.as_str(),
+                    Some(write_params),
+                )
+                .await
             }
             WriteMode::Append | WriteMode::Overwrite => {
-                let mut builder = DatasetBuilder::from_uri(ctx.location.as_str());
+                let mut builder =
+                    DatasetBuilder::from_uri(namespace_client_table_context.location.as_str());
                 if let Some(ref store_params) = write_params.store_params
                     && let Some(accessor) = &store_params.storage_options_accessor
                 {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -40,7 +40,7 @@ use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::utils::{
     CachedFileSize, read_last_block, read_message, read_metadata_offset, read_struct,
 };
-use lance_namespace::LanceNamespace;
+use lance_namespace::{LanceNamespace, NamespaceClientTableContext};
 use lance_table::format::{
     DataFile, DataStorageFormat, DeletionFile, Fragment, IndexMetadata, Manifest, RowIdMeta, pb,
 };
@@ -756,20 +756,13 @@ impl Dataset {
     ///
     /// For CREATE mode, calls declare_table() to initialize the table.
     /// For other modes, calls describe_table() and opens dataset with namespace client credentials.
-    ///
-    /// # Arguments
-    ///
-    /// * `batches` - The record batches to write
-    /// * `namespace_client` - The namespace client to use for table management
-    /// * `table_id` - The table identifier
-    /// * `params` - Write parameters
     pub async fn write_into_namespace(
         batches: impl RecordBatchReader + Send + 'static,
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
         mut params: Option<WriteParams>,
     ) -> Result<Self> {
-        let mut write_params = params.take().unwrap_or_default();
+        let write_params = params.take().unwrap_or_default();
 
         match write_params.mode {
             WriteMode::Create => {
@@ -782,52 +775,17 @@ impl Dataset {
                     .await
                     .map_err(|e| Error::namespace_source(Box::new(e)))?;
 
-                let uri = response.location.ok_or_else(|| {
-                    Error::namespace_source(Box::new(std::io::Error::other(
-                        "Table location not found in declare_table response",
-                    )))
-                })?;
+                let ctx = NamespaceClientTableContext::from_declare_table_response(response)
+                    .map_err(|e| Error::namespace_source(Box::new(std::io::Error::other(e))))?;
 
-                // Set up commit handler when managed_versioning is enabled
-                if response.managed_versioning == Some(true) {
-                    let external_store = LanceNamespaceExternalManifestStore::new(
-                        namespace_client.clone(),
-                        table_id.clone(),
-                    );
-                    let commit_handler: Arc<dyn CommitHandler> =
-                        Arc::new(ExternalManifestCommitHandler {
-                            external_manifest_store: Arc::new(external_store),
-                        });
-                    write_params.commit_handler = Some(commit_handler);
-                }
-
-                // Set initial credentials and provider from namespace_client
-                if let Some(namespace_storage_options) = response.storage_options {
-                    let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
-                        LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
-                    );
-
-                    // Merge namespace client storage options with any existing options
-                    let mut merged_options = write_params
-                        .store_params
-                        .as_ref()
-                        .and_then(|p| p.storage_options().cloned())
-                        .unwrap_or_default();
-                    merged_options.extend(namespace_storage_options);
-
-                    let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                        merged_options,
-                        provider,
-                    ));
-
-                    let existing_params = write_params.store_params.take().unwrap_or_default();
-                    write_params.store_params = Some(ObjectStoreParams {
-                        storage_options_accessor: Some(accessor),
-                        ..existing_params
-                    });
-                }
-
-                Self::write(batches, uri.as_str(), Some(write_params)).await
+                Self::write_with_namespace_context(
+                    batches,
+                    namespace_client,
+                    table_id,
+                    &ctx,
+                    write_params,
+                )
+                .await
             }
             WriteMode::Append | WriteMode::Overwrite => {
                 let request = DescribeTableRequest {
@@ -839,64 +797,95 @@ impl Dataset {
                     .await
                     .map_err(|e| Error::namespace_source(Box::new(e)))?;
 
-                let uri = response.location.ok_or_else(|| {
-                    Error::namespace_source(Box::new(std::io::Error::other(
-                        "Table location not found in describe_table response",
-                    )))
-                })?;
+                let ctx = NamespaceClientTableContext::from_describe_table_response(response)
+                    .map_err(|e| Error::namespace_source(Box::new(std::io::Error::other(e))))?;
 
-                // Set up commit handler when managed_versioning is enabled
-                if response.managed_versioning == Some(true) {
-                    let external_store = LanceNamespaceExternalManifestStore::new(
-                        namespace_client.clone(),
-                        table_id.clone(),
-                    );
-                    let commit_handler: Arc<dyn CommitHandler> =
-                        Arc::new(ExternalManifestCommitHandler {
-                            external_manifest_store: Arc::new(external_store),
-                        });
-                    write_params.commit_handler = Some(commit_handler);
-                }
+                Self::write_with_namespace_context(
+                    batches,
+                    namespace_client,
+                    table_id,
+                    &ctx,
+                    write_params,
+                )
+                .await
+            }
+        }
+    }
 
-                // Set initial credentials and provider from namespace_client
-                if let Some(namespace_storage_options) = response.storage_options {
-                    let provider: Arc<dyn StorageOptionsProvider> =
-                        Arc::new(LanceNamespaceStorageOptionsProvider::new(
-                            namespace_client.clone(),
-                            table_id.clone(),
-                        ));
+    /// Write into a namespace client-managed table using a cached
+    /// [`NamespaceClientTableContext`].
+    ///
+    /// Unlike [`write_into_namespace`](Self::write_into_namespace), this method
+    /// does **not** call `declare_table` or `describe_table` — it uses the
+    /// location, storage options, and managed-versioning flag already cached in
+    /// `ctx`.
+    pub async fn write_into_namespace_context(
+        batches: impl RecordBatchReader + Send + 'static,
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        ctx: &NamespaceClientTableContext,
+        params: Option<WriteParams>,
+    ) -> Result<Self> {
+        let write_params = params.unwrap_or_default();
+        Self::write_with_namespace_context(batches, namespace_client, table_id, ctx, write_params)
+            .await
+    }
 
-                    // Merge namespace client storage options with any existing options
-                    let mut merged_options = write_params
-                        .store_params
-                        .as_ref()
-                        .and_then(|p| p.storage_options().cloned())
-                        .unwrap_or_default();
-                    merged_options.extend(namespace_storage_options);
+    /// Shared implementation for writing with a [`NamespaceClientTableContext`].
+    async fn write_with_namespace_context(
+        batches: impl RecordBatchReader + Send + 'static,
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        ctx: &NamespaceClientTableContext,
+        mut write_params: WriteParams,
+    ) -> Result<Self> {
+        if ctx.managed_versioning {
+            let external_store = LanceNamespaceExternalManifestStore::new(
+                namespace_client.clone(),
+                table_id.clone(),
+            );
+            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
+                external_manifest_store: Arc::new(external_store),
+            });
+            write_params.commit_handler = Some(commit_handler);
+        }
 
-                    let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                        merged_options,
-                        provider,
-                    ));
+        if let Some(ref namespace_storage_options) = ctx.storage_options {
+            let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
+                LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
+            );
 
-                    let existing_params = write_params.store_params.take().unwrap_or_default();
-                    write_params.store_params = Some(ObjectStoreParams {
-                        storage_options_accessor: Some(accessor),
-                        ..existing_params
-                    });
-                }
+            let mut merged_options = write_params
+                .store_params
+                .as_ref()
+                .and_then(|p| p.storage_options().cloned())
+                .unwrap_or_default();
+            merged_options.extend(namespace_storage_options.clone());
 
-                // For APPEND/OVERWRITE modes, we must open the existing dataset first
-                // and pass it to InsertBuilder. If we pass just the URI, InsertBuilder
-                // assumes no dataset exists and converts the mode to CREATE.
-                let mut builder = DatasetBuilder::from_uri(uri.as_str());
+            let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                merged_options,
+                provider,
+            ));
+
+            let existing_params = write_params.store_params.take().unwrap_or_default();
+            write_params.store_params = Some(ObjectStoreParams {
+                storage_options_accessor: Some(accessor),
+                ..existing_params
+            });
+        }
+
+        match write_params.mode {
+            WriteMode::Create => {
+                Self::write(batches, ctx.location.as_str(), Some(write_params)).await
+            }
+            WriteMode::Append | WriteMode::Overwrite => {
+                let mut builder = DatasetBuilder::from_uri(ctx.location.as_str());
                 if let Some(ref store_params) = write_params.store_params
                     && let Some(accessor) = &store_params.storage_options_accessor
                 {
                     builder = builder.with_storage_options_accessor(accessor.clone());
                 }
                 let dataset = Arc::new(builder.load().await?);
-
                 Self::write(batches, dataset, Some(write_params)).await
             }
         }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -814,23 +814,27 @@ impl Dataset {
             write_params.commit_handler = Some(commit_handler);
         }
 
-        if let Some(ref namespace_storage_options) = namespace_client_table_context.storage_options
         {
             let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
                 LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
             );
 
-            let mut merged_options = write_params
-                .store_params
-                .as_ref()
-                .and_then(|p| p.storage_options().cloned())
-                .unwrap_or_default();
-            merged_options.extend(namespace_storage_options.clone());
-
-            let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                merged_options,
-                provider,
-            ));
+            let accessor = if let Some(ref namespace_storage_options) =
+                namespace_client_table_context.storage_options
+            {
+                let mut merged_options = write_params
+                    .store_params
+                    .as_ref()
+                    .and_then(|p| p.storage_options().cloned())
+                    .unwrap_or_default();
+                merged_options.extend(namespace_storage_options.clone());
+                Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                    merged_options,
+                    provider,
+                ))
+            } else {
+                Arc::new(StorageOptionsAccessor::with_provider(provider))
+            };
 
             let existing_params = write_params.store_params.take().unwrap_or_default();
             write_params.store_params = Some(ObjectStoreParams {
@@ -855,6 +859,9 @@ impl Dataset {
                     && let Some(accessor) = &store_params.storage_options_accessor
                 {
                     builder = builder.with_storage_options_accessor(accessor.clone());
+                }
+                if let Some(ref commit_handler) = write_params.commit_handler {
+                    builder = builder.with_commit_handler(commit_handler.clone());
                 }
                 let dataset = Arc::new(builder.load().await?);
                 Self::write(batches, dataset, Some(write_params)).await

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -134,14 +134,15 @@ impl DatasetBuilder {
 
         builder.storage_options_override = namespace_client_table_context.storage_options.clone();
 
-        if let Some(initial_opts) = &namespace_client_table_context.storage_options {
-            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
-                LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
-            );
-            builder.options.storage_options_accessor = Some(Arc::new(
-                StorageOptionsAccessor::with_initial_and_provider(initial_opts.clone(), provider),
-            ));
-        }
+        let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
+            LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
+        );
+        let accessor = if let Some(initial_opts) = &namespace_client_table_context.storage_options {
+            StorageOptionsAccessor::with_initial_and_provider(initial_opts.clone(), provider)
+        } else {
+            StorageOptionsAccessor::with_provider(provider)
+        };
+        builder.options.storage_options_accessor = Some(Arc::new(accessor));
 
         Ok(builder)
     }

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -18,6 +18,7 @@ use lance_io::object_store::{
     ObjectStoreParams, StorageOptions, StorageOptionsAccessor,
 };
 use lance_namespace::LanceNamespace;
+use lance_namespace::NamespaceClientTableContext;
 use lance_namespace::models::DescribeTableRequest;
 use lance_table::{
     format::Manifest,
@@ -172,6 +173,58 @@ impl DatasetBuilder {
         }
 
         Ok(builder)
+    }
+
+    /// Create a DatasetBuilder from a cached [`NamespaceClientTableContext`].
+    ///
+    /// Unlike [`from_namespace`](Self::from_namespace), this method does **not** make
+    /// a `describe_table` call — it uses the location, storage options, and
+    /// managed-versioning flag that were already cached in `ctx`.
+    ///
+    /// # Example
+    /// ```ignore
+    /// use lance_namespace::NamespaceClientTableContext;
+    /// use lance::dataset::DatasetBuilder;
+    ///
+    /// let dataset = DatasetBuilder::from_namespace_context(
+    ///     namespace_client,
+    ///     vec!["my_table".to_string()],
+    ///     &ctx,
+    /// )
+    /// .load()
+    /// .await?;
+    /// ```
+    #[allow(deprecated)]
+    pub fn from_namespace_context(
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        ctx: &NamespaceClientTableContext,
+    ) -> Self {
+        let mut builder = Self::from_uri(&ctx.location);
+
+        if ctx.managed_versioning {
+            let external_store = LanceNamespaceExternalManifestStore::new(
+                namespace_client.clone(),
+                table_id.clone(),
+            );
+            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
+                external_manifest_store: Arc::new(external_store),
+            });
+            builder.commit_handler = Some(commit_handler);
+        }
+
+        builder.storage_options_override = ctx.storage_options.clone();
+
+        if let Some(initial_opts) = &ctx.storage_options {
+            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
+                LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
+            );
+            builder.options.storage_options_accessor = Some(Arc::new(
+                StorageOptionsAccessor::with_initial_and_provider(initial_opts.clone(), provider),
+            ));
+        }
+
+        builder
     }
 }
 

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -90,64 +90,38 @@ impl DatasetBuilder {
         }
     }
 
-    /// Create a DatasetBuilder from a LanceNamespace client
+    /// Create a DatasetBuilder from a LanceNamespace client.
     ///
-    /// This will automatically fetch the table location and storage options from the namespace
-    /// client via `describe_table()`.
-    ///
-    /// Storage options from the namespace client will override any user-provided storage options
-    /// set via `.with_storage_options()`. This ensures the namespace client is always the source
-    /// of truth for storage options.
-    ///
-    /// # Arguments
-    /// * `namespace_client` - The namespace client implementation to fetch table info from
-    /// * `table_id` - The table identifier (e.g., vec!["my_table"])
-    ///
-    /// # Example
-    /// ```ignore
-    /// use lance_namespace_impls::ConnectBuilder;
-    /// use lance::dataset::DatasetBuilder;
-    ///
-    /// // Connect to a REST namespace
-    /// let namespace_client = ConnectBuilder::new("rest")
-    ///     .property("uri", "http://localhost:8080")
-    ///     .connect()
-    ///     .await?;
-    ///
-    /// // Load a dataset using storage options from namespace client
-    /// let dataset = DatasetBuilder::from_namespace(
-    ///     namespace_client,
-    ///     vec!["my_table".to_string()],
-    /// )
-    /// .await?
-    /// .load()
-    /// .await?;
-    /// ```
+    /// When `namespace_client_table_context` is `None`, calls `describe_table()`
+    /// to fetch the table location, storage options, and managed-versioning flag.
+    /// When provided, uses the cached values directly without making a namespace call.
     #[allow(deprecated)]
     pub async fn from_namespace(
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
+        namespace_client_table_context: Option<&NamespaceClientTableContext>,
     ) -> Result<Self> {
-        let request = DescribeTableRequest {
-            id: Some(table_id.clone()),
-            ..Default::default()
+        let owned_context;
+        let namespace_client_table_context = match namespace_client_table_context {
+            Some(c) => c,
+            None => {
+                let request = DescribeTableRequest {
+                    id: Some(table_id.clone()),
+                    ..Default::default()
+                };
+                let response = namespace_client
+                    .describe_table(request)
+                    .await
+                    .map_err(|e| Error::namespace_source(Box::new(e)))?;
+                owned_context = NamespaceClientTableContext::from_describe_table_response(response)
+                    .map_err(|e| Error::namespace_source(Box::new(std::io::Error::other(e))))?;
+                &owned_context
+            }
         };
 
-        let response = namespace_client
-            .describe_table(request)
-            .await
-            .map_err(|e| Error::namespace_source(Box::new(e)))?;
+        let mut builder = Self::from_uri(&namespace_client_table_context.location);
 
-        let table_uri = response.location.ok_or_else(|| {
-            Error::namespace_source(Box::new(std::io::Error::other(
-                "Table location not found in namespace response",
-            )))
-        })?;
-
-        let mut builder = Self::from_uri(&table_uri);
-
-        // Check managed_versioning flag to determine if namespace-managed commits should be used
-        if response.managed_versioning == Some(true) {
+        if namespace_client_table_context.managed_versioning {
             let external_store = LanceNamespaceExternalManifestStore::new(
                 namespace_client.clone(),
                 table_id.clone(),
@@ -158,64 +132,9 @@ impl DatasetBuilder {
             builder.commit_handler = Some(commit_handler);
         }
 
-        // Use namespace storage options if available
-        let namespace_storage_options = response.storage_options;
+        builder.storage_options_override = namespace_client_table_context.storage_options.clone();
 
-        builder.storage_options_override = namespace_storage_options.clone();
-
-        if let Some(initial_opts) = namespace_storage_options {
-            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
-                LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
-            );
-            builder.options.storage_options_accessor = Some(Arc::new(
-                StorageOptionsAccessor::with_initial_and_provider(initial_opts, provider),
-            ));
-        }
-
-        Ok(builder)
-    }
-
-    /// Create a DatasetBuilder from a cached [`NamespaceClientTableContext`].
-    ///
-    /// Unlike [`from_namespace`](Self::from_namespace), this method does **not** make
-    /// a `describe_table` call — it uses the location, storage options, and
-    /// managed-versioning flag that were already cached in `ctx`.
-    ///
-    /// # Example
-    /// ```ignore
-    /// use lance_namespace::NamespaceClientTableContext;
-    /// use lance::dataset::DatasetBuilder;
-    ///
-    /// let dataset = DatasetBuilder::from_namespace_context(
-    ///     namespace_client,
-    ///     vec!["my_table".to_string()],
-    ///     &ctx,
-    /// )
-    /// .load()
-    /// .await?;
-    /// ```
-    #[allow(deprecated)]
-    pub fn from_namespace_context(
-        namespace_client: Arc<dyn LanceNamespace>,
-        table_id: Vec<String>,
-        ctx: &NamespaceClientTableContext,
-    ) -> Self {
-        let mut builder = Self::from_uri(&ctx.location);
-
-        if ctx.managed_versioning {
-            let external_store = LanceNamespaceExternalManifestStore::new(
-                namespace_client.clone(),
-                table_id.clone(),
-            );
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            builder.commit_handler = Some(commit_handler);
-        }
-
-        builder.storage_options_override = ctx.storage_options.clone();
-
-        if let Some(initial_opts) = &ctx.storage_options {
+        if let Some(initial_opts) = &namespace_client_table_context.storage_options {
             let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
                 LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
             );
@@ -224,7 +143,7 @@ impl DatasetBuilder {
             ));
         }
 
-        builder
+        Ok(builder)
     }
 }
 


### PR DESCRIPTION
This is a second part of the namespace SDK refactoring.

When user uses namespace client to get table information via `namespace.describe_table` or `namesapce.declare_table`, it is very important that the information can be reused, so that you don't have to call the API repeatedly to gain the same information. Instead, you can get info in driver, distribute it, and use it directly in worker.

There are 3 information today falls in this category:
1. table location
2. catalog-provided storage options
3. managed-versioning boolean

Today, this is implemented by passing the known location, managed_versioning boolean, and merge storage_options with user provided ones. And this creates 2 problems:
1. code repetition: we have to pass these information repeatedly for all information, today it is done for all SDKs and for all engine integrations. This is prune to error for engineers and code agents that don't have much context on this feature.
2. missing intent: we don't know if the caller has really passed in cached info, or if it is just passed in by mistake. e.g. if I have passed in location, but not managed verisoning, do we call the API again to reconfirm? 

This PR does the following:

- Introduce `NamespaceClientTableContext` (Rust struct, Python class, Java class) that holds cached `describe_table`/`declare_table` response data (location, storage_options, managed_versioning)
- Context is passed all the way to Rust layer where all decisions about storage options merging and managed versioning are made — Python and Java make no decisions

We also remove deprecated `Dataset.create`/`open` overloads and `createWithFfiSchema` JNI path in Java along the way.