### PR TITLE
perf: parallel create/update bloomfilter

### DIFF
--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -19,7 +19,7 @@ use crate::{Any, pb};
 use arrow_array::{Array, UInt64Array};
 mod as_bytes;
 pub mod sbbf;
-use arrow_schema::{DataType, Field};
+use arrow_schema::{DataType, Field, Schema};
 use serde::{Deserialize, Serialize};
 
 use std::sync::LazyLock;
@@ -44,6 +44,8 @@ use super::zoned::{ZoneBound, ZoneProcessor, ZoneTrainer, rebuild_zones, search_
 const BLOOMFILTER_FILENAME: &str = "bloomfilter.lance";
 const BLOOMFILTER_ITEM_META_KEY: &str = "bloomfilter_item";
 const BLOOMFILTER_PROBABILITY_META_KEY: &str = "bloomfilter_probability";
+const MAX_BLOOMFILTER_ARRAY_LENGTH: usize = i32::MAX as usize - 1024 * 1024;
+const BLOOMFILTER_READ_BATCH_SIZE: usize = 4 * 1024;
 const BLOOMFILTER_INDEX_VERSION: u32 = 0;
 
 #[derive(Debug, Clone)]
@@ -94,9 +96,6 @@ impl BloomFilterIndex {
         _index_cache: &LanceCache,
     ) -> Result<Arc<Self>> {
         let index_file = store.open_index_file(BLOOMFILTER_FILENAME).await?;
-        let bloom_data = index_file
-            .read_range(0..index_file.num_rows(), None)
-            .await?;
         let file_schema = index_file.schema();
 
         let number_of_items: u64 = file_schema
@@ -111,25 +110,23 @@ impl BloomFilterIndex {
             .and_then(|bs| bs.parse().ok())
             .unwrap_or(*DEFAULT_PROBABILITY);
 
-        Ok(Arc::new(Self::try_from_serialized(
-            bloom_data,
+        let mut zones = Vec::new();
+        for start in (0..index_file.num_rows()).step_by(BLOOMFILTER_READ_BATCH_SIZE) {
+            let end = (start + BLOOMFILTER_READ_BATCH_SIZE).min(index_file.num_rows());
+            let bloom_data = index_file.read_range(start..end, None).await?;
+            zones.extend(Self::try_from_serialized(bloom_data)?);
+        }
+
+        Ok(Arc::new(Self {
+            zones,
             number_of_items,
             probability,
-        )?))
+        }))
     }
 
-    fn try_from_serialized(
-        data: RecordBatch,
-        number_of_items: u64,
-        probability: f64,
-    ) -> Result<Self> {
+    fn try_from_serialized(data: RecordBatch) -> Result<Vec<BloomFilterStatistics>> {
         if data.num_rows() == 0 {
-            // Return empty index for empty data
-            return Ok(Self {
-                zones: Vec::new(),
-                number_of_items,
-                probability,
-            });
+            return Ok(Vec::new());
         }
 
         let fragment_id_col = data
@@ -189,7 +186,6 @@ impl BloomFilterIndex {
                 Vec::new()
             };
 
-            // Convert bytes back to Sbbf
             let bloom_filter = Sbbf::new(&bloom_filter_bytes).map_err(|e| {
                 Error::invalid_input(format!("Failed to deserialize bloom filter: {:?}", e))
             })?;
@@ -205,11 +201,7 @@ impl BloomFilterIndex {
             });
         }
 
-        Ok(Self {
-            zones: blocks,
-            number_of_items,
-            probability,
-        })
+        Ok(blocks)
     }
 
     fn evaluate_block_against_query(
@@ -458,7 +450,9 @@ impl ScalarIndex for BloomFilterIndex {
         // Write the combined zones back to storage
         let mut builder = BloomFilterIndexBuilder::try_new(params)?;
         builder.blocks = updated_blocks;
-        builder.write_index(dest_store).await?;
+        builder
+            .write_index(dest_store, MAX_BLOOMFILTER_ARRAY_LENGTH)
+            .await?;
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default())
@@ -567,47 +561,36 @@ impl BloomFilterIndexBuilder {
         Ok(())
     }
 
-    fn bloomfilter_stats_as_batch(&self) -> Result<RecordBatch> {
-        let fragment_ids =
-            UInt64Array::from_iter_values(self.blocks.iter().map(|block| block.bound.fragment_id));
+    fn bloomfilter_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("fragment_id", DataType::UInt64, false),
+            Field::new("zone_start", DataType::UInt64, false),
+            Field::new("zone_length", DataType::UInt64, false),
+            Field::new("has_null", DataType::Boolean, false),
+            Field::new("bloom_filter_data", DataType::Binary, false),
+        ]))
+    }
 
