### PR TITLE
feat: support zonemap index segments

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3122,8 +3122,8 @@ fn inner_get_zonemap_stats<'local>(
 
     let column_name: String = jcolumn_name.extract(env)?;
 
-    // 1. Get the dataset and find the zonemap index for this column
-    let zonemap_data = {
+    // 1. Get the dataset and find every committed zonemap segment for this column
+    let zonemap_batches = {
         let dataset = {
             let dataset_guard = unsafe {
                 env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET)
@@ -3159,127 +3159,134 @@ fn inner_get_zonemap_stats<'local>(
 
             match zonemap_desc {
                 Some(desc) => {
-                    let indices = dataset.load_indices().await.map_err(Error::from)?;
-                    let index_meta = indices.iter().find(|idx| idx.name == desc.name());
-                    match index_meta {
-                        Some(index) => {
-                            let index_store = Arc::new(
-                                LanceIndexStore::from_dataset_for_existing(&dataset, index)
-                                    .map_err(Error::from)?,
-                            );
-                            let index_file = index_store
-                                .open_index_file("zonemap.lance")
-                                .await
-                                .map_err(Error::from)?;
-                            let record_batch = index_file
+                    let mut indices = dataset
+                        .load_indices_by_name(desc.name())
+                        .await
+                        .map_err(Error::from)?;
+                    indices.sort_by_key(|idx| {
+                        idx.fragment_bitmap
+                            .as_ref()
+                            .and_then(|bitmap| bitmap.iter().next())
+                            .unwrap_or_default()
+                    });
+
+                    let mut batches = Vec::with_capacity(indices.len());
+                    for index in &indices {
+                        let index_store = Arc::new(
+                            LanceIndexStore::from_dataset_for_existing(&dataset, index)
+                                .map_err(Error::from)?,
+                        );
+                        let index_file = index_store
+                            .open_index_file("zonemap.lance")
+                            .await
+                            .map_err(Error::from)?;
+                        if index_file.num_rows() == 0 {
+                            continue;
+                        }
+                        batches.push(
+                            index_file
                                 .read_range(0..index_file.num_rows(), None)
                                 .await
-                                .map_err(Error::from)?;
-                            Ok::<_, Error>(Some(record_batch))
-                        }
-                        None => Ok(None),
+                                .map_err(Error::from)?,
+                        );
                     }
+                    Ok::<_, Error>(batches)
                 }
-                None => Ok(None),
+                None => Ok(Vec::new()),
             }
         })?
     };
 
-    // 3. Convert the RecordBatch to a Java ArrayList<ZoneStats>
+    // 3. Convert the RecordBatch rows to a Java ArrayList<ZoneStats>
     let array_list = env.new_object("java/util/ArrayList", "()V", &[])?;
-
-    let record_batch = match zonemap_data {
-        Some(batch) => batch,
-        None => return Ok(array_list), // empty list if no zonemap index
-    };
-
-    if record_batch.num_rows() == 0 {
+    if zonemap_batches.is_empty() {
         return Ok(array_list);
     }
 
-    let min_col = record_batch
-        .column_by_name("min")
-        .ok_or_else(|| Error::input_error("ZoneMap index file missing 'min' column".to_string()))?;
-    let max_col = record_batch
-        .column_by_name("max")
-        .ok_or_else(|| Error::input_error("ZoneMap index file missing 'max' column".to_string()))?;
-    let null_count_col = record_batch
-        .column_by_name("null_count")
-        .ok_or_else(|| {
-            Error::input_error("ZoneMap index file missing 'null_count' column".to_string())
-        })?
-        .as_any()
-        .downcast_ref::<arrow_array::UInt32Array>()
-        .ok_or_else(|| {
-            Error::input_error("ZoneMap 'null_count' column is not UInt32".to_string())
+    for record_batch in zonemap_batches {
+        let min_col = record_batch.column_by_name("min").ok_or_else(|| {
+            Error::input_error("ZoneMap index file missing 'min' column".to_string())
         })?;
-    let fragment_id_col = record_batch
-        .column_by_name("fragment_id")
-        .ok_or_else(|| {
-            Error::input_error("ZoneMap index file missing 'fragment_id' column".to_string())
-        })?
-        .as_any()
-        .downcast_ref::<arrow_array::UInt64Array>()
-        .ok_or_else(|| {
-            Error::input_error("ZoneMap 'fragment_id' column is not UInt64".to_string())
+        let max_col = record_batch.column_by_name("max").ok_or_else(|| {
+            Error::input_error("ZoneMap index file missing 'max' column".to_string())
         })?;
-    let zone_start_col = record_batch
-        .column_by_name("zone_start")
-        .ok_or_else(|| {
-            Error::input_error("ZoneMap index file missing 'zone_start' column".to_string())
-        })?
-        .as_any()
-        .downcast_ref::<arrow_array::UInt64Array>()
-        .ok_or_else(|| {
-            Error::input_error("ZoneMap 'zone_start' column is not UInt64".to_string())
-        })?;
-    let zone_length_col = record_batch
-        .column_by_name("zone_length")
-        .ok_or_else(|| {
-            Error::input_error("ZoneMap index file missing 'zone_length' column".to_string())
-        })?
-        .as_any()
-        .downcast_ref::<arrow_array::UInt64Array>()
-        .ok_or_else(|| {
-            Error::input_error("ZoneMap 'zone_length' column is not UInt64".to_string())
-        })?;
+        let null_count_col = record_batch
+            .column_by_name("null_count")
+            .ok_or_else(|| {
+                Error::input_error("ZoneMap index file missing 'null_count' column".to_string())
+            })?
+            .as_any()
+            .downcast_ref::<arrow_array::UInt32Array>()
+            .ok_or_else(|| {
+                Error::input_error("ZoneMap 'null_count' column is not UInt32".to_string())
+            })?;
+        let fragment_id_col = record_batch
+            .column_by_name("fragment_id")
+            .ok_or_else(|| {
+                Error::input_error("ZoneMap index file missing 'fragment_id' column".to_string())
+            })?
+            .as_any()
+            .downcast_ref::<arrow_array::UInt64Array>()
+            .ok_or_else(|| {
+                Error::input_error("ZoneMap 'fragment_id' column is not UInt64".to_string())
+            })?;
+        let zone_start_col = record_batch
+            .column_by_name("zone_start")
+            .ok_or_else(|| {
+                Error::input_error("ZoneMap index file missing 'zone_start' column".to_string())
+            })?
+            .as_any()
+            .downcast_ref::<arrow_array::UInt64Array>()
+            .ok_or_else(|| {
+                Error::input_error("ZoneMap 'zone_start' column is not UInt64".to_string())
+            })?;
+        let zone_length_col = record_batch
+            .column_by_name("zone_length")
+            .ok_or_else(|| {
+                Error::input_error("ZoneMap index file missing 'zone_length' column".to_string())
+            })?
+            .as_any()
+            .downcast_ref::<arrow_array::UInt64Array>()
+            .ok_or_else(|| {
+                Error::input_error("ZoneMap 'zone_length' column is not UInt64".to_string())
+            })?;
 
-    for i in 0..record_batch.num_rows() {
-        let fragment_id = fragment_id_col.value(i) as i32;
-        let zone_start = zone_start_col.value(i) as i64;
-        let zone_length = zone_length_col.value(i) as i64;
-        let null_count = null_count_col.value(i) as i64;
+        for i in 0..record_batch.num_rows() {
+            let fragment_id = fragment_id_col.value(i) as i32;
+            let zone_start = zone_start_col.value(i) as i64;
+            let zone_length = zone_length_col.value(i) as i64;
+            let null_count = null_count_col.value(i) as i64;
 
-        // Convert min/max ScalarValues to Java Comparable objects
-        let min_scalar = ScalarValue::try_from_array(min_col, i).map_err(|e| {
-            Error::input_error(format!("Failed to read min value at row {}: {}", i, e))
-        })?;
-        let max_scalar = ScalarValue::try_from_array(max_col, i).map_err(|e| {
-            Error::input_error(format!("Failed to read max value at row {}: {}", i, e))
-        })?;
+            let min_scalar = ScalarValue::try_from_array(min_col, i).map_err(|e| {
+                Error::input_error(format!("Failed to read min value at row {}: {}", i, e))
+            })?;
+            let max_scalar = ScalarValue::try_from_array(max_col, i).map_err(|e| {
+                Error::input_error(format!("Failed to read max value at row {}: {}", i, e))
+            })?;
 
-        let j_min = crate::utils::scalar_value_to_java(env, &min_scalar)?;
-        let j_max = crate::utils::scalar_value_to_java(env, &max_scalar)?;
+            let j_min = crate::utils::scalar_value_to_java(env, &min_scalar)?;
+            let j_max = crate::utils::scalar_value_to_java(env, &max_scalar)?;
 
-        let zone_stats = env.new_object(
-            "org/lance/index/scalar/ZoneStats",
-            "(IJJLjava/lang/Comparable;Ljava/lang/Comparable;J)V",
-            &[
-                JValue::Int(fragment_id),
-                JValue::Long(zone_start),
-                JValue::Long(zone_length),
-                JValue::Object(&j_min),
-                JValue::Object(&j_max),
-                JValue::Long(null_count),
-            ],
-        )?;
+            let zone_stats = env.new_object(
+                "org/lance/index/scalar/ZoneStats",
+                "(IJJLjava/lang/Comparable;Ljava/lang/Comparable;J)V",
+                &[
+                    JValue::Int(fragment_id),
+                    JValue::Long(zone_start),
+                    JValue::Long(zone_length),
+                    JValue::Object(&j_min),
+                    JValue::Object(&j_max),
+                    JValue::Long(null_count),
+                ],
+            )?;
 
-        env.call_method(
-            &array_list,
-            "add",
-            "(Ljava/lang/Object;)Z",
-            &[JValue::Object(&zone_stats)],
-        )?;
+            env.call_method(
+                &array_list,
+                "add",
+                "(Ljava/lang/Object;)Z",
+                &[JValue::Object(&zone_stats)],
+            )?;
+        }
     }
 
     Ok(array_list)

--- a/java/src/test/java/org/lance/index/ZonemapStatsTest.java
+++ b/java/src/test/java/org/lance/index/ZonemapStatsTest.java
@@ -216,6 +216,57 @@ public class ZonemapStatsTest {
   }
 
   @Test
+  public void testGetZonemapStatsCommittedSegments(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("segmented_zonemap_stats").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset ds =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        // empty
+      }
+      Dataset ds2 = writeIntFragment(allocator, path, 1, 0, 50);
+      ds2.close();
+      Dataset ds3 = writeIntFragment(allocator, path, 2, 50, 50);
+      ds3.close();
+
+      try (Dataset dataset = Dataset.open(path, allocator)) {
+        List<Fragment> fragments = dataset.getFragments();
+        assertEquals(2, fragments.size());
+
+        ScalarIndexParams params = ScalarIndexParams.create("zonemap", "{}");
+        IndexParams indexParams = IndexParams.builder().setScalarIndexParams(params).build();
+
+        Index firstSegment =
+            dataset.createIndex(
+                IndexOptions.builder(
+                        Collections.singletonList("value"), IndexType.ZONEMAP, indexParams)
+                    .withIndexName("value_zm")
+                    .withFragmentIds(Collections.singletonList(fragments.get(0).getId()))
+                    .build());
+        Index secondSegment =
+            dataset.createIndex(
+                IndexOptions.builder(
+                        Collections.singletonList("value"), IndexType.ZONEMAP, indexParams)
+                    .withIndexName("value_zm")
+                    .withFragmentIds(Collections.singletonList(fragments.get(1).getId()))
+                    .build());
+
+        dataset.commitExistingIndexSegments(
+            "value_zm", "value", List.of(firstSegment, secondSegment));
+
+        List<ZoneStats> stats = dataset.getZonemapStats("value");
+        assertNotNull(stats);
+        assertFalse(stats.isEmpty());
+
+        Set<Integer> fragmentIds = new HashSet<>();
+        for (ZoneStats z : stats) {
+          fragmentIds.add(z.getFragmentId());
+        }
+        assertEquals(2, fragmentIds.size(), "Expected zones from 2 committed segments");
+      }
+    }
+  }
+
+  @Test
   public void testGetZonemapStatsWrongColumnReturnsEmpty(@TempDir Path tempDir) throws Exception {
     String path = tempDir.resolve("wrong_col").toString();
     try (BufferAllocator allocator = new RootAllocator()) {

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -24,7 +24,9 @@ use crate::scalar::{
 };
 use datafusion::functions_aggregate::min_max::{MaxAccumulator, MinAccumulator};
 use datafusion_expr::Accumulator;
+use futures::future::try_join_all;
 use lance_core::cache::{LanceCache, WeakLanceCache};
+use lance_core::utils::mask::NullableRowAddrSet;
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 
@@ -111,6 +113,12 @@ pub struct ZoneMapIndex {
     index_cache: WeakLanceCache,
 }
 
+#[derive(Debug)]
+pub struct LogicalZoneMapIndex {
+    segments: Vec<Arc<ZoneMapIndex>>,
+    rows_per_zone: u64,
+}
+
 impl std::fmt::Debug for ZoneMapIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ZoneMapIndex")
@@ -127,6 +135,55 @@ impl std::fmt::Debug for ZoneMapIndex {
 impl DeepSizeOf for ZoneMapIndex {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
         self.zones.deep_size_of_children(context)
+    }
+}
+
+impl LogicalZoneMapIndex {
+    pub async fn load(
+        stores: Vec<Arc<dyn IndexStore>>,
+        fri: Option<Arc<FragReuseIndex>>,
+        index_cache: &LanceCache,
+    ) -> Result<Arc<Self>> {
+        if stores.is_empty() {
+            return Err(Error::invalid_input(
+                "LogicalZoneMapIndex requires at least one segment".to_string(),
+            ));
+        }
+
+        let segments = try_join_all(
+            stores
+                .into_iter()
+                .map(|store| ZoneMapIndex::load(store, fri.clone(), index_cache)),
+        )
+        .await?;
+
+        let data_type = segments[0].data_type.clone();
+        let rows_per_zone = segments[0].rows_per_zone;
+        for segment in segments.iter().skip(1) {
+            if segment.data_type != data_type {
+                return Err(Error::invalid_input(format!(
+                    "LogicalZoneMapIndex requires identical data types across segments, found {:?} and {:?}",
+                    data_type, segment.data_type
+                )));
+            }
+            if segment.rows_per_zone != rows_per_zone {
+                return Err(Error::invalid_input(format!(
+                    "LogicalZoneMapIndex requires identical rows_per_zone across segments, found {} and {}",
+                    rows_per_zone, segment.rows_per_zone
+                )));
+            }
+        }
+
+        Ok(Arc::new(Self {
+            segments,
+            rows_per_zone,
+        }))
+    }
+}
+
+impl DeepSizeOf for LogicalZoneMapIndex {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.segments.deep_size_of_children(context)
     }
 }
 
@@ -621,6 +678,126 @@ impl ScalarIndex for ZoneMapIndex {
     }
 }
 
+#[async_trait]
+impl Index for LogicalZoneMapIndex {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn VectorIndex>> {
+        Err(Error::invalid_input_source(
+            "LogicalZoneMapIndex is not a vector index".into(),
+        ))
+    }
+
+    async fn prewarm(&self) -> Result<()> {
+        for segment in &self.segments {
+            segment.prewarm().await?;
+        }
+        Ok(())
+    }
+
+    fn statistics(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::json!({
+            "num_segments": self.segments.len(),
+            "num_zones": self.segments.iter().map(|segment| segment.zones.len()).sum::<usize>(),
+            "rows_per_zone": self.rows_per_zone,
+        }))
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::ZoneMap
+    }
+
+    async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+        let mut frag_ids = RoaringBitmap::new();
+        for segment in &self.segments {
+            frag_ids |= segment.calculate_included_frags().await?;
+        }
+        Ok(frag_ids)
+    }
+}
+
+#[async_trait]
+impl ScalarIndex for LogicalZoneMapIndex {
+    async fn search(
+        &self,
+        query: &dyn AnyQuery,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
+        let results = try_join_all(
+            self.segments
+                .iter()
+                .map(|segment| segment.search(query, metrics)),
+        )
+        .await?;
+
+        let mut selections = Vec::with_capacity(results.len());
+        let mut all_exact = true;
+        for result in results {
+            match result {
+                SearchResult::Exact(rows) => selections.push(rows),
+                SearchResult::AtMost(rows) => {
+                    all_exact = false;
+                    selections.push(rows);
+                }
+                SearchResult::AtLeast(_) => {
+                    return Err(Error::not_supported(
+                        "LogicalZoneMapIndex does not support AtLeast search results".to_string(),
+                    ));
+                }
+            }
+        }
+
+        let selection = NullableRowAddrSet::union_all(&selections);
+        Ok(if all_exact {
+            SearchResult::Exact(selection)
+        } else {
+            SearchResult::AtMost(selection)
+        })
+    }
+
+    fn can_remap(&self) -> bool {
+        false
+    }
+
+    async fn remap(
+        &self,
+        _mapping: &HashMap<u64, Option<u64>>,
+        _dest_store: &dyn IndexStore,
+    ) -> Result<CreatedIndex> {
+        Err(Error::invalid_input_source(
+            "LogicalZoneMapIndex does not support remap".into(),
+        ))
+    }
+
+    async fn update(
+        &self,
+        _new_data: SendableRecordBatchStream,
+        _dest_store: &dyn IndexStore,
+        _old_data_filter: Option<super::OldIndexDataFilter>,
+    ) -> Result<CreatedIndex> {
+        Err(Error::invalid_input_source(
+            "LogicalZoneMapIndex does not support update".into(),
+        ))
+    }
+
+    fn update_criteria(&self) -> UpdateCriteria {
+        UpdateCriteria::only_new_data(
+            TrainingCriteria::new(TrainingOrdering::Addresses).with_row_addr(),
+        )
+    }
+
+    fn derive_index_params(&self) -> Result<ScalarIndexParams> {
+        let params = serde_json::to_value(ZoneMapIndexBuilderParams::new(self.rows_per_zone))?;
+        Ok(ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap).with_params(&params))
+    }
+}
+
 fn default_rows_per_zone() -> u64 {
     *DEFAULT_ROWS_PER_ZONE
 }
@@ -918,15 +1095,9 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
         data: SendableRecordBatchStream,
         index_store: &dyn IndexStore,
         request: Box<dyn TrainingRequest>,
-        fragment_ids: Option<Vec<u32>>,
+        _fragment_ids: Option<Vec<u32>>,
         _progress: Arc<dyn crate::progress::IndexBuildProgress>,
     ) -> Result<CreatedIndex> {
-        if fragment_ids.is_some() {
-            return Err(Error::invalid_input_source(
-                "ZoneMap index does not support fragment training".into(),
-            ));
-        }
-
         let request = (request as Box<dyn std::any::Any>)
             .downcast::<ZoneMapIndexTrainingRequest>()
             .map_err(|_| {

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -24,9 +24,7 @@ use crate::scalar::{
 };
 use datafusion::functions_aggregate::min_max::{MaxAccumulator, MinAccumulator};
 use datafusion_expr::Accumulator;
-use futures::future::try_join_all;
 use lance_core::cache::{LanceCache, WeakLanceCache};
-use lance_core::utils::mask::NullableRowAddrSet;
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 
@@ -113,12 +111,6 @@ pub struct ZoneMapIndex {
     index_cache: WeakLanceCache,
 }
 
-#[derive(Debug)]
-pub struct LogicalZoneMapIndex {
-    segments: Vec<Arc<ZoneMapIndex>>,
-    rows_per_zone: u64,
-}
-
 impl std::fmt::Debug for ZoneMapIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ZoneMapIndex")
@@ -135,55 +127,6 @@ impl std::fmt::Debug for ZoneMapIndex {
 impl DeepSizeOf for ZoneMapIndex {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
         self.zones.deep_size_of_children(context)
-    }
-}
-
-impl LogicalZoneMapIndex {
-    pub async fn load(
-        stores: Vec<Arc<dyn IndexStore>>,
-        fri: Option<Arc<FragReuseIndex>>,
-        index_cache: &LanceCache,
-    ) -> Result<Arc<Self>> {
-        if stores.is_empty() {
-            return Err(Error::invalid_input(
-                "LogicalZoneMapIndex requires at least one segment".to_string(),
-            ));
-        }
-
-        let segments = try_join_all(
-            stores
-                .into_iter()
-                .map(|store| ZoneMapIndex::load(store, fri.clone(), index_cache)),
-        )
-        .await?;
-
-        let data_type = segments[0].data_type.clone();
-        let rows_per_zone = segments[0].rows_per_zone;
-        for segment in segments.iter().skip(1) {
-            if segment.data_type != data_type {
-                return Err(Error::invalid_input(format!(
-                    "LogicalZoneMapIndex requires identical data types across segments, found {:?} and {:?}",
-                    data_type, segment.data_type
-                )));
-            }
-            if segment.rows_per_zone != rows_per_zone {
-                return Err(Error::invalid_input(format!(
-                    "LogicalZoneMapIndex requires identical rows_per_zone across segments, found {} and {}",
-                    rows_per_zone, segment.rows_per_zone
-                )));
-            }
-        }
-
-        Ok(Arc::new(Self {
-            segments,
-            rows_per_zone,
-        }))
-    }
-}
-
-impl DeepSizeOf for LogicalZoneMapIndex {
-    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        self.segments.deep_size_of_children(context)
     }
 }
 
@@ -664,126 +607,6 @@ impl ScalarIndex for ZoneMapIndex {
             index_version: ZONEMAP_INDEX_VERSION,
             files: Some(dest_store.list_files_with_sizes().await?),
         })
-    }
-
-    fn update_criteria(&self) -> UpdateCriteria {
-        UpdateCriteria::only_new_data(
-            TrainingCriteria::new(TrainingOrdering::Addresses).with_row_addr(),
-        )
-    }
-
-    fn derive_index_params(&self) -> Result<ScalarIndexParams> {
-        let params = serde_json::to_value(ZoneMapIndexBuilderParams::new(self.rows_per_zone))?;
-        Ok(ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap).with_params(&params))
-    }
-}
-
-#[async_trait]
-impl Index for LogicalZoneMapIndex {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
-        self
-    }
-
-    fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn VectorIndex>> {
-        Err(Error::invalid_input_source(
-            "LogicalZoneMapIndex is not a vector index".into(),
-        ))
-    }
-
-    async fn prewarm(&self) -> Result<()> {
-        for segment in &self.segments {
-            segment.prewarm().await?;
-        }
-        Ok(())
-    }
-
-    fn statistics(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::json!({
-            "num_segments": self.segments.len(),
-            "num_zones": self.segments.iter().map(|segment| segment.zones.len()).sum::<usize>(),
-            "rows_per_zone": self.rows_per_zone,
-        }))
-    }
-
-    fn index_type(&self) -> IndexType {
-        IndexType::ZoneMap
-    }
-
-    async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
-        let mut frag_ids = RoaringBitmap::new();
-        for segment in &self.segments {
-            frag_ids |= segment.calculate_included_frags().await?;
-        }
-        Ok(frag_ids)
-    }
-}
-
-#[async_trait]
-impl ScalarIndex for LogicalZoneMapIndex {
-    async fn search(
-        &self,
-        query: &dyn AnyQuery,
-        metrics: &dyn MetricsCollector,
-    ) -> Result<SearchResult> {
-        let results = try_join_all(
-            self.segments
-                .iter()
-                .map(|segment| segment.search(query, metrics)),
-        )
-        .await?;
-
-        let mut selections = Vec::with_capacity(results.len());
-        let mut all_exact = true;
-        for result in results {
-            match result {
-                SearchResult::Exact(rows) => selections.push(rows),
-                SearchResult::AtMost(rows) => {
-                    all_exact = false;
-                    selections.push(rows);
-                }
-                SearchResult::AtLeast(_) => {
-                    return Err(Error::not_supported(
-                        "LogicalZoneMapIndex does not support AtLeast search results".to_string(),
-                    ));
-                }
-            }
-        }
-
-        let selection = NullableRowAddrSet::union_all(&selections);
-        Ok(if all_exact {
-            SearchResult::Exact(selection)
-        } else {
-            SearchResult::AtMost(selection)
-        })
-    }
-
-    fn can_remap(&self) -> bool {
-        false
-    }
-
-    async fn remap(
-        &self,
-        _mapping: &HashMap<u64, Option<u64>>,
-        _dest_store: &dyn IndexStore,
-    ) -> Result<CreatedIndex> {
-        Err(Error::invalid_input_source(
-            "LogicalZoneMapIndex does not support remap".into(),
-        ))
-    }
-
-    async fn update(
-        &self,
-        _new_data: SendableRecordBatchStream,
-        _dest_store: &dyn IndexStore,
-        _old_data_filter: Option<super::OldIndexDataFilter>,
-    ) -> Result<CreatedIndex> {
-        Err(Error::invalid_input_source(
-            "LogicalZoneMapIndex does not support update".into(),
-        ))
     }
 
     fn update_criteria(&self) -> UpdateCriteria {

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -81,6 +81,7 @@ use super::Dataset;
 use crate::dataset::row_offsets_to_row_addresses;
 use crate::dataset::utils::SchemaAdapter;
 use crate::index::DatasetIndexInternalExt;
+use crate::index::scalar::scalar_index_fragment_bitmap;
 use crate::index::vector::utils::{
     default_distance_type_for, get_vector_dim, get_vector_type, validate_distance_type_for,
 };
@@ -3810,16 +3811,18 @@ impl Scanner {
             ScalarIndexExpr::Or(lhs, rhs) => Ok(self.fragments_covered_by_index_query(lhs).await?
                 & self.fragments_covered_by_index_query(rhs).await?),
             ScalarIndexExpr::Not(expr) => self.fragments_covered_by_index_query(expr).await,
-            ScalarIndexExpr::Query(search) => {
-                let idx = self
-                    .dataset
-                    .load_scalar_index(IndexCriteria::default().with_name(&search.index_name))
-                    .await?
-                    .expect("Index not found even though it must have been found earlier");
-                Ok(idx
-                    .fragment_bitmap
-                    .expect("scalar indices should always have a fragment bitmap"))
-            }
+            ScalarIndexExpr::Query(search) => scalar_index_fragment_bitmap(
+                self.dataset.as_ref(),
+                &search.column,
+                &search.index_name,
+            )
+            .await?
+            .ok_or_else(|| {
+                crate::Error::internal(format!(
+                    "Index not found even though it must have been found earlier: {}",
+                    search.index_name
+                ))
+            }),
         }
     }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -8184,6 +8184,121 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
     }
 
     #[tokio::test]
