### PR TITLE
feat: expose has_stable_row_ids property on LanceDataset

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1145,6 +1145,13 @@ class LanceDataset(pa.dataset.Dataset):
         return self._ds.data_storage_version
 
     @property
+    def has_stable_row_ids(self) -> bool:
+        """
+        Whether this dataset has stable row IDs enabled
+        """
+        return self._ds.has_stable_row_ids
+
+    @property
     def max_field_id(self) -> int:
         """
         The max_field_id in manifest

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -424,6 +424,18 @@ def test_enable_stable_row_ids(tmp_path: Path):
     assert table_after["_rowaddr"][3].as_py() == (2 << 32) + 3
 
 
+def test_has_stable_row_ids_property(tmp_path: Path):
+    table = pa.Table.from_pylist([{"a": 1}, {"a": 2}])
+
+    stable_path = tmp_path / "stable"
+    lance.write_dataset(table, stable_path, enable_stable_row_ids=True)
+    assert lance.dataset(stable_path).has_stable_row_ids is True
+
+    non_stable_path = tmp_path / "non_stable"
+    lance.write_dataset(table, non_stable_path, enable_stable_row_ids=False)
+    assert lance.dataset(non_stable_path).has_stable_row_ids is False
+
+
 def test_v2_manifest_paths(tmp_path: Path):
     lance.write_dataset(
         pa.table({"a": range(100)}), tmp_path, enable_v2_manifest_paths=True

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -701,6 +701,11 @@ impl Dataset {
         Ok(self.ds.manifest().data_storage_format.version.clone())
     }
 
+    #[getter(has_stable_row_ids)]
+    fn has_stable_row_ids(&self) -> bool {
+        self.ds.manifest().uses_stable_row_ids()
+    }
+
     /// Get index statistics
     fn index_statistics(&self, index_name: String) -> PyResult<String> {
         rt().block_on(None, self.ds.index_statistics(&index_name))?


### PR DESCRIPTION
Expose `LanceDataset.has_stable_row_ids` (bool) to Python, wrapping the existing Rust `Manifest::uses_stable_row_ids()`.

Currently the only way to check from Python is inspecting fragment metadata (`fragment.metadata.row_id_meta is not None`), which is less discoverable. This property reads directly from the manifest feature flags.