### PR TITLE
feat: support segmented btree indices

### DIFF
--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1216,7 +1216,21 @@ impl BTreeIndex {
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
         index_cache: &LanceCache,
     ) -> Result<Arc<Self>> {
-        let page_lookup_file = store.open_index_file(BTREE_LOOKUP_NAME).await?;
+        let (page_lookup_file, standalone_partition_page_file) =
+            match store.open_index_file(BTREE_LOOKUP_NAME).await {
+                Ok(page_lookup_file) => (page_lookup_file, None),
+                Err(original_err) => {
+                    let files = store.list_files_with_sizes().await?;
+                    let Some((lookup_file, page_file)) = find_single_partition_files(&files)?
+                    else {
+                        return Err(original_err);
+                    };
+                    (
+                        store.open_index_file(lookup_file).await?,
+                        Some(page_file.to_string()),
+                    )
+                }
+            };
         let num_rows_in_lookup = page_lookup_file.num_rows();
         let serialized_lookup = page_lookup_file
             .read_range(0..num_rows_in_lookup, None)
@@ -1236,7 +1250,17 @@ impl BTreeIndex {
         // For range-partitioned indices, construct the `ranges_to_files` map.
         // This converts the list of (partition ID, page count) from metadata into a map
         // from a global page range to its corresponding file and starting offset.
-        let ranges_to_files = if range_partitioned {
+        let ranges_to_files = if let Some(page_file_name) = standalone_partition_page_file {
+            let page_numbers = serialized_lookup
+                .column(3)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap();
+            let max_page_number = page_numbers.values().iter().copied().max().unwrap_or(0);
+            let mut range_map = RangeInclusiveMap::new();
+            range_map.insert(0..=max_page_number, (page_file_name, 0));
+            Some(Arc::new(range_map))
+        } else if range_partitioned {
             let part_sizes_str = file_schema
             .metadata
             .get(PAGE_NUM_PER_RANGE_PARTITION_META_KEY)
@@ -1986,6 +2010,37 @@ async fn list_page_lookup_files(
     }
 
     Ok((part_page_files, part_lookup_files))
+}
+
+fn find_single_partition_files(
+    files: &[lance_table::format::IndexFile],
+) -> Result<Option<(&str, &str)>> {
+    let lookup_files = files
+        .iter()
+        .filter_map(|file| {
+            (file.path.starts_with("part_") && file.path.ends_with("_page_lookup.lance"))
+                .then_some(file.path.as_str())
+        })
+        .collect::<Vec<_>>();
+    let page_files = files
+        .iter()
+        .filter_map(|file| {
+            (file.path.starts_with("part_") && file.path.ends_with("_page_data.lance"))
+                .then_some(file.path.as_str())
+        })
+        .collect::<Vec<_>>();
+
+    if lookup_files.len() != 1 || page_files.len() != 1 {
+        return Ok(None);
+    }
+
+    let lookup_partition_id = extract_partition_id(lookup_files[0])?;
+    let page_partition_id = extract_partition_id(page_files[0])?;
+    if lookup_partition_id != page_partition_id {
+        return Ok(None);
+    }
+
+    Ok(Some((lookup_files[0], page_files[0])))
 }
 
 /// Merge multiple partition page / lookup files into a complete metadata file

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -60,7 +60,7 @@ use lance_datafusion::{
 };
 use lance_io::object_store::ObjectStore;
 use log::{debug, warn};
-use object_store::path::Path;
+use object_store::{Error as ObjectStoreError, path::Path};
 use rangemap::RangeInclusiveMap;
 use roaring::RoaringBitmap;
 use serde::{Deserialize, Serialize, Serializer};
@@ -1219,7 +1219,7 @@ impl BTreeIndex {
         let (page_lookup_file, standalone_partition_page_file) =
             match store.open_index_file(BTREE_LOOKUP_NAME).await {
                 Ok(page_lookup_file) => (page_lookup_file, None),
-                Err(original_err) => {
+                Err(original_err) if is_missing_lookup_error(&original_err) => {
                     let files = store.list_files_with_sizes().await?;
                     let Some((lookup_file, page_file)) = find_single_partition_files(&files)?
                     else {
@@ -1230,6 +1230,7 @@ impl BTreeIndex {
                         Some(page_file.to_string()),
                     )
                 }
+                Err(other_err) => return Err(other_err),
             };
         let num_rows_in_lookup = page_lookup_file.num_rows();
         let serialized_lookup = page_lookup_file
@@ -2041,6 +2042,18 @@ fn find_single_partition_files(
     }
 
     Ok(Some((lookup_files[0], page_files[0])))
+}
+
+fn is_missing_lookup_error(err: &Error) -> bool {
+    matches!(err, Error::NotFound { .. })
+        || matches!(
+            err,
+            Error::IO { source, .. }
+                if source
+                    .downcast_ref::<ObjectStoreError>()
+                    .map(|os_err| matches!(os_err, ObjectStoreError::NotFound { .. }))
+                    .unwrap_or(false)
+        )
 }
 
 /// Merge multiple partition page / lookup files into a complete metadata file

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -8299,6 +8299,119 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
     }
 
     #[tokio::test]
+    async fn test_like_prefix_with_segmented_btree() {
+        let data = gen_batch()
+            .col(
+                "name",
+                array::cycle_utf8_literals(&[
+                    "apple",
+                    "application",
+                    "app",
+                    "banana",
+                    "band",
+                    "testns1",
+                    "testns2",
+                    "test",
+                    "testing",
+                    "zoo",
+                ]),
+            )
+            .col("id", array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(150), BatchCount::from(6));
+
+        let write_params = WriteParams {
+            max_rows_per_file: 25,
+            max_rows_per_group: 10,
+            ..Default::default()
+        };
+
+        let mut dataset = Dataset::write(
+            data,
+            "memory://test_like_segmented_btree",
+            Some(write_params),
+        )
+        .await
+        .unwrap();
+
+        let fragments = dataset.get_fragments();
+        assert!(fragments.len() > 1, "expected multiple fragments");
+
+        let params = ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::BTree);
+        let mut segments = Vec::with_capacity(fragments.len());
+        for fragment in &fragments {
+            let mut builder = dataset.create_index_builder(&["name"], IndexType::BTree, &params);
+            builder = builder
+                .name("name_btree".to_string())
+                .fragments(vec![fragment.id() as u32]);
+            segments.push(builder.execute_uncommitted().await.unwrap());
+        }
+
+        dataset
+            .commit_existing_index_segments("name_btree", "name", segments)
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("name_btree").await.unwrap();
+        assert_eq!(committed.len(), fragments.len());
+
+        let mut scanner = dataset.scan();
+        scanner.filter("name LIKE 'app%'").unwrap();
+        let plan = scanner.create_plan().await.unwrap();
+        let plan_str = format!("{:?}", plan);
+        assert!(
+            plan_str.contains("ScalarIndexExec") && plan_str.contains("LikePrefix(Utf8(\"app\"))"),
+            "segmented btree should use scalar index pruning, but got: {}",
+            plan_str
+        );
+
+        let with_index = dataset
+            .scan()
+            .filter("name LIKE 'app%'")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let without_index = dataset
+            .scan()
+            .use_scalar_index(false)
+            .filter("name LIKE 'app%'")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+
+        let with_index_ids = with_index
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<Int32Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let without_index_ids = without_index
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<Int32Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        assert_eq!(with_index_ids, without_index_ids);
+        assert!(!with_index_ids.is_empty());
+
+        let names = with_index
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .iter()
+            .map(|value| value.unwrap())
+            .collect::<Vec<_>>();
+        assert!(names.iter().all(|name| name.starts_with("app")));
+    }
+
+    #[tokio::test]
     async fn test_like_prefix_correctness_with_zone_map() {
         use lance_index::scalar::BuiltinIndexType;
 

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -313,11 +313,13 @@ pub async fn open_named_scalar_index(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::ops::Bound;
 
     use arrow::datatypes::Int32Type;
     use datafusion::scalar::ScalarValue;
     use lance_core::utils::address::RowAddress;
+    use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::array;
     use lance_index::IndexType;
     use lance_index::metrics::NoOpMetricsCollector;
@@ -373,6 +375,127 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(combined_bitmap, dataset.fragment_bitmap.as_ref().clone());
+    }
+
+    #[tokio::test]
+    async fn test_open_named_scalar_index_uses_all_btree_segments() {
+        let test_dir = TempStrDir::default();
+        let dataset = lance_datagen::gen_batch()
+            .col("value", array::step::<Int32Type>())
+            .into_dataset(
+                test_dir.as_str(),
+                FragmentCount::from(4),
+                FragmentRowCount::from(16),
+            )
+            .await
+            .unwrap();
+        let mut dataset = dataset;
+        let fragments = dataset.get_fragments();
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::BTree);
+        let mut segments = Vec::new();
+
+        for fragment in &fragments {
+            let segment =
+                CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::BTree, &params)
+                    .name("value_btree".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap();
+            segments.push(segment);
+        }
+
+        dataset
+            .commit_existing_index_segments("value_btree", "value", segments)
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("value_btree").await.unwrap();
+        assert_eq!(committed.len(), fragments.len());
+
+        let logical =
+            open_named_scalar_index(&dataset, "value", "value_btree", &NoOpMetricsCollector)
+                .await
+                .unwrap();
+        assert_eq!(logical.index_type(), IndexType::BTree);
+        assert_eq!(
+            logical.calculate_included_frags().await.unwrap(),
+            dataset.fragment_bitmap.as_ref().clone()
+        );
+
+        let combined_bitmap = scalar_index_fragment_bitmap(&dataset, "value", "value_btree")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(combined_bitmap, dataset.fragment_bitmap.as_ref().clone());
+    }
+
+    #[tokio::test]
+    async fn test_btree_segment_search_is_exact_across_fragments() {
+        let test_dir = TempStrDir::default();
+        let dataset = lance_datagen::gen_batch()
+            .col("value", array::step::<Int32Type>())
+            .into_dataset(
+                test_dir.as_str(),
+                FragmentCount::from(4),
+                FragmentRowCount::from(16),
+            )
+            .await
+            .unwrap();
+        let mut dataset = dataset;
+        let fragments = dataset.get_fragments();
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::BTree);
+        let mut segments = Vec::new();
+
+        for fragment in &fragments {
+            segments.push(
+                CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::BTree, &params)
+                    .name("value_btree_search".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        dataset
+            .commit_existing_index_segments("value_btree_search", "value", segments)
+            .await
+            .unwrap();
+
+        let logical = open_named_scalar_index(
+            &dataset,
+            "value",
+            "value_btree_search",
+            &NoOpMetricsCollector,
+        )
+        .await
+        .unwrap();
+
+        let query = SargableQuery::Range(
+            Bound::Included(ScalarValue::Int32(Some(20))),
+            Bound::Included(ScalarValue::Int32(Some(43))),
+        );
+        let result = logical.search(&query, &NoOpMetricsCollector).await.unwrap();
+        let row_addrs = match result {
+            SearchResult::Exact(row_addrs) => row_addrs,
+            other => panic!(
+                "expected exact result from segmented btree, got {:?}",
+                other
+            ),
+        };
+
+        let searched_fragments = row_addrs
+            .true_rows()
+            .row_addrs()
+            .unwrap()
+            .map(|row_addr| RowAddress::from(u64::from(row_addr)).fragment_id())
+            .collect::<Vec<_>>();
+        assert_eq!(searched_fragments.len(), 24);
+        assert_eq!(
+            searched_fragments.into_iter().collect::<BTreeSet<_>>(),
+            BTreeSet::from([1, 2])
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Add segmented BTREE support on top of the logical scalar index segment path that landed for zonemap.

This teaches BTREE loading to open committed standalone `part_*` segment artifacts when a merged `page_lookup.lance` is not present, and adds coverage that logical BTREE segments load together, return exact results across fragments, and drive scanner prefix pruning.

## Testing
- cargo test -p lance test_open_named_scalar_index_uses_all_btree_segments -- --nocapture
- cargo test -p lance test_btree_segment_search_is_exact_across_fragments -- --nocapture
- cargo test -p lance test_like_prefix_with_segmented_btree -- --nocapture