### PR TITLE
fix: use UnsafeCommitHandler on Android where hard_link is blocked

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -725,16 +725,23 @@ pub async fn commit_handler_from_url(
     // This looks unused if dynamodb feature disabled
     #[allow(unused_variables)] options: &Option<ObjectStoreParams>,
 ) -> Result<Arc<dyn CommitHandler>> {
-    // On Android, both ConditionalPutCommitHandler and RenameCommitHandler rely
-    // on hard_link() internally, which is blocked by Android's filesystem/SELinux
-    // with EACCES. UnsafeCommitHandler uses ObjectWriter (temp file + rename via
-    // tempfile::persist) which works correctly on Android.
-    let local_handler: Arc<dyn CommitHandler> = if cfg!(target_os = "android") {
-        Arc::new(UnsafeCommitHandler)
-    } else if cfg!(windows) {
-        Arc::new(RenameCommitHandler)
-    } else {
-        Arc::new(ConditionalPutCommitHandler)
+    // Android's filesystem/SELinux restricts hard_link() with EACCES, which both
+    // ConditionalPutCommitHandler and RenameCommitHandler rely on internally.
+    // UnsafeCommitHandler uses ObjectWriter (temp file + rename via tempfile::persist)
+    // which works correctly on Android.
+    let local_handler: Arc<dyn CommitHandler> = {
+        #[cfg(target_os = "android")]
+        {
+            Arc::new(UnsafeCommitHandler)
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            if cfg!(windows) {
+                Arc::new(RenameCommitHandler)
+            } else {
+                Arc::new(ConditionalPutCommitHandler)
+            }
+        }
     };
 
     let url = match Url::parse(url_or_path) {

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -10,11 +10,13 @@
 //! to allow for different implementations.
 //!
 //! The trait [CommitHandler] can be implemented to provide different commit
-//! strategies. The default implementation for most object stores is
-//! [RenameCommitHandler], which writes the manifest to a temporary path, then
-//! renames the temporary path to the final path if no object already exists
-//! at the final path. This is an atomic operation in most object stores, but
-//! not in AWS S3. So for AWS S3, the default commit handler is
+//! strategies. The default implementation for local filesystems on Linux/macOS is
+//! [ConditionalPutCommitHandler], which uses `hard_link` for atomic file creation.
+//! On Windows, [RenameCommitHandler] is used instead because `hard_link` is not
+//! reliable on all Windows filesystems. On Android, [UnsafeCommitHandler] is used
+//! because Android's filesystem/SELinux restricts `hard_link` with EACCES.
+//!
+//! For cloud object stores (AWS S3, GCS, Azure), the default is
 //! [UnsafeCommitHandler], which writes the manifest to the final path without
 //! any checks.
 //!
@@ -723,7 +725,13 @@ pub async fn commit_handler_from_url(
     // This looks unused if dynamodb feature disabled
     #[allow(unused_variables)] options: &Option<ObjectStoreParams>,
 ) -> Result<Arc<dyn CommitHandler>> {
-    let local_handler: Arc<dyn CommitHandler> = if cfg!(windows) {
+    // On Android, both ConditionalPutCommitHandler and RenameCommitHandler rely
+    // on hard_link() internally, which is blocked by Android's filesystem/SELinux
+    // with EACCES. UnsafeCommitHandler uses ObjectWriter (temp file + rename via
+    // tempfile::persist) which works correctly on Android.
+    let local_handler: Arc<dyn CommitHandler> = if cfg!(target_os = "android") {
+        Arc::new(UnsafeCommitHandler)
+    } else if cfg!(windows) {
         Arc::new(RenameCommitHandler)
     } else {
         Arc::new(ConditionalPutCommitHandler)


### PR DESCRIPTION
## Summary

- Use `UnsafeCommitHandler` instead of `ConditionalPutCommitHandler` on Android, where `hard_link()` is restricted by the filesystem/SELinux with `EACCES`.

## Problem

On Android, LanceDB fails to create or commit tables on the local filesystem. The error chain:

1. `commit_handler_from_url()` selects `ConditionalPutCommitHandler` for non-Windows platforms
2. `ConditionalPutCommitHandler` calls `object_store::put_opts` with `PutMode::Create`
3. `object_store::LocalFileSystem` implements `PutMode::Create` via `std::fs::hard_link()`
4. Android's filesystem/SELinux blocks `hard_link()` in app data directories (`/data/user/0/<pkg>/`) with `Permission denied (os error 13)`

The same issue affects `RenameCommitHandler` — it uses `rename_if_not_exists` which internally falls back to `copy + delete`, and the `copy` with `CopyMode::Create` also uses `hard_link()`.

This makes LanceDB **completely unusable on Android** — the app crashes on startup when trying to create/open tables.

## Fix

Use `UnsafeCommitHandler` on Android. This handler writes manifests via `ObjectWriter`, which creates a temp file then renames it to the final path using `tempfile::TempPath::persist()` (which calls `std::fs::rename`). This avoids `hard_link()` entirely.

**"Unsafe" is fine here** — it only means no protection against concurrent writes to the same version. A single-user mobile app will never have concurrent writers.

## Testing

Tested on real hardware: Samsung SM-F946B (Android 16, arm64-v8a).

**Before fix:**
```
thread '<unnamed>' panicked at tauri-2.10.3/src/app.rs:1299:11:
Failed to setup app: Failed to initialize Core: Failed to initialize database: 
Failed to create chats table: lance error: LanceError(IO): 
Generic LocalFileSystem error: Unable to rename file: Permission denied (os error 13)
```

**After fix:** App initializes successfully, LanceDB tables created, UI renders normally.