### PR TITLE
perf: route SQ L2/Cosine distance through SIMD u8 kernel

### DIFF
--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -428,9 +428,7 @@ impl DistCalculator for SQDistCalculator<'_> {
         let (offset, chunk) = self.storage.chunk(id);
         let sq_code = chunk.sq_code_slice(id - offset);
         let dist = match self.storage.distance_type {
-            DistanceType::L2 | DistanceType::Cosine => {
-                l2_u8(sq_code, &self.query_sq_code) as f32
-            }
+            DistanceType::L2 | DistanceType::Cosine => l2_u8(sq_code, &self.query_sq_code) as f32,
             DistanceType::Dot => dot_distance(sq_code, &self.query_sq_code),
             _ => panic!("We should not reach here: sq distance can only be L2 or Dot"),
         };

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -16,7 +16,8 @@ use deepsize::DeepSizeOf;
 use lance_core::{Error, ROW_ID, Result};
 use lance_file::previous::reader::FileReader as PreviousFileReader;
 use lance_io::object_store::ObjectStore;
-use lance_linalg::distance::{DistanceType, dot_distance, l2_distance_uint_scalar};
+use lance_linalg::distance::l2_u8::l2_u8;
+use lance_linalg::distance::{DistanceType, dot_distance};
 use lance_table::format::SelfDescribingFileReader;
 use object_store::path::Path;
 use serde::{Deserialize, Serialize};
@@ -428,7 +429,7 @@ impl DistCalculator for SQDistCalculator<'_> {
         let sq_code = chunk.sq_code_slice(id - offset);
         let dist = match self.storage.distance_type {
             DistanceType::L2 | DistanceType::Cosine => {
-                l2_distance_uint_scalar(sq_code, &self.query_sq_code)
+                l2_u8(sq_code, &self.query_sq_code) as f32
             }
             DistanceType::Dot => dot_distance(sq_code, &self.query_sq_code),
             _ => panic!("We should not reach here: sq distance can only be L2 or Dot"),
@@ -446,7 +447,7 @@ impl DistCalculator for SQDistCalculator<'_> {
                     c.sq_codes
                         .values()
                         .chunks_exact(c.dim())
-                        .map(|sq_codes| l2_distance_uint_scalar(sq_codes, &self.query_sq_code))
+                        .map(|sq_codes| l2_u8(sq_codes, &self.query_sq_code) as f32)
                 })
                 .map(|dist| dist * self.scale)
                 .collect(),


### PR DESCRIPTION
## Summary

Follow-up from #6517, per [BubbleCal's review comment](https://github.com/lance-format/lance/pull/6517#pullrequestreview-4110862161) ("Followup: switch to the new kernels for SQ").

\`SQDistCalculator::distance()\` and \`distance_all()\` were still calling \`l2_distance_uint_scalar\` on the \`L2 | Cosine\` path while \`Dot\` already dispatched through \`dot_u8\` via the \`Dot\` trait. This PR switches L2/Cosine to the \`l2_u8\` SIMD kernel so x86 users actually get the AVX2 / AVX-512 VNNI backends that #6517 already shipped.

## Benchmark

\`cargo bench -p lance-index --bench sq\` on Linux x86 (AVX2):

| chunks × 10K | before | after | change |
|---|---|---|---|
| 1    | 315.3 ns | 304.8 ns | **−3.4%** |
| 32   | 390.1 ns | 363.1 ns | **−6.7%** |
| 128  | 499.7 ns | 482.2 ns | **−3.7%** |
| 1024 | 531.3 ns | 515.1 ns | **−3.1%** |

All changes are statistically significant (p < 0.05). The end-to-end gain is smaller than the raw \`l2_u8\` kernel speedup (1.26× on Ryzen per #6517) because this bench is dominated by chunk-lookup overhead (\`binary_search\`, \`row_id\` resolution, RNG, function-pointer dispatch) — distance computation is a minority of per-call cost.

On aarch64 the kernel falls through to its scalar path (same loop as \`l2_distance_uint_scalar\`), so Apple Silicon shows noise (±2%).

## Scope note

This PR preserves the existing \`L2 | Cosine\` grouping — SQ has computed L2 on the quantized codes for both distance types as long as this code has existed. Changing that behaviour is orthogonal to the kernel wiring and can be revisited separately.

## Test plan

- [x] \`cargo test -p lance-index --lib -- vector::sq\` — all 5 tests pass
- [x] \`cargo clippy -p lance-index --tests --benches -- -D warnings\` clean
- [x] Benchmarked on Linux x86 (AVX2) — −3.1% to −6.7% across chunk sizes
- [x] Benchmarked on aarch64 (Apple Silicon) — within noise, as expected