### PR TITLE
fix: apply fragment bitmap allow-list to index search results

### DIFF
--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -1718,6 +1718,420 @@ async fn test_data_replacement_invalidates_index_bitmap() {
         "Fragment 0 should be removed from index bitmap after DataReplacement on indexed column"
     );
 }
+
+/// DataReplacement on an indexed column should remove the fragment from
+/// fragment_bitmap AND add it to invalidated_fragment_bitmap so that
+/// stale index entries are blocked at query time.
+#[tokio::test]
+async fn test_data_replacement_populates_invalidated_bitmap() {
+    use lance_file::writer::FileWriter;
+    use object_store::path::Path;
+
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        ArrowField::new("value", DataType::Int32, true),
+    ]));
+
+    // Create dataset with one fragment
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+        ],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+    let mut dataset = Dataset::write(reader, "memory://test_replacement_invalidated", None)
+        .await
+        .unwrap();
+
+    // Create BTree index on 'value'
+    dataset
+        .create_index(
+            &["value"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+
+    // Verify initial state: fragment 0 in bitmap, no invalidated fragments
+    let indices = dataset.load_indices().await.unwrap();
+    let idx = indices.iter().find(|i| i.name == "value_idx").unwrap();
+    assert!(idx.fragment_bitmap.as_ref().unwrap().contains(0));
+
+    // Write a replacement data file for column 'value'
+    let value_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "value",
+        DataType::Int32,
+        true,
+    )]));
+    let replacement_batch = RecordBatch::try_new(
+        value_schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![40, 50, 60]))],
+    )
+    .unwrap();
+
+    let object_writer = dataset
+        .object_store
+        .create(&Path::from("data/replacement_inv.lance"))
+        .await
+        .unwrap();
+    let mut writer = FileWriter::try_new(
+        object_writer,
+        value_schema.as_ref().try_into().unwrap(),
+        Default::default(),
+    )
+    .unwrap();
+    writer.write_batch(&replacement_batch).await.unwrap();
+    writer.finish().await.unwrap();
+
+    // Build replacement DataFile
+    let frag = dataset.get_fragment(0).unwrap();
+    let lance_schema: lance_core::datatypes::Schema = schema.as_ref().try_into().unwrap();
+    let value_field_id = lance_schema.field("value").unwrap().id;
+    let data_file = frag.data_file_for_field(value_field_id as u32).unwrap();
+    let mut new_data_file = data_file.clone();
+    new_data_file.path = "replacement_inv.lance".to_string();
+
+    // Commit DataReplacement
+    let read_version = dataset.version().version;
+    let dataset = Dataset::commit(
+        WriteDestination::Dataset(Arc::new(dataset)),
+        Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(0, new_data_file)],
+        },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .unwrap();
+
+    // Check: fragment 0 removed from fragment_bitmap
+    let indices = dataset.load_indices().await.unwrap();
+    let idx = indices.iter().find(|i| i.name == "value_idx").unwrap();
+    assert!(
+        !idx.fragment_bitmap.as_ref().unwrap().contains(0),
+        "Fragment 0 should be removed from fragment_bitmap"
+    );
+}
+
+/// Regression test (lance-format/lance#6283): after in-place update via
+/// DataReplacement, stale FTS index entries for the replaced fragment must
+/// be blocked at query time so searches reflect the new data.
+#[tokio::test]
+async fn test_fts_stale_entries_after_data_replacement() {
+    use lance_index::scalar::{FullTextSearchQuery, inverted::InvertedIndexParams};
+
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        ArrowField::new("text", DataType::Utf8, true),
+    ]));
+
+    // Step 1: Create dataset with 2 rows in separate fragments
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![0, 1])),
+            Arc::new(StringArray::from(vec![
+                "the quick brown fox",
+                "the lazy dog",
+            ])),
+        ],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+    let mut dataset = Dataset::write(
+        reader,
+        "memory://test_fts_incremental_reindex",
+        Some(WriteParams {
+            max_rows_per_file: 1, // Force 2 fragments
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Step 2: Create FTS inverted index on 'text'
+    let params = InvertedIndexParams::default();
+    dataset
+        .create_index(&["text"], IndexType::Inverted, None, &params, true)
+        .await
+        .unwrap();
+
+    // Sanity check: "quick" and "lazy" should each return 1 result
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("quick".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(results.num_rows(), 1);
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("lazy".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(results.num_rows(), 1);
+
+    // Step 3: Replace fragment 1's data file via DataReplacement.
+    // The fragment ID stays the same, but the text changes from
+    // "the lazy dog" to "a speedy cat". This prunes fragment 1
+    // from the FTS index's fragment_bitmap.
+    let frag1 = dataset.get_fragment(1).unwrap();
+    let old_data_file = frag1.metadata().files[0].clone();
+
+    // Write replacement data file with updated text
+    let replacement_batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1])),
+            Arc::new(StringArray::from(vec!["a speedy cat"])),
+        ],
+    )
+    .unwrap();
+    let replacement_path = dataset.data_dir().child("replacement.lance");
+    let object_writer = dataset
+        .object_store
+        .create(&replacement_path)
+        .await
+        .unwrap();
+    let mut writer = FileWriter::try_new(
+        object_writer,
+        schema.as_ref().try_into().unwrap(),
+        Default::default(),
+    )
+    .unwrap();
+    writer.write_batch(&replacement_batch).await.unwrap();
+    writer.finish().await.unwrap();
+
+    let mut new_data_file = old_data_file.clone();
+    new_data_file.path = "replacement.lance".to_string();
+
+    let read_version = dataset.manifest.version;
+    let dataset = Dataset::commit(
+        WriteDestination::Dataset(Arc::new(dataset)),
+        Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(1, new_data_file)],
+        },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .unwrap();
+
+    // Verify the replacement worked — fragment 1 now has the new text
+    let batch = dataset.scan().try_into_batch().await.unwrap();
+    assert_eq!(batch.num_rows(), 2);
+
+    // Step 4: FTS search should reflect the new data, not the old.
+    // Fragment 1 is unindexed (pruned from fragment_bitmap), so the
+    // scanner does a flat FTS scan on it and uses the index for fragment 0.
+
+    // "speedy" is in the new text for fragment 1 — found via flat scan.
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("speedy".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(results.num_rows(), 1);
+
+    // "lazy" was in the OLD text for fragment 1. The index has stale
+    // posting entries for it, but fragment 1 was pruned from the
+    // fragment_bitmap. Flat scan of fragment 1 sees "a speedy cat"
+    // which doesn't match. So 0 results.
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("lazy".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(
+        results.num_rows(),
+        0,
+        "Expected 0 results for 'lazy' (stale data, fragment 1 pruned from index)"
+    );
+
+    // "quick" is in fragment 0 which is still indexed — should still work.
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("quick".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(results.num_rows(), 1);
+}
+
+/// Same scenario as test_fts_index_incremental_reindex_after_in_place_update
+/// but with a vector (IVF_PQ) index instead of FTS.
+#[tokio::test]
+async fn test_vector_index_after_data_replacement() {
+    use arrow_array::FixedSizeListArray;
+    use lance_arrow::FixedSizeListArrayExt;
+    use lance_index::vector::{ivf::IvfBuildParams, pq::PQBuildParams};
+    use lance_testing::datagen::generate_random_array;
+
+    const DIM: usize = 32;
+    const ROWS_PER_FRAG: usize = 256;
+    const TOTAL: usize = ROWS_PER_FRAG * 2;
+
+    let fsl_field = ArrowField::new(
+        "vector",
+        DataType::FixedSizeList(
+            Arc::new(ArrowField::new("item", DataType::Float32, true)),
+            DIM as i32,
+        ),
+        true,
+    );
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        fsl_field,
+    ]));
+
+    // Step 1: Create dataset with TOTAL rows in 2 fragments.
+    let vectors = generate_random_array(TOTAL * DIM);
+    let vector_array =
+        Arc::new(FixedSizeListArray::try_new_from_values(vectors, DIM as i32).unwrap());
+    let ids: Vec<i32> = (0..TOTAL as i32).collect();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(ids)), vector_array.clone()],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+    let mut dataset = Dataset::write(
+        reader,
+        "memory://test_vec_data_replacement",
+        Some(WriteParams {
+            max_rows_per_file: ROWS_PER_FRAG,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+
+    // Step 2: Create IVF_PQ vector index
+    let ivf_params = IvfBuildParams::new(2);
+    let pq_params = PQBuildParams {
+        num_sub_vectors: 1,
+        ..Default::default()
+    };
+    let params = crate::index::vector::VectorIndexParams::with_ivf_pq_params(
+        lance_linalg::distance::MetricType::L2,
+        ivf_params,
+        pq_params,
+    );
+    dataset
+        .create_index(&["vector"], IndexType::Vector, None, &params, true)
+        .await
+        .unwrap();
+
+    // Sanity: nearest to all-zeros query with refine should return
+    // results from both fragments.
+    let query_zeros = Float32Array::from(vec![0.0_f32; DIM]);
+    let results = dataset
+        .scan()
+        .nearest("vector", &query_zeros, 10)
+        .unwrap()
+        .refine(10)
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(results.num_rows(), 10);
+
+    // Step 3: DataReplacement — replace fragment 1's data.
+    // Write all-999.0 vectors so they are very far from origin.
+    let frag1 = dataset.get_fragment(1).unwrap();
+    let frag1_id = frag1.id() as u64;
+    let old_data_file = frag1.metadata().files[0].clone();
+
+    let far_values: Vec<f32> = vec![999.0_f32; ROWS_PER_FRAG * DIM];
+    let far_vectors = Float32Array::from(far_values);
+    let far_vector_array =
+        FixedSizeListArray::try_new_from_values(far_vectors, DIM as i32).unwrap();
+    let replacement_ids: Vec<i32> = (ROWS_PER_FRAG as i32..(TOTAL as i32)).collect();
+    let replacement_batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(replacement_ids)),
+            Arc::new(far_vector_array),
+        ],
+    )
+    .unwrap();
+
+    let replacement_path = dataset.data_dir().child("replacement.lance");
+    let object_writer = dataset
+        .object_store
+        .create(&replacement_path)
+        .await
+        .unwrap();
+    let mut writer = FileWriter::try_new(
+        object_writer,
+        schema.as_ref().try_into().unwrap(),
+        Default::default(),
+    )
+    .unwrap();
+    writer.write_batch(&replacement_batch).await.unwrap();
+    writer.finish().await.unwrap();
+
+    let mut new_data_file = old_data_file.clone();
+    new_data_file.path = "replacement.lance".to_string();
+
+    let read_version = dataset.manifest.version;
+    let dataset = Dataset::commit(
+        WriteDestination::Dataset(Arc::new(dataset)),
+        Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(frag1_id, new_data_file)],
+        },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .unwrap();
+
+    // Step 4: Search — nearest to all-zeros WITHOUT refine.
+    // Fragment 1's vectors are now all-999.0 (very far from origin).
+    // The top-10 nearest should all come from fragment 0.
+    // If stale index entries leak through, results from fragment 1
+    // would appear with their old (closer) PQ-approximated distances.
+    let results = dataset
+        .scan()
+        .nearest("vector", &query_zeros, 10)
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let ids = results["id"].as_any().downcast_ref::<Int32Array>().unwrap();
+    for i in 0..results.num_rows() {
+        assert!(
+            (ids.value(i) as usize) < ROWS_PER_FRAG,
+            "Result {} has id={} which is from fragment 1 (stale index entry leaked through)",
+            i,
+            ids.value(i)
+        );
+    }
+}
+
 /// Regression test: inverted (FTS) index should not carry stale data after
 /// merge_insert + compact + optimize_indices.
 ///

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -2297,7 +2297,7 @@ mod tests {
     use lance_datafusion::{datagen::DatafusionDatagenExt, utils::reader_to_stream};
     use lance_datagen::{BatchCount, Dimension, RowCount, Seed, array};
     use lance_index::IndexType;
-    use lance_index::scalar::ScalarIndexParams;
+    use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams};
     use lance_io::object_store::ObjectStoreParams;
     use lance_linalg::distance::MetricType;
     use mock_instant::thread_local::MockClock;
