### PR TITLE
feat: update lance-namespace to 0.7.2 and align namespace declared table lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d23901a0d1fa4fea67c08798abf4070b406be4af5ab667f2b6eeab7fa1469b8"
+checksum = "970af68f932a4650f753feb9eed6b20e3f49f23337c6dc4541ba1fde3ec55874"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2e48de899e2931afb67fcddd0a08e439bf5d8b6ea2a2ed9cb8f4df669bd5cc"
+checksum = "8d23901a0d1fa4fea67c08798abf4070b406be4af5ab667f2b6eeab7fa1469b8"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970af68f932a4650f753feb9eed6b20e3f49f23337c6dc4541ba1fde3ec55874"
+checksum = "0f061dd6fe63e3ba4052702a9d40973ee4ac57f612f04222897a149576213832"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ lance-linalg = { version = "=6.0.0-beta.3", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=6.0.0-beta.3", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=6.0.0-beta.3", path = "./rust/lance-namespace-impls" }
 lance-namespace-datafusion = { version = "=6.0.0-beta.3", path = "./rust/lance-namespace-datafusion" }
-lance-namespace-reqwest-client = "0.6.1"
+lance-namespace-reqwest-client = "0.7.1"
 lance-tokenizer = { version = "=6.0.0-beta.3", path = "./rust/lance-tokenizer" }
 lance-table = { version = "=6.0.0-beta.3", path = "./rust/lance-table" }
 lance-test-macros = { version = "=6.0.0-beta.3", path = "./rust/lance-test-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ lance-linalg = { version = "=6.0.0-beta.3", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=6.0.0-beta.3", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=6.0.0-beta.3", path = "./rust/lance-namespace-impls" }
 lance-namespace-datafusion = { version = "=6.0.0-beta.3", path = "./rust/lance-namespace-datafusion" }
-lance-namespace-reqwest-client = "0.7.1"
+lance-namespace-reqwest-client = "0.7.2"
 lance-tokenizer = { version = "=6.0.0-beta.3", path = "./rust/lance-tokenizer" }
 lance-table = { version = "=6.0.0-beta.3", path = "./rust/lance-table" }
 lance-test-macros = { version = "=6.0.0-beta.3", path = "./rust/lance-test-macros" }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3770,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d23901a0d1fa4fea67c08798abf4070b406be4af5ab667f2b6eeab7fa1469b8"
+checksum = "970af68f932a4650f753feb9eed6b20e3f49f23337c6dc4541ba1fde3ec55874"
 dependencies = [
  "reqwest",
  "serde",

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3770,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970af68f932a4650f753feb9eed6b20e3f49f23337c6dc4541ba1fde3ec55874"
+checksum = "0f061dd6fe63e3ba4052702a9d40973ee4ac57f612f04222897a149576213832"
 dependencies = [
  "reqwest",
  "serde",

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3770,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2e48de899e2931afb67fcddd0a08e439bf5d8b6ea2a2ed9cb8f4df669bd5cc"
+checksum = "8d23901a0d1fa4fea67c08798abf4070b406be4af5ab667f2b6eeab7fa1469b8"
 dependencies = [
  "reqwest",
  "serde",

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.0</version>
+            <version>0.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.lance</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -109,12 +109,12 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.6.1</version>
+            <version>0.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.6.1</version>
+            <version>0.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -109,12 +109,12 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.1</version>
+            <version>0.7.2</version>
         </dependency>
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.0</version>
+            <version>0.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/java/src/test/java/org/lance/namespace/CustomNamespace.java
+++ b/java/src/test/java/org/lance/namespace/CustomNamespace.java
@@ -29,8 +29,6 @@ import org.lance.namespace.model.BatchCreateTableVersionsResponse;
 import org.lance.namespace.model.BatchDeleteTableVersionsRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsResponse;
 import org.lance.namespace.model.CountTableRowsRequest;
-import org.lance.namespace.model.CreateEmptyTableRequest;
-import org.lance.namespace.model.CreateEmptyTableResponse;
 import org.lance.namespace.model.CreateNamespaceRequest;
 import org.lance.namespace.model.CreateNamespaceResponse;
 import org.lance.namespace.model.CreateTableIndexRequest;
@@ -227,12 +225,6 @@ public class CustomNamespace implements LanceNamespace, Closeable {
   @Override
   public DeclareTableResponse declareTable(DeclareTableRequest request) {
     return inner.declareTable(request);
-  }
-
-  @Override
-  @SuppressWarnings("deprecation")
-  public CreateEmptyTableResponse createEmptyTable(CreateEmptyTableRequest request) {
-    return inner.createEmptyTable(request);
   }
 
   @Override

--- a/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
+++ b/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
@@ -1275,6 +1275,18 @@ public class DirectoryNamespaceTest {
     DeclareTableResponse declareResp = namespaceClient.declareTable(declareReq);
     assertNotNull(declareResp);
     assertNotNull(declareResp.getLocation());
+
+    DescribeTableRequest descReq =
+        new DescribeTableRequest().id(Arrays.asList("workspace", "declared_table"));
+    DescribeTableResponse descResp = namespaceClient.describeTable(descReq);
+    assertNull(descResp.getIsOnlyDeclared());
+
+    DescribeTableRequest checkReq =
+        new DescribeTableRequest()
+            .id(Arrays.asList("workspace", "declared_table"))
+            .checkDeclared(true);
+    DescribeTableResponse checkResp = namespaceClient.describeTable(checkReq);
+    assertEquals(Boolean.TRUE, checkResp.getIsOnlyDeclared());
   }
 
   @Test

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4155,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2e48de899e2931afb67fcddd0a08e439bf5d8b6ea2a2ed9cb8f4df669bd5cc"
+checksum = "8d23901a0d1fa4fea67c08798abf4070b406be4af5ab667f2b6eeab7fa1469b8"
 dependencies = [
  "reqwest",
  "serde",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4155,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d23901a0d1fa4fea67c08798abf4070b406be4af5ab667f2b6eeab7fa1469b8"
+checksum = "970af68f932a4650f753feb9eed6b20e3f49f23337c6dc4541ba1fde3ec55874"
 dependencies = [
  "reqwest",
  "serde",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4155,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970af68f932a4650f753feb9eed6b20e3f49f23337c6dc4541ba1fde3ec55874"
+checksum = "0f061dd6fe63e3ba4052702a9d40973ee4ac57f612f04222897a149576213832"
 dependencies = [
  "reqwest",
  "serde",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pylance"
 dynamic = ["version"]
-dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.7.0"]
+dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.7.1,<8.0"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lance.org" }]
 license = { file = "LICENSE" }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pylance"
 dynamic = ["version"]
-dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.7.1,<8.0"]
+dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.7.2,<8.0"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lance.org" }]
 license = { file = "LICENSE" }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pylance"
 dynamic = ["version"]
-dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.6.1"]
+dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.7.0"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lance.org" }]
 license = { file = "LICENSE" }

--- a/python/python/tests/test_namespace_dir.py
+++ b/python/python/tests/test_namespace_dir.py
@@ -626,6 +626,16 @@ class TestChildNamespaceOperations:
         exists_req = TableExistsRequest(id=["test_ns", "declared_table"])
         memory_ns_client.table_exists(exists_req)
 
+        describe_req = DescribeTableRequest(id=["test_ns", "declared_table"])
+        describe_resp = memory_ns_client.describe_table(describe_req)
+        assert describe_resp.is_only_declared is None
+
+        describe_req = DescribeTableRequest(
+            id=["test_ns", "declared_table"], check_declared=True
+        )
+        describe_resp = memory_ns_client.describe_table(describe_req)
+        assert describe_resp.is_only_declared is True
+
 
 class TestDeeplyNestedNamespaces:
     """Tests for deeply nested namespace hierarchies.
@@ -871,10 +881,6 @@ def _get_ops_metric(ns_client, metric_name: str) -> int:
     return metrics.get(metric_name, 0)
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="External manifest store has known issues on Windows",
-)
 @pytest.mark.parametrize("use_custom", [False, True], ids=["DirectoryNS", "CustomNS"])
 def test_external_manifest_store_invokes_namespace_apis(use_custom):
     """Test that namespace APIs are invoked correctly for managed versioning.
@@ -1336,10 +1342,6 @@ class TestDataManipulation:
         assert result_table.num_rows == 2  # Alice and Charlie
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Table version listing not supported on Windows",
-)
 class TestTableVersions:
     """Tests for table version operations."""
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1083,19 +1083,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.6.1"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/9f/7906ba4117df8d965510285eaf07264a77de2fd283b9d44ec7fc63a4a57a/lance_namespace-0.6.1.tar.gz", hash = "sha256:f0deea442bd3f1056a8e2fed056ae2778e3356517ec2e680db049058b824d131", size = 10666, upload-time = "2026-03-17T17:55:44.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/24/3de040859ec51a778760c61a7d2285df6c4ceee67f7d36b510eafba80603/lance_namespace-0.7.0.tar.gz", hash = "sha256:ecfe1f1ed6abfb0e767ddf74196dd321eda920ded78fd6c5162b407b0efb2c6e", size = 10528, upload-time = "2026-04-21T23:43:46.364Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/91/aee1c0a04d17f2810173bd304bd444eb78332045df1b0c1b07cebd01f530/lance_namespace-0.6.1-py3-none-any.whl", hash = "sha256:9699c9e3f12236e5e08ea979cc4e036a8e3c67ed2f37ae6f25c5353ab908e1be", size = 12498, upload-time = "2026-03-17T17:55:44.062Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/58/4ceee78927be6897c363f6a7bcbe41596ddb924420a1a4add55878f8f45c/lance_namespace-0.7.0-py3-none-any.whl", hash = "sha256:b9a84eb1b2077116b70b2df26d27704c0b85a47174ba41ee1ad8b67e2370a16d", size = 12353, upload-time = "2026-04-21T23:43:42.223Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.6.1"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1104,9 +1104,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/a1/8706a2be25bd184acccc411e48f1a42a4cbf3b6556cba15b9fcf4c15cfcc/lance_namespace_urllib3_client-0.6.1.tar.gz", hash = "sha256:31fbd058ce1ea0bf49045cdeaa756360ece0bc61e9e10276f41af6d217debe87", size = 182567, upload-time = "2026-03-17T17:55:46.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/2f/2f77b5c32cf8c0133f1763ee87d8030c3369483efbe76b976384362ffe92/lance_namespace_urllib3_client-0.7.0.tar.gz", hash = "sha256:e1384d4d0c6b1de4b344bb709ea53bd9cef6f471b864b1ee8968aa89698a30c5", size = 182930, upload-time = "2026-04-21T23:43:43.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/c7/cb9580602dec25f0fdd6005c1c9ba1d4c8c0c3dc8d543107e5a9f248bba8/lance_namespace_urllib3_client-0.6.1-py3-none-any.whl", hash = "sha256:b9c103e1377ad46d2bd70eec894bfec0b1e2133dae0964d7e4de543c6e16293b", size = 317111, upload-time = "2026-03-17T17:55:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/13/ce/70adb410015e73ff4419c7e47edc5e1c142b13f4ed9438f600beaeedbcfd/lance_namespace_urllib3_client-0.7.0-py3-none-any.whl", hash = "sha256:d0aa13b510abf4b0cd8bc5c602207b8c9afc99ef4de1f4ea023492ccb5ec07e9", size = 313715, upload-time = "2026-04-21T23:43:44.973Z" },
 ]
 
 [[package]]
@@ -2628,7 +2628,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'tests'" },
     { name = "geoarrow-rust-core", marker = "extra == 'geo'" },
     { name = "geoarrow-rust-io", marker = "extra == 'geo'" },
-    { name = "lance-namespace", specifier = ">=0.6.1" },
+    { name = "lance-namespace", specifier = ">=0.7.0" },
     { name = "ml-dtypes", marker = "extra == 'tests'" },
     { name = "numpy", specifier = ">=1.22" },
     { name = "pandas", marker = "extra == 'tests'" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1083,19 +1083,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.7.1"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/90/ab4062f609a1749a7b587d7fd91ddbfa0c107e6aad925bd36367eeeba2f9/lance_namespace-0.7.1.tar.gz", hash = "sha256:739c3c5b021c1582223a23056af085575a6f8bd577e744bafbafc4db76f89f22", size = 10523, upload-time = "2026-04-24T06:30:01.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/04/633687a8e64383058cdf5e36c69c016006225880242804f35ec1241c82cb/lance_namespace-0.7.2.tar.gz", hash = "sha256:43d6e7be6773c4f0b4c8d36602e7245066fc0c06fa334a239a0452f00492768a", size = 10526, upload-time = "2026-04-25T00:01:40.836Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/a3/c1d804a1bcd05d2a84dbc5d1b6795599fcee1866e322be55c18cbe109229/lance_namespace-0.7.1-py3-none-any.whl", hash = "sha256:c050c4a2bcd27a75551268449b74a8ac23dde4077f9bf7df460d52c50355d5f0", size = 12354, upload-time = "2026-04-24T06:29:58.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/6fae405ec2503e14afdf0490cbdb8314db702a804189a5d01f46e5b00b63/lance_namespace-0.7.2-py3-none-any.whl", hash = "sha256:c7f35b99f79cd7c08ebcda3c06fe4d1acdb4db72458cb9e211971c46964db9e1", size = 12356, upload-time = "2026-04-25T00:01:41.558Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.7.1"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1104,9 +1104,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/e8/7a1ad66f0bf268f6e83769eb7139d7c4865e890a241c8e35ee67a5147da6/lance_namespace_urllib3_client-0.7.1.tar.gz", hash = "sha256:eb49cebd36b94d892de9c6fa1157df5021ff451549fc9dab11ba572e8e38a2ab", size = 183789, upload-time = "2026-04-24T06:30:02.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d7/c7d9ae1a2815e3c846fdd6e49f5882d60ffd76a5ddccd34af5fe8ac8124e/lance_namespace_urllib3_client-0.7.2.tar.gz", hash = "sha256:853dcd7affb14fd6ae3039748d1fff4906d51ec41026e43f787ee56f339e18f6", size = 184709, upload-time = "2026-04-25T00:01:42.301Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/9d/ca5d723cb52bbf18bf7aeea017689e8c156193deb0c2e959ca5f4f62078a/lance_namespace_urllib3_client-0.7.1-py3-none-any.whl", hash = "sha256:b7c02fa5c79ff176a898062a4cd1a13909a6d7c591bf56e8715d5af10d4ea919", size = 314229, upload-time = "2026-04-24T06:29:59.687Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/eb/941780e022d9f7c01256eb5d6a1cc1d097a80b188795212d504723ba8fc8/lance_namespace_urllib3_client-0.7.2-py3-none-any.whl", hash = "sha256:0d0316f1a7d6da61c1f17b8f3dfb3643cf882d67712eaa709619c17b2cd9c880", size = 314775, upload-time = "2026-04-25T00:01:39.679Z" },
 ]
 
 [[package]]
@@ -2628,7 +2628,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'tests'" },
     { name = "geoarrow-rust-core", marker = "extra == 'geo'" },
     { name = "geoarrow-rust-io", marker = "extra == 'geo'" },
