### PR TITLE
feat: add prefilter_type to ANNIvfSubIndexExecProto

### DIFF
--- a/protos/ann.proto
+++ b/protos/ann.proto
@@ -29,15 +29,21 @@ message VectorQueryProto {
 
 // Serializable form of ANNIvfSubIndexExec — the IVF sub-index search node.
 //
-// Note: ANNIvfSubIndexExec.prefilter_source (child ExecutionPlan) is NOT
-// serialized here. DataFusion's PhysicalExtensionCodec handles child plans
-// automatically via children() / with_new_children(). The codec receives
-// deserialized children in the `inputs` parameter of try_decode and
-// reconstructs the PreFilterSource from them.
+// The prefilter child ExecutionPlan is serialized by DataFusion's codec
+// automatically via children() / with_new_children(). The prefilter_type
+// field tells the decoder which PreFilterSource variant to use when
+// reconstructing from the deserialized child inputs.
 message ANNIvfSubIndexExecProto {
+  enum PreFilterType {
+    NONE = 0;
+    FILTERED_ROW_IDS = 1;
+    SCALAR_INDEX_QUERY = 2;
+  }
+
   VectorQueryProto query = 1;
   lance.datafusion.TableIdentifier table = 2;
   repeated lance.table.IndexMetadata indices = 3;
+  PreFilterType prefilter_type = 4;
 }
 
 // Serializable form of ANNIvfPartitionExec — the IVF centroid routing node.

--- a/rust/lance/src/io/exec/ann_proto.rs
+++ b/rust/lance/src/io/exec/ann_proto.rs
@@ -232,8 +232,11 @@ pub async fn ann_ivf_sub_index_exec_from_proto(
     }
 
     use pb::ann_ivf_sub_index_exec_proto::PreFilterType;
-    let prefilter_type =
-        PreFilterType::try_from(proto.prefilter_type).unwrap_or(PreFilterType::None);
+    let prefilter_type = PreFilterType::try_from(proto.prefilter_type).map_err(|_| {
+        Error::invalid_input_source(
+            format!("Invalid PreFilterType value: {}", proto.prefilter_type).into(),
+        )
+    })?;
 
     let prefilter_source = match (prefilter_type, prefilter_input) {
         (PreFilterType::None, None) => PreFilterSource::None,

--- a/rust/lance/src/io/exec/ann_proto.rs
+++ b/rust/lance/src/io/exec/ann_proto.rs
@@ -183,23 +183,34 @@ pub async fn ann_ivf_sub_index_exec_to_proto(
     let indices: Vec<table_pb::IndexMetadata> =
         exec.indices().iter().map(|idx| idx.into()).collect();
 
+    let prefilter_type = match exec.prefilter_source() {
+        PreFilterSource::None => pb::ann_ivf_sub_index_exec_proto::PreFilterType::None as i32,
+        PreFilterSource::FilteredRowIds(_) => {
+            pb::ann_ivf_sub_index_exec_proto::PreFilterType::FilteredRowIds as i32
+        }
+        PreFilterSource::ScalarIndexQuery(_) => {
+            pb::ann_ivf_sub_index_exec_proto::PreFilterType::ScalarIndexQuery as i32
+        }
+    };
+
     Ok(pb::AnnIvfSubIndexExecProto {
         query: Some(query),
         table: Some(table),
         indices,
+        prefilter_type,
     })
 }
 
 /// Reconstruct an [`ANNIvfSubIndexExec`] from proto.
 ///
-/// The caller (codec) is responsible for extracting child inputs:
-/// - `input`: the child execution plan (e.g. partition exec)
-/// - `prefilter_source`: optional prefilter input
+/// The caller (codec) is responsible for providing deserialized child inputs.
+/// The `prefilter_type` field from the proto determines which `PreFilterSource`
+/// variant wraps the optional second child input.
 pub async fn ann_ivf_sub_index_exec_from_proto(
     proto: pb::AnnIvfSubIndexExecProto,
     dataset: Option<Arc<Dataset>>,
     input: Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-    prefilter_source: PreFilterSource,
+    prefilter_input: Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>>,
 ) -> Result<ANNIvfSubIndexExec> {
     let dataset = resolve_dataset(dataset, proto.table.as_ref()).await?;
 
@@ -219,6 +230,29 @@ pub async fn ann_ivf_sub_index_exec_from_proto(
             "ANNIvfSubIndexExecProto contains no indices".into(),
         ));
     }
+
+    use pb::ann_ivf_sub_index_exec_proto::PreFilterType;
+    let prefilter_type =
+        PreFilterType::try_from(proto.prefilter_type).unwrap_or(PreFilterType::None);
+
+    let prefilter_source = match (prefilter_type, prefilter_input) {
+        (PreFilterType::None, None) => PreFilterSource::None,
+        (PreFilterType::FilteredRowIds, Some(plan)) => PreFilterSource::FilteredRowIds(plan),
+        (PreFilterType::ScalarIndexQuery, Some(plan)) => PreFilterSource::ScalarIndexQuery(plan),
+        (PreFilterType::None, Some(_)) => {
+            return Err(Error::invalid_input_source(
+                "ANNIvfSubIndexExecProto: prefilter_type is None but a prefilter child was provided".into(),
+            ));
+        }
+        (_, None) => {
+            return Err(Error::invalid_input_source(
+                format!(
+                    "ANNIvfSubIndexExecProto: prefilter_type is {:?} but no prefilter child was provided",
+                    prefilter_type
+                ).into(),
+            ));
+        }
+    };
 
     ANNIvfSubIndexExec::try_new(input, dataset, indices, query, prefilter_source)
 }
