### PR TITLE
docs: correct repetition level example in encoding docs

### DIFF
--- a/docs/src/format/file/encoding.md
+++ b/docs/src/format/file/encoding.md
@@ -126,7 +126,7 @@ We can convert these into repetition levels as follows:
 | 3      | 2          | Start of new middle list                  |
 | ?      | 2          | Start of new inner-most list (empty list) |
 | ?      | 3          | Start of new outer-most list (empty list) |
-| 4      | 0          | Start of new outer-most list              |
+| 4      | 3          | Start of new outer-most list              |
 
 ### Mini Block Page Layout
 


### PR DESCRIPTION
The example shows `4 | 0 | Start of new outer-most list`, which does not match the nested list structure documented immediately above and can mislead readers validating Lance repetition levels.

Closes #6584
