### PR TITLE
ci: fix cargo-deny advisories check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7367,9 +7367,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -81,7 +81,6 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2021-0153", reason = "`encoding` is used by lindera" },
-    { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is used by jieba-rs via include-flate" },
     { id = "RUSTSEC-2024-0436", reason = "`paste` is used by datafusion" },
     { id = "RUSTSEC-2023-0071", reason = "`rsa` is used by opendal via reqsign" },
     { id = "RUSTSEC-2025-0119", reason = "`number_prefix` used by hf-hub in examples" },


### PR DESCRIPTION
## Summary

Two independent advisory-db drifts since main's last green cargo-deny run (2026-04-20) now block CI on any new PR. This patch is the minimum fix that restores a green `cargo deny check` on main.

1. **Drop stale `RUSTSEC-2024-0370` ignore in `deny.toml`.** `proc-macro-error` was removed from `Cargo.lock` by #4657 (jieba-rs 0.8.1 bump). cargo-deny now reports `advisory-not-detected` for this ignore and fails the advisories check. Mirrors the cleanup pattern used in #5882.

2. **Bump `rustls-webpki` 0.103.12 → 0.103.13 in `Cargo.lock`** for [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) — reachable panic when parsing a CRL with an empty `onlySomeReasons` BIT STRING. SemVer-compatible patch update; no `Cargo.toml` change.

## Scope

Minimum diff to get main green. Deliberately out of scope (separate triage):

- `python/Cargo.lock` also pins `rustls-webpki 0.103.12` — not checked by the current CI workflow. Happy to add that bump if reviewers prefer.
- `python/` `cargo deny` also surfaces `RUSTSEC-2024-0014` (`generational-arena` unmaintained), which needs its own decision (ignore-with-justification vs. dependency swap).

## Test plan

Local reproduction on upstream `main` before the fix:

```
$ cargo deny --all-features check advisories
error[vulnerability]: Reachable panic in certificate revocation list parsing
    ID: RUSTSEC-2026-0104 (rustls-webpki 0.103.12)
warning[advisory-not-detected]: advisory was not encountered
    deny.toml:84  RUSTSEC-2024-0370 — no crate matched advisory criteria
advisories FAILED
```

After this patch:

```
$ cargo deny --all-features check
advisories ok, bans ok, licenses ok, sources ok
```

- [x] CI `Check Rust dependencies (cargo-deny)` passes