### PR TITLE
fix: reject Rewrite vs CreateIndex when FRI groups straddle bitmap

### DIFF
--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -4639,36 +4639,28 @@ mod tests {
             .unwrap();
 
         // optimize_indices on the stale handle indexes frag1 only (frag2
-        // didn't exist at that version), commits as CreateIndex.
+        // didn't exist at that version), commits as CreateIndex. `dataset`
+        // stays at its pre-optimize version so the Rewrite commit has to
+        // conflict-check against this CreateIndex.
         stale
             .optimize_indices(&lance_index::optimize::OptimizeOptions::append())
             .await
             .unwrap();
-        dataset.checkout_latest().await.unwrap();
 
-        // Commit the pre-executed Rewrite. The bug: check_rewrite_txn returns
-        // Ok despite the FRI group [frag1, frag2] straddling the new index.
-        commit_compaction(
+        // Commit the pre-executed Rewrite. The FRI group [frag1, frag2]
+        // straddles the new CreateIndex bitmap (frag1 indexed, frag2 not), so
+        // check_rewrite_txn must reject this as a retryable conflict rather
+        // than letting it commit into a broken state that fails queries.
+        let err = commit_compaction(
             &mut dataset,
             completed,
             Arc::new(DatasetIndexRemapperOptions::default()),
             &options,
         )
         .await
-        .unwrap();
-
-        let query = Float32Array::from_iter_values((0..16).map(|_| 0.0_f32));
-        let err = dataset
-            .scan()
-            .nearest("vec", &query, 10)
-            .unwrap()
-            .try_into_stream()
-            .await
-            .err()
-            .expect("query should fail with split error");
+        .expect_err("commit should fail with retryable conflict");
         assert!(
-            err.to_string()
-                .contains("split of indexed and non-indexed data"),
+            matches!(err, Error::RetryableCommitConflict { .. }),
             "unexpected error: {err}"
         );
     }

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -4564,4 +4564,150 @@ mod tests {
         // validate() should have turned off materialize_deletions since threshold >= 1.0
         assert!(!plan.options.materialize_deletions);
     }
+
+    // Repro for the bug in check_rewrite_txn when defer_index_remap=true.
+    //
+    // check_rewrite_txn handles the case (Rewrite self, CreateIndex other) via:
+    //
+    //   match (fri_in_create_index, self.frag_reuse_index) {
+    //       (None, Some(_)) => Ok(()),   // ← too permissive
+    //       ...
+    //   }
+    //
+    // When the in-memory Rewrite carries frag_reuse_index=Some (defer_index_remap=true),
+    // it declares COMPATIBLE with any preceding CreateIndex without checking whether the
+    // rewritten fragments overlap with the indexed ones.
+    //
+    // Production sequence:
+    //   1. Compaction plans to merge [frag1, frag2] while both are unindexed.
+    //   2. optimize_indices commits a CreateIndex covering frag1 (and frag0).
+    //   3. Compaction commits the Rewrite with an FRI; conflict check hits
+    //      (None, Some(_)) → COMPATIBLE despite the split.
+    //   4. Query: remap_fragment_bitmap sees group [frag1, frag2] where only frag1
+    //      is indexed → "split of indexed and non-indexed data".
+    #[tokio::test]
+    async fn test_deferred_compaction_after_optimize_indices() {
+        use crate::dataset::WriteMode;
+        use crate::index::vector::VectorIndexParams;
+        use crate::index::{CreateIndexBuilder, DatasetIndexExt};
+        use futures::TryStreamExt;
+        use lance_datagen::{BatchCount, Dimension, RowCount, array, gen_batch};
+        use lance_index::IndexType;
+        use lance_linalg::distance::MetricType;
+
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+
+        fn make_reader(
+            rows: usize,
+            batches: usize,
+            mode: WriteMode,
+        ) -> (
+            impl arrow_array::RecordBatchReader + Send + 'static,
+            WriteParams,
+        ) {
+            let reader = gen_batch()
+                .col(
+                    "vec",
+                    array::rand_vec::<arrow_array::types::Float32Type>(Dimension::from(16)),
+                )
+                .into_reader_rows(
+                    RowCount::from(rows as u64),
+                    BatchCount::from(batches as u32),
+                );
+            let params = WriteParams {
+                max_rows_per_file: rows,
+                mode,
+                ..Default::default()
+            };
+            (reader, params)
+        }
+
+        // Step 1: initial dataset with 256 rows (fragment 0).
+        let (reader, params) = make_reader(256, 1, WriteMode::Overwrite);
+        let mut dataset = Dataset::write(reader, &dataset_uri, Some(params))
+            .await
+            .unwrap();
+
+        // Step 2: base IVF index on fragment 0.
+        let params = VectorIndexParams::ivf_pq(2, 8, 2, MetricType::L2, 50);
+        CreateIndexBuilder::new(&mut dataset, &["vec"], IndexType::Vector, &params)
+            .name("vec_idx".to_string())
+            .await
+            .unwrap();
+
+        // Step 3: append frag1 (unindexed).
+        let (reader, params) = make_reader(64, 1, WriteMode::Append);
+        dataset = Dataset::write(reader, &dataset_uri, Some(params))
+            .await
+            .unwrap();
+        // Snapshot here — frag1 exists, frag2 does not. optimize_indices
+        // on this handle will cover frag1 only.
+        let mut stale_handle = dataset.clone();
+
+        // Step 4: append frag2 (unindexed).
+        let (reader, params) = make_reader(64, 1, WriteMode::Append);
+        dataset = Dataset::write(reader, &dataset_uri, Some(params))
+            .await
+            .unwrap();
+
+        // Step 5: plan and execute compaction while both frag1 and frag2 are
+        // unindexed. plan_compaction puts them in the same bin.
+        let options = CompactionOptions {
+            defer_index_remap: true,
+            ..Default::default()
+        };
+        let plan = plan_compaction(&dataset, &options).await.unwrap();
+        assert!(
+            !plan.tasks.is_empty(),
+            "expected compaction to plan a rewrite of frag1+frag2"
+        );
+        let dataset_snap = dataset.clone();
+        let completed: Vec<RewriteResult> = futures::stream::iter(plan.tasks.iter().cloned())
+            .map(|task| rewrite_files(std::borrow::Cow::Borrowed(&dataset_snap), task, &options))
+            .buffer_unordered(1)
+            .try_collect()
+            .await
+            .unwrap();
+
+        // Step 6: optimize_indices on stale handle — sees only frag0+frag1.
+        // Commits a CreateIndex covering frag1 (but NOT frag2).
+        stale_handle
+            .optimize_indices(&lance_index::optimize::OptimizeOptions::append())
+            .await
+            .unwrap();
+        dataset.checkout_latest().await.unwrap();
+
+        // Step 7: commit the pre-executed compaction. The Rewrite carries
+        // frag_reuse_index=Some in memory. check_rewrite_txn hits
+        // (None, Some(_)) → COMPATIBLE with the CreateIndex — the bug.
+        // It should reject because frag1 is indexed but frag2 is not.
+        commit_compaction(
+            &mut dataset,
+            completed,
+            Arc::new(DatasetIndexRemapperOptions::default()),
+            &options,
+        )
+        .await
+        .unwrap();
+
+        // Step 8: query fails — remap_fragment_bitmap detects group [frag1, frag2]
+        // where only frag1 is indexed → "split of indexed and non-indexed data".
+        let query = Float32Array::from_iter_values((0..16).map(|_| 0.0_f32));
+        let stream_result = dataset
+            .scan()
+            .nearest("vec", &query, 10)
+            .unwrap()
+            .try_into_stream()
+            .await;
+        let err = match stream_result {
+            Err(e) => e,
+            Ok(_) => panic!("expected query to fail with 'split of indexed and non-indexed data'"),
+        };
+        assert!(
+            err.to_string()
+                .contains("split of indexed and non-indexed data"),
+            "expected 'split of indexed and non-indexed data', got: {err}"
+        );
+    }
 }

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -4565,123 +4565,89 @@ mod tests {
         assert!(!plan.options.materialize_deletions);
     }
 
