### PR TITLE
fix: upgrade ethnum 1.5.2 to 1.5.3 and unpin nightly toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,12 +94,10 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      # pin the toolchain version to avoid surprises (ethnum 1.5.2
-      # fails on nightly > 2026-04-16 due to a transmute size check)
       - name: Setup rust toolchain
         run: |
-          rustup toolchain install nightly-2026-04-16
-          rustup default nightly-2026-04-16
+          rustup toolchain install nightly
+          rustup default nightly
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - name: Install dependencies
@@ -113,7 +111,7 @@ jobs:
       - name: Run tests
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc -e slow_tests | sort | uniq | paste -s -d "," -`
-          cargo +nightly-2026-04-16 llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
+          cargo +nightly llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"


### PR DESCRIPTION
## Summary

Upgrade transitive dependency `ethnum` from 1.5.2 to 1.5.3 and revert the nightly toolchain pin from #6570.

Dependency chain: `lance-arrow` → `jsonb 0.5.6` → `ethnum 1.5.3`

## Root Cause

`ethnum 1.5.2` used `unsafe { mem::transmute(()) }` to construct `TryFromIntError`, which broke on nightly > 2026-04-16 when `TryFromIntError` grew from 0 to 1 byte on Linux x86_64.

`ethnum 1.5.3` ([nlordell/ethnum-rs#58](https://github.com/nlordell/ethnum-rs/pull/58)) replaced all transmute with safe stdlib operations, so the pin is no longer needed.

## Test plan

- [x] Verified ethnum 1.5.3 compiles on `nightly-2026-04-18` (the version that broke 1.5.2) in Docker Linux x86_64
- [x] `linux-build` job should pass with unpinned nightly