### PR TITLE
feat: generalize dynamic object store credentials

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -34,9 +34,15 @@ use url::Url;
 use super::local::LocalObjectReader;
 #[cfg(target_os = "linux")]
 use crate::uring::{UringCurrentThreadReader, UringReader};
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
+pub(crate) mod dynamic_credentials;
+#[cfg(any(feature = "oss", feature = "huggingface"))]
+pub(crate) mod dynamic_opendal;
 mod list_retry;
 pub mod providers;
 pub mod storage_options;
+#[cfg(test)]
+pub(crate) mod test_utils;
 pub mod throttle;
 mod tracing;
 use crate::object_reader::SmallReader;

--- a/rust/lance-io/src/object_store/dynamic_credentials.rs
+++ b/rust/lance-io/src/object_store/dynamic_credentials.rs
@@ -72,20 +72,39 @@ impl<T> NamespaceCredentialsProvider<T> {
     }
 }
 
-pub async fn supports_dynamic_credentials<T>(accessor: &Arc<StorageOptionsAccessor>) -> Result<bool>
+/// Build a dynamic credential provider for any cloud type, returning `None`
+/// if the accessor has no provider or the vended options are incompatible with `T`.
+pub async fn build_dynamic_credential_provider<T>(
+    accessor: Option<Arc<StorageOptionsAccessor>>,
+) -> Result<Option<Arc<dyn CredentialProvider<Credential = T>>>>
 where