-    // Repro for the bug in check_rewrite_txn when defer_index_remap=true.
-    //
-    // check_rewrite_txn handles the case (Rewrite self, CreateIndex other) via:
-    //
-    //   match (fri_in_create_index, self.frag_reuse_index) {
-    //       (None, Some(_)) => Ok(()),   // ← too permissive
-    //       ...
-    //   }
-    //
-    // When the in-memory Rewrite carries frag_reuse_index=Some (defer_index_remap=true),
-    // it declares COMPATIBLE with any preceding CreateIndex without checking whether the
-    // rewritten fragments overlap with the indexed ones.
-    //
-    // Production sequence:
-    //   1. Compaction plans to merge [frag1, frag2] while both are unindexed.
-    //   2. optimize_indices commits a CreateIndex covering frag1 (and frag0).
-    //   3. Compaction commits the Rewrite with an FRI; conflict check hits
-    //      (None, Some(_)) → COMPATIBLE despite the split.
-    //   4. Query: remap_fragment_bitmap sees group [frag1, frag2] where only frag1
-    //      is indexed → "split of indexed and non-indexed data".
+    // check_rewrite_txn takes the (None, Some(_)) branch when a Rewrite with
+    // defer_index_remap=true is committed against a previously committed
+    // CreateIndex, declaring COMPATIBLE without verifying that the Rewrite's
+    // FRI groups don't straddle the CreateIndex's fragment bitmap. When a
+    // group mixes indexed and unindexed fragments, commit succeeds and later
+    // queries fail at load_indices with "split of indexed and non-indexed
+    // data".
     #[tokio::test]
