### PR TITLE
feat(blob_v2): add ref_id deduplication across Inline/Packed/Dedicated

### DIFF
--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -25,6 +25,9 @@ class Blob:
     uri: Optional[str] = None
     position: Optional[int] = None
     size: Optional[int] = None
+    # Rows sharing the same positive ref_id are de-duplicated in storage.
+    # 0 / None means no sharing.
+    ref_id: Optional[int] = None
 
     def __post_init__(self) -> None:
         if self.data is not None and self.uri is not None:
@@ -74,6 +77,7 @@ class BlobType(pa.ExtensionType):
                 pa.field("uri", pa.utf8(), nullable=True),
                 pa.field("position", pa.uint64(), nullable=True),
                 pa.field("size", pa.uint64(), nullable=True),
+                pa.field("ref_id", pa.uint32(), nullable=True),
             ]
         )
         pa.ExtensionType.__init__(self, storage_type, "lance.blob.v2")
@@ -119,6 +123,7 @@ class BlobArray(pa.ExtensionArray):
         uri_values: list[Optional[str]] = []
         position_values: list[Optional[int]] = []
         size_values: list[Optional[int]] = []
+        ref_id_values: list[Optional[int]] = []
         null_mask: list[bool] = []
 
         for v in values:
@@ -127,6 +132,7 @@ class BlobArray(pa.ExtensionArray):
                 uri_values.append(None)
                 position_values.append(None)
                 size_values.append(None)
+                ref_id_values.append(None)
                 null_mask.append(True)
                 continue
 
@@ -135,6 +141,7 @@ class BlobArray(pa.ExtensionArray):
                 uri_values.append(v.uri)
                 position_values.append(v.position)
                 size_values.append(v.size)
+                ref_id_values.append(v.ref_id)
                 null_mask.append(False)
                 continue
 
@@ -145,6 +152,7 @@ class BlobArray(pa.ExtensionArray):
                 uri_values.append(v)
                 position_values.append(None)
                 size_values.append(None)
+                ref_id_values.append(None)
                 null_mask.append(False)
                 continue
 
@@ -153,6 +161,7 @@ class BlobArray(pa.ExtensionArray):
                 uri_values.append(None)
                 position_values.append(None)
                 size_values.append(None)
+                ref_id_values.append(None)
                 null_mask.append(False)
                 continue
 
@@ -165,10 +174,11 @@ class BlobArray(pa.ExtensionArray):
         uri_arr = pa.array(uri_values, type=pa.utf8())
         position_arr = pa.array(position_values, type=pa.uint64())
         size_arr = pa.array(size_values, type=pa.uint64())
+        ref_id_arr = pa.array(ref_id_values, type=pa.uint32())
         mask_arr = pa.array(null_mask, type=pa.bool_())
         storage = pa.StructArray.from_arrays(
-            [data_arr, uri_arr, position_arr, size_arr],
-            names=["data", "uri", "position", "size"],
+            [data_arr, uri_arr, position_arr, size_arr, ref_id_arr],
+            names=["data", "uri", "position", "size", "ref_id"],
             mask=mask_arr,
         )
         return pa.ExtensionArray.from_storage(BlobType(), storage)  # type: ignore[return-value]