@@ -461,14 +495,9 @@ mod tests {
         assert_eq!(proto.indices.len(), indices.len());
 
         // Decode
-        let back = ann_ivf_sub_index_exec_from_proto(
-            proto,
-            Some(dataset.clone()),
-            input,
-            PreFilterSource::None,
-        )
-        .await
-        .unwrap();
+        let back = ann_ivf_sub_index_exec_from_proto(proto, Some(dataset.clone()), input, None)
+            .await
+            .unwrap();
 
         assert_eq!(back.query().column, "vector");
         assert_eq!(back.query().k, 10);
@@ -481,5 +510,184 @@ mod tests {
             assert_eq!(original.dataset_version, decoded.dataset_version);
             assert_eq!(original.fields, decoded.fields);
         }
+    }
+
+    /// Helper: build an ANNIvfSubIndexExec with a given prefilter source.
+    async fn build_sub_index_exec(
+        dataset: &Arc<Dataset>,
+        prefilter: PreFilterSource,
+    ) -> ANNIvfSubIndexExec {
+        let indices = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        let key: ArrayRef = Arc::new(Float32Array::from(vec![0.1f32; 128]));
+        let query = Query {
+            column: "vector".to_string(),
+            key,
+            k: 10,
+            lower_bound: None,
+            upper_bound: None,
+            minimum_nprobes: 2,
+            maximum_nprobes: None,
+            ef: None,
+            refine_factor: None,
+            metric_type: Some(DistanceType::L2),
+            use_index: true,
+            dist_q_c: 0.0,
+        };
+        let input: Arc<dyn datafusion::physical_plan::ExecutionPlan> =
+            TestMemoryExec::try_new_exec(
+                &[],
+                super::super::knn::KNN_PARTITION_SCHEMA.clone(),
+                None,
+            )
+            .unwrap();
+        ANNIvfSubIndexExec::try_new(input, dataset.clone(), indices, query, prefilter).unwrap()
+    }
+
+    /// Helper: a dummy execution plan to use as a prefilter child.
+    fn make_dummy_prefilter_plan(
+        schema: arrow_schema::SchemaRef,
+    ) -> Arc<dyn datafusion::physical_plan::ExecutionPlan> {
+        TestMemoryExec::try_new_exec(&[], schema, None).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_sub_index_proto_roundtrip_filtered_row_ids() {
+        let (dataset, _dir) = make_indexed_dataset().await;
+        let row_id_schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "row_id",
+            arrow_schema::DataType::UInt64,
+            false,
+        )]));
+        let prefilter_plan = make_dummy_prefilter_plan(row_id_schema.clone());
+        let exec = build_sub_index_exec(
+            &dataset,
+            PreFilterSource::FilteredRowIds(prefilter_plan.clone()),
+        )
+        .await;
+
+        let proto = ann_ivf_sub_index_exec_to_proto(&exec).await.unwrap();
+        assert_eq!(
+            proto.prefilter_type,
+            pb::ann_ivf_sub_index_exec_proto::PreFilterType::FilteredRowIds as i32
+        );
+
+        let input: Arc<dyn datafusion::physical_plan::ExecutionPlan> =
+            TestMemoryExec::try_new_exec(
+                &[],
+                super::super::knn::KNN_PARTITION_SCHEMA.clone(),
+                None,
+            )
+            .unwrap();
+        let back = ann_ivf_sub_index_exec_from_proto(
+            proto,
+            Some(dataset.clone()),
+            input,
+            Some(make_dummy_prefilter_plan(row_id_schema)),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            back.prefilter_source(),
+            PreFilterSource::FilteredRowIds(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_sub_index_proto_roundtrip_scalar_index_query() {
+        let (dataset, _dir) = make_indexed_dataset().await;
+        let scalar_schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "result",
+            arrow_schema::DataType::Binary,
+            true,
+        )]));
+        let prefilter_plan = make_dummy_prefilter_plan(scalar_schema.clone());
+        let exec = build_sub_index_exec(
+            &dataset,
+            PreFilterSource::ScalarIndexQuery(prefilter_plan.clone()),
+        )
+        .await;
+
+        let proto = ann_ivf_sub_index_exec_to_proto(&exec).await.unwrap();
+        assert_eq!(
+            proto.prefilter_type,
+            pb::ann_ivf_sub_index_exec_proto::PreFilterType::ScalarIndexQuery as i32
+        );
+
+        let input: Arc<dyn datafusion::physical_plan::ExecutionPlan> =
+            TestMemoryExec::try_new_exec(
+                &[],
+                super::super::knn::KNN_PARTITION_SCHEMA.clone(),
+                None,
+            )
+            .unwrap();
+        let back = ann_ivf_sub_index_exec_from_proto(
+            proto,
+            Some(dataset.clone()),
+            input,
+            Some(make_dummy_prefilter_plan(scalar_schema)),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            back.prefilter_source(),
+            PreFilterSource::ScalarIndexQuery(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_sub_index_proto_error_type_none_but_child_provided() {
+        let (dataset, _dir) = make_indexed_dataset().await;
+        let exec = build_sub_index_exec(&dataset, PreFilterSource::None).await;
+
+        let proto = ann_ivf_sub_index_exec_to_proto(&exec).await.unwrap();
+        assert_eq!(
+            proto.prefilter_type,
+            pb::ann_ivf_sub_index_exec_proto::PreFilterType::None as i32
+        );
+
+        let input: Arc<dyn datafusion::physical_plan::ExecutionPlan> =
+            TestMemoryExec::try_new_exec(
+                &[],
+                super::super::knn::KNN_PARTITION_SCHEMA.clone(),
+                None,
+            )
+            .unwrap();
+        let dummy = make_dummy_prefilter_plan(Arc::new(arrow_schema::Schema::empty()));
+        let result =
+            ann_ivf_sub_index_exec_from_proto(proto, Some(dataset.clone()), input, Some(dummy))
+                .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_sub_index_proto_error_type_set_but_no_child() {
+        let (dataset, _dir) = make_indexed_dataset().await;
+        let scalar_schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "result",
+            arrow_schema::DataType::Binary,
+            true,
+        )]));
+        let exec = build_sub_index_exec(
+            &dataset,
+            PreFilterSource::ScalarIndexQuery(make_dummy_prefilter_plan(scalar_schema)),
+        )
+        .await;
+
+        let proto = ann_ivf_sub_index_exec_to_proto(&exec).await.unwrap();
+        assert_eq!(
+            proto.prefilter_type,
+            pb::ann_ivf_sub_index_exec_proto::PreFilterType::ScalarIndexQuery as i32
+        );
+
+        let input: Arc<dyn datafusion::physical_plan::ExecutionPlan> =
+            TestMemoryExec::try_new_exec(
+                &[],
+                super::super::knn::KNN_PARTITION_SCHEMA.clone(),
+                None,
+            )
+            .unwrap();
+        let result =
+            ann_ivf_sub_index_exec_from_proto(proto, Some(dataset.clone()), input, None).await;
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Add `PreFilterType` enum (`None`, `FilteredRowIds`, `ScalarIndexQuery`) to `ANNIvfSubIndexExecProto` in `ann.proto`
- Encode sets `prefilter_type` based on the exec's `PreFilterSource` variant
- Decode uses `prefilter_type` from the proto to reconstruct the correct `PreFilterSource` variant, replacing the schema-sniffing heuristic used by downstream codecs
- Errors on inconsistent state: prefilter type set but no child plan provided, or child plan provided but type is `None`

This enables downstream codecs (e.g. sophon's `LancePhysicalExtensionCodec`) to correctly reconstruct `PreFilterSource` without guessing from the child plan's schema.

## Test plan

- [x] `test_ann_ivf_sub_index_proto_roundtrip` — existing None prefilter roundtrip (updated to new API)
- [x] `test_sub_index_proto_roundtrip_filtered_row_ids` — FilteredRowIds encode/decode
- [x] `test_sub_index_proto_roundtrip_scalar_index_query` — ScalarIndexQuery encode/decode
- [x] `test_sub_index_proto_error_type_none_but_child_provided` — errors on mismatch
- [x] `test_sub_index_proto_error_type_set_but_no_child` — errors on mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)