-    { name = "lance-namespace", specifier = ">=0.7.1,<8.0" },
+    { name = "lance-namespace", specifier = ">=0.7.2,<8.0" },
     { name = "ml-dtypes", marker = "extra == 'tests'" },
     { name = "numpy", specifier = ">=1.22" },
     { name = "pandas", marker = "extra == 'tests'" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1083,19 +1083,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.7.0"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/24/3de040859ec51a778760c61a7d2285df6c4ceee67f7d36b510eafba80603/lance_namespace-0.7.0.tar.gz", hash = "sha256:ecfe1f1ed6abfb0e767ddf74196dd321eda920ded78fd6c5162b407b0efb2c6e", size = 10528, upload-time = "2026-04-21T23:43:46.364Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/90/ab4062f609a1749a7b587d7fd91ddbfa0c107e6aad925bd36367eeeba2f9/lance_namespace-0.7.1.tar.gz", hash = "sha256:739c3c5b021c1582223a23056af085575a6f8bd577e744bafbafc4db76f89f22", size = 10523, upload-time = "2026-04-24T06:30:01.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/58/4ceee78927be6897c363f6a7bcbe41596ddb924420a1a4add55878f8f45c/lance_namespace-0.7.0-py3-none-any.whl", hash = "sha256:b9a84eb1b2077116b70b2df26d27704c0b85a47174ba41ee1ad8b67e2370a16d", size = 12353, upload-time = "2026-04-21T23:43:42.223Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a3/c1d804a1bcd05d2a84dbc5d1b6795599fcee1866e322be55c18cbe109229/lance_namespace-0.7.1-py3-none-any.whl", hash = "sha256:c050c4a2bcd27a75551268449b74a8ac23dde4077f9bf7df460d52c50355d5f0", size = 12354, upload-time = "2026-04-24T06:29:58.268Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.7.0"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1104,9 +1104,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/2f/2f77b5c32cf8c0133f1763ee87d8030c3369483efbe76b976384362ffe92/lance_namespace_urllib3_client-0.7.0.tar.gz", hash = "sha256:e1384d4d0c6b1de4b344bb709ea53bd9cef6f471b864b1ee8968aa89698a30c5", size = 182930, upload-time = "2026-04-21T23:43:43.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/e8/7a1ad66f0bf268f6e83769eb7139d7c4865e890a241c8e35ee67a5147da6/lance_namespace_urllib3_client-0.7.1.tar.gz", hash = "sha256:eb49cebd36b94d892de9c6fa1157df5021ff451549fc9dab11ba572e8e38a2ab", size = 183789, upload-time = "2026-04-24T06:30:02.036Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/ce/70adb410015e73ff4419c7e47edc5e1c142b13f4ed9438f600beaeedbcfd/lance_namespace_urllib3_client-0.7.0-py3-none-any.whl", hash = "sha256:d0aa13b510abf4b0cd8bc5c602207b8c9afc99ef4de1f4ea023492ccb5ec07e9", size = 313715, upload-time = "2026-04-21T23:43:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9d/ca5d723cb52bbf18bf7aeea017689e8c156193deb0c2e959ca5f4f62078a/lance_namespace_urllib3_client-0.7.1-py3-none-any.whl", hash = "sha256:b7c02fa5c79ff176a898062a4cd1a13909a6d7c591bf56e8715d5af10d4ea919", size = 314229, upload-time = "2026-04-24T06:29:59.687Z" },
 ]
 
 [[package]]
@@ -2628,7 +2628,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'tests'" },
     { name = "geoarrow-rust-core", marker = "extra == 'geo'" },
     { name = "geoarrow-rust-io", marker = "extra == 'geo'" },
-    { name = "lance-namespace", specifier = ">=0.7.0" },
+    { name = "lance-namespace", specifier = ">=0.7.1,<8.0" },
     { name = "ml-dtypes", marker = "extra == 'tests'" },
     { name = "numpy", specifier = ">=1.22" },
     { name = "pandas", marker = "extra == 'tests'" },

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -124,6 +124,10 @@ mod tests {
                 "file-object-store:///C:/Users/ADMINI~1/AppData/Local",
                 "C:/Users/ADMINI~1/AppData/Local",
             ),