-    T: TryFrom<DynamicCredentials, Error = Error>,
+    T: TryFrom<DynamicCredentials, Error = Error> + fmt::Debug + Send + Sync + 'static,
 {
-    if let Some(initial) = accessor.initial_storage_options() {
-        return Ok(T::try_from(DynamicCredentials(initial.clone())).is_ok());
+    let Some(accessor) = accessor.filter(|a| a.has_provider()) else {
+        return Ok(None);
+    };
+
+    // Validate that the provider vends credentials compatible with T.
+    // Try initial options first, then fall back to a provider fetch.
+    // Initial options may contain only non-credential fields (e.g. region)
+    // while the provider vends the actual credentials.
+    let compatible = if let Some(initial) = accessor.initial_storage_options()
+        && T::try_from(DynamicCredentials(initial.clone())).is_ok()
+    {
+        true
+    } else {
+        let fetched = accessor.get_storage_options().await?.0;
+        T::try_from(DynamicCredentials(fetched)).is_ok()
+    };
+
+    if !compatible {
+        return Ok(None);
     }
 
-    // If there is no initial snapshot, trust that the accessor's provider is
-    // being used for credential vending for this store type. This avoids an
-    // eager fetch during store construction, but means callers should only use
-    // this helper when the provider is expected to vend credentials compatible
-    // with `T`.
-    Ok(accessor.has_provider())
+    Ok(Some(
+        Arc::new(NamespaceCredentialsProvider::<T>::new(accessor))
+            as Arc<dyn CredentialProvider<Credential = T>>,
+    ))
 }
 
 #[async_trait]
@@ -140,9 +159,23 @@ impl TryFrom<DynamicCredentials> for ObjectStoreAwsCredential {
     type Error = Error;
 
     fn try_from(credentials: DynamicCredentials) -> Result<Self> {
-        let key_id = credentials.0.get("aws_access_key_id").cloned();
-        let secret_key = credentials.0.get("aws_secret_access_key").cloned();
-        let token = credentials.0.get("aws_session_token").cloned();
+        let key_id = credentials
+            .0
+            .get("aws_access_key_id")
+            .or_else(|| credentials.0.get("access_key_id"))
+            .cloned();
+        let secret_key = credentials
+            .0
+            .get("aws_secret_access_key")
+            .or_else(|| credentials.0.get("secret_access_key"))
+            .cloned();
+        let token = credentials
+            .0
+            .get("aws_session_token")
+            .or_else(|| credentials.0.get("aws_security_token"))
+            .or_else(|| credentials.0.get("session_token"))
+            .or_else(|| credentials.0.get("token"))
+            .cloned();
 
         match (key_id, secret_key) {
             (Some(key_id), Some(secret_key)) => Ok(Self {
@@ -164,6 +197,8 @@ impl TryFrom<DynamicCredentials> for AzureCredential {
             .0
             .get("azure_storage_sas_token")
             .or_else(|| credentials.0.get("azure_storage_sas_key"))
+            .or_else(|| credentials.0.get("sas_token"))
+            .or_else(|| credentials.0.get("sas_key"))
         {
             return Ok(Self::SASToken(split_azure_sas(sas)?));
         }
@@ -172,6 +207,7 @@ impl TryFrom<DynamicCredentials> for AzureCredential {
             .0
             .get("azure_storage_token")
             .or_else(|| credentials.0.get("bearer_token"))
+            .or_else(|| credentials.0.get("token"))
         {
             return Ok(Self::BearerToken(token.clone()));
         }
@@ -270,6 +306,35 @@ mod tests {
                 );
             }
             other => panic!("expected SAS token, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "azure")]
+    #[tokio::test]
+    async fn test_dynamic_azure_credentials_short_sas_aliases() {
+        for key in ["sas_token", "sas_key"] {
+            let provider = Arc::new(StaticMockStorageOptionsProvider {
+                options: HashMap::from([(
+                    key.to_string(),
+                    "?sv=2022-11-02&sp=rl&sig=short".to_string(),
+                )]),
+            });
+
+            let credentials =
+                NamespaceCredentialsProvider::<AzureCredential>::from_provider(provider)
+                    .get_credential()
+                    .await
+                    .unwrap_or_else(|_| panic!("azure credentials should convert for key '{key}'"));
+
+            match credentials.as_ref() {
+                AzureCredential::SASToken(pairs) => {
+                    assert!(
+                        pairs.iter().any(|(k, v)| k == "sig" && v == "short"),
+                        "SAS token from key '{key}' should contain sig=short"
+                    );
+                }
+                other => panic!("expected SAS token for key '{key}', got {other:?}"),
+            }
         }
     }
 

--- a/rust/lance-io/src/object_store/dynamic_credentials.rs
+++ b/rust/lance-io/src/object_store/dynamic_credentials.rs
@@ -73,7 +73,7 @@ impl<T> NamespaceCredentialsProvider<T> {
 }
 
 /// Build a dynamic credential provider for any cloud type, returning `None`
-/// if the accessor has no provider or the vended options are incompatible with `T`.
+/// if the accessor has no provider or the provider options are incompatible with `T`.
 pub async fn build_dynamic_credential_provider<T>(
     accessor: Option<Arc<StorageOptionsAccessor>>,
 ) -> Result<Option<Arc<dyn CredentialProvider<Credential = T>>>>
@@ -84,16 +84,12 @@ where
         return Ok(None);
     };
 
-    // Validate that the provider vends credentials compatible with T.
-    // Try initial options first, then fall back to a provider fetch.
-    // Initial options may contain only non-credential fields (e.g. region)
-    // while the provider vends the actual credentials.
     let compatible = if let Some(initial) = accessor.initial_storage_options()
         && T::try_from(DynamicCredentials(initial.clone())).is_ok()
     {
         true
     } else {
-        let fetched = accessor.get_storage_options().await?.0;
+        let fetched = accessor.refresh_storage_options().await?.0;
         T::try_from(DynamicCredentials(fetched)).is_ok()
     };
 
@@ -107,6 +103,13 @@ where
     ))
 }
 
+fn map_credential_error(error: Error) -> object_store::Error {
+    object_store::Error::Generic {
+        store: "NamespaceCredentialsProvider",
+        source: Box::new(error),
+    }
+}
+
 #[async_trait]
 impl<T> CredentialProvider for NamespaceCredentialsProvider<T>
 where
@@ -115,19 +118,24 @@ where
     type Credential = T;
 
     async fn get_credential(&self) -> ObjectStoreResult<Arc<Self::Credential>> {
-        let storage_options = self.accessor.get_storage_options().await.map_err(|e| {
-            object_store::Error::Generic {
-                store: "NamespaceCredentialsProvider",
-                source: Box::new(e),
-            }
-        })?;
+        let storage_options = self
+            .accessor
+            .get_storage_options()
+            .await
+            .map_err(map_credential_error)?;
 
-        let credential = T::try_from(DynamicCredentials(storage_options.0)).map_err(|e| {
-            object_store::Error::Generic {
-                store: "NamespaceCredentialsProvider",
-                source: Box::new(e),
+        let credential = match T::try_from(DynamicCredentials(storage_options.0)) {
+            Ok(credential) => credential,
+            Err(_) if self.accessor.has_provider() => {
+                let storage_options = self
+                    .accessor
+                    .refresh_storage_options()
+                    .await
+                    .map_err(map_credential_error)?;
+                T::try_from(DynamicCredentials(storage_options.0)).map_err(map_credential_error)?
             }
-        })?;
+            Err(error) => return Err(map_credential_error(error)),
+        };
 
         Ok(Arc::new(credential))
     }
@@ -172,6 +180,7 @@ impl TryFrom<DynamicCredentials> for ObjectStoreAwsCredential {
         let token = credentials
             .0
             .get("aws_session_token")
+            .or_else(|| credentials.0.get("aws_token"))
             .or_else(|| credentials.0.get("aws_security_token"))
             .or_else(|| credentials.0.get("session_token"))
             .or_else(|| credentials.0.get("token"))
@@ -275,6 +284,53 @@ mod tests {
         assert_eq!(credentials.key_id, "AKID");
         assert_eq!(credentials.secret_key, "SECRET");
         assert_eq!(credentials.token.as_deref(), Some("TOKEN"));
+    }
+
+    #[cfg(feature = "aws")]
+    #[tokio::test]
+    async fn test_dynamic_aws_credentials_aws_token_alias() {
+        let provider = Arc::new(StaticMockStorageOptionsProvider {
+            options: HashMap::from([
+                ("aws_access_key_id".to_string(), "AKID".to_string()),
+                ("aws_secret_access_key".to_string(), "SECRET".to_string()),
+                ("aws_token".to_string(), "TOKEN".to_string()),
+            ]),
+        });
+
+        let credentials =
+            NamespaceCredentialsProvider::<ObjectStoreAwsCredential>::from_provider(provider)
+                .get_credential()
+                .await
+                .expect("aws credentials should convert");
+
+        assert_eq!(credentials.token.as_deref(), Some("TOKEN"));
+    }
+
+    #[cfg(feature = "aws")]
+    #[tokio::test]
+    async fn test_dynamic_credentials_fetch_provider_when_initial_has_metadata_only() {
+        let provider = Arc::new(StaticMockStorageOptionsProvider {
+            options: HashMap::from([
+                ("aws_access_key_id".to_string(), "AKID".to_string()),
+                ("aws_secret_access_key".to_string(), "SECRET".to_string()),
+            ]),
+        });
+        let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+            HashMap::from([("region".to_string(), "us-west-2".to_string())]),
+            provider,
+        ));
+
+        let credentials =
+            build_dynamic_credential_provider::<ObjectStoreAwsCredential>(Some(accessor))
+                .await
+                .expect("dynamic credential provider should build")
+                .expect("provider should be returned")
+                .get_credential()
+                .await
+                .expect("provider-vended aws credentials should convert");
+
+        assert_eq!(credentials.key_id, "AKID");
+        assert_eq!(credentials.secret_key, "SECRET");
     }
 
     #[cfg(feature = "azure")]

--- a/rust/lance-io/src/object_store/dynamic_credentials.rs
+++ b/rust/lance-io/src/object_store/dynamic_credentials.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::HashMap;
+use std::fmt;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lance_core::error::{Error, Result};
+use object_store::{CredentialProvider, Result as ObjectStoreResult};
+
+use crate::object_store::{StorageOptionsAccessor, StorageOptionsProvider};
+
+#[cfg(feature = "aws")]
+use object_store::aws::AwsCredential as ObjectStoreAwsCredential;
+#[cfg(feature = "azure")]
+use object_store::azure::{AzureAccessKey, AzureCredential};
+#[cfg(feature = "gcp")]
+use object_store::gcp::GcpCredential;
+
+/// Raw dynamic storage options fetched from a credential-vending source.
+///
+/// Callers must convert this bag into a cloud-specific credential type via
+/// `TryFrom<DynamicCredentials>`.
+#[derive(Clone)]
+pub struct DynamicCredentials(pub HashMap<String, String>);
+
+impl fmt::Debug for DynamicCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DynamicCredentials")
+            .field(&format_args!("[{} keys redacted]", self.0.len()))
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub struct NamespaceCredentialsProvider<T> {
+    accessor: Arc<StorageOptionsAccessor>,
+    _credential: PhantomData<T>,
+}
+
+impl<T> fmt::Debug for NamespaceCredentialsProvider<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NamespaceCredentialsProvider")
+            .field("accessor", &self.accessor)
+            .field("credential_type", &std::any::type_name::<T>())
+            .finish()
+    }
+}
+
+impl<T> NamespaceCredentialsProvider<T> {
+    pub fn new(accessor: Arc<StorageOptionsAccessor>) -> Self {
+        Self {
+            accessor,
+            _credential: PhantomData,
+        }
+    }
+
+    pub fn from_provider(provider: Arc<dyn StorageOptionsProvider>) -> Self {
+        Self::new(Arc::new(StorageOptionsAccessor::with_provider(provider)))
+    }
+
+    pub fn from_provider_with_initial(
+        provider: Arc<dyn StorageOptionsProvider>,
+        initial_options: HashMap<String, String>,
+    ) -> Self {
+        Self::new(Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+            initial_options,
+            provider,
+        )))
+    }
+}
+
+pub async fn supports_dynamic_credentials<T>(accessor: &Arc<StorageOptionsAccessor>) -> Result<bool>
+where
+    T: TryFrom<DynamicCredentials, Error = Error>,
+{
+    if let Some(initial) = accessor.initial_storage_options() {
+        return Ok(T::try_from(DynamicCredentials(initial.clone())).is_ok());
+    }
+
+    // If there is no initial snapshot, trust that the accessor's provider is
+    // being used for credential vending for this store type. This avoids an
+    // eager fetch during store construction, but means callers should only use
+    // this helper when the provider is expected to vend credentials compatible
+    // with `T`.
+    Ok(accessor.has_provider())
+}
+
+#[async_trait]
+impl<T> CredentialProvider for NamespaceCredentialsProvider<T>
+where
+    T: TryFrom<DynamicCredentials, Error = Error> + fmt::Debug + Send + Sync + 'static,
+{
+    type Credential = T;
+
+    async fn get_credential(&self) -> ObjectStoreResult<Arc<Self::Credential>> {
+        let storage_options = self.accessor.get_storage_options().await.map_err(|e| {
+            object_store::Error::Generic {
+                store: "NamespaceCredentialsProvider",
+                source: Box::new(e),
+            }
+        })?;
+
+        let credential = T::try_from(DynamicCredentials(storage_options.0)).map_err(|e| {
+            object_store::Error::Generic {
+                store: "NamespaceCredentialsProvider",
+                source: Box::new(e),
+            }
+        })?;
+
+        Ok(Arc::new(credential))
+    }
+}
+
+fn missing_dynamic_credential(kind: &str) -> Error {
+    Error::invalid_input(format!(
+        "Missing required {kind} credential fields in dynamic storage options"
+    ))
+}
+
+#[cfg(feature = "azure")]
+fn split_azure_sas(sas: &str) -> Result<Vec<(String, String)>> {
+    let pairs = url::form_urlencoded::parse(sas.trim_start_matches('?').as_bytes())
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect::<Vec<_>>();
+
+    if pairs.is_empty() {
+        return Err(Error::invalid_input(
+            "Azure SAS token is empty or invalid in dynamic storage options",
+        ));
+    }
+
+    Ok(pairs)
+}
+
+#[cfg(feature = "aws")]
+impl TryFrom<DynamicCredentials> for ObjectStoreAwsCredential {
+    type Error = Error;
+
+    fn try_from(credentials: DynamicCredentials) -> Result<Self> {
+        let key_id = credentials.0.get("aws_access_key_id").cloned();
+        let secret_key = credentials.0.get("aws_secret_access_key").cloned();
+        let token = credentials.0.get("aws_session_token").cloned();
+
+        match (key_id, secret_key) {
+            (Some(key_id), Some(secret_key)) => Ok(Self {
+                key_id,
+                secret_key,
+                token,
+            }),
+            _ => Err(missing_dynamic_credential("AWS")),
+        }
+    }
+}
+
+#[cfg(feature = "azure")]
+impl TryFrom<DynamicCredentials> for AzureCredential {
+    type Error = Error;
+
+    fn try_from(credentials: DynamicCredentials) -> Result<Self> {
+        if let Some(sas) = credentials
+            .0
+            .get("azure_storage_sas_token")
+            .or_else(|| credentials.0.get("azure_storage_sas_key"))
+        {
+            return Ok(Self::SASToken(split_azure_sas(sas)?));
+        }
+
+        if let Some(token) = credentials
+            .0
+            .get("azure_storage_token")
+            .or_else(|| credentials.0.get("bearer_token"))
+        {
+            return Ok(Self::BearerToken(token.clone()));
+        }
+
+        if let Some(access_key) = credentials
+            .0
+            .get("azure_storage_account_key")
+            .or_else(|| credentials.0.get("azure_storage_access_key"))
+            .or_else(|| credentials.0.get("azure_storage_master_key"))
+            .or_else(|| credentials.0.get("access_key"))
+            .or_else(|| credentials.0.get("master_key"))
+            .or_else(|| credentials.0.get("account_key"))
+        {
+            return Ok(Self::AccessKey(
+                AzureAccessKey::try_new(access_key).map_err(|source| {
+                    Error::invalid_input(format!("Invalid Azure access key: {source}"))
+                })?,
+            ));
+        }
+
+        Err(missing_dynamic_credential("Azure"))
+    }
+}
+
+#[cfg(feature = "gcp")]
+impl TryFrom<DynamicCredentials> for GcpCredential {
+    type Error = Error;
+
+    fn try_from(credentials: DynamicCredentials) -> Result<Self> {
+        let bearer = credentials
+            .0
+            .get("google_storage_token")
+            .cloned()
+            .ok_or_else(|| missing_dynamic_credential("GCP"))?;
+
+        Ok(Self { bearer })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::object_store::test_utils::StaticMockStorageOptionsProvider;
+
+    #[cfg(feature = "aws")]
+    #[tokio::test]
+    async fn test_dynamic_aws_credentials() {
+        let provider = Arc::new(StaticMockStorageOptionsProvider {
+            options: HashMap::from([
+                ("aws_access_key_id".to_string(), "AKID".to_string()),
+                ("aws_secret_access_key".to_string(), "SECRET".to_string()),
+                ("aws_session_token".to_string(), "TOKEN".to_string()),
+            ]),
+        });
+
+        let credentials =
+            NamespaceCredentialsProvider::<ObjectStoreAwsCredential>::from_provider(provider)
+                .get_credential()
+                .await
+                .expect("aws credentials should convert");
+
+        assert_eq!(credentials.key_id, "AKID");
+        assert_eq!(credentials.secret_key, "SECRET");
+        assert_eq!(credentials.token.as_deref(), Some("TOKEN"));
+    }
+
+    #[cfg(feature = "azure")]
+    #[tokio::test]
+    async fn test_dynamic_azure_credentials() {
+        let provider = Arc::new(StaticMockStorageOptionsProvider {
+            options: HashMap::from([(
+                "azure_storage_sas_token".to_string(),
+                "?sv=2022-11-02&sp=rl&sig=test".to_string(),
+            )]),
+        });
+
+        let credentials = NamespaceCredentialsProvider::<AzureCredential>::from_provider(provider)
+            .get_credential()
+            .await
+            .expect("azure credentials should convert");
+
+        match credentials.as_ref() {
+            AzureCredential::SASToken(pairs) => {
+                assert!(
+                    pairs
+                        .iter()
+                        .any(|(key, value)| key == "sv" && value == "2022-11-02")
+                );
+                assert!(
+                    pairs
+                        .iter()
+                        .any(|(key, value)| key == "sig" && value == "test")
+                );
+            }
+            other => panic!("expected SAS token, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "gcp")]
+    #[tokio::test]
+    async fn test_dynamic_gcp_credentials() {
+        let provider = Arc::new(StaticMockStorageOptionsProvider {
+            options: HashMap::from([("google_storage_token".to_string(), "gcp-token".to_string())]),
+        });
+
+        let credentials = NamespaceCredentialsProvider::<GcpCredential>::from_provider(provider)
+            .get_credential()
+            .await
+            .expect("gcp credentials should convert");
+
+        assert_eq!(credentials.bearer, "gcp-token");
+    }
+}

--- a/rust/lance-io/src/object_store/dynamic_opendal.rs
+++ b/rust/lance-io/src/object_store/dynamic_opendal.rs
@@ -33,6 +33,7 @@ pub(in crate::object_store) struct DynamicOpenDalStore {
     accessor: Arc<StorageOptionsAccessor>,
     normalize_config: NormalizeConfigFn,
     build_store: BuildStoreFn,
+    protected_keys: Vec<&'static str>,
     cache: Arc<RwLock<Option<CachedOpenDalStore>>>,
 }
 
@@ -59,11 +60,26 @@ impl DynamicOpenDalStore {
             accessor,
             normalize_config,
             build_store,
+            protected_keys: Vec::new(),
             cache: Arc::new(RwLock::new(None)),
         }
     }
 
-    fn merge_options(&self, dynamic_options: HashMap<String, String>) -> HashMap<String, String> {
+    pub(in crate::object_store) fn with_protected_keys(
+        mut self,
+        keys: impl IntoIterator<Item = &'static str>,
+    ) -> Self {
+        self.protected_keys = keys.into_iter().collect();
+        self
+    }
+
+    fn merge_options(
+        &self,
+        mut dynamic_options: HashMap<String, String>,
+    ) -> HashMap<String, String> {
+        for key in &self.protected_keys {
+            dynamic_options.remove(*key);
+        }
         let mut merged = self.base_options.as_ref().clone();
         merged.extend(dynamic_options);
         merged
@@ -258,5 +274,43 @@ mod tests {
             .expect("second store should reuse cache");
 
         assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn test_merge_options_preserves_protected_base_keys() {
+        let accessor = Arc::new(StorageOptionsAccessor::with_provider(Arc::new(
+            StaticMockStorageOptionsProvider {
+                options: HashMap::new(),
+            },
+        )));
+        let store = DynamicOpenDalStore::new(
+            "memory",
+            HashMap::from([
+                ("bucket".to_string(), "url-bucket".to_string()),
+                ("root".to_string(), "/".to_string()),
+                ("token".to_string(), "base-token".to_string()),
+            ]),
+            accessor,
+            |options| Ok(options.clone()),
+            |_| {
+                let operator = Operator::new(Memory::default()).map_err(|e| {
+                    lance_core::Error::invalid_input(format!(
+                        "Failed to create memory operator: {e:?}"
+                    ))
+                })?;
+                Ok(OpendalStore::new(operator.finish()))
+            },
+        )
+        .with_protected_keys(["bucket", "root"]);
+
+        let merged = store.merge_options(HashMap::from([
+            ("bucket".to_string(), "provider-bucket".to_string()),
+            ("root".to_string(), "/provider-root".to_string()),
+            ("token".to_string(), "provider-token".to_string()),
+        ]));
+
+        assert_eq!(merged.get("bucket").unwrap(), "url-bucket");
+        assert_eq!(merged.get("root").unwrap(), "/");
+        assert_eq!(merged.get("token").unwrap(), "provider-token");
     }
 }

--- a/rust/lance-io/src/object_store/dynamic_opendal.rs
+++ b/rust/lance-io/src/object_store/dynamic_opendal.rs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use futures::{StreamExt, TryStreamExt, stream, stream::BoxStream};
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore as OSObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+};
+use object_store_opendal::OpendalStore;
+use tokio::sync::RwLock;
+
+use crate::object_store::StorageOptionsAccessor;
+use lance_core::Result;
+
+type NormalizeConfigFn = fn(&HashMap<String, String>) -> Result<HashMap<String, String>>;
+type BuildStoreFn = fn(HashMap<String, String>) -> Result<OpendalStore>;
+
+#[derive(Debug, Clone)]
+struct CachedOpenDalStore {
+    config: HashMap<String, String>,
+    store: Arc<OpendalStore>,
+}
+
+#[derive(Clone)]
+pub(in crate::object_store) struct DynamicOpenDalStore {
+    name: Arc<str>,
+    base_options: Arc<HashMap<String, String>>,
+    accessor: Arc<StorageOptionsAccessor>,
+    normalize_config: NormalizeConfigFn,
+    build_store: BuildStoreFn,
+    cache: Arc<RwLock<Option<CachedOpenDalStore>>>,
+}
+
+impl fmt::Debug for DynamicOpenDalStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DynamicOpenDalStore")
+            .field("name", &self.name)
+            .field("accessor", &self.accessor)
+            .finish()
+    }
+}
+
+impl DynamicOpenDalStore {
+    pub(in crate::object_store) fn new(
+        name: impl Into<Arc<str>>,
+        base_options: HashMap<String, String>,
+        accessor: Arc<StorageOptionsAccessor>,
+        normalize_config: NormalizeConfigFn,
+        build_store: BuildStoreFn,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            base_options: Arc::new(base_options),
+            accessor,
+            normalize_config,
+            build_store,
+            cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    fn merge_options(&self, dynamic_options: HashMap<String, String>) -> HashMap<String, String> {
+        let mut merged = self.base_options.as_ref().clone();
+        merged.extend(dynamic_options);
+        merged
+    }
+
+    pub(in crate::object_store) async fn current_store(&self) -> Result<Arc<OpendalStore>> {
+        let merged_options = self.merge_options(self.accessor.get_storage_options().await?.0);
+        let config = (self.normalize_config)(&merged_options)?;
+
+        // Cache reuse depends on exact normalized config equality. Providers
+        // should return stable, canonicalized values for semantically identical
+        // configurations to avoid unnecessary store rebuilds.
+        {
+            let cache = self.cache.read().await;
+            if let Some(cached) = cache.as_ref()
+                && cached.config == config
+            {
+                return Ok(cached.store.clone());
+            }
+        }
+
+        let store = Arc::new((self.build_store)(config.clone())?);
+        let mut cache = self.cache.write().await;
+        if let Some(cached) = cache.as_ref()
+            && cached.config == config
+        {
+            return Ok(cached.store.clone());
+        }
+
+        *cache = Some(CachedOpenDalStore {
+            config,
+            store: store.clone(),
+        });
+        Ok(store)
+    }
+
+    fn map_store_error(&self, error: lance_core::Error) -> object_store::Error {
+        object_store::Error::Generic {
+            store: "DynamicOpenDalStore",
+            source: Box::new(error),
+        }
+    }
+}
+
+impl fmt::Display for DynamicOpenDalStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DynamicOpenDalStore({})", self.name)
+    }
+}
+
+#[async_trait::async_trait]
+impl OSObjectStore for DynamicOpenDalStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .put_opts(location, payload, opts)
+            .await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .put_multipart_opts(location, opts)
+            .await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .get_opts(location, options)
+            .await
+    }
+
+    async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .delete(location)
+            .await
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        let prefix = prefix.cloned();
+        let this = self.clone();
+        stream::once(async move {
+            this.current_store()
+                .await
+                .map_err(|e| this.map_store_error(e))
+        })
+        .map_ok(move |store| store.list(prefix.as_ref()))
+        .try_flatten()
+        .boxed()
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .list_with_delimiter(prefix)
+            .await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .copy(from, to)
+            .await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .copy_if_not_exists(from, to)
+            .await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .rename(from, to)
+            .await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .rename_if_not_exists(from, to)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use opendal::{Operator, services::Memory};
+
+    use super::*;
+    use crate::object_store::test_utils::StaticMockStorageOptionsProvider;
+
+    #[tokio::test]
+    async fn test_dynamic_store_caches_by_normalized_config() {
+        let accessor = Arc::new(StorageOptionsAccessor::with_provider(Arc::new(
+            StaticMockStorageOptionsProvider {
+                options: HashMap::from([("token".to_string(), "value".to_string())]),
+            },
+        )));
+
+        let store = DynamicOpenDalStore::new(
+            "memory",
+            HashMap::new(),
+            accessor,
+            |options| Ok(options.clone()),
+            |_| {
+                let operator = Operator::new(Memory::default()).map_err(|e| {
+                    lance_core::Error::invalid_input(format!(
+                        "Failed to create memory operator: {e:?}"
+                    ))
+                })?;
+                Ok(OpendalStore::new(operator.finish()))
+            },
+        );
+
+        let first = store
+            .current_store()
+            .await
+            .expect("first store should build");
+        let second = store
+            .current_store()
+            .await
+            .expect("second store should reuse cache");
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+}

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -29,7 +29,7 @@ use url::Url;
 use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