-        let zone_starts =
-            UInt64Array::from_iter_values(self.blocks.iter().map(|block| block.bound.start));
-
-        let zone_lengths = UInt64Array::from_iter_values(
-            self.blocks.iter().map(|block| block.bound.length as u64),
-        );
-
-        let has_nulls = arrow_array::BooleanArray::from(
-            self.blocks
-                .iter()
-                .map(|block| block.has_null)
-                .collect::<Vec<bool>>(),
-        );
-
-        // Convert bloom filters to binary data for serialization
-        let bloom_filter_data = if self.blocks.is_empty() {
+    fn bloomfilter_stats_as_batch(
+        fragment_ids: Vec<u64>,
+        zone_starts: Vec<u64>,
+        zone_lengths: Vec<u64>,
+        has_nulls: Vec<bool>,
+        binary_data: Vec<Vec<u8>>,
+    ) -> Result<RecordBatch> {
+        let fragment_ids = UInt64Array::from(fragment_ids);
+        let zone_starts = UInt64Array::from(zone_starts);
+        let zone_lengths = UInt64Array::from(zone_lengths);
+        let has_nulls = arrow_array::BooleanArray::from(has_nulls);
+        let bloom_filter_data = if binary_data.is_empty() {
             Arc::new(arrow_array::BinaryArray::new_null(0)) as ArrayRef
         } else {
-            let binary_data: Vec<Vec<u8>> = self
-                .blocks
-                .iter()
-                .map(|block| block.bloom_filter.to_bytes())
-                .collect();
             let binary_refs: Vec<Option<&[u8]>> = binary_data
                 .iter()
                 .map(|bytes| Some(bytes.as_slice()))
                 .collect();
             Arc::new(arrow_array::BinaryArray::from_opt_vec(binary_refs)) as ArrayRef
         };
-
-        let schema = Arc::new(arrow_schema::Schema::new(vec![
-            Field::new("fragment_id", DataType::UInt64, false),
-            Field::new("zone_start", DataType::UInt64, false),
-            Field::new("zone_length", DataType::UInt64, false),
-            Field::new("has_null", DataType::Boolean, false),
-            Field::new("bloom_filter_data", DataType::Binary, false),
-        ]));
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(fragment_ids) as ArrayRef,
@@ -617,13 +600,15 @@ impl BloomFilterIndexBuilder {
             bloom_filter_data,
         ];
 
-        Ok(RecordBatch::try_new(schema, columns)?)
+        Ok(RecordBatch::try_new(Self::bloomfilter_schema(), columns)?)
     }
 
-    pub async fn write_index(self, index_store: &dyn IndexStore) -> Result<()> {
-        let record_batch = self.bloomfilter_stats_as_batch()?;
-
-        let mut file_schema = record_batch.schema().as_ref().clone();
+    pub async fn write_index(
+        self,
+        index_store: &dyn IndexStore,
+        max_array_length: usize,
+    ) -> Result<()> {
+        let mut file_schema = Self::bloomfilter_schema().as_ref().clone();
         file_schema.metadata.insert(
             BLOOMFILTER_ITEM_META_KEY.to_string(),
             self.params.number_of_items.to_string(),
@@ -634,11 +619,113 @@ impl BloomFilterIndexBuilder {
             self.params.probability.to_string(),
         );
 
-        let mut index_file = index_store
+        let index_file = index_store
             .new_index_file(BLOOMFILTER_FILENAME, Arc::new(file_schema))
             .await?;
-        index_file.write_record_batch(record_batch).await?;
-        index_file.finish().await?;
+
+        let mut writer = BloomFilterBatchWriter::new(index_file, max_array_length);
+        for block in self.blocks {
+            writer.emit(block).await?;
+        }
+        writer.finish().await
+    }
+}
+
+/// Buffers serialized bloom filter zone statistics and flushes them as record batches
+/// to the index file, respecting the `max_array_length` limit.
+struct BloomFilterBatchWriter {
+    file: Box<dyn super::IndexWriter>,
+    max_array_length: usize,
+    fragment_ids: Vec<u64>,
+    zone_starts: Vec<u64>,
+    zone_lengths: Vec<u64>,
+    has_nulls: Vec<bool>,
+    bloom_filter_data: Vec<Vec<u8>>,
+    current_bytes: usize,
+    has_written: bool,
+}
+
+impl BloomFilterBatchWriter {
+    fn new(file: Box<dyn super::IndexWriter>, max_array_length: usize) -> Self {
+        Self {
+            file,
+            max_array_length,
+            fragment_ids: Vec::new(),
+            zone_starts: Vec::new(),
+            zone_lengths: Vec::new(),
+            has_nulls: Vec::new(),
+            bloom_filter_data: Vec::new(),
+            current_bytes: 0,
+            has_written: false,
+        }
+    }
+
+    async fn emit(&mut self, block: BloomFilterStatistics) -> Result<()> {
+        let serialized_filter = block.bloom_filter.to_bytes();
+        let serialized_len = serialized_filter.len();
+
+        if serialized_len > self.max_array_length {
+            return Err(Error::invalid_input(format!(
+                "Serialized bloom filter size {} exceeds max supported batch bytes {}",
+                serialized_len, self.max_array_length
+            )));
+        }
+
+        let next_bytes = self
+            .current_bytes
+            .checked_add(serialized_len)
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "Bloom filter batch size overflow when adding {} bytes to {} bytes",
+                    serialized_len, self.current_bytes
+                ))
+            })?;
+
+        if !self.bloom_filter_data.is_empty() && next_bytes > self.max_array_length {
+            self.flush().await?;
+        }
+
+        self.fragment_ids.push(block.bound.fragment_id);
+        self.zone_starts.push(block.bound.start);
+        self.zone_lengths.push(block.bound.length as u64);
+        self.has_nulls.push(block.has_null);
+        self.bloom_filter_data.push(serialized_filter);
+        self.current_bytes += serialized_len;
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<()> {
+        if self.bloom_filter_data.is_empty() {
+            return Ok(());
+        }
+
+        let batch = BloomFilterIndexBuilder::bloomfilter_stats_as_batch(
+            std::mem::take(&mut self.fragment_ids),
+            std::mem::take(&mut self.zone_starts),
+            std::mem::take(&mut self.zone_lengths),
+            std::mem::take(&mut self.has_nulls),
+            std::mem::take(&mut self.bloom_filter_data),
+        )?;
+        self.file.write_record_batch(batch).await?;
+        self.current_bytes = 0;
+        self.has_written = true;
+        Ok(())
+    }
+
+    async fn finish(mut self) -> Result<()> {
+        self.flush().await?;
+        if !self.has_written {
+            self.file
+                .write_record_batch(BloomFilterIndexBuilder::bloomfilter_stats_as_batch(
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                )?)
+                .await?;
+        }
+        self.file.finish().await?;
         Ok(())
     }
 }
@@ -981,7 +1068,9 @@ impl BloomFilterIndexPlugin {
 
         builder.train(batches_source).await?;
 
-        builder.write_index(index_store).await?;
+        builder
+            .write_index(index_store, MAX_BLOOMFILTER_ARRAY_LENGTH)
+            .await?;
         Ok(())
     }
 }
