### PR TITLE
docs: fix broken intra-doc link in DatasetPreFilter

### DIFF
--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -214,7 +214,7 @@ impl DatasetPreFilter {
         Self::create_deletion_mask_impl(dataset, fragments, false)
     }
 
-    /// Like [`create_deletion_mask`] but also restricts results to the given
+    /// Like [`Self::create_deletion_mask`] but also restricts results to the given
     /// `fragments`, blocking any row from a fragment not in the set.
     pub fn create_restricted_deletion_mask(
         dataset: Arc<Dataset>,


### PR DESCRIPTION
## Summary

Fix `unresolved link to create_deletion_mask` rustdoc error introduced in #6563.

`[create_deletion_mask]` → `[Self::create_deletion_mask]` in the doc comment for `create_restricted_deletion_mask`.

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p lance --no-deps` passes