-    async fn test_deferred_compaction_after_optimize_indices() {
-        use crate::dataset::WriteMode;
+    async fn test_rewrite_fri_vs_create_index_conflict() {
+        use crate::index::DatasetIndexExt;
         use crate::index::vector::VectorIndexParams;
-        use crate::index::{CreateIndexBuilder, DatasetIndexExt};
         use futures::TryStreamExt;
         use lance_datagen::{BatchCount, Dimension, RowCount, array, gen_batch};
         use lance_index::IndexType;
         use lance_linalg::distance::MetricType;
 
-        let tmpdir = TempStrDir::default();
-        let dataset_uri = format!("file://{}", tmpdir.as_str());
-
-        fn make_reader(
-            rows: usize,
-            batches: usize,
-            mode: WriteMode,
-        ) -> (
-            impl arrow_array::RecordBatchReader + Send + 'static,
-            WriteParams,
-        ) {
+        async fn append_fragment(uri: &str, rows: u64) -> Dataset {
             let reader = gen_batch()
-                .col(
-                    "vec",
-                    array::rand_vec::<arrow_array::types::Float32Type>(Dimension::from(16)),
-                )
-                .into_reader_rows(
-                    RowCount::from(rows as u64),
-                    BatchCount::from(batches as u32),
-                );
+                .col("vec", array::rand_vec::<Float32Type>(Dimension::from(16)))
+                .into_reader_rows(RowCount::from(rows), BatchCount::from(1));
             let params = WriteParams {
-                max_rows_per_file: rows,
-                mode,
+                max_rows_per_file: rows as usize,
+                mode: WriteMode::Append,
                 ..Default::default()
             };
-            (reader, params)
+            Dataset::write(reader, uri, Some(params)).await.unwrap()
         }
 
-        // Step 1: initial dataset with 256 rows (fragment 0).
-        let (reader, params) = make_reader(256, 1, WriteMode::Overwrite);
-        let mut dataset = Dataset::write(reader, &dataset_uri, Some(params))
+        let tmpdir = TempStrDir::default();
+        let uri = format!("file://{}", tmpdir.as_str());
+
+        // frag0 (256 rows) with a base IVF index.
+        let reader = gen_batch()
+            .col("vec", array::rand_vec::<Float32Type>(Dimension::from(16)))
+            .into_reader_rows(RowCount::from(256), BatchCount::from(1));
+        let mut dataset = Dataset::write(
+            reader,
+            &uri,
+            Some(WriteParams {
+                max_rows_per_file: 256,
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        let index_params = VectorIndexParams::ivf_pq(2, 8, 2, MetricType::L2, 50);
+        dataset
+            .create_index(&["vec"], IndexType::Vector, None, &index_params, true)
             .await
             .unwrap();
 
-        // Step 2: base IVF index on fragment 0.
-        let params = VectorIndexParams::ivf_pq(2, 8, 2, MetricType::L2, 50);
-        CreateIndexBuilder::new(&mut dataset, &["vec"], IndexType::Vector, &params)
-            .name("vec_idx".to_string())
-            .await
-            .unwrap();
+        // Append frag1 (unindexed), snapshot a stale handle pointing here,
+        // then append frag2 (also unindexed).
+        dataset = append_fragment(&uri, 64).await;
+        let mut stale = dataset.clone();
+        dataset = append_fragment(&uri, 64).await;
 
-        // Step 3: append frag1 (unindexed).
-        let (reader, params) = make_reader(64, 1, WriteMode::Append);
-        dataset = Dataset::write(reader, &dataset_uri, Some(params))
-            .await
-            .unwrap();
-        // Snapshot here — frag1 exists, frag2 does not. optimize_indices
-        // on this handle will cover frag1 only.
-        let mut stale_handle = dataset.clone();
-
-        // Step 4: append frag2 (unindexed).
-        let (reader, params) = make_reader(64, 1, WriteMode::Append);
-        dataset = Dataset::write(reader, &dataset_uri, Some(params))
-            .await
-            .unwrap();
-
-        // Step 5: plan and execute compaction while both frag1 and frag2 are
-        // unindexed. plan_compaction puts them in the same bin.
+        // Plan + execute compaction of frag1+frag2 with deferred remap.
         let options = CompactionOptions {
             defer_index_remap: true,
             ..Default::default()
         };
         let plan = plan_compaction(&dataset, &options).await.unwrap();
-        assert!(
-            !plan.tasks.is_empty(),
-            "expected compaction to plan a rewrite of frag1+frag2"
-        );
-        let dataset_snap = dataset.clone();
-        let completed: Vec<RewriteResult> = futures::stream::iter(plan.tasks.iter().cloned())
-            .map(|task| rewrite_files(std::borrow::Cow::Borrowed(&dataset_snap), task, &options))
+        assert!(!plan.tasks.is_empty());
+        let snapshot = dataset.clone();
+        let completed: Vec<RewriteResult> = futures::stream::iter(plan.tasks.into_iter())
+            .map(|task| rewrite_files(Cow::Borrowed(&snapshot), task, &options))
             .buffer_unordered(1)
             .try_collect()
             .await
             .unwrap();
 
-        // Step 6: optimize_indices on stale handle — sees only frag0+frag1.
-        // Commits a CreateIndex covering frag1 (but NOT frag2).
-        stale_handle
+        // optimize_indices on the stale handle indexes frag1 only (frag2
+        // didn't exist at that version), commits as CreateIndex.
+        stale
             .optimize_indices(&lance_index::optimize::OptimizeOptions::append())
             .await
             .unwrap();
         dataset.checkout_latest().await.unwrap();
 
-        // Step 7: commit the pre-executed compaction. The Rewrite carries
-        // frag_reuse_index=Some in memory. check_rewrite_txn hits
-        // (None, Some(_)) → COMPATIBLE with the CreateIndex — the bug.
-        // It should reject because frag1 is indexed but frag2 is not.
+        // Commit the pre-executed Rewrite. The bug: check_rewrite_txn returns
+        // Ok despite the FRI group [frag1, frag2] straddling the new index.
         commit_compaction(
             &mut dataset,
             completed,
@@ -4691,23 +4657,19 @@ mod tests {
         .await
         .unwrap();
 
-        // Step 8: query fails — remap_fragment_bitmap detects group [frag1, frag2]
-        // where only frag1 is indexed → "split of indexed and non-indexed data".
         let query = Float32Array::from_iter_values((0..16).map(|_| 0.0_f32));
-        let stream_result = dataset
+        let err = dataset
             .scan()
             .nearest("vec", &query, 10)
             .unwrap()
             .try_into_stream()
-            .await;
-        let err = match stream_result {
-            Err(e) => e,
-            Ok(_) => panic!("expected query to fail with 'split of indexed and non-indexed data'"),
-        };
+            .await
+            .err()
+            .expect("query should fail with split error");
         assert!(
             err.to_string()
                 .contains("split of indexed and non-indexed data"),
-            "expected 'split of indexed and non-indexed data', got: {err}"
+            "unexpected error: {err}"
         );
     }
 }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -848,11 +848,11 @@ impl DatasetIndexExt for Dataset {
                 })
                 .await?;
             let mut indices = indices.as_ref().clone();
-            indices.iter_mut().for_each(|idx| {
+            for idx in indices.iter_mut() {
                 if let Some(bitmap) = idx.fragment_bitmap.as_mut() {
-                    frag_reuse_index.remap_fragment_bitmap(bitmap).unwrap();
+                    frag_reuse_index.remap_fragment_bitmap(bitmap)?;
                 }
-            });
+            }
             Ok(Arc::new(indices))
         } else {
             Ok(indices)

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -635,7 +635,6 @@ impl<'a> IndexSegmentBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dataset::optimize::{CompactionOptions, compact_files};
     use crate::dataset::{WriteMode, WriteParams};
     use crate::index::DatasetIndexExt;
     use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
@@ -647,7 +646,7 @@ mod tests {
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use lance_arrow::FixedSizeListArrayExt;
     use lance_core::utils::tempfile::TempStrDir;
-    use lance_datagen::{self, BatchCount, Dimension, RowCount, array, gen_batch};
+    use lance_datagen::{self, gen_batch};
     use lance_index::optimize::OptimizeOptions;
     use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
     use lance_index::vector::hnsw::builder::HnswBuildParams;
@@ -1593,137 +1592,6 @@ mod tests {
                 .iter()
                 .any(|idx| idx.fragment_bitmap.as_ref().unwrap().contains(1)
                     && idx.fragment_bitmap.as_ref().unwrap().len() == 1)
-        );
-    }
-
-    // Repro for the bug in check_rewrite_txn when defer_index_remap=true.
-    //
-    // When a Rewrite transaction with frag_reuse_index=Some (i.e. deferred index
-    // remap) is committed, its conflict resolver takes the (None, Some(_)) branch
-    // for any previously committed CreateIndex, declaring COMPATIBLE without
-    // checking whether the rewritten fragments overlap with the indexed ones.
-    //
-    // Sequence:
-    //   1. optimize_indices commits a CreateIndex covering frag 0 + frag 1.
-    //   2. Frag 2 is appended (unindexed).
-    //   3. Compaction commits a Rewrite merging [frag1, frag2] → frag3 with an
-    //      FRI (defer_index_remap=true). Conflict check for Rewrite vs CreateIndex
-    //      hits (None, Some(_)) → COMPATIBLE, even though frag1 is indexed and
-    //      frag2 is not — a split of indexed and non-indexed data.
-    //   4. Query processes the FRI and fails with "split of indexed and
-    //      non-indexed data".
-    #[tokio::test]
-    async fn test_deferred_compaction_after_optimize_indices() {
-        let tmpdir = TempStrDir::default();
-        let dataset_uri = format!("file://{}", tmpdir.as_str());
-
-        // Step 1: Create initial dataset (fragment 0, 256 rows).
-        let reader = gen_batch()
-            .col("id", array::step::<Int32Type>())
-            .col(
-                "vector",
-                array::rand_vec::<Float32Type>(Dimension::from(16)),
-            )
-            .into_reader_rows(RowCount::from(256), BatchCount::from(1));
-        let mut dataset = Dataset::write(
-            reader,
-            &dataset_uri,
-            Some(WriteParams {
-                max_rows_per_file: 256,
-                mode: WriteMode::Overwrite,
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
-
-        // Step 2: Create base IVF index on fragment 0.
-        let ivf_params = prepare_vector_ivf(&dataset, "vector").await;
-        let params = VectorIndexParams::with_ivf_flat_params(DistanceType::L2, ivf_params);
-        CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
-            .name("vector_idx".to_string())
-            .await
-            .unwrap();
-
-        // Step 3: Append fragment 1 (unindexed).
-        let reader = gen_batch()
-            .col("id", array::step::<Int32Type>())
-            .col(
-                "vector",
-                array::rand_vec::<Float32Type>(Dimension::from(16)),
-            )
-            .into_reader_rows(RowCount::from(64), BatchCount::from(1));
-        dataset = Dataset::write(
-            reader,
-            &dataset_uri,
-            Some(WriteParams {
-                mode: WriteMode::Append,
-                max_rows_per_file: 64,
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
-
-        // Step 4: optimize_indices indexes frag 1, committing a CreateIndex that
-        // covers [frag0, frag1].
-        dataset
-            .optimize_indices(&lance_index::optimize::OptimizeOptions::append())
-            .await
-            .unwrap();
-
-        // Step 5: Append fragment 2 (unindexed).
-        let reader = gen_batch()
-            .col("id", array::step::<Int32Type>())
-            .col(
-                "vector",
-                array::rand_vec::<Float32Type>(Dimension::from(16)),
-            )
-            .into_reader_rows(RowCount::from(64), BatchCount::from(1));
-        dataset = Dataset::write(
-            reader,
-            &dataset_uri,
-            Some(WriteParams {
-                mode: WriteMode::Append,
-                max_rows_per_file: 64,
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
-
-        // Step 6: Compact frags 1+2 → frag3 with defer_index_remap=true.
-        // check_rewrite_txn sees the CreateIndex and hits (None, Some(_)) →
-        // COMPATIBLE, even though frag1 is indexed and frag2 is not.
-        compact_files(
-            &mut dataset,
-            CompactionOptions {
-                defer_index_remap: true,
-                ..Default::default()
-            },
-            None,
-        )
-        .await
-        .unwrap();
-
-        // Step 7: Query processes the FRI. remap_fragment_bitmap sees group
-        // [frag1, frag2] → [frag3]: frag1 is in the index bitmap but frag2 is
-        // not → "split of indexed and non-indexed data".
-        let query = arrow_array::Float32Array::from_iter_values((0..16).map(|_| 0.0_f32));
-        let stream_result = dataset
-            .scan()
-            .nearest("vector", &query, 10)
-            .unwrap()
-            .try_into_stream()
-            .await;
-        let err = match stream_result {
-            Err(e) => e,
-            Ok(_) => panic!("expected query to fail with 'split of indexed and non-indexed data'"),
-        };
-        assert!(
-            err.to_string()
-                .contains("split of indexed and non-indexed data"),
-            "expected 'split of indexed and non-indexed data', got: {err}"
         );
     }
 }

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -635,6 +635,7 @@ impl<'a> IndexSegmentBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dataset::optimize::{CompactionOptions, compact_files};
     use crate::dataset::{WriteMode, WriteParams};
     use crate::index::DatasetIndexExt;
     use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
@@ -646,7 +647,7 @@ mod tests {
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use lance_arrow::FixedSizeListArrayExt;
     use lance_core::utils::tempfile::TempStrDir;
-    use lance_datagen::{self, gen_batch};
+    use lance_datagen::{self, BatchCount, Dimension, RowCount, array, gen_batch};
     use lance_index::optimize::OptimizeOptions;
     use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
     use lance_index::vector::hnsw::builder::HnswBuildParams;
@@ -1592,6 +1593,137 @@ mod tests {
                 .iter()
                 .any(|idx| idx.fragment_bitmap.as_ref().unwrap().contains(1)
                     && idx.fragment_bitmap.as_ref().unwrap().len() == 1)
+        );
+    }
+
+    // Repro for the bug in check_rewrite_txn when defer_index_remap=true.
+    //
+    // When a Rewrite transaction with frag_reuse_index=Some (i.e. deferred index
+    // remap) is committed, its conflict resolver takes the (None, Some(_)) branch
+    // for any previously committed CreateIndex, declaring COMPATIBLE without
+    // checking whether the rewritten fragments overlap with the indexed ones.
+    //
+    // Sequence:
+    //   1. optimize_indices commits a CreateIndex covering frag 0 + frag 1.
+    //   2. Frag 2 is appended (unindexed).
+    //   3. Compaction commits a Rewrite merging [frag1, frag2] → frag3 with an
+    //      FRI (defer_index_remap=true). Conflict check for Rewrite vs CreateIndex
+    //      hits (None, Some(_)) → COMPATIBLE, even though frag1 is indexed and
+    //      frag2 is not — a split of indexed and non-indexed data.
+    //   4. Query processes the FRI and fails with "split of indexed and
+    //      non-indexed data".
+    #[tokio::test]
+    async fn test_deferred_compaction_after_optimize_indices() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+
+        // Step 1: Create initial dataset (fragment 0, 256 rows).
+        let reader = gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<Float32Type>(Dimension::from(16)),
+            )
+            .into_reader_rows(RowCount::from(256), BatchCount::from(1));
+        let mut dataset = Dataset::write(
+            reader,
+            &dataset_uri,
+            Some(WriteParams {
+                max_rows_per_file: 256,
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Step 2: Create base IVF index on fragment 0.
+        let ivf_params = prepare_vector_ivf(&dataset, "vector").await;
+        let params = VectorIndexParams::with_ivf_flat_params(DistanceType::L2, ivf_params);
+        CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
+            .name("vector_idx".to_string())
+            .await
+            .unwrap();
+
+        // Step 3: Append fragment 1 (unindexed).
+        let reader = gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<Float32Type>(Dimension::from(16)),
+            )
+            .into_reader_rows(RowCount::from(64), BatchCount::from(1));
+        dataset = Dataset::write(
+            reader,
+            &dataset_uri,
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                max_rows_per_file: 64,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Step 4: optimize_indices indexes frag 1, committing a CreateIndex that
+        // covers [frag0, frag1].
+        dataset
+            .optimize_indices(&lance_index::optimize::OptimizeOptions::append())
+            .await
+            .unwrap();
+
+        // Step 5: Append fragment 2 (unindexed).
+        let reader = gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<Float32Type>(Dimension::from(16)),
+            )
+            .into_reader_rows(RowCount::from(64), BatchCount::from(1));
+        dataset = Dataset::write(
+            reader,
+            &dataset_uri,
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                max_rows_per_file: 64,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Step 6: Compact frags 1+2 → frag3 with defer_index_remap=true.
+        // check_rewrite_txn sees the CreateIndex and hits (None, Some(_)) →
+        // COMPATIBLE, even though frag1 is indexed and frag2 is not.
+        compact_files(
+            &mut dataset,
+            CompactionOptions {
+                defer_index_remap: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Step 7: Query processes the FRI. remap_fragment_bitmap sees group
+        // [frag1, frag2] → [frag3]: frag1 is in the index bitmap but frag2 is
+        // not → "split of indexed and non-indexed data".
+        let query = arrow_array::Float32Array::from_iter_values((0..16).map(|_| 0.0_f32));
+        let stream_result = dataset
+            .scan()
+            .nearest("vector", &query, 10)
+            .unwrap()
+            .try_into_stream()
+            .await;
+        let err = match stream_result {
+            Err(e) => e,
+            Ok(_) => panic!("expected query to fail with 'split of indexed and non-indexed data'"),
+        };
+        assert!(
+            err.to_string()
+                .contains("split of indexed and non-indexed data"),
+            "expected 'split of indexed and non-indexed data', got: {err}"
         );
     }
 }

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -746,9 +746,38 @@ impl<'a> TransactionRebase<'a> {
                                 .push(committed_fri.clone());
                             Ok(())
                         }
-                        // If rewrite defers index remap,
-                        // then it does not conflict with index creation
-                        (None, Some(_)) => Ok(()),
+                        // If rewrite defers index remap, the FRI handles the
+                        // post-commit bitmap update — but only if each rewrite
+                        // group is fully inside or fully outside each new
+                        // index's fragment bitmap. A group that straddles
+                        // would produce a bitmap with a mix of indexed and
+                        // non-indexed fragments, which load_indices rejects.
+                        (None, Some(_)) => {
+                            for index in new_indices {
+                                let Some(frag_bitmap) = &index.fragment_bitmap else {
+                                    return Err(self
+                                        .retryable_conflict_err(other_transaction, other_version));
+                                };
+                                for group in groups {
+                                    let mut indexed = 0usize;
+                                    let mut unindexed = 0usize;
+                                    for frag in &group.old_fragments {
+                                        if frag_bitmap.contains(frag.id as u32) {
+                                            indexed += 1;
+                                        } else {
+                                            unindexed += 1;
+                                        }
+                                    }
+                                    if indexed > 0 && unindexed > 0 {
+                                        return Err(self.retryable_conflict_err(
+                                            other_transaction,
+                                            other_version,
+                                        ));
+                                    }
+                                }
+                            }
+                            Ok(())
+                        }
                         // Rewrite with remapping and frag_reuse_index creation can commit without conflict
                         (Some(_), None) => {
                             // this should not happen today since we don't support committing


### PR DESCRIPTION
## Summary

`check_rewrite_txn` returned `Ok` for any `(None, Some(_))` — a Rewrite with a deferred-remap FRI committing against a concurrently committed CreateIndex — on the assumption that the FRI would correct index bitmaps post-commit. That is only safe when each rewrite group's old fragments are fully inside or fully outside the new index's bitmap. If a group straddles (some fragments indexed, some not), `load_indices` later fails with `split of indexed and non-indexed data` and queries against the index break.

This PR rejects the straddling case as a retryable conflict so the rewrite is replanned against the post-CreateIndex view.

Production trigger (with `defer_index_remap=true` now enabled):
1. Compaction plans `[frag1, frag2]` while both are unindexed.
2. `optimize_indices` commits a CreateIndex covering `frag1` only (ran on an older version that didn't see `frag2`).
3. Compaction's Rewrite commits against a read_version earlier than the CreateIndex; the conflict resolver incorrectly returns COMPATIBLE.
4. Queries fail: the FRI group `[frag1, frag2]` straddles the new index bitmap.

Also fixes an `.unwrap()` in `remap_fragment_bitmap` so the underlying error propagates instead of panicking.

## Test plan

- [x] New test `test_rewrite_fri_vs_create_index_conflict` in `rust/lance/src/dataset/optimize.rs` reproduces the production sequence and asserts `commit_compaction` returns `RetryableCommitConflict` (before the fix, commit succeeded and the query failed with "split of indexed and non-indexed data").
- [x] Existing `dataset::optimize::` and `io::commit::` tests pass.
- [x] `cargo clippy -p lance --tests -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)