### PR TITLE
ci: add active release retarget workflow

### DIFF
--- a/.github/workflows/retarget-active-release.yml
+++ b/.github/workflows/retarget-active-release.yml
@@ -1,0 +1,73 @@
+name: Retarget Active Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: 'Source branch to retarget from'
+        required: true
+        default: 'main'
+        type: string
+      dry_run:
+        description: 'Dry run (simulate without pushing)'
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  retarget-active-release:
+    runs-on: ubuntu-latest
+    outputs:
+      active_release_branch: ${{ steps.retarget.outputs.ACTIVE_RELEASE_BRANCH }}
+      release_version: ${{ steps.retarget.outputs.RELEASE_VERSION }}
+      previous_head: ${{ steps.retarget.outputs.PREVIOUS_HEAD }}
+      source_sha: ${{ steps.retarget.outputs.SOURCE_SHA }}
+      target_sha: ${{ steps.retarget.outputs.TARGET_SHA }}
+    steps:
+    - name: Output Inputs
+      run: echo "${{ toJSON(github.event.inputs) }}"
+
+    - name: Check out repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        ref: ${{ inputs.source_branch }}
+        token: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        fetch-depth: 0
+        lfs: true
+
+    - name: Setup release environment
+      uses: ./.github/actions/setup-release-env
+
+    - name: Retarget active release branch
+      id: retarget
+      run: |
+        bash ci/retarget_active_release.sh "${{ inputs.source_branch }}"
+
+    - name: Push changes (if not dry run)
+      if: ${{ !inputs.dry_run }}
+      run: |
+        git push --force-with-lease=refs/heads/${{ steps.retarget.outputs.ACTIVE_RELEASE_BRANCH }}:${{ steps.retarget.outputs.PREVIOUS_HEAD }} \
+          origin HEAD:refs/heads/${{ steps.retarget.outputs.ACTIVE_RELEASE_BRANCH }}
+
+    - name: Summary
+      run: |
+        echo "## Active Release Retarget Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Source Branch:** ${{ inputs.source_branch }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Active Release Branch:** ${{ steps.retarget.outputs.ACTIVE_RELEASE_BRANCH }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Release Version:** ${{ steps.retarget.outputs.RELEASE_VERSION }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Previous Head:** ${{ steps.retarget.outputs.PREVIOUS_HEAD }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Source Head:** ${{ steps.retarget.outputs.SOURCE_SHA }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Retargeted Head:** ${{ steps.retarget.outputs.TARGET_SHA }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Dry Run:** ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+
+        if [ "${{ inputs.dry_run }}" == "true" ]; then
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⚠️ This was a dry run. No changes were pushed." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Retargeted ${{ steps.retarget.outputs.ACTIVE_RELEASE_BRANCH }} to ${{ inputs.source_branch }} while keeping version ${{ steps.retarget.outputs.RELEASE_VERSION }}." >> $GITHUB_STEP_SUMMARY
+        fi

--- a/ci/release_common.sh
+++ b/ci/release_common.sh
@@ -8,6 +8,14 @@ get_version_from_cargo() {
     grep '^version = ' Cargo.toml | head -n1 | cut -d'"' -f2
 }
 
+# Gets the version from Cargo.toml at a git ref
+# Args: GIT_REF
+# Returns: version string (e.g., "1.3.0-beta.1")
+get_version_from_cargo_ref() {
+    local GIT_REF=$1
+    git show "${GIT_REF}:Cargo.toml" | grep '^version = ' | head -n1 | cut -d'"' -f2
+}
+
 # Parses version components from a version string
 # Args: VERSION_STRING
 # Returns: three values separated by spaces: MAJOR MINOR PATCH
@@ -20,6 +28,19 @@ parse_version_components() {
     echo "${MAJOR} ${MINOR} ${PATCH}"
 }
 