-    dynamic_credentials::{NamespaceCredentialsProvider, supports_dynamic_credentials},
+    dynamic_credentials::{NamespaceCredentialsProvider, build_dynamic_credential_provider},
     throttle::{AimdThrottleConfig, AimdThrottledStore},
 };
 use lance_core::error::{Error, Result};
@@ -274,24 +274,20 @@ pub async fn build_aws_credential(
 
     let storage_options_credentials = storage_options.and_then(extract_static_s3_credentials);
 
-    // If accessor has a provider, check whether it vends credentials.
-    // If it does, use DynamicStorageOptionsCredentialProvider for ongoing
-    // refresh. If not, fall through to the default credentials chain.
-    if let Some(accessor) = storage_options_accessor
-        && accessor.has_provider()
+    // Explicit aws_credentials takes precedence over dynamic credentials.
+    if credentials.is_none()
+        && let Some(dynamic_creds) = build_dynamic_credential_provider::<ObjectStoreAwsCredential>(
+            storage_options_accessor.clone(),
+        )
+        .await?
     {
-        // Explicit aws_credentials takes precedence
-        if let Some(creds) = credentials {
-            return Ok((creds, region));
-        }
+        return Ok((dynamic_creds, region));
+    }
 
-        if supports_dynamic_credentials::<ObjectStoreAwsCredential>(&accessor).await? {
-            return Ok((
-                Arc::new(DynamicStorageOptionsCredentialProvider::new(accessor)),
-                region,
-            ));
-        }
-
+    if storage_options_accessor
+        .as_ref()
+        .is_some_and(|a| a.has_provider())
+    {
         log::debug!(
             "Storage options from provider do not contain explicit AWS credentials, \
              falling back to default AWS credentials chain."

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{collections::HashMap, fmt, str::FromStr, sync::Arc, time::Duration};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 #[cfg(test)]
 use mock_instant::thread_local::{SystemTime, UNIX_EPOCH};
@@ -29,7 +29,7 @@ use url::Url;
 use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
-    StorageOptionsProvider,
+    dynamic_credentials::{NamespaceCredentialsProvider, supports_dynamic_credentials},
     throttle::{AimdThrottleConfig, AimdThrottledStore},
 };
 use lance_core::error::{Error, Result};
@@ -285,10 +285,7 @@ pub async fn build_aws_credential(
             return Ok((creds, region));
         }
 
-        // Check if the accessor's storage options contain credentials
-        let opts = accessor.get_storage_options().await?;
-        let s3_options = opts.as_s3_options();
-        if extract_static_s3_credentials(&s3_options).is_some() {
+        if supports_dynamic_credentials::<ObjectStoreAwsCredential>(&accessor).await? {
             return Ok((
                 Arc::new(DynamicStorageOptionsCredentialProvider::new(accessor)),
                 region,
@@ -467,106 +464,13 @@ impl ObjectStoreParams {
     }
 }
 
-/// AWS Credential Provider that delegates to StorageOptionsAccessor
-///
-/// This adapter converts storage options from a [`StorageOptionsAccessor`] into
-/// AWS-specific credentials that can be used with S3. All caching and refresh logic
-/// is handled by the accessor.
-///
-/// # Future Work
-///
-/// TODO: Support AWS/GCP/Azure together in a unified credential provider.
-/// Currently this is AWS-specific. Needs investigation of how GCP and Azure credential
-/// refresh mechanisms work and whether they can be unified with AWS's approach.
-///
-/// See: <https://github.com/lance-format/lance/pull/4905#discussion_r2474605265>
-pub struct DynamicStorageOptionsCredentialProvider {
-    accessor: Arc<StorageOptionsAccessor>,
-}
-
-impl fmt::Debug for DynamicStorageOptionsCredentialProvider {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DynamicStorageOptionsCredentialProvider")
-            .field("accessor", &self.accessor)
-            .finish()
-    }
-}
-
-impl DynamicStorageOptionsCredentialProvider {
-    /// Create a new credential provider from a storage options accessor
-    pub fn new(accessor: Arc<StorageOptionsAccessor>) -> Self {
-        Self { accessor }
-    }
-
-    /// Create a new credential provider from a storage options provider
-    ///
-    /// This is a convenience constructor for backward compatibility.
-    /// The refresh offset will be extracted from storage options using
-    /// the `refresh_offset_millis` key, defaulting to 60 seconds.
-    ///
-    /// # Arguments
-    /// * `provider` - The storage options provider
-    pub fn from_provider(provider: Arc<dyn StorageOptionsProvider>) -> Self {
-        Self {
-            accessor: Arc::new(StorageOptionsAccessor::with_provider(provider)),
-        }
-    }
-
-    /// Create a new credential provider with initial credentials
-    ///
-    /// This is a convenience constructor for backward compatibility.
-    /// The refresh offset will be extracted from initial_options using
-    /// the `refresh_offset_millis` key, defaulting to 60 seconds.
-    ///
-    /// # Arguments
-    /// * `provider` - The storage options provider
-    /// * `initial_options` - Initial storage options to cache
-    pub fn from_provider_with_initial(
-        provider: Arc<dyn StorageOptionsProvider>,
-        initial_options: HashMap<String, String>,
-    ) -> Self {
-        Self {
-            accessor: Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                initial_options,
-                provider,
-            )),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl CredentialProvider for DynamicStorageOptionsCredentialProvider {
-    type Credential = ObjectStoreAwsCredential;
-
-    async fn get_credential(&self) -> ObjectStoreResult<Arc<Self::Credential>> {
-        let storage_options = self.accessor.get_storage_options().await.map_err(|e| {
-            object_store::Error::Generic {
-                store: "DynamicStorageOptionsCredentialProvider",
-                source: Box::new(e),
-            }
-        })?;
-
-        let s3_options = storage_options.as_s3_options();
-        let static_creds = extract_static_s3_credentials(&s3_options).ok_or_else(|| {
-            object_store::Error::Generic {
-                store: "DynamicStorageOptionsCredentialProvider",
-                source: "Missing required credentials in storage options".into(),
-            }
-        })?;
-
-        static_creds
-            .get_credential()
-            .await
-            .map_err(|e| object_store::Error::Generic {
-                store: "DynamicStorageOptionsCredentialProvider",
-                source: Box::new(e),
-            })
-    }
-}
+pub type DynamicStorageOptionsCredentialProvider =
+    NamespaceCredentialsProvider<ObjectStoreAwsCredential>;
 
 #[cfg(test)]
 mod tests {
     use crate::object_store::ObjectStoreRegistry;
+    use crate::object_store::StorageOptionsProvider;
     use mock_instant::thread_local::MockClock;
     use object_store::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -14,14 +14,14 @@ use opendal::{Operator, services::Azblob, services::Azdls};
 
 use object_store::{
     RetryConfig,
-    azure::{AzureConfigKey, AzureCredential, AzureCredentialProvider, MicrosoftAzureBuilder},
+    azure::{AzureConfigKey, AzureCredential, MicrosoftAzureBuilder},
 };
 use url::Url;
 
 use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
-    dynamic_credentials::{NamespaceCredentialsProvider, supports_dynamic_credentials},
+    dynamic_credentials::build_dynamic_credential_provider,
     throttle::{AimdThrottleConfig, AimdThrottledStore},
 };
 use lance_core::error::{Error, Result};
@@ -30,58 +30,55 @@ use lance_core::error::{Error, Result};
 pub struct AzureBlobStoreProvider;
 
 impl AzureBlobStoreProvider {
+    /// Normalize Azure storage options for OpenDAL, resolving aliases for
+    /// well-known keys while passing through all other options (e.g.
+    /// `client_id`, `tenant_id`, `encryption_key`, etc.) so that OpenDAL
+    /// can use them directly.
     fn normalize_opendal_azure_options(
         options: &HashMap<String, String>,
     ) -> HashMap<String, String> {
-        let mut config_map = HashMap::new();
+        // Start with all options so unknown keys are forwarded to OpenDAL.
+        let mut config_map = options.clone();
 
-        if let Some(account_name) = options
-            .get("account_name")
-            .cloned()
-            .or_else(|| options.get("azure_storage_account_name").cloned())
-        {
-            config_map.insert("account_name".to_string(), account_name);
-        }
+        // Normalize well-known aliases into canonical OpenDAL key names.
+        // Remove the alias after resolving to avoid duplicate/conflicting entries.
+        let alias_groups: &[(&str, &[&str])] = &[
+            ("account_name", &["azure_storage_account_name"]),
+            ("endpoint", &["azure_storage_endpoint", "azure_endpoint"]),
+            (
+                "account_key",
+                &[
+                    "azure_storage_account_key",
+                    "azure_storage_access_key",
+                    "azure_storage_master_key",
+                    "access_key",
+                    "master_key",
+                ],
+            ),
+            (
+                "sas_token",
+                &[
+                    "azure_storage_sas_token",
+                    "azure_storage_sas_key",
+                    "sas_key",
+                ],
+            ),
+        ];
 
-        if let Some(endpoint) = options
-            .get("endpoint")
-            .cloned()
-            .or_else(|| options.get("azure_storage_endpoint").cloned())
-            .or_else(|| options.get("azure_endpoint").cloned())
-        {
-            config_map.insert("endpoint".to_string(), endpoint);
-        }
-
-        if let Some(account_key) = options
-            .get("account_key")
-            .cloned()
-            .or_else(|| options.get("azure_storage_account_key").cloned())
-            .or_else(|| options.get("azure_storage_access_key").cloned())
-            .or_else(|| options.get("azure_storage_master_key").cloned())
-            .or_else(|| options.get("access_key").cloned())
-            .or_else(|| options.get("master_key").cloned())
-        {
-            config_map.insert("account_key".to_string(), account_key);
-        }
-
-        if let Some(sas_token) = options
-            .get("sas_token")
-            .cloned()
-            .or_else(|| options.get("azure_storage_sas_token").cloned())
-            .or_else(|| options.get("azure_storage_sas_key").cloned())
-            .or_else(|| options.get("sas_key").cloned())
-        {
-            config_map.insert("sas_token".to_string(), sas_token);
-        }
-
-        if let Some(container) = options.get("container").cloned() {
-            config_map.insert("container".to_string(), container);
-        }
-        if let Some(filesystem) = options.get("filesystem").cloned() {
-            config_map.insert("filesystem".to_string(), filesystem);
-        }
-        if let Some(root) = options.get("root").cloned() {
-            config_map.insert("root".to_string(), root);
+        for (canonical, aliases) in alias_groups {
+            if !config_map.contains_key(*canonical) {
+                for alias in *aliases {
+                    if let Some(value) = config_map.remove(*alias) {
+                        config_map.insert(canonical.to_string(), value);
+                        break;
+                    }
+                }
+            } else {
+                // Canonical key exists; remove aliases to avoid conflicts.
+                for alias in *aliases {
+                    config_map.remove(*alias);
+                }
+            }
         }
 
         config_map
@@ -189,29 +186,13 @@ impl AzureBlobStoreProvider {
             builder = builder.with_config(key, value);
         }
 
-        if let Some(credentials) = build_dynamic_azure_credentials(accessor).await? {
+        if let Some(credentials) =
+            build_dynamic_credential_provider::<AzureCredential>(accessor).await?
+        {
             builder = builder.with_credentials(credentials);
         }
 
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
-    }
-}
-
-async fn build_dynamic_azure_credentials(
-    accessor: Option<Arc<StorageOptionsAccessor>>,
-) -> Result<Option<AzureCredentialProvider>> {
-    let Some(accessor) = accessor.filter(|accessor| accessor.has_provider()) else {
-        return Ok(None);
-    };
-
-    if supports_dynamic_credentials::<AzureCredential>(&accessor).await? {
-        Ok(Some(
-            Arc::new(NamespaceCredentialsProvider::<AzureCredential>::new(
-                accessor,
-            )) as AzureCredentialProvider,
-        ))
-    } else {
-        Ok(None)
     }
 }
 
@@ -428,7 +409,7 @@ mod tests {
             },
         )));
 
-        let credentials = build_dynamic_azure_credentials(Some(accessor))
+        let credentials = build_dynamic_credential_provider::<AzureCredential>(Some(accessor))
             .await
             .expect("dynamic azure credentials should build")
             .expect("expected credential provider")

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -14,13 +14,14 @@ use opendal::{Operator, services::Azblob, services::Azdls};
 
 use object_store::{
     RetryConfig,
-    azure::{AzureConfigKey, MicrosoftAzureBuilder},
+    azure::{AzureConfigKey, AzureCredential, AzureCredentialProvider, MicrosoftAzureBuilder},
 };
 use url::Url;
 
 use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
-    ObjectStoreParams, ObjectStoreProvider, StorageOptions,
+    ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
+    dynamic_credentials::{NamespaceCredentialsProvider, supports_dynamic_credentials},
     throttle::{AimdThrottleConfig, AimdThrottledStore},
 };
 use lance_core::error::{Error, Result};
@@ -29,13 +30,70 @@ use lance_core::error::{Error, Result};
 pub struct AzureBlobStoreProvider;
 
 impl AzureBlobStoreProvider {
+    fn normalize_opendal_azure_options(
+        options: &HashMap<String, String>,
+    ) -> HashMap<String, String> {
+        let mut config_map = HashMap::new();
+
+        if let Some(account_name) = options
+            .get("account_name")
+            .cloned()
+            .or_else(|| options.get("azure_storage_account_name").cloned())
+        {
+            config_map.insert("account_name".to_string(), account_name);
+        }
+
+        if let Some(endpoint) = options
+            .get("endpoint")
+            .cloned()
+            .or_else(|| options.get("azure_storage_endpoint").cloned())
+            .or_else(|| options.get("azure_endpoint").cloned())
+        {
+            config_map.insert("endpoint".to_string(), endpoint);
+        }
+
+        if let Some(account_key) = options
+            .get("account_key")
+            .cloned()
+            .or_else(|| options.get("azure_storage_account_key").cloned())
+            .or_else(|| options.get("azure_storage_access_key").cloned())
+            .or_else(|| options.get("azure_storage_master_key").cloned())
+            .or_else(|| options.get("access_key").cloned())
+            .or_else(|| options.get("master_key").cloned())
+        {
+            config_map.insert("account_key".to_string(), account_key);
+        }
+
+        if let Some(sas_token) = options
+            .get("sas_token")
+            .cloned()
+            .or_else(|| options.get("azure_storage_sas_token").cloned())
+            .or_else(|| options.get("azure_storage_sas_key").cloned())
+            .or_else(|| options.get("sas_key").cloned())
+        {
+            config_map.insert("sas_token".to_string(), sas_token);
+        }
+
+        if let Some(container) = options.get("container").cloned() {
+            config_map.insert("container".to_string(), container);
+        }
+        if let Some(filesystem) = options.get("filesystem").cloned() {
+            config_map.insert("filesystem".to_string(), filesystem);
+        }
+        if let Some(root) = options.get("root").cloned() {
+            config_map.insert("root".to_string(), root);
+        }
+
+        config_map
+    }
+
     fn build_opendal_operator(
         base_path: &Url,
         storage_options: &StorageOptions,
     ) -> Result<Operator> {
         // Start with all storage options as the config map
         // OpenDAL will handle environment variables through its default credentials chain
-        let mut config_map: HashMap<String, String> = storage_options.0.clone();
+        let mut config_map = Self::normalize_opendal_azure_options(&storage_options.0);
 
         match base_path.scheme() {
             "az" => {
@@ -113,6 +171,7 @@ impl AzureBlobStoreProvider {
         &self,
         base_path: &Url,
         storage_options: &StorageOptions,
+        accessor: Option<Arc<StorageOptionsAccessor>>,
     ) -> Result<Arc<dyn OSObjectStore>> {
         // Use a low retry count since the AIMD throttle layer handles
         // throttle recovery with its own retry loop.
@@ -130,7 +189,29 @@ impl AzureBlobStoreProvider {
             builder = builder.with_config(key, value);
         }
 
+        if let Some(credentials) = build_dynamic_azure_credentials(accessor).await? {
+            builder = builder.with_credentials(credentials);
+        }
+
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+    }
+}
+
+async fn build_dynamic_azure_credentials(
+    accessor: Option<Arc<StorageOptionsAccessor>>,
+) -> Result<Option<AzureCredentialProvider>> {
+    let Some(accessor) = accessor.filter(|accessor| accessor.has_provider()) else {
+        return Ok(None);
+    };
+
+    if supports_dynamic_credentials::<AzureCredential>(&accessor).await? {
+        Ok(Some(
+            Arc::new(NamespaceCredentialsProvider::<AzureCredential>::new(
+                accessor,
+            )) as AzureCredentialProvider,
+        ))
+    } else {
+        Ok(None)
     }
 }
 
@@ -157,11 +238,15 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             .map(|v| v.as_str() == "true")
             .unwrap_or(false);
 
+        let accessor = params.get_accessor();
+
         let inner: Arc<dyn OSObjectStore> = if use_opendal {
+            // OpenDAL Azure intentionally uses static/environment-backed configuration only.
+            // Namespace-vended dynamic credentials are supported on the native object_store path.
             self.build_opendal_azure_store(&base_path, &storage_options)
                 .await?
         } else {
-            self.build_microsoft_azure_store(&base_path, &storage_options)
+            self.build_microsoft_azure_store(&base_path, &storage_options, accessor)
                 .await?
         };
         let throttle_config = AimdThrottleConfig::from_storage_options(params.storage_options())?;
@@ -281,7 +366,10 @@ impl StorageOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::object_store::ObjectStoreParams;
+    use std::sync::Arc;
+
+    use crate::object_store::test_utils::StaticMockStorageOptionsProvider;
+    use crate::object_store::{ObjectStoreParams, StorageOptionsAccessor};
     use std::collections::HashMap;
 
     #[test]
@@ -296,7 +384,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_use_opendal_flag() {
-        use crate::object_store::StorageOptionsAccessor;
         let provider = AzureBlobStoreProvider;
         let url = Url::parse("az://test-container/path").unwrap();
         let params_with_flag = ObjectStoreParams {
@@ -328,6 +415,37 @@ mod tests {
             "az:// with use_opendal=true should use OpenDAL Azblob, got: {}",
             inner_desc
         );
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_azure_credentials_provider() {
+        let accessor = Arc::new(StorageOptionsAccessor::with_provider(Arc::new(
+            StaticMockStorageOptionsProvider {
+                options: HashMap::from([(
+                    "azure_storage_sas_token".to_string(),
+                    "?sv=2022-11-02&sp=rl&sig=test".to_string(),
+                )]),
+            },
+        )));
+
+        let credentials = build_dynamic_azure_credentials(Some(accessor))
+            .await
+            .expect("dynamic azure credentials should build")
+            .expect("expected credential provider")
+            .get_credential()
+            .await
+            .expect("expected azure credential");
+
+        match credentials.as_ref() {
+            AzureCredential::SASToken(pairs) => {
+                assert!(
+                    pairs
+                        .iter()
+                        .any(|(key, value)| key == "sig" && value == "test")
+                );
+            }
+            other => panic!("expected SAS token, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -194,6 +194,42 @@ impl AzureBlobStoreProvider {
 
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
     }
+
+    fn calculate_object_store_prefix_with_env(
+        url: &Url,
+        storage_options: Option<&HashMap<String, String>>,
+        env_options: &HashMap<String, String>,
+    ) -> Result<String> {
+        let authority = url.authority();
+        let (container, account) = match authority.find("@") {
+            Some(at_index) => {
+                // The URI has an:
+                // - az:// schema type and is similar to 'az://container@account.dfs.core.windows.net/path-part/file
+                //         or possibly 'az://container@account/path-part/file' (the short version).
+                // - abfss:// schema type and is similar to 'abfss://filesystem@account.dfs.core.windows.net/path-part/file'.
+                let container = &authority[..at_index];
+                let account = &authority[at_index + 1..];
+                (
+                    container,
+                    account.split(".").next().unwrap_or_default().to_string(),
+                )
+            }
+            None => {
+                // The URI looks like 'az://container/path-part/file'.
+                // We must look at the storage options to find the account.
+                let mut account = match storage_options {
+                    Some(opts) => StorageOptions::find_configured_storage_account(opts),
+                    None => None,
+                };
+                if account.is_none() {
+                    account = StorageOptions::find_configured_storage_account(env_options);
+                }
+                let account = account.ok_or(Error::invalid_input("Unable to find object store prefix: no Azure account name in URI, and no storage account configured."))?;
+                (authority, account)
+            }
+        };
+        Ok(format!("{}${}@{}", url.scheme(), container, account))
+    }
 }
 
 #[async_trait::async_trait]
@@ -264,35 +300,7 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
         url: &Url,
         storage_options: Option<&HashMap<String, String>>,
     ) -> Result<String> {
-        let authority = url.authority();
-        let (container, account) = match authority.find("@") {
-            Some(at_index) => {
-                // The URI has an:
-                // - az:// schema type and is similar to 'az://container@account.dfs.core.windows.net/path-part/file
-                //         or possibly 'az://container@account/path-part/file' (the short version).
-                // - abfss:// schema type and is similar to 'abfss://filesystem@account.dfs.core.windows.net/path-part/file'.
-                let container = &authority[..at_index];
-                let account = &authority[at_index + 1..];
-                (
-                    container,
-                    account.split(".").next().unwrap_or_default().to_string(),
-                )
-            }
-            None => {
-                // The URI looks like 'az://container/path-part/file'.
-                // We must look at the storage options to find the account.
-                let mut account = match storage_options {
-                    Some(opts) => StorageOptions::find_configured_storage_account(opts),
-                    None => None,
-                };
-                if account.is_none() {
-                    account = StorageOptions::find_configured_storage_account(&ENV_OPTIONS.0);
-                }
-                let account = account.ok_or(Error::invalid_input("Unable to find object store prefix: no Azure account name in URI, and no storage account configured."))?;
-                (authority, account)
-            }
-        };
-        Ok(format!("{}${}@{}", url.scheme(), container, account))
+        Self::calculate_object_store_prefix_with_env(url, storage_options, &ENV_OPTIONS.0)
     }
 }
 
@@ -493,16 +501,15 @@ mod tests {
 
     #[test]
     fn test_fail_to_calculate_object_store_prefix_from_url() {
-        let provider = AzureBlobStoreProvider;
         let options = HashMap::from_iter([("access_key".to_string(), "myaccesskey".to_string())]);
         let expected = "Invalid user input: Unable to find object store prefix: no Azure account name in URI, and no storage account configured.";
-        let result = provider
-            .calculate_object_store_prefix(
-                &Url::parse("az://container/path").unwrap(),
-                Some(&options),
-            )
-            .expect_err("expected error")
-            .to_string();
+        let result = AzureBlobStoreProvider::calculate_object_store_prefix_with_env(
+            &Url::parse("az://container/path").unwrap(),
+            Some(&options),
+            &HashMap::new(),
+        )
+        .expect_err("expected error")
+        .to_string();
         assert_eq!(expected, &result[..expected.len()]);
     }
 

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -9,14 +9,14 @@ use opendal::{Operator, services::Gcs};
 
 use object_store::{
     RetryConfig, StaticCredentialProvider,
-    gcp::{GcpCredential, GcpCredentialProvider, GoogleCloudStorageBuilder, GoogleConfigKey},
+    gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
 };
 use url::Url;
 
 use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
-    dynamic_credentials::{NamespaceCredentialsProvider, supports_dynamic_credentials},
+    dynamic_credentials::build_dynamic_credential_provider,
     throttle::{AimdThrottleConfig, AimdThrottledStore},
 };
 use lance_core::error::{Error, Result};
@@ -77,7 +77,9 @@ impl GcsStoreProvider {
             builder = builder.with_config(key, value);
         }
 
-        if let Some(credentials) = build_dynamic_gcp_credentials(accessor).await? {
+        if let Some(credentials) =
+            build_dynamic_credential_provider::<GcpCredential>(accessor).await?
+        {
             builder = builder.with_credentials(credentials);
         } else if let Some(storage_token) = storage_options.get("google_storage_token") {
             let credential = GcpCredential {
@@ -88,23 +90,6 @@ impl GcsStoreProvider {
         }
 
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
-    }
-}
-
-async fn build_dynamic_gcp_credentials(
-    accessor: Option<Arc<StorageOptionsAccessor>>,
-) -> Result<Option<GcpCredentialProvider>> {
-    let Some(accessor) = accessor.filter(|accessor| accessor.has_provider()) else {
-        return Ok(None);
-    };
-
-    if supports_dynamic_credentials::<GcpCredential>(&accessor).await? {
-        Ok(Some(
-            Arc::new(NamespaceCredentialsProvider::<GcpCredential>::new(accessor))
-                as GcpCredentialProvider,
-        ))
-    } else {
-        Ok(None)
     }
 }
 
@@ -252,7 +237,7 @@ mod tests {
             },
         )));
 
-        let credentials = build_dynamic_gcp_credentials(Some(accessor))
+        let credentials = build_dynamic_credential_provider::<GcpCredential>(Some(accessor))
             .await
             .expect("dynamic gcp credentials should build")
             .expect("expected credential provider")

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -9,13 +9,14 @@ use opendal::{Operator, services::Gcs};
 
 use object_store::{
     RetryConfig, StaticCredentialProvider,
-    gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
+    gcp::{GcpCredential, GcpCredentialProvider, GoogleCloudStorageBuilder, GoogleConfigKey},
 };
 use url::Url;
 
 use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
-    ObjectStoreParams, ObjectStoreProvider, StorageOptions,
+    ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
+    dynamic_credentials::{NamespaceCredentialsProvider, supports_dynamic_credentials},
     throttle::{AimdThrottleConfig, AimdThrottledStore},
 };
 use lance_core::error::{Error, Result};
@@ -58,6 +59,7 @@ impl GcsStoreProvider {
         &self,
         base_path: &Url,
         storage_options: &StorageOptions,
+        accessor: Option<Arc<StorageOptionsAccessor>>,
     ) -> Result<Arc<dyn OSObjectStore>> {
         // Use a low retry count since the AIMD throttle layer handles
         // throttle recovery with its own retry loop.
@@ -74,8 +76,10 @@ impl GcsStoreProvider {
         for (key, value) in storage_options.as_gcs_options() {
             builder = builder.with_config(key, value);
         }
-        let token_key = "google_storage_token";
-        if let Some(storage_token) = storage_options.get(token_key) {
+
+        if let Some(credentials) = build_dynamic_gcp_credentials(accessor).await? {
+            builder = builder.with_credentials(credentials);
+        } else if let Some(storage_token) = storage_options.get("google_storage_token") {
             let credential = GcpCredential {
                 bearer: storage_token.clone(),
             };
@@ -84,6 +88,23 @@ impl GcsStoreProvider {
         }
 
         Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+    }
+}
+
+async fn build_dynamic_gcp_credentials(
+    accessor: Option<Arc<StorageOptionsAccessor>>,
+) -> Result<Option<GcpCredentialProvider>> {
+    let Some(accessor) = accessor.filter(|accessor| accessor.has_provider()) else {
+        return Ok(None);
+    };
+
+    if supports_dynamic_credentials::<GcpCredential>(&accessor).await? {
+        Ok(Some(
+            Arc::new(NamespaceCredentialsProvider::<GcpCredential>::new(accessor))
+                as GcpCredentialProvider,
+        ))
+    } else {
+        Ok(None)
     }
 }
 
@@ -102,11 +123,15 @@ impl ObjectStoreProvider for GcsStoreProvider {
             .map(|v| v.as_str() == "true")
             .unwrap_or(false);
 
+        let accessor = params.get_accessor();
+
         let inner = if use_opendal {
+            // OpenDAL GCS intentionally uses static/environment-backed configuration only.
+            // Namespace-vended dynamic credentials are supported on the native object_store path.
             self.build_opendal_gcs_store(&base_path, &storage_options)
                 .await?
         } else {
-            self.build_google_cloud_store(&base_path, &storage_options)
+            self.build_google_cloud_store(&base_path, &storage_options, accessor)
                 .await?
         };
         let throttle_config = AimdThrottleConfig::from_storage_options(params.storage_options())?;
@@ -176,7 +201,10 @@ impl StorageOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::object_store::ObjectStoreParams;
+    use std::sync::Arc;
+
+    use crate::object_store::test_utils::StaticMockStorageOptionsProvider;
+    use crate::object_store::{ObjectStoreParams, StorageOptionsAccessor};
     use std::collections::HashMap;
 
     #[test]
@@ -191,7 +219,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_use_opendal_flag() {
-        use crate::object_store::StorageOptionsAccessor;
         let provider = GcsStoreProvider;
         let url = Url::parse("gs://test-bucket/path").unwrap();
         let params_with_flag = ObjectStoreParams {
@@ -212,5 +239,27 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(store.scheme, "gs");
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_gcp_credentials_provider() {
+        let accessor = Arc::new(StorageOptionsAccessor::with_provider(Arc::new(
+            StaticMockStorageOptionsProvider {
+                options: HashMap::from([(
+                    "google_storage_token".to_string(),
+                    "gcp-token".to_string(),
+                )]),
+            },
+        )));
+
+        let credentials = build_dynamic_gcp_credentials(Some(accessor))
+            .await
+            .expect("dynamic gcp credentials should build")
+            .expect("expected credential provider")
+            .get_credential()
+            .await
+            .expect("expected gcp credential");
+
+        assert_eq!(credentials.bearer, "gcp-token");
     }
 }

--- a/rust/lance-io/src/object_store/providers/huggingface.rs
+++ b/rust/lance-io/src/object_store/providers/huggingface.rs
@@ -62,10 +62,9 @@ fn build_hf_base_options(
     repo_id: &str,
     storage_options: &StorageOptions,
 ) -> HashMap<String, String> {
-    let mut options = HashMap::new();
+    let mut options = storage_options.0.clone();
     options.insert("repo_type".to_string(), repo_type.to_string());
     options.insert("repo_id".to_string(), repo_id.to_string());
-    options.extend(storage_options.0.clone());
     options
 }
 
@@ -146,13 +145,16 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
         let accessor = params.get_accessor();
         let inner: Arc<dyn OSObjectStore> =
             if let Some(accessor) = accessor.filter(|a| a.has_provider()) {
-                Arc::new(DynamicOpenDalStore::new(
-                    format!("hf:{}", base_path),
-                    base_options,
-                    accessor,
-                    normalize_hf_config,
-                    build_hf_store,
-                ))
+                Arc::new(
+                    DynamicOpenDalStore::new(
+                        format!("hf:{}", base_path),
+                        base_options,
+                        accessor,
+                        normalize_hf_config,
+                        build_hf_store,
+                    )
+                    .with_protected_keys(["repo_type", "repo_id"]),
+                )
             } else {
                 Arc::new(build_hf_store(normalize_hf_config(&base_options)?)?)
             };
@@ -241,6 +243,24 @@ mod tests {
             config_map.insert("revision".to_string(), rev);
         }
         assert_eq!(config_map.get("revision").unwrap(), "stable");
+    }
+
+    #[test]
+    fn storage_options_cannot_override_url_repo_identity() {
+        let config = normalize_hf_config(&build_hf_base_options(
+            "dataset",
+            "acme/repo",
+            &crate::object_store::StorageOptions(HashMap::from([
+                ("repo_type".to_string(), "model".to_string()),
+                ("repo_id".to_string(), "other/repo".to_string()),
+                ("hf_revision".to_string(), "stable".to_string()),
+            ])),
+        ))
+        .unwrap();
+
+        assert_eq!(config.get("repo_type").unwrap(), "dataset");
+        assert_eq!(config.get("repo_id").unwrap(), "acme/repo");
+        assert_eq!(config.get("revision").unwrap(), "stable");
     }
 
     #[test]

--- a/rust/lance-io/src/object_store/providers/huggingface.rs
+++ b/rust/lance-io/src/object_store/providers/huggingface.rs
@@ -10,6 +10,7 @@ use object_store_opendal::OpendalStore;
 use opendal::{Operator, services::Huggingface};
 use url::Url;
 
+use crate::object_store::dynamic_opendal::DynamicOpenDalStore;
 use crate::object_store::parse_hf_repo_id;
 use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
@@ -56,6 +57,72 @@ fn parse_hf_url(url: &Url) -> Result<ParsedHfUrl> {
     })
 }
 
+fn build_hf_base_options(
+    repo_type: &str,
+    repo_id: &str,
+    storage_options: &StorageOptions,
+) -> HashMap<String, String> {
+    let mut options = HashMap::new();
+    options.insert("repo_type".to_string(), repo_type.to_string());
+    options.insert("repo_id".to_string(), repo_id.to_string());
+    options.extend(storage_options.0.clone());
+    options
+}
+
+fn normalize_hf_config(options: &HashMap<String, String>) -> Result<HashMap<String, String>> {
+    let mut config_map = HashMap::new();
+
+    let repo_type = options
+        .get("repo_type")
+        .cloned()
+        .ok_or_else(|| Error::invalid_input("Huggingface repo_type is required"))?;
+    let repo_id = options
+        .get("repo_id")
+        .cloned()
+        .ok_or_else(|| Error::invalid_input("Huggingface repo_id is required"))?;
+
+    config_map.insert("repo_type".to_string(), repo_type);
+    config_map.insert("repo_id".to_string(), repo_id);
+
+    if let Some(revision) = options
+        .get("hf_revision")
+        .cloned()
+        .or_else(|| options.get("revision").cloned())
+    {
+        config_map.insert("revision".to_string(), revision);
+    }
+
+    if let Some(root) = options
+        .get("hf_root")
+        .cloned()
+        .or_else(|| options.get("root").cloned())
+        && !root.is_empty()
+    {
+        config_map.insert("root".to_string(), root);
+    }
+
+    if let Some(token) = options
+        .get("hf_token")
+        .cloned()
+        .or_else(|| options.get("token").cloned())
+        && !token.is_empty()
+    {
+        config_map.insert("token".to_string(), token);
+    }
+
+    Ok(config_map)
+}
+
+fn build_hf_store(config_map: HashMap<String, String>) -> Result<OpendalStore> {
+    let operator = Operator::from_iter::<Huggingface>(config_map)
+        .map_err(|e| {
+            Error::invalid_input(format!("Failed to create Huggingface operator: {:?}", e))
+        })?
+        .finish();
+
+    Ok(OpendalStore::new(operator))
+}
+
 #[async_trait::async_trait]
 impl ObjectStoreProvider for HuggingfaceStoreProvider {
     async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
@@ -67,38 +134,28 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
         let storage_options = StorageOptions(params.storage_options().cloned().unwrap_or_default());
         let download_retry_count = storage_options.download_retry_count();
 
-        // Build OpenDAL config with allowed keys only.
-        let mut config_map: HashMap<String, String> = HashMap::new();
-
-        config_map.insert("repo_type".to_string(), repo_type);
-        config_map.insert("repo_id".to_string(), repo_id);
-
-        if let Some(rev) = storage_options.get("hf_revision").cloned() {
-            config_map.insert("revision".to_string(), rev);
+        let mut base_options = build_hf_base_options(&repo_type, &repo_id, &storage_options);
+        if !base_options.contains_key("hf_token") && !base_options.contains_key("token") {
+            if let Ok(token) = std::env::var("HF_TOKEN") {
+                base_options.insert("hf_token".to_string(), token);
+            } else if let Ok(token) = std::env::var("HUGGINGFACE_TOKEN") {
+                base_options.insert("hf_token".to_string(), token);
+            }
         }
 
-        if let Some(root) = storage_options.get("hf_root").cloned()
-            && !root.is_empty()
-        {
-            config_map.insert("root".to_string(), root);
-        }
-
-        if let Some(token) = storage_options
-            .get("hf_token")
-            .cloned()
-            .or_else(|| std::env::var("HF_TOKEN").ok())
-            .or_else(|| std::env::var("HUGGINGFACE_TOKEN").ok())
-        {
-            config_map.insert("token".to_string(), token);
-        }
-
-        let operator = Operator::from_iter::<Huggingface>(config_map)
-            .map_err(|e| {
-                Error::invalid_input(format!("Failed to create Huggingface operator: {:?}", e))
-            })?
-            .finish();
-
-        let inner: Arc<dyn OSObjectStore> = Arc::new(OpendalStore::new(operator));
+        let accessor = params.get_accessor();
+        let inner: Arc<dyn OSObjectStore> =
+            if let Some(accessor) = accessor.filter(|a| a.has_provider()) {
+                Arc::new(DynamicOpenDalStore::new(
+                    format!("hf:{}", base_path),
+                    base_options,
+                    accessor,
+                    normalize_hf_config,
+                    build_hf_store,
+                ))
+            } else {
+                Arc::new(build_hf_store(normalize_hf_config(&base_options)?)?)
+            };
 
         Ok(ObjectStore {
             scheme: "hf".to_string(),
@@ -135,6 +192,11 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use crate::object_store::StorageOptionsAccessor;
+    use crate::object_store::dynamic_opendal::DynamicOpenDalStore;
+    use crate::object_store::test_utils::StaticMockStorageOptionsProvider;
 
     #[test]
     fn parse_basic_url() {
@@ -234,5 +296,34 @@ mod tests {
         let url = Url::parse("hf://datasets/only-owner").unwrap();
         let err = parse_hf_url(&url).unwrap_err();
         assert!(err.to_string().contains("repository name"));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_opendal_hf_store_uses_provider_token() {
+        let parsed = parse_hf_url(&Url::parse("hf://datasets/acme/repo/path").unwrap()).unwrap();
+        let accessor = Arc::new(StorageOptionsAccessor::with_provider(Arc::new(
+            StaticMockStorageOptionsProvider {
+                options: HashMap::from([("hf_token".to_string(), "dynamic-token".to_string())]),
+            },
+        )));
+
+        let store = DynamicOpenDalStore::new(
+            "hf",
+            build_hf_base_options(
+                &parsed.repo_type,
+                &parsed.repo_id,
+                &crate::object_store::StorageOptions(HashMap::new()),
+            ),
+            accessor,
+            normalize_hf_config,
+            build_hf_store,
+        );
+
+        let current_store = store
+            .current_store()
+            .await
+            .expect("dynamic OpenDAL HuggingFace store should build");
+
+        assert!(current_store.to_string().contains("Opendal"));
     }
 }

--- a/rust/lance-io/src/object_store/providers/oss.rs
+++ b/rust/lance-io/src/object_store/providers/oss.rs
@@ -49,13 +49,14 @@ impl OssStoreProvider {
             })
             .collect();
 
-        config_map.insert("bucket".to_string(), bucket);
+        config_map.extend(storage_options.0.clone());
 
-        if !prefix.is_empty() {
+        config_map.insert("bucket".to_string(), bucket);
+        if prefix.is_empty() {
+            config_map.remove("root");
+        } else {
             config_map.insert("root".to_string(), "/".to_string());
         }
-
-        config_map.extend(storage_options.0.clone());
 
         Ok(config_map)
     }
@@ -75,16 +76,10 @@ impl OssStoreProvider {
         ];
 
         for (canonical, aliases) in alias_groups {
-            if !config_map.contains_key(*canonical) {
-                for alias in *aliases {
-                    if let Some(value) = config_map.remove(*alias) {
-                        config_map.insert(canonical.to_string(), value);
-                        break;
-                    }
-                }
-            } else {
-                for alias in *aliases {
-                    config_map.remove(*alias);
+            for alias in *aliases {
+                if let Some(value) = config_map.remove(*alias) {
+                    config_map.insert(canonical.to_string(), value);
+                    break;
                 }
             }
         }
@@ -118,13 +113,16 @@ impl ObjectStoreProvider for OssStoreProvider {
 
         let inner: Arc<dyn OSObjectStore> =
             if let Some(accessor) = accessor.filter(|a| a.has_provider()) {
-                Arc::new(DynamicOpenDalStore::new(
-                    format!("oss:{}", base_path),
-                    base_options,
-                    accessor,
-                    Self::normalize_oss_config,
-                    Self::build_oss_store,
-                ))
+                Arc::new(
+                    DynamicOpenDalStore::new(
+                        format!("oss:{}", base_path),
+                        base_options,
+                        accessor,
+                        Self::normalize_oss_config,
+                        Self::build_oss_store,
+                    )
+                    .with_protected_keys(["bucket", "root"]),
+                )
             } else {
                 Arc::new(Self::build_oss_store(Self::normalize_oss_config(
                     &base_options,
@@ -170,6 +168,82 @@ mod tests {
         let path = provider.extract_path(&url).unwrap();
         let expected_path = object_store::path::Path::from("path/to/file");
         assert_eq!(path, expected_path);
+    }
+
+    #[test]
+    fn test_oss_alias_options_override_canonical_env_options() {
+        let config = OssStoreProvider::normalize_oss_config(&HashMap::from([
+            (
+                "endpoint".to_string(),
+                "https://env.example.com".to_string(),
+            ),
+            (
+                "oss_endpoint".to_string(),
+                "https://user.example.com".to_string(),
+            ),
+            ("access_key_id".to_string(), "env-akid".to_string()),
+            ("oss_access_key_id".to_string(), "user-akid".to_string()),
+            ("access_key_secret".to_string(), "env-secret".to_string()),
+            (
+                "oss_secret_access_key".to_string(),
+                "user-secret".to_string(),
+            ),
+            ("region".to_string(), "env-region".to_string()),
+            ("oss_region".to_string(), "user-region".to_string()),
+            ("security_token".to_string(), "env-token".to_string()),
+            ("oss_security_token".to_string(), "user-token".to_string()),
+            ("bucket".to_string(), "bucket".to_string()),
+        ]))
+        .unwrap();
+
+        assert_eq!(config.get("endpoint").unwrap(), "https://user.example.com");
+        assert_eq!(config.get("access_key_id").unwrap(), "user-akid");
+        assert_eq!(config.get("access_key_secret").unwrap(), "user-secret");
+        assert_eq!(config.get("region").unwrap(), "user-region");
+        assert_eq!(config.get("security_token").unwrap(), "user-token");
+        assert!(!config.contains_key("oss_endpoint"));
+        assert!(!config.contains_key("oss_security_token"));
+    }
+
+    #[test]
+    fn test_oss_url_bucket_and_root_are_authoritative() {
+        let storage_options = crate::object_store::StorageOptions(HashMap::from([
+            (
+                "oss_endpoint".to_string(),
+                "https://oss-cn-hangzhou.aliyuncs.com".to_string(),
+            ),
+            ("bucket".to_string(), "storage-options-bucket".to_string()),
+            ("root".to_string(), "/storage-options-root".to_string()),
+        ]));
+        let base_options = OssStoreProvider::base_oss_options(
+            &Url::parse("oss://url-bucket/path").unwrap(),
+            &storage_options,
+        )
+        .unwrap();
+        let config = OssStoreProvider::normalize_oss_config(&base_options).unwrap();
+
+        assert_eq!(config.get("bucket").unwrap(), "url-bucket");
+        assert_eq!(config.get("root").unwrap(), "/");
+    }
+
+    #[test]
+    fn test_oss_empty_url_path_removes_storage_option_root() {
+        let storage_options = crate::object_store::StorageOptions(HashMap::from([
+            (
+                "oss_endpoint".to_string(),
+                "https://oss-cn-hangzhou.aliyuncs.com".to_string(),
+            ),
+            ("root".to_string(), "/storage-options-root".to_string()),
+        ]));
+        let base_options = OssStoreProvider::base_oss_options(
+            &Url::parse("oss://url-bucket").unwrap(),
+            &storage_options,
+        )
+        .unwrap();
+        let config = OssStoreProvider::normalize_oss_config(&base_options).unwrap();
+
+        assert_eq!(config.get("bucket").unwrap(), "url-bucket");
+        assert!(!config.contains_key("root"));
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store/providers/oss.rs
+++ b/rust/lance-io/src/object_store/providers/oss.rs
@@ -4,10 +4,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use object_store::ObjectStore as OSObjectStore;
 use object_store_opendal::OpendalStore;
 use opendal::{Operator, services::Oss};
 use url::Url;
 
+use crate::object_store::dynamic_opendal::DynamicOpenDalStore;
 use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions,
@@ -17,12 +19,11 @@ use lance_core::error::{Error, Result};
 #[derive(Default, Debug)]
 pub struct OssStoreProvider;
 
-#[async_trait::async_trait]
-impl ObjectStoreProvider for OssStoreProvider {
-    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
-        let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
-        let storage_options = StorageOptions(params.storage_options().cloned().unwrap_or_default());
-
+impl OssStoreProvider {
+    fn base_oss_options(
+        base_path: &Url,
+        storage_options: &StorageOptions,
+    ) -> Result<HashMap<String, String>> {
         let bucket = base_path
             .host_str()
             .ok_or_else(|| Error::invalid_input("OSS URL must contain bucket name"))?
@@ -30,19 +31,21 @@ impl ObjectStoreProvider for OssStoreProvider {
 
         let prefix = base_path.path().trim_start_matches('/').to_string();
 
-        // Start with environment variables as base configuration
+        // Snapshot env-backed OSS defaults at store construction time. Dynamic provider
+        // options can still override these values during per-request config merging.
         let mut config_map: HashMap<String, String> = std::env::vars()
-            .filter(|(k, _)| {
-                k.starts_with("OSS_") || k.starts_with("AWS_") || k.starts_with("ALIBABA_CLOUD_")
+            .filter(|(key, _)| {
+                key.starts_with("OSS_")
+                    || key.starts_with("AWS_")
+                    || key.starts_with("ALIBABA_CLOUD_")
             })
-            .map(|(k, v)| {
-                // Convert env var names to opendal config keys
-                let key = k
+            .map(|(key, value)| {
+                let normalized_key = key
                     .to_lowercase()
                     .replace("oss_", "")
                     .replace("aws_", "")
                     .replace("alibaba_cloud_", "");
-                (key, v)
+                (normalized_key, value)
             })
             .collect();
 
@@ -52,25 +55,55 @@ impl ObjectStoreProvider for OssStoreProvider {
             config_map.insert("root".to_string(), "/".to_string());
         }
 
-        // Override with storage options if provided
-        if let Some(endpoint) = storage_options.0.get("oss_endpoint") {
-            config_map.insert("endpoint".to_string(), endpoint.clone());
+        config_map.extend(storage_options.0.clone());
+
+        Ok(config_map)
+    }
+
+    fn normalize_oss_config(options: &HashMap<String, String>) -> Result<HashMap<String, String>> {
+        let mut config_map = HashMap::new();
+
+        if let Some(bucket) = options.get("bucket").cloned() {
+            config_map.insert("bucket".to_string(), bucket);
+        }
+        if let Some(root) = options.get("root").cloned() {
+            config_map.insert("root".to_string(), root);
         }
 
-        if let Some(access_key_id) = storage_options.0.get("oss_access_key_id") {
-            config_map.insert("access_key_id".to_string(), access_key_id.clone());
+        if let Some(endpoint) = options
+            .get("oss_endpoint")
+            .cloned()
+            .or_else(|| options.get("endpoint").cloned())
+        {
+            config_map.insert("endpoint".to_string(), endpoint);
         }
-
-        if let Some(secret_access_key) = storage_options.0.get("oss_secret_access_key") {
-            config_map.insert("access_key_secret".to_string(), secret_access_key.clone());
+        if let Some(access_key_id) = options
+            .get("oss_access_key_id")
+            .cloned()
+            .or_else(|| options.get("access_key_id").cloned())
+        {
+            config_map.insert("access_key_id".to_string(), access_key_id);
         }
-
-        if let Some(region) = storage_options.0.get("oss_region") {
-            config_map.insert("region".to_string(), region.clone());
+        if let Some(secret_access_key) = options
+            .get("oss_secret_access_key")
+            .cloned()
+            .or_else(|| options.get("access_key_secret").cloned())
+        {
+            config_map.insert("access_key_secret".to_string(), secret_access_key);
         }
-
-        if let Some(security_token) = storage_options.0.get("oss_security_token") {
-            config_map.insert("security_token".to_string(), security_token.clone());
+        if let Some(region) = options
+            .get("oss_region")
+            .cloned()
+            .or_else(|| options.get("region").cloned())
+        {
+            config_map.insert("region".to_string(), region);
+        }
+        if let Some(security_token) = options
+            .get("oss_security_token")
+            .cloned()
+            .or_else(|| options.get("security_token").cloned())
+        {
+            config_map.insert("security_token".to_string(), security_token);
         }
 
         if !config_map.contains_key("endpoint") {
@@ -79,11 +112,41 @@ impl ObjectStoreProvider for OssStoreProvider {
             ));
         }
 
+        Ok(config_map)
+    }
+
+    fn build_oss_store(config_map: HashMap<String, String>) -> Result<OpendalStore> {
         let operator = Operator::from_iter::<Oss>(config_map)
             .map_err(|e| Error::invalid_input(format!("Failed to create OSS operator: {:?}", e)))?
             .finish();
 
-        let opendal_store = Arc::new(OpendalStore::new(operator));
+        Ok(OpendalStore::new(operator))
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for OssStoreProvider {
+    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
+        let storage_options = StorageOptions(params.storage_options().cloned().unwrap_or_default());
+
+        let base_options = Self::base_oss_options(&base_path, &storage_options)?;
+        let accessor = params.get_accessor();
+
+        let inner: Arc<dyn OSObjectStore> =
+            if let Some(accessor) = accessor.filter(|a| a.has_provider()) {
+                Arc::new(DynamicOpenDalStore::new(
+                    format!("oss:{}", base_path),
+                    base_options,
+                    accessor,
+                    Self::normalize_oss_config,
+                    Self::build_oss_store,
+                ))
+            } else {
+                Arc::new(Self::build_oss_store(Self::normalize_oss_config(
+                    &base_options,
+                )?)?)
+            };
 
         let mut url = base_path;
         if !url.path().ends_with('/') {
@@ -92,7 +155,7 @@ impl ObjectStoreProvider for OssStoreProvider {
 
         Ok(ObjectStore {
             scheme: "oss".to_string(),
-            inner: opendal_store,
+            inner,
             block_size,
             max_iop_size: *DEFAULT_MAX_IOP_SIZE,
             use_constant_size_upload_parts: params.use_constant_size_upload_parts,
@@ -107,8 +170,13 @@ impl ObjectStoreProvider for OssStoreProvider {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
     use super::OssStoreProvider;
-    use crate::object_store::ObjectStoreProvider;
+    use crate::object_store::dynamic_opendal::DynamicOpenDalStore;
+    use crate::object_store::test_utils::StaticMockStorageOptionsProvider;
+    use crate::object_store::{ObjectStoreProvider, StorageOptionsAccessor};
     use url::Url;
 
     #[test]
@@ -119,5 +187,43 @@ mod tests {
         let path = provider.extract_path(&url).unwrap();
         let expected_path = object_store::path::Path::from("path/to/file");
         assert_eq!(path, expected_path);
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_opendal_oss_store_uses_provider_credentials() {
+        let accessor = Arc::new(StorageOptionsAccessor::with_provider(Arc::new(
+            StaticMockStorageOptionsProvider {
+                options: HashMap::from([
+                    (
+                        "oss_endpoint".to_string(),
+                        "https://oss-cn-hangzhou.aliyuncs.com".to_string(),
+                    ),
+                    ("oss_access_key_id".to_string(), "akid".to_string()),
+                    ("oss_secret_access_key".to_string(), "secret".to_string()),
+                    ("oss_security_token".to_string(), "token".to_string()),
+                ]),
+            },
+        )));
+
+        let base_options = OssStoreProvider::base_oss_options(
+            &Url::parse("oss://bucket/path").unwrap(),
+            &crate::object_store::StorageOptions(HashMap::new()),
+        )
+        .unwrap();
+
+        let store = DynamicOpenDalStore::new(
+            "oss",
+            base_options,
+            accessor,
+            OssStoreProvider::normalize_oss_config,
+            OssStoreProvider::build_oss_store,
+        );
+
+        let current_store = store
+            .current_store()
+            .await
+            .expect("dynamic OpenDAL OSS store should build");
+
+        assert!(current_store.to_string().contains("Opendal"));
     }
 }

--- a/rust/lance-io/src/object_store/providers/oss.rs
+++ b/rust/lance-io/src/object_store/providers/oss.rs
@@ -60,50 +60,33 @@ impl OssStoreProvider {
         Ok(config_map)
     }
 
+    /// Normalize OSS storage options, resolving aliases for well-known keys
+    /// while passing through all other options (e.g. `role_arn`,
+    /// `sts_endpoint`, `allow_anonymous`, etc.) so that OpenDAL can use them.
     fn normalize_oss_config(options: &HashMap<String, String>) -> Result<HashMap<String, String>> {
-        let mut config_map = HashMap::new();
+        let mut config_map = options.clone();
 
-        if let Some(bucket) = options.get("bucket").cloned() {
-            config_map.insert("bucket".to_string(), bucket);
-        }
-        if let Some(root) = options.get("root").cloned() {
-            config_map.insert("root".to_string(), root);
-        }
+        let alias_groups: &[(&str, &[&str])] = &[
+            ("endpoint", &["oss_endpoint"]),
+            ("access_key_id", &["oss_access_key_id"]),
+            ("access_key_secret", &["oss_secret_access_key"]),
+            ("region", &["oss_region"]),
+            ("security_token", &["oss_security_token"]),
+        ];
 
-        if let Some(endpoint) = options
-            .get("oss_endpoint")
-            .cloned()
-            .or_else(|| options.get("endpoint").cloned())
-        {
-            config_map.insert("endpoint".to_string(), endpoint);
-        }
-        if let Some(access_key_id) = options
-            .get("oss_access_key_id")
-            .cloned()
-            .or_else(|| options.get("access_key_id").cloned())
-        {
-            config_map.insert("access_key_id".to_string(), access_key_id);
-        }
-        if let Some(secret_access_key) = options
-            .get("oss_secret_access_key")
-            .cloned()
-            .or_else(|| options.get("access_key_secret").cloned())
-        {
-            config_map.insert("access_key_secret".to_string(), secret_access_key);
-        }
-        if let Some(region) = options
-            .get("oss_region")
-            .cloned()
-            .or_else(|| options.get("region").cloned())
-        {
-            config_map.insert("region".to_string(), region);
-        }
-        if let Some(security_token) = options
-            .get("oss_security_token")
-            .cloned()
-            .or_else(|| options.get("security_token").cloned())
-        {
-            config_map.insert("security_token".to_string(), security_token);
+        for (canonical, aliases) in alias_groups {
+            if !config_map.contains_key(*canonical) {
+                for alias in *aliases {
+                    if let Some(value) = config_map.remove(*alias) {
+                        config_map.insert(canonical.to_string(), value);
+                        break;
+                    }
+                }
+            } else {
+                for alias in *aliases {
+                    config_map.remove(*alias);
+                }
+            }
         }
 
         if !config_map.contains_key("endpoint") {

--- a/rust/lance-io/src/object_store/storage_options.rs
+++ b/rust/lance-io/src/object_store/storage_options.rs
@@ -303,6 +303,51 @@ impl StorageOptionsAccessor {
         }
     }
 
+    /// Fetch fresh options from the provider and update the cache.
+    ///
+    /// This bypasses the cache for callers that need to validate provider-vended
+    /// credentials even when initial metadata has no expiration.
+    pub(crate) async fn refresh_storage_options(&self) -> Result<super::StorageOptions> {
+        let Some(provider) = &self.provider else {
+            return self.get_storage_options().await;
+        };
+
+        log::debug!(
+            "Refreshing storage options from provider: {}",
+            provider.provider_id()
+        );
+
+        let storage_options_map = provider.fetch_storage_options().await.map_err(|e| {
+            Error::io_source(Box::new(std::io::Error::other(format!(
+                "Failed to fetch storage options: {}",
+                e
+            ))))
+        })?;
+
+        let Some(options) = storage_options_map else {
+            if let Some(initial) = &self.initial_options {
+                return Ok(super::StorageOptions(initial.clone()));
+            }
+            log::debug!(
+                "Provider {} returned no storage options, using default credentials",
+                provider.provider_id()
+            );
+            return Ok(super::StorageOptions(HashMap::new()));
+        };
+
+        let expires_at_millis = options
+            .get(EXPIRES_AT_MILLIS_KEY)
+            .and_then(|s| s.parse::<u64>().ok());
+
+        let mut cache = self.cache.write().await;
+        *cache = Some(CachedStorageOptions {
+            options: options.clone(),
+            expires_at_millis,
+        });
+
+        Ok(super::StorageOptions(options))
+    }
+
     async fn do_get_storage_options(&self) -> Result<Option<super::StorageOptions>> {
         // Check if we have valid cached options with read lock
         {

--- a/rust/lance-io/src/object_store/test_utils.rs
+++ b/rust/lance-io/src/object_store/test_utils.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use super::StorageOptionsProvider;
+use lance_core::Result;
+
+#[derive(Debug)]
+pub struct StaticMockStorageOptionsProvider {
+    pub options: HashMap<String, String>,
+}
+
+#[async_trait]
+impl StorageOptionsProvider for StaticMockStorageOptionsProvider {
+    async fn fetch_storage_options(&self) -> Result<Option<HashMap<String, String>>> {
+        Ok(Some(self.options.clone()))
+    }
+
+    fn provider_id(&self) -> String {
+        "StaticMockStorageOptionsProvider".to_string()
+    }
+}


### PR DESCRIPTION
## Summary
- generalize namespace-vended dynamic credentials across AWS, Azure, and GCP object_store backends
- add a cached OpenDAL dynamic store wrapper and use it for OSS and HuggingFace
- keep Azure and GCS OpenDAL paths static while cleaning up provider-specific option normalization