### PR TITLE
fix: propagate tracing context across async boundaries to prevent orphan spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4635,6 +4635,7 @@ dependencies = [
  "chrono",
  "datafusion",
  "datafusion-common",
+ "datafusion-common-runtime",
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-substrait",
@@ -4933,6 +4934,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-mock",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ datafusion = { version = "52.1.0", default-features = false, features = [
     "unicode_expressions",
 ] }
 datafusion-common = "52.1.0"
+datafusion-common-runtime = "52.1.0"
 datafusion-functions = { version = "52.1.0", features = ["regex_expressions"] }
 datafusion-sql = "52.1.0"
 datafusion-expr = "52.1.0"

--- a/docs/src/community/project-specific/index.md
+++ b/docs/src/community/project-specific/index.md
@@ -3,3 +3,5 @@
 This section contains [contributing](../contributing.md) and [release](../release.md) guidelines from different Lance core projects.
 
 Each project maintains its own detailed guidelines that are automatically pulled from their respective repositories during the documentation build process.
+
+For Rust tracing-sensitive execution paths, see [Tracing Context Propagation](./tracing-context.md).

--- a/docs/src/community/project-specific/tracing-context.md
+++ b/docs/src/community/project-specific/tracing-context.md
@@ -1,0 +1,160 @@
+# Tracing Context Propagation
+
+Rust query execution in Lance crosses many async boundaries: boxed futures, boxed streams, `tokio::spawn`, and `spawn_blocking` tasks.
+If those boundaries do not preserve the current span, distributed tracing backends (e.g. Tempo) will show `lance-rust` work as orphan root traces instead of attaching it to the original request trace.
+
+## Architecture
+
+### TracedExec
+
+`TracedExec` (in `lance-datafusion/src/exec.rs`) is a DataFusion `ExecutionPlan` wrapper that captures the caller's tracing span at construction time and enters it during `execute()` and stream polls.
+
+Because DataFusion plan nodes are **lazy** (they build inner streams on first poll, not at plan creation), downstream span-aware calls like `boxed_stream_in_current_span()` would observe `Span::current()` as `<none>` without this wrapper.
+
+`execute_plan()` applies `TracedExec` automatically:
+
+```rust
+let traced_plan = Arc::new(TracedExec::new(plan.clone(), Span::current()));
+let stream = traced_plan.execute(0, task_ctx)?;
+```
+
+### DataFusion JoinSet Tracing
+
+`ensure_datafusion_task_tracing()` registers a `LanceJoinSetTracer` with DataFusion so that tasks spawned internally by DataFusion (e.g. in joins, aggregations) carry the current span.
+
+## Rule of Thumb
+
+Do not add new direct `.in_current_span()` calls in tracing-sensitive execution paths.
+If a helper does not already exist for the boundary you are working on, add or extend a helper in `lance-core` instead of repeating manual span capture at each call site.
+
+## Preferred Helpers
+
+Use the shared helpers from `lance_core`:
+
+| Boundary | Helper |
+|---|---|
+| `tokio::spawn(...)` | `spawn_in_current_span(...)` / `spawn_in_span(...)` |
+| Non-boxed future | `.future_in_current_span()` / `.future_in_span(...)` |
+| Boxed future | `.boxed_in_current_span()` / `.boxed_in_span(...)` |
+| Non-boxed stream | `.stream_in_current_span()` / `.stream_in_span(...)` |
+| Boxed stream | `.boxed_stream_in_current_span()` / `.boxed_stream_in_span(...)` |
+
+These are provided by the `FutureTracingExt` and `StreamTracingExt` traits in `lance_core::utils::tracing`.
+
+## Common Rewrites
+
+### Capture-then-clone in stream/closure chains
+
+`Span::current()` returns the span that is active **at the moment of the call**.
+Inside a stream `.map()` closure, the "current" span depends on whoever is **polling** the stream, which may be a completely different context from the code that created the stream.
+
+The correct pattern is to capture the span **once** before the stream chain, then clone it into each closure iteration:
+
+```rust
+let stream_span = Span::current();            // capture at creation time
+stream
+    .map(move |task| {
+        let stream_span = stream_span.clone(); // clone into each iteration
+        task.map(move |batch| transform(batch?))
+            .boxed_in_span(stream_span)        // use the captured span
+    })
+    .boxed_stream_in_current_span()
+```
+
+**Wrong** — using `_in_current_span()` inside the closure:
+
+```rust
+// BUG: Span::current() here is the *poller's* span, not the creator's
+stream
+    .map(move |task| {
+        task.map(move |batch| transform(batch?))
+            .boxed_in_current_span()
+    })
+    .boxed_stream_in_current_span()
+```
+
+The same principle applies to any `move` closure that will execute later (e.g. callbacks, `then`, `and_then`).
+As a rule: if the closure crosses an async boundary, capture the span outside and pass it in.
+
+### Spawning work
+
+Instead of:
+
+```rust
+tokio::spawn(async move {
+    do_work().await
+}.in_current_span())
+```
+
+Use:
+
+```rust
+spawn_in_current_span(async move {
+    do_work().await
+})
+```
+
+### Boxing a future
+
+Instead of:
+
+```rust
+let fut = async move {
+    load_page().await
+}
+.in_current_span()
+.boxed();
+```
+
+Use:
+
+```rust
+let fut = async move {
+    load_page().await
+}
+.boxed_in_current_span();
+```
+
+### Boxing a stream
+
+Instead of:
+
+```rust
+stream.stream_in_current_span().boxed()
+```
+
+Use:
+
+```rust
+stream.boxed_stream_in_current_span()
+```
+
+## Regression Tests
+
+The integration test suite includes orphan-span detection tests in `rust/lance/tests/query/tracing.rs`.
+These tests use a `SpanTreeRecorder` tracing layer to record all spans and assert that every span is reachable from the test root (no orphans).
+
+Covered query paths:
+
+- Multi-fragment scan
+- FTS with filter
+- Vector search (IVF-PQ index)
+- Hybrid FTS + vector reranker (`fts_rerank`)
+- All of the above on local filesystem (exercises `spawn_blocking` in `local.rs`)
+
+Run with:
+
+```bash
+cargo test -p lance --features slow_tests --test integration_tests query::tracing::
+```
+
+## Code Review Policy
+
+Tracing context rules are enforced through code review (see `.github/copilot-instructions.md`).
+When reviewing PRs that touch async execution paths, check that new code follows the patterns described above.
+
+## How to Validate End-to-End
+
+For tracing regressions beyond the in-process tests, validate with a real request and inspect the full Tempo time window around that request.
+Do not only search for a single span name.
+Success means the window contains one request root trace and `lance-rust` spans remain underneath it instead of appearing as a separate root trace.

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -3858,6 +3858,7 @@ dependencies = [
  "chrono",
  "datafusion",
  "datafusion-common",
+ "datafusion-common-runtime",
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-substrait",

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -61,7 +61,7 @@ use std::sync::{
 
 use futures::{Future, FutureExt};
 
-use crate::Result;
+use crate::{Result, utils::tracing::FutureTracingExt};
 
 pub use deepsize::{Context, DeepSizeOf};
 
@@ -338,12 +338,15 @@ impl LanceCache {
     {
         let key = build_key(&self.prefix, &cache_key.key(), K::type_name());
 
-        let typed_loader = Box::pin(async move {
-            let value = loader().await?;
-            let arc = Arc::new(value);
-            let size = cache_entry_size(&*arc);
-            Ok((arc as CacheEntry, size))
-        });
+        let typed_loader = Box::pin(
+            async move {
+                let value = loader().await?;
+                let arc = Arc::new(value);
+                let size = cache_entry_size(&*arc);
+                Ok((arc as CacheEntry, size))
+            }
+            .future_in_current_span(),
+        );
 
         let (entry, was_cached) = self
             .cache
@@ -468,12 +471,15 @@ impl WeakLanceCache {
     {
         if let Some(cache) = self.inner.upgrade() {
             let key = build_key(&self.prefix, &cache_key.key(), K::type_name());
-            let typed_loader = Box::pin(async move {
-                let value = loader().await?;
-                let arc = Arc::new(value);
-                let size = cache_entry_size(&*arc);
-                Ok((arc as CacheEntry, size))
-            });
+            let typed_loader = Box::pin(
+                async move {
+                    let value = loader().await?;
+                    let arc = Arc::new(value);
+                    let size = cache_entry_size(&*arc);
+                    Ok((arc as CacheEntry, size))
+                }
+                .future_in_current_span(),
+            );
             let (entry, was_cached) = cache.get_or_insert(&key, typed_loader, K::codec()).await?;
             if was_cached {
                 self.hits.fetch_add(1, Ordering::Relaxed);

--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use futures::{Future, FutureExt};
 use tokio::runtime::{Builder, Runtime};
-use tracing::Span;
+use tracing::{Instrument, Span};
 
 /// We cache the call to num_cpus::get() because:
 ///
@@ -124,4 +124,20 @@ pub fn spawn_cpu<
         let _ = send.send(result);
     });
     recv.map(|res| res.unwrap())
+}
+
+pub fn spawn_in_current_span<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    spawn_in_span(future, Span::current())
+}
+
+pub fn spawn_in_span<F>(future: F, span: Span) -> tokio::task::JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    tokio::spawn(future.instrument(span))
 }

--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -119,8 +119,12 @@ pub fn spawn_cpu<
     // Propagate the current span into the task
     let span = Span::current();
     global_cpu_runtime().spawn_blocking(move || {
-        let _span_guard = span.enter();
-        let result = func();
+        let result = {
+            let _span_guard = span.enter();
+            func()
+        };
+        // Exit the span BEFORE sending the result so the caller never
+        // observes the span as "still active" after receiving the value.
         let _ = send.send(result);
     });
     recv.map(|res| res.unwrap())

--- a/rust/lance-core/src/utils/tracing.rs
+++ b/rust/lance-core/src/utils/tracing.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use futures::Stream;
+use futures::{Future, FutureExt, Stream, StreamExt, future::BoxFuture, stream::BoxStream};
 use pin_project::pin_project;
-use tracing::Span;
+use tracing::{Instrument, Span};
 
 #[pin_project]
 pub struct InstrumentedStream<I: Stream> {
@@ -27,6 +27,63 @@ impl<I: Stream> Stream for InstrumentedStream<I> {
 
 // It would be nice to call the method in_current_span but sadly the Instrumented trait in
 // the tracing crate already stole the name for all Sized types
+pub trait FutureTracingExt {
+    /// All calls to poll the future will be done in the context of the current span (when this method is called)
+    fn future_in_current_span(self) -> tracing::instrument::Instrumented<Self>
+    where
+        Self: Future,
+        Self: Sized;
+
+    fn future_in_span(self, span: Span) -> tracing::instrument::Instrumented<Self>
+    where
+        Self: Future,
+        Self: Sized;
+
+    fn boxed_in_current_span(self) -> BoxFuture<'static, <Self as Future>::Output>
+    where
+        Self: Future + Send + 'static,
+        Self: Sized;
+
+    fn boxed_in_span(self, span: Span) -> BoxFuture<'static, <Self as Future>::Output>
+    where
+        Self: Future + Send + 'static,
+        Self: Sized;
+}
+
+impl<F: Future> FutureTracingExt for F {
+    fn future_in_current_span(self) -> tracing::instrument::Instrumented<Self>
+    where
+        Self: Future,
+        Self: Sized,
+    {
+        self.future_in_span(Span::current())
+    }
+
+    fn future_in_span(self, span: Span) -> tracing::instrument::Instrumented<Self>
+    where
+        Self: Future,
+        Self: Sized,
+    {
+        self.instrument(span)
+    }
+
+    fn boxed_in_current_span(self) -> BoxFuture<'static, <Self as Future>::Output>
+    where
+        Self: Future + Send + 'static,
+        Self: Sized,
+    {
+        self.boxed_in_span(Span::current())
+    }
+
+    fn boxed_in_span(self, span: Span) -> BoxFuture<'static, <Self as Future>::Output>
+    where
+        Self: Future + Send + 'static,
+        Self: Sized,
+    {
+        self.instrument(span).boxed()
+    }
+}
+
 pub trait StreamTracingExt {
     /// All calls to poll the stream will be done in the context of the current span (when this method is called)
     fn stream_in_current_span(self) -> InstrumentedStream<Self>
@@ -37,6 +94,16 @@ pub trait StreamTracingExt {
     fn stream_in_span(self, span: Span) -> InstrumentedStream<Self>
     where
         Self: Stream,
+        Self: Sized;
+
+    fn boxed_stream_in_current_span(self) -> BoxStream<'static, <Self as Stream>::Item>
+    where
+        Self: Stream + Send + 'static,
+        Self: Sized;
+
+    fn boxed_stream_in_span(self, span: Span) -> BoxStream<'static, <Self as Stream>::Item>
+    where
+        Self: Stream + Send + 'static,
         Self: Sized;
 }
 
@@ -55,6 +122,22 @@ impl<S: Stream> StreamTracingExt for S {
         Self: Sized,
     {
         InstrumentedStream { stream: self, span }
+    }
+
+    fn boxed_stream_in_current_span(self) -> BoxStream<'static, <Self as Stream>::Item>
+    where
+        Self: Stream + Send + 'static,
+        Self: Sized,
+    {
+        self.boxed_stream_in_span(Span::current())
+    }
+
+    fn boxed_stream_in_span(self, span: Span) -> BoxStream<'static, <Self as Stream>::Item>
+    where
+        Self: Stream + Send + 'static,
+        Self: Sized,
+    {
+        self.stream_in_span(span).boxed()
     }
 }
 

--- a/rust/lance-datafusion/Cargo.toml
+++ b/rust/lance-datafusion/Cargo.toml
@@ -19,6 +19,7 @@ arrow-schema.workspace = true
 arrow-select.workspace = true
 async-trait.workspace = true
 datafusion-common.workspace = true
+datafusion-common-runtime.workspace = true
 datafusion-functions.workspace = true
 datafusion-physical-expr.workspace = true
 datafusion-substrait = {workspace = true, optional = true}

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -4,6 +4,7 @@
 //! Utilities for working with datafusion execution plans
 
 use std::{
+    any::Any,
     collections::HashMap,
     fmt::{self, Formatter},
     sync::{Arc, Mutex, OnceLock},
@@ -36,9 +37,10 @@ use datafusion::{
     },
 };
 use datafusion_common::{DataFusionError, Statistics};
+use datafusion_common_runtime::{JoinSetTracer, set_join_set_tracer};
 use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 
-use futures::{StreamExt, stream};
+use futures::{FutureExt, StreamExt, future::BoxFuture, stream};
 use lance_arrow::SchemaExt;
 use lance_core::{
     Error, Result,
@@ -48,7 +50,7 @@ use lance_core::{
     },
 };
 use log::{debug, info, warn};
-use tracing::Span;
+use tracing::{Instrument, Span};
 
 use crate::udf::register_functions;
 use crate::{
@@ -58,6 +60,37 @@ use crate::{
         MetricsExt, PARTS_LOADED_METRIC, REQUESTS_METRIC,
     },
 };
+
+static DATAFUSION_JOIN_SET_TRACER: LanceJoinSetTracer = LanceJoinSetTracer;
+static DATAFUSION_JOIN_SET_TRACER_INIT: OnceLock<()> = OnceLock::new();
+
+struct LanceJoinSetTracer;
+
+impl JoinSetTracer for LanceJoinSetTracer {
+    fn trace_future(
+        &self,
+        fut: BoxFuture<'static, Box<dyn Any + Send>>,
+    ) -> BoxFuture<'static, Box<dyn Any + Send>> {
+        fut.instrument(Span::current()).boxed()
+    }
+
+    fn trace_block(
+        &self,
+        f: Box<dyn FnOnce() -> Box<dyn Any + Send> + Send>,
+    ) -> Box<dyn FnOnce() -> Box<dyn Any + Send> + Send> {
+        let span = Span::current();
+        Box::new(move || {
+            let _guard = span.enter();
+            f()
+        })
+    }
+}
+
+fn ensure_datafusion_task_tracing() {
+    DATAFUSION_JOIN_SET_TRACER_INIT.get_or_init(|| {
+        let _ = set_join_set_tracer(&DATAFUSION_JOIN_SET_TRACER);
+    });
+}
 
 /// An source execution node created from an existing stream
 ///
@@ -598,6 +631,8 @@ pub fn execute_plan(
     plan: Arc<dyn ExecutionPlan>,
     options: LanceExecutionOptions,
 ) -> Result<SendableRecordBatchStream> {
+    ensure_datafusion_task_tracing();
+
     if !options.skip_logging {
         debug!(
             "Executing plan:\n{}",
@@ -605,12 +640,19 @@ pub fn execute_plan(
         );
     }
 
+    // Keep the entire execution plan stream under the caller's current span.
+    // Without this wrapper, lazy plan nodes like FilteredReadExec only build
+    // their inner streams on first poll, after execute_with_options() has
+    // already returned to the caller. In multi-threaded runtimes that means
+    // downstream spawn_in_current_span()/boxed_in_current_span() sites can
+    // observe <none> and emit detached spans.
+    let traced_plan = Arc::new(TracedExec::new(plan.clone(), Span::current()));
     let session_ctx = get_session_context(&options);
 
     // NOTE: we are only executing the first partition here. Therefore, if
     // the plan has more than one partition, we will be missing data.
-    assert_eq!(plan.properties().partitioning.partition_count(), 1);
-    let stream = plan.execute(0, get_task_context(&session_ctx, &options))?;
+    assert_eq!(traced_plan.properties().partitioning.partition_count(), 1);
+    let stream = traced_plan.execute(0, get_task_context(&session_ctx, &options))?;
 
     let schema = stream.schema();
     let stream = stream.finally(move || {
@@ -625,6 +667,8 @@ pub async fn analyze_plan(
     plan: Arc<dyn ExecutionPlan>,
     options: LanceExecutionOptions,
 ) -> Result<String> {
+    ensure_datafusion_task_tracing();
+
     // This is needed as AnalyzeExec launches a thread task per
     // partition, and we want these to be connected to the parent span
     let plan = Arc::new(TracedExec::new(plan, Span::current()));

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -1119,9 +1119,8 @@ mod tests {
     #[test]
     fn test_traced_exec_display_and_debug() {
         let schema = Arc::new(ArrowSchema::empty());
-        let input: Arc<dyn ExecutionPlan> = Arc::new(OneShotExec::from_batch(
-            RecordBatch::new_empty(schema),
-        ));
+        let input: Arc<dyn ExecutionPlan> =
+            Arc::new(OneShotExec::from_batch(RecordBatch::new_empty(schema)));
         let traced = TracedExec::new(input, Span::current());
 
         // Debug
@@ -1150,9 +1149,8 @@ mod tests {
         let input1: Arc<dyn ExecutionPlan> = Arc::new(OneShotExec::from_batch(
             RecordBatch::new_empty(schema.clone()),
         ));
-        let input2: Arc<dyn ExecutionPlan> = Arc::new(OneShotExec::from_batch(
-            RecordBatch::new_empty(schema),
-        ));
+        let input2: Arc<dyn ExecutionPlan> =
+            Arc::new(OneShotExec::from_batch(RecordBatch::new_empty(schema)));
 
         let traced = Arc::new(TracedExec::new(input1, Span::current()));
         let new_traced = traced.with_new_children(vec![input2]).unwrap();

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -1095,4 +1095,69 @@ mod tests {
             );
         }
     }
+
+    #[tokio::test]
+    async fn test_join_set_tracer_trace_future() {
+        let tracer = LanceJoinSetTracer;
+        let fut: BoxFuture<'static, Box<dyn Any + Send>> =
+            (async { Box::new(42i32) as Box<dyn Any + Send> }).boxed();
+        let traced_fut = tracer.trace_future(fut);
+        let result = traced_fut.await;
+        assert_eq!(*result.downcast::<i32>().unwrap(), 42);
+    }
+
+    #[test]
+    fn test_join_set_tracer_trace_block() {
+        let tracer = LanceJoinSetTracer;
+        let f: Box<dyn FnOnce() -> Box<dyn Any + Send> + Send> =
+            Box::new(|| Box::new(42i32) as Box<dyn Any + Send>);
+        let traced_f = tracer.trace_block(f);
+        let result = traced_f();
+        assert_eq!(*result.downcast::<i32>().unwrap(), 42);
+    }
+
+    #[test]
+    fn test_traced_exec_display_and_debug() {
+        let schema = Arc::new(ArrowSchema::empty());
+        let input: Arc<dyn ExecutionPlan> = Arc::new(OneShotExec::from_batch(
+            RecordBatch::new_empty(schema),
+        ));
+        let traced = TracedExec::new(input, Span::current());
+
+        // Debug
+        assert_eq!(format!("{:?}", traced), "TracedExec");
+
+        // DisplayAs (all variants should produce "TracedExec")
+        struct Wrapper<'a>(&'a TracedExec, DisplayFormatType);
+        impl<'a> std::fmt::Display for Wrapper<'a> {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                self.0.fmt_as(self.1, f)
+            }
+        }
+        assert_eq!(
+            format!("{}", Wrapper(&traced, DisplayFormatType::Default)),
+            "TracedExec"
+        );
+        assert_eq!(
+            format!("{}", Wrapper(&traced, DisplayFormatType::Verbose)),
+            "TracedExec"
+        );
+    }
+
+    #[test]
+    fn test_traced_exec_with_new_children() {
+        let schema = Arc::new(ArrowSchema::empty());
+        let input1: Arc<dyn ExecutionPlan> = Arc::new(OneShotExec::from_batch(
+            RecordBatch::new_empty(schema.clone()),
+        ));
+        let input2: Arc<dyn ExecutionPlan> = Arc::new(OneShotExec::from_batch(
+            RecordBatch::new_empty(schema),
+        ));
+
+        let traced = Arc::new(TracedExec::new(input1, Span::current()));
+        let new_traced = traced.with_new_children(vec![input2]).unwrap();
+
+        assert_eq!(new_traced.name(), "TracedExec");
+        assert_eq!(new_traced.children().len(), 1);
+    }
 }

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -223,19 +223,21 @@ use arrow_schema::{ArrowError, DataType, Field as ArrowField, Fields, Schema as 
 use bytes::Bytes;
 use futures::future::{BoxFuture, MaybeDone, maybe_done};
 use futures::stream::{self, BoxStream};
-use futures::{FutureExt, StreamExt};
+use futures::{Future, FutureExt, StreamExt};
 use lance_arrow::DataTypeExt;
 use lance_core::cache::LanceCache;
 use lance_core::datatypes::{BLOB_DESC_LANCE_FIELD, Field, Schema};
 use lance_core::utils::futures::{FinallyStreamExt, StreamOnDropExt};
 use lance_core::utils::parse::parse_env_as_bool;
+use lance_core::utils::tokio::{spawn_in_current_span, spawn_in_span};
+use lance_core::utils::tracing::{FutureTracingExt, StreamTracingExt};
 use log::{debug, trace, warn};
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{self, unbounded_channel};
 
 use lance_core::error::LanceOptionExt;
 use lance_core::{ArrowResult, Error, Result};
-use tracing::instrument;
+use tracing::{Span, instrument};
 
 use crate::compression::{DecompressionStrategy, DefaultDecompressionStrategy};
 use crate::data::DataBlock;
@@ -1333,9 +1335,32 @@ impl DecodeBatchScheduler {
     }
 }
 
+pub type ReadBatchFut = BoxFuture<'static, Result<RecordBatch>>;
+pub type ReadBatchTaskStream = BoxStream<'static, ReadBatchTask>;
+pub type ReadBatchFutStream = BoxStream<'static, ReadBatchFut>;
+
 pub struct ReadBatchTask {
-    pub task: BoxFuture<'static, Result<RecordBatch>>,
+    pub task: ReadBatchFut,
     pub num_rows: u32,
+}
+
+impl ReadBatchTask {
+    pub fn from_future<F>(task: F, num_rows: u32) -> Self
+    where
+        F: Future<Output = Result<RecordBatch>> + Send + 'static,
+    {
+        Self::from_future_in_span(task, num_rows, Span::current())
+    }
+
+    pub fn from_future_in_span<F>(task: F, num_rows: u32, span: Span) -> Self
+    where
+        F: Future<Output = Result<RecordBatch>> + Send + 'static,
+    {
+        Self {
+            task: task.boxed_in_span(span),
+            num_rows,
+        }
+    }
 }
 
 /// A stream that takes scheduled jobs and generates decode tasks from them.
@@ -1463,37 +1488,45 @@ impl BatchDecodeStream {
     }
 
     pub fn into_stream(self) -> BoxStream<'static, ReadBatchTask> {
-        let stream = futures::stream::unfold(self, |mut slf| async move {
-            let next_task = slf.next_batch_task().await;
-            let next_task = next_task.transpose().map(|next_task| {
-                let num_rows = next_task.as_ref().map(|t| t.num_rows).unwrap_or(0);
-                let emitted_batch_size_warning = slf.emitted_batch_size_warning.clone();
-                let task = async move {
-                    let next_task = next_task?;
-                    // Real decode work happens inside into_batch, which can block the current
-                    // thread for a long time. By spawning it as a new task, we allow Tokio's
-                    // worker threads to keep making progress.
-                    let (batch, _data_size) =
-                        tokio::spawn(
+        let stream_span = Span::current();
+        let stream = futures::stream::unfold(self, move |mut slf| {
+            let future_span = stream_span.clone();
+            let task_stream_span = stream_span.clone();
+            async move {
+                let next_task = slf.next_batch_task().await;
+                let next_task = next_task.transpose().map(|next_task| {
+                    let num_rows = next_task.as_ref().map(|t| t.num_rows).unwrap_or(0);
+                    let emitted_batch_size_warning = slf.emitted_batch_size_warning.clone();
+                    let task_span = task_stream_span.clone();
+                    let task = async move {
+                        let next_task = next_task?;
+                        // Real decode work happens inside into_batch, which can block the current
+                        // thread for a long time. By spawning it as a new task, we allow Tokio's
+                        // worker threads to keep making progress.
+                        let (batch, _data_size) = spawn_in_span(
                             async move { next_task.into_batch(emitted_batch_size_warning) },
+                            task_span,
                         )
                         .await
                         .map_err(|err| Error::wrapped(err.into()))??;
-                    Ok(batch)
-                };
-                (task, num_rows)
-            });
-            next_task.map(|(task, num_rows)| {
-                // This should be true since batch size is u32
-                debug_assert!(num_rows <= u32::MAX as u64);
-                let next_task = ReadBatchTask {
-                    task: task.boxed(),
-                    num_rows: num_rows as u32,
-                };
-                (next_task, slf)
-            })
+                        Ok(batch)
+                    };
+                    (task, num_rows)
+                });
+                next_task.map(|(task, num_rows)| {
+                    // This should be true since batch size is u32
+                    debug_assert!(num_rows <= u32::MAX as u64);
+                    let next_task = ReadBatchTask::from_future_in_span(
+                        task,
+                        num_rows as u32,
+                        task_stream_span.clone(),
+                    );
+                    (next_task, slf)
+                })
+            }
+            .boxed_in_span(future_span)
         });
-        stream.boxed()
+        stream.boxed_stream_in_current_span()
     }
 }
 
@@ -1547,6 +1580,7 @@ struct BatchDecodeIterator<T: RootDecoderType> {
     rows_scheduled: u64,
     rows_drained: u64,
     emitted_batch_size_warning: Arc<Once>,
+    span: Span,
     // Note: this is not the runtime on which I/O happens.
     // That's always in the scheduler.  This is just a runtime we use to
     // sleep the current thread if I/O is unready
@@ -1574,6 +1608,7 @@ impl<T: RootDecoderType> BatchDecodeIterator<T> {
                 .build()
                 .unwrap(),
             emitted_batch_size_warning: Arc::new(Once::new()),
+            span: Span::current(),
             schema,
         }
     }
@@ -1675,6 +1710,8 @@ impl<T: RootDecoderType> Iterator for BatchDecodeIterator<T> {
     type Item = ArrowResult<RecordBatch>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let span = self.span.clone();
+        let _guard = span.enter();
         self.next_batch_task()
             .transpose()
             .map(|r| r.map_err(ArrowError::from))
@@ -1868,57 +1905,66 @@ impl StructuralBatchDecodeStream {
     }
 
     pub fn into_stream(self) -> BoxStream<'static, ReadBatchTask> {
-        let stream = futures::stream::unfold(self, |mut slf| async move {
-            let next_task = slf.next_batch_task().await;
-            let next_task = next_task.transpose().map(|next_task| {
-                let num_rows = next_task.as_ref().map(|t| t.num_rows).unwrap_or(0);
-                let emitted_batch_size_warning = slf.emitted_batch_size_warning.clone();
-                let bytes_per_row_feedback = slf.bytes_per_row_feedback.clone();
-                // Capture the per-stream policy once so every emitted batch task follows the
-                // same throughput-vs-overhead choice made by the scheduler.
-                let spawn_batch_decode_tasks = slf.spawn_batch_decode_tasks;
-                let task = async move {
-                    let next_task = next_task?;
-                    let (batch, data_size) = if spawn_batch_decode_tasks {
-                        tokio::spawn(
-                            async move { next_task.into_batch(emitted_batch_size_warning) },
-                        )
-                        .await
-                        .map_err(|err| Error::wrapped(err.into()))??
-                    } else {
-                        next_task.into_batch(emitted_batch_size_warning)?
-                    };
-                    let num_rows = batch.num_rows() as u64;
-                    if num_rows > 0 {
-                        let bpr = data_size / num_rows;
-                        let prev = bytes_per_row_feedback.load(Ordering::Relaxed);
-                        let next = if prev == 0 || bpr >= prev {
-                            // First batch or actual size is larger than estimate:
-                            // adopt immediately to avoid OOM.
-                            bpr
+        let stream_span = Span::current();
+        let stream = futures::stream::unfold(self, move |mut slf| {
+            let future_span = stream_span.clone();
+            let task_stream_span = stream_span.clone();
+            async move {
+                let next_task = slf.next_batch_task().await;
+                let next_task = next_task.transpose().map(|next_task| {
+                    let num_rows = next_task.as_ref().map(|t| t.num_rows).unwrap_or(0);
+                    let emitted_batch_size_warning = slf.emitted_batch_size_warning.clone();
+                    let bytes_per_row_feedback = slf.bytes_per_row_feedback.clone();
+                    // Capture the per-stream policy once so every emitted batch task follows the
+                    // same throughput-vs-overhead choice made by the scheduler.
+                    let spawn_batch_decode_tasks = slf.spawn_batch_decode_tasks;
+                    let task_span = task_stream_span.clone();
+                    let task = async move {
+                        let next_task = next_task?;
+                        let (batch, data_size) = if spawn_batch_decode_tasks {
+                            spawn_in_span(
+                                async move { next_task.into_batch(emitted_batch_size_warning) },
+                                task_span.clone(),
+                            )
+                            .await
+                            .map_err(|err| Error::wrapped(err.into()))??
                         } else {
-                            // Actual size is smaller: degrade gradually toward
-                            // the true value to avoid over-correcting on a
-                            // single anomalous batch.
-                            (prev + bpr) / 2
+                            next_task.into_batch(emitted_batch_size_warning)?
                         };
-                        bytes_per_row_feedback.store(next.max(1), Ordering::Relaxed);
-                    }
-                    Ok(batch)
-                };
-                (task, num_rows)
-            });
-            next_task.map(|(task, num_rows)| {
-                // This should be true since batch size is u32
-                debug_assert!(num_rows <= u32::MAX as u64);
-                let next_task = ReadBatchTask {
-                    task: task.boxed(),
-                    num_rows: num_rows as u32,
-                };
-                (next_task, slf)
-            })
+                        let num_rows = batch.num_rows() as u64;
+                        if num_rows > 0 {
+                            let bpr = data_size / num_rows;
+                            let prev = bytes_per_row_feedback.load(Ordering::Relaxed);
+                            let next = if prev == 0 || bpr >= prev {
+                                // First batch or actual size is larger than estimate:
+                                // adopt immediately to avoid OOM.
+                                bpr
+                            } else {
+                                // Actual size is smaller: degrade gradually toward
+                                // the true value to avoid over-correcting on a
+                                // single anomalous batch.
+                                (prev + bpr) / 2
+                            };
+                            bytes_per_row_feedback.store(next.max(1), Ordering::Relaxed);
+                        }
+                        Ok(batch)
+                    };
+                    (task, num_rows)
+                });
+                next_task.map(|(task, num_rows)| {
+                    // This should be true since batch size is u32
+                    debug_assert!(num_rows <= u32::MAX as u64);
+                    let next_task = ReadBatchTask::from_future_in_span(
+                        task,
+                        num_rows as u32,
+                        task_stream_span.clone(),
+                    );
+                    (next_task, slf)
+                })
+            }
+            .boxed_in_span(future_span)
         });
-        stream.boxed()
+        stream.boxed_stream_in_current_span()
     }
 }
 
@@ -2012,7 +2058,7 @@ fn check_scheduler_on_drop(
             // ScanScheduler to drop and cancel pending I/O.
             abort_handle.abort();
         })
-        .boxed()
+        .boxed_stream_in_current_span()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2120,7 +2166,7 @@ fn create_scheduler_decoder(
         config.batch_size_bytes,
     )?;
 
-    let scheduler_handle = tokio::task::spawn(async move {
+    let scheduler_handle = spawn_in_current_span(async move {
         let mut decode_scheduler = match DecodeBatchScheduler::try_new(
             target_schema.as_ref(),
             &column_indices,
@@ -2169,7 +2215,7 @@ pub fn schedule_and_decode(
     config: SchedulerDecoderConfig,
 ) -> BoxStream<'static, ReadBatchTask> {
     if requested_rows.num_rows() == 0 {
-        return stream::empty().boxed();
+        return stream::empty().boxed_stream_in_current_span();
     }
 
     // If the user requested any ranges that are empty, ignore them.  They are pointless and
@@ -2191,13 +2237,15 @@ pub fn schedule_and_decode(
     ) {
         // Keep the io alive until the stream is dropped or finishes.  Otherwise the
         // I/O drops as soon as the scheduling is finished and the I/O loop terminates.
-        Ok(stream) => stream.finally(move || drop(io)).boxed(),
+        Ok(stream) => stream
+            .finally(move || drop(io))
+            .boxed_stream_in_current_span(),
         // If the initialization failed make it look like a failed task
-        Err(e) => stream::once(std::future::ready(ReadBatchTask {
-            num_rows: 0,
-            task: std::future::ready(Err(e)).boxed(),
-        }))
-        .boxed(),
+        Err(e) => stream::once(std::future::ready(ReadBatchTask::from_future(
+            std::future::ready(Err(e)),
+            0,
+        )))
+        .boxed_stream_in_current_span(),
     }
 }
 

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -34,7 +34,7 @@ use lance_arrow::deepcopy::deep_copy_nulls;
 use lance_core::{
     cache::{CacheKey, Context, DeepSizeOf},
     error::{Error, LanceOptionExt},
-    utils::bit::pad_bytes,
+    utils::{bit::pad_bytes, tracing::FutureTracingExt},
 };
 use log::trace;
 
@@ -1940,7 +1940,7 @@ impl StructuralPageScheduler for MiniBlockScheduler {
                 has_large_chunk,
             }) as Box<dyn StructuralPageDecoder>)
         }
-        .boxed();
+        .boxed_in_current_span();
         let page_load_task = PageLoadTask {
             decoder_fut: res,
             num_rows,
@@ -2178,7 +2178,7 @@ impl FullZipScheduler {
                 .collect::<VecDeque<_>>();
             Self::create_decoder(details, data, num_rows, bits_per_offset)
         }
-        .boxed();
+        .boxed_in_current_span();
         PageLoadTask {
             decoder_fut: load_task,
             num_rows,
@@ -2320,7 +2320,7 @@ impl FullZipScheduler {
                 let data = source.fetch(&read_ranges, priority).await?;
                 Self::create_decoder(details, data, num_rows, bits_per_offset)
             }
-            .boxed();
+            .boxed_in_current_span();
             let page_load_task = PageLoadTask {
                 decoder_fut: load_task,
                 num_rows,
@@ -2361,7 +2361,7 @@ impl FullZipScheduler {
             let data = source.fetch(&byte_ranges, priority).await?;
             Self::create_decoder(details, data, num_rows, bits_per_offset)
         }
-        .boxed();
+        .boxed_in_current_span();
         let page_load_task = PageLoadTask {
             decoder_fut: load_task,
             num_rows,
@@ -3192,7 +3192,7 @@ impl StructuralSchedulingJob for StructuralPrimitiveFieldSchedulingJob<'_> {
                         path: cur_path,
                     })
                 }
-                .boxed();
+                .boxed_in_current_span();
                 Ok(ScheduledScanLine {
                     decoders: vec![MessageType::UnloadedPage(UnloadedPageShard(unloaded_page))],
                     rows_scheduled: page_load_task.num_rows,

--- a/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
@@ -14,6 +14,7 @@ use futures::{FutureExt, future::BoxFuture};
 
 use lance_core::{
     Error, Result, cache::DeepSizeOf, datatypes::BLOB_DESC_TYPE, error::LanceOptionExt,
+    utils::tracing::FutureTracingExt,
 };
 
 use crate::{
@@ -60,7 +61,7 @@ impl BlobDescriptionPageScheduler {
                     as Box<dyn StructuralPageDecoder>,
             )
         }
-        .boxed()
+        .boxed_in_current_span()
     }
 }
 
@@ -266,7 +267,7 @@ impl BlobPageScheduler {
             Ok(Box::new(BlobPageDecoder::new(loaded_blobs, def_meaning))
                 as Box<dyn StructuralPageDecoder>)
         }
-        .boxed();
+        .boxed_in_current_span();
         Ok(PageLoadTask {
             decoder_fut,
             num_rows,

--- a/rust/lance-encoding/src/previous/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/list.rs
@@ -12,7 +12,7 @@ use arrow_array::{
 use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, Buffer, NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field, Fields};
 use futures::{FutureExt, future::BoxFuture};
-use lance_core::{Error, Result, cache::LanceCache};
+use lance_core::{Error, Result, cache::LanceCache, utils::tokio::spawn_in_current_span};
 use log::trace;
 use tokio::task::JoinHandle;
 
@@ -458,7 +458,7 @@ impl SchedulingJob for ListFieldSchedulingJob<'_> {
         let cache = context.cache().clone();
 
         // Immediately spawn the indirect scheduling
-        let indirect_fut = tokio::spawn(indirect_schedule_task(
+        let indirect_fut = spawn_in_current_span(indirect_schedule_task(
             next_offsets_decoder,
             list_reqs,
             null_offset_adjustment,

--- a/rust/lance-encoding/src/previous/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/binary.rs
@@ -30,7 +30,10 @@ use crate::{
 
 use arrow_array::{PrimitiveArray, UInt64Array};
 use arrow_schema::DataType;
-use lance_core::Result;
+use lance_core::{
+    Result,
+    utils::{tokio::spawn_in_current_span, tracing::FutureTracingExt},
+};
 
 struct IndicesNormalizer {
     indices: Vec<u64>,
@@ -168,7 +171,7 @@ impl PageScheduler for BinaryPageScheduler {
         let null_adjustment = self.null_adjustment;
         let offsets_type = self.offsets_type.clone();
 
-        tokio::spawn(async move {
+        spawn_in_current_span(async move {
             // For the following data:
             // "abcd", "hello", "abcd", "apple", "hello", "abcd"
             //   4,        9,     13,      18,      23,     27
@@ -251,7 +254,7 @@ impl PageScheduler for BinaryPageScheduler {
                 }) as Box<dyn PrimitivePageDecoder>)
             }
         })
-        .boxed()
+        .boxed_in_current_span()
     }
 }
 

--- a/rust/lance-encoding/src/previous/encodings/physical/dictionary.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/dictionary.rs
@@ -13,7 +13,10 @@ use arrow_array::{
 use arrow_schema::DataType;
 use futures::{FutureExt, future::BoxFuture};
 use lance_arrow::DataTypeExt;
-use lance_core::{Error, Result};
+use lance_core::{
+    Error, Result,
+    utils::{tokio::spawn_in_current_span, tracing::FutureTracingExt},
+};
 use std::collections::HashMap;
 
 use crate::buffer::LanceBuffer;
@@ -87,7 +90,7 @@ impl PageScheduler for DictionaryPageScheduler {
         let copy_size = self.num_dictionary_items as u64;
 
         if self.should_decode_dict {
-            tokio::spawn(async move {
+            spawn_in_current_span(async move {
                 let items_decoder: Arc<dyn PrimitivePageDecoder> =
                     Arc::from(items_page_decoder.await?);
 
@@ -111,10 +114,10 @@ impl PageScheduler for DictionaryPageScheduler {
                 }) as Box<dyn PrimitivePageDecoder>)
             })
             .map(|join_handle| join_handle.unwrap())
-            .boxed()
+            .boxed_in_current_span()
         } else {
             let num_dictionary_items = self.num_dictionary_items;
-            tokio::spawn(async move {
+            spawn_in_current_span(async move {
                 let items_decoder: Arc<dyn PrimitivePageDecoder> =
                     Arc::from(items_page_decoder.await?);
 
@@ -130,7 +133,7 @@ impl PageScheduler for DictionaryPageScheduler {
                 }) as Box<dyn PrimitivePageDecoder>)
             })
             .map(|join_handle| join_handle.unwrap())
-            .boxed()
+            .boxed_in_current_span()
         }
     }
 }

--- a/rust/lance-encoding/src/previous/encodings/physical/packed_struct.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/packed_struct.rs
@@ -8,7 +8,10 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use futures::{FutureExt, future::BoxFuture};
 use lance_arrow::DataTypeExt;
-use lance_core::{Error, Result};
+use lance_core::{
+    Error, Result,
+    utils::{tokio::spawn_in_current_span, tracing::FutureTracingExt},
+};
 
 use crate::data::BlockInfo;
 use crate::data::FixedSizeListBlock;
@@ -81,7 +84,7 @@ impl PageScheduler for PackedStructPageScheduler {
 
         let copy_struct_fields = self.fields.clone();
 
-        tokio::spawn(async move {
+        spawn_in_current_span(async move {
             let bytes = bytes.await?;
 
             let mut combined_bytes = BytesMut::default();
@@ -96,7 +99,7 @@ impl PageScheduler for PackedStructPageScheduler {
             }) as Box<dyn PrimitivePageDecoder>)
         })
         .map(|join_handle| join_handle.unwrap())
-        .boxed()
+        .boxed_in_current_span()
     }
 }
 

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -19,8 +19,7 @@ use lance_encoding::{
     EncodingsIo,
     decoder::{
         ColumnInfo, DecoderConfig, DecoderPlugins, FilterExpression, PageEncoding, PageInfo,
-        ReadBatchTask, RequestedRows, SchedulerDecoderConfig, schedule_and_decode,
-        schedule_and_decode_blocking,
+        RequestedRows, SchedulerDecoderConfig, schedule_and_decode, schedule_and_decode_blocking,
     },
     encoder::EncodedBatch,
     version::LanceFileVersion,
@@ -33,6 +32,7 @@ use lance_core::{
     Error, Result,
     cache::LanceCache,
     datatypes::{Field, Schema},
+    utils::tracing::StreamTracingExt,
 };
 use lance_encoding::format::pb as pbenc;
 use lance_encoding::format::pb21 as pbenc21;
@@ -47,6 +47,10 @@ use crate::{
     format::{MAGIC, MAJOR_VERSION, MINOR_VERSION, pb, pbfile},
     io::LanceEncodingsIo,
     writer::PAGE_BUFFER_ALIGNMENT,
+};
+
+pub use lance_encoding::decoder::{
+    ReadBatchFut, ReadBatchFutStream, ReadBatchTask, ReadBatchTaskStream,
 };
 
 /// Default chunk size for reading large pages (8MiB)
@@ -1222,7 +1226,7 @@ impl FileReader {
         let batch_stream = tasks_stream
             .map(|task| task.task)
             .buffered(batch_readahead as usize)
-            .boxed();
+            .boxed_stream_in_current_span();
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             arrow_schema,
             batch_stream,

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -61,6 +61,7 @@ mockall.workspace = true
 rstest.workspace = true
 mock_instant.workspace = true
 tracing-mock = { workspace = true }
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof.workspace = true

--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -17,7 +17,7 @@ use futures::{
     future::{BoxFuture, Shared},
     stream::{self, StreamExt},
 };
-use lance_core::{Error, Result, error::CloneableError};
+use lance_core::{Error, Result, error::CloneableError, utils::tracing::FutureTracingExt};
 use object_store::{GetOptions, GetResult, ObjectStore, Result as OSResult, path::Path};
 use tokio::sync::OnceCell;
 use tracing::instrument;
@@ -305,7 +305,7 @@ impl SmallReader {
     ) -> Self {
         let path_ref = path.clone();
         let state = SmallReaderState::Loading(
-            Box::pin(async move {
+            async move {
                 let object_reader =
                     CloudObjectReader::new(store, path_ref, 0, None, download_retry_count)
                         .map_err(CloneableError)?;
@@ -313,8 +313,8 @@ impl SmallReader {
                     .get_all()
                     .await
                     .map_err(|err| CloneableError(Error::from(err)))
-            })
-            .boxed()
+            }
+            .boxed_in_current_span()
             .shared(),
         );
         Self {

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -15,8 +15,12 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::Notify;
 
-use lance_core::utils::parse::str_is_truthy;
+use lance_core::utils::{
+    parse::str_is_truthy,
+    tokio::{spawn_in_current_span, spawn_in_span},
+};
 use lance_core::{Error, Result};
+use tracing::Span;
 
 use crate::object_store::ObjectStore;
 use crate::traits::Reader;
@@ -329,6 +333,7 @@ struct IoTask {
     to_read: Range<u64>,
     when_done: Box<dyn FnOnce(Result<Bytes>) + Send>,
     priority: u128,
+    span: Span,
 }
 
 impl Eq for IoTask {}
@@ -402,7 +407,10 @@ async fn run_io_loop(tasks: Arc<IoQueue>) {
         let next_task = tasks.pop().await;
         match next_task {
             Some(task) => {
-                tokio::spawn(task.run());
+                // The I/O loop itself may outlive any one query span, so each task needs to
+                // carry the span that was current when it was submitted.
+                let span = task.span.clone();
+                spawn_in_span(task.run(), span);
             }
             None => {
                 // The sender has been dropped, we are done
@@ -573,7 +581,7 @@ impl ScanScheduler {
             // Best we can do here is fire and forget.  If the I/O loop is still running when the scheduler is
             // dropped we can't wait for it to finish or we'd block a tokio thread.  We could spawn a blocking task
             // to wait for it to finish but that doesn't seem helpful.
-            tokio::task::spawn(async move { run_io_loop(io_queue_clone).await });
+            spawn_in_current_span(async move { run_io_loop(io_queue_clone).await });
             IoQueueType::Standard(io_queue)
         };
         Arc::new(Self {
@@ -653,6 +661,7 @@ impl ScanScheduler {
             priority,
             request.len(),
         ))));
+        let request_span = Span::current();
 
         for (task_idx, iop) in request.into_iter().enumerate() {
             let dest = dest.clone();
@@ -662,6 +671,7 @@ impl ScanScheduler {
                 reader: reader.clone(),
                 to_read: iop,
                 priority,
+                span: request_span.clone(),
                 when_done: Box::new(move |data| {
                     io_queue_clone.on_iop_complete();
                     let mut dest = dest.lock().unwrap();
@@ -957,6 +967,8 @@ mod tests {
 
     use object_store::{GetRange, ObjectStore as OSObjectStore, memory::InMemory};
     use tokio::{runtime::Handle, time::timeout};
+    use tracing::Instrument;
+    use tracing_subscriber::registry;
     use url::Url;
 
     use crate::{
@@ -1184,6 +1196,64 @@ mod tests {
         // Finally, the low priority request
         semaphore_copy.add_permits(1);
         assert!(second_fut.await.unwrap().unwrap().len() == 20);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_standard_scheduler_uses_submit_span_for_io_tasks() {
+        let some_path = Path::parse("foo").unwrap();
+        let base_store = Arc::new(InMemory::new());
+        base_store
+            .put(&some_path, vec![0; 1000].into())
+            .await
+            .unwrap();
+
+        let seen_spans = Arc::new(Mutex::new(Vec::new()));
+        let mut obj_store = MockObjectStore::default();
+        let seen_spans_copy = seen_spans.clone();
+        obj_store
+            .expect_get_opts()
+            .returning(move |location, options| {
+                let current_span = tracing::Span::current()
+                    .metadata()
+                    .map(|metadata| metadata.name().to_string())
+                    .unwrap_or_else(|| "<none>".to_string());
+                seen_spans_copy.lock().unwrap().push(current_span);
+
+                let base_store = base_store.clone();
+                let location = location.clone();
+                async move { base_store.get_opts(&location, options).await }.boxed()
+            });
+        let obj_store = Arc::new(ObjectStore::new(
+            Arc::new(obj_store),
+            Url::parse("mem://").unwrap(),
+            Some(500),
+            None,
+            false,
+            false,
+            1,
+            DEFAULT_DOWNLOAD_RETRY_COUNT,
+            None,
+        ));
+
+        let _guard = tracing::subscriber::set_default(registry());
+        let scheduler_root = tracing::info_span!("scheduler_root");
+        let scheduler = scheduler_root
+            .in_scope(|| ScanScheduler::new(obj_store, SchedulerConfig::default_for_testing()));
+        let file_scheduler = scheduler
+            .open_file(&some_path, &CachedFileSize::new(1000))
+            .await
+            .unwrap();
+
+        async move {
+            file_scheduler.submit_single(0..10, 0).await.unwrap();
+        }
+        .instrument(tracing::info_span!("request_root"))
+        .await;
+
+        assert_eq!(
+            *seen_spans.lock().unwrap(),
+            vec!["request_root".to_string()]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -5,31 +5,24 @@ use std::sync::Arc;
 
 use arrow_array::{BooleanArray, RecordBatch, RecordBatchOptions, UInt64Array, make_array};
 use arrow_buffer::NullBuffer;
-use futures::{
-    FutureExt, Stream, StreamExt,
-    future::BoxFuture,
-    stream::{BoxStream, FuturesOrdered},
-};
+use futures::{FutureExt, Stream, StreamExt, stream::FuturesOrdered};
 use lance_arrow::RecordBatchExt;
 use lance_core::{
     ROW_ADDR, ROW_ADDR_FIELD, ROW_CREATED_AT_VERSION_FIELD, ROW_ID, ROW_ID_FIELD,
     ROW_LAST_UPDATED_AT_VERSION_FIELD, Result,
-    utils::{address::RowAddress, deletion::DeletionVector},
+    utils::{
+        address::RowAddress,
+        deletion::DeletionVector,
+        tracing::{FutureTracingExt, StreamTracingExt},
+    },
+};
+pub use lance_file::reader::{
+    ReadBatchFut, ReadBatchFutStream, ReadBatchTask, ReadBatchTaskStream,
 };
 use lance_io::ReadBatchParams;
-use tracing::instrument;
+use tracing::{Span, instrument};
 
 use crate::rowids::RowIdSequence;
-
-pub type ReadBatchFut = BoxFuture<'static, Result<RecordBatch>>;
-/// A task, emitted by a file reader, that will produce a batch (of the
-/// given size)
-pub struct ReadBatchTask {
-    pub task: ReadBatchFut,
-    pub num_rows: u32,
-}
-pub type ReadBatchTaskStream = BoxStream<'static, ReadBatchTask>;
-pub type ReadBatchFutStream = BoxStream<'static, ReadBatchFut>;
 
 struct MergeStream {
     streams: Vec<ReadBatchTaskStream>,
@@ -48,11 +41,10 @@ impl MergeStream {
                 batch = batch.merge(&next)?;
             }
             Ok(batch)
-        }
-        .boxed();
+        };
         let num_rows = self.next_num_rows;
         self.next_num_rows = 0;
-        ReadBatchTask { task, num_rows }
+        ReadBatchTask::from_future(task, num_rows)
     }
 }
 
@@ -110,7 +102,7 @@ pub fn merge_streams(streams: Vec<ReadBatchTaskStream>) -> ReadBatchTaskStream {
         next_num_rows: 0,
         index: 0,
     }
-    .boxed()
+    .boxed_stream_in_current_span()
 }
 
 /// Apply a mask to the batch, where rows are "deleted" by the _rowid column null.
@@ -398,10 +390,12 @@ pub fn wrap_with_row_id_and_delete(
     config: RowIdAndDeletesConfig,
 ) -> ReadBatchFutStream {
     let config = Arc::new(config);
+    let stream_span = Span::current();
     let mut offset = 0;
     stream
         .map(move |batch_task| {
             let config = config.clone();
+            let stream_span = stream_span.clone();
             let this_offset = offset;
             let num_rows = batch_task.num_rows;
             offset += num_rows;
@@ -410,9 +404,9 @@ pub fn wrap_with_row_id_and_delete(
                 .map(move |batch| {
                     apply_row_id_and_deletes(batch?, this_offset, fragment_id, config.as_ref())
                 })
-                .boxed()
+                .boxed_in_span(stream_span)
         })
-        .boxed()
+        .boxed_stream_in_current_span()
 }
 
 #[cfg(test)]

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -24,7 +24,8 @@ use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, join, stream};
 use lance_arrow::{RecordBatchExt, SchemaExt};
 use lance_core::datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions};
 use lance_core::utils::deletion::DeletionVector;
-use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_in_current_span};
+use lance_core::utils::tracing::{FutureTracingExt, StreamTracingExt};
 use lance_core::{Error, Result, cache::CacheKey, datatypes::Schema};
 use lance_core::{
     ROW_ADDR, ROW_ADDR_FIELD, ROW_CREATED_AT_VERSION_FIELD, ROW_ID, ROW_ID_FIELD,
@@ -48,6 +49,7 @@ use lance_table::utils::stream::{
     ReadBatchFutStream, ReadBatchTask, ReadBatchTaskStream, RowIdAndDeletesConfig,
     wrap_with_row_id_and_delete,
 };
+use tracing::Span;
 
 use self::write::FragmentCreateBuilder;
 
@@ -148,7 +150,7 @@ fn ranges_to_tasks(
             let num_rows = range.end - range.start;
             let reader = reader.clone();
             let projection = projection.clone();
-            let task = tokio::task::spawn(async move {
+            let task = spawn_in_current_span(async move {
                 previous_read_batch(
                     &reader,
                     &ReadBatchParams::Range(range.clone()),
@@ -157,14 +159,10 @@ fn ranges_to_tasks(
                 )
                 .await
             })
-            .map(|task_out| task_out.unwrap())
-            .boxed();
-            ReadBatchTask {
-                task,
-                num_rows: num_rows as u32,
-            }
+            .map(|task_out| task_out.unwrap());
+            ReadBatchTask::from_future(task, num_rows as u32)
         })
-        .boxed()
+        .boxed_stream_in_current_span()
 }
 
 #[derive(Clone, Debug)]
@@ -251,13 +249,9 @@ impl GenericFileReader for V1Reader {
         let indices_vec = indices.to_vec();
         let reader = self.reader.clone();
         // In the new path the row id is added by the fragment and not the file
-        let task_fut = async move { reader.take(&indices_vec, projection.as_ref()).await }.boxed();
-        let task = std::future::ready(ReadBatchTask {
-            task: task_fut,
-            num_rows: indices.len() as u32,
-        })
-        .boxed();
-        Ok(futures::stream::once(task).boxed())
+        let task_fut = async move { reader.take(&indices_vec, projection.as_ref()).await };
+        let task = std::future::ready(ReadBatchTask::from_future(task_fut, indices.len() as u32));
+        Ok(futures::stream::once(task).boxed_stream_in_current_span())
     }
 
     fn projection(&self) -> &Arc<Schema> {
@@ -336,6 +330,7 @@ mod v2_adapter {
                 projection.as_ref(),
                 self.field_id_to_column_idx.as_ref(),
             )?;
+            let task_span = Span::current();
             Ok(self
                 .reader
                 .read_tasks(
@@ -344,11 +339,14 @@ mod v2_adapter {
                     Some(projection),
                     FilterExpression::no_filter(),
                 )?
-                .map(|v2_task| ReadBatchTask {
-                    task: v2_task.task.map_err(Error::from).boxed(),
-                    num_rows: v2_task.num_rows,
+                .map(move |v2_task| {
+                    ReadBatchTask::from_future_in_span(
+                        v2_task.task.map_err(Error::from),
+                        v2_task.num_rows,
+                        task_span.clone(),
+                    )
                 })
-                .boxed())
+                .boxed_stream_in_current_span())
         }
 
         fn read_ranges_tasks(
@@ -362,6 +360,7 @@ mod v2_adapter {
                 projection.as_ref(),
                 self.field_id_to_column_idx.as_ref(),
             )?;
+            let task_span = Span::current();
             Ok(self
                 .reader
                 .read_tasks(
@@ -370,11 +369,14 @@ mod v2_adapter {
                     Some(projection),
                     FilterExpression::no_filter(),
                 )?
-                .map(|v2_task| ReadBatchTask {
-                    task: v2_task.task.map_err(Error::from).boxed(),
-                    num_rows: v2_task.num_rows,
+                .map(move |v2_task| {
+                    ReadBatchTask::from_future_in_span(
+                        v2_task.task.map_err(Error::from),
+                        v2_task.num_rows,
+                        task_span.clone(),
+                    )
                 })
-                .boxed())
+                .boxed_stream_in_current_span())
         }
 
         fn read_all_tasks(
@@ -387,6 +389,7 @@ mod v2_adapter {
                 projection.as_ref(),
                 self.field_id_to_column_idx.as_ref(),
             )?;
+            let task_span = Span::current();
             Ok(self
                 .reader
                 .read_tasks(
@@ -395,11 +398,14 @@ mod v2_adapter {
                     Some(projection),
                     FilterExpression::no_filter(),
                 )?
-                .map(|v2_task| ReadBatchTask {
-                    task: v2_task.task.map_err(Error::from).boxed(),
-                    num_rows: v2_task.num_rows,
+                .map(move |v2_task| {
+                    ReadBatchTask::from_future_in_span(
+                        v2_task.task.map_err(Error::from),
+                        v2_task.num_rows,
+                        task_span.clone(),
+                    )
                 })
-                .boxed())
+                .boxed_stream_in_current_span())
         }
 
         fn take_all_tasks(
@@ -427,6 +433,7 @@ mod v2_adapter {
                 self.reader.clone()
             };
 
+            let task_span = Span::current();
             Ok(reader
                 .read_tasks(
                     ReadBatchParams::Indices(indices),
@@ -434,11 +441,14 @@ mod v2_adapter {
                     Some(projection),
                     FilterExpression::no_filter(),
                 )?
-                .map(|v2_task| ReadBatchTask {
-                    task: v2_task.task.map_err(Error::from).boxed(),
-                    num_rows: v2_task.num_rows,
+                .map(move |v2_task| {
+                    ReadBatchTask::from_future_in_span(
+                        v2_task.task.map_err(Error::from),
+                        v2_task.num_rows,
+                        task_span.clone(),
+                    )
                 })
-                .boxed())
+                .boxed_stream_in_current_span())
         }
 
         fn storage_stats(&self) -> Vec<(u32, u64)> {
@@ -539,14 +549,12 @@ impl GenericFileReader for NullReader {
             let num_rows = remaining_rows.min(batch_size as u64) as usize;
             remaining_rows -= num_rows as u64;
             let batch = Self::batch(projection.clone(), num_rows);
-            let task = ReadBatchTask {
-                task: futures::future::ready(Ok(batch)).boxed(),
-                num_rows: num_rows as u32,
-            };
+            let task =
+                ReadBatchTask::from_future(futures::future::ready(Ok(batch)), num_rows as u32);
             Some(task)
         });
 
-        Ok(futures::stream::iter(task_iter).boxed())
+        Ok(futures::stream::iter(task_iter).boxed_stream_in_current_span())
     }
 
     fn read_all_tasks(
@@ -2309,6 +2317,7 @@ impl FragmentReader {
         batch_size: u32,
         read_fn: impl Fn(&dyn GenericFileReader) -> Result<ReadBatchTaskStream>,
     ) -> Result<ReadBatchFutStream> {
+        let stream_span = Span::current();
         let total_num_rows = self.num_physical_rows as u32;
         // Note that the fragment length might be considerably smaller if there are deleted rows.
         // E.g. if a fragment has 100 rows but rows 0..10 are deleted we still need to make
@@ -2331,17 +2340,20 @@ impl FragmentReader {
         // we can delete this path once we migrate away from any support of v1.
         let merged = if self.num_system_cols() == self.output_schema.fields.len() {
             let selected_rows = params.to_offsets_total(total_num_rows).len();
+            let task_span = stream_span.clone();
+            let stream_box_span = stream_span.clone();
             let tasks = (0..selected_rows)
                 .step_by(batch_size as usize)
                 .map(move |offset| {
                     let num_rows = (batch_size as usize).min(selected_rows - offset);
                     let batch = RecordBatch::from(StructArray::new_empty_fields(num_rows, None));
-                    ReadBatchTask {
-                        task: std::future::ready(Ok(batch)).boxed(),
-                        num_rows: num_rows as u32,
-                    }
+                    ReadBatchTask::from_future_in_span(
+                        std::future::ready(Ok(batch)),
+                        num_rows as u32,
+                        task_span.clone(),
+                    )
                 });
-            stream::iter(tasks).boxed()
+            stream::iter(tasks).boxed_stream_in_span(stream_box_span)
         } else {
             // Read each data file, these reads should produce streams of equal sized
             // tasks.  In other words, if we get 3 tasks of 20 rows and then a task
@@ -2381,20 +2393,22 @@ impl FragmentReader {
             total_num_rows,
         };
         let output_schema = Arc::new(self.output_schema.clone());
+        let final_stream_span = stream_span.clone();
         Ok(
             wrap_with_row_id_and_delete(merged, self.fragment_id as u32, config)
                 // Finally, reorder the columns to match the order specified in the projection
                 .map(move |batch_fut| {
                     let output_schema = output_schema.clone();
+                    let future_span = final_stream_span.clone();
                     batch_fut
                         .map(move |batch| {
                             batch?
                                 .project_by_schema(&output_schema)
                                 .map_err(Error::from)
                         })
-                        .boxed()
+                        .boxed_in_span(future_span)
                 })
-                .boxed(),
+                .boxed_stream_in_span(stream_span),
         )
     }
 
@@ -2473,6 +2487,7 @@ impl FragmentReader {
         ranges: Arc<[Range<u64>]>,
         batch_size: u32,
     ) -> Result<ReadBatchFutStream> {
+        let stream_span = Span::current();
         let total_num_rows = self.num_physical_rows as u32;
         let mut num_requested_rows = 0;
         // Note that row ranges at this point are physical and not logical.
@@ -2487,18 +2502,21 @@ impl FragmentReader {
         }
 
         let merged_stream = if self.num_system_cols() == self.output_schema.fields.len() {
+            let task_span = stream_span.clone();
+            let stream_box_span = stream_span.clone();
             let tasks = (0..num_requested_rows)
                 .step_by(batch_size as usize)
                 .map(move |offset| {
                     let num_rows = (batch_size as u64).min(num_requested_rows - offset);
                     let batch =
                         RecordBatch::from(StructArray::new_empty_fields(num_rows as usize, None));
-                    ReadBatchTask {
-                        task: std::future::ready(Ok(batch)).boxed(),
-                        num_rows: num_rows as u32,
-                    }
+                    ReadBatchTask::from_future_in_span(
+                        std::future::ready(Ok(batch)),
+                        num_rows as u32,
+                        task_span.clone(),
+                    )
                 });
-            stream::iter(tasks).boxed()
+            stream::iter(tasks).boxed_stream_in_span(stream_box_span)
         } else {
             // Read each data file, these reads should produce streams of equal sized
             // tasks.  In other words, if we get 3 tasks of 20 rows and then a task
@@ -2534,20 +2552,22 @@ impl FragmentReader {
             total_num_rows,
         };
         let output_schema = Arc::new(self.output_schema.clone());
+        let final_stream_span = stream_span.clone();
         Ok(
             wrap_with_row_id_and_delete(merged_stream, self.fragment_id as u32, config)
                 // Finally, reorder the columns to match the order specified in the projection
                 .map(move |batch_fut| {
                     let output_schema = output_schema.clone();
+                    let future_span = final_stream_span.clone();
                     batch_fut
                         .map(move |batch| {
                             batch?
                                 .project_by_schema(&output_schema)
                                 .map_err(Error::from)
                         })
-                        .boxed()
+                        .boxed_in_span(future_span)
                 })
-                .boxed(),
+                .boxed_stream_in_span(stream_span),
         )
     }
 

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -21,6 +21,7 @@ use lance_arrow::RecordBatchExt;
 use lance_core::datatypes::Schema;
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::deletion::OffsetMapper;
+use lance_core::utils::tracing::FutureTracingExt;
 use lance_core::{ROW_ADDR, ROW_OFFSET};
 use lance_datafusion::projection::{OutputColumn, ProjectionPlan};
 
@@ -201,6 +202,7 @@ async fn do_take_rows(
                 )
                 .await
         }
+        .future_in_current_span()
     }
 
     let physical_schema = Arc::new(projection.physical_projection.to_bare_schema());

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -11,7 +11,6 @@ use arrow::array::AsArray;
 use arrow::datatypes::UInt32Type;
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
-use datafusion::common::runtime::SpawnedTask;
 use datafusion::common::stats::Precision;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -35,7 +34,8 @@ use lance_core::utils::futures::FinallyStreamExt;
 use lance_core::utils::mask::{
     RowAddrMask, RowAddrSelection, RowAddrTreeMap, bitmap_to_ranges, ranges_to_bitmap,
 };
-use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_in_current_span};
+use lance_core::utils::tracing::{FutureTracingExt, StreamTracingExt};
 use lance_core::{Error, Result, datatypes::Projection};
 use lance_datafusion::planner::Planner;
 use lance_datafusion::utils::{
@@ -439,14 +439,14 @@ impl FilteredReadStream {
                 move |scoped_fragment| {
                     let metrics = global_metrics_clone.clone();
                     let limit = scan_range_after_filter.as_ref().map(|r| r.end);
-                    SpawnedTask::spawn(
-                        Self::read_fragment(scoped_fragment, metrics, limit).in_current_span(),
-                    )
-                    .map(|thread_result| thread_result.unwrap())
+                    spawn_in_current_span(Self::read_fragment(scoped_fragment, metrics, limit))
+                        .map(|thread_result| thread_result.unwrap())
                 }
             })
             .buffered(fragment_readahead);
-        let task_stream = fragment_streams.try_flatten().boxed();
+        let task_stream = fragment_streams
+            .try_flatten()
+            .boxed_stream_in_current_span();
 
         Ok(Self {
             output_schema,
@@ -975,10 +975,11 @@ impl FilteredReadStream {
                         });
 
                 let batch_stream = if let Some(ref range) = self.scan_range_after_filter {
-                    Self::apply_hard_range(base_batch_stream, range.clone()).boxed()
+                    Self::apply_hard_range(base_batch_stream, range.clone())
+                        .boxed_stream_in_current_span()
                 } else {
                     // Need to box here otherwise the if/else returns incompatible types
-                    base_batch_stream.boxed()
+                    base_batch_stream.boxed_stream_in_current_span()
                 };
 
                 let batch_stream = batch_stream
@@ -992,7 +993,7 @@ impl FilteredReadStream {
                         partition_metrics.baseline_metrics.done();
                     })
                     .map_err(|e: lance_core::Error| DataFusionError::External(e.into()))
-                    .boxed();
+                    .boxed_stream_in_current_span();
 
                 Box::pin(RecordBatchStreamAdapter::new(output_schema, batch_stream))
             }
@@ -1044,7 +1045,8 @@ impl FilteredReadStream {
                         Some(batch)
                     }))
                 })
-                .map_err(|e: lance_core::Error| DataFusionError::External(e.into()));
+                .map_err(|e: lance_core::Error| DataFusionError::External(e.into()))
+                .boxed_stream_in_current_span();
                 Box::pin(RecordBatchStreamAdapter::new(output_schema, batch_stream))
             }
         }
@@ -1127,13 +1129,14 @@ impl FilteredReadStream {
                             global_metrics.ranges_scanned.add(additional_ranges);
                         }
                     })
-                    .boxed()
+                    .boxed_in_current_span()
             })
             .zip(futures::stream::repeat((
                 physical_filter.clone(),
                 output_schema.clone(),
             )))
-            .map(|(batch_fut, args)| Self::wrap_with_filter(batch_fut, args.0, args.1));
+            .map(|(batch_fut, args)| Self::wrap_with_filter(batch_fut, args.0, args.1))
+            .boxed_stream_in_current_span();
 
         let result: Pin<Box<dyn Stream<Item = Result<ReadBatchFut>> + Send>> =
             if let Some(limit) = fragment_soft_limit {
@@ -1162,7 +1165,7 @@ impl FilteredReadStream {
                     // Drop any fields loaded purely for the purpose of applying the filter
                     Ok(batch.project_by_schema(output_schema.as_ref())?)
                 })
-                .boxed())
+                .boxed_in_current_span())
         } else {
             Ok(batch_fut)
         }
@@ -1170,7 +1173,7 @@ impl FilteredReadStream {
 
     fn apply_soft_limit<S>(stream: S, limit: u64) -> impl Stream<Item = Result<ReadBatchFut>>
     where
-        S: Stream<Item = Result<ReadBatchFut>>,
+        S: Stream<Item = Result<ReadBatchFut>> + Send + 'static,
     {
         let rows_read = Arc::new(AtomicUsize::new(0));
 
@@ -1189,9 +1192,10 @@ impl FilteredReadStream {
                                 rows_read.fetch_add(batch_rows, Ordering::Relaxed);
                             })
                         })
-                        .boxed()
+                        .boxed_in_current_span()
                 })
             })
+            .boxed_stream_in_current_span()
     }
 
     fn apply_hard_range<S>(stream: S, range: Range<u64>) -> impl Stream<Item = Result<RecordBatch>>
@@ -1734,7 +1738,8 @@ impl FilteredReadExec {
                 DataFusionResult::Ok(first_stream)
             }
         })
-        .try_flatten();
+        .try_flatten()
+        .boxed_stream_in_current_span();
 
         Box::pin(RecordBatchStreamAdapter::new(self.schema(), stream))
     }

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -11,6 +11,7 @@ use arrow::array::AsArray;
 use arrow::datatypes::UInt32Type;
 use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
+use datafusion::common::runtime::SpawnedTask;
 use datafusion::common::stats::Precision;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -34,7 +35,7 @@ use lance_core::utils::futures::FinallyStreamExt;
 use lance_core::utils::mask::{
     RowAddrMask, RowAddrSelection, RowAddrTreeMap, bitmap_to_ranges, ranges_to_bitmap,
 };
-use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_in_current_span};
+use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::utils::tracing::{FutureTracingExt, StreamTracingExt};
 use lance_core::{Error, Result, datatypes::Projection};
 use lance_datafusion::planner::Planner;
@@ -439,8 +440,11 @@ impl FilteredReadStream {
                 move |scoped_fragment| {
                     let metrics = global_metrics_clone.clone();
                     let limit = scan_range_after_filter.as_ref().map(|r| r.end);
-                    spawn_in_current_span(Self::read_fragment(scoped_fragment, metrics, limit))
-                        .map(|thread_result| thread_result.unwrap())
+                    SpawnedTask::spawn(
+                        Self::read_fragment(scoped_fragment, metrics, limit)
+                            .future_in_current_span(),
+                    )
+                    .map(|thread_result| thread_result.unwrap())
                 }
             })
             .buffered(fragment_readahead);

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -29,7 +29,8 @@ use datafusion_functions::core::expr_ext::FieldAccessor;
 use datafusion_physical_expr::EquivalenceProperties;
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use lance_arrow::{RecordBatchExt, SchemaExt};
-use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_in_current_span};
+use lance_core::utils::tracing::FutureTracingExt;
 use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID_FIELD};
 use lance_file::reader::FileReaderOptions;
 use lance_io::ReadBatchParams;
@@ -213,18 +214,21 @@ impl ExecutionPlan for LancePushdownScanExec {
             }
         });
 
-        let batch_stream = fragment_stream.map(|(exec, fragment)| async move {
-            let frag_scanner = FragmentScanner::open(
-                fragment,
-                exec.dataset,
-                exec.projection,
-                exec.predicate_projection,
-                exec.predicate,
-                exec.config.clone(),
-            )
-            .await?;
+        let batch_stream = fragment_stream.map(|(exec, fragment)| {
+            async move {
+                let frag_scanner = FragmentScanner::open(
+                    fragment,
+                    exec.dataset,
+                    exec.projection,
+                    exec.predicate_projection,
+                    exec.predicate,
+                    exec.config.clone(),
+                )
+                .await?;
 
-            frag_scanner.scan().await
+                frag_scanner.scan().await
+            }
+            .future_in_current_span()
         });
 
         let batch_stream = batch_stream
@@ -350,12 +354,14 @@ impl FragmentScanner {
             })
             .map(move |(batch_id, predicate)| {
                 let scanner_ref = scanner.clone();
-                tokio::task::spawn(async move { scanner_ref.read_batch(batch_id, predicate).await })
-                    .map(|res| match res {
-                        Ok(Ok(batch)) => Ok(batch),
-                        Ok(Err(err)) => Err(err),
-                        Err(join_err) => Err(DataFusionError::ExecutionJoin(Box::new(join_err))),
-                    })
+                spawn_in_current_span(
+                    async move { scanner_ref.read_batch(batch_id, predicate).await },
+                )
+                .map(|res| match res {
+                    Ok(Ok(batch)) => Ok(batch),
+                    Ok(Err(err)) => Err(err),
+                    Err(join_err) => Err(DataFusionError::ExecutionJoin(Box::new(join_err))),
+                })
             });
 
         let stream = if ordered_output {

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -24,14 +24,13 @@ use futures::stream::{BoxStream, Stream};
 use futures::{FutureExt, TryFutureExt, stream};
 use futures::{StreamExt, TryStreamExt};
 use lance_arrow::SchemaExt;
-use lance_core::utils::tokio::get_num_compute_intensive_cpus;
-use lance_core::utils::tracing::StreamTracingExt;
+use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_in_current_span};
+use lance_core::utils::tracing::{FutureTracingExt, StreamTracingExt};
 use lance_core::{Error, ROW_ADDR_FIELD, ROW_ID_FIELD};
-use lance_file::reader::FileReaderOptions;
+use lance_file::reader::{FileReaderOptions, ReadBatchFutStream};
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_table::format::Fragment;
 use log::debug;
-use tracing::Instrument;
 
 use crate::dataset::Dataset;
 use crate::dataset::fragment::{FileFragment, FragReadConfig, FragmentReader};
@@ -284,44 +283,39 @@ impl LanceStream {
                 #[allow(clippy::type_complexity)]
                 let frag_task: BoxFuture<
                     Result<BoxStream<Result<BoxFuture<Result<RecordBatch>>>>>,
-                > = tokio::spawn(
-                    (async move {
-                        let mut frag_config = FragReadConfig::default()
-                            .with_row_id(config.with_row_id)
-                            .with_row_address(config.with_row_address)
-                            .with_row_last_updated_at_version(
-                                config.with_row_last_updated_at_version,
-                            )
-                            .with_row_created_at_version(config.with_row_created_at_version);
-                        if let Some(file_reader_options) = config.file_reader_options {
-                            frag_config = frag_config.with_file_reader_options(file_reader_options);
-                        }
-                        let reader = open_file(
-                            file_fragment.fragment,
-                            project_schema,
-                            frag_config,
-                            config.with_make_deletions_null,
-                            Some((scan_scheduler, priority as u32)),
-                        )
-                        .await?;
-                        let batch_stream = if let Some(range) = file_fragment.range {
-                            reader.read_range(range, config.batch_size as u32)?.boxed()
-                        } else {
-                            reader.read_all(config.batch_size as u32)?.boxed()
-                        };
-                        let batch_stream: BoxStream<Result<BoxFuture<Result<RecordBatch>>>> =
-                            batch_stream
-                                .map(|fut| {
-                                    Result::Ok(
-                                        fut.map_err(|e| DataFusionError::External(Box::new(e)))
-                                            .boxed(),
-                                    )
-                                })
-                                .boxed();
-                        Result::Ok(batch_stream)
-                    })
-                    .in_current_span(),
-                )
+                > = spawn_in_current_span(async move {
+                    let mut frag_config = FragReadConfig::default()
+                        .with_row_id(config.with_row_id)
+                        .with_row_address(config.with_row_address)
+                        .with_row_last_updated_at_version(config.with_row_last_updated_at_version)
+                        .with_row_created_at_version(config.with_row_created_at_version);
+                    if let Some(file_reader_options) = config.file_reader_options {
+                        frag_config = frag_config.with_file_reader_options(file_reader_options);
+                    }
+                    let reader = open_file(
+                        file_fragment.fragment,
+                        project_schema,
+                        frag_config,
+                        config.with_make_deletions_null,
+                        Some((scan_scheduler, priority as u32)),
+                    )
+                    .await?;
+                    let batch_stream = if let Some(range) = file_fragment.range {
+                        reader.read_range(range, config.batch_size as u32)?.boxed()
+                    } else {
+                        reader.read_all(config.batch_size as u32)?.boxed()
+                    };
+                    let batch_stream: BoxStream<Result<BoxFuture<Result<RecordBatch>>>> =
+                        batch_stream
+                            .map(|fut| {
+                                Result::Ok(
+                                    fut.map_err(|e| DataFusionError::External(Box::new(e)))
+                                        .boxed_in_current_span(),
+                                )
+                            })
+                            .boxed_stream_in_current_span();
+                    Result::Ok(batch_stream)
+                })
                 .map(|res_res| res_res.unwrap())
                 .boxed();
                 Ok(frag_task)
@@ -340,8 +334,7 @@ impl LanceStream {
             // us fully fuse decode into the first half of the plan.  Currently there is likely to be a thread
             // transfer between the two steps.
             .try_buffered(get_num_compute_intensive_cpus())
-            .stream_in_current_span()
-            .boxed();
+            .boxed_stream_in_current_span();
 
         timer.done();
         Ok(Self {
@@ -393,14 +386,15 @@ impl LanceStream {
                             .with_row_created_at_version(config.with_row_created_at_version),
                         config.with_make_deletions_null,
                         None,
-                    ))
+                    )
+                    .future_in_current_span())
                 })
                 .try_buffered(fragment_readahead);
             let tasks = readers.and_then(move |reader| {
                 std::future::ready(
                     reader
                         .read_all(config.batch_size as u32)
-                        .map(|task_stream| task_stream.map(Ok))
+                        .map(|task_stream: ReadBatchFutStream| task_stream.map(Ok))
                         .map_err(DataFusionError::from),
                 )
             });
@@ -409,8 +403,7 @@ impl LanceStream {
                 .try_flatten()
                 // We buffer up to `batch_readahead` batches across all streams.
                 .try_buffered(config.batch_readahead)
-                .stream_in_current_span()
-                .boxed()
+                .boxed_stream_in_current_span()
         } else {
             let readers = stream::iter(file_fragments)
                 .map(move |file_fragment| {
@@ -426,14 +419,15 @@ impl LanceStream {
                             .with_row_created_at_version(config.with_row_created_at_version),
                         config.with_make_deletions_null,
                         None,
-                    ))
+                    )
+                    .future_in_current_span())
                 })
                 .try_buffered(fragment_readahead);
             let tasks = readers.and_then(move |reader| {
                 std::future::ready(
                     reader
                         .read_all(config.batch_size as u32)
-                        .map(|task_stream| task_stream.map(Ok))
+                        .map(|task_stream: ReadBatchFutStream| task_stream.map(Ok))
                         .map_err(DataFusionError::from),
                 )
             });
@@ -443,8 +437,7 @@ impl LanceStream {
                 .try_flatten_unordered(config.fragment_readahead)
                 // We buffer up to `batch_readahead` batches across all streams.
                 .try_buffer_unordered(config.batch_readahead)
-                .stream_in_current_span()
-                .boxed()
+                .boxed_stream_in_current_span()
         };
 
         let inner_stream = Box::pin(batches.map_err(|e| DataFusionError::External(Box::new(e))))
@@ -698,12 +691,13 @@ impl ExecutionPlan for LanceScanExec {
         let config = self.config.clone();
         let metrics = self.metrics.clone();
 
-        let lance_fut_stream = stream::once(async move {
+        let lance_stream = stream::once(async move {
             LanceStream::try_new(
                 dataset, fragments, range, projection, config, &metrics, partition,
             )
-        });
-        let lance_stream = lance_fut_stream.try_flatten();
+        })
+        .boxed_stream_in_current_span()
+        .try_flatten();
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
             lance_stream,

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -27,7 +27,10 @@ use lance_arrow::RecordBatchExt;
 use lance_core::datatypes::{Field, OnMissing, Projection};
 use lance_core::error::{DataFusionResult, LanceOptionExt};
 use lance_core::utils::address::RowAddress;
-use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_core::utils::{
+    tokio::{get_num_compute_intensive_cpus, spawn_in_current_span},
+    tracing::{FutureTracingExt, StreamTracingExt},
+};
 use lance_core::{ROW_ADDR, ROW_ID};
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use tracing::error;
@@ -289,7 +292,7 @@ impl TakeStream {
                     let offsets = std::mem::take(&mut current_offsets);
                     futures.push_back(
                         async move { reader.take_as_batch(&offsets, Some(batch_number)).await }
-                            .boxed(),
+                            .boxed_in_current_span(),
                     );
                 }
                 current_fragment_id = Some(addr.fragment_id());
@@ -307,7 +310,7 @@ impl TakeStream {
                         .take_as_batch(&current_offsets, Some(batch_number))
                         .await
                 }
-                .boxed(),
+                .boxed_in_current_span(),
             );
         }
 
@@ -372,14 +375,15 @@ impl TakeStream {
                 let batch = batch?;
                 let this = self.clone();
                 Ok(
-                    tokio::task::spawn(this.map_batch(batch, batch_index as u32))
+                    spawn_in_current_span(this.map_batch(batch, batch_index as u32))
                         .map(|res| res.unwrap()),
                 )
             })
-            .boxed();
+            .boxed_stream_in_current_span();
         batches
             .inspect_ok(move |_| metrics.io_metrics.record(&scan_scheduler))
             .try_buffered(get_num_compute_intensive_cpus())
+            .stream_in_current_span()
     }
 }
 
@@ -631,9 +635,10 @@ impl ExecutionPlan for TakeExec {
             take_stream.apply(input_stream)
         });
         let output_schema = self.output_schema.clone();
+        let stream = lazy_take_stream.flatten().boxed_stream_in_current_span();
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             output_schema,
-            lazy_take_stream.flatten(),
+            stream,
         )))
     }
 