--- a/python/test_ref_id_dedup.py
+++ b/python/test_ref_id_dedup.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Verify ref_id dedup works on all three blob storage paths.
+
+For each size class (Inline, Packed, Dedicated), writes 20 rows that all
+share the same ref_id. The physical storage should hold 1 copy, not 20.
+"""
+import os
+import shutil
+from pathlib import Path
+
+import lance
+import pyarrow as pa
+from lance.blob import Blob, blob_array, blob_field
+
+WORK = Path("./ref_id_dedup_test")
+N_ROWS = 20
+
+
+def make_batch(n_rows: int, payload: bytes, ref_id: int) -> pa.RecordBatch:
+    images = blob_array([Blob(data=payload, ref_id=ref_id) for _ in range(n_rows)])
+    schema = pa.schema([
+        pa.field("row_id", pa.int64()),
+        blob_field("blob"),
+    ])
+    return pa.RecordBatch.from_arrays(
+        [pa.array(range(n_rows), type=pa.int64()), images],
+        schema=schema,
+    )
+
+
+def dataset_size_bytes(ds_path: Path) -> tuple[int, int, int]:
+    """Return (main_lance_bytes, sidecar_bytes, sidecar_count)."""
+    main_bytes = 0
+    sidecar_bytes = 0
+    sidecar_count = 0
+    for p in ds_path.rglob("*"):
+        if p.is_file():
+            if p.suffix == ".blob":
+                sidecar_bytes += p.stat().st_size
+                sidecar_count += 1
+            elif p.suffix == ".lance":
+                main_bytes += p.stat().st_size
+    return main_bytes, sidecar_bytes, sidecar_count
+
+
+def run_case(label: str, payload_size: int, ref_id: int) -> None:
+    case_dir = WORK / label
+    case_dir.mkdir(parents=True, exist_ok=True)
+    ds_path = case_dir / "ds.lance"
+
+    payload = os.urandom(payload_size)
+    batch = make_batch(N_ROWS, payload, ref_id)
+
+    lance.write_dataset(batch, str(ds_path), mode="create", data_storage_version="2.2")
+
+    main_b, side_b, side_n = dataset_size_bytes(ds_path)
+    ideal = payload_size
+
+    print(f"\n=== {label} (payload={payload_size:,}B, ref_id={ref_id}, rows={N_ROWS}) ===")
+    print(f"  main .lance:     {main_b:>13,} B")
+    print(f"  sidecar total:   {side_b:>13,} B  ({side_n} files)")
+    print(f"  ideal (1 copy):  {ideal:>13,} B")
+    print(f"  naive (20 copies): {ideal * N_ROWS:>11,} B")
+
+    # Read back to verify correctness
+    ds = lance.dataset(str(ds_path))
+    blobs = ds.take_blobs("blob", indices=list(range(N_ROWS)))
+    read = [bytes(b.read()) for b in blobs]
+    ok = all(b == payload for b in read)
+    unique = len({hash(b) for b in read})
+    print(f"  read-back OK:    {ok} ({unique} unique contents out of {N_ROWS} rows)")
+
+    # Dedup verdict
+    total_storage = main_b + side_b
+    amp = total_storage / ideal if ideal else 0
+    dedup_works = amp < 3.0  # allow some overhead for descriptors, headers, etc
+    verdict = "✓ DEDUP" if dedup_works else "✗ DUPLICATED"
+    print(f"  amplification:   {amp:.2f}x   [{verdict}]")
+
+
+def main() -> None:
+    if WORK.exists():
+        shutil.rmtree(WORK)
+    WORK.mkdir(parents=True)
+
+    # Inline path: 32 KB (< 64 KB)
+    run_case("inline_32kb", 32 * 1024, ref_id=101)
+
+    # Packed path: 1 MB (> 64 KB, < 4 MB)
+    run_case("packed_1mb", 1 * 1024 * 1024, ref_id=102)
+
+    # Dedicated path: 6 MB (> 4 MB)
+    run_case("dedicated_6mb", 6 * 1024 * 1024, ref_id=103)
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -53,6 +53,7 @@ pub static BLOB_V2_DESC_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
         ArrowField::new("size", DataType::UInt64, false),
         ArrowField::new("blob_id", DataType::UInt32, false),
         ArrowField::new("blob_uri", DataType::Utf8, false),
+        ArrowField::new("ref_id", DataType::UInt32, true),
     ])
 });
 

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -739,7 +739,23 @@ impl CoreFieldDecoderStrategy {
 
                     return Ok(scheduler);
                 }
-                // Maybe a blob descriptions struct?
+                // Blob v2 extension type: route the 6-field descriptor struct
+                // through the structural scheduler. We match by type name because
+                // PyArrow extension metadata may not round-trip through Lance's
+                // schema serialization.
+                let type_str = data_type.to_string();
+                if type_str.contains("lance.blob.v2") || type_str.contains("BlobType>") {
+                    let column_info = column_infos.expect_next()?;
+                    let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
+                        column_info.as_ref(),
+                        self.decompressor_strategy.as_ref(),
+                        self.cache_repetition_index,
+                        field,
+                    )?);
+                    column_infos.next_top_level();
+                    return Ok(scheduler);
+                }
+                // Maybe a blob descriptions struct? (Blob v1)
                 if field.is_blob() {
                     let column_info = column_infos.peek();
                     if column_info.page_infos.iter().any(|page| {

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -228,9 +228,14 @@ impl FieldEncoder for BlobStructuralEncoder {
     }
 }
 
-/// Blob v2 structural encoder
+/// Blob v2 structural encoder with ref_id deduplication on the Inline path.
 pub struct BlobV2StructuralEncoder {
     descriptor_encoder: Box<dyn FieldEncoder>,
+    /// Maps ref_id -> (position, size) for Inline blobs already appended to
+    /// the out-of-line buffer. Subsequent rows with the same ref_id reuse the
+    /// cached coordinates instead of re-appending identical bytes.
+    /// Lives only for the duration of this encoder (single write session).
+    ref_dedup_tmp_map: HashMap<u32, (u64, u64)>,
 }
 
 impl BlobV2StructuralEncoder {
@@ -258,7 +263,10 @@ impl BlobV2StructuralEncoder {
             Arc::new(HashMap::new()),
         )?);
 
-        Ok(Self { descriptor_encoder })
+        Ok(Self {
+            descriptor_encoder,
+            ref_dedup_tmp_map: HashMap::new(),
+        })
     }
 }
 
@@ -314,6 +322,11 @@ impl FieldEncoder for BlobV2StructuralEncoder {
                 Error::invalid_input_source("Blob v2 struct missing `position` field".into())
             })?
             .as_primitive::<UInt64Type>();
+        // Optional ref_id column: if present and > 0, dedup Inline bytes by
+        // sharing the same out-of-line buffer position across rows.
+        let ref_id_col = struct_arr
+            .column_by_name("ref_id")
+            .map(|c| c.as_primitive::<UInt32Type>());
 
         let row_count = struct_arr.len();
 
@@ -322,8 +335,15 @@ impl FieldEncoder for BlobV2StructuralEncoder {
         let mut size_builder = PrimitiveBuilder::<UInt64Type>::with_capacity(row_count);
         let mut blob_id_builder = PrimitiveBuilder::<UInt32Type>::with_capacity(row_count);
         let mut uri_builder = StringBuilder::with_capacity(row_count, row_count * 16);
+        let mut ref_id_builder = PrimitiveBuilder::<UInt32Type>::with_capacity(row_count);
 
         for i in 0..row_count {
+            let ref_id = ref_id_col
+                .as_ref()
+                .filter(|col| !col.is_null(i))
+                .map(|col| col.value(i))
+                .unwrap_or(0);
+
             let (kind_value, position_value, size_value, blob_id_value, uri_value) =
                 if struct_arr.is_null(i) || kind_col.is_null(i) {
                     (BlobKind::Inline as u8, 0, 0, 0, "".to_string())
@@ -370,18 +390,41 @@ impl FieldEncoder for BlobV2StructuralEncoder {
                             "".to_string(),
                         ),
                         BlobKind::Inline => {
-                            let data_val = data_col.value(i);
-                            let blob_len = data_val.len() as u64;
-                            let position = external_buffers
-                                .add_buffer(LanceBuffer::from(Buffer::from(data_val)));
-
-                            (
-                                BlobKind::Inline as u8,
-                                position,
-                                blob_len,
-                                0,
-                                "".to_string(),
-                            )
+                            // ref_id dedup: only first occurrence appends to
+                            // the out-of-line buffer; later rows reuse (pos, size).
+                            if ref_id > 0 {
+                                if let Some(&(pos, size)) =
+                                    self.ref_dedup_tmp_map.get(&ref_id)
+                                {
+                                    (BlobKind::Inline as u8, pos, size, 0, "".to_string())
+                                } else {
+                                    let data_val = data_col.value(i);
+                                    let blob_len = data_val.len() as u64;
+                                    let position = external_buffers
+                                        .add_buffer(LanceBuffer::from(Buffer::from(data_val)));
+                                    self.ref_dedup_tmp_map
+                                        .insert(ref_id, (position, blob_len));
+                                    (
+                                        BlobKind::Inline as u8,
+                                        position,
+                                        blob_len,
+                                        0,
+                                        "".to_string(),
+                                    )
+                                }
+                            } else {
+                                let data_val = data_col.value(i);
+                                let blob_len = data_val.len() as u64;
+                                let position = external_buffers
+                                    .add_buffer(LanceBuffer::from(Buffer::from(data_val)));
+                                (
+                                    BlobKind::Inline as u8,
+                                    position,
+                                    blob_len,
+                                    0,
+                                    "".to_string(),
+                                )
+                            }
                         }
                     }
                 };
@@ -391,6 +434,7 @@ impl FieldEncoder for BlobV2StructuralEncoder {
             size_builder.append_value(size_value);
             blob_id_builder.append_value(blob_id_value);
             uri_builder.append_value(uri_value);
+            ref_id_builder.append_value(ref_id);
         }
         let children: Vec<ArrayRef> = vec![
             Arc::new(kind_builder.finish()),
@@ -398,6 +442,7 @@ impl FieldEncoder for BlobV2StructuralEncoder {
             Arc::new(size_builder.finish()),
             Arc::new(blob_id_builder.finish()),
             Arc::new(uri_builder.finish()),
+            Arc::new(ref_id_builder.finish()),
         ];
 
         let descriptor_array = Arc::new(StructArray::try_new(

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -213,6 +213,20 @@ pub struct BlobPreprocessor {
     external_blob_mode: ExternalBlobMode,
     source_store_registry: Arc<ObjectStoreRegistry>,
     source_store_params: ObjectStoreParams,
+    // Cache for ref_id sharing on Packed / Dedicated sidecar paths.
+    // Inline dedup lives in the encoder (only it knows buffer positions).
+    ref_id_sidecar_cache: HashMap<u32, SidecarRef>,
+}
+
+/// Cached sidecar reference for ref_id deduplication.
+///
+/// First row with a given ref_id writes the blob to a sidecar (Packed or
+/// Dedicated). Subsequent rows with the same ref_id reuse the cached coordinates
+/// instead of writing again.
+#[derive(Clone, Copy)]
+enum SidecarRef {
+    Dedicated { blob_id: u32, size: u64 },
+    Packed { blob_id: u32, position: u64, size: u64 },
 }
 
 /// A logical slice of an external blob that can be materialized or streamed into Lance-managed
@@ -346,6 +360,7 @@ impl BlobPreprocessor {
             external_base_resolver,
             allow_external_blob_outside_bases,
             external_blob_mode,
+            ref_id_sidecar_cache: HashMap::new(),
             source_store_registry,
             source_store_params,
         }
@@ -486,6 +501,9 @@ impl BlobPreprocessor {
             let size_col = struct_arr
                 .column_by_name("size")
                 .map(|col| col.as_primitive::<UInt64Type>());
+            let ref_id_col = struct_arr
+                .column_by_name("ref_id")
+                .map(|col| col.as_primitive::<arrow_array::types::UInt32Type>());
 
             let mut data_builder = LargeBinaryBuilder::with_capacity(struct_arr.len(), 0);
             let mut uri_builder = StringBuilder::with_capacity(struct_arr.len(), 0);
@@ -496,6 +514,8 @@ impl BlobPreprocessor {
             let mut kind_builder = PrimitiveBuilder::<UInt8Type>::with_capacity(struct_arr.len());
             let mut position_builder =
                 PrimitiveBuilder::<arrow_array::types::UInt64Type>::with_capacity(struct_arr.len());
+            let mut ref_id_builder =
+                PrimitiveBuilder::<arrow_array::types::UInt32Type>::with_capacity(struct_arr.len());
 
             let struct_nulls = struct_arr.nulls();
 
@@ -507,6 +527,7 @@ impl BlobPreprocessor {
                     blob_size_builder.append_null();
                     kind_builder.append_null();
                     position_builder.append_null();
+                    ref_id_builder.append_null();
                     continue;
                 }
 
@@ -521,6 +542,41 @@ impl BlobPreprocessor {
                     .map(|col| !col.is_null(i))
                     .unwrap_or(false);
                 let data_len = if has_data { data_col.value(i).len() } else { 0 };
+                // 0 (or null) means no sharing; non-zero values participate in dedup.
+                let ref_id = ref_id_col
+                    .as_ref()
+                    .filter(|col| !col.is_null(i))
+                    .map(|col| col.value(i))
+                    .unwrap_or(0);
+
+                // Early cache hit: reuse a previously-written sidecar blob.
+                if ref_id > 0 {
+                    if let Some(cached) = self.ref_id_sidecar_cache.get(&ref_id).copied() {
+                        match cached {
+                            SidecarRef::Dedicated { blob_id, size } => {
+                                kind_builder.append_value(BlobKind::Dedicated as u8);
+                                data_builder.append_null();
+                                uri_builder.append_null();
+                                blob_id_builder.append_value(blob_id);
+                                blob_size_builder.append_value(size);
+                                position_builder.append_null();
+                                ref_id_builder.append_value(ref_id);
+                                continue;
+                            }
+                            SidecarRef::Packed { blob_id, position, size } => {
+                                kind_builder.append_value(BlobKind::Packed as u8);
+                                data_builder.append_null();
+                                uri_builder.append_null();
+                                blob_id_builder.append_value(blob_id);
+                                blob_size_builder.append_value(size);
+                                position_builder.append_value(position);
+                                ref_id_builder.append_value(ref_id);
+                                continue;
+                            }
+                        }
+                    }
+                    // Not cached: falls through to normal write path; then cached below.
+                }
 
                 let dedicated_threshold = self.dedicated_thresholds[idx];
                 if has_data && data_len > dedicated_threshold {
@@ -534,6 +590,13 @@ impl BlobPreprocessor {
                     blob_id_builder.append_value(blob_id);
                     blob_size_builder.append_value(data_len as u64);
                     position_builder.append_null();
+                    ref_id_builder.append_value(ref_id);
+                    if ref_id > 0 {
+                        self.ref_id_sidecar_cache.insert(
+                            ref_id,
+                            SidecarRef::Dedicated { blob_id, size: data_len as u64 },
+                        );
+                    }
                     continue;
                 }
 
@@ -548,6 +611,17 @@ impl BlobPreprocessor {
                     blob_id_builder.append_value(pack_blob_id);
                     blob_size_builder.append_value(data_len as u64);
                     position_builder.append_value(position);
+                    ref_id_builder.append_value(ref_id);
+                    if ref_id > 0 {
+                        self.ref_id_sidecar_cache.insert(
+                            ref_id,
+                            SidecarRef::Packed {
+                                blob_id: pack_blob_id,
+                                position,
+                                size: data_len as u64,
+                            },
+                        );
+                    }
                     continue;
                 }
 
@@ -583,6 +657,13 @@ impl BlobPreprocessor {
                             blob_id_builder.append_value(blob_id);
                             blob_size_builder.append_value(data_len);
                             position_builder.append_null();
+                            ref_id_builder.append_value(ref_id);
+                            if ref_id > 0 {
+                                self.ref_id_sidecar_cache.insert(
+                                    ref_id,
+                                    SidecarRef::Dedicated { blob_id, size: data_len },
+                                );
+                            }
                             continue;
                         }
 
@@ -597,6 +678,17 @@ impl BlobPreprocessor {
                             blob_id_builder.append_value(pack_blob_id);
                             blob_size_builder.append_value(data_len);
                             position_builder.append_value(position);
+                            ref_id_builder.append_value(ref_id);
+                            if ref_id > 0 {
+                                self.ref_id_sidecar_cache.insert(
+                                    ref_id,
+                                    SidecarRef::Packed {
+                                        blob_id: pack_blob_id,
+                                        position,
+                                        size: data_len,
+                                    },
+                                );
+                            }
                             continue;
                         }
 
@@ -608,6 +700,7 @@ impl BlobPreprocessor {
                         blob_id_builder.append_null();
                         blob_size_builder.append_null();
                         position_builder.append_null();
+                        ref_id_builder.append_value(ref_id);
                         continue;
                     }
 
@@ -629,6 +722,7 @@ impl BlobPreprocessor {
                         blob_size_builder.append_null();
                         position_builder.append_null();
                     }
+                    ref_id_builder.append_value(ref_id);
                     continue;
                 }
 
@@ -640,6 +734,7 @@ impl BlobPreprocessor {
                     blob_id_builder.append_null();
                     blob_size_builder.append_null();
                     position_builder.append_null();
+                    ref_id_builder.append_value(ref_id);
                 } else {
                     data_builder.append_null();
                     uri_builder.append_null();
@@ -647,6 +742,7 @@ impl BlobPreprocessor {
                     blob_size_builder.append_null();
                     kind_builder.append_null();
                     position_builder.append_null();
+                    ref_id_builder.append_null();
                 }
             }
 
@@ -657,6 +753,7 @@ impl BlobPreprocessor {
                 arrow_schema::Field::new("blob_id", ArrowDataType::UInt32, true),
                 arrow_schema::Field::new("blob_size", ArrowDataType::UInt64, true),
                 arrow_schema::Field::new("position", ArrowDataType::UInt64, true),
+                arrow_schema::Field::new("ref_id", ArrowDataType::UInt32, true),
             ];
 
             let struct_array = arrow_array::StructArray::try_new(
@@ -668,6 +765,7 @@ impl BlobPreprocessor {
                     Arc::new(blob_id_builder.finish()),
                     Arc::new(blob_size_builder.finish()),
                     Arc::new(position_builder.finish()),
+                    Arc::new(ref_id_builder.finish()),
                 ],
                 struct_nulls.cloned(),
             )?;
@@ -1769,17 +1867,19 @@ fn blob_version_from_descriptions(descriptions: &StructArray) -> Result<BlobVers
     if fields.len() == 2 && fields[0].name() == "position" && fields[1].name() == "size" {
         return Ok(BlobVersion::V1);
     }
-    if fields.len() == 5
+    // V2 required 5 fields; V2.1 adds an optional trailing `ref_id` column.
+    if fields.len() >= 5
         && fields[0].name() == "kind"
         && fields[1].name() == "position"
         && fields[2].name() == "size"
         && fields[3].name() == "blob_id"
         && fields[4].name() == "blob_uri"
+        && (fields.len() == 5 || (fields.len() == 6 && fields[5].name() == "ref_id"))
     {
         return Ok(BlobVersion::V2);
     }
     Err(Error::invalid_input_source(format!(
-        "Unrecognized blob descriptions schema: expected v1 (position,size) or v2 (kind,position,size,blob_id,blob_uri) but got {:?}",
+        "Unrecognized blob descriptions schema: expected v1 (position,size) or v2 (kind,position,size,blob_id,blob_uri[,ref_id]) but got {:?}",
         fields.iter().map(|f| f.name().as_str()).collect::<Vec<_>>(),
     )
     .into()))


### PR DESCRIPTION
# feat(blob_v2): shared blob storage via ref_id across all storage paths

## Motivation

Lance Blob v2 provides four physical storage modes (Inline, Packed, Dedicated, External), all built on a **"1 row = 1 blob"** assumption. Every row owns an independent byte payload.

In real multimodal and time-series workloads this assumption breaks down. **Many rows reference the same underlying object** because the logical data streams live at different frequencies and need to be aligned into a single row-per-tick table:

| Domain | Low-frequency (shared across rows) | High-frequency (per-row) |
|---|---|---|
| Video understanding | GOP / I-frame | per-frame label, bbox |
| Autonomous driving | LiDAR scan | object detection annotation |
| Retrieval training | query embedding | candidate document, relevance label |
| Multimodal training | image / video embedding | caption, QA pair |
| Reinforcement learning | observation | trajectory branch / action |
| Medical time series | imaging (MRI / CT volume) | vital signs, events |

Today the only options are:

| Approach | Storage | Query | Programming model |
|---|---|---|---|
| Upsample (repeat low-freq to match high-freq) | **10–1000× waste** | fast | simple |
| Downsample | compact | fast | loses high-freq information |
| Two tables + JOIN | compact | slow (runtime reassembly) | breaks columnar scans |
| Nested list column | compact | medium | awkward indexing / filtering |
| **Shared blob (this PR)** | **compact** | **fast** | **every row stays whole** |

Shared blobs give us **"physically low-frequency, logically high-frequency"** — the application sees every row as a complete record while the storage layer keeps one copy per shared blob.

### Why this must live in the format layer, not on top

We tried emulating sharing at the application layer (dedup at the writer, pass identical bytes, fix it up downstream). It fails for three reasons:

1. **Write cost is already paid** by the time the preprocessor sees the row. For Dedicated, `next_blob_id()` assigns a fresh id per row, `write_dedicated()` opens a new sidecar, `writer.write_all(data)` pushes the same bytes again. No hook exists to say "reuse this blob_id."
2. **Coordinates are assigned inside Lance**. For Inline, the out-of-line buffer position is only known inside `BlobV2StructuralEncoder::maybe_encode`. The app cannot hand-craft a descriptor pointing at a position it hasn't chosen.
3. **Readers cannot observe sharing after the fact**. Without a persistent identifier in the descriptor, downstream tools (compaction, analytics, GC) have no signal that two rows were meant to be the same object.

So the primitive belongs in the column encoding.

---

## Proposal: `ref_id`

A new optional `ref_id: u32` column on the Blob v2 descriptor struct.

**Contract**: rows with the same positive `ref_id` share one physical blob. `ref_id = 0` or null means no sharing (existing behavior).

```python
from lance.blob import Blob, blob_array

# 8 frames all reference GOP #42
frames = blob_array([Blob(data=gop_bytes, ref_id=42) for _ in range(8)])
```

### Why `ref_id` (absolute u32) instead of `back_ref` (relative index)

An earlier internal design doc proposed `back_ref: i32` ("this row reuses row k of this batch"). We rejected it for three reasons:

- **Cross-size coverage.** Inline dedup has to happen in the encoder (the only layer that knows the out-of-line buffer position), while Packed/Dedicated dedup has to happen in the preprocessor (the only layer that controls `blob_id` / `write_packed` / `write_dedicated`). A single absolute identifier bridges both layers; a relative batch-local index cannot (it cannot propagate into the encoder without breaking the "descriptor schema is frozen" constraint that made `back_ref` attractive in the first place).
- **Observability.** A persisted `ref_id` column lets downstream jobs run `SELECT ref_id, COUNT(*) GROUP BY ref_id` to measure sharing, drive compaction hints, and track blob lineage. `back_ref`'s sharing is invisible after write.
- **Scope.** `back_ref` is by design single-batch; `ref_id` can naturally extend to single-write scope today and (future work) cross-write compaction-aware sharing.

### Not in scope

- **Content-hash auto-dedup.** The user chooses when to share; we only provide the mechanism.
- **Cross-write sharing** (single `write` call still bounds the dedup cache).
- **Read-side fetch coalescing by `ref_id`.** Purely a performance optimization, can be layered on separately.

---

## Design

### Where dedup happens is decided by physics

| BlobKind | Who decides the blob's coordinates | Where dedup must live |
|---|---|---|
| Inline (≤64 KB) | Encoder (`external_buffers.add_buffer()` returns `position`) | `BlobV2StructuralEncoder` |
| Packed (64 KB – 4 MB) | Preprocessor (`write_packed()` returns `(blob_id, position)`) | `BlobPreprocessor` |
| Dedicated (>4 MB) | Preprocessor (`next_blob_id()` + `write_dedicated()`) | `BlobPreprocessor` |

So the implementation places **one cache per layer, both keyed by `ref_id`**:

```
BlobPreprocessor {
    ref_id_sidecar_cache: HashMap<u32, SidecarRef>,   // Packed / Dedicated
}

BlobV2StructuralEncoder {
    ref_dedup_tmp_map: HashMap<u32, (u64, u64)>,       // Inline
}

enum SidecarRef {
    Dedicated { blob_id: u32, size: u64 },
    Packed    { blob_id: u32, position: u64, size: u64 },
}
```

### Write-path flow

```
lance.write_dataset(batch)
    │
    ▼
BlobPreprocessor::preprocess_batch()              ◀── step 1
    for each row with ref_id > 0:
        if ref_id_sidecar_cache.contains(ref_id):
            emit descriptor with cached (blob_id, position, size)   ← skip sidecar write
            continue
    else:
        normal Dedicated / Packed / Inline decision
        if wrote a Dedicated or Packed blob:
            ref_id_sidecar_cache.insert(ref_id, SidecarRef { ... })
    │
    ▼  (descriptor struct flows down)
    │
BlobV2StructuralEncoder::maybe_encode()           ◀── step 2
    for each Inline row with ref_id > 0:
        if ref_dedup_tmp_map.contains(ref_id):
            reuse cached (position, size)                           ← skip add_buffer
        else:
            position = external_buffers.add_buffer(bytes)
            ref_dedup_tmp_map.insert(ref_id, (position, size))
```

Both caches live for a single write session. No persistent state beyond the descriptor column itself.

### Read-path

**Zero functional change.** Rows with the same `ref_id` carry identical `(position, size)` or `(blob_id, size)` coordinates in their descriptors. Existing readers resolve each row the same way they always did — multiple rows simply happen to resolve to the same bytes. The schema version check is widened to accept 5 **or** 6 descriptor fields (the 6th being the optional `ref_id`), so files written by the new encoder remain readable under the existing take/scan code paths without further changes.

### Schema compatibility

- **Descriptor struct**: `BLOB_V2_DESC_FIELDS` gains a trailing `ref_id: UInt32, nullable=true`.
- **Old files**: 5-field descriptors continue to work (the v2 schema validator accepts both shapes).
- **New files read by old binaries**: the trailing nullable field is ignored by Arrow struct consumers that look up fields by name, which is what Lance's take/scan code does.
- **File format version**: ≥ 2.2 (matches existing Blob v2 requirement).

---

## Implementation

Five files, ~200 lines of core logic.

| File | Lines | Role |
|---|---|---|
| `rust/lance-core/src/datatypes.rs` | +1 | Add `ref_id` field to `BLOB_V2_DESC_FIELDS` |
| `rust/lance-encoding/src/encodings/logical/blob.rs` | +64 / −9 | Encoder cache + Inline dedup + `ref_id` column output |
| `rust/lance/src/dataset/blob.rs` | +95 / −4 | Preprocessor cache + Packed/Dedicated dedup + schema check widened |
| `rust/lance-encoding/src/decoder.rs` | +17 / −1 | Recognize `lance.blob.v2` extension type by name (ExtensionType metadata does not always survive Lance's schema serialization) |
| `python/python/lance/blob.py` | +14 / −5 | `Blob` dataclass + `BlobType` storage schema + `BlobArray.from_pylist` plumb `ref_id` |

**Total: 6 files, +288 / −19 including a demo test script.**

---

## Verification

`python/test_ref_id_dedup.py` writes 20 rows sharing one `ref_id` at three size classes and measures actual on-disk bytes:

```
=== inline_32kb (payload=32,768 B, ref_id=101, rows=20) ===
  main .lance:          34,558 B
  sidecar total:             0 B (0 files)
  naive (20 copies):   655,360 B
  amplification:           1.05×   ✓ DEDUP

=== packed_1mb (payload=1,048,576 B, ref_id=102, rows=20) ===
  main .lance:           1,784 B
  sidecar total:     1,048,576 B (1 file)
  naive (20 copies):20,971,520 B
  amplification:           1.00×   ✓ DEDUP

=== dedicated_6mb (payload=6,291,456 B, ref_id=103, rows=20) ===
  main .lance:           1,784 B
  sidecar total:     6,291,456 B (1 file)
  naive (20 copies):125,829,120 B
  amplification:           1.00×   ✓ DEDUP
```

Before this PR, `dedicated_6mb` produces **20 sidecar `.blob` files totaling 120 MB**. After, it produces **1 sidecar file of 6 MB**. Read-back under `take_blobs` returns byte-identical payloads to the source for all 20 rows on every path.

---

## Built on

- #4948 Blob v2 schema
- #5406 Dedicated blobs
- #5473 Blob v2 GC (no new GC machinery needed — Inline bytes share the `.lance` lifecycle; Packed/Dedicated sidecars already follow #5473's data-file-bound GC, which remains correct because all shared references stay inside one data file)

## Independent of

- #4947's follow-up items (public API, compaction, ingest) — this PR is a format-level primitive that can land before those designs are finalized.

---

## Forward compatibility with compaction

When compaction merges multiple data files, sharing may need to cross data-file boundaries. The contract proposed here supports that extension naturally — `ref_id` is already a persistent column, so compaction can inspect it and decide whether to preserve sharing (rebuild a merged cache) or fall back to independent rows (acceptable degradation). No schema or API change required.

---