+# Updates lockfiles after a version rewrite.
+# Set LANCE_RELEASE_SKIP_LOCK_UPDATE=1 to skip this in tests.
+update_lockfiles() {
+    if [ "${LANCE_RELEASE_SKIP_LOCK_UPDATE:-0}" = "1" ]; then
+        echo "Skipping lockfile updates because LANCE_RELEASE_SKIP_LOCK_UPDATE=1"
+        return
+    fi
+
+    cargo update
+    (cd python && cargo update)
+    (cd java/lance-jni && cargo update)
+}
+
 # Bumps version and commits the change
 # Args: NEW_VERSION COMMIT_MESSAGE
 bump_and_commit_version() {
@@ -29,12 +50,87 @@ bump_and_commit_version() {
     bump-my-version bump -vv --new-version "${NEW_VERSION}" --no-tag patch
 
     # Update Cargo.lock files after version bump
-    cargo update
-    (cd python && cargo update)
-    (cd java/lance-jni && cargo update)
+    update_lockfiles
 
     git add -A
     git commit -m "${COMMIT_MESSAGE}"
+}
+
+# Lists release branches from a remote.
+# Args: [REMOTE]
+list_release_branches() {
+    local REMOTE=${1:-origin}
+    git for-each-ref --format='%(refname:short)' "refs/remotes/${REMOTE}/release/*" \
+        | sed "s#^${REMOTE}/##"
+}
+
+# Returns 0 if the release branch has already published its stable X.Y.0 tag.
+# Args: RELEASE_BRANCH [TAG_PREFIX]
+release_branch_has_stable_tag() {
+    local RELEASE_BRANCH=$1
+    local TAG_PREFIX=${2:-"v"}
+
+    if [[ ! "${RELEASE_BRANCH}" =~ ^release/v([0-9]+)\.([0-9]+)$ ]]; then
+        echo "ERROR: Invalid release branch name: ${RELEASE_BRANCH}" >&2
+        return 2
+    fi
+
+    local MAJOR="${BASH_REMATCH[1]}"
+    local MINOR="${BASH_REMATCH[2]}"
+    git rev-parse "${TAG_PREFIX}${MAJOR}.${MINOR}.0" >/dev/null 2>&1
+}
+
+# Finds the unique active release branch on a remote.
+# An active release branch is a release/vX.Y branch whose stable vX.Y.0 tag does not exist yet.
+# Args: [REMOTE] [TAG_PREFIX]
+# Returns: branch name (e.g. release/v5.0)
+find_active_release_branch() {
+    local REMOTE=${1:-origin}
+    local TAG_PREFIX=${2:-"v"}
+    local ACTIVE_BRANCHES=()
+    local RELEASE_BRANCH
+
+    while IFS= read -r RELEASE_BRANCH; do
+        [ -z "${RELEASE_BRANCH}" ] && continue
+        if ! release_branch_has_stable_tag "${RELEASE_BRANCH}" "${TAG_PREFIX}"; then
+            ACTIVE_BRANCHES+=("${RELEASE_BRANCH}")
+        fi
+    done < <(list_release_branches "${REMOTE}")
+
+    if [ "${#ACTIVE_BRANCHES[@]}" -ne 1 ]; then
+        echo "ERROR: Expected exactly one active release branch, found ${#ACTIVE_BRANCHES[@]}: ${ACTIVE_BRANCHES[*]-}" >&2
+        return 1
+    fi
+
+    echo "${ACTIVE_BRANCHES[0]}"
+}
+
+# Validates that a prerelease version belongs to a release branch line and remains on the RC/Beta track.
+# Args: RELEASE_BRANCH VERSION
+validate_release_branch_version() {
+    local RELEASE_BRANCH=$1
+    local VERSION=$2
+
+    if [[ ! "${RELEASE_BRANCH}" =~ ^release/v([0-9]+)\.([0-9]+)$ ]]; then
+        echo "ERROR: Invalid release branch name: ${RELEASE_BRANCH}" >&2
+        return 1
+    fi
+
+    local EXPECTED_MAJOR="${BASH_REMATCH[1]}"
+    local EXPECTED_MINOR="${BASH_REMATCH[2]}"
+
+    if [[ ! "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.0-(beta|rc)\.([0-9]+)$ ]]; then
+        echo "ERROR: Release branch version must stay on the prerelease track: ${VERSION}" >&2
+        return 1
+    fi
+
+    local VERSION_MAJOR="${BASH_REMATCH[1]}"
+    local VERSION_MINOR="${BASH_REMATCH[2]}"
+
+    if [ "${EXPECTED_MAJOR}" != "${VERSION_MAJOR}" ] || [ "${EXPECTED_MINOR}" != "${VERSION_MINOR}" ]; then
+        echo "ERROR: Version ${VERSION} does not match release branch ${RELEASE_BRANCH}" >&2
+        return 1
+    fi
 }
 
 # Determines the previous tag for release notes comparison

--- a/ci/retarget_active_release.sh
+++ b/ci/retarget_active_release.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+# Rebuilds the unique active release branch from the latest source branch tip
+# while keeping the release branch on its existing prerelease version line.
+#
+# Usage: retarget_active_release.sh [source_branch] [tag_prefix]
+# Example: retarget_active_release.sh main
+
+SOURCE_BRANCH=${1:-main}
+TAG_PREFIX=${2:-"v"}
+
+readonly SELF_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+source "${SELF_DIR}/release_common.sh"
+
+echo "Retargeting active release branch from source branch: ${SOURCE_BRANCH}"
+
+git fetch --tags origin \
+    "refs/heads/${SOURCE_BRANCH}:refs/remotes/origin/${SOURCE_BRANCH}" \
+    "refs/heads/release/*:refs/remotes/origin/release/*"
+
+SOURCE_REF="origin/${SOURCE_BRANCH}"
+if ! git rev-parse "${SOURCE_REF}" >/dev/null 2>&1; then
+    echo "ERROR: Source branch ${SOURCE_BRANCH} does not exist on origin"
+    exit 1
+fi
+
+ACTIVE_RELEASE_BRANCH=$(find_active_release_branch origin "${TAG_PREFIX}")
+ACTIVE_RELEASE_REF="origin/${ACTIVE_RELEASE_BRANCH}"
+
+PREVIOUS_HEAD=$(git rev-parse "${ACTIVE_RELEASE_REF}")
+SOURCE_SHA=$(git rev-parse "${SOURCE_REF}")
+RELEASE_VERSION=$(get_version_from_cargo_ref "${ACTIVE_RELEASE_REF}")
+
+validate_release_branch_version "${ACTIVE_RELEASE_BRANCH}" "${RELEASE_VERSION}"
+
+echo "Active release branch: ${ACTIVE_RELEASE_BRANCH}"
+echo "Previous release head: ${PREVIOUS_HEAD}"
+echo "Source branch head: ${SOURCE_SHA}"
+echo "Retaining release version: ${RELEASE_VERSION}"
+
+git checkout --detach "${SOURCE_REF}"
+
+SOURCE_VERSION=$(get_version_from_cargo)
+echo "Source branch version: ${SOURCE_VERSION}"
+
+if [ "${SOURCE_VERSION}" != "${RELEASE_VERSION}" ]; then
+    echo "Rewriting source version ${SOURCE_VERSION} -> ${RELEASE_VERSION}"
+    bump-my-version bump -vv --new-version "${RELEASE_VERSION}" --no-tag patch
+    update_lockfiles
+else
+    echo "Source branch already uses ${RELEASE_VERSION}"
+fi
+
+if ! git diff --quiet; then
+    git add -A
+    git commit -m "chore: retarget ${ACTIVE_RELEASE_BRANCH} to ${SOURCE_BRANCH}
+
+Source: ${SOURCE_SHA}
+Release version: ${RELEASE_VERSION}"
+fi
+
+TARGET_SHA=$(git rev-parse HEAD)
+echo "Retargeted branch head: ${TARGET_SHA}"
+
+OUTPUT_FILE=${GITHUB_OUTPUT:-/dev/null}
+echo "ACTIVE_RELEASE_BRANCH=${ACTIVE_RELEASE_BRANCH}" >> "${OUTPUT_FILE}" 2>/dev/null || true
+echo "PREVIOUS_HEAD=${PREVIOUS_HEAD}" >> "${OUTPUT_FILE}" 2>/dev/null || true
+echo "SOURCE_BRANCH=${SOURCE_BRANCH}" >> "${OUTPUT_FILE}" 2>/dev/null || true
+echo "SOURCE_SHA=${SOURCE_SHA}" >> "${OUTPUT_FILE}" 2>/dev/null || true
+echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${OUTPUT_FILE}" 2>/dev/null || true
+echo "TARGET_SHA=${TARGET_SHA}" >> "${OUTPUT_FILE}" 2>/dev/null || true

--- a/ci/test_retarget_active_release.sh
+++ b/ci/test_retarget_active_release.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+set -euo pipefail
+
+readonly REPO_ROOT=$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd)
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+assert_eq() {
+    local EXPECTED=$1
+    local ACTUAL=$2
+    local MESSAGE=$3
+    if [ "${EXPECTED}" != "${ACTUAL}" ]; then
+        fail "${MESSAGE}: expected '${EXPECTED}', got '${ACTUAL}'"
+    fi
+}
+
+assert_file_contains() {
+    local PATHNAME=$1
+    local PATTERN=$2
+    if ! grep -q "${PATTERN}" "${PATHNAME}"; then
+        fail "${PATHNAME} does not contain pattern: ${PATTERN}"
+    fi
+}
+
+write_version_files() {
+    local VERSION=$1
+
+    cat > Cargo.toml <<EOF
+[workspace]
+members = ["python", "java/lance-jni"]
+
+[workspace.package]
+version = "${VERSION}"
+EOF
+
+    cat > .bumpversion.toml <<EOF
+[tool.bumpversion]
+current_version = "${VERSION}"
+parse = "(?P<major>\\\\d+)\\\\.(?P<minor>\\\\d+)\\\\.(?P<patch>\\\\d+)(-(?P<prerelease>(beta|rc))\\\\.(?P<prerelease_num>\\\\d+))?"
+serialize = [
+    "{major}.{minor}.{patch}-{prerelease}.{prerelease_num}",
+    "{major}.{minor}.{patch}"
+]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_files = false
+ignore_missing_version = false
+tag = false
+commit = false
+
+[[tool.bumpversion.files]]
+filename = "Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "python/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "java/lance-jni/Cargo.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "java/pom.xml"
+search = "<version>{current_version}</version>"
+replace = "<version>{new_version}</version>"
+EOF
+
+    mkdir -p python java/lance-jni
+    cat > python/Cargo.toml <<EOF
+[package]
+name = "python"
+version = "${VERSION}"
+EOF
+
+    cat > java/lance-jni/Cargo.toml <<EOF
+[package]
+name = "lance-jni"
+version = "${VERSION}"
+EOF
+
+    cat > java/pom.xml <<EOF
+<project>
+  <version>${VERSION}</version>
+</project>
+EOF
+}
+
+init_repo() {
+    local TARGET_DIR=$1
+    local ORIGIN_DIR=$2
+
+    mkdir -p "${TARGET_DIR}"
+    cd "${TARGET_DIR}"
+    git init -b main >/dev/null
+    git config user.name "Test User"
+    git config user.email "test@example.com"
+
+    write_version_files "5.0.0-beta.6"
+    echo "base" > feature.txt
+    git add .
+    git commit -m "base release line" >/dev/null
+    git tag -a v5.0.0-beta.6 -m "v5.0.0-beta.6" >/dev/null
+
+    git checkout -b release/v5.0 >/dev/null
+    write_version_files "5.0.0-rc.1"
+    git add .
+    git commit -m "release candidate" >/dev/null
+    git tag -a v5.0.0-rc.1 -m "v5.0.0-rc.1" >/dev/null
+
+    git checkout main >/dev/null
+    write_version_files "5.1.0-beta.3"
+    echo "main" > feature.txt
+    echo "new data" > main-only.txt
+    git add .
+    git commit -m "main diverges" >/dev/null
+
+    git init --bare "${ORIGIN_DIR}" >/dev/null
+    git remote add origin "${ORIGIN_DIR}"
+    git push origin main release/v5.0 --tags >/dev/null
+}
+
+test_retarget_preserves_release_version_and_imports_main() {
+    local TMP_DIR
+    TMP_DIR=$(mktemp -d)
+    trap 'rm -rf "${TMP_DIR}"' RETURN
+
+    init_repo "${TMP_DIR}/seed" "${TMP_DIR}/origin.git"
+
+    git clone "${TMP_DIR}/origin.git" "${TMP_DIR}/work" >/dev/null
+    cd "${TMP_DIR}/work"
+    git config user.name "Test User"
+    git config user.email "test@example.com"
+
+    LANCE_RELEASE_SKIP_LOCK_UPDATE=1 bash "${REPO_ROOT}/ci/retarget_active_release.sh" main >/dev/null
+
+    assert_eq "5.0.0-rc.1" "$(grep '^version = ' Cargo.toml | head -n1 | cut -d'"' -f2)" "root Cargo.toml version"
+    assert_file_contains ".bumpversion.toml" 'current_version = "5.0.0-rc.1"'
+    assert_file_contains "python/Cargo.toml" 'version = "5.0.0-rc.1"'
+    assert_file_contains "java/lance-jni/Cargo.toml" 'version = "5.0.0-rc.1"'
+    assert_file_contains "java/pom.xml" '<version>5.0.0-rc.1</version>'
+    assert_eq "new data" "$(cat main-only.txt)" "main-only file should be present"
+    assert_eq "main" "$(cat feature.txt)" "main content should be retained"
+    assert_eq "chore: retarget release/v5.0 to main" "$(git log -1 --format=%s)" "retarget commit subject"
+
+    local DIFF_FILES
+    DIFF_FILES=$(git diff --name-only origin/main..HEAD | sort)
+    assert_eq $'.bumpversion.toml\nCargo.toml\njava/lance-jni/Cargo.toml\njava/pom.xml\npython/Cargo.toml' "${DIFF_FILES}" "retarget diff against main"
+}
+
+test_stable_release_branch_is_not_active() {
+    local TMP_DIR
+    TMP_DIR=$(mktemp -d)
+    trap 'rm -rf "${TMP_DIR}"' RETURN
+
+    mkdir -p "${TMP_DIR}/seed"
+    cd "${TMP_DIR}/seed"
+    git init -b main >/dev/null
+    git config user.name "Test User"
+    git config user.email "test@example.com"
+
+    write_version_files "4.1.0-rc.1"
+    git add .
+    git commit -m "seed" >/dev/null
+    git checkout -b release/v4.1 >/dev/null
+    git commit --allow-empty -m "release branch" >/dev/null
+    git tag -a v4.1.0 -m "stable" >/dev/null
+    git checkout main >/dev/null
+
+    git init --bare "${TMP_DIR}/origin.git" >/dev/null
+    git remote add origin "${TMP_DIR}/origin.git"
+    git push origin main release/v4.1 --tags >/dev/null
+
+    git clone "${TMP_DIR}/origin.git" "${TMP_DIR}/work" >/dev/null
+    cd "${TMP_DIR}/work"
+    git config user.name "Test User"
+    git config user.email "test@example.com"
+
+    set +e
+    OUTPUT=$(LANCE_RELEASE_SKIP_LOCK_UPDATE=1 bash "${REPO_ROOT}/ci/retarget_active_release.sh" main 2>&1)
+    STATUS=$?
+    set -e
+
+    if [ "${STATUS}" -eq 0 ]; then
+        fail "retarget_active_release.sh should fail when no active release branch exists"
+    fi
+
+    if ! echo "${OUTPUT}" | grep -q "Expected exactly one active release branch"; then
+        fail "unexpected failure output: ${OUTPUT}"
+    fi
+}
+
+test_retarget_preserves_release_version_and_imports_main
+test_stable_release_branch_is_not_active
+
+echo "retarget_active_release.sh tests passed"

--- a/docs/src/community/release.md
+++ b/docs/src/community/release.md
@@ -28,6 +28,11 @@ All Lance projects follow [semantic versioning](https://semver.org/) spec for re
 
 Preview releases use the `-beta.X` prerelease suffix appended to the target stable version (e.g., `1.2.3-beta.1`, `1.2.3-beta.2`).
 
+Once a release branch is created for a major or minor release, that release train moves to the `-rc.X` track and should not go back to `-beta.X`.
+If the active release branch needs the latest code from `main`, maintainers should retarget the active release branch to `main` and then cut the next RC from that branch.
+Retargeting only moves the active release branch forward to the latest `main` contents while keeping the release branch on its existing prerelease version line.
+It never rewrites existing tags, and it only applies to the unique active release branch whose final `vX.Y.0` tag does not exist yet.
+
 Note that unlike major and minor version releases that are cut from the main branch,
 patch version releases should be applied on top of an existing major, minor or patch release commit.
 Patch releases should only contain critical fixes for cases such as security vulnerabilities, major correctness issues,
@@ -37,6 +42,15 @@ It is strongly discouraged to continue adding patch releases to old versions.
 
 For major version releases, it is recommended to include a migration guide for users to understand how to
 handle any breaking changes introduced in the major version.
+
+## Release Workflow
+
+The default release workflow for a major or minor release is:
+
+1. Use `create-release-branch` to create the initial release branch and `rc.1`.
+2. If more changes from `main` should be included before the stable release, use `retarget-active-release` to rebuild the active release branch from the latest `main`.
+3. Use `create-rc` to publish the next RC (`rc.2`, `rc.3`, and so on).
+4. Once the vote passes, use `approve-rc` to publish the stable release.
 
 ## Project Specific Release Process
 


### PR DESCRIPTION
This adds a dedicated workflow for retargeting the current active release branch to the latest `main` while preserving that release branch's existing prerelease version. It also documents the release-train rule that once a release branch exists, it stays on the RC track and should be refreshed through explicit retargeting instead of moving back to beta. The goal is to make "bring latest main into the pending release" an explicit, auditable action without rewriting published tags or relying on repeated cherry-picks.