### PR TITLE
feat(blob_v2): add ref_id deduplication (Plan A — input-only hint)

### DIFF
--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -25,6 +25,9 @@ class Blob:
     uri: Optional[str] = None
     position: Optional[int] = None
     size: Optional[int] = None
+    # Rows sharing the same positive ref_id are de-duplicated in storage.
+    # 0 / None means no sharing.
+    ref_id: Optional[int] = None
 
     def __post_init__(self) -> None:
         if self.data is not None and self.uri is not None:
@@ -74,6 +77,7 @@ class BlobType(pa.ExtensionType):
                 pa.field("uri", pa.utf8(), nullable=True),
                 pa.field("position", pa.uint64(), nullable=True),
                 pa.field("size", pa.uint64(), nullable=True),
+                pa.field("ref_id", pa.uint32(), nullable=True),
             ]
         )
         pa.ExtensionType.__init__(self, storage_type, "lance.blob.v2")
@@ -119,6 +123,7 @@ class BlobArray(pa.ExtensionArray):
         uri_values: list[Optional[str]] = []
         position_values: list[Optional[int]] = []
         size_values: list[Optional[int]] = []
+        ref_id_values: list[Optional[int]] = []
         null_mask: list[bool] = []
 
         for v in values:
@@ -127,6 +132,7 @@ class BlobArray(pa.ExtensionArray):
                 uri_values.append(None)
                 position_values.append(None)
                 size_values.append(None)
+                ref_id_values.append(None)
                 null_mask.append(True)
                 continue
 
@@ -135,6 +141,7 @@ class BlobArray(pa.ExtensionArray):
                 uri_values.append(v.uri)
                 position_values.append(v.position)
                 size_values.append(v.size)
+                ref_id_values.append(v.ref_id)
                 null_mask.append(False)
                 continue
 
@@ -145,6 +152,7 @@ class BlobArray(pa.ExtensionArray):
                 uri_values.append(v)
                 position_values.append(None)
                 size_values.append(None)
+                ref_id_values.append(None)
                 null_mask.append(False)
                 continue
 
@@ -153,6 +161,7 @@ class BlobArray(pa.ExtensionArray):
                 uri_values.append(None)
                 position_values.append(None)
                 size_values.append(None)
+                ref_id_values.append(None)
                 null_mask.append(False)
                 continue
 
@@ -165,10 +174,11 @@ class BlobArray(pa.ExtensionArray):
         uri_arr = pa.array(uri_values, type=pa.utf8())
         position_arr = pa.array(position_values, type=pa.uint64())
         size_arr = pa.array(size_values, type=pa.uint64())
+        ref_id_arr = pa.array(ref_id_values, type=pa.uint32())
         mask_arr = pa.array(null_mask, type=pa.bool_())
         storage = pa.StructArray.from_arrays(
-            [data_arr, uri_arr, position_arr, size_arr],
-            names=["data", "uri", "position", "size"],
+            [data_arr, uri_arr, position_arr, size_arr, ref_id_arr],
+            names=["data", "uri", "position", "size", "ref_id"],
             mask=mask_arr,
         )
         return pa.ExtensionArray.from_storage(BlobType(), storage)  # type: ignore[return-value]

