### PR TITLE
fix(java): reuse session for OpenDatasetBuilder.buildFromNamespaceClient

### DIFF
--- a/java/src/main/java/org/lance/OpenDatasetBuilder.java
+++ b/java/src/main/java/org/lance/OpenDatasetBuilder.java
@@ -222,6 +222,7 @@ public class OpenDatasetBuilder {
     options.getVersion().ifPresent(optionsBuilder::setVersion);
     options.getBlockSize().ifPresent(optionsBuilder::setBlockSize);
     options.getSerializedManifest().ifPresent(optionsBuilder::setSerializedManifest);
+    options.getSession().ifPresent(optionsBuilder::setSession);
 
     Map<String, String> storageOptions = new HashMap<>(options.getStorageOptions());
     if (namespaceStorageOptions != null) {

--- a/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
+++ b/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
@@ -18,6 +18,7 @@ import org.lance.Dataset;
 import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.ReadOptions;
+import org.lance.Session;
 import org.lance.Transaction;
 import org.lance.WriteParams;
 import org.lance.namespace.errors.ErrorCode;
@@ -399,6 +400,39 @@ public class DirectoryNamespaceTest {
           "Expected managedVersioning=true, got " + descResp.getManagedVersioning());
     } finally {
       trackingNs.close();
+    }
+  }
+
+  @Test
+  void testOpenDatasetBuilderSetsSessionFromReadOptions() throws Exception {
+    // Create parent namespace
+    CreateNamespaceRequest createNsReq =
+        new CreateNamespaceRequest().id(Arrays.asList("workspace"));
+    namespaceClient.createNamespace(createNsReq);
+
+    // Create a table
+    byte[] tableData = createTestTableData();
+    CreateTableRequest createReq =
+        new CreateTableRequest().id(Arrays.asList("workspace", "test_table"));
+    namespaceClient.createTable(createReq, tableData);
+
+    try (Session session = Session.builder().build()) {
+      ReadOptions readOptions = new ReadOptions.Builder().setSession(session).build();
+
+      try (Dataset dataset =
+          Dataset.open()
+              .allocator(allocator)
+              .namespaceClient(namespaceClient)
+              .tableId(Arrays.asList("workspace", "test_table"))
+              .readOptions(readOptions)
+              .build()) {
+        Session datasetSession = dataset.session();
+        assertNotNull(datasetSession);
+        assertTrue(datasetSession.isSameAs(session));
+      }
+
+      // The provided session should not be closed when the dataset is closed.
+      assertFalse(session.isClosed());
     }
   }
 


### PR DESCRIPTION
@jackye1995 I think the session can be reused. Could you please take a look and see if this makes sense? Thank you.