+            (
+                "file:///C:/Users/RUNNER~1/AppData/Local/Temp/tmpm49j_w0f",
+                "C:/Users/RUNNER~1/AppData/Local/Temp/tmpm49j_w0f",
+            ),
         ];
 
         for (uri, expected_path) in cases {

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1235,7 +1235,8 @@ impl DirectoryNamespace {
             let storage_options = self
                 .get_storage_options_for_table(&table_uri, vend_credentials, identity)
                 .await?;
-            let is_only_declared = !self.table_has_actual_manifests(&table_name).await?;
+            let is_only_declared =
+                status.has_reserved_file && !self.table_has_actual_manifests(&table_name).await?;
             return Ok(DescribeTableResponse {
                 table: Some(table_name),
                 namespace: request.id.as_ref().map(|id| {
@@ -1321,6 +1322,7 @@ impl DirectoryNamespace {
             }
             Err(err) => {
                 if manifest::ManifestNamespace::is_not_found_load_error(&err)
+                    && status.has_reserved_file
                     && !self.table_has_actual_manifests(&table_name).await?
                 {
                     let storage_options = self

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -6466,7 +6466,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.version, Some(1));
-        assert!(response.properties.is_none());
+        assert_eq!(
+            response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"alice".to_string())
+        );
 
         let mut describe_req = DescribeTableRequest::new();
         describe_req.id = Some(vec!["test_table".to_string()]);
@@ -6567,7 +6573,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(response.properties.is_none());
+        assert_eq!(
+            response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"alice".to_string())
+        );
         assert_eq!(
             open_dataset(&namespace, "test_table")
                 .await

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -7460,7 +7460,7 @@ mod tests {
         let version_info = response
             .version
             .expect("response should contain version info");
-        let version_2_path = Path::from(version_info.manifest_path);
+        let version_2_path = Path::parse(&version_info.manifest_path).unwrap();
         let head_result = dataset.object_store().inner.head(&version_2_path).await;
         assert!(
             head_result.is_ok(),

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -4216,6 +4216,22 @@ mod tests {
         create_ipc_data_from_batches(schema, vec![batch])
     }
 
+    fn create_single_row_test_ipc_data() -> Vec<u8> {
+        use arrow::array::{Int32Array, StringArray};
+        use arrow::record_batch::RecordBatch;
+
+        let schema = Arc::new(convert_json_arrow_schema(&create_test_schema()).unwrap());
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![10])),
+                Arc::new(StringArray::from(vec![Some("carol")])),
+            ],
+        )
+        .unwrap();
+        create_ipc_data_from_batches(schema, vec![batch])
+    }
+
     /// Helper to create a simple test schema
     fn create_test_schema() -> JsonArrowSchema {
         let int_type = JsonArrowDataType::new("int32".to_string());
@@ -6440,6 +6456,7 @@ mod tests {
 
         let mut create_req = CreateTableRequest::new();
         create_req.id = Some(vec!["test_table".to_string()]);
+        create_req.mode = Some("Overwrite".to_string());
         let response = namespace
             .create_table(
                 create_req,
@@ -6449,13 +6466,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.version, Some(1));
-        assert_eq!(
-            response
-                .properties
-                .as_ref()
-                .and_then(|properties| properties.get("owner")),
-            Some(&"alice".to_string())
-        );
+        assert!(response.properties.is_none());
 
         let mut describe_req = DescribeTableRequest::new();
         describe_req.id = Some(vec!["test_table".to_string()]);
@@ -6516,6 +6527,164 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("cannot set properties for already declared table")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_with_manifest_exist_ok_keeps_existing_table() {
+        use lance_namespace::models::{CreateTableRequest, DescribeTableRequest};
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        create_req.properties = Some(HashMap::from([("owner".to_string(), "alice".to_string())]));
+        namespace
+            .create_table(
+                create_req,
+                bytes::Bytes::from(create_non_empty_test_ipc_data()),
+            )
+            .await
+            .unwrap();
+
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        create_req.mode = Some("ExistOk".to_string());
+        create_req.properties = Some(HashMap::from([("owner".to_string(), "bob".to_string())]));
+        let response = namespace
+            .create_table(
+                create_req,
+                bytes::Bytes::from(create_single_row_test_ipc_data()),
+            )
+            .await
+            .unwrap();
+
+        assert!(response.properties.is_none());
+        assert_eq!(
+            open_dataset(&namespace, "test_table")
+                .await
+                .count_rows(None)
+                .await
+                .unwrap(),
+            2
+        );
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(
+            describe_response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"alice".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_with_manifest_overwrite_replaces_existing_table() {
+        use lance_namespace::models::{CreateTableRequest, DescribeTableRequest};
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        create_req.properties = Some(HashMap::from([("owner".to_string(), "alice".to_string())]));
+        namespace
+            .create_table(
+                create_req,
+                bytes::Bytes::from(create_non_empty_test_ipc_data()),
+            )
+            .await
+            .unwrap();
+
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        create_req.mode = Some("overwrite".to_string());
+        create_req.properties = Some(HashMap::from([("owner".to_string(), "bob".to_string())]));
+        let response = namespace
+            .create_table(
+                create_req,
+                bytes::Bytes::from(create_single_row_test_ipc_data()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.version, Some(2));
+        assert_eq!(
+            response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"bob".to_string())
+        );
+        assert_eq!(
+            open_dataset(&namespace, "test_table")
+                .await
+                .count_rows(None)
+                .await
+                .unwrap(),
+            1
+        );
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(
+            describe_response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"bob".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_with_manifest_invalid_mode_rejected() {
+        use lance_namespace::models::CreateTableRequest;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        create_req.mode = Some("append".to_string());
+        let result = namespace
+            .create_table(
+                create_req,
+                bytes::Bytes::from(create_non_empty_test_ipc_data()),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unsupported create_table mode")
         );
     }
 

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -13,12 +13,15 @@ use arrow::record_batch::RecordBatchIterator;
 use arrow_ipc::reader::StreamReader;
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::scanner::Scanner;
 use lance::dataset::statistics::DatasetStatisticsExt;
 use lance::dataset::transaction::{Operation, Transaction};
-use lance::dataset::{Dataset, WriteMode, WriteParams};
+use lance::dataset::{
+    Dataset, MergeInsertBuilder, WhenMatched, WhenNotMatched, WhenNotMatchedBySource, WriteMode,
+    WriteParams,
+};
 use lance::index::{DatasetIndexExt, IndexParams, vector::VectorIndexParams};
 use lance::session::Session;
 use lance_index::scalar::{
@@ -54,7 +57,8 @@ use lance_namespace::models::{
     GetTableStatsResponse, Identity, IndexContent, InsertIntoTableRequest, InsertIntoTableResponse,
     ListNamespacesRequest, ListNamespacesResponse, ListTableIndicesRequest,
     ListTableIndicesResponse, ListTableVersionsRequest, ListTableVersionsResponse,
-    ListTablesRequest, ListTablesResponse, NamespaceExistsRequest, QueryTableRequest,
+    ListTablesRequest, ListTablesResponse, MergeInsertIntoTableRequest,
+    MergeInsertIntoTableResponse, NamespaceExistsRequest, QueryTableRequest,
     QueryTableRequestColumns, QueryTableRequestVector, RestoreTableRequest, RestoreTableResponse,
     TableExistsRequest, TableVersion, UpdateTableSchemaMetadataRequest,
     UpdateTableSchemaMetadataResponse,
@@ -939,9 +943,9 @@ impl DirectoryNamespace {
 
             let table_name = &path[..path.len() - 6];
 
-            // Use atomic check to skip deregistered tables and declared-but-not-written tables
+            // Use atomic check to skip deregistered tables.
             let status = self.check_table_status(table_name).await;
-            if status.is_deregistered || status.has_reserved_file {
+            if status.is_deregistered {
                 continue;
             }
 
@@ -1016,6 +1020,154 @@ impl DirectoryNamespace {
         })
     }
 
+    async fn table_has_actual_manifests(&self, table_name: &str) -> Result<bool> {
+        manifest::ManifestNamespace::path_has_actual_manifests(
+            &self.object_store,
+            &self.table_path(table_name),
+        )
+        .await
+    }
+
+    async fn filter_declared_tables(
+        &self,
+        tables: Vec<String>,
+        include_declared: bool,
+    ) -> Result<Vec<String>> {
+        if include_declared {
+            return Ok(tables);
+        }
+
+        let mut stream = futures::stream::iter(tables.into_iter().map(|table_name| async move {
+            // `include_declared=false` is an explicit opt-in. We still pay one `_versions/` probe
+            // per table here so declared-state is derived from actual manifests. This is linear in
+            // the total number of listed tables, but we probe a bounded number concurrently.
+            if self.table_has_actual_manifests(&table_name).await? {
+                Ok::<Option<String>, Error>(Some(table_name))
+            } else {
+                Ok::<Option<String>, Error>(None)
+            }
+        }))
+        .buffered(manifest::DECLARED_FILTER_CONCURRENCY);
+
+        let mut filtered = Vec::new();
+        while let Some(result) = stream.next().await {
+            if let Some(table_name) = result? {
+                filtered.push(table_name);
+            }
+        }
+        Ok(filtered)
+    }
+
+    fn ipc_reader_from_request_data(
+        request_data: &Bytes,
+        operation: &str,
+    ) -> Result<(
+        Box<dyn arrow::record_batch::RecordBatchReader + Send>,
+        usize,
+    )> {
+        if request_data.is_empty() {
+            return Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "Request data (Arrow IPC stream) is required for {}",
+                    operation
+                ),
+            }
+            .into());
+        }
+
+        let cursor = Cursor::new(request_data.as_ref());
+        let stream_reader =
+            StreamReader::try_new(cursor, None).map_err(|e| NamespaceError::InvalidInput {
+                message: format!("Invalid Arrow IPC stream: {}", e),
+            })?;
+        let arrow_schema = stream_reader.schema();
+
+        let mut num_rows = 0usize;
+        let mut batches = Vec::new();
+        for batch_result in stream_reader {
+            let batch = batch_result.map_err(|e| NamespaceError::Internal {
+                message: format!("Failed to read batch from IPC stream: {}", e),
+            })?;
+            num_rows += batch.num_rows();
+            batches.push(batch);
+        }
+
+        let reader: Box<dyn arrow::record_batch::RecordBatchReader + Send> = if batches.is_empty() {
+            let batch = arrow::record_batch::RecordBatch::new_empty(arrow_schema.clone());
+            Box::new(RecordBatchIterator::new(vec![Ok(batch)], arrow_schema))
+        } else {
+            let batch_results: Vec<_> = batches.into_iter().map(Ok).collect();
+            Box::new(RecordBatchIterator::new(batch_results, arrow_schema))
+        };
+
+        Ok((reader, num_rows))
+    }
+
+    async fn table_uri_has_actual_manifests(&self, table_uri: &str) -> Result<bool> {
+        manifest::ManifestNamespace::path_has_actual_manifests(
+            &self.object_store,
+            &Self::uri_to_object_store_path(table_uri),
+        )
+        .await
+    }
+
+    fn validate_dir_only_properties(
+        properties: Option<&HashMap<String, String>>,
+        operation: &str,
+    ) -> Result<()> {
+        // Dir-only mode has no metadata catalog, so non-empty table properties would be accepted
+        // and then lost. Reject them instead. Request-level storage options are different: they
+        // directly affect the current write and remain supported in dir-only mode.
+        if properties.is_some_and(|properties| !properties.is_empty()) {
+            return Err(NamespaceError::Unsupported {
+                message: format!(
+                    "{} with non-empty table properties requires manifest_enabled=true",
+                    operation
+                ),
+            }
+            .into());
+        }
+        Ok(())
+    }
+
+    async fn write_reader_to_table(
+        &self,
+        table_uri: &str,
+        reader: Box<dyn arrow::record_batch::RecordBatchReader + Send>,
+        mode: WriteMode,
+        extra_storage_options: Option<HashMap<String, String>>,
+    ) -> Result<Dataset> {
+        // Insert and merge-insert request models do not carry request-level storage options,
+        // so these writes intentionally use the namespace-level storage options only.
+        let mut merged_storage_options = self.storage_options.clone().unwrap_or_default();
+        if let Some(extra_storage_options) = extra_storage_options {
+            merged_storage_options.extend(extra_storage_options);
+        }
+        let store_params = (!merged_storage_options.is_empty()).then(|| ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(
+                lance_io::object_store::StorageOptionsAccessor::with_static_options(
+                    merged_storage_options,
+                ),
+            )),
+            ..Default::default()
+        });
+
+        let write_params = WriteParams {
+            mode,
+            store_params,
+            session: self.session.clone(),
+            ..Default::default()
+        };
+
+        let dataset = Dataset::write(reader, table_uri, Some(write_params))
+            .await
+            .map_err(|e| NamespaceError::Internal {
+                message: format!("Failed to write table at '{}': {}", table_uri, e),
+            })?;
+
+        Ok(dataset)
+    }
+
     /// Internal describe_table implementation that doesn't record metrics.
     /// Used by both the public describe_table (which records metrics) and
     /// internal callers like resolve_table_location (which shouldn't).
@@ -1079,11 +1231,11 @@ impl DirectoryNamespace {
         let vend_credentials = request.vend_credentials.unwrap_or(true);
         let identity = request.identity.as_deref();
 
-        // If not loading detailed metadata, return minimal response with just location
         if !load_detailed_metadata {
             let storage_options = self
                 .get_storage_options_for_table(&table_uri, vend_credentials, identity)
                 .await?;
+            let is_only_declared = !self.table_has_actual_manifests(&table_name).await?;
             return Ok(DescribeTableResponse {
                 table: Some(table_name),
                 namespace: request.id.as_ref().map(|id| {
@@ -1096,6 +1248,7 @@ impl DirectoryNamespace {
                 location: Some(table_uri.clone()),
                 table_uri: Some(table_uri),
                 storage_options,
+                is_only_declared: is_only_declared.then_some(true),
                 managed_versioning: if self.table_version_tracking_enabled {
                     Some(true)
                 } else {
@@ -1167,8 +1320,9 @@ impl DirectoryNamespace {
                 })
             }
             Err(err) => {
-                // Use the reserved file status from the atomic check
-                if status.has_reserved_file {
+                if manifest::ManifestNamespace::is_not_found_load_error(&err)
+                    && !self.table_has_actual_manifests(&table_name).await?
+                {
                     let storage_options = self
                         .get_storage_options_for_table(&table_uri, vend_credentials, identity)
                         .await?;
@@ -1184,6 +1338,7 @@ impl DirectoryNamespace {
                         location: Some(table_uri.clone()),
                         table_uri: Some(table_uri),
                         storage_options,
+                        is_only_declared: Some(true),
                         managed_versioning: if self.table_version_tracking_enabled {
                             Some(true)
                         } else {
@@ -1786,8 +1941,11 @@ impl DirectoryNamespace {
         // Get all table locations already in the manifest
         let manifest_locations = manifest_ns.list_manifest_table_locations().await?;
 
-        // Get all tables from directory
-        let dir_tables = self.list_directory_tables().await?;
+        // Get all tables from directory and skip declared-only tables that have not
+        // written any actual version manifests yet.
+        let dir_tables = self
+            .filter_declared_tables(self.list_directory_tables().await?, false)
+            .await?;
 
         // Register each directory table that doesn't have an overlapping location
         // If a directory name already exists in the manifest,
@@ -2191,6 +2349,10 @@ impl LanceNamespace for DirectoryNamespace {
             self.list_directory_tables().await?
         };
 
+        tables = self
+            .filter_declared_tables(tables, request.include_declared.unwrap_or(true))
+            .await?;
+
         // Apply sorting and pagination
         let next_page_token =
             Self::apply_pagination(&mut tables, request.page_token, request.limit);
@@ -2281,78 +2443,43 @@ impl LanceNamespace for DirectoryNamespace {
             return manifest_ns.create_table(request, request_data).await;
         }
 
+        Self::validate_dir_only_properties(request.properties.as_ref(), "create_table")?;
+
         let table_name = Self::table_name_from_id(&request.id)?;
         let table_uri = self.table_full_uri(&table_name);
-        if request_data.is_empty() {
-            return Err(NamespaceError::InvalidInput {
-                message: "Request data (Arrow IPC stream) is required for create_table".to_string(),
+        let status = self.check_table_status(&table_name).await;
+        let (reader, _num_rows) =
+            Self::ipc_reader_from_request_data(&request_data, "create_table")?;
+
+        if status.exists && self.table_has_actual_manifests(&table_name).await? {
+            return Err(NamespaceError::TableAlreadyExists {
+                message: table_name,
             }
             .into());
         }
 
-        // Parse the Arrow IPC stream from request_data
-        let cursor = Cursor::new(request_data.to_vec());
-        let stream_reader = StreamReader::try_new(cursor, None).map_err(|e| {
-            lance_core::Error::from(NamespaceError::InvalidInput {
-                message: format!("Invalid Arrow IPC stream: {:?}", e),
-            })
-        })?;
-        let arrow_schema = stream_reader.schema();
-
-        // Collect all batches from the stream
-        let mut batches = Vec::new();
-        for batch_result in stream_reader {
-            batches.push(batch_result.map_err(|e| {
-                lance_core::Error::from(NamespaceError::InvalidInput {
-                    message: format!("Failed to read batch from IPC stream: {:?}", e),
-                })
-            })?);
+        let write_result = self
+            .write_reader_to_table(
+                &table_uri,
+                reader,
+                WriteMode::Create,
+                request.storage_options.clone(),
+            )
+            .await;
+        if let Err(err) = write_result {
+            if self.table_uri_has_actual_manifests(&table_uri).await? {
+                return Err(NamespaceError::TableAlreadyExists {
+                    message: table_name,
+                }
+                .into());
+            }
+            return Err(err);
         }
-
-        // Create RecordBatchReader from the batches
-        let reader = if batches.is_empty() {
-            let batch = arrow::record_batch::RecordBatch::new_empty(arrow_schema.clone());
-            let batches = vec![Ok(batch)];
-            RecordBatchIterator::new(batches, arrow_schema.clone())
-        } else {
-            let batch_results: Vec<_> = batches.into_iter().map(Ok).collect();
-            RecordBatchIterator::new(batch_results, arrow_schema)
-        };
-
-        let store_params = self.storage_options.as_ref().map(|opts| ObjectStoreParams {
-            storage_options_accessor: Some(Arc::new(
-                lance_io::object_store::StorageOptionsAccessor::with_static_options(opts.clone()),
-            )),
-            ..Default::default()
-        });
-
-        let write_params = WriteParams {
-            mode: WriteMode::Create,
-            store_params,
-            ..Default::default()
-        };
-
-        // Create the Lance dataset using the actual Lance API
-        Dataset::write(reader, &table_uri, Some(write_params))
-            .await
-            .map_err(|e| {
-                let err_msg = format!("{}", e);
-                let ns_err = if err_msg.contains("already exists") {
-                    NamespaceError::TableAlreadyExists {
-                        message: format!("Table already exists at '{}': {:?}", table_uri, e),
-                    }
-                } else {
-                    NamespaceError::Internal {
-                        message: format!("Failed to create Lance dataset: {:?}", e),
-                    }
-                };
-                lance_core::Error::from(ns_err)
-            })?;
-
         Ok(CreateTableResponse {
             version: Some(1),
             location: Some(table_uri),
             storage_options: self.storage_options.clone(),
+            properties: request.properties,
             ..Default::default()
         })
     }
@@ -2375,6 +2502,8 @@ impl LanceNamespace for DirectoryNamespace {
             }
             return Ok(response);
         }
+
+        Self::validate_dir_only_properties(request.properties.as_ref(), "declare_table")?;
 
         let table_name = Self::table_name_from_id(&request.id)?;
         let table_uri = self.table_full_uri(&table_name);
@@ -2432,6 +2561,7 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(DeclareTableResponse {
             location: Some(table_uri),
             storage_options,
+            properties: request.properties,
             managed_versioning: if self.table_version_tracking_enabled {
                 Some(true)
             } else {
@@ -3210,6 +3340,9 @@ impl LanceNamespace for DirectoryNamespace {
         // In dir-only mode there are no child namespaces, so all tables live in the
         // root directory. This is equivalent to listing the root namespace.
         let mut tables = self.list_directory_tables().await?;
+        tables = self
+            .filter_declared_tables(tables, request.include_declared.unwrap_or(true))
+            .await?;
         Self::apply_pagination(&mut tables, request.page_token, request.limit);
         Ok(ListTablesResponse::new(tables))
     }
@@ -3506,37 +3639,8 @@ impl LanceNamespace for DirectoryNamespace {
     ) -> Result<InsertIntoTableResponse> {
         self.record_op("insert_into_table");
         let table_uri = self.resolve_table_location(&request.id).await?;
-
-        if request_data.is_empty() {
-            return Err(NamespaceError::InvalidInput {
-                message: "Request data (Arrow IPC stream) is required for insert_into_table"
-                    .to_string(),
-            }
-            .into());
-        }
-
-        let cursor = Cursor::new(request_data.as_ref());
-        let stream_reader =
-            StreamReader::try_new(cursor, None).map_err(|e| NamespaceError::InvalidInput {
-                message: format!("Invalid Arrow IPC stream: {:?}", e),
-            })?;
-        let arrow_schema = stream_reader.schema();
-
-        let mut batches = Vec::new();
-        for batch_result in stream_reader {
-            batches.push(batch_result.map_err(|e| NamespaceError::InvalidInput {
-                message: format!("Failed to read batch from IPC stream: {:?}", e),
-            })?);
-        }
-
-        let reader = if batches.is_empty() {
-            let batch = arrow::record_batch::RecordBatch::new_empty(arrow_schema.clone());
-            let batches = vec![Ok(batch)];
-            RecordBatchIterator::new(batches, arrow_schema.clone())
-        } else {
-            let batch_results: Vec<_> = batches.into_iter().map(Ok).collect();
-            RecordBatchIterator::new(batch_results, arrow_schema)
-        };
+        let (reader, _num_rows) =
+            Self::ipc_reader_from_request_data(&request_data, "insert_into_table")?;
 
         let mode = match request.mode.as_deref() {
             Some(m) if m.eq_ignore_ascii_case("overwrite") => WriteMode::Overwrite,
@@ -3553,40 +3657,122 @@ impl LanceNamespace for DirectoryNamespace {
             }
         };
 
-        let store_params = self.storage_options.as_ref().map(|opts| ObjectStoreParams {
-            storage_options_accessor: Some(Arc::new(
-                lance_io::object_store::StorageOptionsAccessor::with_static_options(opts.clone()),
-            )),
-            ..Default::default()
-        });
-
-        let write_params = WriteParams {
-            mode,
-            store_params,
-            session: self.session.clone(),
-            ..Default::default()
-        };
-
-        Dataset::write(reader, &table_uri, Some(write_params))
-            .await
-            .map_err(|e| {
-                let err_msg = format!("{}", e);
-                if err_msg.contains("conflict") || err_msg.contains("CommitConflict") {
-                    NamespaceError::ConcurrentModification {
-                        message: format!(
-                            "Concurrent modification on table at '{}': {:?}",
-                            table_uri, e
-                        ),
-                    }
-                } else {
-                    NamespaceError::Internal {
-                        message: format!("Failed to insert into table at '{}': {:?}", table_uri, e),
-                    }
-                }
-            })?;
+        if !self.table_uri_has_actual_manifests(&table_uri).await? {
+            self.write_reader_to_table(&table_uri, reader, WriteMode::Create, None)
+                .await?;
+        } else {
+            self.write_reader_to_table(&table_uri, reader, mode, None)
+                .await?;
+        }
 
         Ok(InsertIntoTableResponse {
             transaction_id: None,
+        })
+    }
+
+    async fn merge_insert_into_table(
+        &self,
+        request: MergeInsertIntoTableRequest,
+        request_data: Bytes,
+    ) -> Result<MergeInsertIntoTableResponse> {
+        self.record_op("merge_insert_into_table");
+        let table_uri = self.resolve_table_location(&request.id).await?;
+        let on = request.on.as_ref().ok_or_else(|| {
+            lance_core::Error::from(NamespaceError::InvalidInput {
+                message: "'on' field is required for merge_insert_into_table".to_string(),
+            })
+        })?;
+
+        let table_has_manifests = self.table_uri_has_actual_manifests(&table_uri).await?;
+        let (reader, num_rows) =
+            Self::ipc_reader_from_request_data(&request_data, "merge_insert_into_table")?;
+
+        if !table_has_manifests {
+            let dataset = self
+                .write_reader_to_table(&table_uri, reader, WriteMode::Create, None)
+                .await?;
+            let version = dataset.version().version as i64;
+            return Ok(MergeInsertIntoTableResponse {
+                transaction_id: None,
+                num_updated_rows: Some(0),
+                num_inserted_rows: Some(num_rows as i64),
+                num_deleted_rows: Some(0),
+                version: Some(version),
+            });
+        }
+
+        let dataset = Arc::new(
+            self.load_dataset(&table_uri, None, "merge_insert_into_table")
+                .await?,
+        );
+
+        let mut merge_builder = MergeInsertBuilder::try_new(dataset.clone(), vec![on.clone()])
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::InvalidInput {
+                    message: format!("Failed to create merge_insert_into_table builder: {}", e),
+                })
+            })?;
+
+        if let Some(filter) = request.when_matched_update_all_filt.as_deref() {
+            let behavior = WhenMatched::update_if(dataset.as_ref(), filter).map_err(|e| {
+                lance_core::Error::from(NamespaceError::InvalidInput {
+                    message: format!(
+                        "Invalid when_matched_update_all_filt for merge_insert_into_table: {}",
+                        e
+                    ),
+                })
+            })?;
+            merge_builder.when_matched(behavior);
+        } else if request.when_matched_update_all.unwrap_or(false) {
+            merge_builder.when_matched(WhenMatched::UpdateAll);
+        }
+
+        if matches!(request.when_not_matched_insert_all, Some(false)) {
+            merge_builder.when_not_matched(WhenNotMatched::DoNothing);
+        } else {
+            merge_builder.when_not_matched(WhenNotMatched::InsertAll);
+        }
+
+        if let Some(filter) = request.when_not_matched_by_source_delete_filt.as_deref() {
+            let behavior = WhenNotMatchedBySource::delete_if(dataset.as_ref(), filter).map_err(|e| {
+                lance_core::Error::from(NamespaceError::InvalidInput {
+                    message: format!(
+                        "Invalid when_not_matched_by_source_delete_filt for merge_insert_into_table: {}",
+                        e
+                    ),
+                })
+            })?;
+            merge_builder.when_not_matched_by_source(behavior);
+        } else if request.when_not_matched_by_source_delete.unwrap_or(false) {
+            merge_builder.when_not_matched_by_source(WhenNotMatchedBySource::Delete);
+        }
+
+        if let Some(use_index) = request.use_index {
+            merge_builder.use_index(use_index);
+        }
+
+        let (dataset, stats) = merge_builder
+            .try_build()
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::InvalidInput {
+                    message: format!("Failed to build merge_insert_into_table job: {}", e),
+                })
+            })?
+            .execute_reader(reader)
+            .await
+            .map_err(|e| NamespaceError::Internal {
+                message: format!(
+                    "Failed to merge_insert_into_table at '{}': {}",
+                    table_uri, e
+                ),
+            })?;
+
+        Ok(MergeInsertIntoTableResponse {
+            transaction_id: None,
+            num_updated_rows: Some(stats.num_updated_rows as i64),
+            num_inserted_rows: Some(stats.num_inserted_rows as i64),
+            num_deleted_rows: Some(stats.num_deleted_rows as i64),
+            version: Some(dataset.version().version as i64),
         })
     }
 
@@ -3954,6 +4140,22 @@ mod tests {
             writer.finish().unwrap();
         }
         buffer
+    }
+
+    fn create_non_empty_test_ipc_data() -> Vec<u8> {
+        use arrow::array::{Int32Array, StringArray};
+        use arrow::record_batch::RecordBatch;
+
+        let schema = Arc::new(convert_json_arrow_schema(&create_test_schema()).unwrap());
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec![Some("alice"), Some("bob")])),
+            ],
+        )
+        .unwrap();
+        create_ipc_data_from_batches(schema, vec![batch])
     }
 
     /// Helper to create a simple test schema
@@ -5965,7 +6167,7 @@ mod tests {
     #[tokio::test]
     async fn test_declare_table_v1_mode() {
         use lance_namespace::models::{
-            DeclareTableRequest, DescribeTableRequest, TableExistsRequest,
+            DeclareTableRequest, DescribeTableRequest, ListTablesRequest, TableExistsRequest,
         };
 
         let temp_dir = TempStdDir::default();
@@ -6000,11 +6202,365 @@ mod tests {
         assert!(describe_response.location.is_some());
         assert!(describe_response.version.is_none()); // Not written yet
         assert!(describe_response.schema.is_none()); // Not written yet
+        assert_eq!(describe_response.is_only_declared, Some(true));
+
+        let mut list_req = ListTablesRequest::new();
+        list_req.id = Some(vec![]);
+        let list_response = namespace.list_tables(list_req.clone()).await.unwrap();
+        assert_eq!(list_response.tables, vec!["test_table".to_string()]);
+
+        list_req.include_declared = Some(false);
+        let list_response = namespace.list_tables(list_req).await.unwrap();
+        assert!(list_response.tables.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_declared_table_promotes_it_from_declared_state() {
+        use lance_namespace::models::{
+            DeclareTableRequest, DescribeTableRequest, InsertIntoTableRequest,
+        };
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["test_table".to_string()]);
+        namespace.declare_table(declare_req).await.unwrap();
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut insert_req = InsertIntoTableRequest::new();
+        insert_req.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .insert_into_table(insert_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        describe_req.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+
+        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.version, Some(1));
+        assert!(describe_response.schema.is_some());
+
+        let mut list_req = ListTablesRequest::new();
+        list_req.id = Some(vec![]);
+        list_req.include_declared = Some(false);
+        assert_eq!(
+            namespace.list_tables(list_req).await.unwrap().tables,
+            vec!["test_table".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_after_declare_table_v1_mode_creates_table() {
+        use lance_namespace::models::{
+            DeclareTableRequest, DescribeTableRequest, ListTablesRequest,
+        };
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["test_table".to_string()]);
+        namespace.declare_table(declare_req).await.unwrap();
+
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        let response = namespace
+            .create_table(
+                create_req,
+                bytes::Bytes::from(create_non_empty_test_ipc_data()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.version, Some(1));
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        describe_req.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.version, Some(1));
+
+        let mut list_req = ListTablesRequest::new();
+        list_req.id = Some(vec![]);
+        list_req.include_declared = Some(false);
+        assert_eq!(
+            namespace.list_tables(list_req).await.unwrap().tables,
+            vec!["test_table".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_insert_into_declared_table_with_manifest_promotes_it() {
+        use lance_namespace::models::{
+            DeclareTableRequest, DescribeTableRequest, InsertIntoTableRequest, ListTablesRequest,
+        };
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["test_table".to_string()]);
+        namespace.declare_table(declare_req).await.unwrap();
+
+        let mut insert_req = InsertIntoTableRequest::new();
+        insert_req.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .insert_into_table(
+                insert_req,
+                bytes::Bytes::from(create_non_empty_test_ipc_data()),
+            )
+            .await
+            .unwrap();
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        describe_req.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.version, Some(1));
+
+        let mut list_req = ListTablesRequest::new();
+        list_req.id = Some(vec![]);
+        list_req.include_declared = Some(false);
+        assert_eq!(
+            namespace.list_tables(list_req).await.unwrap().tables,
+            vec!["test_table".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_after_declare_table_with_manifest_creates_table() {
+        use lance_namespace::models::{
+            CreateTableRequest, DeclareTableRequest, DescribeTableRequest, ListTablesRequest,
+        };
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["test_table".to_string()]);
+        declare_req.properties = Some(HashMap::from([("owner".to_string(), "alice".to_string())]));
+        namespace.declare_table(declare_req).await.unwrap();
+
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        let response = namespace
+            .create_table(
+                create_req,
+                bytes::Bytes::from(create_non_empty_test_ipc_data()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.version, Some(1));
+        assert_eq!(
+            response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"alice".to_string())
+        );
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        describe_req.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.version, Some(1));
+        assert_eq!(
+            describe_response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"alice".to_string())
+        );
+
+        let mut list_req = ListTablesRequest::new();
+        list_req.id = Some(vec![]);
+        list_req.include_declared = Some(false);
+        assert_eq!(
+            namespace.list_tables(list_req).await.unwrap().tables,
+            vec!["test_table".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_after_declare_table_with_manifest_rejects_new_properties() {
+        use lance_namespace::models::{CreateTableRequest, DeclareTableRequest};
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["test_table".to_string()]);
+        declare_req.properties = Some(HashMap::from([("owner".to_string(), "alice".to_string())]));
+        namespace.declare_table(declare_req).await.unwrap();
+
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        create_req.properties = Some(HashMap::from([("owner".to_string(), "bob".to_string())]));
+
+        let result = namespace
+            .create_table(
+                create_req,
+                bytes::Bytes::from(create_non_empty_test_ipc_data()),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot set properties for already declared table")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_insert_into_declared_table_v1_mode_creates_table() {
+        use lance_namespace::models::{
+            DeclareTableRequest, DescribeTableRequest, ListTablesRequest,
+            MergeInsertIntoTableRequest,
+        };
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["test_table".to_string()]);
+        namespace.declare_table(declare_req).await.unwrap();
+
+        let mut merge_req = MergeInsertIntoTableRequest::new();
+        merge_req.id = Some(vec!["test_table".to_string()]);
+        merge_req.on = Some("id".to_string());
+        let response = namespace
+            .merge_insert_into_table(
+                merge_req,
+                bytes::Bytes::from(create_non_empty_test_ipc_data()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.num_inserted_rows, Some(2));
+        assert_eq!(response.num_updated_rows, Some(0));
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        describe_req.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.version, Some(1));
+
+        let mut list_req = ListTablesRequest::new();
+        list_req.id = Some(vec![]);
+        list_req.include_declared = Some(false);
+        assert_eq!(
+            namespace.list_tables(list_req).await.unwrap().tables,
+            vec!["test_table".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_insert_into_declared_table_with_manifest_creates_table() {
+        use lance_namespace::models::{
+            DeclareTableRequest, DescribeTableRequest, ListTablesRequest,
+            MergeInsertIntoTableRequest,
+        };
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["test_table".to_string()]);
+        namespace.declare_table(declare_req).await.unwrap();
+
+        let mut merge_req = MergeInsertIntoTableRequest::new();
+        merge_req.id = Some(vec!["test_table".to_string()]);
+        merge_req.on = Some("id".to_string());
+        let response = namespace
+            .merge_insert_into_table(
+                merge_req,
+                bytes::Bytes::from(create_non_empty_test_ipc_data()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.num_inserted_rows, Some(2));
+        assert_eq!(response.num_updated_rows, Some(0));
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        describe_req.load_detailed_metadata = Some(true);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.version, Some(1));
+
+        let mut list_req = ListTablesRequest::new();
+        list_req.id = Some(vec![]);
+        list_req.include_declared = Some(false);
+        assert_eq!(
+            namespace.list_tables(list_req).await.unwrap().tables,
+            vec!["test_table".to_string()]
+        );
     }
 
     #[tokio::test]
     async fn test_declare_table_with_manifest() {
-        use lance_namespace::models::{DeclareTableRequest, TableExistsRequest};
+        use lance_namespace::models::{
+            DeclareTableRequest, DescribeTableRequest, ListTablesRequest, TableExistsRequest,
+        };
 
         let temp_dir = TempStdDir::default();
         let temp_path = temp_dir.to_str().unwrap();
@@ -6020,15 +6576,55 @@ mod tests {
         // Declare a table
         let mut declare_req = DeclareTableRequest::new();
         declare_req.id = Some(vec!["test_table".to_string()]);
+        declare_req.properties = Some(HashMap::from([("owner".to_string(), "alice".to_string())]));
         let response = namespace.declare_table(declare_req).await.unwrap();
 
         // Should return location
         assert!(response.location.is_some());
+        assert_eq!(
+            response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"alice".to_string())
+        );
 
         // Table should exist in manifest
         let mut exists_req = TableExistsRequest::new();
         exists_req.id = Some(vec!["test_table".to_string()]);
         assert!(namespace.table_exists(exists_req).await.is_ok());
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(describe_response.is_only_declared, Some(true));
+        assert_eq!(
+            describe_response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"alice".to_string())
+        );
+
+        let mut list_req = ListTablesRequest::new();
+        list_req.id = Some(vec![]);
+        assert_eq!(
+            namespace
+                .list_tables(list_req.clone())
+                .await
+                .unwrap()
+                .tables,
+            vec!["test_table".to_string()]
+        );
+        list_req.include_declared = Some(false);
+        assert!(
+            namespace
+                .list_tables(list_req)
+                .await
+                .unwrap()
+                .tables
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1234,16 +1234,25 @@ impl DirectoryNamespace {
         }
 
         let load_detailed_metadata = request.load_detailed_metadata.unwrap_or(false);
+        let should_check_declared =
+            load_detailed_metadata || request.check_declared.unwrap_or(false);
         // For backwards compatibility, only skip vending credentials when explicitly set to false
         let vend_credentials = request.vend_credentials.unwrap_or(true);
         let identity = request.identity.as_deref();
+        let is_only_declared = if should_check_declared {
+            if status.has_reserved_file {
+                Some(!self.table_has_actual_manifests(&table_name).await?)
+            } else {
+                Some(false)
+            }
+        } else {
+            None
+        };
 
         if !load_detailed_metadata {
             let storage_options = self
                 .get_storage_options_for_table(&table_uri, vend_credentials, identity)
                 .await?;
-            let is_only_declared =
-                status.has_reserved_file && !self.table_has_actual_manifests(&table_name).await?;
             return Ok(DescribeTableResponse {
                 table: Some(table_name),
                 namespace: request.id.as_ref().map(|id| {
@@ -1256,7 +1265,33 @@ impl DirectoryNamespace {
                 location: Some(table_uri.clone()),
                 table_uri: Some(table_uri),
                 storage_options,
-                is_only_declared: is_only_declared.then_some(true),
+                is_only_declared,
+                managed_versioning: if self.table_version_tracking_enabled {
+                    Some(true)
+                } else {
+                    None
+                },
+                ..Default::default()
+            });
+        }
+
+        if is_only_declared == Some(true) {
+            let storage_options = self
+                .get_storage_options_for_table(&table_uri, vend_credentials, identity)
+                .await?;
+            return Ok(DescribeTableResponse {
+                table: Some(table_name),
+                namespace: request.id.as_ref().map(|id| {
+                    if id.len() > 1 {
+                        id[..id.len() - 1].to_vec()
+                    } else {
+                        vec![]
+                    }
+                }),
+                location: Some(table_uri.clone()),
+                table_uri: Some(table_uri),
+                storage_options,
+                is_only_declared,
                 managed_versioning: if self.table_version_tracking_enabled {
                     Some(true)
                 } else {
@@ -1319,6 +1354,7 @@ impl DirectoryNamespace {
                     schema: Some(Box::new(json_schema)),
                     storage_options,
                     metadata: Some(metadata),
+                    is_only_declared,
                     managed_versioning: if self.table_version_tracking_enabled {
                         Some(true)
                     } else {
@@ -1329,8 +1365,7 @@ impl DirectoryNamespace {
             }
             Err(err) => {
                 if manifest::ManifestNamespace::is_not_found_load_error(&err)
-                    && status.has_reserved_file
-                    && !self.table_has_actual_manifests(&table_name).await?
+                    && is_only_declared == Some(true)
                 {
                     let storage_options = self
                         .get_storage_options_for_table(&table_uri, vend_credentials, identity)
@@ -1347,7 +1382,7 @@ impl DirectoryNamespace {
                         location: Some(table_uri.clone()),
                         table_uri: Some(table_uri),
                         storage_options,
-                        is_only_declared: Some(true),
+                        is_only_declared,
                         managed_versioning: if self.table_version_tracking_enabled {
                             Some(true)
                         } else {
@@ -4023,7 +4058,7 @@ mod tests {
     use lance::index::DatasetIndexExt;
     use lance_core::utils::tempfile::{TempStdDir, TempStrDir};
     use lance_core::utils::testing::CountingObjectStore;
-    use lance_io::object_store::providers::local::FileStoreProvider;
+    use lance_io::object_store::{providers::local::FileStoreProvider, uri_to_url};
     use lance_namespace::models::{
         CreateTableRequest, JsonArrowDataType, JsonArrowField, JsonArrowSchema, ListTablesRequest,
         QueryTableRequestColumns,
@@ -4096,8 +4131,10 @@ mod tests {
     }
 
     fn file_object_store_uri(path: &str) -> String {
-        let path_prefix = if path.starts_with('/') { "" } else { "/" };
-        format!("file-object-store://{path_prefix}{path}")
+        let file_url = uri_to_url(path).unwrap();
+        let mut url = Url::parse("file-object-store:///").unwrap();
+        url.set_path(file_url.path());
+        url.to_string()
     }
 
     fn build_listing_counting_session(listing_count: Arc<AtomicUsize>) -> Arc<Session> {
@@ -6202,6 +6239,12 @@ mod tests {
         assert!(describe_response.location.is_some());
         assert!(describe_response.version.is_none()); // Not written yet
         assert!(describe_response.schema.is_none()); // Not written yet
+        assert_eq!(describe_response.is_only_declared, None);
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        describe_req.check_declared = Some(true);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
         assert_eq!(describe_response.is_only_declared, Some(true));
 
         let mut list_req = ListTablesRequest::new();
@@ -6247,7 +6290,7 @@ mod tests {
         describe_req.load_detailed_metadata = Some(true);
         let describe_response = namespace.describe_table(describe_req).await.unwrap();
 
-        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.is_only_declared, Some(false));
         assert_eq!(describe_response.version, Some(1));
         assert!(describe_response.schema.is_some());
 
@@ -6295,7 +6338,7 @@ mod tests {
         describe_req.id = Some(vec!["test_table".to_string()]);
         describe_req.load_detailed_metadata = Some(true);
         let describe_response = namespace.describe_table(describe_req).await.unwrap();
-        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.is_only_declared, Some(false));
         assert_eq!(describe_response.version, Some(1));
 
         let mut list_req = ListTablesRequest::new();
@@ -6341,7 +6384,7 @@ mod tests {
         describe_req.id = Some(vec!["test_table".to_string()]);
         describe_req.load_detailed_metadata = Some(true);
         let describe_response = namespace.describe_table(describe_req).await.unwrap();
-        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.is_only_declared, Some(false));
         assert_eq!(describe_response.version, Some(1));
 
         let mut list_req = ListTablesRequest::new();
@@ -6397,7 +6440,7 @@ mod tests {
         describe_req.id = Some(vec!["test_table".to_string()]);
         describe_req.load_detailed_metadata = Some(true);
         let describe_response = namespace.describe_table(describe_req).await.unwrap();
-        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.is_only_declared, Some(false));
         assert_eq!(describe_response.version, Some(1));
         assert_eq!(
             describe_response
@@ -6493,7 +6536,7 @@ mod tests {
         describe_req.id = Some(vec!["test_table".to_string()]);
         describe_req.load_detailed_metadata = Some(true);
         let describe_response = namespace.describe_table(describe_req).await.unwrap();
-        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.is_only_declared, Some(false));
         assert_eq!(describe_response.version, Some(1));
 
         let mut list_req = ListTablesRequest::new();
@@ -6544,7 +6587,7 @@ mod tests {
         describe_req.id = Some(vec!["test_table".to_string()]);
         describe_req.load_detailed_metadata = Some(true);
         let describe_response = namespace.describe_table(describe_req).await.unwrap();
-        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(describe_response.is_only_declared, Some(false));
         assert_eq!(describe_response.version, Some(1));
 
         let mut list_req = ListTablesRequest::new();
@@ -6596,6 +6639,12 @@ mod tests {
 
         let mut describe_req = DescribeTableRequest::new();
         describe_req.id = Some(vec!["test_table".to_string()]);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(describe_response.is_only_declared, None);
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        describe_req.check_declared = Some(true);
         let describe_response = namespace.describe_table(describe_req).await.unwrap();
         assert_eq!(describe_response.is_only_declared, Some(true));
         assert_eq!(
@@ -7007,7 +7056,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(not(windows))]
     async fn test_list_table_versions() {
         use arrow::array::{Int32Array, RecordBatchIterator};
         use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
@@ -7124,7 +7172,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(not(windows))]
     async fn test_describe_table_version() {
         use arrow::array::{Int32Array, RecordBatchIterator};
         use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
@@ -7239,7 +7286,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(not(windows))]
     async fn test_describe_table_version_latest() {
         use arrow::array::{Int32Array, RecordBatchIterator};
         use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
@@ -7321,7 +7367,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(not(windows))]
     async fn test_create_table_version() {
         use futures::TryStreamExt;
         use lance::dataset::builder::DatasetBuilder;
@@ -7432,7 +7477,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(not(windows))]
     async fn test_create_table_version_conflict() {
         // create_table_version should fail if the version already exists.
         // Each version always writes to a new file location.
@@ -7778,7 +7822,6 @@ mod tests {
         }
 
         #[tokio::test]
-        #[cfg(not(windows))]
         async fn test_external_manifest_store_invokes_namespace_apis() {
             use arrow::array::{Int32Array, StringArray};
             use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
@@ -7898,7 +7941,6 @@ mod tests {
         }
 
         #[tokio::test]
-        #[cfg(not(windows))]
         async fn test_dataset_commit_with_external_manifest_store() {
             use arrow::array::{Int32Array, StringArray};
             use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
@@ -8895,7 +8937,6 @@ mod tests {
         }
 
         #[tokio::test]
-        #[cfg(not(windows))]
         async fn test_create_table_version_records_in_manifest() {
             // When table_version_storage_enabled is enabled, single create_table_version
             // should also record the version in __manifest
@@ -9105,10 +9146,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(
-        windows,
-        ignore = "TODO: https://github.com/lance-format/lance/issues/6557"
-    )]
     async fn test_dir_listing_no_extra_calls_without_migration() {
         let temp_dir = TempStdDir::default();
         let temp_path = temp_dir.to_str().unwrap();
@@ -9177,10 +9214,54 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(
-        windows,
-        ignore = "TODO: https://github.com/lance-format/lance/issues/6557"
-    )]
+    async fn test_describe_declared_table_checks_versions_only_when_requested() {
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let root_uri = file_object_store_uri(temp_path);
+        let listing_count = Arc::new(AtomicUsize::new(0));
+        let session = build_listing_counting_session(listing_count.clone());
+
+        let namespace = DirectoryNamespaceBuilder::new(root_uri)
+            .session(session)
+            .manifest_enabled(false)
+            .dir_listing_enabled(true)
+            .build()
+            .await
+            .unwrap();
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["test_table".to_string()]);
+        namespace.declare_table(declare_req).await.unwrap();
+
+        listing_count.store(0, Ordering::SeqCst);
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+
+        assert_eq!(describe_response.is_only_declared, None);
+        assert_eq!(
+            listing_count.load(Ordering::SeqCst),
+            1,
+            "Default describe_table should only list the table directory"
+        );
+
+        listing_count.store(0, Ordering::SeqCst);
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["test_table".to_string()]);
+        describe_req.check_declared = Some(true);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+
+        assert_eq!(describe_response.is_only_declared, Some(true));
+        assert_eq!(
+            listing_count.load(Ordering::SeqCst),
+            2,
+            "check_declared describe_table should list the table directory and _versions"
+        );
+    }
+
+    #[tokio::test]
     async fn test_dir_listing_extra_calls_with_migration() {
         let temp_dir = TempStdDir::default();
         let temp_path = temp_dir.to_str().unwrap();

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -34,7 +34,7 @@ use lance_index::vector::{
 use lance_index::{IndexType, is_system_index};
 use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
 use lance_linalg::distance::MetricType;
-use lance_table::io::commit::ManifestNamingScheme;
+use lance_table::io::commit::{ManifestNamingScheme, VERSIONS_DIR};
 use object_store::path::Path;
 use object_store::{Error as ObjectStoreError, ObjectStore as OSObjectStore, PutMode, PutOptions};
 use std::collections::HashMap;
@@ -1104,11 +1104,18 @@ impl DirectoryNamespace {
     }
 
     async fn table_uri_has_actual_manifests(&self, table_uri: &str) -> Result<bool> {
-        manifest::ManifestNamespace::path_has_actual_manifests(
-            &self.object_store,
-            &Self::uri_to_object_store_path(table_uri),
-        )
-        .await
+        let table_path = self.object_store_path_from_uri(table_uri)?;
+        manifest::ManifestNamespace::path_has_actual_manifests(&self.object_store, &table_path)
+            .await
+    }
+
+    fn object_store_path_from_uri(&self, uri: &str) -> Result<Path> {
+        let registry = self
+            .session
+            .as_ref()
+            .map(|session| session.store_registry())
+            .unwrap_or_else(|| Arc::new(ObjectStoreRegistry::default()));
+        ObjectStore::extract_path_from_uri(registry, uri)
     }
 
     fn validate_dir_only_properties(
@@ -1742,21 +1749,6 @@ impl DirectoryNamespace {
         format!("{}/{}.lance", &self.root, table_name)
     }
 
-    fn uri_to_object_store_path(uri: &str) -> Path {
-        let path_str = if let Some(rest) = uri.strip_prefix("file://") {
-            rest
-        } else if let Some(rest) = uri.strip_prefix("s3://") {
-            rest.split_once('/').map(|(_, p)| p).unwrap_or(rest)
-        } else if let Some(rest) = uri.strip_prefix("gs://") {
-            rest.split_once('/').map(|(_, p)| p).unwrap_or(rest)
-        } else if let Some(rest) = uri.strip_prefix("az://") {
-            rest.split_once('/').map(|(_, p)| p).unwrap_or(rest)
-        } else {
-            uri
-        };
-        Path::from(path_str)
-    }
-
     /// Get the object store path for a table (relative to base_path)
     fn table_path(&self, table_name: &str) -> Path {
         self.base_path
@@ -1982,9 +1974,8 @@ impl DirectoryNamespace {
         let mut deleted_count = 0i64;
         for te in table_entries {
             let table_uri = self.resolve_table_location(&te.table_id).await?;
-            let table_path = Self::uri_to_object_store_path(&table_uri);
-            let table_path_str = table_path.as_ref();
-            let versions_dir_path = Path::from(format!("{}_versions", table_path_str));
+            let table_path = self.object_store_path_from_uri(&table_uri)?;
+            let versions_dir_path = table_path.child(VERSIONS_DIR);
 
             for (start, end) in &te.ranges {
                 for version in *start..=*end {
@@ -2669,8 +2660,8 @@ impl LanceNamespace for DirectoryNamespace {
         // Fallback when table_version_storage is not enabled: list from _versions/ directory
         let table_uri = self.resolve_table_location(&request.id).await?;
 
-        let table_path = Self::uri_to_object_store_path(&table_uri);
-        let versions_dir = table_path.child("_versions");
+        let table_path = self.object_store_path_from_uri(&table_uri)?;
+        let versions_dir = table_path.child(VERSIONS_DIR);
         let manifest_metas: Vec<_> = self
             .object_store
             .read_dir_all(&versions_dir, None)
@@ -2758,7 +2749,7 @@ impl LanceNamespace for DirectoryNamespace {
         let staging_manifest_path = &request.manifest_path;
         let version = request.version as u64;
 
-        let table_path = Self::uri_to_object_store_path(&table_uri);
+        let table_path = self.object_store_path_from_uri(&table_uri)?;
 
         // Determine naming scheme from request, default to V2
         let naming_scheme = match request.naming_scheme.as_deref() {
@@ -2769,7 +2760,14 @@ impl LanceNamespace for DirectoryNamespace {
         // Compute final path using the naming scheme
         let final_path = naming_scheme.manifest_path(&table_path, version);
 
-        let staging_path = Self::uri_to_object_store_path(staging_manifest_path);
+        let staging_path = Path::parse(staging_manifest_path).map_err(|e| {
+            lance_core::Error::from(NamespaceError::InvalidInput {
+                message: format!(
+                    "Invalid staging manifest path '{}': {}",
+                    staging_manifest_path, e
+                ),
+            })
+        })?;
         let manifest_data = self
             .object_store
             .inner

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1175,6 +1175,86 @@ impl DirectoryNamespace {
         Ok(dataset)
     }
 
+    async fn list_table_versions_from_storage(
+        &self,
+        table_uri: &str,
+        descending: bool,
+        limit: Option<i32>,
+    ) -> Result<Vec<TableVersion>> {
+        let table_path = self.object_store_path_from_uri(table_uri)?;
+        let versions_dir = table_path.child(VERSIONS_DIR);
+        let manifest_metas: Vec<_> = self
+            .object_store
+            .read_dir_all(&versions_dir, None)
+            .try_collect()
+            .await
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to list manifest files for table at '{}': {}",
+                        table_uri, e
+                    ),
+                })
+            })?;
+
+        let is_v2_naming = manifest_metas
+            .first()
+            .is_some_and(|meta| meta.location.filename().is_some_and(|f| f.len() == 29));
+
+        let mut table_versions: Vec<TableVersion> = manifest_metas
+            .into_iter()
+            .filter_map(|meta| {
+                let filename = meta.location.filename()?;
+                let version_str = filename.strip_suffix(".manifest")?;
+                if version_str.starts_with('d') {
+                    return None;
+                }
+                let file_version: u64 = version_str.parse().ok()?;
+
+                let actual_version = if file_version > u64::MAX / 2 {
+                    u64::MAX - file_version
+                } else {
+                    file_version
+                };
+
+                Some(TableVersion {
+                    version: actual_version as i64,
+                    manifest_path: meta.location.to_string(),
+                    manifest_size: Some(meta.size as i64),
+                    e_tag: meta.e_tag,
+                    timestamp_millis: Some(meta.last_modified.timestamp_millis()),
+                    metadata: None,
+                })
+            })
+            .collect();
+
+        let list_is_ordered = self.object_store.list_is_lexically_ordered;
+
+        let needs_sort = if list_is_ordered {
+            if is_v2_naming {
+                !descending
+            } else {
+                descending
+            }
+        } else {
+            true
+        };
+
+        if needs_sort {
+            if descending {
+                table_versions.sort_by(|a, b| b.version.cmp(&a.version));
+            } else {
+                table_versions.sort_by(|a, b| a.version.cmp(&b.version));
+            }
+        }
+
+        if let Some(limit) = limit {
+            table_versions.truncate(limit as usize);
+        }
+
+        Ok(table_versions)
+    }
+
     /// Internal describe_table implementation that doesn't record metrics.
     /// Used by both the public describe_table (which records metrics) and
     /// internal callers like resolve_table_location (which shouldn't).
@@ -2694,79 +2774,10 @@ impl LanceNamespace for DirectoryNamespace {
 
         // Fallback when table_version_storage is not enabled: list from _versions/ directory
         let table_uri = self.resolve_table_location(&request.id).await?;
-
-        let table_path = self.object_store_path_from_uri(&table_uri)?;
-        let versions_dir = table_path.child(VERSIONS_DIR);
-        let manifest_metas: Vec<_> = self
-            .object_store
-            .read_dir_all(&versions_dir, None)
-            .try_collect()
-            .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to list manifest files for table at '{}': {}",
-                        table_uri, e
-                    ),
-                })
-            })?;
-
-        let is_v2_naming = manifest_metas
-            .first()
-            .is_some_and(|meta| meta.location.filename().is_some_and(|f| f.len() == 29));
-
-        let mut table_versions: Vec<TableVersion> = manifest_metas
-            .into_iter()
-            .filter_map(|meta| {
-                let filename = meta.location.filename()?;
-                let version_str = filename.strip_suffix(".manifest")?;
-                if version_str.starts_with('d') {
-                    return None;
-                }
-                let file_version: u64 = version_str.parse().ok()?;
-
-                let actual_version = if file_version > u64::MAX / 2 {
-                    u64::MAX - file_version
-                } else {
-                    file_version
-                };
-
-                // Use full path from object_store (relative to object store root)
-                Some(TableVersion {
-                    version: actual_version as i64,
-                    manifest_path: meta.location.to_string(),
-                    manifest_size: Some(meta.size as i64),
-                    e_tag: meta.e_tag,
-                    timestamp_millis: Some(meta.last_modified.timestamp_millis()),
-                    metadata: None,
-                })
-            })
-            .collect();
-
-        let list_is_ordered = self.object_store.list_is_lexically_ordered;
         let want_descending = request.descending == Some(true);
-
-        let needs_sort = if list_is_ordered {
-            if is_v2_naming {
-                !want_descending
-            } else {
-                want_descending
-            }
-        } else {
-            true
-        };
-
-        if needs_sort {
-            if want_descending {
-                table_versions.sort_by(|a, b| b.version.cmp(&a.version));
-            } else {
-                table_versions.sort_by(|a, b| a.version.cmp(&b.version));
-            }
-        }
-
-        if let Some(limit) = request.limit {
-            table_versions.truncate(limit as usize);
-        }
+        let table_versions = self
+            .list_table_versions_from_storage(&table_uri, want_descending, request.limit)
+            .await?;
 
         Ok(ListTableVersionsResponse {
             versions: table_versions,
@@ -2803,61 +2814,91 @@ impl LanceNamespace for DirectoryNamespace {
                 ),
             })
         })?;
-        let manifest_data = self
+
+        let copy_result = match self
             .object_store
             .inner
-            .get(&staging_path)
+            .copy_if_not_exists(&staging_path, &final_path)
             .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to read staging manifest at '{}': {}",
-                        staging_manifest_path, e
-                    ),
-                })
-            })?
-            .bytes()
-            .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to read staging manifest bytes at '{}': {}",
-                        staging_manifest_path, e
-                    ),
-                })
-            })?;
+        {
+            Ok(()) => Ok(()),
+            Err(ObjectStoreError::NotImplemented) | Err(ObjectStoreError::NotSupported { .. }) => {
+                let manifest_data = self
+                    .object_store
+                    .inner
+                    .get(&staging_path)
+                    .await
+                    .map_err(|e| {
+                        lance_core::Error::from(NamespaceError::Internal {
+                            message: format!(
+                                "Failed to read staging manifest at '{}': {}",
+                                staging_manifest_path, e
+                            ),
+                        })
+                    })?
+                    .bytes()
+                    .await
+                    .map_err(|e| {
+                        lance_core::Error::from(NamespaceError::Internal {
+                            message: format!(
+                                "Failed to read staging manifest bytes at '{}': {}",
+                                staging_manifest_path, e
+                            ),
+                        })
+                    })?;
+                self.object_store
+                    .inner
+                    .put_opts(
+                        &final_path,
+                        manifest_data.into(),
+                        PutOptions {
+                            mode: PutMode::Create,
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                    .map(|_| ())
+            }
+            Err(e) => Err(e),
+        };
 
-        let manifest_size = manifest_data.len() as i64;
-
-        let put_result = self
-            .object_store
-            .inner
-            .put_opts(
-                &final_path,
-                manifest_data.into(),
-                PutOptions {
-                    mode: PutMode::Create,
-                    ..Default::default()
-                },
-            )
-            .await
-            .map_err(|e| match e {
-                object_store::Error::AlreadyExists { .. }
-                | object_store::Error::Precondition { .. } => {
-                    lance_core::Error::from(NamespaceError::ConcurrentModification {
+        match copy_result {
+            Ok(()) => {}
+            Err(ObjectStoreError::AlreadyExists { .. })
+            | Err(ObjectStoreError::Precondition { .. }) => {
+                return Err(lance_core::Error::from(
+                    NamespaceError::ConcurrentModification {
                         message: format!(
                             "Version {} already exists for table at '{}'",
                             version, table_uri
                         ),
-                    })
-                }
-                _ => lance_core::Error::from(NamespaceError::Internal {
+                    },
+                ));
+            }
+            Err(e) => {
+                return Err(lance_core::Error::from(NamespaceError::Internal {
                     message: format!(
                         "Failed to create version {} for table at '{}': {}",
                         version, table_uri, e
                     ),
-                }),
+                }));
+            }
+        }
+
+        let final_meta = self
+            .object_store
+            .inner
+            .head(&final_path)
+            .await
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to stat created version {} for table at '{}': {}",
+                        version, table_uri, e
+                    ),
+                })
             })?;
+        let manifest_size = final_meta.size as i64;
 
         // Delete the staging manifest after successful copy
         if let Err(e) = self.object_store.inner.delete(&staging_path).await {
@@ -2879,7 +2920,7 @@ impl LanceNamespace for DirectoryNamespace {
             let metadata_json = serde_json::json!({
                 "manifest_path": final_path.to_string(),
                 "manifest_size": manifest_size,
-                "e_tag": put_result.e_tag,
+                "e_tag": final_meta.e_tag,
                 "naming_scheme": request.naming_scheme.as_deref().unwrap_or("V2"),
             })
             .to_string();
@@ -2909,7 +2950,7 @@ impl LanceNamespace for DirectoryNamespace {
                 version: version as i64,
                 manifest_path: final_path.to_string(),
                 manifest_size: Some(manifest_size),
-                e_tag: put_result.e_tag,
+                e_tag: final_meta.e_tag,
                 timestamp_millis: None,
                 metadata: None,
             })),
@@ -2930,53 +2971,33 @@ impl LanceNamespace for DirectoryNamespace {
             return manifest_ns.describe_table_version(&table_id, version).await;
         }
 
-        // Fallback when table_version_storage is not enabled: open the dataset to describe the version
+        // Fallback when table_version_storage is not enabled: inspect physical manifests directly.
         let table_uri = self.resolve_table_location(&request.id).await?;
-
-        // Use DatasetBuilder with storage options to support S3 with custom endpoints
-        let mut builder = DatasetBuilder::from_uri(&table_uri);
-        if let Some(opts) = &self.storage_options {
-            builder = builder.with_storage_options(opts.clone());
-        }
-        if let Some(sess) = &self.session {
-            builder = builder.with_session(sess.clone());
-        }
-        let mut dataset = builder.load().await.map_err(|e| {
-            lance_core::Error::from(NamespaceError::TableNotFound {
-                message: format!("Failed to open table at '{}': {:?}", table_uri, e),
-            })
-        })?;
-
-        if let Some(version) = request.version {
-            dataset = dataset
-                .checkout_version(version as u64)
-                .await
-                .map_err(|e| {
+        let versions = self
+            .list_table_versions_from_storage(&table_uri, true, None)
+            .await?;
+        let table_version = if let Some(requested_version) = request.version {
+            versions
+                .into_iter()
+                .find(|version| version.version == requested_version)
+                .ok_or_else(|| {
                     lance_core::Error::from(NamespaceError::TableVersionNotFound {
                         message: format!(
-                            "Failed to checkout version {} for table at '{}': {}",
-                            version, table_uri, e
+                            "version {} for table {}",
+                            requested_version,
+                            Self::format_table_id_from_request(&request.id)
                         ),
                     })
-                })?;
-        }
-
-        let version_info = dataset.version();
-        let manifest_location = dataset.manifest_location();
-        let metadata: std::collections::HashMap<String, String> =
-            version_info.metadata.into_iter().collect();
-
-        let table_version = TableVersion {
-            version: version_info.version as i64,
-            manifest_path: manifest_location.path.to_string(),
-            manifest_size: manifest_location.size.map(|s| s as i64),
-            e_tag: manifest_location.e_tag.clone(),
-            timestamp_millis: Some(version_info.timestamp.timestamp_millis()),
-            metadata: if metadata.is_empty() {
-                None
-            } else {
-                Some(metadata)
-            },
+                })?
+        } else {
+            versions.into_iter().next().ok_or_else(|| {
+                lance_core::Error::from(NamespaceError::TableVersionNotFound {
+                    message: format!(
+                        "latest version for table {}",
+                        Self::format_table_id_from_request(&request.id)
+                    ),
+                })
+            })?
         };
 
         Ok(DescribeTableVersionResponse {
@@ -7566,13 +7587,14 @@ mod tests {
         );
 
         // Get the path from the response for verification
-        let version_2_path = Path::from(
-            first_result
+        let version_2_path = Path::parse(
+            &first_result
                 .unwrap()
                 .version
                 .expect("response should contain version info")
                 .manifest_path,
-        );
+        )
+        .unwrap();
 
         // Create version 2 again (should fail - conflict)
         let mut create_version_req = CreateTableVersionRequest::new(2, staging_path.to_string());

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -488,22 +488,24 @@ impl ManifestNamespace {
     pub(crate) fn construct_full_uri(root: &str, relative_location: &str) -> Result<String> {
         let mut base_url = lance_io::object_store::uri_to_url(root)?;
 
-        // Ensure the base URL has a trailing slash so that URL.join() appends
-        // rather than replaces the last path segment.
-        // Without this fix, "s3://bucket/path/subdir".join("table.lance")
+        // Ensure the base URL has a trailing slash so that path segment mutation
+        // appends rather than replaces the last path segment.
+        // Without this fix, appending "table.lance" to "s3://bucket/path/subdir"
         // would incorrectly produce "s3://bucket/path/table.lance" (missing subdir).
         if !base_url.path().ends_with('/') {
             base_url.set_path(&format!("{}/", base_url.path()));
         }
 
-        let mut full_url = base_url.join(relative_location).map_err(|e| {
-            lance_core::Error::from(NamespaceError::InvalidInput {
-                message: format!(
-                    "Failed to join URI '{}' with '{}': {:?}",
-                    root, relative_location, e
-                ),
-            })
-        })?;
+        let mut full_url = base_url.clone();
+        full_url
+            .path_segments_mut()
+            .map_err(|_| {
+                lance_core::Error::from(NamespaceError::InvalidInput {
+                    message: format!("Cannot modify path segments for URI '{}'", root),
+                })
+            })?
+            .pop_if_empty()
+            .push(relative_location);
 
         // Clear any query string to avoid trailing "?" in the URL.
         // Use set_query(None) instead of set_query("") because the latter
@@ -3803,6 +3805,24 @@ mod tests {
         assert_eq!(
             query_param_result, "s3://bucket/path/table.lance",
             "URL with query parameters should have them stripped"
+        );
+    }
+
+    #[test]
+    fn test_construct_full_uri_with_dollar_sign() {
+        let result =
+            ManifestNamespace::construct_full_uri("/tmp/root", "hash_workspace$test_table")
+                .unwrap();
+
+        assert!(
+            result.ends_with("/tmp/root/hash_workspace$test_table"),
+            "local file URI should preserve dollar signs without adding empty path segments: {}",
+            result
+        );
+        assert!(
+            !result.contains("//hash_workspace$test_table"),
+            "local file URI should not add a double slash before table directory: {}",
+            result
         );
     }
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -12,7 +12,7 @@ use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 use arrow_ipc::reader::StreamReader;
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::{FutureExt, stream::StreamExt};
+use futures::{FutureExt, TryStreamExt, stream::StreamExt};
 use lance::dataset::optimize::{CompactionOptions, compact_files};
 use lance::dataset::{
     DeleteBuilder, MergeInsertBuilder, ReadParams, WhenMatched, WhenNotMatched, WriteParams,
@@ -41,7 +41,7 @@ use lance_namespace::models::{
     TableVersion,
 };
 use lance_namespace::schema::arrow_schema_to_json;
-use object_store::path::Path;
+use object_store::{Error as ObjectStoreError, path::Path};
 use std::io::Cursor;
 use std::{
     collections::HashMap,
@@ -53,6 +53,9 @@ use tokio::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 const MANIFEST_TABLE_NAME: &str = "__manifest";
 const DELIMITER: &str = "$";
+/// Bounded concurrency for per-table `_versions/` probes when filtering declared tables.
+/// Higher values reduce latency but increase burst load against the object store.
+pub(crate) const DECLARED_FILTER_CONCURRENCY: usize = 16;
 
 // Index names for the __manifest table
 /// BTREE index on the object_id column for fast lookups
@@ -101,6 +104,7 @@ pub struct TableInfo {
     pub namespace: Vec<String>,
     pub name: String,
     pub location: String,
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 /// An entry to be inserted into the manifest table.
@@ -778,11 +782,13 @@ impl ManifestNamespace {
                 message: format!("Failed to filter: {:?}", e),
             })
         })?;
-        scanner.project(&["object_id", "location"]).map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to project: {:?}", e),
-            })
-        })?;
+        scanner
+            .project(&["object_id", "location", "metadata"])
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!("Failed to project: {:?}", e),
+                })
+            })?;
         let batches = Self::execute_scanner(scanner).await?;
 
         let mut found_result: Option<TableInfo> = None;
@@ -806,16 +812,91 @@ impl ManifestNamespace {
 
             let object_id_array = Self::get_string_column(&batch, "object_id")?;
             let location_array = Self::get_string_column(&batch, "location")?;
+            let metadata_array = Self::get_string_column(&batch, "metadata")?;
             let location = location_array.value(0).to_string();
+            let metadata = if !metadata_array.is_null(0) {
+                let metadata_str = metadata_array.value(0);
+                match serde_json::from_str::<HashMap<String, String>>(metadata_str) {
+                    Ok(map) => Some(map),
+                    Err(e) => {
+                        return Err(NamespaceError::Internal {
+                            message: format!(
+                                "Failed to deserialize metadata for table '{}': {}",
+                                object_id, e
+                            ),
+                        }
+                        .into());
+                    }
+                }
+            } else {
+                None
+            };
             let (namespace, name) = Self::parse_object_id(object_id_array.value(0));
             found_result = Some(TableInfo {
                 namespace,
                 name,
                 location,
+                metadata,
             });
         }
 
         Ok(found_result)
+    }
+
+    fn serialize_metadata(
+        properties: Option<&HashMap<String, String>>,
+        object_type: &str,
+        object_id: &str,
+    ) -> Result<Option<String>> {
+        match properties {
+            Some(properties) if !properties.is_empty() => {
+                serde_json::to_string(properties).map(Some).map_err(|e| {
+                    LanceError::from(NamespaceError::Internal {
+                        message: format!(
+                            "Failed to serialize {} metadata for '{}': {}",
+                            object_type, object_id, e
+                        ),
+                    })
+                })
+            }
+            _ => Ok(None),
+        }
+    }
+
+    pub(crate) async fn path_has_actual_manifests(
+        object_store: &ObjectStore,
+        table_path: &Path,
+    ) -> Result<bool> {
+        let versions_path = table_path.child(lance_table::io::commit::VERSIONS_DIR);
+        // `_versions/` should only contain manifest files, so probing the first entry is enough
+        // to distinguish declared-only tables (empty `_versions/`) from created tables.
+        Ok(object_store
+            .list(Some(versions_path))
+            .try_next()
+            .await?
+            .is_some())
+    }
+
+    async fn location_has_actual_manifests(&self, location: &str) -> Result<bool> {
+        Self::path_has_actual_manifests(&self.object_store, &self.base_path.child(location)).await
+    }
+
+    pub(crate) fn is_not_found_load_error(err: &LanceError) -> bool {
+        match err {
+            LanceError::NotFound { .. } => true,
+            LanceError::IO { source, .. } => source
+                .downcast_ref::<ObjectStoreError>()
+                .is_some_and(|source| matches!(source, ObjectStoreError::NotFound { .. })),
+            LanceError::DatasetNotFound { source, .. } => {
+                source
+                    .downcast_ref::<LanceError>()
+                    .is_some_and(|source| matches!(source, LanceError::NotFound { .. }))
+                    || source
+                        .downcast_ref::<ObjectStoreError>()
+                        .is_some_and(|source| matches!(source, ObjectStoreError::NotFound { .. }))
+            }
+            _ => false,
+        }
     }
 
     /// List all table locations in the manifest (for root namespace only)
@@ -1198,7 +1279,7 @@ impl ManifestNamespace {
                 message: format!("Failed to filter: {:?}", e),
             })
         })?;
-        scanner.project(&["object_id"]).map_err(|e| {
+        scanner.project(&["object_id", "location"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
                 message: format!("Failed to project: {:?}", e),
             })
@@ -1275,7 +1356,7 @@ impl ManifestNamespace {
                 message: format!("Failed to filter: {:?}", e),
             })
         })?;
-        scanner.project(&["object_id"]).map_err(|e| {
+        scanner.project(&["object_id", "location"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
                 message: format!("Failed to project: {:?}", e),
             })
@@ -1791,7 +1872,7 @@ impl LanceNamespace for ManifestNamespace {
                 message: format!("Failed to filter: {:?}", e),
             })
         })?;
-        scanner.project(&["object_id"]).map_err(|e| {
+        scanner.project(&["object_id", "location"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
                 message: format!("Failed to project: {:?}", e),
             })
@@ -1799,19 +1880,48 @@ impl LanceNamespace for ManifestNamespace {
 
         let batches = Self::execute_scanner(scanner).await?;
 
-        let mut tables = Vec::new();
+        let mut table_entries = Vec::new();
         for batch in batches {
             if batch.num_rows() == 0 {
                 continue;
             }
 
             let object_id_array = Self::get_string_column(&batch, "object_id")?;
+            let location_array = Self::get_string_column(&batch, "location")?;
             for i in 0..batch.num_rows() {
                 let object_id = object_id_array.value(i);
+                let location = location_array.value(i);
                 let (_namespace, name) = Self::parse_object_id(object_id);
-                tables.push(name);
+                table_entries.push((name, location.to_string()));
             }
         }
+
+        let mut tables: Vec<String> = if request.include_declared.unwrap_or(true) {
+            table_entries.into_iter().map(|(name, _)| name).collect()
+        } else {
+            let mut stream = futures::stream::iter(table_entries.into_iter().map(
+                |(name, location)| async move {
+                    // `include_declared=false` is an explicit opt-in. We still pay one
+                    // `_versions/` probe per table so declared-state is derived from actual
+                    // manifests. This is linear in the total number of listed tables, and we do
+                    // the probes with bounded concurrency before pagination.
+                    if self.location_has_actual_manifests(&location).await? {
+                        Ok::<Option<String>, Error>(Some(name))
+                    } else {
+                        Ok::<Option<String>, Error>(None)
+                    }
+                },
+            ))
+            .buffered(DECLARED_FILTER_CONCURRENCY);
+
+            let mut filtered = Vec::new();
+            while let Some(result) = stream.next().await {
+                if let Some(name) = result? {
+                    filtered.push(name);
+                }
+            }
+            filtered
+        };
 
         let next_page_token =
             Self::apply_pagination(&mut tables, request.page_token, request.limit);
@@ -1860,20 +1970,30 @@ impl LanceNamespace for ManifestNamespace {
                     None
                 };
 
-                // If not loading detailed metadata, return minimal response with just location
                 if !load_detailed_metadata {
+                    let is_only_declared =
+                        !self.location_has_actual_manifests(&info.location).await?;
                     return Ok(DescribeTableResponse {
                         table: Some(table_name),
                         namespace: Some(namespace_id),
                         location: Some(table_uri.clone()),
                         table_uri: Some(table_uri),
                         storage_options,
+                        properties: info.metadata,
+                        is_only_declared: is_only_declared.then_some(true),
                         ..Default::default()
                     });
                 }
 
-                // Try to open the dataset to get version and schema
-                match Dataset::open(&table_uri).await {
+                let mut builder = DatasetBuilder::from_uri(&table_uri);
+                if let Some(opts) = &self.storage_options {
+                    builder = builder.with_storage_options(opts.clone());
+                }
+                if let Some(session) = &self.session {
+                    builder = builder.with_session(session.clone());
+                }
+
+                match builder.load().await {
                     Ok(mut dataset) => {
                         // If a specific version is requested, checkout that version
                         if let Some(requested_version) = request.version {
@@ -1893,19 +2013,34 @@ impl LanceNamespace for ManifestNamespace {
                             table_uri: Some(table_uri),
                             schema: Some(Box::new(json_schema)),
                             storage_options,
+                            properties: info.metadata.clone(),
+                            is_only_declared: None,
                             ..Default::default()
                         })
                     }
-                    Err(_) => {
-                        // If dataset can't be opened (e.g., empty table), return minimal info
-                        Ok(DescribeTableResponse {
-                            table: Some(table_name),
-                            namespace: Some(namespace_id),
-                            location: Some(table_uri.clone()),
-                            table_uri: Some(table_uri),
-                            storage_options,
-                            ..Default::default()
-                        })
+                    Err(err) => {
+                        if Self::is_not_found_load_error(&err)
+                            && !self.location_has_actual_manifests(&info.location).await?
+                        {
+                            Ok(DescribeTableResponse {
+                                table: Some(table_name),
+                                namespace: Some(namespace_id),
+                                location: Some(table_uri.clone()),
+                                table_uri: Some(table_uri),
+                                storage_options,
+                                properties: info.metadata,
+                                is_only_declared: Some(true),
+                                ..Default::default()
+                            })
+                        } else {
+                            Err(NamespaceError::Internal {
+                                message: format!(
+                                    "Table exists in manifest but failed to load dataset '{}': {}",
+                                    object_id, err
+                                ),
+                            }
+                            .into())
+                        }
                     }
                 }
             }
@@ -1963,22 +2098,43 @@ impl LanceNamespace for ManifestNamespace {
         let (namespace, table_name) = Self::split_object_id(table_id);
         let object_id = Self::build_object_id(&namespace, &table_name);
 
-        // Check if table already exists in manifest
-        if self.manifest_contains_object(&object_id).await? {
-            return Err(NamespaceError::Internal {
-                message: format!("Table '{}' already exists", table_name),
+        let existing_table = self.query_manifest_for_table(&object_id).await?;
+        let existing_has_manifests = if let Some(existing_table) = &existing_table {
+            Some(
+                self.location_has_actual_manifests(&existing_table.location)
+                    .await?,
+            )
+        } else {
+            None
+        };
+
+        if existing_has_manifests == Some(true) {
+            return Err(NamespaceError::TableAlreadyExists {
+                message: table_name.clone(),
             }
             .into());
         }
 
-        // Create the physical table location with hash-based naming
-        // When dir_listing_enabled is true and it's a root table, use directory-style naming: {table_name}.lance
-        // Otherwise, use hash-based naming: {hash}_{object_id}
-        let dir_name = if namespace.is_empty() && self.dir_listing_enabled {
-            // Root table with directory listing enabled: use {table_name}.lance
+        if existing_has_manifests == Some(false)
+            && request
+                .properties
+                .as_ref()
+                .is_some_and(|properties| !properties.is_empty())
+        {
+            return Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "create_table cannot set properties for already declared table '{}'",
+                    object_id
+                ),
+            }
+            .into());
+        }
+
+        let dir_name = if let Some(existing_table) = &existing_table {
+            existing_table.location.clone()
+        } else if namespace.is_empty() && self.dir_listing_enabled {
             format!("{}.lance", table_name)
         } else {
-            // Child namespace table or dir listing disabled: use hash-based naming
             Self::generate_dir_name(&object_id)
         };
         let table_uri = Self::construct_full_uri(&self.root, &dir_name)?;
@@ -2019,11 +2175,16 @@ impl LanceNamespace for ManifestNamespace {
             batches.into_iter().map(Ok).collect();
         let reader = RecordBatchIterator::new(batch_results, schema);
 
+        let mut write_storage_options = self.storage_options.clone().unwrap_or_default();
+        if let Some(request_storage_options) = request.storage_options.as_ref() {
+            write_storage_options.extend(request_storage_options.clone());
+        }
+
         let store_params = ObjectStoreParams {
-            storage_options_accessor: self.storage_options.as_ref().map(|opts| {
+            storage_options_accessor: (!write_storage_options.is_empty()).then(|| {
                 Arc::new(
                     lance_io::object_store::StorageOptionsAccessor::with_static_options(
-                        opts.clone(),
+                        write_storage_options,
                     ),
                 )
             }),
@@ -2042,16 +2203,38 @@ impl LanceNamespace for ManifestNamespace {
                 })
             })?;
 
-        // Register in manifest (store dir_name, not full URI)
-        self.insert_into_manifest(object_id, ObjectType::Table, Some(dir_name))
-            .await?;
+        match existing_table {
+            Some(existing_table) => Ok(CreateTableResponse {
+                version: Some(1),
+                location: Some(table_uri),
+                storage_options: self.storage_options.clone(),
+                properties: existing_table.metadata,
+                ..Default::default()
+            }),
+            None => {
+                let metadata =
+                    Self::serialize_metadata(request.properties.as_ref(), "table", &object_id)?;
+                // Register in manifest (store dir_name, not full URI)
+                self.insert_into_manifest_with_metadata(
+                    vec![ManifestEntry {
+                        object_id,
+                        object_type: ObjectType::Table,
+                        location: Some(dir_name.clone()),
+                        metadata,
+                    }],
+                    None,
+                )
+                .await?;
 
-        Ok(CreateTableResponse {
-            version: Some(1),
-            location: Some(table_uri),
-            storage_options: self.storage_options.clone(),
-            ..Default::default()
-        })
+                Ok(CreateTableResponse {
+                    version: Some(1),
+                    location: Some(table_uri),
+                    storage_options: self.storage_options.clone(),
+                    properties: request.properties,
+                    ..Default::default()
+                })
+            }
+        }
     }
 
     async fn drop_table(&self, request: DropTableRequest) -> Result<DropTableResponse> {
@@ -2235,14 +2418,8 @@ impl LanceNamespace for ManifestNamespace {
             .into());
         }
 
-        // Serialize properties if provided
-        let metadata = request.properties.as_ref().and_then(|props| {
-            if props.is_empty() {
-                None
-            } else {
-                Some(serde_json::to_string(props).ok()?)
-            }
-        });
+        let metadata =
+            Self::serialize_metadata(request.properties.as_ref(), "namespace", &object_id)?;
 
         self.insert_into_manifest_with_metadata(
             vec![ManifestEntry {
@@ -2421,9 +2598,19 @@ impl LanceNamespace for ManifestNamespace {
                 })
             })?;
 
+        let metadata = Self::serialize_metadata(request.properties.as_ref(), "table", &object_id)?;
+
         // Add entry to manifest marking this as a declared table (store dir_name, not full path)
-        self.insert_into_manifest(object_id, ObjectType::Table, Some(dir_name))
-            .await?;
+        self.insert_into_manifest_with_metadata(
+            vec![ManifestEntry {
+                object_id,
+                object_type: ObjectType::Table,
+                location: Some(dir_name),
+                metadata,
+            }],
+            None,
+        )
+        .await?;
 
         log::info!(
             "Declared table '{}' in manifest at {}",
@@ -2442,6 +2629,7 @@ impl LanceNamespace for ManifestNamespace {
         Ok(DeclareTableResponse {
             location: Some(table_uri),
             storage_options,
+            properties: request.properties,
             ..Default::default()
         })
     }

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -1956,6 +1956,8 @@ impl LanceNamespace for ManifestNamespace {
         };
 
         let load_detailed_metadata = request.load_detailed_metadata.unwrap_or(false);
+        let should_check_declared =
+            load_detailed_metadata || request.check_declared.unwrap_or(false);
         // For backwards compatibility, only skip vending credentials when explicitly set to false
         let vend_credentials = request.vend_credentials.unwrap_or(true);
 
@@ -1969,10 +1971,13 @@ impl LanceNamespace for ManifestNamespace {
                 } else {
                     None
                 };
+                let is_only_declared = if should_check_declared {
+                    Some(!self.location_has_actual_manifests(&info.location).await?)
+                } else {
+                    None
+                };
 
                 if !load_detailed_metadata {
-                    let is_only_declared =
-                        !self.location_has_actual_manifests(&info.location).await?;
                     return Ok(DescribeTableResponse {
                         table: Some(table_name),
                         namespace: Some(namespace_id),
@@ -1980,7 +1985,20 @@ impl LanceNamespace for ManifestNamespace {
                         table_uri: Some(table_uri),
                         storage_options,
                         properties: info.metadata,
-                        is_only_declared: is_only_declared.then_some(true),
+                        is_only_declared,
+                        ..Default::default()
+                    });
+                }
+
+                if is_only_declared == Some(true) {
+                    return Ok(DescribeTableResponse {
+                        table: Some(table_name),
+                        namespace: Some(namespace_id),
+                        location: Some(table_uri.clone()),
+                        table_uri: Some(table_uri),
+                        storage_options,
+                        properties: info.metadata,
+                        is_only_declared,
                         ..Default::default()
                     });
                 }
@@ -2014,14 +2032,12 @@ impl LanceNamespace for ManifestNamespace {
                             schema: Some(Box::new(json_schema)),
                             storage_options,
                             properties: info.metadata.clone(),
-                            is_only_declared: None,
+                            is_only_declared,
                             ..Default::default()
                         })
                     }
                     Err(err) => {
-                        if Self::is_not_found_load_error(&err)
-                            && !self.location_has_actual_manifests(&info.location).await?
-                        {
+                        if Self::is_not_found_load_error(&err) && is_only_declared == Some(true) {
                             Ok(DescribeTableResponse {
                                 table: Some(table_name),
                                 namespace: Some(namespace_id),
@@ -2029,7 +2045,7 @@ impl LanceNamespace for ManifestNamespace {
                                 table_uri: Some(table_uri),
                                 storage_options,
                                 properties: info.metadata,
-                                is_only_declared: Some(true),
+                                is_only_declared,
                                 ..Default::default()
                             })
                         } else {

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -542,7 +542,11 @@ impl ManifestNamespace {
                 })
             })?
             .pop_if_empty()
-            .push(relative_location);
+            .extend(
+                relative_location
+                    .split('/')
+                    .filter(|segment| !segment.is_empty()),
+            );
 
         // Clear any query string to avoid trailing "?" in the URL.
         // Use set_query(None) instead of set_query("") because the latter
@@ -3907,6 +3911,24 @@ mod tests {
         assert!(
             !result.contains("//hash_workspace$test_table"),
             "local file URI should not add a double slash before table directory: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_construct_full_uri_with_nested_relative_location() {
+        let result =
+            ManifestNamespace::construct_full_uri("/tmp/root", "workspace/physical_table.lance")
+                .unwrap();
+
+        assert!(
+            result.ends_with("/tmp/root/workspace/physical_table.lance"),
+            "nested relative location should preserve path separators: {}",
+            result
+        );
+        assert!(
+            !result.contains("%2Fphysical_table.lance"),
+            "nested relative location should not encode path separators: {}",
             result
         );
     }

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -2203,10 +2203,13 @@ impl LanceNamespace for ManifestNamespace {
                     .into());
                 }
                 CreateTableMode::ExistOk => {
+                    let properties = existing_table
+                        .as_ref()
+                        .and_then(|table| table.metadata.clone());
                     return Ok(CreateTableResponse {
                         location: Some(table_uri),
                         storage_options: self.storage_options.clone(),
-                        properties: None,
+                        properties,
                         ..Default::default()
                     });
                 }
@@ -2303,11 +2306,11 @@ impl LanceNamespace for ManifestNamespace {
             })
         } else {
             match existing_table {
-                Some(_) => Ok(CreateTableResponse {
+                Some(existing_table) => Ok(CreateTableResponse {
                     version: Some(version),
                     location: Some(table_uri),
                     storage_options: self.storage_options.clone(),
-                    properties: None,
+                    properties: existing_table.metadata,
                     ..Default::default()
                 }),
                 None => {

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -15,8 +15,8 @@ use bytes::Bytes;
 use futures::{FutureExt, TryStreamExt, stream::StreamExt};
 use lance::dataset::optimize::{CompactionOptions, compact_files};
 use lance::dataset::{
-    DeleteBuilder, MergeInsertBuilder, ReadParams, WhenMatched, WhenNotMatched, WriteParams,
-    builder::DatasetBuilder,
+    DeleteBuilder, MergeInsertBuilder, ReadParams, WhenMatched, WhenNotMatched, WriteMode,
+    WriteParams, builder::DatasetBuilder,
 };
 use lance::index::DatasetIndexExt;
 use lance::session::Session;
@@ -94,6 +94,43 @@ impl ObjectType {
                 message: format!("Invalid object type: {}", s),
             }
             .into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CreateTableMode {
+    Create,
+    ExistOk,
+    Overwrite,
+}
+
+impl CreateTableMode {
+    fn parse(mode: Option<&str>) -> Result<Self> {
+        match mode {
+            None => Ok(Self::Create),
+            Some(mode) if mode.eq_ignore_ascii_case("create") => Ok(Self::Create),
+            Some(mode)
+                if mode.eq_ignore_ascii_case("existok")
+                    || mode.eq_ignore_ascii_case("exist_ok") =>
+            {
+                Ok(Self::ExistOk)
+            }
+            Some(mode) if mode.eq_ignore_ascii_case("overwrite") => Ok(Self::Overwrite),
+            Some(mode) => Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "Unsupported create_table mode '{}'. Supported modes are: 'Create', 'ExistOk', 'Overwrite'",
+                    mode
+                ),
+            }
+            .into()),
+        }
+    }
+
+    fn write_mode(self) -> WriteMode {
+        match self {
+            Self::Overwrite => WriteMode::Overwrite,
+            Self::Create | Self::ExistOk => WriteMode::Create,
         }
     }
 }
@@ -962,6 +999,25 @@ impl ManifestNamespace {
         entries: Vec<ManifestEntry>,
         base_objects: Option<Vec<String>>,
     ) -> Result<()> {
+        self.merge_into_manifest_with_metadata(entries, base_objects, WhenMatched::Fail)
+            .await
+    }
+
+    async fn upsert_into_manifest_with_metadata(
+        &self,
+        entries: Vec<ManifestEntry>,
+        base_objects: Option<Vec<String>>,
+    ) -> Result<()> {
+        self.merge_into_manifest_with_metadata(entries, base_objects, WhenMatched::UpdateAll)
+            .await
+    }
+
+    async fn merge_into_manifest_with_metadata(
+        &self,
+        entries: Vec<ManifestEntry>,
+        base_objects: Option<Vec<String>>,
+        when_matched: WhenMatched,
+    ) -> Result<()> {
         if entries.is_empty() {
             return Ok(());
         }
@@ -1033,7 +1089,7 @@ impl ManifestNamespace {
 
         let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
 
-        // Use MergeInsert to ensure uniqueness on object_id
+        // Use MergeInsert so callers can choose fail-on-existing inserts or metadata upserts.
         let _mutation_guard = self.manifest_mutation_lock.lock().await;
         let dataset_guard = self.manifest_dataset.get().await?;
         let dataset_arc = Arc::new(dataset_guard.clone());
@@ -1047,13 +1103,9 @@ impl ManifestNamespace {
                     })
                 },
             )?;
-        merge_builder.when_matched(WhenMatched::Fail);
+        merge_builder.when_matched(when_matched);
         merge_builder.when_not_matched(WhenNotMatched::InsertAll);
         // Use conflict_retries to handle cross-process races on manifest mutations.
-        // When two processes concurrently insert the same object_id, the second one
-        // hits a commit conflict. With conflict_retries > 0, the retry re-evaluates
-        // the full MergeInsert plan against the latest data, where the join detects
-        // the existing row and WhenMatched::Fail fires, producing a clear error.
         merge_builder.conflict_retries(5);
         // TODO: after BTREE index creation on object_id, has_scalar_index=true causes
         // MergeInsert to use V1 path which lacks bloom filters for conflict detection. This
@@ -2038,28 +2090,13 @@ impl LanceNamespace for ManifestNamespace {
                             ..Default::default()
                         })
                     }
-                    Err(err) => {
-                        if Self::is_not_found_load_error(&err) && is_only_declared == Some(true) {
-                            Ok(DescribeTableResponse {
-                                table: Some(table_name),
-                                namespace: Some(namespace_id),
-                                location: Some(table_uri.clone()),
-                                table_uri: Some(table_uri),
-                                storage_options,
-                                properties: info.metadata,
-                                is_only_declared,
-                                ..Default::default()
-                            })
-                        } else {
-                            Err(NamespaceError::Internal {
-                                message: format!(
-                                    "Table exists in manifest but failed to load dataset '{}': {}",
-                                    object_id, err
-                                ),
-                            }
-                            .into())
-                        }
+                    Err(err) => Err(NamespaceError::Internal {
+                        message: format!(
+                            "Table exists in manifest but failed to load dataset '{}': {}",
+                            object_id, err
+                        ),
                     }
+                    .into()),
                 }
             }
             None => Err(NamespaceError::TableNotFound {
@@ -2126,13 +2163,6 @@ impl LanceNamespace for ManifestNamespace {
             None
         };
 
-        if existing_has_manifests == Some(true) {
-            return Err(NamespaceError::TableAlreadyExists {
-                message: table_name.clone(),
-            }
-            .into());
-        }
-
         if existing_has_manifests == Some(false)
             && request
                 .properties
@@ -2148,6 +2178,11 @@ impl LanceNamespace for ManifestNamespace {
             .into());
         }
 
+        let create_mode = if existing_has_manifests == Some(false) {
+            CreateTableMode::Create
+        } else {
+            CreateTableMode::parse(request.mode.as_deref())?
+        };
         let dir_name = if let Some(existing_table) = &existing_table {
             existing_table.location.clone()
         } else if namespace.is_empty() && self.dir_listing_enabled {
@@ -2156,6 +2191,28 @@ impl LanceNamespace for ManifestNamespace {
             Self::generate_dir_name(&object_id)
         };
         let table_uri = Self::construct_full_uri(&self.root, &dir_name)?;
+        let overwriting_existing_table =
+            existing_has_manifests == Some(true) && create_mode == CreateTableMode::Overwrite;
+
+        if existing_has_manifests == Some(true) {
+            match create_mode {
+                CreateTableMode::Create => {
+                    return Err(NamespaceError::TableAlreadyExists {
+                        message: table_name.clone(),
+                    }
+                    .into());
+                }
+                CreateTableMode::ExistOk => {
+                    return Ok(CreateTableResponse {
+                        location: Some(table_uri),
+                        storage_options: self.storage_options.clone(),
+                        properties: None,
+                        ..Default::default()
+                    });
+                }
+                CreateTableMode::Overwrite => {}
+            }
+        }
 
         // Validate that request_data is provided
         if data.is_empty() {
@@ -2209,48 +2266,73 @@ impl LanceNamespace for ManifestNamespace {
             ..Default::default()
         };
         let write_params = WriteParams {
+            mode: create_mode.write_mode(),
             session: self.session.clone(),
             store_params: Some(store_params),
             ..Default::default()
         };
-        let _dataset = Dataset::write(Box::new(reader), &table_uri, Some(write_params))
+        let dataset = Dataset::write(Box::new(reader), &table_uri, Some(write_params))
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
                     message: format!("Failed to write dataset: {:?}", e),
                 })
             })?;
+        let version = dataset.version().version as i64;
 
-        match existing_table {
-            Some(existing_table) => Ok(CreateTableResponse {
-                version: Some(1),
+        if overwriting_existing_table {
+            let metadata =
+                Self::serialize_metadata(request.properties.as_ref(), "table", &object_id)?;
+            self.upsert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id,
+                    object_type: ObjectType::Table,
+                    location: Some(dir_name),
+                    metadata,
+                }],
+                None,
+            )
+            .await?;
+
+            Ok(CreateTableResponse {
+                version: Some(version),
                 location: Some(table_uri),
                 storage_options: self.storage_options.clone(),
-                properties: existing_table.metadata,
+                properties: request.properties,
                 ..Default::default()
-            }),
-            None => {
-                let metadata =
-                    Self::serialize_metadata(request.properties.as_ref(), "table", &object_id)?;
-                // Register in manifest (store dir_name, not full URI)
-                self.insert_into_manifest_with_metadata(
-                    vec![ManifestEntry {
-                        object_id,
-                        object_type: ObjectType::Table,
-                        location: Some(dir_name.clone()),
-                        metadata,
-                    }],
-                    None,
-                )
-                .await?;
-
-                Ok(CreateTableResponse {
-                    version: Some(1),
+            })
+        } else {
+            match existing_table {
+                Some(_) => Ok(CreateTableResponse {
+                    version: Some(version),
                     location: Some(table_uri),
                     storage_options: self.storage_options.clone(),
-                    properties: request.properties,
+                    properties: None,
                     ..Default::default()
-                })
+                }),
+                None => {
+                    let metadata =
+                        Self::serialize_metadata(request.properties.as_ref(), "table", &object_id)?;
+                    // Register in manifest (store dir_name, not full URI)
+                    self.insert_into_manifest_with_metadata(
+                        vec![ManifestEntry {
+                            object_id,
+                            object_type: ObjectType::Table,
+                            location: Some(dir_name.clone()),
+                            metadata,
+                        }],
+                        None,
+                    )
+                    .await?;
+
+                    Ok(CreateTableResponse {
+                        version: Some(version),
+                        location: Some(table_uri),
+                        storage_options: self.storage_options.clone(),
+                        properties: request.properties,
+                        ..Default::default()
+                    })
+                }
             }
         }
     }

--- a/rust/lance-namespace-impls/src/rest.rs
+++ b/rust/lance-namespace-impls/src/rest.rs
@@ -831,6 +831,11 @@ impl LanceNamespace for RestNamespace {
             limit_str = limit.to_string();
             query.push(("limit", limit_str.as_str()));
         }
+        let include_declared_str;
+        if let Some(include_declared) = request.include_declared {
+            include_declared_str = include_declared.to_string();
+            query.push(("include_declared", include_declared_str.as_str()));
+        }
         self.get_json(&path, &query, "list_tables", &id).await
     }
 
@@ -920,6 +925,32 @@ impl LanceNamespace for RestNamespace {
         if let Some(ref mode) = request.mode {
             mode_str = mode.clone();
             query.push(("mode", mode_str.as_str()));
+        }
+        // The REST spec maps create_table metadata onto query parameters because the request body
+        // is already reserved for the Arrow IPC stream.
+        let properties_str;
+        if let Some(ref properties) = request.properties {
+            properties_str = serde_json::to_string(properties).map_err(|e| {
+                Error::from(NamespaceError::InvalidInput {
+                    message: format!(
+                        "Failed to serialize create_table properties as JSON query parameter: {}",
+                        e
+                    ),
+                })
+            })?;
+            query.push(("properties", properties_str.as_str()));
+        }
+        let storage_options_str;
+        if let Some(ref storage_options) = request.storage_options {
+            storage_options_str = serde_json::to_string(storage_options).map_err(|e| {
+                Error::from(NamespaceError::InvalidInput {
+                    message: format!(
+                        "Failed to serialize create_table storage_options as JSON query parameter: {}",
+                        e
+                    ),
+                })
+            })?;
+            query.push(("storage_options", storage_options_str.as_str()));
         }
         self.post_binary_json(&path, &query, request_data.to_vec(), "create_table", &id)
             .await
@@ -1203,6 +1234,11 @@ impl LanceNamespace for RestNamespace {
         if let Some(limit) = request.limit {
             limit_str = limit.to_string();
             query.push(("limit", limit_str.as_str()));
+        }
+        let include_declared_str;
+        if let Some(include_declared) = request.include_declared {
+            include_declared_str = include_declared.to_string();
+            query.push(("include_declared", include_declared_str.as_str()));
         }
         self.get_json(path, &query, "list_all_tables", "").await
     }
@@ -1794,6 +1830,75 @@ mod tests {
 
         // Should succeed with mock server
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_create_table_sends_properties_and_storage_options_query_params() {
+        use std::collections::HashMap;
+
+        let mock_server = MockServer::start().await;
+
+        let path_str = "/v1/table/test$namespace$table/create".replace("$", "%24");
+        Mock::given(method("POST"))
+            .and(path(path_str.as_str()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "location": "/path/to/table",
+                "version": 1,
+                "properties": {
+                    "owner": "alice",
+                    "team": "eng"
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let namespace = RestNamespaceBuilder::new(mock_server.uri()).build();
+
+        let request = CreateTableRequest {
+            id: Some(vec![
+                "test".to_string(),
+                "namespace".to_string(),
+                "table".to_string(),
+            ]),
+            mode: Some("Create".to_string()),
+            properties: Some(HashMap::from([
+                ("owner".to_string(), "alice".to_string()),
+                ("team".to_string(), "eng".to_string()),
+            ])),
+            storage_options: Some(HashMap::from([
+                ("aws_region".to_string(), "us-east-1".to_string()),
+                ("timeout".to_string(), "30s".to_string()),
+            ])),
+            ..Default::default()
+        };
+
+        let result = namespace
+            .create_table(request, Bytes::from("arrow data here"))
+            .await;
+
+        assert!(result.is_ok(), "Failed: {:?}", result.err());
+
+        let requests = mock_server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+
+        let query_params: HashMap<String, String> =
+            request.url.query_pairs().into_owned().collect();
+        assert_eq!(query_params.get("mode"), Some(&"Create".to_string()));
+
+        let properties: serde_json::Value =
+            serde_json::from_str(query_params.get("properties").unwrap()).unwrap();
+        assert_eq!(
+            properties,
+            serde_json::json!({"owner": "alice", "team": "eng"})
+        );
+
+        let storage_options: serde_json::Value =
+            serde_json::from_str(query_params.get("storage_options").unwrap()).unwrap();
+        assert_eq!(
+            storage_options,
+            serde_json::json!({"aws_region": "us-east-1", "timeout": "30s"})
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/rest.rs
+++ b/rust/lance-namespace-impls/src/rest.rs
@@ -855,6 +855,11 @@ impl LanceNamespace for RestNamespace {
             detailed_str = detailed.to_string();
             query.push(("load_detailed_metadata", detailed_str.as_str()));
         }
+        let check_declared_str;
+        if let Some(check_declared) = request.check_declared {
+            check_declared_str = check_declared.to_string();
+            query.push(("check_declared", check_declared_str.as_str()));
+        }
         self.post_json(&path, &query, &request, "describe_table", &id)
             .await
     }

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -291,6 +291,14 @@ struct PaginationQuery {
     descending: Option<bool>,
 }
 
+#[derive(Debug, Deserialize)]
+struct DescribeTableQuery {
+    delimiter: Option<String>,
+    with_table_uri: Option<bool>,
+    load_detailed_metadata: Option<bool>,
+    check_declared: Option<bool>,
+}
+
 // ============================================================================
 // Error Conversion
 // ============================================================================
@@ -486,11 +494,20 @@ async fn describe_table(
     State(backend): State<Arc<dyn LanceNamespace>>,
     headers: HeaderMap,
     Path(id): Path<String>,
-    Query(params): Query<DelimiterQuery>,
+    Query(params): Query<DescribeTableQuery>,
     Json(mut request): Json<DescribeTableRequest>,
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
     request.identity = extract_identity(&headers);
+    if params.with_table_uri.is_some() {
+        request.with_table_uri = params.with_table_uri;
+    }
+    if params.load_detailed_metadata.is_some() {
+        request.load_detailed_metadata = params.load_detailed_metadata;
+    }
+    if params.check_declared.is_some() {
+        request.check_declared = params.check_declared;
+    }
 
     match backend.describe_table(request).await {
         Ok(response) => (StatusCode::OK, Json(response)).into_response(),
@@ -2004,6 +2021,17 @@ mod tests {
                 location.contains("test_table"),
                 "Location should contain table name"
             );
+            assert_eq!(response.is_only_declared, None);
+
+            let mut describe_req = DescribeTableRequest::new();
+            describe_req.id = Some(vec!["test_namespace".to_string(), "test_table".to_string()]);
+            describe_req.check_declared = Some(true);
+            let response = fixture
+                .namespace
+                .describe_table(describe_req)
+                .await
+                .expect("Should describe declared table with check_declared");
+            assert_eq!(response.is_only_declared, Some(true));
 
             // Declared tables don't have a version until data is written
             // (version is None for declared tables)
@@ -3008,6 +3036,7 @@ mod tests {
                 ]),
                 with_table_uri: None,
                 load_detailed_metadata: None,
+                check_declared: None,
                 vend_credentials: None,
                 version: None,
                 identity: None,

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -287,6 +287,7 @@ struct PaginationQuery {
     delimiter: Option<String>,
     page_token: Option<String>,
     limit: Option<i32>,
+    include_declared: Option<bool>,
     descending: Option<bool>,
 }
 
@@ -454,6 +455,7 @@ async fn list_tables(
         id: Some(parse_id(&id, params.delimiter.as_deref())),
         page_token: params.page_token,
         limit: params.limit,
+        include_declared: params.include_declared,
         identity: extract_identity(&headers),
         ..Default::default()
     };
@@ -554,6 +556,32 @@ async fn deregister_table(
 struct CreateTableQuery {
     delimiter: Option<String>,
     mode: Option<String>,
+    properties: Option<String>,
+    storage_options: Option<String>,
+}
+
+fn parse_json_query_param<T: serde::de::DeserializeOwned>(
+    raw: Option<&str>,
+    operation: &str,
+    param_name: &str,
+) -> std::result::Result<Option<T>, Response> {
+    match raw {
+        Some(raw) => serde_json::from_str(raw).map(Some).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": format!(
+                            "Failed to parse {} {} query parameter as JSON: {}",
+                            operation, param_name, e
+                        )
+                    }
+                })),
+            )
+                .into_response()
+        }),
+        None => Ok(None),
+    }
 }
 
 async fn create_table(
@@ -563,9 +591,24 @@ async fn create_table(
     Query(params): Query<CreateTableQuery>,
     body: Bytes,
 ) -> Response {
+    let properties =
+        match parse_json_query_param(params.properties.as_deref(), "create_table", "properties") {
+            Ok(properties) => properties,
+            Err(response) => return response,
+        };
+    let storage_options = match parse_json_query_param(
+        params.storage_options.as_deref(),
+        "create_table",
+        "storage_options",
+    ) {
+        Ok(storage_options) => storage_options,
+        Err(response) => return response,
+    };
     let request = CreateTableRequest {
         id: Some(parse_id(&id, params.delimiter.as_deref())),
         mode: params.mode.clone(),
+        properties,
+        storage_options,
         identity: extract_identity(&headers),
         ..Default::default()
     };
@@ -874,6 +917,7 @@ async fn list_all_tables(
         id: None,
         page_token: params.page_token,
         limit: params.limit,
+        include_declared: params.include_declared,
         identity: extract_identity(&headers),
         ..Default::default()
     };

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -564,10 +564,10 @@ fn parse_json_query_param<T: serde::de::DeserializeOwned>(
     raw: Option<&str>,
     operation: &str,
     param_name: &str,
-) -> std::result::Result<Option<T>, Response> {
+) -> std::result::Result<Option<T>, Box<Response>> {
     match raw {
         Some(raw) => serde_json::from_str(raw).map(Some).map_err(|e| {
-            (
+            let response = (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({
                     "error": {
@@ -578,7 +578,8 @@ fn parse_json_query_param<T: serde::de::DeserializeOwned>(
                     }
                 })),
             )
-                .into_response()
+                .into_response();
+            Box::new(response)
         }),
         None => Ok(None),
     }
@@ -594,7 +595,7 @@ async fn create_table(
     let properties =
         match parse_json_query_param(params.properties.as_deref(), "create_table", "properties") {
             Ok(properties) => properties,
-            Err(response) => return response,
+            Err(response) => return *response,
         };
     let storage_options = match parse_json_query_param(
         params.storage_options.as_deref(),
@@ -602,7 +603,7 @@ async fn create_table(
         "storage_options",
     ) {
         Ok(storage_options) => storage_options,
-        Err(response) => return response,
+        Err(response) => return *response,
     };
     let request = CreateTableRequest {
         id: Some(parse_id(&id, params.delimiter.as_deref())),

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -48,7 +48,7 @@ pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
         version: u64,
     ) -> Result<ManifestLocation> {
         let path = self.get(base_uri, version).await?;
-        let path = Path::from(path);
+        let path = Path::parse(&path).map_err(|e| Error::invalid_input(e.to_string()))?;
         let naming_scheme = detect_naming_scheme_from_path(&path)?;
         Ok(ManifestLocation {
             version,
@@ -75,7 +75,7 @@ pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
     ) -> Result<Option<ManifestLocation>> {
         self.get_latest_version(base_uri).await.and_then(|res| {
             res.map(|(version, uri)| {
-                let path = Path::from(uri);
+                let path = Path::parse(&uri).map_err(|e| Error::invalid_input(e.to_string()))?;
                 let naming_scheme = detect_naming_scheme_from_path(&path)?;
                 Ok(ManifestLocation {
                     version,

--- a/rust/lance/src/io/commit/namespace_manifest.rs
+++ b/rust/lance/src/io/commit/namespace_manifest.rs
@@ -108,7 +108,12 @@ impl ExternalManifestStore for LanceNamespaceExternalManifestStore {
 
         Ok(ManifestLocation {
             version: version_info.version as u64,
-            path: Path::from(version_info.manifest_path),
+            path: Path::parse(&version_info.manifest_path).map_err(|e| {
+                lance_core::Error::invalid_input(format!(
+                    "Invalid manifest path '{}': {}",
+                    version_info.manifest_path, e
+                ))
+            })?,
             size: version_info.manifest_size.map(|s| s as u64),
             naming_scheme,
             e_tag: version_info.e_tag,


### PR DESCRIPTION
This updates namespace behavior to match the latest declared-table semantics and bumps the namespace SDKs to 0.7.2.

Key changes:
- allow `create_table`, `insert_into_table`, and `merge_insert_into_table` to materialize declared-only tables
- add `include_declared` filtering and `is_only_declared` describe behavior
- propagate namespace table `properties` and `create_table` storage options through the impls and REST layer
- remove the deprecated Java `createEmptyTable` shim