--- a/python/test_ref_id_dedup.py
+++ b/python/test_ref_id_dedup.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Verify ref_id dedup works on all three blob storage paths.
+
+For each size class (Inline, Packed, Dedicated), writes 20 rows that all
+share the same ref_id. The physical storage should hold 1 copy, not 20.
+"""
+import os
+import shutil
+from pathlib import Path
+
+import lance
+import pyarrow as pa
+from lance.blob import Blob, blob_array, blob_field
+
+WORK = Path("./ref_id_dedup_test")
+N_ROWS = 20
+
+
+def make_batch(n_rows: int, payload: bytes, ref_id: int) -> pa.RecordBatch:
+    images = blob_array([Blob(data=payload, ref_id=ref_id) for _ in range(n_rows)])
+    schema = pa.schema([
+        pa.field("row_id", pa.int64()),
+        blob_field("blob"),
+    ])
+    return pa.RecordBatch.from_arrays(
+        [pa.array(range(n_rows), type=pa.int64()), images],
+        schema=schema,
+    )
+
+
+def dataset_size_bytes(ds_path: Path) -> tuple[int, int, int]:
+    """Return (main_lance_bytes, sidecar_bytes, sidecar_count)."""
+    main_bytes = 0
+    sidecar_bytes = 0
+    sidecar_count = 0
+    for p in ds_path.rglob("*"):
+        if p.is_file():
+            if p.suffix == ".blob":
+                sidecar_bytes += p.stat().st_size
+                sidecar_count += 1
+            elif p.suffix == ".lance":
+                main_bytes += p.stat().st_size
+    return main_bytes, sidecar_bytes, sidecar_count
+
+
+def run_case(label: str, payload_size: int, ref_id: int) -> None:
+    case_dir = WORK / label
+    case_dir.mkdir(parents=True, exist_ok=True)
+    ds_path = case_dir / "ds.lance"
+
+    payload = os.urandom(payload_size)
+    batch = make_batch(N_ROWS, payload, ref_id)
+
+    lance.write_dataset(batch, str(ds_path), mode="create", data_storage_version="2.2")
+
+    main_b, side_b, side_n = dataset_size_bytes(ds_path)
+    ideal = payload_size
+
+    print(f"\n=== {label} (payload={payload_size:,}B, ref_id={ref_id}, rows={N_ROWS}) ===")
+    print(f"  main .lance:     {main_b:>13,} B")
+    print(f"  sidecar total:   {side_b:>13,} B  ({side_n} files)")
+    print(f"  ideal (1 copy):  {ideal:>13,} B")
+    print(f"  naive (20 copies): {ideal * N_ROWS:>11,} B")
+
+    # Read back to verify correctness
+    ds = lance.dataset(str(ds_path))
+    blobs = ds.take_blobs("blob", indices=list(range(N_ROWS)))
+    read = [bytes(b.read()) for b in blobs]
+    ok = all(b == payload for b in read)
+    unique = len({hash(b) for b in read})
+    print(f"  read-back OK:    {ok} ({unique} unique contents out of {N_ROWS} rows)")
+
+    # Dedup verdict
+    total_storage = main_b + side_b
+    amp = total_storage / ideal if ideal else 0
+    dedup_works = amp < 3.0  # allow some overhead for descriptors, headers, etc
+    verdict = "✓ DEDUP" if dedup_works else "✗ DUPLICATED"
+    print(f"  amplification:   {amp:.2f}x   [{verdict}]")
+
+
+def main() -> None:
+    if WORK.exists():
+        shutil.rmtree(WORK)
+    WORK.mkdir(parents=True)
+
+    # Inline path: 32 KB (< 64 KB)
+    run_case("inline_32kb", 32 * 1024, ref_id=101)
+
+    # Packed path: 1 MB (> 64 KB, < 4 MB)
+    run_case("packed_1mb", 1 * 1024 * 1024, ref_id=102)
+
+    # Dedicated path: 6 MB (> 4 MB)
+    run_case("dedicated_6mb", 6 * 1024 * 1024, ref_id=103)
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -739,7 +739,23 @@ impl CoreFieldDecoderStrategy {
 
                     return Ok(scheduler);
                 }
-                // Maybe a blob descriptions struct?
+                // Blob v2 extension type: route the 6-field descriptor struct
+                // through the structural scheduler. We match by type name because
+                // PyArrow extension metadata may not round-trip through Lance's
+                // schema serialization.
+                let type_str = data_type.to_string();
+                if type_str.contains("lance.blob.v2") || type_str.contains("BlobType>") {
+                    let column_info = column_infos.expect_next()?;
+                    let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
+                        column_info.as_ref(),
+                        self.decompressor_strategy.as_ref(),
+                        self.cache_repetition_index,
+                        field,
+                    )?);
+                    column_infos.next_top_level();
+                    return Ok(scheduler);
+                }
+                // Maybe a blob descriptions struct? (Blob v1)
                 if field.is_blob() {
                     let column_info = column_infos.peek();
                     if column_info.page_infos.iter().any(|page| {

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -228,9 +228,14 @@ impl FieldEncoder for BlobStructuralEncoder {
     }
 }
 
-/// Blob v2 structural encoder
+/// Blob v2 structural encoder with ref_id deduplication on the Inline path.
 pub struct BlobV2StructuralEncoder {
     descriptor_encoder: Box<dyn FieldEncoder>,
+    /// Maps ref_id -> (position, size) for Inline blobs already appended to
+    /// the out-of-line buffer. Subsequent rows with the same ref_id reuse the
+    /// cached coordinates instead of re-appending identical bytes.
+    /// Lives only for the duration of this encoder (single write session).
+    ref_dedup_tmp_map: HashMap<u32, (u64, u64)>,
 }
 
 impl BlobV2StructuralEncoder {
@@ -258,7 +263,10 @@ impl BlobV2StructuralEncoder {
             Arc::new(HashMap::new()),
         )?);
 
-        Ok(Self { descriptor_encoder })
+        Ok(Self {
+            descriptor_encoder,
+            ref_dedup_tmp_map: HashMap::new(),
+        })
     }
 }
 
@@ -314,6 +322,11 @@ impl FieldEncoder for BlobV2StructuralEncoder {
                 Error::invalid_input_source("Blob v2 struct missing `position` field".into())
             })?
             .as_primitive::<UInt64Type>();
+        // Optional ref_id column: if present and > 0, dedup Inline bytes by
+        // sharing the same out-of-line buffer position across rows.
+        let ref_id_col = struct_arr
+            .column_by_name("ref_id")
+            .map(|c| c.as_primitive::<UInt32Type>());
 
         let row_count = struct_arr.len();
 
@@ -323,7 +336,15 @@ impl FieldEncoder for BlobV2StructuralEncoder {
         let mut blob_id_builder = PrimitiveBuilder::<UInt32Type>::with_capacity(row_count);
         let mut uri_builder = StringBuilder::with_capacity(row_count, row_count * 16);
 
+        // Plan A: ref_id is read here only for in-memory dedup of Inline rows.
+        // It is NOT emitted into the on-disk descriptor (5 fields, unchanged).
         for i in 0..row_count {
+            let ref_id = ref_id_col
+                .as_ref()
+                .filter(|col| !col.is_null(i))
+                .map(|col| col.value(i))
+                .unwrap_or(0);
+
             let (kind_value, position_value, size_value, blob_id_value, uri_value) =
                 if struct_arr.is_null(i) || kind_col.is_null(i) {
                     (BlobKind::Inline as u8, 0, 0, 0, "".to_string())
@@ -370,18 +391,41 @@ impl FieldEncoder for BlobV2StructuralEncoder {
                             "".to_string(),
                         ),
                         BlobKind::Inline => {
-                            let data_val = data_col.value(i);
-                            let blob_len = data_val.len() as u64;
-                            let position = external_buffers
-                                .add_buffer(LanceBuffer::from(Buffer::from(data_val)));
-
-                            (
-                                BlobKind::Inline as u8,
-                                position,
-                                blob_len,
-                                0,
-                                "".to_string(),
-                            )
+                            // ref_id dedup: only first occurrence appends to
+                            // the out-of-line buffer; later rows reuse (pos, size).
+                            if ref_id > 0 {
+                                if let Some(&(pos, size)) =
+                                    self.ref_dedup_tmp_map.get(&ref_id)
+                                {
+                                    (BlobKind::Inline as u8, pos, size, 0, "".to_string())
+                                } else {
+                                    let data_val = data_col.value(i);
+                                    let blob_len = data_val.len() as u64;
+                                    let position = external_buffers
+                                        .add_buffer(LanceBuffer::from(Buffer::from(data_val)));
+                                    self.ref_dedup_tmp_map
+                                        .insert(ref_id, (position, blob_len));
+                                    (
+                                        BlobKind::Inline as u8,
+                                        position,
+                                        blob_len,
+                                        0,
+                                        "".to_string(),
+                                    )
+                                }
+                            } else {
+                                let data_val = data_col.value(i);
+                                let blob_len = data_val.len() as u64;
+                                let position = external_buffers
+                                    .add_buffer(LanceBuffer::from(Buffer::from(data_val)));
+                                (
+                                    BlobKind::Inline as u8,
+                                    position,
+                                    blob_len,
+                                    0,
+                                    "".to_string(),
+                                )
+                            }
                         }
                     }
                 };
@@ -391,6 +435,7 @@ impl FieldEncoder for BlobV2StructuralEncoder {
             size_builder.append_value(size_value);
             blob_id_builder.append_value(blob_id_value);
             uri_builder.append_value(uri_value);
+            let _ = ref_id; // consumed by Inline dedup above; not persisted.
         }
         let children: Vec<ArrayRef> = vec![
             Arc::new(kind_builder.finish()),

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -213,6 +213,20 @@ pub struct BlobPreprocessor {
     external_blob_mode: ExternalBlobMode,
     source_store_registry: Arc<ObjectStoreRegistry>,
     source_store_params: ObjectStoreParams,
+    // Cache for ref_id sharing on Packed / Dedicated sidecar paths.
+    // Inline dedup lives in the encoder (only it knows buffer positions).
+    ref_id_sidecar_cache: HashMap<u32, SidecarRef>,
+}
+
+/// Cached sidecar reference for ref_id deduplication.
+///
+/// First row with a given ref_id writes the blob to a sidecar (Packed or
+/// Dedicated). Subsequent rows with the same ref_id reuse the cached coordinates
+/// instead of writing again.
+#[derive(Clone, Copy)]
+enum SidecarRef {
+    Dedicated { blob_id: u32, size: u64 },
+    Packed { blob_id: u32, position: u64, size: u64 },
 }
 
 /// A logical slice of an external blob that can be materialized or streamed into Lance-managed
@@ -346,6 +360,7 @@ impl BlobPreprocessor {
             external_base_resolver,
             allow_external_blob_outside_bases,
             external_blob_mode,
+            ref_id_sidecar_cache: HashMap::new(),
             source_store_registry,
             source_store_params,
         }
@@ -486,6 +501,9 @@ impl BlobPreprocessor {
             let size_col = struct_arr
                 .column_by_name("size")
                 .map(|col| col.as_primitive::<UInt64Type>());
+            let ref_id_col = struct_arr
+                .column_by_name("ref_id")
+                .map(|col| col.as_primitive::<arrow_array::types::UInt32Type>());
 
             let mut data_builder = LargeBinaryBuilder::with_capacity(struct_arr.len(), 0);
             let mut uri_builder = StringBuilder::with_capacity(struct_arr.len(), 0);
@@ -496,6 +514,8 @@ impl BlobPreprocessor {
             let mut kind_builder = PrimitiveBuilder::<UInt8Type>::with_capacity(struct_arr.len());
             let mut position_builder =
                 PrimitiveBuilder::<arrow_array::types::UInt64Type>::with_capacity(struct_arr.len());
+            let mut ref_id_builder =
+                PrimitiveBuilder::<arrow_array::types::UInt32Type>::with_capacity(struct_arr.len());
 
             let struct_nulls = struct_arr.nulls();
 
@@ -507,6 +527,7 @@ impl BlobPreprocessor {
                     blob_size_builder.append_null();
                     kind_builder.append_null();
                     position_builder.append_null();
+                    ref_id_builder.append_null();
                     continue;
                 }
 
@@ -521,6 +542,41 @@ impl BlobPreprocessor {
                     .map(|col| !col.is_null(i))
                     .unwrap_or(false);
                 let data_len = if has_data { data_col.value(i).len() } else { 0 };
+                // 0 (or null) means no sharing; non-zero values participate in dedup.
+                let ref_id = ref_id_col
+                    .as_ref()
+                    .filter(|col| !col.is_null(i))
+                    .map(|col| col.value(i))
+                    .unwrap_or(0);
+
+                // Early cache hit: reuse a previously-written sidecar blob.
+                if ref_id > 0 {
+                    if let Some(cached) = self.ref_id_sidecar_cache.get(&ref_id).copied() {
+                        match cached {
+                            SidecarRef::Dedicated { blob_id, size } => {
+                                kind_builder.append_value(BlobKind::Dedicated as u8);
+                                data_builder.append_null();
+                                uri_builder.append_null();
+                                blob_id_builder.append_value(blob_id);
+                                blob_size_builder.append_value(size);
+                                position_builder.append_null();
+                                ref_id_builder.append_value(ref_id);
+                                continue;
+                            }
+                            SidecarRef::Packed { blob_id, position, size } => {
+                                kind_builder.append_value(BlobKind::Packed as u8);
+                                data_builder.append_null();
+                                uri_builder.append_null();
+                                blob_id_builder.append_value(blob_id);
+                                blob_size_builder.append_value(size);
+                                position_builder.append_value(position);
+                                ref_id_builder.append_value(ref_id);
+                                continue;
+                            }
+                        }
+                    }
+                    // Not cached: falls through to normal write path; then cached below.
+                }
 
                 let dedicated_threshold = self.dedicated_thresholds[idx];
                 if has_data && data_len > dedicated_threshold {
@@ -534,6 +590,13 @@ impl BlobPreprocessor {
                     blob_id_builder.append_value(blob_id);
                     blob_size_builder.append_value(data_len as u64);
                     position_builder.append_null();
+                    ref_id_builder.append_value(ref_id);
+                    if ref_id > 0 {
+                        self.ref_id_sidecar_cache.insert(
+                            ref_id,
+                            SidecarRef::Dedicated { blob_id, size: data_len as u64 },
+                        );
+                    }
                     continue;
                 }
 
@@ -548,6 +611,17 @@ impl BlobPreprocessor {
                     blob_id_builder.append_value(pack_blob_id);
                     blob_size_builder.append_value(data_len as u64);
                     position_builder.append_value(position);
+                    ref_id_builder.append_value(ref_id);
+                    if ref_id > 0 {
+                        self.ref_id_sidecar_cache.insert(
+                            ref_id,
+                            SidecarRef::Packed {
+                                blob_id: pack_blob_id,
+                                position,
+                                size: data_len as u64,
+                            },
+                        );
+                    }
                     continue;
                 }
 
@@ -583,6 +657,13 @@ impl BlobPreprocessor {
                             blob_id_builder.append_value(blob_id);
                             blob_size_builder.append_value(data_len);
                             position_builder.append_null();
+                            ref_id_builder.append_value(ref_id);
+                            if ref_id > 0 {
+                                self.ref_id_sidecar_cache.insert(
+                                    ref_id,
+                                    SidecarRef::Dedicated { blob_id, size: data_len },
+                                );
+                            }
                             continue;
                         }
 
@@ -597,6 +678,17 @@ impl BlobPreprocessor {
                             blob_id_builder.append_value(pack_blob_id);
                             blob_size_builder.append_value(data_len);
                             position_builder.append_value(position);
+                            ref_id_builder.append_value(ref_id);
+                            if ref_id > 0 {
+                                self.ref_id_sidecar_cache.insert(
+                                    ref_id,
+                                    SidecarRef::Packed {
+                                        blob_id: pack_blob_id,
+                                        position,
+                                        size: data_len,
+                                    },
+                                );
+                            }
                             continue;
                         }
 
@@ -608,6 +700,7 @@ impl BlobPreprocessor {
                         blob_id_builder.append_null();
                         blob_size_builder.append_null();
                         position_builder.append_null();
+                        ref_id_builder.append_value(ref_id);
                         continue;
                     }
 
@@ -629,6 +722,7 @@ impl BlobPreprocessor {
                         blob_size_builder.append_null();
                         position_builder.append_null();
                     }
+                    ref_id_builder.append_value(ref_id);
                     continue;
                 }
 
@@ -640,6 +734,7 @@ impl BlobPreprocessor {
                     blob_id_builder.append_null();
                     blob_size_builder.append_null();
                     position_builder.append_null();
+                    ref_id_builder.append_value(ref_id);
                 } else {
                     data_builder.append_null();
                     uri_builder.append_null();
@@ -647,6 +742,7 @@ impl BlobPreprocessor {
                     blob_size_builder.append_null();
                     kind_builder.append_null();
                     position_builder.append_null();
+                    ref_id_builder.append_null();
                 }
             }
 
@@ -657,6 +753,7 @@ impl BlobPreprocessor {
                 arrow_schema::Field::new("blob_id", ArrowDataType::UInt32, true),
                 arrow_schema::Field::new("blob_size", ArrowDataType::UInt64, true),
                 arrow_schema::Field::new("position", ArrowDataType::UInt64, true),
+                arrow_schema::Field::new("ref_id", ArrowDataType::UInt32, true),
             ];
 
             let struct_array = arrow_array::StructArray::try_new(
@@ -668,6 +765,7 @@ impl BlobPreprocessor {
                     Arc::new(blob_id_builder.finish()),
                     Arc::new(blob_size_builder.finish()),
                     Arc::new(position_builder.finish()),
+                    Arc::new(ref_id_builder.finish()),
                 ],
                 struct_nulls.cloned(),
             )?;
@@ -1769,6 +1867,8 @@ fn blob_version_from_descriptions(descriptions: &StructArray) -> Result<BlobVers
     if fields.len() == 2 && fields[0].name() == "position" && fields[1].name() == "size" {
         return Ok(BlobVersion::V1);
     }
+    // Plan A: on-disk V2 descriptor is always 5 fields. ref_id (if present)
+    // is an input-only hint consumed by the preprocessor / encoder.
     if fields.len() == 5
         && fields[0].name() == "kind"
         && fields[1].name() == "position"


### PR DESCRIPTION
# feat(blob_v2): add ref_id deduplication across Inline / Packed / Dedicated

**Zero on-disk format change.** `ref_id` is a write-time input hint only —
consumed by the preprocessor and encoder, then dropped before any byte touches
disk. On-disk Blob v2 descriptor remains exactly the 5 fields it has today.
---

## Motivation

Blob v2 today assumes **1 row = 1 blob**. Every row owns its own bytes. There
is no API, no descriptor field, no internal cache to say "these rows reuse
that row's blob."

But real multimodal / time-series workloads routinely align rows at different
logical frequencies into a single table, where **many rows reference the same
underlying object**:

| Low-frequency (shared) | High-frequency (per-row) |
|---|---|
| Reference image / keyframe / video GOP / packaged archive (tar, zip) | per-frame label, bbox, annotation |
| LiDAR scan | per-object detection |
| Video embedding | caption / QA pair |
| RL observation | action / reward |

Without format-level dedup, the current options are all bad:

| Approach | Storage | Query | Programming model |
|---|---|---|---|
| Upsample (repeat low-freq to match high-freq) | **10–1000× waste** | fast | simple |
| Downsample | compact | fast | loses data |
| Two tables + JOIN | compact | slow (runtime reassembly) | breaks columnar scans |
| Nested list column | compact | medium | awkward indexing |
| **Shared blob (this PR)** | **compact** | **fast** | **every row stays whole** |

### Concrete impact

**Today** — 20 rows carrying the same 6 MB payload produce 20 independent
sidecar files totaling 120 MB. The 120 MB is purely duplicate bytes.

**With this PR** — the same 20 rows produce 1 sidecar file of 6 MB. The 20
rows' descriptors all share one `blob_id`; read-back returns byte-identical
payloads per row.

Verified savings (`python/test_ref_id_dedup.py`, 20 rows, single `ref_id`):

```
inline_32kb   (payload 32 KB,   20 rows):  1.05× amplification  [✓ DEDUP]
packed_1mb    (payload 1 MB,    20 rows):  1.00× amplification  [✓ DEDUP, 1 sidecar]
dedicated_6mb (payload 6 MB,    20 rows):  1.00× amplification  [✓ DEDUP, 1 sidecar]
```

For real training workloads where 8 labels reference 1 GOP (video column),
expected savings on the video column are **~8×**, which typically dominates
dataset size.

---

## User-facing API

The only user-visible change is one new optional field on `Blob`:

```python
from lance.blob import Blob, blob_array, blob_field
import lance, numpy as np, pyarrow as pa

shared_bytes = np.random.default_rng(42).integers(
    0, 256, size=(1450, 1450, 3), dtype=np.uint8
).tobytes()                                     # ~6 MB

# Every row carries ref_id=42 -> Lance dedups on write.
blobs = blob_array([Blob(data=shared_bytes, ref_id=42) for _ in range(20)])

batch = pa.RecordBatch.from_arrays(
    [pa.array(range(20), type=pa.int64()), blobs],
    schema=pa.schema([pa.field("row_idx", pa.int64()), blob_field("payload")]),
)

lance.write_dataset(batch, "ds.lance", mode="create", data_storage_version="2.2")
```

`ref_id = None` or `0` (the default) means "no sharing" — identical to pre-PR
behavior. Existing code without `ref_id` is unaffected.

On disk, the 20 rows share a single sidecar file:

```
ds.lance/
└── data/
    ├── <stem>.lance                    # 20 rows × descriptors, all same blob_id
    └── <stem>/
        └── blob_1.blob                 # 6 MB, single physical copy
    total sidecar storage: 6 MB         # 20× reduction vs. today's 120 MB
```

Read-back is invisible to readers — every row sees the full 6 MB payload;
only the disk layout differs.

---

## Design: where dedup happens

The PR hooks into **two** existing layers; it does not add a new pipeline
stage. Each hook consults one in-memory cache keyed by `ref_id`, then updates
it. The cache lives for exactly one fragment's write and is dropped at
finalization.

```mermaid
flowchart TD
    P["<b>Python</b><br/>20 × Blob(data=bytes, ref_id=42)<br/>lance.write_dataset(batch, ...)"]
    P -->|PyO3| R

    R["<b>Rust orchestration</b><br/>Dataset::write → InsertBuilder::execute_stream<br/>→ write_fragments_internal <i>(gate: version ≥ 2.2)</i><br/>→ do_write_fragments"]
    R --> V

    V["V2WriterAdapter::write<br/><i>one BlobPreprocessor per fragment</i>"]
    V --> H1

    H1(["<b>Hook 1 · BlobPreprocessor::preprocess_batch</b><br/>5-field Struct ──▶ 7-field Struct<br/>Packed / Dedicated dedup<br/><i>via ref_id_sidecar_cache</i>"])
    H1 --> F

    F["FileWriter::write_batch<br/>encode_batch — per-column dispatch"]
    F --> H2

    H2(["<b>Hook 2 · BlobV2StructuralEncoder::maybe_encode</b><br/>7-field Struct ──▶ 5-field descriptor<br/>Inline dedup<br/><i>via ref_dedup_tmp_map</i>"])
    H2 --> D

    D[("<b>On disk</b><br/>kind · position · size · blob_id · blob_uri<br/><i>ref_id not persisted</i>")]

    classDef hook fill:#fff3e0,stroke:#e65100,stroke-width:2.5px,color:#3e2723
    classDef normal fill:#fafafa,stroke:#9e9e9e,color:#212121
    classDef disk fill:#e0f2f1,stroke:#00695c,stroke-width:2px,color:#004d40

    class H1,H2 hook
    class P,R,V,F normal
    class D disk
```

The two amber pill nodes are the only new decision points. `ref_id` enters
the pipeline with the user's input StructArray, flows through the in-memory
7-field intermediate struct between preprocessor and encoder, and exits at
Hook 2 when the 5-field descriptor is constructed for disk.

### Where the dedup decision happens

**Hook 1 — `BlobPreprocessor::preprocess_batch`** (`rust/lance/src/dataset/blob.rs`)

Owns a per-fragment cache covering the two preprocessor-written paths:

```rust
pub struct BlobPreprocessor {
    object_store: ObjectStore,
    local_counter: u32,                                // allocates blob_id
    pack_writer: PackWriter,                           // Packed rolling sidecar
    ...
    ref_id_sidecar_cache: HashMap<u32, SidecarRef>,    // <-- new in this PR
}

#[derive(Clone, Copy)]
enum SidecarRef {
    Dedicated { blob_id: u32, size: u64 },
    Packed    { blob_id: u32, position: u64, size: u64 },
}
```

Row-level loop consults the cache *before* routing by size:

```rust
let ref_id = ref_id_col.as_ref()
    .filter(|c| !c.is_null(i)).map(|c| c.value(i)).unwrap_or(0);

if ref_id > 0 {
    if let Some(cached) = self.ref_id_sidecar_cache.get(&ref_id).copied() {
        match cached {
            SidecarRef::Dedicated { blob_id, size } => {
                kind_builder.append_value(BlobKind::Dedicated as u8);
                blob_id_builder.append_value(blob_id);
                blob_size_builder.append_value(size);
                continue;                              // reuse; no write_dedicated
            }
            SidecarRef::Packed { blob_id, position, size } => { /* analogous */ }
        }
    }
}

// miss: normal write path + cache.insert
let blob_id = self.next_blob_id();
self.write_dedicated(blob_id, BlobWriteSource::Bytes(bytes)).await?;
if ref_id > 0 {
    self.ref_id_sidecar_cache.insert(
        ref_id, SidecarRef::Dedicated { blob_id, size: data_len as u64 },
    );
}
```

For the example (20 rows, ref_id=42, 6 MB each): row 0 misses and writes one
Dedicated sidecar file; rows 1..19 hit and reuse the cached `(blob_id, size)`
without any additional I/O.

**Hook 2 — `BlobV2StructuralEncoder::maybe_encode`** (`rust/lance-encoding/src/encodings/logical/blob.rs`)

Owns a symmetric cache for Inline, because only the encoder knows the
out-of-line buffer offset:

```rust
pub struct BlobV2StructuralEncoder {
    descriptor_encoder: Box<dyn FieldEncoder>,
    ref_dedup_tmp_map: HashMap<u32, (u64, u64)>,   // ref_id -> (position, size)
}

BlobKind::Inline => {
    if ref_id > 0 {
        if let Some(&(pos, sz)) = self.ref_dedup_tmp_map.get(&ref_id) {
            (pos, sz)                                   // reuse, no add_buffer
        } else {
            let pos = external_buffers.add_buffer(bytes);
            self.ref_dedup_tmp_map.insert(ref_id, (pos, bytes.len() as u64));
            (pos, bytes.len() as u64)
        }
    } else { /* unconditional add_buffer */ }
}
```

The two caches partition the problem cleanly:

| Cache | Owner | Covers |
|---|---|---|
| `ref_id_sidecar_cache` | `BlobPreprocessor` | Packed + Dedicated (sidecar files) |
| `ref_dedup_tmp_map` | `BlobV2StructuralEncoder` | Inline (main-file out-of-line buffer) |

### What lands on disk

`BLOB_V2_DESC_FIELDS` is **unchanged** from upstream:

```rust
pub static BLOB_V2_DESC_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
    Fields::from(vec![
        ArrowField::new("kind", DataType::UInt8, false),
        ArrowField::new("position", DataType::UInt64, false),
        ArrowField::new("size", DataType::UInt64, false),
        ArrowField::new("blob_id", DataType::UInt32, false),
        ArrowField::new("blob_uri", DataType::Utf8, false),
    ])
});
```

The encoder constructs the descriptor StructArray with exactly 5 children;
`ref_id` is read in Hook 2 for cache lookup but intentionally not appended
to the children vector.

Verified via `LanceFileReader.metadata().schema` on a dataset written by this
PR:
```
kind:     uint8 not null
position: uint64 not null
size:     uint64 not null
blob_id:  uint32 not null
blob_uri: string not null
```
Byte-identical structure to any dataset written by upstream.

---

## Non-intrusiveness

### Readers: zero change required

Old readers see 20 rows with the same `blob_id` in the same 5-field
descriptor. Each row independently resolves `blob_id=1` to the same sidecar
file — 20 reads, 20 correct byte payloads. No coordination needed. **No
schema version bump.**

### Compaction / GC: unaffected

- **GC** (#5473 data-file-bound GC): sidecars are collected when their owning
  data file is gone. Shared rows all live in one data file, so deleting any
  subset leaves the fragment alive; deleting the whole fragment triggers the
  blob's GC. No changes.
- **Compaction** operates on descriptors. Rewriting 20 rows sharing `blob_id=1`
  will either preserve the sharing (if the compactor treats equal `blob_id`
  as a single blob) or produce 20 independent blob_ids (regressing to
  upstream behavior). Correctness is preserved either way; only storage
  efficiency may regress. No compactor change needed for this PR.

### Old files work unchanged

The schema validator in `blob_version_from_descriptions` accepts the 5-field
V2 descriptor exactly as upstream — this PR doesn't widen or narrow that
check. Files written by any prior Lance version continue to work.

---

## Implementation footprint

```
 python/python/lance/blob.py                       |  14 +/-  5
 python/test_ref_id_dedup.py                       |  97 +  0    (new)
 rust/lance-encoding/src/decoder.rs                |  17 +/-  1
 rust/lance-encoding/src/encodings/logical/blob.rs |  60 +/-  9
 rust/lance/src/dataset/blob.rs                    |  97 +/-  3
 5 files changed, 285 insertions(+), 17 deletions(-)
```

Production code (excluding the 97-line test script): **~188 lines added**.
All changes are additive: two `HashMap` fields, one `SidecarRef` enum, two
cache lookup/insert call sites, and the Python `Blob.ref_id` plumbing.

---

## Testing

```bash
cd python
python test_ref_id_dedup.py
```

Expected output — all three size classes dedup, read-back is byte-identical:

```
=== inline_32kb (payload=32,768B, ref_id=101, rows=20) ===
  amplification:   1.05x   [✓ DEDUP]
  read-back OK:    True (1 unique contents out of 20 rows)

=== packed_1mb (payload=1,048,576B, ref_id=102, rows=20) ===
  amplification:   1.00x   [✓ DEDUP]
  read-back OK:    True (1 unique contents out of 20 rows)

=== dedicated_6mb (payload=6,291,456B, ref_id=103, rows=20) ===
  amplification:   1.00x   [✓ DEDUP]
  read-back OK:    True (1 unique contents out of 20 rows)
```

---

## Explicitly not in scope

- **Content-hash auto-dedup.** Users explicitly pick when to share.
- **Cross-write sharing.** Caches live for one `write_dataset` invocation /
  one fragment. Cross-fragment / cross-write sharing is natural future work.
- **Post-write observability.** `SELECT ref_id, COUNT(*) GROUP BY ref_id` is
  not possible because `ref_id` is not persisted. The discussion thread
  includes "Option B" (persist `ref_id` in the descriptor) as a candidate
  for users who need this.
- **Read-side fetch coalescing by `ref_id`.** Lance's `FileScheduler` already
  merges adjacent reads to the same file, so the penalty is modest. Explicit
  ref_id-aware read caching can be layered on separately.

---

## Built on

- #4948 Blob v2 schema (5-field descriptor — unchanged by this PR)
- #5406 Dedicated blobs (sidecar write path reused)
- #5413 Packed blobs (`PackWriter` reused)
- #5473 Blob v2 GC (no new GC machinery needed; sharing stays within a
  single data file, so data-file-bound GC remains correct)
