### PR TITLE
fix(blobV2): blob.from_uri optional validation

### DIFF
--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -47,10 +47,14 @@ class Blob:
         return Blob(data=bytes(data))
 
     @staticmethod
-    def from_uri(uri: str, position: int = None, size: int = None) -> "Blob":
+    def from_uri(
+        uri: str, position: Optional[int] = None, size: Optional[int] = None
+    ) -> "Blob":
         if uri == "":
             raise ValueError("Blob uri cannot be empty")
-        if position < 0 or size < 0:
+        if (position is not None and position < 0) or (
+            size is not None and size < 0
+        ):
             raise ValueError("External blob position and size must be non-negative")
         return Blob(uri=uri, position=position, size=size)
 

--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -47,7 +47,9 @@ class Blob:
         return Blob(data=bytes(data))
 
     @staticmethod
-    def from_uri(uri: str, position: int = None, size: int = None) -> "Blob":
+    def from_uri(
+        uri: str, position: Optional[int] = None, size: Optional[int] = None
+    ) -> "Blob":
         if uri == "":
             raise ValueError("Blob uri cannot be empty")
         if (position is not None and position < 0) or (size is not None and size < 0):
@@ -83,7 +85,7 @@ class BlobType(pa.ExtensionType):
 
     @classmethod
     def __arrow_ext_deserialize__(
-            cls, storage_type: pa.DataType, serialized: bytes
+        cls, storage_type: pa.DataType, serialized: bytes
     ) -> "BlobType":
         return BlobType()
 
@@ -223,7 +225,7 @@ class BlobColumn:
             )
 
         if not pa.types.is_large_binary(blob_column.type) and not pa.types.is_binary(
-                blob_column.type
+            blob_column.type
         ):
             raise ValueError(f"Expected a binary array, got {blob_column.type}")
 

--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -47,7 +47,8 @@ class Blob:
         return Blob(data=bytes(data))
 
     @staticmethod
-    def from_uri(uri: str, position: Optional[int] = None, size: Optional[int] = None) -> "Blob":
+    def from_uri(uri: str, position: Optional[int] = None,
+                 size: Optional[int] = None) -> "Blob":
         if uri == "":
             raise ValueError("Blob uri cannot be empty")
         if (position is not None and position < 0) or (size is not None and size < 0):

--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -47,8 +47,7 @@ class Blob:
         return Blob(data=bytes(data))
 
     @staticmethod
-    def from_uri(uri: str, position: Optional[int] = None,
-                 size: Optional[int] = None) -> "Blob":
+    def from_uri(uri: str, position: int = None, size: int = None) -> "Blob":
         if uri == "":
             raise ValueError("Blob uri cannot be empty")
         if (position is not None and position < 0) or (size is not None and size < 0):
@@ -84,7 +83,7 @@ class BlobType(pa.ExtensionType):
 
     @classmethod
     def __arrow_ext_deserialize__(
-        cls, storage_type: pa.DataType, serialized: bytes
+            cls, storage_type: pa.DataType, serialized: bytes
     ) -> "BlobType":
         return BlobType()
 
@@ -224,7 +223,7 @@ class BlobColumn:
             )
 
         if not pa.types.is_large_binary(blob_column.type) and not pa.types.is_binary(
-            blob_column.type
+                blob_column.type
         ):
             raise ValueError(f"Expected a binary array, got {blob_column.type}")
 

--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -47,14 +47,10 @@ class Blob:
         return Blob(data=bytes(data))
 
     @staticmethod
-    def from_uri(
-        uri: str, position: Optional[int] = None, size: Optional[int] = None
-    ) -> "Blob":
+    def from_uri(uri: str, position: Optional[int] = None, size: Optional[int] = None) -> "Blob":
         if uri == "":
             raise ValueError("Blob uri cannot be empty")
-        if (position is not None and position < 0) or (
-            size is not None and size < 0
-        ):
+        if (position is not None and position < 0) or (size is not None and size < 0):
             raise ValueError("External blob position and size must be non-negative")
         return Blob(uri=uri, position=position, size=size)
 

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -381,6 +381,21 @@ def test_blob_extension_write_external(tmp_path):
         assert f.read() == b"hello"
 
 
+@pytest.mark.parametrize(
+    ("position", "size"),
+    [
+        pytest.param(None, None, id="explicit_none"),
+        pytest.param(1, 3, id="slice"),
+    ],
+)
+def test_blob_from_uri_accepts_optional_slice_metadata(position, size):
+    blob = Blob.from_uri("file:///tmp/blob.bin", position=position, size=size)
+
+    assert blob.uri == "file:///tmp/blob.bin"
+    assert blob.position == position
+    assert blob.size == size
+
+
 def test_blob_extension_write_external_ingest(tmp_path):
     blob_path = tmp_path / "external_blob.bin"
     blob_path.write_bytes(b"hello")


### PR DESCRIPTION
Fix validation in Blob.from_uri() when position / size are omitted or explicitly passed as None.
- Previously, from_uri() used None as the default for these parameters, but the
    validation logic directly evaluated position < 0 / size < 0, causing valid calls like
    Blob.from_uri(uri) to raise a TypeError.