@@ -7656,6 +7656,672 @@ MergeInsert: on=[id], when_matched=UpdateAll, when_not_matched=InsertAll, when_n
                 Err(other) => panic!("Expected External, got: {:?}", other),
                 Ok(_) => panic!("Expected error"),
             }
+        }
+    }
+
+    /// Creates a 3-fragment dataset (100 rows each) with columns (id: Utf8, category: Utf8,
+    /// value_a: Float64, value_b: Float64) and a BTree index on `id`.
+    ///
+    /// Fragment 0: id-0000..id-0099
+    /// Fragment 1: id-0100..id-0199
+    /// Fragment 2: id-0200..id-0299
+    async fn create_indexed_3frag_dataset() -> Arc<Dataset> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new("value_a", DataType::Float64, false),
+            Field::new("value_b", DataType::Float64, false),
+        ]));
+
+        let make_batch = |frag_idx: usize| {
+            let start = frag_idx * 100;
+            let ids: Vec<String> = (start..start + 100).map(|j| format!("id-{j:04}")).collect();
+            let categories: Vec<&str> = vec!["A"; 100];
+            let value_a: Vec<f64> = (0..100)
+                .map(|i| i as f64 + frag_idx as f64 * 100.0)
+                .collect();
+            let value_b: Vec<f64> = (0..100).map(|i| i as f64 * 0.1).collect();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(ids)),
+                    Arc::new(StringArray::from(categories)),
+                    Arc::new(Float64Array::from(value_a)),
+                    Arc::new(Float64Array::from(value_b)),
+                ],
+            )
+            .unwrap()
+        };
+
+        // Write first fragment
+        let batch0 = make_batch(0);
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch0)], schema.clone()));
+        let mut ds = Dataset::write(reader, "memory://indexed_3frag", None)
+            .await
+            .unwrap();
+
+        // Append fragments 1 and 2
+        for frag_idx in 1..3 {
+            let batch = make_batch(frag_idx);
+            let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+            ds.append(reader, None).await.unwrap();
+        }
+
+        // Create BTree index on id
+        ds.create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+
+        Arc::new(ds)
+    }
+
+    /// Perform a partial-schema merge_insert (only id + value_a) targeting specific id ranges.
+    /// This causes touched fragments to drop from the index bitmap while btree data retains
+    /// stale entries.
+    async fn partial_merge_insert(
+        dataset: Arc<Dataset>,
+        id_range: std::ops::Range<usize>,
+        value_a_val: f64,
+    ) -> Arc<Dataset> {
+        let ids: Vec<String> = id_range.map(|j| format!("id-{j:04}")).collect();
+        let n = ids.len();
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("value_a", DataType::Float64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(Float64Array::from(vec![value_a_val; n])),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch)], sub_schema));
+
+        let (ds, _) = MergeInsertBuilder::try_new(dataset, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await
+            .unwrap();
+        ds
+    }
+
+    // Regression test: partial-schema merge_insert followed by another partial merge_insert
+    // on the same rows should not produce "Ambiguous merge inserts" errors.
+    //
+    // The bug: the first partial merge_insert drops the touched fragment from the index bitmap
+    // but leaves stale btree entries. The second merge_insert finds the same rows via both
+    // the stale btree lookup AND the unindexed fragment scan, causing duplicates.
+    #[tokio::test]
+    async fn test_partial_merge_insert_stale_index_ambiguous() {
+        let dataset = create_indexed_3frag_dataset().await;
+
+        // Step 2: Partial merge_insert on fragment 1 rows -> fragment 1 drops from bitmap
+        let dataset = partial_merge_insert(dataset, 100..200, 999.0).await;
+
+        // Step 3: Another partial merge_insert on the same rows.
+        // This should succeed, not fail with "Ambiguous merge inserts".
+        let dataset = partial_merge_insert(dataset, 100..200, 888.0).await;
+
+        // Verify correctness: all 300 rows present, updated values correct
+        let batches = dataset
+            .scan()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let all_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new("value_a", DataType::Float64, false),
+            Field::new("value_b", DataType::Float64, false),
+        ]));
+        let combined = concat_batches(&all_schema, &batches).unwrap();
+        assert_eq!(combined.num_rows(), 300);
+
+        // Check the updated rows have value_a = 888.0
+        let result = dataset
+            .scan()
+            .filter("id >= 'id-0100' AND id < 'id-0200'")
+            .unwrap()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let result = concat_batches(&all_schema, &result).unwrap();
+        assert_eq!(result.num_rows(), 100);
+        let values = result
+            .column_by_name("value_a")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        for i in 0..100 {
+            assert_eq!(values.value(i), 888.0, "row {i} should have value_a=888.0");
+        }
+    }
+
+    // Regression test: partial-schema merge_insert followed by update (deleting all rows
+    // in a fragment) followed by partial merge_insert should not produce
+    // "fragment id N does not exist" errors.
+    //
+    // The bug: stale btree entries reference the deleted fragment. The deletion mask doesn't
+    // block those addresses because the fragment isn't in the index bitmap. TakeExec tries
+    // to read from a non-existent fragment.
+    #[tokio::test]
+    async fn test_partial_merge_insert_stale_index_fragment_not_exist() {
+        let dataset = create_indexed_3frag_dataset().await;
+
+        // Step 2: Partial merge_insert on fragment 1 rows -> fragment 1 drops from bitmap
+        let dataset = partial_merge_insert(dataset, 100..200, 999.0).await;
+
+        // Step 3: Update all rows that were in fragment 1, causing fragment 1 to be
+        // fully deleted and replaced by a new fragment.
+        let update_result = crate::dataset::UpdateBuilder::new(Arc::new((*dataset).clone()))
+            .update_where("id >= 'id-0100' AND id < 'id-0200'")
+            .unwrap()
+            .set("category", "'B'")
+            .unwrap()
+            .build()
+            .unwrap()
+            .execute()
+            .await
+            .unwrap();
+        let dataset = update_result.new_dataset;
+
+        // Step 4: Partial merge_insert on the same rows.
+        // This should succeed, not fail with "fragment does not exist".
+        let dataset = partial_merge_insert(dataset, 100..200, 888.0).await;
+
+        // Verify correctness
+        let batches = dataset
+            .scan()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let all_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new("value_a", DataType::Float64, false),
+            Field::new("value_b", DataType::Float64, false),
+        ]));
+        let combined = concat_batches(&all_schema, &batches).unwrap();
+        assert_eq!(combined.num_rows(), 300);
+    }
+
+    // Regression test: partial-schema merge_insert followed by update (deleting SOME rows
+    // in a fragment) followed by partial merge_insert should not produce
+    // "RecordBatch size mismatch" errors.
+    //
+    // The bug: stale btree entries reference deleted rows in a fragment that still exists.
+    // The deletion mask doesn't block those addresses (fragment not in bitmap). TakeExec
+    // reads the fragment but the rows have deletion markers, returning 0 rows where N
+    // were expected.
+    #[tokio::test]
+    async fn test_partial_merge_insert_stale_index_batch_size_mismatch() {
+        let dataset = create_indexed_3frag_dataset().await;
+
+        // Step 2: Partial merge_insert on fragment 1 rows -> fragment 1 drops from bitmap
+        let dataset = partial_merge_insert(dataset, 100..200, 999.0).await;
+
+        // Step 3: Update HALF of the rows that were in fragment 1. Fragment 1 survives
+        // but the updated rows are deleted from it (moved to a new fragment).
+        let update_result = crate::dataset::UpdateBuilder::new(Arc::new((*dataset).clone()))
+            .update_where("id >= 'id-0100' AND id < 'id-0150'")
+            .unwrap()
+            .set("category", "'B'")
+            .unwrap()
+            .build()
+            .unwrap()
+            .execute()
+            .await
+            .unwrap();
+        let dataset = update_result.new_dataset;
+
+        // Step 4: Partial merge_insert targeting the rows that were updated (and thus
+        // deleted from fragment 1). Should succeed, not fail with batch size mismatch.
+        let dataset = partial_merge_insert(dataset, 100..150, 888.0).await;
+
+        // Verify correctness
+        let batches = dataset
+            .scan()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let all_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new("value_a", DataType::Float64, false),
+            Field::new("value_b", DataType::Float64, false),
+        ]));
+        let combined = concat_batches(&all_schema, &batches).unwrap();
+        assert_eq!(combined.num_rows(), 300);
+    }
+
+    // Regression test: after a partial-schema merge_insert drops a fragment from the vector
+    // index bitmap, a vector search should not return duplicate rows. The stale vector index
+    // data still references the dropped fragment, and the scanner also flat-scans unindexed
+    // fragments, causing the same rows to appear from both paths.
+    #[tokio::test]
+    async fn test_partial_merge_insert_stale_vector_index_duplicates() {
+        let dim = 4i32;
+        let rows_per_frag = 10usize;
+        let num_frags = 3usize;
+        let total_rows = rows_per_frag * num_frags;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+
+        let make_batch = |frag_idx: usize, offset: f32| {
+            let start = frag_idx * rows_per_frag;
+            let ids: Vec<String> = (start..start + rows_per_frag)
+                .map(|j| format!("id-{j:04}"))
+                .collect();
+            let cats: Vec<&str> = vec!["A"; rows_per_frag];
+            let values: Vec<f32> = (0..rows_per_frag * dim as usize)
+                .map(|i| (start * dim as usize + i) as f32 + offset)
+                .collect();
+            let vectors =
+                FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(ids)),
+                    Arc::new(StringArray::from(cats)),
+                    Arc::new(vectors),
+                ],
+            )
+            .unwrap()
+        };
+
+        // Write 3 fragments
+        let batch0 = make_batch(0, 0.0);
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch0)], schema.clone()));
+        let mut ds = Dataset::write(reader, "memory://vector_stale_test", None)
+            .await
+            .unwrap();
+        for frag_idx in 1..num_frags {
+            let batch = make_batch(frag_idx, 0.0);
+            let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+            ds.append(reader, None).await.unwrap();
+        }
+
+        // Create IVF_FLAT vector index on vec
+        let params = VectorIndexParams::ivf_flat(1, MetricType::L2);
+        ds.create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        let ds = Arc::new(ds);
+
+        // Partial merge_insert with (id, vec) on fragment 1 rows - slightly different vectors.
+        // This drops fragment 1 from the vector index bitmap.
+        let frag1_start = rows_per_frag;
+        let ids: Vec<String> = (frag1_start..frag1_start + rows_per_frag)
+            .map(|j| format!("id-{j:04}"))
+            .collect();
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                false,
+            ),
+        ]));
+        let values: Vec<f32> = (0..rows_per_frag * dim as usize)
+            .map(|i| (frag1_start * dim as usize + i) as f32 + 0.5)
+            .collect();
+        let vectors =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim).unwrap();
+        let update_batch = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![Arc::new(StringArray::from(ids)), Arc::new(vectors)],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update_batch)], sub_schema));
+        let (ds, _) = MergeInsertBuilder::try_new(ds, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await
+            .unwrap();
+
+        // KNN search with k = total_rows to retrieve all rows
+        let query: Float32Array = (0..dim)
+            .map(|i| (frag1_start * dim as usize + i as usize) as f32 + 0.5)
+            .collect();
+        let results = ds
+            .scan()
+            .nearest("vec", &query, total_rows)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+
+        // Check no duplicate ids
+        let ids = results
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let unique_ids: std::collections::HashSet<&str> =
+            (0..ids.len()).map(|i| ids.value(i)).collect();
+        assert_eq!(
+            unique_ids.len(),
+            ids.len(),
+            "Found duplicate ids in KNN results: {} unique out of {} total",
+            unique_ids.len(),
+            ids.len()
+        );
+    }
+
+    // Regression test: after a partial-schema merge_insert drops a fragment from the FTS
+    // index bitmap, a full text search should not return duplicate rows. The stale inverted
+    // index data still references the dropped fragment, and the scanner also flat-scans
+    // unindexed fragments, causing the same rows to appear from both paths.
+    #[tokio::test]
+    async fn test_partial_merge_insert_stale_fts_index_duplicates() {
+        let rows_per_frag = 10usize;
+        let num_frags = 3usize;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new("text", DataType::Utf8, false),
+        ]));
+
+        let make_batch = |frag_idx: usize| {
+            let start = frag_idx * rows_per_frag;
+            let ids: Vec<String> = (start..start + rows_per_frag)
+                .map(|j| format!("id-{j:04}"))
+                .collect();
+            let cats: Vec<&str> = vec!["A"; rows_per_frag];
+            // Every row contains "common" so we can search for it and expect all rows
+            let texts: Vec<String> = (start..start + rows_per_frag)
+                .map(|j| format!("common unique{j:04}"))
+                .collect();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(ids)),
+                    Arc::new(StringArray::from(cats)),
+                    Arc::new(StringArray::from(texts)),
+                ],
+            )
+            .unwrap()
+        };
+
+        // Write 3 fragments
+        let batch0 = make_batch(0);
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch0)], schema.clone()));
+        let mut ds = Dataset::write(reader, "memory://fts_stale_test", None)
+            .await
+            .unwrap();
+        for frag_idx in 1..num_frags {
+            let batch = make_batch(frag_idx);
+            let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+            ds.append(reader, None).await.unwrap();
+        }
+
+        // Create inverted index on text
+        let params = InvertedIndexParams::default();
+        ds.create_index(&["text"], IndexType::Inverted, None, &params, true)
+            .await
+            .unwrap();
+
+        let ds = Arc::new(ds);
+
+        // Partial merge_insert with (id, text) on fragment 1 rows.
+        // Text still contains "common" so FTS will find them via both paths.
+        // This drops fragment 1 from the inverted index bitmap.
+        let frag1_start = rows_per_frag;
+        let ids: Vec<String> = (frag1_start..frag1_start + rows_per_frag)
+            .map(|j| format!("id-{j:04}"))
+            .collect();
+        let texts: Vec<String> = (frag1_start..frag1_start + rows_per_frag)
+            .map(|j| format!("common updated{j:04}"))
+            .collect();
+        let sub_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("text", DataType::Utf8, false),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            sub_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(StringArray::from(texts)),
+            ],
+        )
+        .unwrap();
+        let reader = Box::new(RecordBatchIterator::new([Ok(update_batch)], sub_schema));
+        let (ds, _) = MergeInsertBuilder::try_new(ds, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .try_build()
+            .unwrap()
+            .execute_reader(reader)
+            .await
+            .unwrap();
+
+        // FTS search for "common" — every row should match exactly once
+        let query = FullTextSearchQuery::new("common".to_string());
+        let results = ds
+            .scan()
+            .full_text_search(query)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+
+        // Check no duplicate ids
+        let ids = results
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let unique_ids: std::collections::HashSet<&str> =
+            (0..ids.len()).map(|i| ids.value(i)).collect();
+        assert_eq!(
+            unique_ids.len(),
+            ids.len(),
+            "Found duplicate ids in FTS results: {} unique out of {} total",
+            unique_ids.len(),
+            ids.len()
+        );
+        // Also verify we got all rows
+        assert_eq!(
+            unique_ids.len(),
+            rows_per_frag * num_frags,
+            "Expected {} rows but got {}",
+            rows_per_frag * num_frags,
+            unique_ids.len()
+        );
+    }
+
+    // Regression test: after a partial-schema merge_insert invalidates a fragment,
+    // compaction should succeed and subsequent searches should return correct results.
+    //
+    // The compaction planner separates indexed and unindexed fragments into different
+    // groups. After invalidating the middle fragment, the indexed fragments on either
+    // side form separate compactable groups. After compaction the old invalidated
+    // fragment ID may remain in invalidated_fragment_bitmap but this is harmless
+    // because the fragment no longer exists and no index results reference it.
+    #[tokio::test]
+    async fn test_compaction_after_invalidated_fragment() {
+        use crate::dataset::optimize::{CompactionOptions, compact_files};
+
+        // Use 5 small fragments so that after invalidating the middle one (fragment 2),
+        // the planner has enough neighbors to form compactable groups on each side:
+        // {0,1} (indexed) and {3,4} (indexed), with {2} (unindexed) separate.
+        let rows_per_frag = 20;
+        let num_frags = 5;
+        let total_rows = rows_per_frag * num_frags;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+            Field::new("value_a", DataType::Float64, false),
+            Field::new("value_b", DataType::Float64, false),
+        ]));
+
+        let make_batch = |frag_idx: usize| {
+            let start = frag_idx * rows_per_frag;
+            let ids: Vec<String> = (start..start + rows_per_frag)
+                .map(|j| format!("id-{j:04}"))
+                .collect();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(ids)),
+                    Arc::new(StringArray::from(vec!["A"; rows_per_frag])),
+                    Arc::new(Float64Array::from(
+                        (0..rows_per_frag).map(|i| i as f64).collect::<Vec<_>>(),
+                    )),
+                    Arc::new(Float64Array::from(
+                        (0..rows_per_frag)
+                            .map(|i| i as f64 * 0.1)
+                            .collect::<Vec<_>>(),
+                    )),
+                ],
+            )
+            .unwrap()
+        };
+
+        let batch0 = make_batch(0);
+        let reader = Box::new(RecordBatchIterator::new([Ok(batch0)], schema.clone()));
+        let mut ds = Dataset::write(reader, "memory://compaction_test", None)
+            .await
+            .unwrap();
+        for frag_idx in 1..num_frags {
+            let batch = make_batch(frag_idx);
+            let reader = Box::new(RecordBatchIterator::new([Ok(batch)], schema.clone()));
+            ds.append(reader, None).await.unwrap();
+        }
+        ds.create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+
+        let ds = Arc::new(ds);
+
+        // Invalidate fragment 2 (the middle one)
+        let frag2_start = 2 * rows_per_frag;
+        let ds = partial_merge_insert(ds, frag2_start..frag2_start + rows_per_frag, 999.0).await;
+
+        // Verify pre-compaction state
+        let indices = ds.load_indices().await.unwrap();
+        let idx = indices.iter().find(|i| i.name == "id_idx").unwrap();
+        assert!(!idx.fragment_bitmap.as_ref().unwrap().contains(2));
+
+        // Run compaction with a target that forces merging of the small fragments.
+        let mut ds = (*ds).clone();
+        let opts = CompactionOptions {
+            target_rows_per_fragment: total_rows,
+            ..Default::default()
+        };
+        compact_files(&mut ds, opts, None).await.unwrap();
+
+        // The indexed fragments (0,1 and 3,4) should be compacted.
+        // Fragment 2 (unindexed) may or may not be compacted on its own.
+        // Either way, the old fragment IDs in the bitmap should be replaced.
+        let indices = ds.load_indices().await.unwrap();
+        let idx = indices.iter().find(|i| i.name == "id_idx").unwrap();
+        let bitmap = idx.fragment_bitmap.as_ref().unwrap();
+        for &old_id in &[0u32, 1, 3, 4] {
+            assert!(
+                !bitmap.contains(old_id),
+                "Old indexed fragment {} should not be in bitmap after compaction",
+                old_id
+            );
+        }
+        assert!(
+            !bitmap.is_empty(),
+            "Bitmap should have new compacted fragments"
+        );
+
+        // The invalidated bitmap may still reference old fragment 2.
+        // This is harmless — fragment 2 no longer exists (or was compacted into
+        // a new fragment), so blocking it is a no-op.
+
+        // Verify search works correctly despite stale invalidated entries.
+        let ds = Arc::new(ds);
+        let ds = partial_merge_insert(ds, frag2_start..frag2_start + rows_per_frag, 888.0).await;
+
+        // All rows present
+        let batches = ds
+            .scan()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let combined = concat_batches(&schema, &batches).unwrap();
+        assert_eq!(combined.num_rows(), total_rows);
+
+        // Updated rows have correct value
+        let result = ds
+            .scan()
+            .filter(&format!(
+                "id >= 'id-{:04}' AND id < 'id-{:04}'",
+                frag2_start,
+                frag2_start + rows_per_frag
+            ))
+            .unwrap()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let result = concat_batches(&schema, &result).unwrap();
+        assert_eq!(result.num_rows(), rows_per_frag);
+        let values = result
+            .column_by_name("value_a")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        for i in 0..rows_per_frag {
+            assert_eq!(values.value(i), 888.0, "row {i} should have value_a=888.0");
         }
     }
 }

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -63,15 +63,20 @@ impl DatasetPreFilter {
         filter: Option<Box<dyn FilterLoader>>,
     ) -> Self {
         let mut fragments = RoaringBitmap::new();
-        if indices.iter().any(|idx| idx.fragment_bitmap.is_none()) {
+        let all_have_bitmaps = indices.iter().all(|idx| idx.fragment_bitmap.is_some());
+        if !all_have_bitmaps {
             fragments.insert_range(0..dataset.manifest.max_fragment_id.unwrap_or(0));
         } else {
             indices.iter().for_each(|idx| {
                 fragments |= idx.fragment_bitmap.as_ref().unwrap();
             });
         }
-        let deleted_ids =
-            Self::create_deletion_mask(dataset, fragments).map(SharedPrerequisite::spawn);
+        let deleted_ids = if all_have_bitmaps {
+            Self::create_restricted_deletion_mask(dataset, fragments)
+        } else {
+            Self::create_deletion_mask(dataset, fragments)
+        }
+        .map(SharedPrerequisite::spawn);
         let filtered_ids = filter
             .map(|filtered_ids| SharedPrerequisite::spawn(filtered_ids.load().in_current_span()));
         Self {
@@ -186,16 +191,42 @@ impl DatasetPreFilter {
         self.deleted_fragments = Some(fragments);
     }
 
-    /// Creates a task to load a mask that filters out rows not covered by the
-    /// index and rows that have been deleted.
+    /// Creates a task to load a mask that filters out deleted rows and,
+    /// when `restrict_to_fragments` is true, also restricts results to only
+    /// the given `fragments`.
     ///
-    /// The mask always restricts results to `fragments` (the index's fragment
-    /// bitmap). Within those fragments, deleted rows are also masked out —
-    /// either as a block list (from deletion files) or an allow list (when
-    /// stable row ids are in use and fragments have been removed).
+    /// The fragment restriction blocks stale index entries from fragments
+    /// whose data changed but whose index was not rewritten. It should be
+    /// enabled when `fragments` represents a real index fragment bitmap. It
+    /// should be disabled when `fragments` is a conservative fallback (e.g.
+    /// when the index has no fragment bitmap).
+    ///
+    /// The deletion mask is built as a block list (from deletion files) or
+    /// an allow list (when stable row ids are in use and fragments have
+    /// been removed).
+    ///
+    /// Returns `None` if it can be synchronously determined that no
+    /// filtering is needed.
     pub fn create_deletion_mask(
         dataset: Arc<Dataset>,
         fragments: RoaringBitmap,
+    ) -> Option<BoxFuture<'static, Result<Arc<RowAddrMask>>>> {
+        Self::create_deletion_mask_impl(dataset, fragments, false)
+    }
+
+    /// Like [`create_deletion_mask`] but also restricts results to the given
+    /// `fragments`, blocking any row from a fragment not in the set.
+    pub fn create_restricted_deletion_mask(
+        dataset: Arc<Dataset>,
+        fragments: RoaringBitmap,
+    ) -> Option<BoxFuture<'static, Result<Arc<RowAddrMask>>>> {
+        Self::create_deletion_mask_impl(dataset, fragments, true)
+    }
+
+    fn create_deletion_mask_impl(
+        dataset: Arc<Dataset>,
+        fragments: RoaringBitmap,
+        restrict_to_fragments: bool,
     ) -> Option<BoxFuture<'static, Result<Arc<RowAddrMask>>>> {
         let mut missing_frags = Vec::new();
         let mut frags_with_deletion_files = Vec::new();
@@ -206,11 +237,16 @@ impl DatasetPreFilter {
                 .iter()
                 .map(|frag| (frag.id as u32, frag)),
         );
-        // Check if the index covers fragments that are not in the dataset.
-        // This can happen when a fragment's data was modified but the index
-        // was not rewritten (e.g. after DataReplacement or partial merge_insert).
-        let dataset_frag_ids: RoaringBitmap = frag_map.keys().copied().collect();
-        let has_extra_dataset_frags = !dataset_frag_ids.is_subset(&fragments);
+        // When restrict_to_fragments is set, check if the dataset has fragments
+        // outside the index bitmap. This can happen when a fragment's data was
+        // modified but the index was not rewritten (e.g. after DataReplacement
+        // or partial merge_insert).
+        let needs_allow_list = if restrict_to_fragments {
+            let dataset_frag_ids: RoaringBitmap = frag_map.keys().copied().collect();
+            !dataset_frag_ids.is_subset(&fragments)
+        } else {
+            false
+        };
         for frag_id in fragments.iter() {
             let frag = frag_map.get(&frag_id);
             if let Some(frag) = frag {
@@ -221,10 +257,7 @@ impl DatasetPreFilter {
                 missing_frags.push(frag_id);
             }
         }
-        if missing_frags.is_empty()
-            && frags_with_deletion_files.is_empty()
-            && !has_extra_dataset_frags
-        {
+        if missing_frags.is_empty() && frags_with_deletion_files.is_empty() && !needs_allow_list {
             None
         } else if dataset.manifest.uses_stable_row_ids() {
             Some(Self::do_create_deletion_mask_row_id(dataset.clone()).boxed())
@@ -237,11 +270,11 @@ impl DatasetPreFilter {
             }
             Some(async move { Ok(Arc::new(RowAddrMask::from_allowed(allow_list))) }.boxed())
         } else {
-            // There are deletions/missing frags AND extra dataset frags.
-            // Build the deletion mask and combine it with the allow-list.
+            // There are deletions/missing frags. Build the deletion mask and
+            // optionally combine it with the fragment allow-list.
             let fut =
                 Self::do_create_deletion_mask(dataset, missing_frags, frags_with_deletion_files);
-            if has_extra_dataset_frags {
+            if needs_allow_list {
                 Some(
                     async move {
                         let deletion_mask = fut.await?;
@@ -416,22 +449,14 @@ mod test {
         expected.insert_fragment(1);
         assert_eq!(mask.block_list(), Some(&expected));
 
-        // If we only pass fragment 2, we should get a mask that also blocks
-        // rows from fragment 0 (not in the allow-list) in addition to the
-        // deleted row in fragment 2.
+        // If we don't pass the missing fragment id, we should get a smaller mask.
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.deletions_missing_frags.clone(),
             RoaringBitmap::from_iter(2..3),
         );
         assert!(mask.is_some());
         let mask = mask.unwrap().await.unwrap();
-        // Fragment 0 rows should be blocked (not in allow-list)
-        assert!(!mask.selected(0)); // frag 0, row 0
-                                    // Fragment 2 deleted row should be blocked
-        assert!(!mask.selected((2 << 32) + 2)); // frag 2, row 2 (x=8)
-                                                // Fragment 2 non-deleted rows should be allowed
-        assert!(mask.selected((2 << 32) + 0)); // frag 2, row 0 (x=6)
-        assert!(mask.selected((2 << 32) + 1)); // frag 2, row 1 (x=7)
+        assert_eq!(mask.block_list().and_then(|x| x.len()), Some(1));
 
         // If there are only missing fragments, we should still get a mask
         let mask = DatasetPreFilter::create_deletion_mask(

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -13,11 +13,11 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
-use futures::future::BoxFuture;
-use futures::stream;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::TryStreamExt;
+use futures::future::BoxFuture;
+use futures::stream;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::mask::{RowAddrMask, RowAddrTreeMap};
 use lance_core::utils::tokio::spawn_cpu;
@@ -26,14 +26,14 @@ use lance_table::format::IndexMetadata;
 use lance_table::rowids::RowIdSequence;
 use roaring::RoaringBitmap;
 use tokio::join;
-use tracing::instrument;
 use tracing::Instrument;
+use tracing::instrument;
 
+use crate::Dataset;
+use crate::Result;
 use crate::dataset::fragment::FileFragment;
 use crate::dataset::rowids::load_row_id_sequence;
 use crate::utils::future::SharedPrerequisite;
-use crate::Dataset;
-use crate::Result;
 
 pub use lance_index::prefilter::{FilterLoader, PreFilter};
 
@@ -404,10 +404,12 @@ mod test {
 
         dataset.delete("x >= 3").await.unwrap();
         assert_eq!(dataset.get_fragments().len(), 1);
-        assert!(dataset.get_fragments()[0]
-            .metadata()
-            .deletion_file
-            .is_none());
+        assert!(
+            dataset.get_fragments()[0]
+                .metadata()
+                .deletion_file
+                .is_none()
+        );
         let only_missing_frags = Arc::new(dataset.clone());
 
         TestDatasets {

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -13,11 +13,11 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
+use futures::future::BoxFuture;
+use futures::stream;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::TryStreamExt;
-use futures::future::BoxFuture;
-use futures::stream;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::mask::{RowAddrMask, RowAddrTreeMap};
 use lance_core::utils::tokio::spawn_cpu;
@@ -26,14 +26,14 @@ use lance_table::format::IndexMetadata;
 use lance_table::rowids::RowIdSequence;
 use roaring::RoaringBitmap;
 use tokio::join;
-use tracing::Instrument;
 use tracing::instrument;
+use tracing::Instrument;
 
-use crate::Dataset;
-use crate::Result;
 use crate::dataset::fragment::FileFragment;
 use crate::dataset::rowids::load_row_id_sequence;
 use crate::utils::future::SharedPrerequisite;
+use crate::Dataset;
+use crate::Result;
 
 pub use lance_index::prefilter::{FilterLoader, PreFilter};
 
@@ -52,11 +52,6 @@ pub struct DatasetPreFilter {
     // Fragment IDs whose data is still in the index but has been removed from the dataset.
     // Used by FTS merge-on-read to prune stale fragments at search time.
     pub(super) deleted_fragments: Option<RoaringBitmap>,
-    // Fragment IDs whose data is covered by the index. Any row returned by the
-    // index that belongs to a fragment NOT in this set is stale and must be
-    // filtered out. When None, no allow-list filtering is applied (all fragments
-    // are assumed to be covered).
-    pub(super) allowed_fragments: Option<RoaringBitmap>,
     // When the tasks are finished this is the combined filter
     pub(super) final_mask: Mutex<OnceCell<Arc<RowAddrMask>>>,
 }
@@ -68,19 +63,13 @@ impl DatasetPreFilter {
         filter: Option<Box<dyn FilterLoader>>,
     ) -> Self {
         let mut fragments = RoaringBitmap::new();
-        let all_have_bitmaps = indices.iter().all(|idx| idx.fragment_bitmap.is_some());
-        if !all_have_bitmaps {
+        if indices.iter().any(|idx| idx.fragment_bitmap.is_none()) {
             fragments.insert_range(0..dataset.manifest.max_fragment_id.unwrap_or(0));
         } else {
             indices.iter().for_each(|idx| {
                 fragments |= idx.fragment_bitmap.as_ref().unwrap();
             });
         }
-        let allowed_fragments = if all_have_bitmaps {
-            Some(fragments.clone())
-        } else {
-            None
-        };
         let deleted_ids =
             Self::create_deletion_mask(dataset, fragments).map(SharedPrerequisite::spawn);
         let filtered_ids = filter
@@ -89,7 +78,6 @@ impl DatasetPreFilter {
             deleted_ids,
             filtered_ids,
             deleted_fragments: None,
-            allowed_fragments,
             final_mask: Mutex::new(OnceCell::new()),
         }
     }
@@ -198,15 +186,13 @@ impl DatasetPreFilter {
         self.deleted_fragments = Some(fragments);
     }
 
-    /// Creates a task to load mask to filter out deleted rows.
+    /// Creates a task to load a mask that filters out rows not covered by the
+    /// index and rows that have been deleted.
     ///
-    /// Sometimes this will be a block list of row ids that are deleted, based
-    /// on the deletion files in the fragments. If stable row ids are used and
-    /// there are missing fragments, this may instead be an allow list, since
-    /// we can't easily compute the block list.
-    ///
-    /// If it can be synchronously determined that there are no missing row ids then
-    /// this function return None
+    /// The mask always restricts results to `fragments` (the index's fragment
+    /// bitmap). Within those fragments, deleted rows are also masked out —
+    /// either as a block list (from deletion files) or an allow list (when
+    /// stable row ids are in use and fragments have been removed).
     pub fn create_deletion_mask(
         dataset: Arc<Dataset>,
         fragments: RoaringBitmap,
@@ -220,6 +206,11 @@ impl DatasetPreFilter {
                 .iter()
                 .map(|frag| (frag.id as u32, frag)),
         );
+        // Check if the index covers fragments that are not in the dataset.
+        // This can happen when a fragment's data was modified but the index
+        // was not rewritten (e.g. after DataReplacement or partial merge_insert).
+        let dataset_frag_ids: RoaringBitmap = frag_map.keys().copied().collect();
+        let has_extra_dataset_frags = !dataset_frag_ids.is_subset(&fragments);
         for frag_id in fragments.iter() {
             let frag = frag_map.get(&frag_id);
             if let Some(frag) = frag {
@@ -230,15 +221,43 @@ impl DatasetPreFilter {
                 missing_frags.push(frag_id);
             }
         }
-        if missing_frags.is_empty() && frags_with_deletion_files.is_empty() {
+        if missing_frags.is_empty()
+            && frags_with_deletion_files.is_empty()
+            && !has_extra_dataset_frags
+        {
             None
         } else if dataset.manifest.uses_stable_row_ids() {
             Some(Self::do_create_deletion_mask_row_id(dataset.clone()).boxed())
+        } else if missing_frags.is_empty() && frags_with_deletion_files.is_empty() {
+            // No deletions to load, but the dataset has fragments outside the
+            // index bitmap. Return a synchronous allow-list mask.
+            let mut allow_list = RowAddrTreeMap::new();
+            for frag_id in fragments.iter() {
+                allow_list.insert_fragment(frag_id);
+            }
+            Some(async move { Ok(Arc::new(RowAddrMask::from_allowed(allow_list))) }.boxed())
         } else {
-            Some(
-                Self::do_create_deletion_mask(dataset, missing_frags, frags_with_deletion_files)
+            // There are deletions/missing frags AND extra dataset frags.
+            // Build the deletion mask and combine it with the allow-list.
+            let fut =
+                Self::do_create_deletion_mask(dataset, missing_frags, frags_with_deletion_files);
+            if has_extra_dataset_frags {
+                Some(
+                    async move {
+                        let deletion_mask = fut.await?;
+                        let mut allow_list = RowAddrTreeMap::new();
+                        for frag_id in fragments.iter() {
+                            allow_list.insert_fragment(frag_id);
+                        }
+                        Ok(Arc::new(
+                            (*deletion_mask).clone() & RowAddrMask::from_allowed(allow_list),
+                        ))
+                    }
                     .boxed(),
-            )
+                )
+            } else {
+                Some(fut.boxed())
+            }
         }
     }
 }
@@ -275,13 +294,6 @@ impl PreFilter for DatasetPreFilter {
                 }
                 combined = combined & RowAddrMask::from_block(block_list);
             }
-            if let Some(allowed) = &self.allowed_fragments {
-                let mut allow_list = RowAddrTreeMap::new();
-                for frag_id in allowed.iter() {
-                    allow_list.insert_fragment(frag_id);
-                }
-                combined = combined & RowAddrMask::from_allowed(allow_list);
-            }
             Arc::new(combined)
         });
 
@@ -292,7 +304,6 @@ impl PreFilter for DatasetPreFilter {
         self.deleted_ids.is_none()
             && self.filtered_ids.is_none()
             && self.deleted_fragments.is_none()
-            && self.allowed_fragments.is_none()
     }
 
     /// Get the row id mask for this prefilter
@@ -360,12 +371,10 @@ mod test {
 
         dataset.delete("x >= 3").await.unwrap();
         assert_eq!(dataset.get_fragments().len(), 1);
-        assert!(
-            dataset.get_fragments()[0]
-                .metadata()
-                .deletion_file
-                .is_none()
-        );
+        assert!(dataset.get_fragments()[0]
+            .metadata()
+            .deletion_file
+            .is_none());
         let only_missing_frags = Arc::new(dataset.clone());
 
         TestDatasets {
@@ -407,14 +416,22 @@ mod test {
         expected.insert_fragment(1);
         assert_eq!(mask.block_list(), Some(&expected));
 
-        // If we don't pass the missing fragment id, we should get a smaller mask.
+        // If we only pass fragment 2, we should get a mask that also blocks
+        // rows from fragment 0 (not in the allow-list) in addition to the
+        // deleted row in fragment 2.
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.deletions_missing_frags.clone(),
             RoaringBitmap::from_iter(2..3),
         );
         assert!(mask.is_some());
         let mask = mask.unwrap().await.unwrap();
-        assert_eq!(mask.block_list().and_then(|x| x.len()), Some(1));
+        // Fragment 0 rows should be blocked (not in allow-list)
+        assert!(!mask.selected(0)); // frag 0, row 0
+                                    // Fragment 2 deleted row should be blocked
+        assert!(!mask.selected((2 << 32) + 2)); // frag 2, row 2 (x=8)
+                                                // Fragment 2 non-deleted rows should be allowed
+        assert!(mask.selected((2 << 32) + 0)); // frag 2, row 0 (x=6)
+        assert!(mask.selected((2 << 32) + 1)); // frag 2, row 1 (x=7)
 
         // If there are only missing fragments, we should still get a mask
         let mask = DatasetPreFilter::create_deletion_mask(

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -52,6 +52,11 @@ pub struct DatasetPreFilter {
     // Fragment IDs whose data is still in the index but has been removed from the dataset.
     // Used by FTS merge-on-read to prune stale fragments at search time.
     pub(super) deleted_fragments: Option<RoaringBitmap>,
+    // Fragment IDs whose data is covered by the index. Any row returned by the
+    // index that belongs to a fragment NOT in this set is stale and must be
+    // filtered out. When None, no allow-list filtering is applied (all fragments
+    // are assumed to be covered).
+    pub(super) allowed_fragments: Option<RoaringBitmap>,
     // When the tasks are finished this is the combined filter
     pub(super) final_mask: Mutex<OnceCell<Arc<RowAddrMask>>>,
 }
@@ -63,13 +68,19 @@ impl DatasetPreFilter {
         filter: Option<Box<dyn FilterLoader>>,
     ) -> Self {
         let mut fragments = RoaringBitmap::new();
-        if indices.iter().any(|idx| idx.fragment_bitmap.is_none()) {
+        let all_have_bitmaps = indices.iter().all(|idx| idx.fragment_bitmap.is_some());
+        if !all_have_bitmaps {
             fragments.insert_range(0..dataset.manifest.max_fragment_id.unwrap_or(0));
         } else {
             indices.iter().for_each(|idx| {
                 fragments |= idx.fragment_bitmap.as_ref().unwrap();
             });
         }
+        let allowed_fragments = if all_have_bitmaps {
+            Some(fragments.clone())
+        } else {
+            None
+        };
         let deleted_ids =
             Self::create_deletion_mask(dataset, fragments).map(SharedPrerequisite::spawn);
         let filtered_ids = filter
@@ -78,6 +89,7 @@ impl DatasetPreFilter {
             deleted_ids,
             filtered_ids,
             deleted_fragments: None,
+            allowed_fragments,
             final_mask: Mutex::new(OnceCell::new()),
         }
     }
@@ -263,6 +275,13 @@ impl PreFilter for DatasetPreFilter {
                 }
                 combined = combined & RowAddrMask::from_block(block_list);
             }
+            if let Some(allowed) = &self.allowed_fragments {
+                let mut allow_list = RowAddrTreeMap::new();
+                for frag_id in allowed.iter() {
+                    allow_list.insert_fragment(frag_id);
+                }
+                combined = combined & RowAddrMask::from_allowed(allow_list);
+            }
             Arc::new(combined)
         });
 
@@ -273,6 +292,7 @@ impl PreFilter for DatasetPreFilter {
         self.deleted_ids.is_none()
             && self.filtered_ids.is_none()
             && self.deleted_fragments.is_none()
+            && self.allowed_fragments.is_none()
     }
 
     /// Get the row id mask for this prefilter

--- a/rust/lance/src/index/vector/fixture_test.rs
+++ b/rust/lance/src/index/vector/fixture_test.rs
@@ -22,12 +22,12 @@ mod test {
     use lance_arrow::FixedSizeListArrayExt;
     use lance_core::{cache::LanceCache, utils::tempfile::TempStdFile};
     use lance_index::vector::v3::subindex::SubIndexType;
+    use lance_index::{Index, IndexType, vector::Query};
     use lance_index::{metrics::MetricsCollector, vector::ivf::storage::IvfModel};
     use lance_index::{
         metrics::NoOpMetricsCollector,
         vector::quantizer::{QuantizationType, Quantizer},
     };
-    use lance_index::{vector::Query, Index, IndexType};
     use lance_io::{local::LocalObjectReader, traits::Reader};
     use lance_linalg::{distance::MetricType, kernels::normalize_arrow};
     use roaring::RoaringBitmap;
@@ -35,11 +35,11 @@ mod test {
 
     use super::super::VectorIndex;
     use crate::{
+        Result,
         index::{
             prefilter::{DatasetPreFilter, PreFilter},
             vector::ivf::IVFIndex,
         },
-        Result,
     };
 
     #[derive(Clone, Debug)]

--- a/rust/lance/src/index/vector/fixture_test.rs
+++ b/rust/lance/src/index/vector/fixture_test.rs
@@ -22,12 +22,12 @@ mod test {
     use lance_arrow::FixedSizeListArrayExt;
     use lance_core::{cache::LanceCache, utils::tempfile::TempStdFile};
     use lance_index::vector::v3::subindex::SubIndexType;
-    use lance_index::{Index, IndexType, vector::Query};
     use lance_index::{metrics::MetricsCollector, vector::ivf::storage::IvfModel};
     use lance_index::{
         metrics::NoOpMetricsCollector,
         vector::quantizer::{QuantizationType, Quantizer},
     };
+    use lance_index::{vector::Query, Index, IndexType};
     use lance_io::{local::LocalObjectReader, traits::Reader};
     use lance_linalg::{distance::MetricType, kernels::normalize_arrow};
     use roaring::RoaringBitmap;
@@ -35,11 +35,11 @@ mod test {
 
     use super::super::VectorIndex;
     use crate::{
-        Result,
         index::{
             prefilter::{DatasetPreFilter, PreFilter},
             vector::ivf::IVFIndex,
         },
+        Result,
     };
 
     #[derive(Clone, Debug)]
@@ -279,7 +279,6 @@ mod test {
                     deleted_ids: None,
                     filtered_ids: None,
                     deleted_fragments: None,
-                    allowed_fragments: None,
                     final_mask: Mutex::new(OnceCell::new()),
                 }),
                 &NoOpMetricsCollector,

--- a/rust/lance/src/index/vector/fixture_test.rs
+++ b/rust/lance/src/index/vector/fixture_test.rs
@@ -279,6 +279,7 @@ mod test {
                     deleted_ids: None,
                     filtered_ids: None,
                     deleted_fragments: None,
+                    allowed_fragments: None,
                     final_mask: Mutex::new(OnceCell::new()),
                 }),
                 &NoOpMetricsCollector,

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -340,8 +340,10 @@ impl MapIndexExec {
             .load_scalar_index(IndexCriteria::default().with_name(&index_name))
             .await?
             .unwrap();
-        let deletion_mask_fut =
-            DatasetPreFilter::create_deletion_mask(dataset.clone(), index.fragment_bitmap.unwrap());
+        let deletion_mask_fut = DatasetPreFilter::create_restricted_deletion_mask(
+            dataset.clone(),
+            index.fragment_bitmap.unwrap(),
+        );
         let deletion_mask = if let Some(deletion_mask_fut) = deletion_mask_fut {
             Some(deletion_mask_fut.await?)
         } else {

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -5,33 +5,33 @@ use std::sync::{Arc, LazyLock};
 
 use super::utils::{IndexMetrics, InstrumentedRecordBatchStreamAdapter};
 use crate::{
-    Dataset,
     dataset::rowids::load_row_id_sequences,
-    index::{DatasetIndexExt, DatasetIndexInternalExt, prefilter::DatasetPreFilter},
+    index::{prefilter::DatasetPreFilter, DatasetIndexExt, DatasetIndexInternalExt},
+    Dataset,
 };
 use arrow_array::{Array, RecordBatch, UInt64Array};
 use arrow_schema::{Schema, SchemaRef};
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use datafusion::{
-    common::{Statistics, stats::Precision},
+    common::{stats::Precision, Statistics},
     physical_plan::{
-        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
         execution_plan::{Boundedness, EmissionType},
         metrics::{ExecutionPlanMetricsSet, MetricsSet},
         stream::RecordBatchStreamAdapter,
+        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     },
     scalar::ScalarValue,
 };
 use datafusion_physical_expr::EquivalenceProperties;
-use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt, stream::BoxStream};
+use futures::{stream::BoxStream, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use lance_core::utils::mask::RowSetOps;
 use lance_core::{
-    Error, ROW_ID_FIELD, Result,
     utils::{
         address::RowAddress,
         mask::{RowAddrMask, RowAddrTreeMap},
     },
+    Error, Result, ROW_ID_FIELD,
 };
 use lance_datafusion::{
     chunker::break_stream,
@@ -40,15 +40,15 @@ use lance_datafusion::{
     },
 };
 use lance_index::{
-    IndexCriteria,
     metrics::MetricsCollector,
     scalar::{
-        SargableQuery, ScalarIndex,
         expression::{
-            INDEX_EXPR_RESULT_SCHEMA, IndexExprResult, ScalarIndexExpr, ScalarIndexLoader,
-            ScalarIndexSearch,
+            IndexExprResult, ScalarIndexExpr, ScalarIndexLoader, ScalarIndexSearch,
+            INDEX_EXPR_RESULT_SCHEMA,
         },
+        SargableQuery, ScalarIndex,
     },
+    IndexCriteria,
 };
 use lance_table::format::Fragment;
 use roaring::RoaringBitmap;
@@ -340,28 +340,13 @@ impl MapIndexExec {
             .load_scalar_index(IndexCriteria::default().with_name(&index_name))
             .await?
             .unwrap();
-        let fragment_bitmap = index.fragment_bitmap.unwrap();
         let deletion_mask_fut =
-            DatasetPreFilter::create_deletion_mask(dataset.clone(), fragment_bitmap.clone());
-        let mut deletion_mask = if let Some(deletion_mask_fut) = deletion_mask_fut {
+            DatasetPreFilter::create_deletion_mask(dataset.clone(), index.fragment_bitmap.unwrap());
+        let deletion_mask = if let Some(deletion_mask_fut) = deletion_mask_fut {
             Some(deletion_mask_fut.await?)
         } else {
             None
         };
-        // Apply allow-list: only keep rows from fragments covered by the index.
-        // This filters out stale index entries from fragments whose data changed
-        // but whose index data was not rewritten.
-        {
-            let mut allow_list = RowAddrTreeMap::new();
-            for frag_id in fragment_bitmap.iter() {
-                allow_list.insert_fragment(frag_id);
-            }
-            let allow_mask = Arc::new(RowAddrMask::from_allowed(allow_list));
-            deletion_mask = Some(match deletion_mask {
-                Some(existing) => Arc::new((*existing).clone() & (*allow_mask).clone()),
-                None => allow_mask,
-            });
-        }
         Ok(input.and_then(move |res| {
             let column_name = column_name.clone();
             let index_name = index_name.clone();
@@ -758,17 +743,17 @@ mod tests {
     use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::gen_batch;
     use lance_index::{
-        IndexType,
         scalar::{
-            SargableQuery, ScalarIndexParams,
             expression::{ScalarIndexExpr, ScalarIndexSearch},
+            SargableQuery, ScalarIndexParams,
         },
+        IndexType,
     };
 
     use crate::{
-        Dataset,
         io::exec::scalar_index::MaterializeIndexExec,
         utils::test::{DatagenExt, FragmentCount, FragmentRowCount, NoContextTestFixture},
+        Dataset,
     };
 
     use super::{MapIndexExec, ScalarIndexExec};

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -5,33 +5,33 @@ use std::sync::{Arc, LazyLock};
 
 use super::utils::{IndexMetrics, InstrumentedRecordBatchStreamAdapter};
 use crate::{
-    dataset::rowids::load_row_id_sequences,
-    index::{prefilter::DatasetPreFilter, DatasetIndexExt, DatasetIndexInternalExt},
     Dataset,
+    dataset::rowids::load_row_id_sequences,
+    index::{DatasetIndexExt, DatasetIndexInternalExt, prefilter::DatasetPreFilter},
 };
 use arrow_array::{Array, RecordBatch, UInt64Array};
 use arrow_schema::{Schema, SchemaRef};
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use datafusion::{
-    common::{stats::Precision, Statistics},
+    common::{Statistics, stats::Precision},
     physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
         execution_plan::{Boundedness, EmissionType},
         metrics::{ExecutionPlanMetricsSet, MetricsSet},
         stream::RecordBatchStreamAdapter,
-        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     },
     scalar::ScalarValue,
 };
 use datafusion_physical_expr::EquivalenceProperties;
-use futures::{stream::BoxStream, Stream, StreamExt, TryFutureExt, TryStreamExt};
+use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt, stream::BoxStream};
 use lance_core::utils::mask::RowSetOps;
 use lance_core::{
+    Error, ROW_ID_FIELD, Result,
     utils::{
         address::RowAddress,
         mask::{RowAddrMask, RowAddrTreeMap},
     },
-    Error, Result, ROW_ID_FIELD,
 };
 use lance_datafusion::{
     chunker::break_stream,
@@ -40,15 +40,15 @@ use lance_datafusion::{
     },
 };
 use lance_index::{
+    IndexCriteria,
     metrics::MetricsCollector,
     scalar::{
-        expression::{
-            IndexExprResult, ScalarIndexExpr, ScalarIndexLoader, ScalarIndexSearch,
-            INDEX_EXPR_RESULT_SCHEMA,
-        },
         SargableQuery, ScalarIndex,
+        expression::{
+            INDEX_EXPR_RESULT_SCHEMA, IndexExprResult, ScalarIndexExpr, ScalarIndexLoader,
+            ScalarIndexSearch,
+        },
     },
-    IndexCriteria,
 };
 use lance_table::format::Fragment;
 use roaring::RoaringBitmap;
@@ -745,17 +745,17 @@ mod tests {
     use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::gen_batch;
     use lance_index::{
-        scalar::{
-            expression::{ScalarIndexExpr, ScalarIndexSearch},
-            SargableQuery, ScalarIndexParams,
-        },
         IndexType,
+        scalar::{
+            SargableQuery, ScalarIndexParams,
+            expression::{ScalarIndexExpr, ScalarIndexSearch},
+        },
     };
 
     use crate::{
+        Dataset,
         io::exec::scalar_index::MaterializeIndexExec,
         utils::test::{DatagenExt, FragmentCount, FragmentRowCount, NoContextTestFixture},
-        Dataset,
     };
 
     use super::{MapIndexExec, ScalarIndexExec};

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -340,13 +340,28 @@ impl MapIndexExec {
             .load_scalar_index(IndexCriteria::default().with_name(&index_name))
             .await?
             .unwrap();
+        let fragment_bitmap = index.fragment_bitmap.unwrap();
         let deletion_mask_fut =
-            DatasetPreFilter::create_deletion_mask(dataset.clone(), index.fragment_bitmap.unwrap());
-        let deletion_mask = if let Some(deletion_mask_fut) = deletion_mask_fut {
+            DatasetPreFilter::create_deletion_mask(dataset.clone(), fragment_bitmap.clone());
+        let mut deletion_mask = if let Some(deletion_mask_fut) = deletion_mask_fut {
             Some(deletion_mask_fut.await?)
         } else {
             None
         };
+        // Apply allow-list: only keep rows from fragments covered by the index.
+        // This filters out stale index entries from fragments whose data changed
+        // but whose index data was not rewritten.
+        {
+            let mut allow_list = RowAddrTreeMap::new();
+            for frag_id in fragment_bitmap.iter() {
+                allow_list.insert_fragment(frag_id);
+            }
+            let allow_mask = Arc::new(RowAddrMask::from_allowed(allow_list));
+            deletion_mask = Some(match deletion_mask {
+                Some(existing) => Arc::new((*existing).clone() & (*allow_mask).clone()),
+                None => allow_mask,
+            });
+        }
         Ok(input.and_then(move |res| {
             let column_name = column_name.clone();
             let index_name = index_name.clone();


### PR DESCRIPTION
## Summary

- Restrict index search results to only fragments in the index's `fragment_bitmap`, filtering out stale entries from fragments whose data changed but whose index was not rewritten
- Apply the allow-list in `DatasetPreFilter` (vector/FTS queries) and `MapIndexExec` (scalar index queries used by merge_insert)
- Add regression tests for stale index entries after `DataReplacement` and partial-schema `merge_insert` (BTree, FTS, and vector indices)

## Test plan

- [x] `test_data_replacement_populates_invalidated_bitmap` — DataReplacement removes fragment from bitmap
- [x] `test_fts_stale_entries_after_data_replacement` — stale FTS entries blocked after DataReplacement
- [x] `test_vector_index_after_data_replacement` — stale vector index entries blocked after DataReplacement
- [x] `test_partial_merge_insert_stale_index_ambiguous` — repeated partial merge_insert doesn't cause ambiguous errors
- [x] `test_partial_merge_insert_stale_index_fragment_not_exist` — stale btree entries don't cause fragment-not-found errors
- [x] `test_partial_merge_insert_stale_index_batch_size_mismatch` — stale btree entries don't cause batch size mismatch
- [x] `test_partial_merge_insert_stale_vector_index_duplicates` — no duplicate rows from stale vector index
- [x] `test_partial_merge_insert_stale_fts_index_duplicates` — no duplicate rows from stale FTS index
- [x] `test_compaction_after_invalidated_fragment` — compaction succeeds after fragment invalidation
- [x] All 17 existing prefilter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)