### PR TITLE
fix: map `object_store::Error::NotFound` to `Error::NotFound` instead of `Error::IO`

### DIFF
--- a/java/src/test/java/org/lance/FileReaderWriterTest.java
+++ b/java/src/test/java/org/lance/FileReaderWriterTest.java
@@ -256,7 +256,9 @@ public class FileReaderWriterTest {
       LanceFileReader.open("/tmp/does_not_exist.lance", allocator);
       fail("Expected LanceException to be thrown");
     } catch (IOException e) {
-      assertTrue(e.getMessage().contains("/tmp/does_not_exist.lance"));
+      String message = e.getMessage();
+      assertTrue(message.contains("/tmp/does_not_exist.lance"));
+      assertTrue(message.toLowerCase().contains("not found"));
     }
     try {
       LanceFileReader.open("", allocator);

--- a/java/src/test/java/org/lance/FileReaderWriterTest.java
+++ b/java/src/test/java/org/lance/FileReaderWriterTest.java
@@ -256,7 +256,7 @@ public class FileReaderWriterTest {
       LanceFileReader.open("/tmp/does_not_exist.lance", allocator);
       fail("Expected LanceException to be thrown");
     } catch (IOException e) {
-      assertTrue(e.getMessage().contains("Object at location /tmp/does_not_exist.lance not found"));
+      assertTrue(e.getMessage().contains("/tmp/does_not_exist.lance"));
     }
     try {
       LanceFileReader.open("", allocator);

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -505,7 +505,11 @@ impl From<std::io::Error> for Error {
 impl From<object_store::Error> for Error {
     #[track_caller]
     fn from(e: object_store::Error) -> Self {
-        Self::io_source(box_error(e))
+        match e {
+            // source intentionally dropped; Error::NotFound carries only the path
+            object_store::Error::NotFound { path, .. } => Self::not_found(path),
+            other => Self::io_source(box_error(other)),
+        }
     }
 }
 
@@ -687,6 +691,41 @@ mod test {
             }
             #[allow(unreachable_patterns)]
             _ => panic!("expected ObjectStore error"),
+        }
+    }
+
+    #[test]
+    fn test_caller_location_capture_not_found() {
+        let current_fn = get_caller_location();
+        let f: Box<dyn Fn() -> Result<()>> = Box::new(|| {
+            Err(object_store::Error::NotFound {
+                path: "some/path".to_string(),
+                source: "not found".into(),
+            })?;
+            Ok(())
+        });
+        match f().unwrap_err() {
+            Error::NotFound { location, .. } => {
+                // +2 is the beginning of object_store::Error::NotFound...
+                assert_eq!(location.line(), current_fn.line() + 2, "{}", location)
+            }
+            #[allow(unreachable_patterns)]
+            other => panic!("expected NotFound, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_object_store_not_found_converts_to_not_found() {
+        let os_err = object_store::Error::NotFound {
+            path: "test/path".to_string(),
+            source: "no such file".into(),
+        };
+        let lance_err: Error = os_err.into();
+        match lance_err {
+            Error::NotFound { uri, .. } => {
+                assert_eq!(uri, "test/path");
+            }
+            other => panic!("Expected NotFound, got {:?}", other),
         }
     }
 

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -57,8 +57,8 @@ use lance_table::{
         manifest::{read_manifest, read_manifest_indexes},
     },
 };
+use object_store::ObjectMeta;
 use object_store::path::Path;
-use object_store::{Error as ObjectStoreError, ObjectMeta};
 use std::fmt::Debug;
 use std::{
     collections::{HashMap, HashSet},
@@ -324,16 +324,7 @@ impl<'a> CleanupTask<'a> {
         let verification_threshold = utc_now()
             - TimeDelta::try_days(UNVERIFIED_THRESHOLD_DAYS).expect("TimeDelta::try_days");
 
-        let is_not_found_err = |e: &Error| {
-            matches!(
-                e,
-                Error::IO { source,.. }
-                    if source
-                      .downcast_ref::<ObjectStoreError>()
-                      .map(|os_err| matches!(os_err, ObjectStoreError::NotFound {.. }))
-                      .unwrap_or(false)
-            )
-        };
+        let is_not_found_err = |e: &Error| matches!(e, Error::NotFound { .. });
         // Build stream for a managed subtree
         let build_listing_stream = |dir: Path, file_type: Option<RemovedFileType>| {
             let inspection_ref = &inspection;

--- a/rust/lance/src/dataset/refs.rs
+++ b/rust/lance/src/dataset/refs.rs
@@ -19,7 +19,6 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Formatter;
-use std::io::ErrorKind;
 use uuid::Uuid;
 
 pub const MAIN_BRANCH: &str = "main";
@@ -532,16 +531,8 @@ impl Branches<'_> {
             && let Err(e) = self.refs.object_store.remove_dir_all(delete_path).await
         {
             match &e {
-                Error::IO { source, .. } => {
-                    if let Some(io_err) = source.downcast_ref::<std::io::Error>() {
-                        if io_err.kind() == ErrorKind::NotFound {
-                            log::debug!("Branch directory already deleted: {}", io_err);
-                        } else {
-                            return Err(e);
-                        }
-                    } else {
-                        return Err(e);
-                    }
+                Error::NotFound { .. } => {
+                    log::debug!("Branch directory already deleted");
                 }
                 _ => return Err(e),
             }


### PR DESCRIPTION
Closes https://github.com/lancedb/lance/issues/2067

### Summary

The blanket `From<object_store::Error>` impl mapped **all** object-store errors to `Error::IO`, losing the semantic meaning of "not found." This forced downstream code into fragile multi-level downcasting and left several `Error::NotFound` match arms unreachable for the object-store path (e.g., in `dataset.rs`, `builder.rs`, `insert.rs`).

This PR:
- Discriminates `object_store::Error::NotFound` in the `From` impl so it converts to `Error::NotFound`
- Simplifies two call sites that relied on downcasting (`cleanup.rs`, `refs.rs`)
- Adds tests for the conversion and `#[track_caller]` location propagation

### Breaking Changes

`object_store::Error::NotFound` now produces `Error::NotFound` instead of `Error::IO`. Code matching `Error::IO` to detect object-store not-found conditions (via downcasting) will stop catching them. Match on `Error::NotFound` instead. This is expected during the current `6.0.0-beta.1` pre-release cycle.

### Design Notes

- The `source` field from the object-store variant is intentionally dropped — `Error::NotFound` carries only `uri` and `location`, consistent with all other `Error::not_found()` call sites in the codebase.
- Call sites matching raw `object_store::Error::NotFound` before conversion (e.g., `exists()`, commit resolution, external manifests) are unaffected.