+    async fn test_like_prefix_with_segmented_zone_map() {
+        use lance_index::scalar::BuiltinIndexType;
+
+        let data = gen_batch()
+            .col(
+                "name",
+                array::cycle_utf8_literals(&[
+                    "apple",
+                    "application",
+                    "app",
+                    "banana",
+                    "band",
+                    "testns1",
+                    "testns2",
+                    "test",
+                    "testing",
+                    "zoo",
+                ]),
+            )
+            .col("id", array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(150), BatchCount::from(6));
+
+        let write_params = WriteParams {
+            max_rows_per_file: 25,
+            max_rows_per_group: 10,
+            ..Default::default()
+        };
+
+        let mut dataset = Dataset::write(
+            data,
+            "memory://test_like_segmented_zonemap",
+            Some(write_params),
+        )
+        .await
+        .unwrap();
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() > 1, "expected multiple fragments");
+
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap);
+        let mut segments = Vec::with_capacity(fragments.len());
+        for fragment in &fragments {
+            let mut builder = dataset.create_index_builder(&["name"], IndexType::Scalar, &params);
+            builder = builder
+                .name("name_zonemap".to_string())
+                .fragments(vec![fragment.id() as u32]);
+            segments.push(builder.execute_uncommitted().await.unwrap());
+        }
+
+        dataset
+            .commit_existing_index_segments("name_zonemap", "name", segments)
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("name_zonemap").await.unwrap();
+        assert_eq!(committed.len(), fragments.len());
+
+        let mut scanner = dataset.scan();
+        scanner.filter("name LIKE 'app%'").unwrap();
+        let plan = scanner.create_plan().await.unwrap();
+        let plan_str = format!("{:?}", plan);
+        assert!(
+            plan_str.contains("ScalarIndexExec") && plan_str.contains("LikePrefix"),
+            "segmented zonemap should use LikePrefix pruning, but got: {}",
+            plan_str
+        );
+
+        let with_index = dataset
+            .scan()
+            .filter("name LIKE 'app%'")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let without_index = dataset
+            .scan()
+            .use_scalar_index(false)
+            .filter("name LIKE 'app%'")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+
+        let with_index_ids = with_index
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<Int32Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let without_index_ids = without_index
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<Int32Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        assert_eq!(with_index_ids, without_index_ids);
+        assert!(!with_index_ids.is_empty());
+
+        let names = with_index
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .iter()
+            .map(|value| value.unwrap())
+            .collect::<Vec<_>>();
+        assert!(names.iter().all(|name| name.starts_with("app")));
+    }
+
+    #[tokio::test]
     async fn test_like_prefix_correctness_with_zone_map() {
         use lance_index::scalar::BuiltinIndexType;
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -81,7 +81,7 @@ use super::Dataset;
 use crate::dataset::row_offsets_to_row_addresses;
 use crate::dataset::utils::SchemaAdapter;
 use crate::index::DatasetIndexInternalExt;
-use crate::index::scalar::scalar_index_fragment_bitmap;
+use crate::index::scalar_logical::scalar_index_fragment_bitmap;
 use crate::index::vector::utils::{
     default_distance_type_for, get_vector_dim, get_vector_type, validate_distance_type_for,
 };

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -995,6 +995,11 @@ impl DatasetIndexExt for Dataset {
         validate_segment_metadata(index_name, &segments)?;
         validate_segment_index_details(index_name, &segments)?;
 
+        let incoming_type_url = segments[0]
+            .index_details
+            .as_ref()
+            .map(|details| details.type_url.clone());
+        let mut incoming_fragments = RoaringBitmap::new();
         let mut new_indices = Vec::with_capacity(segments.len());
         for mut segment in segments {
             if segment.fields != [field.id] {
@@ -1003,16 +1008,57 @@ impl DatasetIndexExt for Dataset {
                     segment.uuid, segment.fields, field.id
                 )));
             }
+            if let (Some(expected), Some(actual)) = (
+                incoming_type_url.as_deref(),
+                segment
+                    .index_details
+                    .as_ref()
+                    .map(|details| details.type_url.as_str()),
+            ) && expected != actual
+            {
+                return Err(Error::invalid_input(format!(
+                    "CreateIndex: segment set for index '{}' mixes incompatible index detail types",
+                    index_name
+                )));
+            }
+            if let Some(fragment_bitmap) = &segment.fragment_bitmap {
+                incoming_fragments |= fragment_bitmap.clone();
+            }
             segment.name = index_name.to_string();
             segment.dataset_version = self.manifest.version;
             new_indices.push(segment);
         }
 
