### PR TITLE
fix(python): fix tuple bug in _coerce_query_vector condition check

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6582,8 +6582,7 @@ def _coerce_query_vector(query: QueryVectorLike) -> tuple[pa.Array, int]:
         if isinstance(query.type, pa.FixedSizeListType):
             query = query.values
     elif isinstance(query, (list, tuple)) or (
-        _check_for_numpy(query),
-        isinstance(query, np.ndarray),
+        _check_for_numpy(query) and isinstance(query, np.ndarray)
     ):
         query = np.array(query).astype("float64")  # workaround for GH-608
         query = pa.FloatingPointArray.from_pandas(query, type=pa.float32())

--- a/python/python/tests/test_coerce_query_vector.py
+++ b/python/python/tests/test_coerce_query_vector.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Tests for _coerce_query_vector to ensure invalid input types
+raise TypeError instead of falling into the numpy conversion branch."""
+
+import numpy as np
+import pyarrow as pa
+import pytest
+from lance.dataset import _coerce_query_vector
+
+
+class TestCoerceQueryVectorInvalidTypes:
+    """Non-vector inputs should raise TypeError, not numpy ValueError."""
+
+    def test_string_raises_typeerror(self):
+        with pytest.raises(TypeError, match="query vector must be list-like"):
+            _coerce_query_vector("not a vector")
+
+    def test_integer_raises_typeerror(self):
+        with pytest.raises(
+            TypeError, match="Query vectors should be an array of floats"
+        ):
+            _coerce_query_vector(42)
+
+    def test_object_raises_typeerror(self):
+        """A random object that is not array-like should raise TypeError."""
+
+        class NotAVector:
+            pass
+
+        with pytest.raises(
+            TypeError, match="Query vectors should be an array of floats"
+        ):
+            _coerce_query_vector(NotAVector())
+
+    def test_none_raises_typeerror(self):
+        with pytest.raises(
+            TypeError, match="Query vectors should be an array of floats"
+        ):
+            _coerce_query_vector(None)
+
+
+class TestCoerceQueryVectorValidTypes:
+    """Valid vector inputs should be coerced successfully."""
+
+    def test_list_of_floats(self):
+        result, dim = _coerce_query_vector([1.0, 2.0, 3.0])
+        assert isinstance(result, pa.FloatingPointArray)
+        assert dim == 3
+
+    def test_tuple_of_floats(self):
+        result, dim = _coerce_query_vector((1.0, 2.0, 3.0))
+        assert isinstance(result, pa.FloatingPointArray)
+        assert dim == 3
+
+    def test_numpy_array(self):
+        result, dim = _coerce_query_vector(np.array([1.0, 2.0, 3.0]))
+        assert isinstance(result, pa.FloatingPointArray)
+        assert dim == 3
+
+    def test_pa_float_array(self):
+        result, dim = _coerce_query_vector(pa.array([1.0, 2.0, 3.0]))
+        assert isinstance(result, pa.FloatingPointArray)
+        assert dim == 3
+
+    def test_pa_int_array_cast_to_float(self):
+        result, dim = _coerce_query_vector(pa.array([1, 2, 3]))
+        assert isinstance(result, pa.FloatingPointArray)
+        assert dim == 3
+
+    def test_pa_chunked_array(self):
+        chunked = pa.chunked_array([[1.0, 2.0, 3.0]])
+        result, dim = _coerce_query_vector(chunked)
+        assert isinstance(result, pa.FloatingPointArray)
+        assert dim == 3


### PR DESCRIPTION
In `dataset.py` line 6584-6587, the condition to check for numpy arrays was:

```python
elif isinstance(query, (list, tuple)) or (
    _check_for_numpy(query),
    isinstance(query, np.ndarray),
):
```
The expression (_check_for_numpy(query), isinstance(query, np.ndarray)) creates a tuple (bool, bool), which is always truthy (a non-empty tuple). This means any input that is not a list, tuple, pa.Scalar, or pa.Array would incorrectly enter the numpy conversion branch. This will result in an unexpected conversion error: ValueError: could not convert string to float: np.str_('not a vector')