### PR TITLE
fix: pin lance-namespace to <0.7 in pylance

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pylance"
 dynamic = ["version"]
-dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.5.2"]
+dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.5.2,<0.7"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lance.org" }]
 license = { file = "LICENSE" }

--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -106,6 +106,11 @@ class VenvExecutor:
                 "--extra-index-url",
                 "https://pypi.fury.io/lancedb/",
                 f"pylance=={self.version}",
+                # Released Lance wheels (e.g. 2.0.1, 4.0.0b1) import
+                # CreateEmptyTableRequest from lance_namespace, which was
+                # removed in lance-namespace 0.7.0. Pin to <0.7 so old wheels
+                # resolve a compatible transitive dep.
+                "lance-namespace<0.7",
                 "pytest",
             ],
             check=True,


### PR DESCRIPTION
Backport of the following PRs:
- https://github.com/lance-format/lance/pull/6597

This PR backports the changes from the original PRs to the release/v4.0 branch.
