### PR TITLE
ci: pin nightly toolchain to 2026-04-16 for ethnum 1.5.2 compat

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,11 +94,12 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      # pin the toolchain version to avoid surprises
+      # pin the toolchain version to avoid surprises (ethnum 1.5.2
+      # fails on nightly > 2026-04-16 due to a transmute size check)
       - name: Setup rust toolchain
         run: |
-          rustup toolchain install nightly
-          rustup default nightly
+          rustup toolchain install nightly-2026-04-16
+          rustup default nightly-2026-04-16
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - name: Install dependencies
@@ -112,7 +113,7 @@ jobs:
       - name: Run tests
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc -e slow_tests | sort | uniq | paste -s -d "," -`
-          cargo +nightly llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
+          cargo +nightly-2026-04-16 llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:


### PR DESCRIPTION
## Summary

The `linux-build` CI job installs unpinned `nightly`, which broke after 2026-04-17 because `ethnum 1.5.2` uses `unsafe { mem::transmute(()) }` to create `TryFromIntError`. Newer nightly builds reject this with `error[E0512]: cannot transmute between types of different sizes`.

Dependency chain: `lance-arrow` → `jsonb 0.5.6` → `ethnum 1.5.2`

This PR pins `nightly-2026-04-16` (last known-good date) in both the toolchain install step and the `cargo +nightly` invocation.

## Root Cause

`ethnum-1.5.2/src/error.rs:16`:
```rust
pub const fn tfie() -> TryFromIntError {
    unsafe { mem::transmute(()) }  // () is 0 bits, TryFromIntError is 8 bits
}
```

Rust nightly `e9e32aca5` (2026-04-17) tightened `transmute` checks, making this a hard error.

## Follow-up

- Upstream fix needed in [`nlordell/ethnum-rs`](https://github.com/nlordell/ethnum-rs) to replace the transmute hack
- Once `ethnum` publishes a fix and `jsonb` picks it up, the pin can be removed

## Test plan

- [x] `linux-build` job passes with pinned nightly