@@ -1159,7 +1248,7 @@ mod tests {
 
     use crate::scalar::{
         BloomFilterQuery, ScalarIndex, SearchResult,
-        bloomfilter::{BloomFilterIndex, BloomFilterIndexBuilderParams},
+        bloomfilter::{BloomFilterIndex, BloomFilterIndexBuilder, BloomFilterIndexBuilderParams},
         lance_format::LanceIndexStore,
     };
 
@@ -2121,5 +2210,85 @@ mod tests {
             }
             _ => panic!("Expected AtMost search result from bloomfilter"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_bloomfilter_chunked_write_and_load() {
+        let tmpdir = TempObjDir::default();
+        let test_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let row_count = 5_000;
+        let data = arrow_array::Int32Array::from_iter_values(0..row_count);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            VALUE_COLUMN_NAME,
+            DataType::Int32,
+            false,
+        )]));
+        let data = RecordBatch::try_new(schema.clone(), vec![Arc::new(data)]).unwrap();
+        let data_stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::once(std::future::ready(Ok(data))),
+        ));
+        let data_stream = add_row_addr(data_stream);
+
+        let mut builder =
+            BloomFilterIndexBuilder::try_new(BloomFilterIndexBuilderParams::new(1, 0.25)).unwrap();
+        builder.train(data_stream).await.unwrap();
+        assert_eq!(builder.blocks.len(), row_count as usize);
+
+        builder.write_index(test_store.as_ref(), 64).await.unwrap();
+
+        let index = BloomFilterIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+            .await
+            .expect("Failed to load chunked BloomFilterIndex");
+
+        assert_eq!(index.zones.len(), row_count as usize);
+        assert_eq!(index.zones[0].bound.start, 0);
+        assert_eq!(index.zones[4096].bound.start, 4096);
+        assert_eq!(index.zones[4999].bound.start, 4999);
+        assert_eq!(index.zones[4999].bound.length, 1);
+        assert!(!index.zones[4096].bloom_filter.to_bytes().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_bloomfilter_chunked_write_rejects_oversized_filter() {
+        let tmpdir = TempObjDir::default();
+        let test_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let data = arrow_array::Int32Array::from_iter_values(0..1);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            VALUE_COLUMN_NAME,
+            DataType::Int32,
+            false,
+        )]));
+        let data = RecordBatch::try_new(schema.clone(), vec![Arc::new(data)]).unwrap();
+        let data_stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::once(std::future::ready(Ok(data))),
+        ));
+        let data_stream = add_row_addr(data_stream);
+
+        let mut builder =
+            BloomFilterIndexBuilder::try_new(BloomFilterIndexBuilderParams::new(1, 0.25)).unwrap();
+        builder.train(data_stream).await.unwrap();
+
+        let error = builder
+            .write_index(test_store.as_ref(), 16)
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("exceeds max supported batch bytes 16"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -39,7 +39,7 @@ use lance_core::Result;
 use lance_core::cache::LanceCache;
 use roaring::RoaringBitmap;
 
-use super::zoned::{ZoneBound, ZoneProcessor, ZoneTrainer, rebuild_zones, search_zones};
+use super::zoned::{ZoneBound, ZoneProcessor, ZoneTrainer, rebuild_zones_parallel, search_zones};
 
 const BLOOMFILTER_FILENAME: &str = "bloomfilter.lance";
 const BLOOMFILTER_ITEM_META_KEY: &str = "bloomfilter_item";
@@ -441,11 +441,19 @@ impl ScalarIndex for BloomFilterIndex {
         let params = BloomFilterIndexBuilderParams {
             number_of_items: self.number_of_items,
             probability: self.probability,
+            ..Default::default()
         };
 
-        let processor = BloomFilterProcessor::new(params.clone())?;
-        let trainer = ZoneTrainer::new(processor, params.number_of_items)?;
-        let updated_blocks = rebuild_zones(&self.zones, trainer, new_data).await?;
+        let parallelism = params.train_threads.unwrap_or(1);
+        let params_for_factory = params.clone();
+        let updated_blocks = rebuild_zones_parallel::<BloomFilterProcessor, _>(
+            &self.zones,
+            move || BloomFilterProcessor::new(params_for_factory.clone()),
+            params.number_of_items,
+            new_data,
+            parallelism,
+        )
+        .await?;
 
         // Write the combined zones back to storage
         let mut builder = BloomFilterIndexBuilder::try_new(params)?;
@@ -472,6 +480,7 @@ impl ScalarIndex for BloomFilterIndex {
         let params = serde_json::to_value(BloomFilterIndexBuilderParams {
             number_of_items: self.number_of_items,
             probability: self.probability,
+            ..Default::default()
         })?;
         Ok(ScalarIndexParams::for_builtin(BuiltinIndexType::BloomFilter).with_params(&params))
     }
@@ -483,6 +492,10 @@ fn default_number_of_items() -> u64 {
 
 fn default_probability() -> f64 {
     *DEFAULT_PROBABILITY
+}
+
+fn default_train_threads() -> Option<usize> {
+    *DEFAULT_TRAIN_THREADS
 }
 
 // NumberOfItems: 8192 + Probability: 0.00057(1 in 1754) -> NumberOfBytes: 16384(16KiB) + 8 SALT values
@@ -511,12 +524,31 @@ static DEFAULT_PROBABILITY: LazyLock<f64> = LazyLock::new(|| {
         .expect("failed to parse LANCE_BLOOMFILTER_DEFAULT_PROBABILITY")
 });
 
+static DEFAULT_TRAIN_THREADS: LazyLock<Option<usize>> = LazyLock::new(|| {
+    std::env::var("LANCE_BLOOMFILTER_TRAIN_THREADS")
+        .ok()
+        .map(|value| {
+            let parsed: usize = value
+                .parse()
+                .expect("failed to parse LANCE_BLOOMFILTER_TRAIN_THREADS as usize");
+            assert!(
+                parsed > 0,
+                "LANCE_BLOOMFILTER_TRAIN_THREADS must be greater than 0, got {}",
+                parsed
+            );
+            parsed
+        })
+});
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BloomFilterIndexBuilderParams {
     #[serde(default = "default_number_of_items")]
     number_of_items: u64,
     #[serde(default = "default_probability")]
     probability: f64,
+    #[serde(default = "default_train_threads")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    train_threads: Option<usize>,
 }
 
 impl Default for BloomFilterIndexBuilderParams {
@@ -524,6 +556,7 @@ impl Default for BloomFilterIndexBuilderParams {
         Self {
             number_of_items: *DEFAULT_NUMBER_OF_ITEMS,
             probability: *DEFAULT_PROBABILITY,
+            train_threads: default_train_threads(),
         }
     }
 }
@@ -534,6 +567,7 @@ impl BloomFilterIndexBuilderParams {
         Self {
             number_of_items,
             probability,
+            train_threads: None,
         }
     }
 }
@@ -555,9 +589,13 @@ impl BloomFilterIndexBuilder {
     /// contain the value column followed by `_rowaddr`, matching the order emitted by
     /// the scalar index training pipeline.
     pub async fn train(&mut self, batches_source: SendableRecordBatchStream) -> Result<()> {
-        let processor = BloomFilterProcessor::new(self.params.clone())?;
-        let trainer = ZoneTrainer::new(processor, self.params.number_of_items)?;
-        self.blocks = trainer.train(batches_source).await?;
+        let parallelism = self.params.train_threads.unwrap_or(1);
+        let params = self.params.clone();
+        let trainer = ZoneTrainer::new(
+            move || BloomFilterProcessor::new(params.clone()),
+            self.params.number_of_items,
+        )?;
+        self.blocks = trainer.train_parallel(batches_source, parallelism).await?;
         Ok(())
     }
 

--- a/rust/lance-index/src/scalar/zoned.rs
+++ b/rust/lance-index/src/scalar/zoned.rs
@@ -9,12 +9,13 @@
 
 use arrow_array::{ArrayRef, UInt64Array};
 use datafusion::execution::SendableRecordBatchStream;
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt, stream::FuturesUnordered};
 use lance_core::error::Error;
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::mask::RowAddrTreeMap;
 use lance_core::{ROW_ADDR, Result};
 use lance_datafusion::chunker::chunk_concat_stream;
+use tokio::task::JoinHandle;
 
 //
 // Example: Suppose we have two fragments, each with 4 rows.
@@ -58,10 +59,48 @@ pub trait ZoneProcessor {
 }
 
 /// Trainer that handles chunking, fragment boundaries, and zone flushing.
-#[derive(Debug)]
 pub struct ZoneTrainer<P> {
-    processor: P,
+    processor_factory: Box<dyn Fn() -> Result<P> + Send + Sync>,
     zone_capacity: u64,
+}
+
+/// ZoneBound with data.
+#[derive(Debug)]
+struct BufferedZone {
+    bound: ZoneBound,
+    chunks: Vec<ArrayRef>,
+}
+
+struct CompletedZoneTraining<P>
+where
+    P: ZoneProcessor,
+{
+    zone_idx: usize,
+    stats: P::ZoneStatistics,
+    processor: P,
+}
+
+type ZoneTrainingTask<P> = JoinHandle<Result<CompletedZoneTraining<P>>>;
+
+fn train_buffered_zone<P>(
+    mut processor: P,
+    zone: BufferedZone,
+    zone_idx: usize,
+) -> Result<CompletedZoneTraining<P>>
+where
+    P: ZoneProcessor,
+{
+    processor.reset()?;
+    for chunk in &zone.chunks {
+        processor.process_chunk(chunk)?;
+    }
+    let stats = processor.finish_zone(zone.bound)?;
+    processor.reset()?;
+    Ok(CompletedZoneTraining {
+        zone_idx,
+        stats,
+        processor,
+    })
 }
 
 impl<P> ZoneTrainer<P>
@@ -69,14 +108,17 @@ where
     P: ZoneProcessor,
 {
     /// Create a new trainer that buffers at most `zone_capacity` rows per zone.
-    pub fn new(processor: P, zone_capacity: u64) -> Result<Self> {
+    pub fn new<F>(processor_factory: F, zone_capacity: u64) -> Result<Self>
+    where
+        F: Fn() -> Result<P> + Send + Sync + 'static,
+    {
         if zone_capacity == 0 {
             return Err(Error::invalid_input(
                 "zone capacity must be greater than zero",
             ));
         }
         Ok(Self {
-            processor,
+            processor_factory: Box::new(processor_factory),
             zone_capacity,
         })
     }
@@ -89,14 +131,19 @@ where
     /// the `_rowaddr` column with physical row addresses. Future zone-based
     /// indexes should maintain this ordering or extend the trainer to accept an
     /// explicit column index.
-    pub async fn train(
-        mut self,
+    pub async fn train_serial(
+        self,
         stream: SendableRecordBatchStream,
     ) -> Result<Vec<P::ZoneStatistics>> {
         let zone_size = usize::try_from(self.zone_capacity).map_err(|_| {
             Error::invalid_input("zone capacity does not fit into usize on this platform")
         })?;
 
+        let Self {
+            processor_factory,
+            zone_capacity: _,
+        } = self;
+        let mut processor = processor_factory()?;
         let mut batches = chunk_concat_stream(stream, zone_size);
         let mut zones = Vec::new();
         let mut current_fragment_id: Option<u64> = None;
@@ -104,7 +151,7 @@ where
         let mut zone_start_offset: Option<u64> = None;
         let mut zone_end_offset: Option<u64> = None;
 
-        self.processor.reset()?;
+        processor.reset()?;
 
         while let Some(batch) = batches.try_next().await? {
             if batch.num_rows() == 0 {
@@ -129,7 +176,7 @@ where
                     Some(current) if current != fragment_id => {
                         if current_zone_len > 0 {
                             Self::flush_zone(
-                                &mut self.processor,
+                                &mut processor,
                                 &mut zones,
                                 current,
                                 &mut current_zone_len,
@@ -152,8 +199,7 @@ where
                 let capacity = zone_size - current_zone_len;
                 let take = run_len.min(capacity);
 
-                self.processor
-                    .process_chunk(&values.slice(batch_offset, take))?;
+                processor.process_chunk(&values.slice(batch_offset, take))?;
 
                 // Track the first and last row offsets to handle non-contiguous offsets
                 // after deletions. Zone length (offset span) is computed as (last - first + 1),
@@ -174,7 +220,7 @@ where
 
                 if current_zone_len == zone_size {
                     Self::flush_zone(
-                        &mut self.processor,
+                        &mut processor,
                         &mut zones,
                         fragment_id,
                         &mut current_zone_len,
@@ -188,7 +234,7 @@ where
         if current_zone_len > 0 {
             if let Some(fragment_id) = current_fragment_id {
                 Self::flush_zone(
-                    &mut self.processor,
+                    &mut processor,
                     &mut zones,
                     fragment_id,
                     &mut current_zone_len,
@@ -196,14 +242,177 @@ where
                     &mut zone_end_offset,
                 )?;
             } else {
-                self.processor.reset()?;
+                processor.reset()?;
             }
         }
 
         Ok(zones)
     }
 
-    /// Flushes a non-empty zone and resets the processor state.
+    pub async fn train_parallel(
+        self,
+        stream: SendableRecordBatchStream,
+        parallelism: usize,
+    ) -> Result<Vec<P::ZoneStatistics>>
+    where
+        P: Send + 'static,
+        P::ZoneStatistics: Send + 'static,
+    {
+        if parallelism == 0 {
+            return Err(Error::invalid_input(
+                "parallelism must be greater than zero",
+            ));
+        }
+        let zone_size = usize::try_from(self.zone_capacity).map_err(|_| {
+            Error::invalid_input("zone capacity does not fit into usize on this platform")
+        })?;
+
+        let Self {
+            processor_factory,
+            zone_capacity: _,
+        } = self;
+
+        let mut available_processors = Vec::with_capacity(parallelism);
+        for _ in 0..parallelism {
+            available_processors.push(processor_factory()?);
+        }
+
+        let mut batches = chunk_concat_stream(stream, zone_size);
+        let mut current_fragment_id: Option<u64> = None;
+        let mut current_zone_len: usize = 0;
+        let mut zone_start_offset: Option<u64> = None;
+        let mut zone_end_offset: Option<u64> = None;
+        let mut current_chunks: Vec<ArrayRef> = Vec::new();
+        let mut next_zone_idx = 0usize;
+        let mut completed = Vec::new();
+        let mut in_flight = FuturesUnordered::new();
+
+        while let Some(batch) = batches.try_next().await? {
+            if batch.num_rows() == 0 {
+                continue;
+            }
+
+            let values = batch.column(0);
+            let row_addr_col = batch
+                .column_by_name(ROW_ADDR)
+                .unwrap()
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .unwrap();
+
+            let mut batch_offset = 0usize;
+            while batch_offset < batch.num_rows() {
+                let row_addr = row_addr_col.value(batch_offset);
+                let fragment_id = row_addr >> 32;
+
+                // Zones cannot span fragments; flush current zone (if non-empty) at boundary
+                match current_fragment_id {
+                    Some(current) if current != fragment_id => {
+                        if let Some(zone) = Self::take_buffered_zone(
+                            current,
+                            &mut current_zone_len,
+                            &mut zone_start_offset,
+                            &mut zone_end_offset,
+                            &mut current_chunks,
+                        )? {
+                            Self::schedule_zone_training(
+                                zone,
+                                &mut available_processors,
+                                &mut in_flight,
+                                &mut completed,
+                                &mut next_zone_idx,
+                            )
+                            .await?;
+                        }
+                        current_fragment_id = Some(fragment_id);
+                    }
+                    None => {
+                        current_fragment_id = Some(fragment_id);
+                    }
+                    _ => {}
+                }
+
+                // Count consecutive rows in the same fragment
+                let run_len = (batch_offset..batch.num_rows())
+                    .take_while(|&idx| (row_addr_col.value(idx) >> 32) == fragment_id)
+                    .count();
+                let capacity = zone_size - current_zone_len;
+                let take = run_len.min(capacity);
+
+                current_chunks.push(values.slice(batch_offset, take));
+
+                // Track the first and last row offsets to handle non-contiguous offsets
+                // after deletions. Zone length (offset span) is computed as (last - first + 1),
+                // not the actual row count.
+                let first_offset =
+                    RowAddress::new_from_u64(row_addr_col.value(batch_offset)).row_offset() as u64;
+                let last_offset =
+                    RowAddress::new_from_u64(row_addr_col.value(batch_offset + take - 1))
+                        .row_offset() as u64;
+
+                if zone_start_offset.is_none() {
+                    zone_start_offset = Some(first_offset);
+                }
+                zone_end_offset = Some(last_offset);
+
+                current_zone_len += take;
+                batch_offset += take;
+
+                if current_zone_len == zone_size
+                    && let Some(zone) = Self::take_buffered_zone(
+                        fragment_id,
+                        &mut current_zone_len,
+                        &mut zone_start_offset,
+                        &mut zone_end_offset,
+                        &mut current_chunks,
+                    )?
+                {
+                    Self::schedule_zone_training(
+                        zone,
+                        &mut available_processors,
+                        &mut in_flight,
+                        &mut completed,
+                        &mut next_zone_idx,
+                    )
+                    .await?;
+                }
+            }
+        }
+
+        if let Some(fragment_id) = current_fragment_id
+            && let Some(zone) = Self::take_buffered_zone(
+                fragment_id,
+                &mut current_zone_len,
+                &mut zone_start_offset,
+                &mut zone_end_offset,
+                &mut current_chunks,
+            )?
+        {
+            Self::schedule_zone_training(
+                zone,
+                &mut available_processors,
+                &mut in_flight,
+                &mut completed,
+                &mut next_zone_idx,
+            )
+            .await?;
+        }
+
+        while let Some(result) = in_flight.next().await {
+            let completed_zone = result.map_err(|e| {
+                Error::internal(format!("parallel zone training task failed to join: {e}"))
+            })??;
+            available_processors.push(completed_zone.processor);
+            completed.push((completed_zone.zone_idx, completed_zone.stats));
+        }
+
+        completed.sort_by_key(|(zone_idx, _)| *zone_idx);
+        Ok(completed
+            .into_iter()
+            .map(|(_, stats)| stats)
+            .collect::<Vec<_>>())
+    }
+
     fn flush_zone(
         processor: &mut P,
         zones: &mut Vec<P::ZoneStatistics>,
@@ -212,17 +421,12 @@ where
         zone_start_offset: &mut Option<u64>,
         zone_end_offset: &mut Option<u64>,
     ) -> Result<()> {
-        let start = zone_start_offset.unwrap_or(0);
-        let inferred_end =
-            zone_end_offset.unwrap_or_else(|| start + (*current_zone_len as u64).saturating_sub(1));
-        if inferred_end < start {
-            return Err(Error::invalid_input("zone row offsets are out of order"));
-        }
-        let bound = ZoneBound {
+        let bound = Self::build_zone_bound(
             fragment_id,
-            start,
-            length: (inferred_end - start + 1) as usize,
-        };
+            *current_zone_len,
+            *zone_start_offset,
+            *zone_end_offset,
+        )?;
         let stats = processor.finish_zone(bound)?;
         zones.push(stats);
         *current_zone_len = 0;
@@ -231,6 +435,110 @@ where
         processor.reset()?;
         Ok(())
     }
+
+    fn build_zone_bound(
+        fragment_id: u64,
+        current_zone_len: usize,
+        zone_start_offset: Option<u64>,
+        zone_end_offset: Option<u64>,
+    ) -> Result<ZoneBound> {
+        let start = zone_start_offset.unwrap_or(0);
+        let inferred_end =
+            zone_end_offset.unwrap_or_else(|| start + (current_zone_len as u64).saturating_sub(1));
+        if inferred_end < start {
+            return Err(Error::invalid_input("zone row offsets are out of order"));
+        }
+        Ok(ZoneBound {
+            fragment_id,
+            start,
+            length: (inferred_end - start + 1) as usize,
+        })
+    }
+
+    fn take_buffered_zone(
+        fragment_id: u64,
+        current_zone_len: &mut usize,
+        zone_start_offset: &mut Option<u64>,
+        zone_end_offset: &mut Option<u64>,
+        current_chunks: &mut Vec<ArrayRef>,
+    ) -> Result<Option<BufferedZone>> {
+        if *current_zone_len == 0 {
+            current_chunks.clear();
+            *zone_start_offset = None;
+            *zone_end_offset = None;
+            return Ok(None);
+        }
+
+        let bound = Self::build_zone_bound(
+            fragment_id,
+            *current_zone_len,
+            *zone_start_offset,
+            *zone_end_offset,
+        )?;
+        *current_zone_len = 0;
+        *zone_start_offset = None;
+        *zone_end_offset = None;
+        Ok(Some(BufferedZone {
+            bound,
+            chunks: std::mem::take(current_chunks),
+        }))
+    }
+
+    async fn schedule_zone_training(
+        zone: BufferedZone,
+        available_processors: &mut Vec<P>,
+        in_flight: &mut FuturesUnordered<ZoneTrainingTask<P>>,
+        completed: &mut Vec<(usize, P::ZoneStatistics)>,
+        next_zone_idx: &mut usize,
+    ) -> Result<()>
+    where
+        P: Send + 'static,
+        P::ZoneStatistics: Send + 'static,
+    {
+        while available_processors.is_empty() {
+            let Some(result) = in_flight.next().await else {
+                return Err(Error::internal(
+                    "zone processor pool is empty but no training task is in flight",
+                ));
+            };
+            let completed_zone = result.map_err(|e| {
+                Error::internal(format!("parallel zone training task failed to join: {e}"))
+            })??;
+            available_processors.push(completed_zone.processor);
+            completed.push((completed_zone.zone_idx, completed_zone.stats));
+        }
+
+        let Some(processor) = available_processors.pop() else {
+            return Err(Error::internal(
+                "zone processor pool unexpectedly empty before scheduling training",
+            ));
+        };
+        let zone_idx = *next_zone_idx;
+        *next_zone_idx += 1;
+        in_flight.push(tokio::task::spawn_blocking(move || {
+            train_buffered_zone(processor, zone, zone_idx)
+        }));
+        Ok(())
+    }
+}
+
+pub async fn rebuild_zones_parallel<P, F>(
+    existing: &[P::ZoneStatistics],
+    processor_factory: F,
+    zone_capacity: u64,
+    stream: SendableRecordBatchStream,
+    parallelism: usize,
+) -> Result<Vec<P::ZoneStatistics>>
+where
+    P: ZoneProcessor + Send + 'static,
+    P::ZoneStatistics: Clone + Send + 'static,
+    F: Fn() -> Result<P> + Send + Sync + 'static,
+{
+    let trainer = ZoneTrainer::new(processor_factory, zone_capacity)?;
+    let mut combined = existing.to_vec();
+    let mut new_zones = trainer.train_parallel(stream, parallelism).await?;
+    combined.append(&mut new_zones);
+    Ok(combined)
 }
 
 /// Shared search helper that loops over zones, records metrics, and
@@ -268,7 +576,7 @@ where
 /// Helper that retrains zones from `stream` and appends them to the existing
 /// statistics. Useful for index update paths that need to merge new fragments
 /// into an existing zone list.
-pub async fn rebuild_zones<P>(
+pub async fn rebuild_zones_serial<P>(
     existing: &[P::ZoneStatistics],
     trainer: ZoneTrainer<P>,
     stream: SendableRecordBatchStream,
@@ -278,7 +586,7 @@ where
     P::ZoneStatistics: Clone,
 {
     let mut combined = existing.to_vec();
-    let mut new_zones = trainer.train(stream).await?;
+    let mut new_zones = trainer.train_serial(stream).await?;
     combined.append(&mut new_zones);
     Ok(combined)
 }
@@ -292,7 +600,11 @@ mod tests {
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
     use futures::stream;
     use lance_core::ROW_ADDR;
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
 
     #[derive(Debug, Clone, PartialEq)]
     struct MockStats {
@@ -333,6 +645,83 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct ConcurrencyTrackingProcessor {
+        tracker: Arc<ConcurrencyTracker>,
+        current_sum: i32,
+        is_active: bool,
+    }
+
+    #[derive(Debug, Default)]
+    struct ConcurrencyTracker {
+        created: AtomicUsize,
+        current: AtomicUsize,
+        max_seen: AtomicUsize,
+    }
+
+    impl ConcurrencyTrackingProcessor {
+        fn new(tracker: Arc<ConcurrencyTracker>) -> Self {
+            Self {
+                tracker,
+                current_sum: 0,
+                is_active: false,
+            }
+        }
+
+        fn mark_active(&mut self) {
+            if self.is_active {
+                return;
+            }
+            self.is_active = true;
+            let current = self.tracker.current.fetch_add(1, Ordering::SeqCst) + 1;
+            let _ = self.tracker.max_seen.fetch_update(
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+                |max_seen| (current > max_seen).then_some(current),
+            );
+        }
+
+        fn mark_inactive(&mut self) {
+            if !self.is_active {
+                return;
+            }
+            self.is_active = false;
+            self.tracker.current.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    impl Drop for ConcurrencyTrackingProcessor {
+        fn drop(&mut self) {
+            self.mark_inactive();
+        }
+    }
+
+    impl ZoneProcessor for ConcurrencyTrackingProcessor {
+        type ZoneStatistics = MockStats;
+
+        fn process_chunk(&mut self, values: &ArrayRef) -> Result<()> {
+            self.mark_active();
+            std::thread::sleep(Duration::from_millis(25));
+            let arr = values.as_any().downcast_ref::<Int32Array>().unwrap();
+            self.current_sum += arr.iter().map(|v| v.unwrap_or(0)).sum::<i32>();
+            Ok(())
+        }
+
+        fn finish_zone(&mut self, bound: ZoneBound) -> Result<Self::ZoneStatistics> {
+            self.mark_inactive();
+            Ok(MockStats {
+                sum: self.current_sum,
+                bound,
+            })
+        }
+
+        fn reset(&mut self) -> Result<()> {
+            self.mark_inactive();
+            self.current_sum = 0;
+            Ok(())
+        }
+    }
+
     fn batch(values: Vec<i32>, fragments: Vec<u64>, offsets: Vec<u64>) -> RecordBatch {
         let val_array = Arc::new(Int32Array::from(values));
         let row_addrs: Vec<u64> = fragments
@@ -348,6 +737,24 @@ mod tests {
         RecordBatch::try_new(schema, vec![val_array, addr_array]).unwrap()
     }
 
+    fn mock_trainer(zone_capacity: u64) -> ZoneTrainer<MockProcessor> {
+        ZoneTrainer::new(|| Ok(MockProcessor::new()), zone_capacity).unwrap()
+    }
+
+    fn concurrency_trainer(
+        tracker: Arc<ConcurrencyTracker>,
+        zone_capacity: u64,
+    ) -> ZoneTrainer<ConcurrencyTrackingProcessor> {
+        ZoneTrainer::new(
+            move || {
+                tracker.created.fetch_add(1, Ordering::SeqCst);
+                Ok(ConcurrencyTrackingProcessor::new(tracker.clone()))
+            },
+            zone_capacity,
+        )
+        .unwrap()
+    }
+
     #[tokio::test]
     async fn splits_single_fragment() {
         // Single fragment with 10 rows, zone capacity = 4.
@@ -360,9 +767,8 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 4).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(4);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // Three zones: offsets [0..=3], [4..=7], [8..=9]
         assert_eq!(stats.len(), 3);
@@ -379,6 +785,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn parallel_training_matches_sequential() {
+        // Mixed fragments + multiple batches to exercise boundary flushes and partial zones.
+        let b1 = batch(
+            vec![1, 2, 3, 4, 5, 6],
+            vec![0, 0, 0, 1, 1, 1],
+            vec![0, 1, 2, 0, 1, 2],
+        );
+        let b2 = batch(vec![7, 8, 9, 10], vec![1, 1, 2, 2], vec![3, 4, 0, 1]);
+        let schema = b1.schema();
+
+        let seq_stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::iter(vec![Ok(b1.clone()), Ok(b2.clone())]),
+        ));
+        let trainer = mock_trainer(4);
+        let seq = trainer.train_serial(seq_stream).await.unwrap();
+
+        let par_stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::iter(vec![Ok(b1), Ok(b2)]),
+        ));
+        let trainer = ZoneTrainer::new(|| Ok(MockProcessor::new()), 4).unwrap();
+        let par = trainer.train_parallel(par_stream, 4).await.unwrap();
+
+        assert_eq!(seq, par);
+    }
+
+    #[tokio::test]
+    async fn parallel_training_respects_concurrency_limit() {
+        let tracker = Arc::new(ConcurrencyTracker::default());
+        let values = vec![1, 2, 3, 4, 5, 6];
+        let offsets: Vec<u64> = (0..values.len() as u64).collect();
+        let batch = batch(values, vec![0; offsets.len()], offsets);
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            batch.schema(),
+            stream::once(async { Ok(batch) }),
+        ));
+
+        let trainer = concurrency_trainer(tracker.clone(), 1);
+        let stats = trainer.train_parallel(stream, 2).await.unwrap();
+
+        assert_eq!(stats.len(), 6);
+        assert_eq!(tracker.created.load(Ordering::SeqCst), 2);
+        assert_eq!(tracker.max_seen.load(Ordering::SeqCst), 2);
+        assert_eq!(tracker.current.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn flushes_on_fragment_boundary() {
         // Two fragments back to back, capacity is large enough that only fragment
         // boundaries cause zone flushes. Expect two zones (one per fragment).
@@ -391,9 +845,8 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 10).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(10);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // Two zones, one per fragment (capacity=10 is large enough)
         assert_eq!(stats.len(), 2);
@@ -416,9 +869,8 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 10).unwrap();
-        let err = trainer.train(stream).await.unwrap_err();
+        let trainer = mock_trainer(10);
+        let err = trainer.train_serial(stream).await.unwrap_err();
         assert!(
             format!("{}", err).contains("zone row offsets are out of order"),
             "unexpected error: {err:?}"
@@ -445,9 +897,8 @@ mod tests {
             ]),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 10).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(10);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // One zone containing the 3 valid rows (empty batches skipped)
         assert_eq!(stats.len(), 1);
@@ -467,9 +918,8 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 1).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(1);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // Three zones, one per row (capacity=1)
         assert_eq!(stats.len(), 3);
@@ -492,9 +942,8 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 10000).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(10000);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // One zone containing all 100 rows (capacity is large enough)
         assert_eq!(stats.len(), 1);
@@ -505,14 +954,30 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_zero_capacity() {
-        let processor = MockProcessor::new();
-        let result = ZoneTrainer::new(processor, 0);
+        let result = ZoneTrainer::new(|| Ok(MockProcessor::new()), 0);
         assert!(result.is_err());
+        let err = result.err().unwrap();
         assert!(
-            result
-                .unwrap_err()
-                .to_string()
+            err.to_string()
                 .contains("zone capacity must be greater than zero")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_zero_parallelism() {
+        let trainer = ZoneTrainer::new(|| Ok(MockProcessor::new()), 1).unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("value", DataType::Int32, false),
+            Field::new(ROW_ADDR, DataType::UInt64, false),
+        ]));
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::once(async { Ok(RecordBatch::new_empty(schema)) }),
+        ));
+        let err = trainer.train_parallel(stream, 0).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("parallelism must be greater than zero")
         );
     }
 
@@ -528,9 +993,8 @@ mod tests {
             stream::iter(vec![Ok(b1), Ok(b2), Ok(b3)]),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 4).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(4);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // Two zones: first 4 rows, then remaining 2 rows
         assert_eq!(stats.len(), 2);
@@ -559,9 +1023,8 @@ mod tests {
             stream::iter(vec![Ok(b1), Ok(b2)]),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 3).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(3);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // Three zones: frag 0 full zone, frag 0 partial (flushed at boundary), frag 1
         assert_eq!(stats.len(), 3);
@@ -600,9 +1063,8 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 4).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(4);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // Should create 2 zones (capacity=4):
         // Zone 0: rows at offsets [0, 1, 5, 7] (4 rows)
@@ -635,9 +1097,8 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 10).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(10);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // One zone with 3 rows, but offset span [0..=200] so length=201 due to large gaps
         assert_eq!(stats.len(), 1);
@@ -661,9 +1122,8 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let processor = MockProcessor::new();
-        let trainer = ZoneTrainer::new(processor, 10).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let trainer = mock_trainer(10);
+        let stats = trainer.train_serial(stream).await.unwrap();
 
         // Should create 3 zones (one per fragment)
         assert_eq!(stats.len(), 3);
@@ -809,8 +1269,10 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let trainer = ZoneTrainer::new(MockProcessor::new(), 2).unwrap();
-        let rebuilt = rebuild_zones(&existing, trainer, stream).await.unwrap();
+        let trainer = mock_trainer(2);
+        let rebuilt = rebuild_zones_serial(&existing, trainer, stream)
+            .await
+            .unwrap();
         // Existing zone should remain unchanged and new stats appended afterwards
         assert_eq!(rebuilt.len(), 2);
         assert_eq!(rebuilt[0].sum, 50);
@@ -839,8 +1301,10 @@ mod tests {
             stream::once(async { Ok(batch) }),
         ));
 
-        let trainer = ZoneTrainer::new(MockProcessor::new(), 2).unwrap();
-        let rebuilt = rebuild_zones(&existing, trainer, stream).await.unwrap();
+        let trainer = mock_trainer(2);
+        let rebuilt = rebuild_zones_serial(&existing, trainer, stream)
+            .await
+            .unwrap();
         // Existing zone plus two new fragments should yield three total zones
         assert_eq!(rebuilt.len(), 3);
         assert_eq!(rebuilt[0].bound.fragment_id, 0);

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -44,7 +44,7 @@ use lance_core::Error;
 use lance_core::Result;
 use roaring::RoaringBitmap;
 
-use super::zoned::{ZoneBound, ZoneProcessor, ZoneTrainer, rebuild_zones, search_zones};
+use super::zoned::{ZoneBound, ZoneProcessor, ZoneTrainer, rebuild_zones_serial, search_zones};
 const ROWS_PER_ZONE_DEFAULT: u64 = 8192; // 1 zone every two batches
 
 const ZONEMAP_FILENAME: &str = "zonemap.lance";
@@ -591,9 +591,11 @@ impl ScalarIndex for ZoneMapIndex {
         let value_type = schema.field(0).data_type().clone();
 
         let options = ZoneMapIndexBuilderParams::new(self.rows_per_zone);
-        let processor = ZoneMapProcessor::new(value_type.clone())?;
-        let trainer = ZoneTrainer::new(processor, self.rows_per_zone)?;
-        let updated_zones = rebuild_zones(&self.zones, trainer, new_data).await?;
+        let trainer = ZoneTrainer::new(
+            move || ZoneMapProcessor::new(value_type.clone()),
+            self.rows_per_zone,
+        )?;
+        let updated_zones = rebuild_zones_serial(&self.zones, trainer, new_data).await?;
 
         // Serialize the combined zones back into the index file
         let mut builder = ZoneMapIndexBuilder::try_new(options, self.data_type.clone())?;
@@ -677,9 +679,12 @@ impl ZoneMapIndexBuilder {
     /// the value column followed by `_rowaddr`, matching the dataset scan order enforced
     /// by the scalar index registry.
     pub async fn train(&mut self, batches_source: SendableRecordBatchStream) -> Result<()> {
-        let processor = ZoneMapProcessor::new(self.items_type.clone())?;
-        let trainer = ZoneTrainer::new(processor, self.options.rows_per_zone)?;
-        self.maps = trainer.train(batches_source).await?;
+        let items_type = self.items_type.clone();
+        let trainer = ZoneTrainer::new(
+            move || ZoneMapProcessor::new(items_type.clone()),
+            self.options.rows_per_zone,
+        )?;
+        self.maps = trainer.train_serial(batches_source).await?;
         Ok(())
     }
 


### PR DESCRIPTION
# Background

When training a Bloom filter on a dataset with **2 billion rows (string type)**, the task did not complete even after **3 hours**.

---

# Analysis

Lance currently supports two types of zone-based indexes:

- **Bloom Filter**
- **ZoneMap**

Their performance characteristics differ significantly:

- **Bloom Filter training**
  - CPU-intensive
  - Can benefit from parallelism

- **ZoneMap construction**
  - Not CPU-intensive
  - Bottleneck lies in **I/O and memory bandwidth**
  - Parallelism does **not** provide noticeable speedup

---

# Experiments

## 1. Bloom Filter Training (Double, 20M rows, object storage)

We evaluated the impact of parallelism on Bloom filter training.

| Parallelism | Time (s) |
|------------|---------|
| 1          | 20.788  |
| 2          | 12.165  |
| 5          | 7.616   |
| 10         | 6.295   |

---

## 2. ZoneMap Index (Int, 200M rows)

We evaluated ZoneMap performance under different parallelism levels.

| Parallelism | Time (s) |
|------------|---------|
| 1          | 25      |
| 2          | 25      |
| 10         | 25      |

---

# Proposed Changes

Update `zoned.rs` to introduce parallel execution support:

- Add:
  - `train_parallel`
  - `rebuild_zones_parallel`

- Rename existing methods:
  - `train` → `train_serial`
  - `rebuild_zones` → `rebuild_zones_serial`

### Usage

- **Bloom Filter** → use `*_parallel`
- **ZoneMap** → use `*_serial`

---

* This pr is blocked by: https://github.com/lance-format/lance/pull/6522