### PR TITLE
feat(index): make btree and bitmap null tracking optional in scalar search

### DIFF
--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -779,6 +779,13 @@ pub enum SearchResult {
     AtLeast(NullableRowAddrSet),
 }
 
+/// Execution-time options for scalar index search.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SearchOptions {
+    /// If true, the search should preserve NULL rows.
+    pub track_nulls: bool,
+}
+
 impl SearchResult {
     pub fn exact(row_ids: impl Into<RowAddrTreeMap>) -> Self {
         Self::Exact(NullableRowAddrSet::new(row_ids.into(), Default::default()))
@@ -962,6 +969,19 @@ pub trait ScalarIndex: Send + Sync + std::fmt::Debug + Index + DeepSizeOf {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult>;
+
+    /// Search the scalar index with execution-time options.
+    ///
+    /// For indices don't need `options`, just ignore `options` and fall back to `search`.
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
+        let _ = options;
+        self.search(query, metrics).await
+    }
 
     /// Returns true if the remap operation is supported
     fn can_remap(&self) -> bool;

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -32,7 +32,7 @@ use roaring::RoaringBitmap;
 use serde::Serialize;
 use tracing::instrument;
 
-use super::{AnyQuery, IndexStore, ScalarIndex};
+use super::{AnyQuery, IndexStore, ScalarIndex, SearchOptions};
 use super::{
     BuiltinIndexType, SargableQuery, ScalarIndexParams, SearchResult, btree::OrderableScalarValue,
 };
@@ -429,7 +429,25 @@ impl ScalarIndex for BitmapIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
+
+        let tracked_null_rows = || {
+            if options.track_nulls && !self.null_map.is_empty() {
+                Some((*self.null_map).clone())
+            } else {
+                None
+            }
+        };
 
         let (row_ids, null_row_ids) = match query {
             SargableQuery::Equals(val) => {
@@ -440,12 +458,7 @@ impl ScalarIndex for BitmapIndex {
                 } else {
                     let key = OrderableScalarValue(val.clone());
                     let bitmap = self.load_bitmap(&key, Some(metrics)).await?;
-                    let null_rows = if !self.null_map.is_empty() {
-                        Some((*self.null_map).clone())
-                    } else {
-                        None
-                    };
-                    ((*bitmap).clone(), null_rows)
+                    ((*bitmap).clone(), tracked_null_rows())
                 }
             }
             SargableQuery::Range(start, end) => {
@@ -496,12 +509,7 @@ impl ScalarIndex for BitmapIndex {
                     RowAddrTreeMap::union_all(&bitmap_refs)
                 };
 
-                let null_rows = if !self.null_map.is_empty() {
-                    Some((*self.null_map).clone())
-                } else {
-                    None
-                };
-                (result, null_rows)
+                (result, tracked_null_rows())
             }
             SargableQuery::IsIn(values) => {
                 metrics.record_comparisons(values.len());
@@ -547,13 +555,9 @@ impl ScalarIndex for BitmapIndex {
                     RowAddrTreeMap::union_all(&bitmap_refs)
                 };
 
-                // If the query explicitly includes null, then nulls are TRUE (not NULL)
-                // Otherwise, nulls remain NULL (unknown)
-                let null_rows = if !has_null && !self.null_map.is_empty() {
-                    Some((*self.null_map).clone())
-                } else {
-                    None
-                };
+                // If the query explicitly includes null, then nulls are TRUE (not NULL).
+                // Otherwise, preserve them only when the caller needs 3VL bookkeeping.
+                let null_rows = if has_null { None } else { tracked_null_rows() };
                 (result, null_rows)
             }
             SargableQuery::IsNull() => {
@@ -1735,9 +1739,36 @@ mod tests {
             .await
             .unwrap();
 
-        // Test 1: Search for value 5 - should return allow=[1], null=[2]
+        // Test 1.1: Search for value 5 - should return allow=[1]
         let query = SargableQuery::Equals(ScalarValue::Int64(Some(5)));
-        let result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
+        let default_result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
+
+        match default_result {
+            SearchResult::Exact(row_ids) => {
+                let actual_rows: Vec<u64> = row_ids
+                    .true_rows()
+                    .row_addrs()
+                    .unwrap()
+                    .map(u64::from)
+                    .collect();
+                assert_eq!(actual_rows, vec![1], "Should find row 1 where value == 5");
+                assert!(
+                    row_ids.null_rows().is_empty(),
+                    "Default equality search should skip null bookkeeping"
+                );
+            }
+            _ => panic!("Expected Exact search result"),
+        }
+
+        // Test 1.2: Search for value 5 with track_nulls - should return allow=[1], null=[2]
+        let result = index
+            .search_with_options(
+                &query,
+                SearchOptions { track_nulls: true },
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
 
         match result {
             SearchResult::Exact(row_ids) => {
@@ -1787,12 +1818,39 @@ mod tests {
             _ => panic!("Expected Exact search result"),
         }
 
-        // Test 3: Range query - should return matching rows and null_list
+        // Test 3.1: Range query - should return matching rows
         let query = SargableQuery::Range(
             std::ops::Bound::Included(ScalarValue::Int64(Some(0))),
             std::ops::Bound::Included(ScalarValue::Int64(Some(3))),
         );
-        let result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
+        let default_result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
+
+        match default_result {
+            SearchResult::Exact(row_addrs) => {
+                let actual_rows: Vec<u64> = row_addrs
+                    .true_rows()
+                    .row_addrs()
+                    .unwrap()
+                    .map(u64::from)
+                    .collect();
+                assert_eq!(actual_rows, vec![0], "Should find row 0 where value == 0");
+                assert!(
+                    row_addrs.null_rows().is_empty(),
+                    "Default range search should skip null bookkeeping"
+                );
+            }
+            _ => panic!("Expected Exact search result"),
+        }
+
+        // Test 3.2: Range query - should return matching rows and null_list
+        let result = index
+            .search_with_options(
+                &query,
+                SearchOptions { track_nulls: true },
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
 
         match result {
             SearchResult::Exact(row_addrs) => {

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -12,7 +12,7 @@ use std::{
 
 use super::{
     AnyQuery, BuiltinIndexType, IndexReader, IndexStore, IndexWriter, MetricsCollector,
-    OldIndexDataFilter, SargableQuery, ScalarIndex, ScalarIndexParams, SearchResult,
+    OldIndexDataFilter, SargableQuery, ScalarIndex, ScalarIndexParams, SearchOptions, SearchResult,
     compute_next_prefix,
 };
 use crate::{Index, IndexType};
@@ -1490,6 +1490,16 @@ impl ScalarIndex for BTreeIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
         let mut pages = match query {
             SargableQuery::Equals(val) => self
@@ -1551,7 +1561,7 @@ impl ScalarIndex for BTreeIndex {
         // We add them as Matches::Some (not Matches::All) so that
         // FlatIndex::search() evaluates the predicate and correctly marks
         // the rows as NULL rather than TRUE.
-        if !matches!(query, SargableQuery::IsNull()) {
+        if options.track_nulls && !matches!(query, SargableQuery::IsNull()) {
             let existing: HashSet<u32> = pages.iter().map(|m| m.page_id()).collect();
             for &page_id in self
                 .page_lookup
@@ -2698,7 +2708,10 @@ mod tests {
     use futures::stream;
     use lance_core::utils::mask::RowSetOps;
     use lance_core::utils::tempfile::TempObjDir;
-    use lance_core::{cache::LanceCache, utils::mask::RowAddrTreeMap};
+    use lance_core::{
+        cache::LanceCache,
+        utils::mask::{NullableRowAddrSet, RowAddrTreeMap},
+    };
     use lance_datafusion::{chunker::break_stream, datagen::DatafusionDatagenExt};
     use lance_datagen::{ArrayGeneratorExt, BatchCount, RowCount, array, gen_batch};
     use lance_io::object_store::ObjectStore;
@@ -2709,7 +2722,8 @@ mod tests {
     use crate::{
         metrics::NoOpMetricsCollector,
         scalar::{
-            IndexStore, OldIndexDataFilter, SargableQuery, ScalarIndex, SearchResult,
+            IndexStore, OldIndexDataFilter, SargableQuery, ScalarIndex, SearchOptions,
+            SearchResult,
             btree::{BTREE_PAGES_NAME, BTreeIndex},
             lance_format::LanceIndexStore,
         },
@@ -2895,6 +2909,64 @@ mod tests {
         let query2 = index.search(&query, &metrics);
         tokio::join!(query1, query2).0.unwrap();
         assert_eq!(metrics.parts_loaded.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn test_equality_can_skip_null_pages_without_null_tracking() {
+        let tmpdir = TempObjDir::default();
+        let test_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let batch = record_batch!(
+            ("value", Int32, [None, Some(5)]),
+            ("_rowid", UInt64, [0, 1])
+        )
+        .unwrap();
+        let schema = batch.schema();
+        let stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::once(async { Ok(batch) }),
+        ));
+
+        train_btree_index(stream, test_store.as_ref(), 1, None, None)
+            .await
+            .unwrap();
+
+        let query = SargableQuery::Equals(ScalarValue::Int32(Some(5)));
+
+        let index = BTreeIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let metrics = LocalMetricsCollector::default();
+        let result = index
+            .search_with_options(&query, SearchOptions::default(), &metrics)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            SearchResult::exact(RowAddrTreeMap::from_iter([1_u64]))
+        );
+        assert_eq!(metrics.parts_loaded.load(Ordering::Relaxed), 1);
+
+        let index = BTreeIndex::load(test_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let metrics = LocalMetricsCollector::default();
+        let result = index
+            .search_with_options(&query, SearchOptions { track_nulls: true }, &metrics)
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            SearchResult::Exact(NullableRowAddrSet::new(
+                RowAddrTreeMap::from_iter([1_u64]),
+                RowAddrTreeMap::from_iter([0_u64]),
+            ))
+        );
+        assert_eq!(metrics.parts_loaded.load(Ordering::Relaxed), 2);
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -20,7 +20,7 @@ use tokio::try_join;
 
 use super::{
     AnyQuery, BloomFilterQuery, LabelListQuery, MetricsCollector, SargableQuery, ScalarIndex,
-    SearchResult, TextQuery, TokenQuery,
+    SearchOptions, SearchResult, TextQuery, TokenQuery,
 };
 #[cfg(feature = "geo")]
 use super::{GeoQuery, RelationQuery};
@@ -1417,10 +1417,12 @@ impl ScalarIndexExpr {
         &self,
         index_loader: &dyn ScalarIndexLoader,
         metrics: &dyn MetricsCollector,
+        track_nulls: bool,
     ) -> Result<NullableIndexExprResult> {
         match self {
             Self::Not(inner) => {
-                let result = inner.evaluate_impl(index_loader, metrics).await?;
+                // `NOT` must preserve NULLs from the child so SQL three-valued logic stays correct.
+                let result = inner.evaluate_impl(index_loader, metrics, true).await?;
                 // Flip certainty: NOT(AtMost) → AtLeast, NOT(AtLeast) → AtMost
                 Ok(match result {
                     NullableIndexExprResult::Exact(mask) => NullableIndexExprResult::Exact(!mask),
@@ -1433,14 +1435,14 @@ impl ScalarIndexExpr {
                 })
             }
             Self::And(lhs, rhs) => {
-                let lhs_result = lhs.evaluate_impl(index_loader, metrics);
-                let rhs_result = rhs.evaluate_impl(index_loader, metrics);
+                let lhs_result = lhs.evaluate_impl(index_loader, metrics, track_nulls);
+                let rhs_result = rhs.evaluate_impl(index_loader, metrics, track_nulls);
                 let (lhs_result, rhs_result) = try_join!(lhs_result, rhs_result)?;
                 Ok(lhs_result & rhs_result)
             }
             Self::Or(lhs, rhs) => {
-                let lhs_result = lhs.evaluate_impl(index_loader, metrics);
-                let rhs_result = rhs.evaluate_impl(index_loader, metrics);
+                let lhs_result = lhs.evaluate_impl(index_loader, metrics, track_nulls);
+                let rhs_result = rhs.evaluate_impl(index_loader, metrics, track_nulls);
                 let (lhs_result, rhs_result) = try_join!(lhs_result, rhs_result)?;
                 Ok(lhs_result | rhs_result)
             }
@@ -1448,7 +1450,13 @@ impl ScalarIndexExpr {
                 let index = index_loader
                     .load_index(&search.column, &search.index_name, metrics)
                     .await?;
-                let search_result = index.search(search.query.as_ref(), metrics).await?;
+                let search_result = index
+                    .search_with_options(
+                        search.query.as_ref(),
+                        SearchOptions { track_nulls },
+                        metrics,
+                    )
+                    .await?;
                 Ok(search_result.into())
             }
         }
@@ -1461,7 +1469,7 @@ impl ScalarIndexExpr {
         metrics: &dyn MetricsCollector,
     ) -> Result<IndexExprResult> {
         Ok(self
-            .evaluate_impl(index_loader, metrics)
+            .evaluate_impl(index_loader, metrics, false)
             .await?
             .drop_nulls())
     }
@@ -2067,17 +2075,144 @@ impl PlannerIndexExt for Planner {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
     use arrow_schema::{Field, Schema};
     use chrono::Utc;
+    use datafusion::physical_plan::SendableRecordBatchStream;
     use datafusion_common::{Column, DFSchema};
     use datafusion_expr::execution_props::ExecutionProps;
     use datafusion_expr::simplify::SimplifyContext;
+    use deepsize::DeepSizeOf;
+    use lance_core::utils::mask::RowAddrTreeMap;
     use lance_datafusion::exec::{LanceExecutionOptions, get_session_context};
+    use roaring::RoaringBitmap;
 
+    use crate::metrics::NoOpMetricsCollector;
     use crate::scalar::json::{JsonQuery, JsonQueryParser};
+    use crate::scalar::registry::TrainingOrdering;
+    use crate::scalar::{
+        CreatedIndex, IndexStore, OldIndexDataFilter, ScalarIndexParams, UpdateCriteria,
+        registry::TrainingCriteria,
+    };
+    use crate::{Index, IndexType};
 
     use super::*;
+
+    #[derive(Debug, DeepSizeOf)]
+    struct TrackingScalarIndex {
+        seen_track_nulls: Arc<Mutex<Vec<bool>>>,
+    }
+
+    #[async_trait]
+    impl Index for TrackingScalarIndex {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+            self
+        }
+
+        fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn crate::vector::VectorIndex>> {
+            Err(Error::invalid_input_source(
+                "tracking scalar index is not a vector index".into(),
+            ))
+        }
+
+        fn statistics(&self) -> Result<serde_json::Value> {
+            Ok(serde_json::Value::Null)
+        }
+
+        async fn prewarm(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn index_type(&self) -> IndexType {
+            IndexType::BTree
+        }
+
+        async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+            Ok(RoaringBitmap::new())
+        }
+    }
+
+    #[async_trait]
+    impl ScalarIndex for TrackingScalarIndex {
+        async fn search(
+            &self,
+            _query: &dyn AnyQuery,
+            _metrics: &dyn MetricsCollector,
+        ) -> Result<SearchResult> {
+            Err(Error::internal(
+                "tracking test expects search_with_options to be used".to_string(),
+            ))
+        }
+
+        async fn search_with_options(
+            &self,
+            _query: &dyn AnyQuery,
+            options: SearchOptions,
+            _metrics: &dyn MetricsCollector,
+        ) -> Result<SearchResult> {
+            self.seen_track_nulls
+                .lock()
+                .unwrap()
+                .push(options.track_nulls);
+            Ok(SearchResult::exact(RowAddrTreeMap::default()))
+        }
+
+        fn can_remap(&self) -> bool {
+            false
+        }
+
+        async fn remap(
+            &self,
+            _mapping: &HashMap<u64, Option<u64>>,
+            _dest_store: &dyn IndexStore,
+        ) -> Result<CreatedIndex> {
+            Err(Error::invalid_input_source(
+                "tracking scalar index does not support remap".into(),
+            ))
+        }
+
+        async fn update(
+            &self,
+            _new_data: SendableRecordBatchStream,
+            _dest_store: &dyn IndexStore,
+            _old_data_filter: Option<OldIndexDataFilter>,
+        ) -> Result<CreatedIndex> {
+            Err(Error::invalid_input_source(
+                "tracking scalar index does not support update".into(),
+            ))
+        }
+
+        fn update_criteria(&self) -> UpdateCriteria {
+            UpdateCriteria::only_new_data(TrainingCriteria::new(TrainingOrdering::Values))
+        }
+
+        fn derive_index_params(&self) -> Result<ScalarIndexParams> {
+            Ok(ScalarIndexParams::for_builtin(
+                crate::scalar::BuiltinIndexType::BTree,
+            ))
+        }
+    }
+
+    struct TrackingIndexLoader {
+        index: Arc<TrackingScalarIndex>,
+    }
+
+    #[async_trait]
+    impl ScalarIndexLoader for TrackingIndexLoader {
+        async fn load_index(
+            &self,
+            _column: &str,
+            _index_name: &str,
+            _metrics: &dyn MetricsCollector,
+        ) -> Result<Arc<dyn ScalarIndex>> {
+            Ok(self.index.clone())
+        }
+    }
 
     struct ColInfo {
         data_type: DataType,
@@ -2568,6 +2703,57 @@ mod tests {
         check_no_index(&index_info, "aisle = NULL");
         check_no_index(&index_info, "aisle BETWEEN 5 AND NULL");
         check_no_index(&index_info, "aisle BETWEEN NULL AND 10");
+    }
+
+    #[tokio::test]
+    async fn test_null_tracking_only_flows_into_negated_subtrees() {
+        let seen_track_nulls = Arc::new(Mutex::new(Vec::new()));
+        let loader = TrackingIndexLoader {
+            index: Arc::new(TrackingScalarIndex {
+                seen_track_nulls: seen_track_nulls.clone(),
+            }),
+        };
+
+        let eq_query = || {
+            ScalarIndexExpr::Query(ScalarIndexSearch {
+                column: "x".to_string(),
+                index_name: "x_idx".to_string(),
+                query: Arc::new(SargableQuery::Equals(ScalarValue::Int32(Some(5)))),
+                needs_recheck: false,
+            })
+        };
+
+        eq_query()
+            .evaluate(&loader, &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert_eq!(seen_track_nulls.lock().unwrap().as_slice(), &[false]);
+
+        seen_track_nulls.lock().unwrap().clear();
+        ScalarIndexExpr::Not(Box::new(eq_query()))
+            .evaluate(&loader, &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert_eq!(seen_track_nulls.lock().unwrap().as_slice(), &[true]);
+
+        seen_track_nulls.lock().unwrap().clear();
+        ScalarIndexExpr::And(
+            Box::new(ScalarIndexExpr::Not(Box::new(ScalarIndexExpr::Query(
+                ScalarIndexSearch {
+                    column: "x".to_string(),
+                    index_name: "x_idx".to_string(),
+                    query: Arc::new(SargableQuery::IsNull()),
+                    needs_recheck: false,
+                },
+            )))),
+            Box::new(eq_query()),
+        )
+        .evaluate(&loader, &NoOpMetricsCollector)
+        .await
+        .unwrap();
+        let mut seen = seen_track_nulls.lock().unwrap().clone();
+        seen.sort();
+        assert_eq!(seen, vec![false, true]);
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -37,7 +37,8 @@ use crate::{
     metrics::MetricsCollector,
     registry::IndexPluginRegistry,
     scalar::{
-        AnyQuery, CreatedIndex, IndexStore, ScalarIndex, SearchResult, UpdateCriteria,
+        AnyQuery, CreatedIndex, IndexStore, ScalarIndex, SearchOptions, SearchResult,
+        UpdateCriteria,
         expression::{IndexedExpression, ScalarIndexExpr, ScalarIndexSearch, ScalarQueryParser},
         registry::{ScalarIndexPlugin, TrainingCriteria, TrainingRequest, VALUE_COLUMN_NAME},
     },
@@ -106,9 +107,19 @@ impl ScalarIndex for JsonIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<JsonQuery>().unwrap();
         self.target_index
-            .search(query.target_query.as_ref(), metrics)
+            .search_with_options(query.target_query.as_ref(), options, metrics)
             .await
     }
 


### PR DESCRIPTION
I have a 5B rows table with a large proportion of NULL values and relatively high cardinality in the value column. I also need to support both range queries and equality queries. When using a btree index for these queries, I found the performance to be very poor—sometimes even slower than a full table scan (without a btree index).

The root cause is that the btree index search tracks all all_null_page and null_page entries (introduced in [PR 6043](https://github.com/lance-format/lance/pull/6043)
 to fix three-valued logic semantics), which results in a large number of small reads.

I’m considering making NULL tracking optional, so that three-valued logic can be handled more precisely, and to avoid tracking NULL rows when it’s unnecessary (for example, in simple equality or range queries without NOT).