+        let existing_named_indices = self.load_indices_by_name(index_name).await?;
+        if existing_named_indices
+            .iter()
+            .any(|idx| idx.fields != [field.id])
+        {
+            return Err(Error::index(format!(
+                "Index name '{index_name}' already exists with different fields, \
+                please specify a different name"
+            )));
+        }
+        let removed_indices = existing_named_indices
+            .into_iter()
+            .filter(|idx| {
+                idx.index_details
+                    .as_ref()
+                    .zip(incoming_type_url.as_deref())
+                    .is_none_or(|(details, expected)| details.type_url == expected)
+            })
+            .filter(|idx| {
+                idx.fragment_bitmap
+                    .as_ref()
+                    .is_none_or(|bitmap| !bitmap.is_disjoint(&incoming_fragments))
+            })
+            .collect::<Vec<_>>();
+
         let transaction = Transaction::new(
             self.manifest.version,
             Operation::CreateIndex {
                 new_indices,
-                removed_indices: vec![],
+                removed_indices,
             },
             None,
         );

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -999,6 +999,7 @@ impl DatasetIndexExt for Dataset {
             .index_details
             .as_ref()
             .map(|details| details.type_url.clone());
+        let dataset_fragments = self.fragment_bitmap.as_ref().clone();
         let mut incoming_fragments = RoaringBitmap::new();
         let mut new_indices = Vec::with_capacity(segments.len());
         for mut segment in segments {
@@ -1006,19 +1007,6 @@ impl DatasetIndexExt for Dataset {
                 return Err(Error::invalid_input(format!(
                     "CreateIndex: segment {} was built for fields {:?}, expected [{}]",
                     segment.uuid, segment.fields, field.id
-                )));
-            }
-            if let (Some(expected), Some(actual)) = (
-                incoming_type_url.as_deref(),
-                segment
-                    .index_details
-                    .as_ref()
-                    .map(|details| details.type_url.as_str()),
-            ) && expected != actual
-            {
-                return Err(Error::invalid_input(format!(
-                    "CreateIndex: segment set for index '{}' mixes incompatible index detail types",
-                    index_name
                 )));
             }
             if let Some(fragment_bitmap) = &segment.fragment_bitmap {
@@ -1047,11 +1035,36 @@ impl DatasetIndexExt for Dataset {
                     .zip(incoming_type_url.as_deref())
                     .is_none_or(|(details, expected)| details.type_url == expected)
             })
-            .filter(|idx| {
-                idx.fragment_bitmap
-                    .as_ref()
-                    .is_none_or(|bitmap| !bitmap.is_disjoint(&incoming_fragments))
+            .map(|idx| -> Result<Option<IndexMetadata>> {
+                let Some(existing_fragments) = idx.fragment_bitmap.as_ref() else {
+                    if incoming_fragments != dataset_fragments {
+                        return Err(Error::invalid_input(format!(
+                            "CreateIndex: cannot replace legacy index segment {} for '{}' with partial fragment coverage; rebuild all fragments in one commit",
+                            idx.uuid, index_name
+                        )));
+                    }
+                    return Ok(Some(idx));
+                };
+
+                if existing_fragments.is_disjoint(&incoming_fragments) {
+                    return Ok(None);
+                }
+
+                let uncovered = existing_fragments - &incoming_fragments;
+                if !uncovered.is_empty() {
+                    return Err(Error::invalid_input(format!(
+                        "CreateIndex: incoming segments for '{}' would orphan fragments {:?} from existing segment {}",
+                        index_name,
+                        uncovered.iter().collect::<Vec<_>>(),
+                        idx.uuid
+                    )));
+                }
+
+                Ok(Some(idx))
             })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
             .collect::<Vec<_>>();
 
         let transaction = Transaction::new(
@@ -6152,6 +6165,55 @@ mod tests {
             err.to_string()
                 .contains("mixes incompatible index detail types")
         );
+    }
+
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_rejects_partial_replacement_of_wider_segment() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(20), BatchCount::from(2));
+
+        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let original = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32, 1_u32],
+            b"original",
+        )
+        .await;
+        dataset
+            .commit_existing_index_segments("vector_idx", "vector", vec![original])
+            .await
+            .unwrap();
+
+        let replacement = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"replacement",
+        )
+        .await;
+
+        let err = dataset
+            .commit_existing_index_segments("vector_idx", "vector", vec![replacement])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("would orphan fragments"));
     }
 
     #[tokio::test]

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -127,6 +127,30 @@ fn validate_segment_metadata(index_name: &str, segments: &[IndexMetadata]) -> Re
     Ok(())
 }
 
