### PR TITLE
fix: pin lance-namespace<0.7 in pylance dependencies

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pylance"
 dynamic = ["version"]
-dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.6.1"]
+dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.6.1,<0.7"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lance.org" }]
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Add upper bound `<0.7` to `lance-namespace` dependency in `python/pyproject.toml` to prevent released pylance wheels from breaking when `lance-namespace>=0.7` is installed

## Root cause

`lance-namespace 0.7.0` removed `CreateEmptyTableRequest` / `CreateEmptyTableResponse` symbols. Released pylance wheels (e.g. `2.0.1`, `4.0.0b1`) still import these symbols in `lance/namespace.py`, causing `ImportError` when users `pip install` an old pylance version and pip resolves `lance-namespace>=0.7`.

PR #6597 fixed this for CI compat tests by pinning in `venv_manager.py`, but real users installing from PyPI are still affected.

Ref: https://github.com/lance-format/lance/pull/6597#issuecomment-4306020639

## Test plan

- [x] Existing CI jobs remain green
- [x] Users installing older pylance wheels resolve `lance-namespace<0.7` and avoid ImportError