### PR TITLE
fix(namespace): align error handling with namespace spec

### DIFF
--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -783,7 +783,7 @@ impl DirectoryNamespaceBuilder {
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to create object store: {}", e),
+                    message: format!("Failed to create object store: {:?}", e),
                 })
             })?;
 
@@ -927,7 +927,7 @@ impl DirectoryNamespace {
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to list directory: {}", e),
+                    message: format!("Failed to list directory: {:?}", e),
                 })
             })?;
 
@@ -1068,7 +1068,7 @@ impl DirectoryNamespace {
         }
 
         if status.is_deregistered {
-            return Err(NamespaceError::InvalidTableState {
+            return Err(NamespaceError::TableNotFound {
                 message: format!("Table is deregistered: {}", table_id),
             }
             .into());
@@ -1118,7 +1118,17 @@ impl DirectoryNamespace {
             Ok(mut dataset) => {
                 // If a specific version is requested, checkout that version
                 if let Some(requested_version) = request.version {
-                    dataset = dataset.checkout_version(requested_version as u64).await?;
+                    dataset = dataset
+                        .checkout_version(requested_version as u64)
+                        .await
+                        .map_err(|e| {
+                            lance_core::Error::from(NamespaceError::TableVersionNotFound {
+                                message: format!(
+                                    "Version {} not found for table '{}': {}",
+                                    requested_version, table_name, e
+                                ),
+                            })
+                        })?;
                 }
 
                 let version_info = dataset.version();
@@ -1523,7 +1533,7 @@ impl DirectoryNamespace {
                 .read_transaction_by_version(version)
                 .await
                 .map_err(|e| {
-                    lance_core::Error::from(NamespaceError::Internal {
+                    lance_core::Error::from(NamespaceError::TransactionNotFound {
                         message: format!(
                             "Failed to read transaction for version {}: {}",
                             version, e
@@ -1657,7 +1667,7 @@ impl DirectoryNamespace {
             | Err(ObjectStoreError::Precondition { .. }) => {
                 Err(format!("{} already exists", file_description))
             }
-            Err(e) => Err(format!("Failed to create {}: {}", file_description, e)),
+            Err(e) => Err(format!("Failed to create {}: {:?}", file_description, e)),
         }
     }
 
@@ -2226,7 +2236,7 @@ impl LanceNamespace for DirectoryNamespace {
         }
 
         if status.is_deregistered {
-            return Err(NamespaceError::InvalidTableState {
+            return Err(NamespaceError::TableNotFound {
                 message: format!("Table is deregistered: {}", table_id),
             }
             .into());
@@ -2250,7 +2260,7 @@ impl LanceNamespace for DirectoryNamespace {
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to drop table {}: {}", table_name, e),
+                    message: format!("Failed to drop table {}: {:?}", table_name, e),
                 })
             })?;
 
@@ -2284,7 +2294,7 @@ impl LanceNamespace for DirectoryNamespace {
         let cursor = Cursor::new(request_data.to_vec());
         let stream_reader = StreamReader::try_new(cursor, None).map_err(|e| {
             lance_core::Error::from(NamespaceError::InvalidInput {
-                message: format!("Invalid Arrow IPC stream: {}", e),
+                message: format!("Invalid Arrow IPC stream: {:?}", e),
             })
         })?;
         let arrow_schema = stream_reader.schema();
@@ -2294,7 +2304,7 @@ impl LanceNamespace for DirectoryNamespace {
         for batch_result in stream_reader {
             batches.push(batch_result.map_err(|e| {
                 lance_core::Error::from(NamespaceError::InvalidInput {
-                    message: format!("Failed to read batch from IPC stream: {}", e),
+                    message: format!("Failed to read batch from IPC stream: {:?}", e),
                 })
             })?);
         }
@@ -2326,9 +2336,17 @@ impl LanceNamespace for DirectoryNamespace {
         Dataset::write(reader, &table_uri, Some(write_params))
             .await
             .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to create Lance dataset: {}", e),
-                })
+                let err_msg = format!("{}", e);
+                let ns_err = if err_msg.contains("already exists") {
+                    NamespaceError::TableAlreadyExists {
+                        message: format!("Table already exists at '{}': {:?}", table_uri, e),
+                    }
+                } else {
+                    NamespaceError::Internal {
+                        message: format!("Failed to create Lance dataset: {:?}", e),
+                    }
+                };
+                lance_core::Error::from(ns_err)
             })?;
 
         Ok(CreateTableResponse {
@@ -2466,7 +2484,7 @@ impl LanceNamespace for DirectoryNamespace {
         }
 
         if status.is_deregistered {
-            return Err(NamespaceError::InvalidTableState {
+            return Err(NamespaceError::TableNotFound {
                 message: format!("Table is already deregistered: {}", table_name),
             }
             .into());
@@ -2759,8 +2777,8 @@ impl LanceNamespace for DirectoryNamespace {
             builder = builder.with_session(sess.clone());
         }
         let mut dataset = builder.load().await.map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to open table at '{}': {}", table_uri, e),
+            lance_core::Error::from(NamespaceError::TableNotFound {
+                message: format!("Failed to open table at '{}': {:?}", table_uri, e),
             })
         })?;
 
@@ -2905,16 +2923,36 @@ impl LanceNamespace for DirectoryNamespace {
             )
             .await
             .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to create {} index '{}' on column '{}' for table '{}': {}",
-                        request.index_type,
-                        request.name.as_deref().unwrap_or("<auto-generated>"),
-                        request.column,
-                        table_uri,
-                        e
-                    ),
-                })
+                let err_msg = format!("{}", e);
+                let ns_err = if err_msg.contains("already exists") {
+                    NamespaceError::TableIndexAlreadyExists {
+                        message: format!(
+                            "Index '{}' already exists on table '{}': {:?}",
+                            request.name.as_deref().unwrap_or("<auto-generated>"),
+                            table_uri,
+                            e
+                        ),
+                    }
+                } else if err_msg.contains("not found") || err_msg.contains("does not exist") {
+                    NamespaceError::TableColumnNotFound {
+                        message: format!(
+                            "Column '{}' not found for table '{}': {:?}",
+                            request.column, table_uri, e
+                        ),
+                    }
+                } else {
+                    NamespaceError::Internal {
+                        message: format!(
+                            "Failed to create {} index '{}' on column '{}' for table '{}': {:?}",
+                            request.index_type,
+                            request.name.as_deref().unwrap_or("<auto-generated>"),
+                            request.column,
+                            table_uri,
+                            e
+                        ),
+                    }
+                };
+                lance_core::Error::from(ns_err)
             })?;
 
         let transaction_id = dataset
@@ -2947,7 +2985,7 @@ impl LanceNamespace for DirectoryNamespace {
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to describe table indices for '{}': {}", table_uri, e),
+                    message: format!("Failed to describe table indices for '{}': {:?}", table_uri, e),
                 })
             })?
             .into_iter()
@@ -3018,7 +3056,7 @@ impl LanceNamespace for DirectoryNamespace {
             .load_indices_by_name(index_name)
             .await
             .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
+                lance_core::Error::from(NamespaceError::TableIndexNotFound {
                     message: format!(
                         "Failed to load index '{}' metadata for table '{}': {}",
                         index_name, table_uri, e
@@ -3035,7 +3073,7 @@ impl LanceNamespace for DirectoryNamespace {
         let stats = <Dataset as DatasetIndexExt>::index_statistics(&dataset, index_name)
             .await
             .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
+                lance_core::Error::from(NamespaceError::TableIndexNotFound {
                     message: format!(
                         "Failed to describe index statistics for '{}' on table '{}': {}",
                         index_name, table_uri, e
@@ -3126,7 +3164,7 @@ impl LanceNamespace for DirectoryNamespace {
             .load_indices_by_name(index_name)
             .await
             .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
+                lance_core::Error::from(NamespaceError::TableIndexNotFound {
                     message: format!(
                         "Failed to load index '{}' before dropping it from table '{}': {}",
                         index_name, table_uri, e
@@ -3144,7 +3182,7 @@ impl LanceNamespace for DirectoryNamespace {
         }
 
         dataset.drop_index(index_name).await.map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
+            lance_core::Error::from(NamespaceError::TableIndexNotFound {
                 message: format!(
                     "Failed to drop index '{}' from table '{}': {}",
                     index_name, table_uri, e
@@ -3455,7 +3493,7 @@ impl LanceNamespace for DirectoryNamespace {
                 .count_rows(request.predicate)
                 .await
                 .map_err(|e| NamespaceError::Internal {
-                    message: format!("Failed to count rows for table at '{}': {}", table_uri, e),
+                    message: format!("Failed to count rows for table at '{}': {:?}", table_uri, e),
                 })?;
 
         Ok(count as i64)
@@ -3480,14 +3518,14 @@ impl LanceNamespace for DirectoryNamespace {
         let cursor = Cursor::new(request_data.as_ref());
         let stream_reader =
             StreamReader::try_new(cursor, None).map_err(|e| NamespaceError::InvalidInput {
-                message: format!("Invalid Arrow IPC stream: {}", e),
+                message: format!("Invalid Arrow IPC stream: {:?}", e),
             })?;
         let arrow_schema = stream_reader.schema();
 
         let mut batches = Vec::new();
         for batch_result in stream_reader {
-            batches.push(batch_result.map_err(|e| NamespaceError::Internal {
-                message: format!("Failed to read batch from IPC stream: {}", e),
+            batches.push(batch_result.map_err(|e| NamespaceError::InvalidInput {
+                message: format!("Failed to read batch from IPC stream: {:?}", e),
             })?);
         }
 
@@ -3531,8 +3569,20 @@ impl LanceNamespace for DirectoryNamespace {
 
         Dataset::write(reader, &table_uri, Some(write_params))
             .await
-            .map_err(|e| NamespaceError::Internal {
-                message: format!("Failed to insert into table at '{}': {}", table_uri, e),
+            .map_err(|e| {
+                let err_msg = format!("{}", e);
+                if err_msg.contains("conflict") || err_msg.contains("CommitConflict") {
+                    NamespaceError::ConcurrentModification {
+                        message: format!(
+                            "Concurrent modification on table at '{}': {:?}",
+                            table_uri, e
+                        ),
+                    }
+                } else {
+                    NamespaceError::Internal {
+                        message: format!("Failed to insert into table at '{}': {:?}", table_uri, e),
+                    }
+                }
             })?;
 
         Ok(InsertIntoTableResponse {
@@ -3600,7 +3650,7 @@ impl LanceNamespace for DirectoryNamespace {
                 scanner
                     .nearest(vector_column, &query_array, k)
                     .map_err(|e| NamespaceError::InvalidInput {
-                        message: format!("Invalid vector search: {}", e),
+                        message: format!("Invalid vector search: {:?}", e),
                     })?;
 
                 // Apply distance type if specified
@@ -3665,14 +3715,14 @@ impl LanceNamespace for DirectoryNamespace {
                     fts = fts
                         .with_columns(columns)
                         .map_err(|e| NamespaceError::InvalidInput {
-                            message: format!("Invalid FTS columns: {}", e),
+                            message: format!("Invalid FTS columns: {:?}", e),
                         })?;
                 }
 
                 scanner
                     .full_text_search(fts)
                     .map_err(|e| NamespaceError::InvalidInput {
-                        message: format!("Invalid full text search: {}", e),
+                        message: format!("Invalid full text search: {:?}", e),
                     })?;
             }
             // Note: structured_query would require more complex parsing
@@ -3687,7 +3737,7 @@ impl LanceNamespace for DirectoryNamespace {
                 scanner
                     .project(column_names)
                     .map_err(|e| NamespaceError::InvalidInput {
-                        message: format!("Invalid column projection: {}", e),
+                        message: format!("Invalid column projection: {:?}", e),
                     })?;
             } else if let Some(ref column_aliases) = columns.column_aliases
                 && !column_aliases.is_empty()
@@ -3705,7 +3755,7 @@ impl LanceNamespace for DirectoryNamespace {
                             .collect::<Vec<_>>(),
                     )
                     .map_err(|e| NamespaceError::InvalidInput {
-                        message: format!("Invalid column alias expression: {}", e),
+                        message: format!("Invalid column alias expression: {:?}", e),
                     })?;
             }
         }
@@ -3717,7 +3767,7 @@ impl LanceNamespace for DirectoryNamespace {
             scanner
                 .filter(filter)
                 .map_err(|e| NamespaceError::InvalidInput {
-                    message: format!("Invalid filter expression: {}", e),
+                    message: format!("Invalid filter expression: {:?}", e),
                 })?;
         }
 
@@ -3733,7 +3783,7 @@ impl LanceNamespace for DirectoryNamespace {
             let offset = request.offset.map(|o| o as i64);
             scanner.limit(Some(request.k as i64), offset).map_err(|e| {
                 NamespaceError::InvalidInput {
-                    message: format!("Invalid limit/offset: {}", e),
+                    message: format!("Invalid limit/offset: {:?}", e),
                 }
             })?;
         } else if has_vector_query && request.offset.is_some() {
@@ -3742,7 +3792,7 @@ impl LanceNamespace for DirectoryNamespace {
             scanner
                 .limit(None, offset)
                 .map_err(|e| NamespaceError::InvalidInput {
-                    message: format!("Invalid offset: {}", e),
+                    message: format!("Invalid offset: {:?}", e),
                 })?;
         }
 
@@ -3751,7 +3801,7 @@ impl LanceNamespace for DirectoryNamespace {
             .try_into_batch()
             .await
             .map_err(|e| NamespaceError::Internal {
-                message: format!("Failed to execute query: {}", e),
+                message: format!("Failed to execute query: {:?}", e),
             })?;
 
         // Serialize to Arrow IPC file format
@@ -3760,14 +3810,14 @@ impl LanceNamespace for DirectoryNamespace {
         {
             let mut writer = FileWriter::try_new(&mut buffer, &schema).map_err(|e| {
                 NamespaceError::Internal {
-                    message: format!("Failed to create IPC writer: {}", e),
+                    message: format!("Failed to create IPC writer: {:?}", e),
                 }
             })?;
             writer.write(&batch).map_err(|e| NamespaceError::Internal {
-                message: format!("Failed to write batch to IPC: {}", e),
+                message: format!("Failed to write batch to IPC: {:?}", e),
             })?;
             writer.finish().map_err(|e| NamespaceError::Internal {
-                message: format!("Failed to finish IPC writer: {}", e),
+                message: format!("Failed to finish IPC writer: {:?}", e),
             })?;
         }
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -182,7 +182,7 @@ impl DatasetConsistencyWrapper {
         );
         let latest_version = read_guard.latest_version_id().await.map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to get latest version: {}", e),
+                message: format!("Failed to get latest version: {:?}", e),
             })
         })?;
         log::debug!(
@@ -205,14 +205,14 @@ impl DatasetConsistencyWrapper {
         // Double-check after acquiring write lock (someone else might have reloaded)
         let latest_version = write_guard.latest_version_id().await.map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to get latest version: {}", e),
+                message: format!("Failed to get latest version: {:?}", e),
             })
         })?;
 
         if latest_version != write_guard.version().version {
             write_guard.checkout_latest().await.map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to checkout latest: {}", e),
+                    message: format!("Failed to checkout latest: {:?}", e),
                 })
             })?;
         }
@@ -293,15 +293,15 @@ impl std::fmt::Debug for ManifestNamespace {
 /// Convert a Lance commit error to an appropriate namespace error.
 ///
 /// Maps lance commit errors to namespace errors:
-/// - `CommitConflict`: version collision retries exhausted -> Throttled (safe to retry)
+/// - `CommitConflict`: version collision retries exhausted -> Throttling (safe to retry)
 /// - `TooMuchWriteContention`: RetryableCommitConflict (semantic conflict) retries exhausted -> ConcurrentModification
 /// - `IncompatibleTransaction`: incompatible concurrent change -> ConcurrentModification
 /// - Errors containing "matched/duplicate/already exists": ConcurrentModification (from WhenMatched::Fail)
 /// - Other errors: IO error with the operation description
 fn convert_lance_commit_error(e: &LanceError, operation: &str, object_id: Option<&str>) -> Error {
     match e {
-        // CommitConflict: version collision retries exhausted -> Throttled (safe to retry)
-        LanceError::CommitConflict { .. } => NamespaceError::Throttled {
+        // CommitConflict: version collision retries exhausted -> Throttling (safe to retry)
+        LanceError::CommitConflict { .. } => NamespaceError::Throttling {
             message: format!("Too many concurrent writes, please retry later: {:?}", e),
         }
         .into(),
@@ -703,7 +703,7 @@ impl ManifestNamespace {
     async fn execute_scanner(scanner: Scanner) -> Result<Vec<RecordBatch>> {
         let mut stream = scanner.try_into_stream().await.map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to create stream: {}", e),
+                message: format!("Failed to create stream: {:?}", e),
             })
         })?;
 
@@ -711,7 +711,7 @@ impl ManifestNamespace {
         while let Some(batch) = stream.next().await {
             batches.push(batch.map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to read batch: {}", e),
+                    message: format!("Failed to read batch: {:?}", e),
                 })
             })?);
         }
@@ -746,14 +746,14 @@ impl ManifestNamespace {
 
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
 
         // Project no columns and enable row IDs for count_rows to work
         scanner.project::<&str>(&[]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
 
@@ -761,7 +761,7 @@ impl ManifestNamespace {
 
         let count = scanner.count_rows().await.map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to count rows: {}", e),
+                message: format!("Failed to count rows: {:?}", e),
             })
         })?;
 
@@ -775,12 +775,12 @@ impl ManifestNamespace {
         let mut scanner = self.manifest_scanner().await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project(&["object_id", "location"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
         let batches = Self::execute_scanner(scanner).await?;
@@ -825,12 +825,12 @@ impl ManifestNamespace {
         let mut scanner = self.manifest_scanner().await?;
         scanner.filter(filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project(&["location"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
 
@@ -944,7 +944,7 @@ impl ManifestNamespace {
         )
         .map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to create manifest entries: {}", e),
+                message: format!("Failed to create manifest entries: {:?}", e),
             })
         })?;
 
@@ -960,7 +960,7 @@ impl ManifestNamespace {
             MergeInsertBuilder::try_new(dataset_arc, vec!["object_id".to_string()]).map_err(
                 |e| {
                     lance_core::Error::from(NamespaceError::Internal {
-                        message: format!("Failed to create merge builder: {}", e),
+                        message: format!("Failed to create merge builder: {:?}", e),
                     })
                 },
             )?;
@@ -985,7 +985,7 @@ impl ManifestNamespace {
             .try_build()
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to build merge: {}", e),
+                    message: format!("Failed to build merge: {:?}", e),
                 })
             })?
             .execute_reader(Box::new(reader))
@@ -1065,12 +1065,12 @@ impl ManifestNamespace {
         let mut scanner = self.manifest_scanner().await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project(&["object_id", "metadata"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
         let batches = Self::execute_scanner(scanner).await?;
@@ -1133,12 +1133,12 @@ impl ManifestNamespace {
         let mut scanner = self.manifest_scanner().await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project(&["metadata"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
         let batches = Self::execute_scanner(scanner).await?;
@@ -1195,12 +1195,12 @@ impl ManifestNamespace {
         let mut scanner = self.manifest_scanner().await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project(&["object_id"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
         let batches = Self::execute_scanner(scanner).await?;
@@ -1272,12 +1272,12 @@ impl ManifestNamespace {
         let mut scanner = self.manifest_scanner().await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project(&["object_id"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
         let batches = Self::execute_scanner(scanner).await?;
@@ -1480,12 +1480,12 @@ impl ManifestNamespace {
         let mut scanner = self.manifest_scanner().await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project(&["object_id", "metadata"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
         let batches = Self::execute_scanner(scanner).await?;
@@ -1594,13 +1594,16 @@ impl ManifestNamespace {
                     .update("object_id", [(LANCE_UNENFORCED_PRIMARY_KEY_POSITION, "0")])
                     .map_err(|e| {
                         lance_core::Error::from(NamespaceError::Internal {
-                            message: format!("Failed to find object_id field for migration: {}", e),
+                            message: format!(
+                                "Failed to find object_id field for migration: {:?}",
+                                e
+                            ),
                         })
                     })?
                     .await
                     .map_err(|e| {
                         lance_core::Error::from(NamespaceError::Internal {
-                            message: format!("Failed to migrate primary key metadata: {}", e),
+                            message: format!("Failed to migrate primary key metadata: {:?}", e),
                         })
                     })?;
             }
@@ -1707,7 +1710,7 @@ impl ManifestNamespace {
                     Ok(DatasetConsistencyWrapper::new(dataset))
                 }
                 Err(e) => Err(lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to create manifest dataset: {}", e),
+                    message: format!("Failed to create manifest dataset: {:?}", e),
                 })),
             }
         }
@@ -1785,12 +1788,12 @@ impl LanceNamespace for ManifestNamespace {
         let mut scanner = self.manifest_scanner().await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project(&["object_id"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
 
@@ -1992,7 +1995,7 @@ impl LanceNamespace for ManifestNamespace {
         let cursor = Cursor::new(data.to_vec());
         let stream_reader = StreamReader::try_new(cursor, None).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to read IPC stream: {}", e),
+                message: format!("Failed to read IPC stream: {:?}", e),
             })
         })?;
 
@@ -2000,7 +2003,7 @@ impl LanceNamespace for ManifestNamespace {
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to collect batches: {}", e),
+                message: format!("Failed to collect batches: {:?}", e),
             })
         })?;
 
@@ -2035,7 +2038,7 @@ impl LanceNamespace for ManifestNamespace {
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to write dataset: {}", e),
+                    message: format!("Failed to write dataset: {:?}", e),
                 })
             })?;
 
@@ -2087,7 +2090,7 @@ impl LanceNamespace for ManifestNamespace {
                     .await
                     .map_err(|e| {
                         lance_core::Error::from(NamespaceError::Internal {
-                            message: format!("Failed to delete table directory: {}", e),
+                            message: format!("Failed to delete table directory: {:?}", e),
                         })
                     })?;
 
@@ -2132,12 +2135,12 @@ impl LanceNamespace for ManifestNamespace {
         let mut scanner = self.manifest_scanner().await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project(&["object_id"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
 
@@ -2290,18 +2293,18 @@ impl LanceNamespace for ManifestNamespace {
         let mut scanner = self.manifest_scanner().boxed().await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to filter: {}", e),
+                message: format!("Failed to filter: {:?}", e),
             })
         })?;
         scanner.project::<&str>(&[]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {}", e),
+                message: format!("Failed to project: {:?}", e),
             })
         })?;
         scanner.with_row_id();
         let count = scanner.count_rows().boxed().await.map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to count rows: {}", e),
+                message: format!("Failed to count rows: {:?}", e),
             })
         })?;
 

--- a/rust/lance-namespace-impls/src/rest.rs
+++ b/rust/lance-namespace-impls/src/rest.rs
@@ -32,7 +32,7 @@ use lance_namespace::models::{
     DescribeTableVersionRequest, DescribeTableVersionResponse, DescribeTransactionRequest,
     DescribeTransactionResponse, DropNamespaceRequest, DropNamespaceResponse,
     DropTableIndexRequest, DropTableIndexResponse, DropTableRequest, DropTableResponse,
-    ExplainTableQueryPlanRequest, GetTableStatsRequest, GetTableStatsResponse,
+    ErrorResponse, ExplainTableQueryPlanRequest, GetTableStatsRequest, GetTableStatsResponse,
     GetTableTagVersionRequest, GetTableTagVersionResponse, InsertIntoTableRequest,
     InsertIntoTableResponse, ListNamespacesRequest, ListNamespacesResponse,
     ListTableIndicesRequest, ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
@@ -534,93 +534,38 @@ impl RestNamespace {
         }
     }
 
+    /// Map a reqwest::Error to the appropriate NamespaceError variant.
+    ///
+    /// Timeout and connection errors are mapped to `ServiceUnavailable`,
+    /// while other errors are mapped to `Internal`.
+    fn request_error(e: reqwest::Error) -> lance_core::Error {
+        let message = format!("Failed to execute request: {:?}", e);
+        if e.is_timeout() || e.is_connect() {
+            NamespaceError::ServiceUnavailable { message }.into()
+        } else {
+            NamespaceError::Internal { message }.into()
+        }
+    }
+
     /// Parse an error response body and return the appropriate NamespaceError.
     ///
-    /// Attempts to parse a JSON body with `{"error": {"code": N, "message": "..."}}`.
-    /// Falls back to mapping the HTTP status code (using the operation to disambiguate)
-    /// if the JSON body doesn't contain an error code.
-    fn parse_error_response(
-        status: reqwest::StatusCode,
-        content: &str,
-        operation: &str,
-    ) -> lance_core::Error {
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(content)
-            && let Some(error_obj) = json.get("error")
-        {
-            let code = error_obj
-                .get("code")
-                .and_then(|c| c.as_u64())
-                .map(|c| c as u32);
-            let message = error_obj
-                .get("message")
-                .and_then(|m| m.as_str())
-                .unwrap_or(content);
-
-            if let Some(code) = code {
-                return NamespaceError::from_code(code, message).into();
+    /// Deserializes the response as an `ErrorResponse` model (the spec-defined
+    /// flat JSON format with a required numeric `code` field). The error code is
+    /// the sole source of truth for error classification. When deserialization
+    /// fails, returns Internal with the raw response as context.
+    fn parse_error_response(status: reqwest::StatusCode, content: &str) -> lance_core::Error {
+        match serde_json::from_str::<ErrorResponse>(content) {
+            Ok(err_resp) => {
+                let message = err_resp.error.as_deref().unwrap_or(content);
+                NamespaceError::from_code(err_resp.code as u32, message).into()
             }
-        }
-
-        let message = format!("Response error: status={}, content={}", status, content);
-        Self::error_from_status(status, operation, message).into()
-    }
-
-    /// Map an HTTP status code to a NamespaceError variant.
-    ///
-    /// For unambiguous status codes (401, 403, 429, 501, 503) the mapping is direct.
-    /// For 404 and 409 the `operation` string is used to select the appropriate
-    /// "not found" or "already exists" variant.
-    fn error_from_status(
-        status: reqwest::StatusCode,
-        operation: &str,
-        message: String,
-    ) -> NamespaceError {
-        match status.as_u16() {
-            400 => NamespaceError::InvalidInput { message },
-            401 => NamespaceError::Unauthenticated { message },
-            403 => NamespaceError::PermissionDenied { message },
-            404 => Self::not_found_for_operation(operation, message),
-            409 => Self::already_exists_for_operation(operation, message),
-            429 => NamespaceError::Throttled { message },
-            501 => NamespaceError::Unsupported { message },
-            503 => NamespaceError::ServiceUnavailable { message },
-            _ => NamespaceError::Internal { message },
-        }
-    }
-
-    /// Pick the appropriate "not found" variant based on the operation.
-    fn not_found_for_operation(operation: &str, message: String) -> NamespaceError {
-        if operation.contains("namespace") {
-            NamespaceError::NamespaceNotFound { message }
-        } else if operation.contains("index") {
-            NamespaceError::TableIndexNotFound { message }
-        } else if operation.contains("tag") {
-            NamespaceError::TableTagNotFound { message }
-        } else if operation.contains("transaction") {
-            NamespaceError::TransactionNotFound { message }
-        } else if operation.contains("version") {
-            NamespaceError::TableVersionNotFound { message }
-        } else if operation.contains("column") {
-            NamespaceError::TableColumnNotFound { message }
-        } else if operation.contains("table") {
-            NamespaceError::TableNotFound { message }
-        } else {
-            NamespaceError::Internal { message }
-        }
-    }
-
-    /// Pick the appropriate "already exists" variant based on the operation.
-    fn already_exists_for_operation(operation: &str, message: String) -> NamespaceError {
-        if operation.contains("namespace") {
-            NamespaceError::NamespaceAlreadyExists { message }
-        } else if operation.contains("index") {
-            NamespaceError::TableIndexAlreadyExists { message }
-        } else if operation.contains("tag") {
-            NamespaceError::TableTagAlreadyExists { message }
-        } else if operation.contains("table") {
-            NamespaceError::TableAlreadyExists { message }
-        } else {
-            NamespaceError::Internal { message }
+            Err(e) => NamespaceError::Internal {
+                message: format!(
+                    "Failed to parse error response: status={}, body={}, error={:?}",
+                    status, content, e
+                ),
+            }
+            .into(),
         }
     }
 
@@ -639,28 +584,24 @@ impl RestNamespace {
             .rest_client
             .execute(req_builder, operation, object_id)
             .await
-            .map_err(|e| {
-                Error::from(NamespaceError::Internal {
-                    message: format!("Failed to execute request: {}", e),
-                })
-            })?;
+            .map_err(Self::request_error)?;
 
         let status = resp.status();
         let content = resp.text().await.map_err(|e| {
             Error::from(NamespaceError::Internal {
-                message: format!("Failed to read response body: {}", e),
+                message: format!("Failed to read response body: {:?}", e),
             })
         })?;
 
         if status.is_success() {
             serde_json::from_str(&content).map_err(|e| {
                 NamespaceError::Internal {
-                    message: format!("Failed to parse response: {}", e),
+                    message: format!("Failed to parse response: {:?}", e),
                 }
                 .into()
             })
         } else {
-            Err(Self::parse_error_response(status, &content, operation))
+            Err(Self::parse_error_response(status, &content))
         }
     }
 
@@ -680,28 +621,24 @@ impl RestNamespace {
             .rest_client
             .execute(req_builder, operation, object_id)
             .await
-            .map_err(|e| {
-                Error::from(NamespaceError::Internal {
-                    message: format!("Failed to execute request: {}", e),
-                })
-            })?;
+            .map_err(Self::request_error)?;
 
         let status = resp.status();
         let content = resp.text().await.map_err(|e| {
             Error::from(NamespaceError::Internal {
-                message: format!("Failed to read response body: {}", e),
+                message: format!("Failed to read response body: {:?}", e),
             })
         })?;
 
         if status.is_success() {
             serde_json::from_str(&content).map_err(|e| {
                 NamespaceError::Internal {
-                    message: format!("Failed to parse response: {}", e),
+                    message: format!("Failed to parse response: {:?}", e),
                 }
                 .into()
             })
         } else {
-            Err(Self::parse_error_response(status, &content, operation))
+            Err(Self::parse_error_response(status, &content))
         }
     }
 
@@ -721,11 +658,7 @@ impl RestNamespace {
             .rest_client
             .execute(req_builder, operation, object_id)
             .await
-            .map_err(|e| {
-                Error::from(NamespaceError::Internal {
-                    message: format!("Failed to execute request: {}", e),
-                })
-            })?;
+            .map_err(Self::request_error)?;
 
         let status = resp.status();
         if status.is_success() {
@@ -733,10 +666,10 @@ impl RestNamespace {
         } else {
             let content = resp.text().await.map_err(|e| {
                 Error::from(NamespaceError::Internal {
-                    message: format!("Failed to read response body: {}", e),
+                    message: format!("Failed to read response body: {:?}", e),
                 })
             })?;
-            Err(Self::parse_error_response(status, &content, operation))
+            Err(Self::parse_error_response(status, &content))
         }
     }
 
@@ -756,28 +689,24 @@ impl RestNamespace {
             .rest_client
             .execute(req_builder, operation, object_id)
             .await
-            .map_err(|e| {
-                Error::from(NamespaceError::Internal {
-                    message: format!("Failed to execute request: {}", e),
-                })
-            })?;
+            .map_err(Self::request_error)?;
 
         let status = resp.status();
         let content = resp.text().await.map_err(|e| {
             Error::from(NamespaceError::Internal {
-                message: format!("Failed to read response body: {}", e),
+                message: format!("Failed to read response body: {:?}", e),
             })
         })?;
 
         if status.is_success() {
             serde_json::from_str(&content).map_err(|e| {
                 NamespaceError::Internal {
-                    message: format!("Failed to parse response: {}", e),
+                    message: format!("Failed to parse response: {:?}", e),
                 }
                 .into()
             })
         } else {
-            Err(Self::parse_error_response(status, &content, operation))
+            Err(Self::parse_error_response(status, &content))
         }
     }
 
@@ -1141,26 +1070,22 @@ impl LanceNamespace for RestNamespace {
             .rest_client
             .execute(req_builder, operation, &id)
             .await
-            .map_err(|e| {
-                Error::from(NamespaceError::Internal {
-                    message: format!("Failed to execute request: {}", e),
-                })
-            })?;
+            .map_err(Self::request_error)?;
 
         let status = resp.status();
         if status.is_success() {
             resp.bytes().await.map_err(|e| {
                 Error::from(NamespaceError::Internal {
-                    message: format!("Failed to read response bytes: {}", e),
+                    message: format!("Failed to read response bytes: {:?}", e),
                 })
             })
         } else {
             let content = resp.text().await.map_err(|e| {
                 Error::from(NamespaceError::Internal {
-                    message: format!("Failed to read response body: {}", e),
+                    message: format!("Failed to read response body: {:?}", e),
                 })
             })?;
-            Err(Self::parse_error_response(status, &content, operation))
+            Err(Self::parse_error_response(status, &content))
         }
     }
 

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -155,7 +155,7 @@ impl RestAdapter {
         let listener = tokio::net::TcpListener::bind(&addr).await.map_err(|e| {
             log::error!("RestAdapter::start() failed to bind to {}: {}", addr, e);
             Error::from(NamespaceError::Internal {
-                message: format!("Failed to bind to {}: {}", addr, e),
+                message: format!("Failed to bind to {}: {:?}", addr, e),
             })
         })?;
 
@@ -309,73 +309,46 @@ fn error_code_to_status(code: u32) -> StatusCode {
         | Some(lance_namespace::error::ErrorCode::TableIndexAlreadyExists)
         | Some(lance_namespace::error::ErrorCode::TableTagAlreadyExists)
         | Some(lance_namespace::error::ErrorCode::ConcurrentModification) => StatusCode::CONFLICT,
+        Some(lance_namespace::error::ErrorCode::NamespaceNotEmpty)
+        | Some(lance_namespace::error::ErrorCode::InvalidTableState) => StatusCode::CONFLICT,
         Some(lance_namespace::error::ErrorCode::InvalidInput)
-        | Some(lance_namespace::error::ErrorCode::InvalidTableState)
-        | Some(lance_namespace::error::ErrorCode::TableSchemaValidationError)
-        | Some(lance_namespace::error::ErrorCode::NamespaceNotEmpty) => StatusCode::BAD_REQUEST,
-        Some(lance_namespace::error::ErrorCode::Unsupported) => StatusCode::NOT_IMPLEMENTED,
+        | Some(lance_namespace::error::ErrorCode::TableSchemaValidationError) => {
+            StatusCode::BAD_REQUEST
+        }
+        Some(lance_namespace::error::ErrorCode::Unsupported) => StatusCode::NOT_ACCEPTABLE,
         Some(lance_namespace::error::ErrorCode::PermissionDenied) => StatusCode::FORBIDDEN,
         Some(lance_namespace::error::ErrorCode::Unauthenticated) => StatusCode::UNAUTHORIZED,
         Some(lance_namespace::error::ErrorCode::ServiceUnavailable) => {
             StatusCode::SERVICE_UNAVAILABLE
         }
-        Some(lance_namespace::error::ErrorCode::Throttled) => StatusCode::TOO_MANY_REQUESTS,
+        Some(lance_namespace::error::ErrorCode::Throttling) => StatusCode::TOO_MANY_REQUESTS,
         Some(lance_namespace::error::ErrorCode::Internal) | None => {
             StatusCode::INTERNAL_SERVER_ERROR
         }
     }
 }
 
-/// Convert Lance errors to HTTP responses
+/// Convert Lance errors to HTTP responses using the spec's `ErrorResponse` model.
 fn error_to_response(err: Error) -> Response {
     match err {
         Error::Namespace { source, .. } => {
             if let Some(ns_err) = source.downcast_ref::<NamespaceError>() {
                 let code = ns_err.code().as_u32();
                 let status = error_code_to_status(code);
-                (
-                    status,
-                    Json(serde_json::json!({
-                        "error": {
-                            "message": ns_err.message(),
-                            "code": code
-                        }
-                    })),
-                )
-                    .into_response()
+                let mut resp = ErrorResponse::new(code as i32);
+                resp.error = Some(ns_err.message().to_string());
+                (status, Json(resp)).into_response()
             } else {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "error": {
-                            "message": source.to_string(),
-                            "code": 18
-                        }
-                    })),
-                )
-                    .into_response()
+                let mut resp = ErrorResponse::new(18);
+                resp.error = Some(source.to_string());
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(resp)).into_response()
             }
         }
-        Error::IO { source, .. } => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "error": {
-                    "message": source.to_string(),
-                    "type": "InternalServerError"
-                }
-            })),
-        )
-            .into_response(),
-        _ => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "error": {
-                    "message": err.to_string(),
-                    "type": "InternalServerError"
-                }
-            })),
-        )
-            .into_response(),
+        _ => {
+            let mut resp = ErrorResponse::new(18);
+            resp.error = Some(err.to_string());
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(resp)).into_response()
+        }
     }
 }
 

--- a/rust/lance-namespace/src/error.rs
+++ b/rust/lance-namespace/src/error.rs
@@ -77,7 +77,7 @@ pub enum ErrorCode {
     /// Table schema validation failed
     TableSchemaValidationError = 20,
     /// Request was throttled due to rate limiting or too many concurrent operations
-    Throttled = 21,
+    Throttling = 21,
 }
 
 impl ErrorCode {
@@ -112,7 +112,7 @@ impl ErrorCode {
             18 => Some(Self::Internal),
             19 => Some(Self::InvalidTableState),
             20 => Some(Self::TableSchemaValidationError),
-            21 => Some(Self::Throttled),
+            21 => Some(Self::Throttling),
             _ => None,
         }
     }
@@ -142,7 +142,7 @@ impl std::fmt::Display for ErrorCode {
             Self::Internal => "Internal",
             Self::InvalidTableState => "InvalidTableState",
             Self::TableSchemaValidationError => "TableSchemaValidationError",
-            Self::Throttled => "Throttled",
+            Self::Throttling => "Throttling",
         };
         write!(f, "{}", name)
     }
@@ -258,8 +258,8 @@ pub enum NamespaceError {
     TableSchemaValidationError { message: String },
 
     /// Request was throttled due to rate limiting or too many concurrent operations.
-    #[snafu(display("Throttled: {message}"))]
-    Throttled { message: String },
+    #[snafu(display("Throttling: {message}"))]
+    Throttling { message: String },
 }
 
 impl NamespaceError {
@@ -291,7 +291,7 @@ impl NamespaceError {
             | Self::Internal { message }
             | Self::InvalidTableState { message }
             | Self::TableSchemaValidationError { message }
-            | Self::Throttled { message } => message,
+            | Self::Throttling { message } => message,
         }
     }
 
@@ -321,7 +321,7 @@ impl NamespaceError {
             Self::Internal { .. } => ErrorCode::Internal,
             Self::InvalidTableState { .. } => ErrorCode::InvalidTableState,
             Self::TableSchemaValidationError { .. } => ErrorCode::TableSchemaValidationError,
-            Self::Throttled { .. } => ErrorCode::Throttled,
+            Self::Throttling { .. } => ErrorCode::Throttling,
         }
     }
 
@@ -354,7 +354,7 @@ impl NamespaceError {
             Some(ErrorCode::TableSchemaValidationError) => {
                 Self::TableSchemaValidationError { message }
             }
-            Some(ErrorCode::Throttled) => Self::Throttled { message },
+            Some(ErrorCode::Throttling) => Self::Throttling { message },
             None => Self::Internal { message },
         }
     }


### PR DESCRIPTION
## Summary

- Fix RestNamespace to parse the spec-defined flat error response format using the generated `ErrorResponse` model, instead of guessing errors from HTTP status codes
- Fix DirectoryNamespace to return correct `NamespaceError` variants per the spec's per-operation error tables
- Fix REST adapter to produce spec-compliant error responses using `ErrorResponse` model, and correct HTTP status code mappings (406 for Unsupported, 409 for NamespaceNotEmpty/InvalidTableState)
- Rename `ErrorCode::Throttled` to `ErrorCode::Throttling` to match spec and Python/Java SDK naming
- Use `{:?}` (Debug) formatting for all source errors to preserve the full error chain