--- a/rust/lance/src/utils/future.rs
+++ b/rust/lance/src/utils/future.rs
@@ -3,8 +3,8 @@
 
 use async_cell::sync::AsyncCell;
 use futures::Future;
+use lance_core::utils::tokio::spawn_in_current_span;
 use std::sync::Arc;
-use tracing::Instrument;
 
 /// An async background task whose output can be shared across threads (via cloning)
 ///
@@ -47,13 +47,10 @@ impl<T: Clone> SharedPrerequisite<T> {
     {
         let cell = AsyncCell::<std::result::Result<T, String>>::shared();
         let dst = cell.clone();
-        tokio::spawn(
-            (async move {
-                let res = future.await;
-                dst.set(res.map_err(|err| err.to_string()));
-            })
-            .in_current_span(),
-        );
+        spawn_in_current_span(async move {
+            let res = future.await;
+            dst.set(res.map_err(|err| err.to_string()));
+        });
         Arc::new(Self(cell))
     }
 }
@@ -74,7 +71,7 @@ mod tests {
         let mut tasks = Vec::with_capacity(10);
         for _ in 0..10 {
             let instance = prereq.clone();
-            tasks.push(tokio::spawn(async move {
+            tasks.push(spawn_in_current_span(async move {
                 instance.wait_ready().await.unwrap();
                 assert_eq!(instance.get_ready(), 7_u32);
             }));
@@ -90,7 +87,7 @@ mod tests {
         let mut tasks = Vec::with_capacity(10);
         for _ in 0..10 {
             let instance = prereq.clone();
-            tasks.push(tokio::spawn(async move {
+            tasks.push(spawn_in_current_span(async move {
                 let err = instance.wait_ready().await.unwrap_err();
                 assert!(err.to_string().contains("xyz"));
                 assert!(err.to_string().contains("task failed"));

--- a/rust/lance/tests/query/mod.rs
+++ b/rust/lance/tests/query/mod.rs
@@ -22,6 +22,7 @@ fn create_datafusion_context() -> SessionContext {
 
 mod inverted;
 mod primitives;
+mod tracing;
 mod vectors;
 
 /// Scanning and ordering by id should give same result as original.

--- a/rust/lance/tests/query/tracing.rs
+++ b/rust/lance/tests/query/tracing.rs
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+use arrow_array::{
+    ArrayRef, FixedSizeListArray, Float32Array, Int32Array, RecordBatch, RecordBatchIterator,
+    StringArray, UInt32Array,
+};
+use lance::Dataset;
+use lance::dataset::scanner::{ColumnOrdering, QueryFilter};
+use lance::index::DatasetIndexExt;
+use lance::index::vector::VectorIndexParams;
+use lance_arrow::FixedSizeListArrayExt;
+use lance_index::IndexType;
+use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
+use lance_index::vector::Query;
+use lance_index::vector::ivf::IvfBuildParams;
+use lance_index::vector::pq::PQBuildParams;
+use lance_linalg::distance::MetricType;
+use tracing::{Id, Instrument, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+
+use lance_core::utils::tempfile::TempStrDir;
+
+use super::{strip_score_column, test_scan};
+use crate::utils::build_multi_fragment_dataset;
+
+const ROW_COUNT: i32 = 12;
+const VALUE_OFFSET: i32 = 100;
+
+#[derive(Clone, Debug)]
+struct RecordedSpan {
+    name: String,
+    parent: Option<Id>,
+    active_count: usize,
+}
+
+#[derive(Clone, Default, Debug)]
+struct SpanTreeRecorder {
+    spans: Arc<Mutex<HashMap<Id, RecordedSpan>>>,
+}
+
+impl SpanTreeRecorder {
+    fn snapshot(&self) -> HashMap<Id, RecordedSpan> {
+        self.spans.lock().unwrap().clone()
+    }
+}
+
+impl<S> Layer<S> for SpanTreeRecorder
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_new_span(&self, attrs: &tracing::span::Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let parent = attrs.parent().cloned().or_else(|| {
+            if attrs.is_contextual() {
+                ctx.current_span().id().cloned()
+            } else {
+                None
+            }
+        });
+
+        let span = RecordedSpan {
+            name: attrs.metadata().name().to_string(),
+            parent,
+            active_count: 0,
+        };
+        self.spans.lock().unwrap().insert(id.clone(), span);
+    }
+
+    fn on_enter(&self, id: &Id, _ctx: Context<'_, S>) {
+        if let Some(span) = self.spans.lock().unwrap().get_mut(id) {
+            span.active_count += 1;
+        }
+    }
+
+    fn on_exit(&self, id: &Id, _ctx: Context<'_, S>) {
+        if let Some(span) = self.spans.lock().unwrap().get_mut(id) {
+            span.active_count = span.active_count.saturating_sub(1);
+        }
+    }
+}
+
+fn multi_fragment_batch() -> RecordBatch {
+    let ids = Int32Array::from((0..ROW_COUNT).collect::<Vec<_>>());
+    let values = Int32Array::from((VALUE_OFFSET..(VALUE_OFFSET + ROW_COUNT)).collect::<Vec<_>>());
+
+    RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(ids) as ArrayRef),
+        ("value", Arc::new(values) as ArrayRef),
+    ])
+    .unwrap()
+}
+
+fn orphan_chain_error(
+    spans: &HashMap<Id, RecordedSpan>,
+    span_id: &Id,
+    root_id: &Id,
+) -> Option<String> {
+    let mut current_id = span_id.clone();
+    let mut visited = HashSet::new();
+    let mut chain = Vec::new();
+
+    loop {
+        let span = spans
+            .get(&current_id)
+            .unwrap_or_else(|| panic!("Missing recorded span for {:?}", current_id));
+        chain.push(span.name.clone());
+
+        if &current_id == root_id {
+            return None;
+        }
+
+        if !visited.insert(current_id.clone()) {
+            return Some(format!(
+                "cycle detected for span '{}' via chain {}",
+                chain.first().cloned().unwrap_or_default(),
+                chain.join(" -> ")
+            ));
+        }
+
+        let Some(parent) = span.parent.clone() else {
+            return Some(format!(
+                "span '{}' was orphaned before reaching test root; observed chain {}",
+                chain.first().cloned().unwrap_or_default(),
+                chain.join(" -> ")
+            ));
+        };
+        current_id = parent;
+    }
+}
+
+async fn assert_query_has_no_orphan_spans<Fut>(query: Fut)
+where
+    Fut: Future<Output = ()>,
+{
+    let recorder = SpanTreeRecorder::default();
+    let subscriber = tracing_subscriber::registry().with(recorder.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let root_span = tracing::info_span!("lance_query_test_root");
+    let root_id = root_span
+        .id()
+        .expect("root span should be recorded by the test subscriber");
+
+    {
+        let instrumented_query = query.instrument(root_span.clone());
+        instrumented_query.await;
+    }
+
+    drop(root_span);
+    tokio::task::yield_now().await;
+
+    let spans = recorder.snapshot();
+    assert!(spans.contains_key(&root_id), "root span was not recorded");
+
+    let descendants = spans
+        .keys()
+        .filter_map(|id| {
+            if id == &root_id {
+                None
+            } else {
+                Some(id.clone())
+            }
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        !descendants.is_empty(),
+        "query produced no descendant spans under the test root"
+    );
+
+    let orphan_errors = descendants
+        .iter()
+        .filter_map(|span_id| orphan_chain_error(&spans, span_id, &root_id))
+        .collect::<Vec<_>>();
+    assert!(
+        orphan_errors.is_empty(),
+        "orphan spans detected: {:?}",
+        orphan_errors
+    );
+
+    let active_spans = spans
+        .values()
+        .filter(|span| span.active_count > 0)
+        .map(|span| span.name.clone())
+        .collect::<Vec<_>>();
+    assert!(
+        active_spans.is_empty(),
+        "spans still active after query finished: {:?}",
+        active_spans
+    );
+}
+
+fn multi_fragment_fts_batch() -> RecordBatch {
+    let ids = Int32Array::from((0..5).collect::<Vec<_>>());
+    let texts = StringArray::from(vec![
+        Some("lance database"),
+        Some("lance vector"),
+        Some("random text"),
+        Some("lance"),
+        None,
+    ]);
+    let categories = StringArray::from(vec![
+        Some("keep"),
+        Some("drop"),
+        Some("keep"),
+        Some("keep"),
+        Some("keep"),
+    ]);
+
+    RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(ids) as ArrayRef),
+        ("text", Arc::new(texts) as ArrayRef),
+        ("category", Arc::new(categories) as ArrayRef),
+    ])
+    .unwrap()
+}
+
+async fn test_fts_with_filter(original: &RecordBatch, ds: &Dataset) {
+    let query = FullTextSearchQuery::new("lance".to_string())
+        .with_column("text".to_string())
+        .unwrap();
+
+    let mut scanner = ds.scan();
+    scanner.full_text_search(query).unwrap();
+    scanner.filter("category = 'keep'").unwrap();
+    scanner
+        .order_by(Some(vec![ColumnOrdering::asc_nulls_first(
+            "id".to_string(),
+        )]))
+        .unwrap();
+
+    let scanned: RecordBatch = scanner.try_into_batch().await.unwrap();
+    let scanned = strip_score_column(&scanned, original.schema().as_ref());
+
+    let expected_ids = UInt32Array::from(vec![0, 3]);
+    let expected = arrow::compute::take_record_batch(original, &expected_ids).unwrap();
+    assert_eq!(expected, scanned);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_multi_fragment_scan_does_not_create_orphan_spans() {
+    let original = multi_fragment_batch();
+    let ds = build_multi_fragment_dataset(original.clone()).await;
+
+    assert_query_has_no_orphan_spans(async {
+        test_scan(&original, &ds).await;
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_multi_fragment_fts_filter_does_not_create_orphan_spans() {
+    let original = multi_fragment_fts_batch();
+    let mut ds = build_multi_fragment_dataset(original.clone()).await;
+    let params = InvertedIndexParams::default();
+    ds.create_index_builder(&["text"], IndexType::Inverted, &params)
+        .await
+        .unwrap();
+
+    assert_query_has_no_orphan_spans(async {
+        test_fts_with_filter(&original, &ds).await;
+    })
+    .await;
+}
+
+// -- Vector + Hybrid query helpers and data builders --
+
+fn vector_batch() -> RecordBatch {
+    let num_rows = 300i32;
+    let ids = Int32Array::from((0..num_rows).collect::<Vec<_>>());
+    let mut vectors = Vec::with_capacity(num_rows as usize * 4);
+    for i in 0..num_rows {
+        vectors.extend_from_slice(&[i as f32, (i * 2) as f32, (i * 3) as f32, (i * 4) as f32]);
+    }
+    let vector_values = Float32Array::from(vectors);
+    let vector_array = FixedSizeListArray::try_new_from_values(vector_values, 4).unwrap();
+
+    RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(ids) as ArrayRef),
+        ("vector", Arc::new(vector_array) as ArrayRef),
+    ])
+    .unwrap()
+}
+
+fn hybrid_batch() -> RecordBatch {
+    let num_rows = 300i32;
+    let ids = Int32Array::from((0..num_rows).collect::<Vec<_>>());
+    let mut vectors = Vec::with_capacity(num_rows as usize * 4);
+    for i in 0..num_rows {
+        vectors.extend_from_slice(&[i as f32, (i * 2) as f32, (i * 3) as f32, (i * 4) as f32]);
+    }
+    let vector_values = Float32Array::from(vectors);
+    let vector_array = FixedSizeListArray::try_new_from_values(vector_values, 4).unwrap();
+
+    let texts: Vec<String> = (0..num_rows)
+        .map(|i| {
+            if i % 3 == 0 {
+                format!("lance database {}", i)
+            } else {
+                format!("other text {}", i)
+            }
+        })
+        .collect();
+    let text_array = StringArray::from(texts);
+
+    let categories: Vec<String> = (0..num_rows)
+        .map(|i| {
+            if i % 2 == 0 {
+                "keep".to_string()
+            } else {
+                "drop".to_string()
+            }
+        })
+        .collect();
+    let category_array = StringArray::from(categories);
+
+    RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(ids) as ArrayRef),
+        ("vector", Arc::new(vector_array) as ArrayRef),
+        ("text", Arc::new(text_array) as ArrayRef),
+        ("category", Arc::new(category_array) as ArrayRef),
+    ])
+    .unwrap()
+}
+
+async fn build_vector_dataset(batch: RecordBatch, uri: &str) -> Dataset {
+    let schema = batch.schema();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    let mut ds = Dataset::write(reader, uri, None).await.unwrap();
+    let params = VectorIndexParams::with_ivf_pq_params(
+        MetricType::L2,
+        IvfBuildParams::new(2),
+        PQBuildParams::new(4, 8),
+    );
+    ds.create_index(&["vector"], IndexType::Vector, None, &params, true)
+        .await
+        .unwrap();
+    ds
+}
+
+async fn build_hybrid_dataset(batch: RecordBatch, uri: &str) -> Dataset {
+    let schema = batch.schema();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    let mut ds = Dataset::write(reader, uri, None).await.unwrap();
+
+    // Vector index
+    let vector_params = VectorIndexParams::with_ivf_pq_params(
+        MetricType::L2,
+        IvfBuildParams::new(2),
+        PQBuildParams::new(4, 8),
+    );
+    ds.create_index(&["vector"], IndexType::Vector, None, &vector_params, true)
+        .await
+        .unwrap();
+
+    // FTS inverted index
+    let fts_params = InvertedIndexParams::default();
+    ds.create_index_builder(&["text"], IndexType::Inverted, &fts_params)
+        .await
+        .unwrap();
+
+    ds
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_vector_search_does_not_create_orphan_spans() {
+    let batch = vector_batch();
+    let ds = build_vector_dataset(batch, "memory://vector_tracing_test").await;
+
+    let query_vector = Float32Array::from(vec![10.0f32, 20.0, 30.0, 40.0]);
+
+    assert_query_has_no_orphan_spans(async {
+        let mut scanner = ds.scan();
+        scanner
+            .nearest("vector", &query_vector, 5)
+            .unwrap()
+            .nprobes(2);
+        let _batch = scanner.try_into_batch().await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_hybrid_fts_vector_rerank_does_not_create_orphan_spans() {
+    let batch = hybrid_batch();
+    let ds = build_hybrid_dataset(batch, "memory://hybrid_tracing_test").await;
+
+    let query_vector = Arc::new(Float32Array::from(vec![10.0f32, 20.0, 30.0, 40.0]));
+    let vector_query = Query {
+        column: "vector".to_string(),
+        key: query_vector,
+        k: 10,
+        lower_bound: None,
+        upper_bound: None,
+        minimum_nprobes: 2,
+        maximum_nprobes: None,
+        ef: None,
+        refine_factor: None,
+        metric_type: Some(MetricType::L2),
+        use_index: true,
+        dist_q_c: 0.0,
+    };
+
+    assert_query_has_no_orphan_spans(async {
+        // FTS as primary search, vector as filter → triggers fts_rerank()
+        let mut scanner = ds.scan();
+        scanner
+            .full_text_search(
+                FullTextSearchQuery::new("lance".to_string())
+                    .with_column("text".to_string())
+                    .unwrap(),
+            )
+            .unwrap();
+        scanner.prefilter(true);
+        scanner
+            .filter_query(QueryFilter::Vector(vector_query))
+            .unwrap();
+        let _batch = scanner.try_into_batch().await.unwrap();
+    })
+    .await;
+}
+
+// -- Local filesystem tests (exercises spawn_blocking in local.rs) --
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_local_scan_does_not_create_orphan_spans() {
+    let test_dir = TempStrDir::default();
+    let original = multi_fragment_batch();
+    let schema = original.schema();
+    let reader = RecordBatchIterator::new(vec![Ok(original.clone())], schema);
+    let ds = Dataset::write(reader, test_dir.as_str(), None)
+        .await
+        .unwrap();
+
+    assert_query_has_no_orphan_spans(async {
+        test_scan(&original, &ds).await;
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_local_vector_search_does_not_create_orphan_spans() {
+    let test_dir = TempStrDir::default();
+    let batch = vector_batch();
+    let ds = build_vector_dataset(batch, test_dir.as_str()).await;
+
+    let query_vector = Float32Array::from(vec![10.0f32, 20.0, 30.0, 40.0]);
+
+    assert_query_has_no_orphan_spans(async {
+        let mut scanner = ds.scan();
+        scanner
+            .nearest("vector", &query_vector, 5)
+            .unwrap()
+            .nprobes(2);
+        let _batch = scanner.try_into_batch().await.unwrap();
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_local_hybrid_fts_vector_rerank_does_not_create_orphan_spans() {
+    let test_dir = TempStrDir::default();
+    let batch = hybrid_batch();
+    let ds = build_hybrid_dataset(batch, test_dir.as_str()).await;
+
+    let query_vector = Arc::new(Float32Array::from(vec![10.0f32, 20.0, 30.0, 40.0]));
+    let vector_query = Query {
+        column: "vector".to_string(),
+        key: query_vector,
+        k: 10,
+        lower_bound: None,
+        upper_bound: None,
+        minimum_nprobes: 2,
+        maximum_nprobes: None,
+        ef: None,
+        refine_factor: None,
+        metric_type: Some(MetricType::L2),
+        use_index: true,
+        dist_q_c: 0.0,
+    };
+
+    assert_query_has_no_orphan_spans(async {
+        let mut scanner = ds.scan();
+        scanner
+            .full_text_search(
+                FullTextSearchQuery::new("lance".to_string())
+                    .with_column("text".to_string())
+                    .unwrap(),
+            )
+            .unwrap();
+        scanner.prefilter(true);
+        scanner
+            .filter_query(QueryFilter::Vector(vector_query))
+            .unwrap();
+        let _batch = scanner.try_into_batch().await.unwrap();
+    })
+    .await;
+}

--- a/rust/lance/tests/utils/mod.rs
+++ b/rust/lance/tests/utils/mod.rs
@@ -149,6 +149,18 @@ impl DatasetTestCases {
     }
 }
 
+pub async fn build_multi_fragment_dataset(original: RecordBatch) -> Dataset {
+    let inverted_index_params = HashMap::new();
+    build_dataset(
+        original,
+        Fragmentation::MultiFragment,
+        DeletionState::NoDeletions,
+        &[],
+        &inverted_index_params,
+    )
+    .await
+}
+
 /// Create an in-memory dataset with the given state and data.
 ///
 /// The data in dataset will exactly match the `original` batch. (Extra rows are


### PR DESCRIPTION
## Summary

When Lance queries are executed through external callers (e.g. NAPI bindings) with distributed tracing enabled, many internal Rust spans appear as disconnected root traces in backends like Tempo instead of nesting under the caller's span tree.

**Root causes:**

1. `execute_plan()` did not wrap the DataFusion plan with `TracedExec`, so lazy plan nodes captured `Span::current()` at poll time (often `<none>`) instead of at plan creation time.
2. Numerous async boundaries (boxed futures, boxed streams, spawned tasks) did not propagate the current span.

**Changes:**

- Add `TracedExec` wrapper in `execute_plan()` to capture and propagate the caller's span through lazy DataFusion plan execution
- Register `LanceJoinSetTracer` via `set_join_set_tracer()` so DataFusion's internal spawned tasks also carry the current span
- Add `FutureTracingExt` trait (`future_in_current_span`, `boxed_in_current_span`, `boxed_in_span`) alongside the existing `StreamTracingExt` in lance-core
- Add `spawn_in_current_span` / `spawn_in_span` helpers for `tokio::spawn`
- Convert all tracing-sensitive execution paths to use these shared helpers: decoder, scheduler, fragment reader, scan, filtered read, take, FTS, pushdown scan, cache
- Add tracing context propagation documentation

## Test plan

- [x] 7 regression tests added in `rust/lance/tests/query/tracing.rs` using a `SpanTreeRecorder` layer that asserts every span is reachable from the test root (no orphans):
  - Multi-fragment scan (memory + local filesystem)
  - FTS with filter
  - Vector search (IVF-PQ)
  - Hybrid FTS + vector reranker
  - Local filesystem variants for scan, vector, and hybrid paths
- [x] `cargo test -p lance --features slow_tests --test integration_tests query::tracing::` — 7/7 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check -p lance --features slow_tests --tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)