+fn validate_segment_index_details(index_name: &str, segments: &[IndexMetadata]) -> Result<()> {
+    let mut type_url = None::<&str>;
+    for segment in segments {
+        let segment_type_url = segment.index_details.as_ref().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "CreateIndex: segment {} is missing index details",
+                segment.uuid
+            ))
+        })?;
+        match type_url {
+            Some(expected) if expected != segment_type_url.type_url => {
+                return Err(Error::invalid_input(format!(
+                    "CreateIndex: segment set for index '{}' mixes incompatible index detail types",
+                    index_name
+                )));
+            }
+            None => type_url = Some(segment_type_url.type_url.as_str()),
+            Some(_) => {}
+        }
+    }
+
+    Ok(())
+}
+
 // Cache keys for different index types
 #[derive(Debug, Clone)]
 pub struct ScalarIndexCacheKey<'a> {
@@ -969,6 +993,7 @@ impl DatasetIndexExt for Dataset {
         };
 
         validate_segment_metadata(index_name, &segments)?;
+        validate_segment_index_details(index_name, &segments)?;
 
         let mut new_indices = Vec::with_capacity(segments.len());
         for mut segment in segments {
@@ -2255,6 +2280,7 @@ mod tests {
     use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::gen_batch;
     use lance_datagen::{BatchCount, ByteCount, Dimension, RowCount, array};
+    use lance_index::pbold::BTreeIndexDetails;
     use lance_index::scalar::bitmap::BITMAP_LOOKUP_NAME;
     use lance_index::scalar::{
         BuiltinIndexType, FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams,
@@ -6028,6 +6054,58 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("overlapping fragment coverage"));
+    }
+
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_rejects_mixed_index_detail_types() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(20), BatchCount::from(2));
+
+        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let seg0 = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"seg0",
+        )
+        .await;
+        let seg1 = IndexMetadata {
+            uuid: Uuid::new_v4(),
+            name: "vector_idx".to_string(),
+            fields: vec![field_id],
+            dataset_version: dataset.manifest.version,
+            fragment_bitmap: Some(std::iter::once(1_u32).collect()),
+            index_details: Some(Arc::new(
+                prost_types::Any::from_msg(&BTreeIndexDetails::default()).unwrap(),
+            )),
+            index_version: IndexType::BTree.version(),
+            created_at: Some(chrono::Utc::now()),
+            base_id: None,
+            files: seg0.files.clone(),
+        };
+
+        let err = dataset
+            .commit_existing_index_segments("vector_idx", "vector", vec![seg0, seg1])
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("mixes incompatible index detail types")
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -73,6 +73,7 @@ pub mod frag_reuse;
 pub mod mem_wal;
 pub mod prefilter;
 pub mod scalar;
