### PR TITLE
ci: pin lance-namespace<0.7 for compat test venvs

### DIFF
--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -106,6 +106,11 @@ class VenvExecutor:
                 "--extra-index-url",
                 "https://pypi.fury.io/lancedb/",
                 f"pylance=={self.version}",
+                # Released Lance wheels (e.g. 2.0.1, 4.0.0b1) import
+                # CreateEmptyTableRequest from lance_namespace, which was
+                # removed in lance-namespace 0.7.0. Pin to <0.7 so old wheels
+                # resolve a compatible transitive dep.
+                "lance-namespace<0.7",
                 "pytest",
             ],
             check=True,


### PR DESCRIPTION
## Summary

Unblock the `Compatibility Tests` job, which has failed on every PR since 2026-04-21 23:43 UTC.

## Root cause

- `python/python/tests/compat/venv_manager.py` installs `pylance=={version}` into per-version test venvs but does **not** pin `lance-namespace`, so pip resolves the latest release.
- `lance-namespace 0.7.0` was uploaded to PyPI on **2026-04-21 23:43 UTC** and removed public symbols `CreateEmptyTableRequest` / `CreateEmptyTableResponse` from `lance_namespace/__init__.py` (the previous release `0.6.1` still exports them).
- Released Lance wheels `pylance==2.0.1` and `pylance==4.0.0b1` contain a `lance/namespace.py` that does `from lance_namespace import CreateEmptyTableRequest, CreateEmptyTableResponse, …`. With `lance-namespace==0.7.0` installed in the compat venv, `import lance` now fails:
  ```
  ImportError: cannot import name 'CreateEmptyTableRequest' from 'lance_namespace'
    (venv_2.0.1/.../lance_namespace/__init__.py). Did you mean: 'CreateTableRequest'?
  ```
- Verified against the published wheels on PyPI: `0.6.1` exports the removed symbols; `0.7.0` does not. Last green `main` Python CI run (`24689949602`, 2026-04-20 20:55 UTC) predates the `0.7.0` upload.
- This is **not** a regression introduced by any PR — `main` would hit the same failure on a rerun today.

## Fix

Add `lance-namespace<0.7` to the `pip install` invocation in the compat venv setup so old Lance wheels resolve a compatible transitive dep.

```diff
                 f"pylance=={self.version}",
+                # Released Lance wheels (e.g. 2.0.1, 4.0.0b1) import
+                # CreateEmptyTableRequest from lance_namespace, which was
+                # removed in lance-namespace 0.7.0. Pin to <0.7 so old wheels
+                # resolve a compatible transitive dep.
+                "lance-namespace<0.7",
                 "pytest",
```

Current `main` Lance builds are unaffected — they install `lance-namespace` from the workspace, not from PyPI.

## Out of scope

- Per-Lance-version pinning (e.g. narrower `==0.6.1` for `2.0.1`/`4.0.0b1`). The simple ceiling is sufficient until new wheels are published with namespace bindings that target `lance-namespace>=0.7`.
- Upstream `lance-namespace` should either re-export the removed names as deprecated shims or bump to `1.0.0` with release notes. Worth a follow-up in that repo.

## Test plan

- [ ] `Compatibility Tests` job passes in CI after this patch.
- [ ] All other Python jobs remain green.