+pub(crate) mod scalar_logical;
 pub mod vector;
 
 use self::append::merge_indices;

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -18,6 +18,7 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::TryStreamExt;
 use itertools::Itertools;
+use lance_core::cache::LanceCache;
 use lance_core::datatypes::Field;
 use lance_core::{Error, ROW_ADDR, ROW_ID, Result};
 use lance_datafusion::exec::LanceExecutionOptions;
@@ -38,11 +39,12 @@ use lance_index::scalar::registry::{
 use lance_index::scalar::{CreatedIndex, InvertedIndexParams};
 use lance_index::scalar::{
     ScalarIndex, ScalarIndexParams, bitmap::BITMAP_LOOKUP_NAME, inverted::INVERT_LIST_FILE,
-    lance_format::LanceIndexStore,
+    lance_format::LanceIndexStore, zonemap::LogicalZoneMapIndex,
 };
 use lance_index::{IndexCriteria, IndexType};
 use lance_table::format::{Fragment, IndexMetadata};
 use log::info;
+use roaring::RoaringBitmap;
 use tracing::instrument;
 
 // Log an update every TRAINING_UPDATE_FREQ million rows processed
@@ -399,6 +401,104 @@ pub async fn open_scalar_index(
         .await
 }
 
+fn index_intersects_dataset(index: &IndexMetadata, dataset: &Dataset) -> bool {
+    index
+        .fragment_bitmap
+        .as_ref()
+        .is_some_and(|index_bitmap| index_bitmap.intersection_len(&dataset.fragment_bitmap) > 0)
+}
+
+fn union_fragment_bitmaps(indices: &[IndexMetadata], index_name: &str) -> Result<RoaringBitmap> {
+    let mut combined = RoaringBitmap::new();
+    for index in indices {
+        let fragment_bitmap = index.fragment_bitmap.as_ref().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Scalar index '{}' segment {} is missing fragment coverage",
+                index_name, index.uuid
+            ))
+        })?;
+        combined |= fragment_bitmap.clone();
+    }
+    Ok(combined)
+}
+
+async fn load_named_zonemap_segments(
+    dataset: &Dataset,
+    column: &str,
+    index_name: &str,
+) -> Result<Option<Vec<IndexMetadata>>> {
+    let usable_indices = dataset
+        .load_indices_by_name(index_name)
+        .await?
+        .into_iter()
+        .filter(|index| index_intersects_dataset(index, dataset))
+        .collect::<Vec<_>>();
+
+    if usable_indices.len() <= 1 {
+        return Ok(None);
+    }
+
+    for index in &usable_indices {
+        let index_details = fetch_index_details(dataset, column, index).await?;
+        if !index_details.type_url.ends_with("ZoneMapIndexDetails") {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(usable_indices))
+}
+
+pub(crate) async fn scalar_index_fragment_bitmap(
+    dataset: &Dataset,
+    column: &str,
+    index_name: &str,
+) -> Result<Option<RoaringBitmap>> {
+    if let Some(indices) = load_named_zonemap_segments(dataset, column, index_name).await? {
+        return union_fragment_bitmaps(&indices, index_name).map(Some);
+    }
+
+    Ok(dataset
+        .load_scalar_index(IndexCriteria::default().with_name(index_name))
+        .await?
+        .and_then(|index| index.fragment_bitmap))
+}
+
+pub(crate) async fn open_named_scalar_index(
+    dataset: &Dataset,
+    column: &str,
+    index_name: &str,
+    metrics: &dyn MetricsCollector,
+) -> Result<Arc<dyn ScalarIndex>> {
+    if let Some(indices) = load_named_zonemap_segments(dataset, column, index_name).await? {
+        let frag_reuse_index = dataset.open_frag_reuse_index(metrics).await?;
+        let stores = indices
+            .iter()
+            .map(|index| {
+                LanceIndexStore::from_dataset_for_existing(dataset, index)
+                    .map(|store| Arc::new(store) as Arc<dyn IndexStore>)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let logical_cache = LanceCache::no_cache();
+        return Ok(
+            LogicalZoneMapIndex::load(stores, frag_reuse_index, &logical_cache).await?
+                as Arc<dyn ScalarIndex>,
+        );
+    }
+
+    let index = dataset
+        .load_scalar_index(IndexCriteria::default().with_name(index_name))
+        .await?
+        .ok_or_else(|| {
+            Error::internal(format!(
+                "Scanner created plan for index query on index {} for column {} but no usable index exists with that name",
+                index_name, column
+            ))
+        })?;
+    dataset
+        .open_scalar_index(column, &index.uuid.to_string(), metrics)
+        .await
+}
+
 pub(crate) async fn infer_scalar_index_details(
     dataset: &Dataset,
     column: &str,
@@ -594,6 +694,8 @@ mod tests {
     use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
 
     use super::*;
+    use crate::dataset::Dataset;
+    use crate::index::create::CreateIndexBuilder;
     use arrow::{
         array::AsArray,
         datatypes::{Int32Type, UInt64Type},
@@ -603,8 +705,12 @@ mod tests {
     use lance_core::utils::tempfile::TempStrDir;
     use lance_core::{datatypes::Field, utils::address::RowAddress};
     use lance_datagen::array;
+    use lance_index::metrics::NoOpMetricsCollector;
     use lance_index::{IndexType, optimize::OptimizeOptions};
-    use lance_index::{pbold::NGramIndexDetails, scalar::BuiltinIndexType};
+    use lance_index::{
+        pbold::NGramIndexDetails,
+        scalar::{BuiltinIndexType, ScalarIndexParams},
+    };
     use lance_table::format::pb::VectorIndexDetails;
 
     fn make_index_metadata(
@@ -815,6 +921,53 @@ mod tests {
             }
         }
         assert_eq!(max_frag_id_seen, 3);
+    }
+
+    #[tokio::test]
+    async fn test_open_named_scalar_index_uses_all_zonemap_segments() {
+        let dataset = lance_datagen::gen_batch()
+            .col("value", array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(4), FragmentRowCount::from(16))
+            .await
+            .unwrap();
+        let mut dataset = dataset;
+        let fragments = dataset.get_fragments();
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap);
+        let mut segments = Vec::new();
+
+        for fragment in &fragments {
+            let segment =
+                CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::ZoneMap, &params)
+                    .name("value_zonemap".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap();
+            segments.push(segment);
+        }
+
+        dataset
+            .commit_existing_index_segments("value_zonemap", "value", segments)
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("value_zonemap").await.unwrap();
+        assert_eq!(committed.len(), fragments.len());
+
+        let logical =
+            open_named_scalar_index(&dataset, "value", "value_zonemap", &NoOpMetricsCollector)
+                .await
+                .unwrap();
+        assert_eq!(
+            logical.calculate_included_frags().await.unwrap(),
+            dataset.fragment_bitmap.as_ref().clone()
+        );
+
+        let combined_bitmap = scalar_index_fragment_bitmap(&dataset, "value", "value_zonemap")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(combined_bitmap, dataset.fragment_bitmap.as_ref().clone());
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -18,7 +18,6 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::TryStreamExt;
 use itertools::Itertools;
-use lance_core::cache::LanceCache;
 use lance_core::datatypes::Field;
 use lance_core::{Error, ROW_ADDR, ROW_ID, Result};
 use lance_datafusion::exec::LanceExecutionOptions;
@@ -39,12 +38,11 @@ use lance_index::scalar::registry::{
 use lance_index::scalar::{CreatedIndex, InvertedIndexParams};
 use lance_index::scalar::{
     ScalarIndex, ScalarIndexParams, bitmap::BITMAP_LOOKUP_NAME, inverted::INVERT_LIST_FILE,
-    lance_format::LanceIndexStore, zonemap::LogicalZoneMapIndex,
+    lance_format::LanceIndexStore,
 };
 use lance_index::{IndexCriteria, IndexType};
 use lance_table::format::{Fragment, IndexMetadata};
 use log::info;
-use roaring::RoaringBitmap;
 use tracing::instrument;
 
 // Log an update every TRAINING_UPDATE_FREQ million rows processed
@@ -401,104 +399,6 @@ pub async fn open_scalar_index(
         .await
 }
 
-fn index_intersects_dataset(index: &IndexMetadata, dataset: &Dataset) -> bool {
-    index
-        .fragment_bitmap
-        .as_ref()
-        .is_some_and(|index_bitmap| index_bitmap.intersection_len(&dataset.fragment_bitmap) > 0)
-}
-
-fn union_fragment_bitmaps(indices: &[IndexMetadata], index_name: &str) -> Result<RoaringBitmap> {
-    let mut combined = RoaringBitmap::new();
-    for index in indices {
-        let fragment_bitmap = index.fragment_bitmap.as_ref().ok_or_else(|| {
-            Error::invalid_input(format!(
-                "Scalar index '{}' segment {} is missing fragment coverage",
-                index_name, index.uuid
-            ))
-        })?;
-        combined |= fragment_bitmap.clone();
-    }
-    Ok(combined)
-}
-
-async fn load_named_zonemap_segments(
-    dataset: &Dataset,
-    column: &str,
-    index_name: &str,
-) -> Result<Option<Vec<IndexMetadata>>> {
-    let usable_indices = dataset
-        .load_indices_by_name(index_name)
-        .await?
-        .into_iter()
-        .filter(|index| index_intersects_dataset(index, dataset))
-        .collect::<Vec<_>>();
-
-    if usable_indices.len() <= 1 {
-        return Ok(None);
-    }
-
-    for index in &usable_indices {
-        let index_details = fetch_index_details(dataset, column, index).await?;
-        if !index_details.type_url.ends_with("ZoneMapIndexDetails") {
-            return Ok(None);
-        }
-    }
-
-    Ok(Some(usable_indices))
-}
-
-pub(crate) async fn scalar_index_fragment_bitmap(
-    dataset: &Dataset,
-    column: &str,
-    index_name: &str,
-) -> Result<Option<RoaringBitmap>> {
-    if let Some(indices) = load_named_zonemap_segments(dataset, column, index_name).await? {
-        return union_fragment_bitmaps(&indices, index_name).map(Some);
-    }
-
-    Ok(dataset
-        .load_scalar_index(IndexCriteria::default().with_name(index_name))
-        .await?
-        .and_then(|index| index.fragment_bitmap))
-}
-
-pub(crate) async fn open_named_scalar_index(
-    dataset: &Dataset,
-    column: &str,
-    index_name: &str,
-    metrics: &dyn MetricsCollector,
-) -> Result<Arc<dyn ScalarIndex>> {
-    if let Some(indices) = load_named_zonemap_segments(dataset, column, index_name).await? {
-        let frag_reuse_index = dataset.open_frag_reuse_index(metrics).await?;
-        let stores = indices
-            .iter()
-            .map(|index| {
-                LanceIndexStore::from_dataset_for_existing(dataset, index)
-                    .map(|store| Arc::new(store) as Arc<dyn IndexStore>)
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let logical_cache = LanceCache::no_cache();
-        return Ok(
-            LogicalZoneMapIndex::load(stores, frag_reuse_index, &logical_cache).await?
-                as Arc<dyn ScalarIndex>,
-        );
-    }
-
-    let index = dataset
-        .load_scalar_index(IndexCriteria::default().with_name(index_name))
-        .await?
-        .ok_or_else(|| {
-            Error::internal(format!(
-                "Scanner created plan for index query on index {} for column {} but no usable index exists with that name",
-                index_name, column
-            ))
-        })?;
-    dataset
-        .open_scalar_index(column, &index.uuid.to_string(), metrics)
-        .await
-}
-
 pub(crate) async fn infer_scalar_index_details(
     dataset: &Dataset,
     column: &str,
@@ -695,7 +595,6 @@ mod tests {
 
     use super::*;
     use crate::dataset::Dataset;
-    use crate::index::create::CreateIndexBuilder;
     use arrow::{
         array::AsArray,
         datatypes::{Int32Type, UInt64Type},
@@ -705,7 +604,6 @@ mod tests {
     use lance_core::utils::tempfile::TempStrDir;
     use lance_core::{datatypes::Field, utils::address::RowAddress};
     use lance_datagen::array;
-    use lance_index::metrics::NoOpMetricsCollector;
     use lance_index::{IndexType, optimize::OptimizeOptions};
     use lance_index::{
         pbold::NGramIndexDetails,
@@ -921,53 +819,6 @@ mod tests {
             }
         }
         assert_eq!(max_frag_id_seen, 3);
-    }
-
-    #[tokio::test]
-    async fn test_open_named_scalar_index_uses_all_zonemap_segments() {
-        let dataset = lance_datagen::gen_batch()
-            .col("value", array::step::<Int32Type>())
-            .into_ram_dataset(FragmentCount::from(4), FragmentRowCount::from(16))
-            .await
-            .unwrap();
-        let mut dataset = dataset;
-        let fragments = dataset.get_fragments();
-        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap);
-        let mut segments = Vec::new();
-
-        for fragment in &fragments {
-            let segment =
-                CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::ZoneMap, &params)
-                    .name("value_zonemap".to_string())
-                    .fragments(vec![fragment.id() as u32])
-                    .execute_uncommitted()
-                    .await
-                    .unwrap();
-            segments.push(segment);
-        }
-
-        dataset
-            .commit_existing_index_segments("value_zonemap", "value", segments)
-            .await
-            .unwrap();
-
-        let committed = dataset.load_indices_by_name("value_zonemap").await.unwrap();
-        assert_eq!(committed.len(), fragments.len());
-
-        let logical =
-            open_named_scalar_index(&dataset, "value", "value_zonemap", &NoOpMetricsCollector)
-                .await
-                .unwrap();
-        assert_eq!(
-            logical.calculate_included_frags().await.unwrap(),
-            dataset.fragment_bitmap.as_ref().clone()
-        );
-
-        let combined_bitmap = scalar_index_fragment_bitmap(&dataset, "value", "value_zonemap")
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(combined_bitmap, dataset.fragment_bitmap.as_ref().clone());
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -142,7 +142,7 @@ impl ScalarIndex for LogicalScalarIndex {
         _dest_store: &dyn lance_index::scalar::IndexStore,
     ) -> Result<CreatedIndex> {
         Err(Error::invalid_input(format!(
-            "LogicalScalarIndex '{}' is a query-time wrapper and does not support remap",
+            "LogicalScalarIndex '{}' is a query-time wrapper and does not support remap; rebuild the index to consolidate segments before remapping",
             self.name
         )))
     }
@@ -154,7 +154,7 @@ impl ScalarIndex for LogicalScalarIndex {
         _old_data_filter: Option<lance_index::scalar::OldIndexDataFilter>,
     ) -> Result<CreatedIndex> {
         Err(Error::invalid_input(format!(
-            "LogicalScalarIndex '{}' is a query-time wrapper and does not support update",
+            "LogicalScalarIndex '{}' is a query-time wrapper and does not support update; rebuild the index to consolidate segments before updating",
             self.name
         )))
     }
@@ -222,17 +222,33 @@ async fn load_named_scalar_segments(
         .filter(|index| index_intersects_dataset(index, dataset))
         .collect::<Vec<_>>();
 
+    let needs_fallback_fetch = usable_indices
+        .iter()
+        .any(|index| index.index_details.is_none());
+
     let mut index_type_url = None::<String>;
     for index in &usable_indices {
-        let index_details = fetch_index_details(dataset, column, index).await?;
+        let segment_type_url = if needs_fallback_fetch {
+            fetch_index_details(dataset, column, index)
+                .await?
+                .type_url
+                .clone()
+        } else {
+            index
+                .index_details
+                .as_ref()
+                .expect("checked above")
+                .type_url
+                .clone()
+        };
         match &index_type_url {
-            Some(expected) if expected != &index_details.type_url => {
+            Some(expected) if expected != &segment_type_url => {
                 return Err(Error::invalid_input(format!(
                     "Scalar index '{}' on column '{}' mixes incompatible segment types",
                     index_name, column
                 )));
             }
-            None => index_type_url = Some(index_details.type_url.clone()),
+            None => index_type_url = Some(segment_type_url),
             Some(_) => {}
         }
     }

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -444,4 +444,75 @@ mod tests {
                 .all(|fragment_id| *fragment_id == target_fragment)
         );
     }
+
+    #[tokio::test]
+    async fn test_commit_existing_zonemap_segments_replaces_overlapping_segments() {
+        let dataset = lance_datagen::gen_batch()
+            .col("value", array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(2), FragmentRowCount::from(16))
+            .await
+            .unwrap();
+        let mut dataset = dataset;
+        let fragments = dataset.get_fragments();
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap);
+
+        let mut first_segments = Vec::new();
+        for fragment in &fragments {
+            first_segments.push(
+                CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::ZoneMap, &params)
+                    .name("value_zonemap_replace".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        dataset
+            .commit_existing_index_segments("value_zonemap_replace", "value", first_segments)
+            .await
+            .unwrap();
+
+        let mut replacement_segments = Vec::new();
+        for fragment in &fragments {
+            replacement_segments.push(
+                CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::ZoneMap, &params)
+                    .name("value_zonemap_replace".to_string())
+                    .replace(true)
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap(),
+            );
+        }
+        let replacement_uuids = replacement_segments
+            .iter()
+            .map(|segment| segment.uuid)
+            .collect::<Vec<_>>();
+
+        dataset
+            .commit_existing_index_segments("value_zonemap_replace", "value", replacement_segments)
+            .await
+            .unwrap();
+
+        let committed = dataset
+            .load_indices_by_name("value_zonemap_replace")
+            .await
+            .unwrap();
+        assert_eq!(committed.len(), fragments.len());
+        assert_eq!(
+            committed
+                .iter()
+                .map(|segment| segment.uuid)
+                .collect::<Vec<_>>(),
+            replacement_uuids
+        );
+        assert_eq!(
+            scalar_index_fragment_bitmap(&dataset, "value", "value_zonemap_replace")
+                .await
+                .unwrap()
+                .unwrap(),
+            dataset.fragment_bitmap.as_ref().clone()
+        );
+    }
 }

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Query-time logical views over scalar index segments.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use deepsize::{Context, DeepSizeOf};
+use futures::future::try_join_all;
+use lance_core::utils::mask::NullableRowAddrSet;
+use lance_core::{Error, Result};
+use lance_index::metrics::MetricsCollector;
+use lance_index::scalar::{AnyQuery, CreatedIndex, ScalarIndex, SearchResult, UpdateCriteria};
+use lance_index::{Index, IndexType};
+use lance_table::format::IndexMetadata;
+use roaring::RoaringBitmap;
+use serde_json::json;
+
+use crate::dataset::Dataset;
+use crate::index::scalar::fetch_index_details;
+use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
+
+#[derive(Debug)]
+pub(crate) struct LogicalScalarIndex {
+    name: String,
+    column: String,
+    index_type: IndexType,
+    segments: Vec<Arc<dyn ScalarIndex>>,
+}
+
+impl LogicalScalarIndex {
+    fn try_new(name: String, column: String, segments: Vec<Arc<dyn ScalarIndex>>) -> Result<Self> {
+        let Some(first) = segments.first() else {
+            return Err(Error::invalid_input(format!(
+                "LogicalScalarIndex '{}' on column '{}' must contain at least one segment",
+                name, column
+            )));
+        };
+        let index_type = first.index_type();
+        if segments
+            .iter()
+            .any(|segment| segment.index_type() != index_type)
+        {
+            return Err(Error::invalid_input(format!(
+                "LogicalScalarIndex '{}' on column '{}' mixes scalar index types",
+                name, column
+            )));
+        }
+
+        Ok(Self {
+            name,
+            column,
+            index_type,
+            segments,
+        })
+    }
+}
+
+impl DeepSizeOf for LogicalScalarIndex {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.name.deep_size_of_children(context)
+            + self.column.deep_size_of_children(context)
+            + self.segments.deep_size_of_children(context)
+    }
+}
+
+#[async_trait]
+impl Index for LogicalScalarIndex {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn lance_index::vector::VectorIndex>> {
+        Err(Error::invalid_input(format!(
+            "LogicalScalarIndex '{}' is not a vector index",
+            self.name
+        )))
+    }
+
+    fn statistics(&self) -> Result<serde_json::Value> {
+        Ok(json!({
+            "index_name": self.name,
+            "column": self.column,
+            "index_type": self.index_type.to_string(),
+            "num_segments": self.segments.len(),
+        }))
+    }
+
+    async fn prewarm(&self) -> Result<()> {
+        try_join_all(self.segments.iter().map(|segment| segment.prewarm())).await?;
+        Ok(())
+    }
+
+    fn index_type(&self) -> IndexType {
+        self.index_type
+    }
+
+    async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+        let fragment_sets = try_join_all(
+            self.segments
+                .iter()
+                .map(|segment| segment.calculate_included_frags()),
+        )
+        .await?;
+        let mut combined = RoaringBitmap::new();
+        for fragment_set in fragment_sets {
+            combined |= fragment_set;
+        }
+        Ok(combined)
+    }
+}
+
+#[async_trait]
+impl ScalarIndex for LogicalScalarIndex {
+    async fn search(
+        &self,
+        query: &dyn AnyQuery,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
+        let results = try_join_all(
+            self.segments
+                .iter()
+                .map(|segment| segment.search(query, metrics)),
+        )
+        .await?;
+        combine_search_results(results)
+    }
+
+    fn can_remap(&self) -> bool {
+        false
+    }
+
+    async fn remap(
+        &self,
+        _mapping: &std::collections::HashMap<u64, Option<u64>>,
+        _dest_store: &dyn lance_index::scalar::IndexStore,
+    ) -> Result<CreatedIndex> {
+        Err(Error::invalid_input(format!(
+            "LogicalScalarIndex '{}' is a query-time wrapper and does not support remap",
+            self.name
+        )))
+    }
+
+    async fn update(
+        &self,
+        _new_data: datafusion::physical_plan::SendableRecordBatchStream,
+        _dest_store: &dyn lance_index::scalar::IndexStore,
+        _old_data_filter: Option<lance_index::scalar::OldIndexDataFilter>,
+    ) -> Result<CreatedIndex> {
+        Err(Error::invalid_input(format!(
+            "LogicalScalarIndex '{}' is a query-time wrapper and does not support update",
+            self.name
+        )))
+    }
+
+    fn update_criteria(&self) -> UpdateCriteria {
+        self.segments[0].update_criteria()
+    }
+
+    fn derive_index_params(&self) -> Result<lance_index::scalar::ScalarIndexParams> {
+        self.segments[0].derive_index_params()
+    }
+}
+
+fn combine_search_results(results: Vec<SearchResult>) -> Result<SearchResult> {
+    let mut saw_at_most = false;
+    let mut saw_at_least = false;
+    let mut sets = Vec::with_capacity(results.len());
+
+    for result in results {
+        match result {
+            SearchResult::Exact(set) => sets.push(set),
+            SearchResult::AtMost(set) => {
+                saw_at_most = true;
+                sets.push(set);
+            }
+            SearchResult::AtLeast(set) => {
+                saw_at_least = true;
+                sets.push(set);
+            }
+        }
+    }
+
+    if saw_at_most && saw_at_least {
+        return Err(Error::not_supported(
+            "Logical scalar index cannot combine mixed AtMost and AtLeast segment results",
+        ));
+    }
+
+    let combined = NullableRowAddrSet::union_all(&sets);
+    Ok(if saw_at_most {
+        SearchResult::AtMost(combined)
+    } else if saw_at_least {
+        SearchResult::AtLeast(combined)
+    } else {
+        SearchResult::Exact(combined)
+    })
+}
+
+fn index_intersects_dataset(index: &IndexMetadata, dataset: &Dataset) -> bool {
+    index
+        .fragment_bitmap
+        .as_ref()
+        .is_some_and(|index_bitmap| index_bitmap.intersection_len(&dataset.fragment_bitmap) > 0)
+}
+
+async fn load_named_scalar_segments(
+    dataset: &Dataset,
+    column: &str,
+    index_name: &str,
+) -> Result<Vec<IndexMetadata>> {
+    let usable_indices = dataset
+        .load_indices_by_name(index_name)
+        .await?
+        .into_iter()
+        .filter(|index| index_intersects_dataset(index, dataset))
+        .collect::<Vec<_>>();
+
+    let mut index_type_url = None::<String>;
+    for index in &usable_indices {
+        let index_details = fetch_index_details(dataset, column, index).await?;
+        match &index_type_url {
+            Some(expected) if expected != &index_details.type_url => {
+                return Err(Error::invalid_input(format!(
+                    "Scalar index '{}' on column '{}' mixes incompatible segment types",
+                    index_name, column
+                )));
+            }
+            None => index_type_url = Some(index_details.type_url.clone()),
+            Some(_) => {}
+        }
+    }
+
+    Ok(usable_indices)
+}
+
+fn union_fragment_bitmaps(indices: &[IndexMetadata], index_name: &str) -> Result<RoaringBitmap> {
+    let mut combined = RoaringBitmap::new();
+    for index in indices {
+        let fragment_bitmap = index.fragment_bitmap.as_ref().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Scalar index '{}' segment {} is missing fragment coverage",
+                index_name, index.uuid
+            ))
+        })?;
+        combined |= fragment_bitmap.clone();
+    }
+    Ok(combined)
+}
+
+pub(crate) async fn scalar_index_fragment_bitmap(
+    dataset: &Dataset,
+    column: &str,
+    index_name: &str,
+) -> Result<Option<RoaringBitmap>> {
+    let indices = load_named_scalar_segments(dataset, column, index_name).await?;
+    match indices.len() {
+        0 => Ok(None),
+        1 => Ok(indices
+            .into_iter()
+            .next()
+            .and_then(|index| index.fragment_bitmap)),
+        _ => union_fragment_bitmaps(&indices, index_name).map(Some),
+    }
+}
+
+pub(crate) async fn open_named_scalar_index(
+    dataset: &Dataset,
+    column: &str,
+    index_name: &str,
+    metrics: &dyn MetricsCollector,
+) -> Result<Arc<dyn ScalarIndex>> {
+    let indices = load_named_scalar_segments(dataset, column, index_name).await?;
+    match indices.len() {
+        0 => Err(Error::internal(format!(
+            "Scanner created plan for index query on index {} for column {} but no usable index exists with that name",
+            index_name, column
+        ))),
+        1 => {
+            let uuid = indices[0].uuid.to_string();
+            dataset.open_scalar_index(column, &uuid, metrics).await
+        }
+        _ => {
+            let segments = try_join_all(indices.iter().map(|index| {
+                let uuid = index.uuid.to_string();
+                async move { dataset.open_scalar_index(column, &uuid, metrics).await }
+            }))
+            .await?;
+
+            Ok(Arc::new(LogicalScalarIndex::try_new(
+                index_name.to_string(),
+                column.to_string(),
+                segments,
+            )?) as Arc<dyn ScalarIndex>)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Bound;
+
+    use arrow::datatypes::Int32Type;
+    use datafusion::scalar::ScalarValue;
+    use lance_core::utils::address::RowAddress;
+    use lance_datagen::array;
+    use lance_index::IndexType;
+    use lance_index::metrics::NoOpMetricsCollector;
+    use lance_index::scalar::{BuiltinIndexType, SargableQuery, ScalarIndexParams};
+
+    use crate::index::create::CreateIndexBuilder;
+    use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_open_named_scalar_index_uses_all_zonemap_segments() {
+        let dataset = lance_datagen::gen_batch()
+            .col("value", array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(4), FragmentRowCount::from(16))
+            .await
+            .unwrap();
+        let mut dataset = dataset;
+        let fragments = dataset.get_fragments();
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap);
+        let mut segments = Vec::new();
+
+        for fragment in &fragments {
+            let segment =
+                CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::ZoneMap, &params)
+                    .name("value_zonemap".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap();
+            segments.push(segment);
+        }
+
+        dataset
+            .commit_existing_index_segments("value_zonemap", "value", segments)
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("value_zonemap").await.unwrap();
+        assert_eq!(committed.len(), fragments.len());
+
+        let logical =
+            open_named_scalar_index(&dataset, "value", "value_zonemap", &NoOpMetricsCollector)
+                .await
+                .unwrap();
+        assert_eq!(
+            logical.calculate_included_frags().await.unwrap(),
+            dataset.fragment_bitmap.as_ref().clone()
+        );
+
+        let combined_bitmap = scalar_index_fragment_bitmap(&dataset, "value", "value_zonemap")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(combined_bitmap, dataset.fragment_bitmap.as_ref().clone());
+    }
+
+    #[tokio::test]
+    async fn test_zonemap_segment_search_keeps_fragment_ids() {
+        let dataset = lance_datagen::gen_batch()
+            .col("value", array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(4), FragmentRowCount::from(16))
+            .await
+            .unwrap();
+        let mut dataset = dataset;
+        let target_fragment = dataset.get_fragments()[2].id() as u32;
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap);
+
+        let segment =
+            CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::ZoneMap, &params)
+                .name("value_zonemap_single_fragment".to_string())
+                .fragments(vec![target_fragment])
+                .execute_uncommitted()
+                .await
+                .unwrap();
+
+        dataset
+            .commit_existing_index_segments("value_zonemap_single_fragment", "value", vec![segment])
+            .await
+            .unwrap();
+
+        let logical = open_named_scalar_index(
+            &dataset,
+            "value",
+            "value_zonemap_single_fragment",
+            &NoOpMetricsCollector,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            logical
+                .calculate_included_frags()
+                .await
+                .unwrap()
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![target_fragment]
+        );
+
+        let query = SargableQuery::Range(
+            Bound::Included(ScalarValue::Int32(Some(0))),
+            Bound::Included(ScalarValue::Int32(Some(10_000))),
+        );
+        let result = logical.search(&query, &NoOpMetricsCollector).await.unwrap();
+        let searched_fragments = result
+            .row_addrs()
+            .true_rows()
+            .row_addrs()
+            .unwrap()
+            .map(|row_addr| RowAddress::from(u64::from(row_addr)).fragment_id())
+            .collect::<Vec<_>>();
+        assert!(!searched_fragments.is_empty());
+        assert!(
+            searched_fragments
+                .iter()
+                .all(|fragment_id| *fragment_id == target_fragment)
+        );
+    }
+}

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -222,24 +222,17 @@ async fn load_named_scalar_segments(
         .filter(|index| index_intersects_dataset(index, dataset))
         .collect::<Vec<_>>();
 
-    let needs_fallback_fetch = usable_indices
-        .iter()
-        .any(|index| index.index_details.is_none());
-
     let mut index_type_url = None::<String>;
     for index in &usable_indices {
-        let segment_type_url = if needs_fallback_fetch {
-            fetch_index_details(dataset, column, index)
-                .await?
-                .type_url
-                .clone()
-        } else {
-            index
-                .index_details
-                .as_ref()
-                .expect("checked above")
-                .type_url
-                .clone()
+        let segment_type_url = match index.index_details.as_ref() {
+            Some(index_details) => index_details.type_url.clone(),
+            None => {
+                // Legacy manifests may omit embedded details, so fetch only the missing ones.
+                fetch_index_details(dataset, column, index)
+                    .await?
+                    .type_url
+                    .clone()
+            }
         };
         match &index_type_url {
             Some(expected) if expected != &segment_type_url => {

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -23,7 +23,7 @@ use crate::index::scalar::fetch_index_details;
 use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
 
 #[derive(Debug)]
-pub(crate) struct LogicalScalarIndex {
+pub struct LogicalScalarIndex {
     name: String,
     column: String,
     index_type: IndexType,
@@ -254,7 +254,7 @@ fn union_fragment_bitmaps(indices: &[IndexMetadata], index_name: &str) -> Result
     Ok(combined)
 }
 
-pub(crate) async fn scalar_index_fragment_bitmap(
+pub async fn scalar_index_fragment_bitmap(
     dataset: &Dataset,
     column: &str,
     index_name: &str,
@@ -270,7 +270,7 @@ pub(crate) async fn scalar_index_fragment_bitmap(
     }
 }
 
-pub(crate) async fn open_named_scalar_index(
+pub async fn open_named_scalar_index(
     dataset: &Dataset,
     column: &str,
     index_name: &str,

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -7,7 +7,11 @@ use super::utils::{IndexMetrics, InstrumentedRecordBatchStreamAdapter};
 use crate::{
     Dataset,
     dataset::rowids::load_row_id_sequences,
-    index::{DatasetIndexExt, DatasetIndexInternalExt, prefilter::DatasetPreFilter},
+    index::{
+        DatasetIndexExt,
+        prefilter::DatasetPreFilter,
+        scalar::{open_named_scalar_index, scalar_index_fragment_bitmap},
+    },
 };
 use arrow_array::{Array, RecordBatch, UInt64Array};
 use arrow_schema::{Schema, SchemaRef};
@@ -62,12 +66,7 @@ impl ScalarIndexLoader for Dataset {
         index_name: &str,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn ScalarIndex>> {
-        let idx = self
-            .load_scalar_index(IndexCriteria::default().with_name(index_name))
-            .await?
-            .ok_or_else(|| Error::internal(format!("Scanner created plan for index query on index {} for column {} but no usable index exists with that name", index_name, column)))?;
-        self.open_scalar_index(column, &idx.uuid.to_string(), metrics)
-            .await
+        open_named_scalar_index(self, column, index_name, metrics).await
     }
 }
 
@@ -133,13 +132,14 @@ impl ScalarIndexExec {
                 Self::fragments_covered_by_index_query(expr, dataset).await
             }
             ScalarIndexExpr::Query(search_key) => {
-                let idx = dataset
-                    .load_scalar_index(IndexCriteria::default().with_name(&search_key.index_name))
+                scalar_index_fragment_bitmap(dataset, &search_key.column, &search_key.index_name)
                     .await?
-                    .expect("Index not found even though it must have been found earlier");
-                Ok(idx
-                    .fragment_bitmap
-                    .expect("scalar indices should always have a fragment bitmap"))
+                    .ok_or_else(|| {
+                        Error::internal(format!(
+                            "Index not found even though it must have been found earlier: {}",
+                            search_key.index_name
+                        ))
+                    })
             }
         }
     }

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -8,7 +8,6 @@ use crate::{
     Dataset,
     dataset::rowids::load_row_id_sequences,
     index::{
-        DatasetIndexExt,
         prefilter::DatasetPreFilter,
         scalar_logical::{open_named_scalar_index, scalar_index_fragment_bitmap},
     },
@@ -44,7 +43,6 @@ use lance_datafusion::{
     },
 };
 use lance_index::{
-    IndexCriteria,
     metrics::MetricsCollector,
     scalar::{
         SargableQuery, ScalarIndex,
@@ -336,14 +334,15 @@ impl MapIndexExec {
     ) -> datafusion::error::Result<
         impl Stream<Item = datafusion::error::Result<RecordBatch>> + Send + 'static,
     > {
-        let index = dataset
-            .load_scalar_index(IndexCriteria::default().with_name(&index_name))
+        let fragment_bitmap = scalar_index_fragment_bitmap(&dataset, &column_name, &index_name)
             .await?
-            .unwrap();
-        let deletion_mask_fut = DatasetPreFilter::create_restricted_deletion_mask(
-            dataset.clone(),
-            index.fragment_bitmap.unwrap(),
-        );
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Internal(format!(
+                    "IndexedLookupExec: index '{index_name}' on column '{column_name}' disappeared after planning"
+                ))
+            })?;
+        let deletion_mask_fut =
+            DatasetPreFilter::create_restricted_deletion_mask(dataset.clone(), fragment_bitmap);
         let deletion_mask = if let Some(deletion_mask_fut) = deletion_mask_fut {
             Some(deletion_mask_fut.await?)
         } else {

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -10,7 +10,7 @@ use crate::{
     index::{
         DatasetIndexExt,
         prefilter::DatasetPreFilter,
-        scalar::{open_named_scalar_index, scalar_index_fragment_bitmap},
+        scalar_logical::{open_named_scalar_index, scalar_index_fragment_bitmap},
     },
 };
 use arrow_array::{Array, RecordBatch, UInt64Array};


### PR DESCRIPTION
## Summary
- allow zonemap to build uncommitted segments over explicit fragment subsets
- add a logical multi-segment zonemap index that unions segment search and fragment coverage
- route name-based scalar zonemap loading through the logical multi-segment path in query execution

## Context
This keeps the public index type as `zonemap` and follows the index-segment direction discussed in the zonemap vote, instead of introducing a separate public partitioned zonemap type.

## Testing
- cargo test -p lance-index test_null_zonemap_index --lib
- cargo test -p lance test_open_named_scalar_index_uses_all_zonemap_segments --lib
- cargo test -p lance test_like_prefix_with_zone_map --lib
