### PR TITLE
feat: replace Azure SDK and google-cloud-auth with direct reqwest for credential vending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "RustyXML"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5ace29ee3216de37c0546865ad08edef58b0f9e76838ed8959a84a990e58c5"
-
-[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,17 +415,6 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
@@ -455,50 +438,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.6.1",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel 2.5.0",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.1",
- "futures-lite 2.6.1",
- "rustix",
 ]
 
 [[package]]
@@ -511,30 +458,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -596,7 +519,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.4.1",
+ "fastrand",
  "hex",
  "http 1.4.0",
  "ring",
@@ -658,7 +581,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "bytes-utils",
- "fastrand 2.4.1",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -686,7 +609,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.4.1",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -714,7 +637,7 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand 2.4.1",
+ "fastrand",
  "hex",
  "hmac",
  "http 0.2.12",
@@ -745,7 +668,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.4.1",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -769,7 +692,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.4.1",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -794,7 +717,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "fastrand 2.4.1",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "regex-lite",
@@ -954,7 +877,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.4.1",
+ "fastrand",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -1088,119 +1011,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "azure_core"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b552ad43a45a746461ec3d3a51dfb6466b4759209414b439c165eb6a6b7729e"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "dyn-clone",
- "futures",
- "getrandom 0.2.17",
- "hmac",
- "http-types",
- "once_cell",
- "paste",
- "pin-project",
- "quick-xml 0.31.0",
- "rand 0.8.6",
- "reqwest",
- "rustc_version",
- "serde",
- "serde_json",
- "sha2",
- "time",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_identity"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ddd80344317c40c04b603807b63a5cefa532f1b43522e72f480a988141f744"
-dependencies = [
- "async-lock",
- "async-process",
- "async-trait",
- "azure_core",
- "futures",
- "oauth2",
- "pin-project",
- "serde",
- "time",
- "tracing",
- "tz-rs",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_storage"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f838159f4d29cb400a14d9d757578ba495ae64feb07a7516bf9e4415127126"
-dependencies = [
- "RustyXML",
- "async-lock",
- "async-trait",
- "azure_core",
- "bytes",
- "serde",
- "serde_derive",
- "time",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_storage_blobs"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e83c3636ae86d9a6a7962b2112e3b19eb3903915c50ce06ff54ff0a2e6a7e4"
-dependencies = [
- "RustyXML",
- "azure_core",
- "azure_storage",
- "azure_svc_blobstorage",
- "bytes",
- "futures",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "azure_svc_blobstorage"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6c6f20c5611b885ba94c7bae5e02849a267381aecb8aee577e8c35ff4064c6"
-dependencies = [
- "azure_core",
- "bytes",
- "futures",
- "log",
- "once_cell",
- "serde",
- "serde_json",
- "time",
-]
-
-[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "fastrand 2.4.1",
+ "fastrand",
  "gloo-timers",
  "tokio",
 ]
@@ -1368,19 +1184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite 2.6.1",
- "piper",
 ]
 
 [[package]]
@@ -1676,12 +1479,6 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "constant_time_eq"
@@ -2721,7 +2518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -3064,12 +2860,6 @@ checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -3085,7 +2875,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -3094,15 +2884,6 @@ name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
 
 [[package]]
 name = "fastrand"
@@ -3305,34 +3086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand 2.4.1",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3527,17 +3280,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -3545,7 +3287,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -3598,26 +3340,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "google-cloud-auth"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5572275b7f06b6fde8eec61a23d87c83aae362bee586bbeb8773b3f98658ae81"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "derive_builder 0.20.2",
- "http 1.4.0",
- "reqwest",
- "rustls",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
- "tokio",
 ]
 
 [[package]]
@@ -3815,26 +3537,6 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
-]
-
-[[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel 1.9.0",
- "base64 0.13.1",
- "futures-lite 1.13.0",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
 ]
 
 [[package]]
@@ -4152,12 +3854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
 name = "inferno"
 version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4183,15 +3879,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -4819,7 +4506,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
- "async-channel 2.5.0",
+ "async-channel",
  "async-recursion",
  "async-trait",
  "bitpacking",
@@ -5004,15 +4691,11 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-sts",
  "axum",
- "azure_core",
- "azure_identity",
- "azure_storage",
- "azure_storage_blobs",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
- "google-cloud-auth",
+ "hmac",
  "lance",
  "lance-core",
  "lance-index",
@@ -5022,15 +4705,17 @@ dependencies = [
  "lance-table",
  "log",
  "object_store",
+ "quick-xml 0.38.4",
  "rand 0.9.4",
  "reqwest",
+ "ring",
  "rstest",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",
  "snafu",
  "tempfile",
- "time",
  "tokio",
  "tower",
  "tower-http 0.5.2",
@@ -5590,7 +5275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -5637,7 +5322,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-util",
  "parking_lot",
  "portable-atomic",
@@ -5859,38 +5544,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "oauth2"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "getrandom 0.2.17",
- "http 0.2.12",
- "rand 0.8.6",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "thiserror 1.0.69",
- "url",
-]
 
 [[package]]
 name = "object"
@@ -6318,7 +5975,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "fastrand 2.4.1",
+ "fastrand",
  "phf_shared 0.13.1",
 ]
 
@@ -6371,17 +6028,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand 2.4.1",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs1"
@@ -6459,20 +6105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6697,16 +6329,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
@@ -6809,19 +6431,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -6843,16 +6452,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -6869,15 +6468,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -6906,15 +6496,6 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -7595,17 +7176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8121,7 +7691,7 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand 2.4.1",
+ "fastrand",
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
@@ -8243,10 +7813,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -8678,15 +8245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8800,7 +8358,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -8879,12 +8436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8902,12 +8453,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/rust/lance-namespace-impls/Cargo.toml
+++ b/rust/lance-namespace-impls/Cargo.toml
@@ -23,8 +23,8 @@ dir-oss = ["lance-io/oss", "lance/oss"]
 dir-huggingface = ["lance-io/huggingface", "lance/huggingface"]
 # Credential vending features
 credential-vendor-aws = ["dep:aws-sdk-sts", "dep:aws-config", "dep:aws-credential-types", "dep:sha2", "dep:base64"]
-credential-vendor-gcp = ["dep:google-cloud-auth", "dep:reqwest", "dep:serde", "dep:sha2", "dep:base64"]
-credential-vendor-azure = ["dep:azure_core", "dep:azure_identity", "dep:azure_storage", "dep:azure_storage_blobs", "dep:time", "dep:sha2", "dep:base64", "dep:reqwest"]
+credential-vendor-gcp = ["dep:reqwest", "dep:serde", "dep:sha2", "dep:base64", "dep:ring", "dep:rustls-pki-types"]
+credential-vendor-azure = ["dep:reqwest", "dep:serde", "dep:sha2", "dep:base64", "dep:hmac", "dep:quick-xml"]
 
 [dependencies]
 lance-namespace.workspace = true
@@ -68,22 +68,22 @@ log.workspace = true
 rand.workspace = true
 chrono.workspace = true
 
+# Shared credential vending dependencies
+sha2 = { version = "0.10", optional = true }
+base64 = { version = "0.22", optional = true }
+
 # AWS credential vending dependencies (optional, enabled by "credential-vendor-aws" feature)
 aws-sdk-sts = { version = "1.38.0", optional = true, default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-config = { workspace = true, optional = true }
 aws-credential-types = { workspace = true, optional = true }
-sha2 = { version = "0.10", optional = true }
-base64 = { version = "0.22", optional = true }
 
-# GCP credential vending dependencies (optional, enabled by "dir-gcp" feature)
-google-cloud-auth = { version = "0.18", optional = true }
+# GCP credential vending dependencies (optional, enabled by "credential-vendor-gcp" feature)
+ring = { version = "0.17", optional = true }
+rustls-pki-types = { version = "1", optional = true }
 
-# Azure credential vending dependencies (optional, enabled by "dir-azure" feature)
-azure_core = { version = "0.21", optional = true }
-azure_identity = { version = "0.21", optional = true }
-azure_storage = { version = "0.21", optional = true }
-azure_storage_blobs = { version = "0.21", optional = true }
-time = { version = "0.3", optional = true }
+# Azure credential vending dependencies (optional, enabled by "credential-vendor-azure" feature)
+hmac = { version = "0.12", optional = true }
+quick-xml = { version = "0.38", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/rust/lance-namespace-impls/src/credentials.rs
+++ b/rust/lance-namespace-impls/src/credentials.rs
@@ -40,10 +40,13 @@
 //! # Note: GCP token duration cannot be configured; it's determined by the STS endpoint
 //! # To use a service account key file, set GOOGLE_APPLICATION_CREDENTIALS env var before starting
 //! credential_vendor.gcp_service_account = "my-sa@project.iam.gserviceaccount.com"
+//! credential_vendor.gcp_workload_identity_provider = "projects/123456/locations/global/workloadIdentityPools/pool/providers/provider"
+//! credential_vendor.gcp_impersonation_service_account = "my-sa@project.iam.gserviceaccount.com"
 //!
 //! # Azure-specific properties (for az:// locations)
 //! credential_vendor.azure_account_name = "mystorageaccount"  # required for Azure
 //! credential_vendor.azure_tenant_id = "my-tenant-id"
+//! credential_vendor.azure_federated_client_id = "my-app-client-id"
 //! credential_vendor.azure_duration_millis = "3600000"  # 1 hour (default, up to 7 days)
 //! ```
 //!
@@ -517,8 +520,14 @@ async fn create_gcp_vendor(
     if let Some(sa) = properties.get(gcp_props::SERVICE_ACCOUNT) {
         config = config.with_service_account(sa);
     }
+    if let Some(provider) = properties.get(gcp_props::WORKLOAD_IDENTITY_PROVIDER) {
+        config = config.with_workload_identity_provider(provider);
+    }
+    if let Some(service_account) = properties.get(gcp_props::IMPERSONATION_SERVICE_ACCOUNT) {
+        config = config.with_impersonation_service_account(service_account);
+    }
 
-    let vendor = GcpCredentialVendor::new(config).await?;
+    let vendor = GcpCredentialVendor::new(config)?;
     Ok(Some(Box::new(vendor)))
 }
 
@@ -548,6 +557,9 @@ fn create_azure_vendor(
 
     if let Some(tenant_id) = properties.get(azure_props::TENANT_ID) {
         config = config.with_tenant_id(tenant_id);
+    }
+    if let Some(client_id) = properties.get(azure_props::FEDERATED_CLIENT_ID) {
+        config = config.with_federated_client_id(client_id);
     }
 
     let vendor = AzureCredentialVendor::new(config);

--- a/rust/lance-namespace-impls/src/credentials/azure.rs
+++ b/rust/lance-namespace-impls/src/credentials/azure.rs
@@ -7,26 +7,39 @@
 //! SAS (Shared Access Signature) tokens with user delegation keys.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::env;
 
 use async_trait::async_trait;
-use azure_core::auth::TokenCredential;
-use azure_identity::DefaultAzureCredential;
-use azure_storage::prelude::*;
-use azure_storage::shared_access_signature::service_sas::{BlobSharedAccessSignature, SasKey};
-use azure_storage_blobs::prelude::*;
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use hmac::{Hmac, Mac};
 use lance_core::Result;
 use lance_io::object_store::uri_to_url;
 use lance_namespace::error::NamespaceError;
 use lance_namespace::models::Identity;
 use log::{debug, info, warn};
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
+use url::{Url, form_urlencoded};
 
 use super::{
     CredentialVendor, DEFAULT_CREDENTIAL_DURATION_MILLIS, VendedCredentials, VendedPermission,
     redact_credential,
 };
+
+const AZURE_STORAGE_SCOPE: &str = "https://storage.azure.com/.default";
+const AZURE_STORAGE_RESOURCE: &str = "https://storage.azure.com";
+const DEFAULT_AUTHORITY_HOST: &str = "https://login.microsoftonline.com";
+const DEFAULT_MANAGED_IDENTITY_ENDPOINT: &str =
+    "http://169.254.169.254/metadata/identity/oauth2/token";
+const MANAGED_IDENTITY_API_VERSION: &str = "2019-08-01";
+const SAS_VERSION: &str = "2022-11-02";
+const MAX_SAS_DURATION_DAYS: i64 = 7;
+const USER_DELEGATION_SKEW_BUFFER_SECONDS: i64 = 60;
 
 /// Configuration for Azure credential vending.
 #[derive(Debug, Clone)]
@@ -128,7 +141,7 @@ impl AzureCredentialVendorConfig {
         self
     }
 
-    /// Set the entire API key hash permissions map.
+    /// Replace all API key hash mappings.
     pub fn with_api_key_hash_permissions(
         mut self,
         permissions: HashMap<String, VendedPermission>,
@@ -136,6 +149,71 @@ impl AzureCredentialVendorConfig {
         self.api_key_hash_permissions = permissions;
         self
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct AzureTokenResponse {
+    access_token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AzureSasPermissions {
+    read: bool,
+    add: bool,
+    create: bool,
+    write: bool,
+    delete: bool,
+    list: bool,
+}
+
+impl std::fmt::Display for AzureSasPermissions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.read {
+            write!(f, "r")?;
+        }
+        if self.add {
+            write!(f, "a")?;
+        }
+        if self.create {
+            write!(f, "c")?;
+        }
+        if self.write {
+            write!(f, "w")?;
+        }
+        if self.delete {
+            write!(f, "d")?;
+        }
+        if self.list {
+            write!(f, "l")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AzureSignedResource {
+    Container,
+    Directory,
+}
+
+impl std::fmt::Display for AzureSignedResource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Container => write!(f, "c"),
+            Self::Directory => write!(f, "d"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AzureUserDelegationKey {
+    signed_oid: String,
+    signed_tid: String,
+    signed_start: String,
+    signed_expiry: String,
+    signed_service: String,
+    signed_version: String,
+    value: String,
 }
 
 /// Azure credential vendor that generates SAS tokens.
@@ -162,319 +240,524 @@ impl AzureCredentialVendor {
         format!("{:x}", hasher.finalize())
     }
 
-    /// Extract a session name from a JWT token (best effort, no validation).
-    /// Decodes the payload and extracts 'sub' or 'email' claim.
-    /// Falls back to "lance-azure-identity" if parsing fails.
-    fn derive_session_name_from_token(token: &str) -> String {
-        // JWT format: header.payload.signature
-        let parts: Vec<&str> = token.split('.').collect();
-        if parts.len() != 3 {
-            return "lance-azure-identity".to_string();
+    fn build_sas_permissions(permission: VendedPermission) -> AzureSasPermissions {
+        AzureSasPermissions {
+            read: true,
+            add: permission.can_write(),
+            create: permission.can_write(),
+            write: permission.can_write(),
+            delete: permission.can_delete(),
+            list: true,
         }
-
-        // Decode the payload (second part)
-        let payload = match URL_SAFE_NO_PAD.decode(parts[1]) {
-            Ok(bytes) => bytes,
-            Err(_) => {
-                // Try standard base64 as fallback
-                match base64::engine::general_purpose::STANDARD_NO_PAD.decode(parts[1]) {
-                    Ok(bytes) => bytes,
-                    Err(_) => return "lance-azure-identity".to_string(),
-                }
-            }
-        };
-
-        // Parse as JSON and extract 'sub' or 'email'
-        let json: serde_json::Value = match serde_json::from_slice(&payload) {
-            Ok(v) => v,
-            Err(_) => return "lance-azure-identity".to_string(),
-        };
-
-        let subject = json
-            .get("sub")
-            .or_else(|| json.get("email"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
-
-        // Sanitize: keep only alphanumeric, @, -, .
-        let sanitized: String = subject
-            .chars()
-            .filter(|c| c.is_alphanumeric() || *c == '@' || *c == '-' || *c == '.')
-            .collect();
-
-        format!("lance-{}", sanitized)
     }
 
-    /// Build SAS permissions based on the VendedPermission level.
-    ///
-    /// - Read: read + list
-    /// - Write: read + list + write + add + create
-    /// - Admin: read + list + write + add + create + delete
-    #[allow(clippy::field_reassign_with_default)]
-    fn build_sas_permissions(permission: VendedPermission) -> BlobSasPermissions {
-        let mut p = BlobSasPermissions::default();
-
-        // All permission levels have read access
-        p.read = true;
-        p.list = true;
-
-        // Write and Admin have write access
-        if permission.can_write() {
-            p.write = true;
-            p.add = true;
-            p.create = true;
-        }
-
-        // Admin has delete access
-        if permission.can_delete() {
-            p.delete = true;
-        }
-
-        p
+    fn authority_host() -> String {
+        env::var("AZURE_AUTHORITY_HOST").unwrap_or_else(|_| DEFAULT_AUTHORITY_HOST.to_string())
     }
 
-    /// Generate a SAS token for the specified container.
-    async fn generate_sas_token(&self, account: &str, container: &str) -> Result<(String, u64)> {
-        let credential =
-            DefaultAzureCredential::create(azure_identity::TokenCredentialOptions::default())
-                .map_err(|e| {
+    fn tenant_id_for_static_auth(&self) -> Option<String> {
+        self.config
+            .tenant_id
+            .clone()
+            .or_else(|| env::var("AZURE_TENANT_ID").ok())
+    }
+
+    /// Resolve the federated client ID from config or `AZURE_CLIENT_ID` env var.
+    /// Note: `AZURE_CLIENT_ID` is also used in the client-secret flow. The precedence
+    /// in `fetch_static_access_token` ensures the federated token file flow is checked
+    /// first, so when both `AZURE_CLIENT_SECRET` and `AZURE_FEDERATED_TOKEN_FILE` are
+    /// set, the federated flow wins.
+    fn federated_client_id_for_static_auth(&self) -> Option<String> {
+        self.config
+            .federated_client_id
+            .clone()
+            .or_else(|| env::var("AZURE_CLIENT_ID").ok())
+    }
+
+    fn effective_expiry(&self, now: DateTime<Utc>) -> Result<DateTime<Utc>> {
+        let requested = now
+            .checked_add_signed(Duration::milliseconds(self.config.duration_millis as i64))
+            .ok_or_else(|| {
+                lance_core::Error::from(NamespaceError::InvalidInput {
+                    message: format!(
+                        "azure_duration_millis value '{}' overflows expiration time calculation",
+                        self.config.duration_millis
+                    ),
+                })
+            })?;
+        let max_expiry = now
+            .checked_add_signed(Duration::days(MAX_SAS_DURATION_DAYS))
+            .and_then(|value| {
+                value.checked_sub_signed(Duration::seconds(USER_DELEGATION_SKEW_BUFFER_SECONDS))
+            })
+            .ok_or_else(|| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: "Failed to calculate maximum Azure SAS expiration time".to_string(),
+                })
+            })?;
+        Ok(requested.min(max_expiry))
+    }
+
+    fn format_azure_time(value: DateTime<Utc>) -> String {
+        value.to_rfc3339_opts(SecondsFormat::Secs, true)
+    }
+
+    /// Resolve a static Azure access token using the following precedence
+    /// (matches object_store's credential resolution order):
+    /// 1. Workload Identity Federation (AZURE_FEDERATED_TOKEN_FILE + tenant + client ID)
+    /// 2. Client Secret OAuth (AZURE_CLIENT_ID + AZURE_CLIENT_SECRET + tenant)
+    /// 3. Managed Identity (IMDS)
+    async fn fetch_static_access_token(&self) -> Result<String> {
+        if let (Some(tenant_id), Some(client_id), Ok(federated_token_file)) = (
+            self.tenant_id_for_static_auth(),
+            self.federated_client_id_for_static_auth(),
+            env::var("AZURE_FEDERATED_TOKEN_FILE"),
+        ) {
+            debug!(
+                "Azure static auth: using federated token file flow with '{}'",
+                federated_token_file
+            );
+            let federated_token =
+                std::fs::read_to_string(&federated_token_file).map_err(|err| {
                     lance_core::Error::from(NamespaceError::Internal {
-                        message: format!("Failed to create Azure credentials: {}", e),
+                        message: format!(
+                            "Failed to read Azure federated token file '{}': {}",
+                            federated_token_file, err
+                        ),
                     })
                 })?;
 
-        let credential: Arc<dyn TokenCredential> = Arc::new(credential);
+            return self
+                .exchange_federated_token_for_azure_token(
+                    &tenant_id,
+                    &client_id,
+                    federated_token.trim(),
+                )
+                .await;
+        }
 
-        let blob_service_client = BlobServiceClient::new(account, credential.clone());
+        if let (Some(tenant_id), Ok(client_id), Ok(client_secret)) = (
+            self.tenant_id_for_static_auth(),
+            env::var("AZURE_CLIENT_ID"),
+            env::var("AZURE_CLIENT_SECRET"),
+        ) {
+            debug!("Azure static auth: using client secret flow");
+            return self
+                .exchange_client_secret_for_azure_token(&tenant_id, &client_id, &client_secret)
+                .await;
+        }
 
-        // Calculate times using time crate (which Azure SDK uses)
-        let now = time::OffsetDateTime::now_utc();
-        let duration_millis = self.config.duration_millis as i64;
-        let end_time = now + time::Duration::milliseconds(duration_millis);
+        debug!("Azure static auth: falling back to managed identity flow");
+        self.fetch_managed_identity_token().await
+    }
 
-        // Azure limits user delegation key to 7 days
-        let max_key_end = now + time::Duration::days(7) - time::Duration::seconds(60);
-        let key_end_time = if end_time > max_key_end {
-            max_key_end
-        } else {
-            end_time
-        };
+    async fn exchange_client_secret_for_azure_token(
+        &self,
+        tenant_id: &str,
+        client_id: &str,
+        client_secret: &str,
+    ) -> Result<String> {
+        let params = [
+            ("client_id", client_id),
+            ("client_secret", client_secret),
+            ("scope", AZURE_STORAGE_SCOPE),
+            ("grant_type", "client_credentials"),
+        ];
+        self.exchange_for_azure_token(tenant_id, &params).await
+    }
 
-        // Get user delegation key (note: typo in the library method name)
-        let user_delegation_key = blob_service_client
-            .get_user_deligation_key(now, key_end_time)
+    async fn exchange_federated_token_for_azure_token(
+        &self,
+        tenant_id: &str,
+        client_id: &str,
+        federated_token: &str,
+    ) -> Result<String> {
+        let params = [
+            ("client_id", client_id),
+            (
+                "client_assertion_type",
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            ),
+            ("client_assertion", federated_token),
+            ("scope", AZURE_STORAGE_SCOPE),
+            ("grant_type", "client_credentials"),
+        ];
+        self.exchange_for_azure_token(tenant_id, &params).await
+    }
+
+    async fn exchange_for_azure_token(
+        &self,
+        tenant_id: &str,
+        params: &[(&str, &str)],
+    ) -> Result<String> {
+        let token_url = format!(
+            "{}/{}/oauth2/v2.0/token",
+            Self::authority_host().trim_end_matches('/'),
+            tenant_id
+        );
+
+        let response = self
+            .http_client
+            .post(&token_url)
+            .form(params)
+            .send()
             .await
-            .map_err(|e| {
+            .map_err(|err| {
                 lance_core::Error::from(NamespaceError::Internal {
                     message: format!(
-                        "Failed to get user delegation key for account '{}': {}",
-                        account, e
+                        "Failed to fetch Azure AD token from '{}': {}",
+                        token_url, err
                     ),
                 })
             })?;
 
-        let permissions = Self::build_sas_permissions(self.config.permission);
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(NamespaceError::Internal {
+                message: format!(
+                    "Azure AD token request to '{}' failed with status {}: {}",
+                    token_url, status, body
+                ),
+            }
+            .into());
+        }
 
-        // Generate SAS token for the container
-        let container_client = blob_service_client.container_client(container);
-
-        let sas_token = container_client
-            .user_delegation_shared_access_signature(
-                permissions,
-                &user_delegation_key.user_deligation_key,
-            )
-            .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to generate SAS token for container '{}': {}",
-                        container, e
-                    ),
-                })
-            })?;
-
-        let expires_at_millis =
-            (end_time.unix_timestamp() * 1000 + end_time.millisecond() as i64) as u64;
-
-        let token = sas_token.token().map_err(|e| {
+        let token_response: AzureTokenResponse = response.json().await.map_err(|err| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to get SAS token: {}", e),
+                message: format!("Failed to parse Azure AD token response: {}", err),
             })
         })?;
 
-        Ok((token, expires_at_millis))
+        Ok(token_response.access_token)
     }
 
-    /// Generate a SAS token with a specific permission level.
-    async fn generate_sas_token_with_permission(
+    async fn fetch_managed_identity_token(&self) -> Result<String> {
+        let endpoint = env::var("IDENTITY_ENDPOINT")
+            .or_else(|_| env::var("MSI_ENDPOINT"))
+            .unwrap_or_else(|_| DEFAULT_MANAGED_IDENTITY_ENDPOINT.to_string());
+
+        let client_id = self.federated_client_id_for_static_auth();
+
+        let mut query = vec![
+            ("api-version", MANAGED_IDENTITY_API_VERSION.to_string()),
+            ("resource", AZURE_STORAGE_RESOURCE.to_string()),
+        ];
+        if let Some(client_id) = client_id {
+            query.push(("client_id", client_id));
+        }
+
+        let mut request = self
+            .http_client
+            .get(&endpoint)
+            .header("metadata", "true")
+            .query(&query);
+
+        if let Ok(identity_header) = env::var("IDENTITY_HEADER") {
+            request = request.header("x-identity-header", identity_header);
+        }
+
+        let response = request.send().await.map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!(
+                    "Failed to fetch Azure managed identity token from '{}': {}",
+                    endpoint, err
+                ),
+            })
+        })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(NamespaceError::Internal {
+                message: format!(
+                    "Azure managed identity token request to '{}' failed with status {}: {}",
+                    endpoint, status, body
+                ),
+            }
+            .into());
+        }
+
+        let token_response: AzureTokenResponse = response.json().await.map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!(
+                    "Failed to parse Azure managed identity token response: {}",
+                    err
+                ),
+            })
+        })?;
+
+        Ok(token_response.access_token)
+    }
+
+    async fn get_user_delegation_key(
         &self,
+        access_token: &str,
+        account: &str,
+    ) -> Result<(AzureUserDelegationKey, DateTime<Utc>)> {
+        let now = Utc::now();
+        let expiry = self.effective_expiry(now)?;
+        let start = Self::format_azure_time(now);
+        let expiry_string = Self::format_azure_time(expiry);
+        let body = format!(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<KeyInfo>\n    <Start>{}</Start>\n    <Expiry>{}</Expiry>\n</KeyInfo>",
+            start, expiry_string
+        );
+
+        let endpoint = format!("https://{}.blob.core.windows.net/", account);
+        let response = self
+            .http_client
+            .post(&endpoint)
+            .query(&[("restype", "service"), ("comp", "userdelegationkey")])
+            .header(AUTHORIZATION, format!("Bearer {}", access_token))
+            .header("x-ms-version", SAS_VERSION)
+            .header(CONTENT_TYPE, "application/xml")
+            .body(body)
+            .send()
+            .await
+            .map_err(|err| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to request Azure user delegation key for account '{}': {}",
+                        account, err
+                    ),
+                })
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(NamespaceError::Internal {
+                message: format!(
+                    "Azure user delegation key request for account '{}' failed with status {}: {}",
+                    account, status, body
+                ),
+            }
+            .into());
+        }
+
+        let body = response.text().await.map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!(
+                    "Failed to read Azure user delegation key response for account '{}': {}",
+                    account, err
+                ),
+            })
+        })?;
+
+        let delegation_key = Self::parse_user_delegation_key_xml(&body)?;
+        Ok((delegation_key, expiry))
+    }
+
+    fn parse_user_delegation_key_xml(xml: &str) -> Result<AzureUserDelegationKey> {
+        let mut reader = Reader::from_str(xml);
+        let mut fields: HashMap<String, String> = HashMap::new();
+        let mut current_tag: Option<String> = None;
+
+        loop {
+            match reader.read_event() {
+                Ok(Event::Start(e)) => {
+                    current_tag =
+                        Some(String::from_utf8_lossy(e.local_name().as_ref()).to_string());
+                }
+                Ok(Event::Text(e)) => {
+                    if let Some(ref tag) = current_tag {
+                        let text = String::from_utf8_lossy(&e).trim().to_string();
+                        fields.insert(tag.clone(), text);
+                    }
+                }
+                Ok(Event::End(_)) => {
+                    current_tag = None;
+                }
+                Ok(Event::Eof) => break,
+                Err(err) => {
+                    return Err(NamespaceError::Internal {
+                        message: format!(
+                            "Failed to parse Azure user delegation key XML response: {}",
+                            err
+                        ),
+                    }
+                    .into());
+                }
+                _ => {}
+            }
+        }
+
+        let mut get_field = |name: &str| -> Result<String> {
+            fields.remove(name).ok_or_else(|| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!("Azure user delegation key response missing '{}'", name),
+                })
+            })
+        };
+
+        Ok(AzureUserDelegationKey {
+            signed_oid: get_field("SignedOid")?,
+            signed_tid: get_field("SignedTid")?,
+            signed_start: get_field("SignedStart")?,
+            signed_expiry: get_field("SignedExpiry")?,
+            signed_service: get_field("SignedService")?,
+            signed_version: get_field("SignedVersion")?,
+            value: get_field("Value")?,
+        })
+    }
+
+    fn base64_hmac_sha256(secret: &str, message: &str) -> Result<String> {
+        let key = STANDARD.decode(secret).map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Failed to decode Azure user delegation key: {}", err),
+            })
+        })?;
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(&key).map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Failed to create HMAC key for Azure SAS signing: {}", err),
+            })
+        })?;
+        mac.update(message.as_bytes());
+
+        Ok(STANDARD.encode(mac.finalize().into_bytes()))
+    }
+
+    fn build_sas_query(
+        delegation_key: &AzureUserDelegationKey,
+        canonicalized_resource: &str,
+        permissions: &AzureSasPermissions,
+        expiry: &str,
+        resource: AzureSignedResource,
+        signed_directory_depth: Option<usize>,
+    ) -> Result<String> {
+        // User delegation SAS string-to-sign fields (version 2020-12-06+):
+        // https://learn.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas
+        let sp = permissions.to_string();
+        let se = expiry.to_string();
+        let sv = SAS_VERSION.to_string();
+        let sr = resource.to_string();
+        let string_to_sign = [
+            sp.as_str(), // sp  (signed permissions)
+            "",          // st  (signed start — empty = immediate)
+            se.as_str(), // se  (signed expiry)
+            canonicalized_resource,
+            &delegation_key.signed_oid,     // skoid
+            &delegation_key.signed_tid,     // sktid
+            &delegation_key.signed_start,   // skt
+            &delegation_key.signed_expiry,  // ske
+            &delegation_key.signed_service, // sks
+            &delegation_key.signed_version, // skv
+            "",                             // saoid (signed authorized OID)
+            "",                             // suoid (signed unauthorized OID)
+            "",                             // scid  (signed correlation ID)
+            "",                             // sip   (signed IP)
+            "",                             // spr   (signed protocol)
+            sv.as_str(),                    // sv    (signed version)
+            sr.as_str(),                    // sr    (signed resource)
+            "",                             // snapshot time
+            "",                             // ses   (signed encryption scope)
+            "",                             // rscc  (response cache-control)
+            "",                             // rscd  (response content-disposition)
+            "",                             // rsce  (response content-encoding)
+            "",                             // rscl  (response content-language)
+            "",                             // rsct  (response content-type)
+        ]
+        .join("\n");
+
+        let signature = Self::base64_hmac_sha256(&delegation_key.value, &string_to_sign)?;
+
+        let mut serializer = form_urlencoded::Serializer::new(String::new());
+        serializer.append_pair("skoid", &delegation_key.signed_oid);
+        serializer.append_pair("sktid", &delegation_key.signed_tid);
+        serializer.append_pair("skt", &delegation_key.signed_start);
+        serializer.append_pair("ske", &delegation_key.signed_expiry);
+        serializer.append_pair("sks", &delegation_key.signed_service);
+        serializer.append_pair("skv", &delegation_key.signed_version);
+        serializer.append_pair("sv", SAS_VERSION);
+        serializer.append_pair("sp", &permissions.to_string());
+        serializer.append_pair("sr", &resource.to_string());
+        serializer.append_pair("se", expiry);
+        if let Some(depth) = signed_directory_depth {
+            serializer.append_pair("sdd", &depth.to_string());
+        }
+        serializer.append_pair("sig", &signature);
+        Ok(serializer.finish())
+    }
+
+    fn parse_container_and_path(url: &Url, table_location: &str) -> Result<(String, String)> {
+        let container = if !url.username().is_empty() {
+            url.username().to_string()
+        } else {
+            url.host_str()
+                .ok_or_else(|| {
+                    lance_core::Error::from(NamespaceError::InvalidInput {
+                        message: format!("Azure URI '{}' missing container", table_location),
+                    })
+                })?
+                .to_string()
+        };
+
+        let path = url
+            .path()
+            .trim_start_matches('/')
+            .trim_end_matches('/')
+            .to_string();
+        Ok((container, path))
+    }
+
+    async fn generate_sas_with_azure_token(
+        &self,
+        azure_token: &str,
         account: &str,
         container: &str,
+        path: &str,
         permission: VendedPermission,
     ) -> Result<(String, u64)> {
-        let credential =
-            DefaultAzureCredential::create(azure_identity::TokenCredentialOptions::default())
-                .map_err(|e| {
-                    lance_core::Error::from(NamespaceError::Internal {
-                        message: format!("Failed to create Azure credentials: {}", e),
-                    })
-                })?;
-
-        let credential: Arc<dyn TokenCredential> = Arc::new(credential);
-        let blob_service_client = BlobServiceClient::new(account, credential.clone());
-
-        let now = time::OffsetDateTime::now_utc();
-        let duration_millis = self.config.duration_millis as i64;
-        let end_time = now + time::Duration::milliseconds(duration_millis);
-
-        let max_key_end = now + time::Duration::days(7) - time::Duration::seconds(60);
-        let key_end_time = if end_time > max_key_end {
-            max_key_end
-        } else {
-            end_time
-        };
-
-        let user_delegation_key = blob_service_client
-            .get_user_deligation_key(now, key_end_time)
-            .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to get user delegation key for account '{}': {}",
-                        account, e
-                    ),
-                })
-            })?;
-
+        let (delegation_key, expiry_time) =
+            self.get_user_delegation_key(azure_token, account).await?;
+        let expires_at_millis = expiry_time.timestamp_millis() as u64;
+        let expiry = Self::format_azure_time(expiry_time);
         let permissions = Self::build_sas_permissions(permission);
-        let container_client = blob_service_client.container_client(container);
+        let normalized_path = path.trim_matches('/');
 
-        let sas_token = container_client
-            .user_delegation_shared_access_signature(
-                permissions,
-                &user_delegation_key.user_deligation_key,
-            )
-            .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to generate SAS token for container '{}': {}",
-                        container, e
-                    ),
-                })
-            })?;
+        let (canonicalized_resource, resource, signed_directory_depth) =
+            if normalized_path.is_empty() {
+                (
+                    format!("/blob/{}/{}", account, container),
+                    AzureSignedResource::Container,
+                    None,
+                )
+            } else {
+                (
+                    format!("/blob/{}/{}/{}", account, container, normalized_path),
+                    AzureSignedResource::Directory,
+                    Some(normalized_path.split('/').count()),
+                )
+            };
 
-        let expires_at_millis =
-            (end_time.unix_timestamp() * 1000 + end_time.millisecond() as i64) as u64;
+        let sas_token = Self::build_sas_query(
+            &delegation_key,
+            &canonicalized_resource,
+            &permissions,
+            &expiry,
+            resource,
+            signed_directory_depth,
+        )?;
 
-        let token = sas_token.token().map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to get SAS token: {}", e),
-            })
-        })?;
-
-        Ok((token, expires_at_millis))
+        Ok((sas_token, expires_at_millis))
     }
 
-    /// Generate a directory-scoped SAS token.
-    ///
-    /// Unlike container-level SAS tokens, this restricts access to a specific directory
-    /// path within the container. This is more secure for multi-tenant scenarios.
-    ///
-    /// # Arguments
-    /// * `account` - Storage account name
-    /// * `container` - Container name
-    /// * `path` - Directory path within the container (e.g., "tenant-a/tables/my-table")
-    /// * `permission` - Permission level for the SAS token
-    async fn generate_directory_sas_token(
+    /// Fetch a static access token and generate a SAS token.
+    async fn generate_sas_with_static_token(
         &self,
         account: &str,
         container: &str,
         path: &str,
         permission: VendedPermission,
     ) -> Result<(String, u64)> {
-        let credential =
-            DefaultAzureCredential::create(azure_identity::TokenCredentialOptions::default())
-                .map_err(|e| {
-                    lance_core::Error::from(NamespaceError::Internal {
-                        message: format!("Failed to create Azure credentials: {}", e),
-                    })
-                })?;
-
-        let credential: Arc<dyn TokenCredential> = Arc::new(credential);
-        let blob_service_client = BlobServiceClient::new(account, credential.clone());
-
-        let now = time::OffsetDateTime::now_utc();
-        let duration_millis = self.config.duration_millis as i64;
-        let end_time = now + time::Duration::milliseconds(duration_millis);
-
-        let max_key_end = now + time::Duration::days(7) - time::Duration::seconds(60);
-        let key_end_time = if end_time > max_key_end {
-            max_key_end
-        } else {
-            end_time
-        };
-
-        let user_delegation_key = blob_service_client
-            .get_user_deligation_key(now, key_end_time)
+        let access_token = self.fetch_static_access_token().await?;
+        self.generate_sas_with_azure_token(&access_token, account, container, path, permission)
             .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to get user delegation key for account '{}': {}",
-                        account, e
-                    ),
-                })
-            })?;
-
-        // Normalize path: remove leading/trailing slashes
-        let normalized_path = path.trim_matches('/');
-        let depth = if normalized_path.is_empty() {
-            0
-        } else {
-            normalized_path.split('/').count()
-        };
-
-        // Build canonical resource path for directory-level SAS
-        let canonical_resource = format!("/blob/{}/{}/{}", account, container, normalized_path);
-
-        // Convert user delegation key to SasKey
-        let sas_key = SasKey::UserDelegationKey(user_delegation_key.user_deligation_key);
-
-        let permissions = Self::build_sas_permissions(permission);
-
-        // Create directory-scoped SAS signature
-        let sas = BlobSharedAccessSignature::new(
-            sas_key,
-            canonical_resource,
-            permissions,
-            end_time,
-            BlobSignedResource::Directory,
-        )
-        .signed_directory_depth(depth as u8);
-
-        let token = sas.token().map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to generate directory SAS token: {}", e),
-            })
-        })?;
-
-        let expires_at_millis =
-            (end_time.unix_timestamp() * 1000 + end_time.millisecond() as i64) as u64;
-
-        info!(
-            "Azure directory-scoped SAS generated: account={}, container={}, path={}, depth={}, permission={}",
-            account, container, normalized_path, depth, permission
-        );
-
-        Ok((token, expires_at_millis))
     }
 
     /// Exchange an OIDC token for Azure AD access token using Workload Identity Federation.
-    ///
-    /// This requires:
-    /// 1. An Azure AD App Registration with Federated Credentials configured
-    /// 2. The OIDC token's issuer and subject to match the Federated Credential configuration
     async fn exchange_oidc_for_azure_token(&self, oidc_token: &str) -> Result<String> {
         let tenant_id = self.config.tenant_id.as_ref().ok_or_else(|| {
             lance_core::Error::from(NamespaceError::InvalidInput {
@@ -489,159 +772,8 @@ impl AzureCredentialVendor {
             })
         })?;
 
-        let token_url = format!(
-            "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
-            tenant_id
-        );
-
-        let params = [
-            ("grant_type", "client_credentials"),
-            (
-                "client_assertion_type",
-                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            ),
-            ("client_assertion", oidc_token),
-            ("client_id", client_id),
-            ("scope", "https://storage.azure.com/.default"),
-        ];
-
-        let response = self
-            .http_client
-            .post(&token_url)
-            .form(&params)
-            .send()
+        self.exchange_federated_token_for_azure_token(tenant_id, client_id, oidc_token)
             .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to exchange OIDC token for Azure AD token: {}", e),
-                })
-            })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(NamespaceError::Internal {
-                message: format!(
-                    "Azure AD token exchange failed with status {}: {}",
-                    status, body
-                ),
-            }
-            .into());
-        }
-
-        let token_response: serde_json::Value = response.json().await.map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to parse Azure AD token response: {}", e),
-            })
-        })?;
-
-        token_response
-            .get("access_token")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: "Azure AD token response missing access_token".to_string(),
-                })
-            })
-    }
-
-    /// Generate a SAS token using a federated Azure AD token.
-    ///
-    /// Uses directory-scoped SAS when path is provided, container-level otherwise.
-    async fn generate_sas_with_azure_token(
-        &self,
-        azure_token: &str,
-        account: &str,
-        container: &str,
-        path: &str,
-        permission: VendedPermission,
-    ) -> Result<(String, u64)> {
-        // Create a custom TokenCredential that uses our Azure AD token
-        let credential = FederatedTokenCredential::new(azure_token.to_string());
-        let credential: Arc<dyn TokenCredential> = Arc::new(credential);
-
-        let blob_service_client = BlobServiceClient::new(account, credential.clone());
-
-        let now = time::OffsetDateTime::now_utc();
-        let duration_millis = self.config.duration_millis as i64;
-        let end_time = now + time::Duration::milliseconds(duration_millis);
-
-        let max_key_end = now + time::Duration::days(7) - time::Duration::seconds(60);
-        let key_end_time = if end_time > max_key_end {
-            max_key_end
-        } else {
-            end_time
-        };
-
-        let user_delegation_key = blob_service_client
-            .get_user_deligation_key(now, key_end_time)
-            .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to get user delegation key with federated token: {}",
-                        e
-                    ),
-                })
-            })?;
-
-        let permissions = Self::build_sas_permissions(permission);
-
-        let expires_at_millis =
-            (end_time.unix_timestamp() * 1000 + end_time.millisecond() as i64) as u64;
-
-        // Use directory-scoped SAS when path is provided
-        let normalized_path = path.trim_matches('/');
-        let token = if normalized_path.is_empty() {
-            // Container-level SAS
-            let container_client = blob_service_client.container_client(container);
-            let sas_token = container_client
-                .user_delegation_shared_access_signature(
-                    permissions,
-                    &user_delegation_key.user_deligation_key,
-                )
-                .await
-                .map_err(|e| {
-                    lance_core::Error::from(NamespaceError::Internal {
-                        message: format!(
-                            "Failed to generate SAS token with federated token: {}",
-                            e
-                        ),
-                    })
-                })?;
-
-            sas_token.token().map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to get SAS token: {}", e),
-                })
-            })?
-        } else {
-            // Directory-scoped SAS
-            let depth = normalized_path.split('/').count();
-            let canonical_resource = format!("/blob/{}/{}/{}", account, container, normalized_path);
-            let sas_key = SasKey::UserDelegationKey(user_delegation_key.user_deligation_key);
-
-            let sas = BlobSharedAccessSignature::new(
-                sas_key,
-                canonical_resource,
-                permissions,
-                end_time,
-                BlobSignedResource::Directory,
-            )
-            .signed_directory_depth(depth as u8);
-
-            sas.token().map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to generate directory SAS token with federated token: {}",
-                        e
-                    ),
-                })
-            })?
-        };
-
-        Ok((token, expires_at_millis))
     }
 
     /// Vend credentials using Workload Identity Federation (for auth_token).
@@ -652,17 +784,12 @@ impl AzureCredentialVendor {
         path: &str,
         auth_token: &str,
     ) -> Result<VendedCredentials> {
-        let session_name = Self::derive_session_name_from_token(auth_token);
         debug!(
-            "Azure vend_with_web_identity: account={}, container={}, path={}, session={}",
-            account, container, path, session_name
+            "Azure vend_with_web_identity: account={}, container={}, path={}",
+            account, container, path
         );
 
-        // Exchange OIDC token for Azure AD token
         let azure_token = self.exchange_oidc_for_azure_token(auth_token).await?;
-
-        // Generate SAS token using the Azure AD token
-        // Use directory-scoped SAS when path is provided
         let (sas_token, expires_at_millis) = self
             .generate_sas_with_azure_token(
                 &azure_token,
@@ -714,7 +841,6 @@ impl AzureCredentialVendor {
 
         let key_hash = Self::hash_api_key(api_key, salt);
 
-        // Look up permission from hash mapping
         let permission = self
             .config
             .api_key_hash_permissions
@@ -735,14 +861,9 @@ impl AzureCredentialVendor {
             account, container, path, permission
         );
 
-        // Use directory-scoped SAS when path is provided, container-level otherwise
-        let (sas_token, expires_at_millis) = if path.is_empty() {
-            self.generate_sas_token_with_permission(account, container, permission)
-                .await?
-        } else {
-            self.generate_directory_sas_token(account, container, path, permission)
-                .await?
-        };
+        let (sas_token, expires_at_millis) = self
+            .generate_sas_with_static_token(account, container, path, permission)
+            .await?;
 
         let mut storage_options = HashMap::new();
         storage_options.insert("azure_storage_sas_token".to_string(), sas_token.clone());
@@ -769,37 +890,6 @@ impl AzureCredentialVendor {
     }
 }
 
-/// A custom TokenCredential that wraps a pre-obtained Azure AD access token.
-#[derive(Debug)]
-struct FederatedTokenCredential {
-    token: String,
-}
-
-impl FederatedTokenCredential {
-    fn new(token: String) -> Self {
-        Self { token }
-    }
-}
-
-#[async_trait]
-impl TokenCredential for FederatedTokenCredential {
-    async fn get_token(
-        &self,
-        _scopes: &[&str],
-    ) -> std::result::Result<azure_core::auth::AccessToken, azure_core::Error> {
-        // Return the pre-obtained token with a 1-hour expiry (conservative estimate)
-        let expires_on = time::OffsetDateTime::now_utc() + time::Duration::hours(1);
-        Ok(azure_core::auth::AccessToken::new(
-            azure_core::auth::Secret::new(self.token.clone()),
-            expires_on,
-        ))
-    }
-
-    async fn clear_cache(&self) -> std::result::Result<(), azure_core::Error> {
-        Ok(())
-    }
-}
-
 #[async_trait]
 impl CredentialVendor for AzureCredentialVendor {
     async fn vend_credentials(
@@ -819,32 +909,26 @@ impl CredentialVendor for AzureCredentialVendor {
         );
 
         let url = uri_to_url(table_location)?;
+        let (container, path) = Self::parse_container_and_path(&url, table_location)?;
 
-        let container = url.host_str().ok_or_else(|| {
+        let account = self.config.account_name.as_ref().ok_or_else(|| {
             lance_core::Error::from(NamespaceError::InvalidInput {
-                message: format!("Azure URI '{}' missing container", table_location),
+                message: "Azure credential vending requires 'credential_vendor.azure_account_name' to be set in configuration".to_string(),
             })
         })?;
 
-        // Extract path for directory-scoped SAS
-        let path = url.path().trim_start_matches('/');
-
-        let account =
-            self.config
-                .account_name
-                .as_ref()
-                .ok_or_else(|| lance_core::Error::from(NamespaceError::InvalidInput { message: "Azure credential vending requires 'credential_vendor.azure_account_name' to be set in configuration".to_string() }))?;
-
-        // Dispatch based on identity
         match identity {
             Some(id) if id.auth_token.is_some() => {
-                let auth_token = id.auth_token.as_ref().unwrap();
-                self.vend_with_web_identity(account, container, path, auth_token)
-                    .await
+                self.vend_with_web_identity(
+                    account,
+                    &container,
+                    &path,
+                    id.auth_token.as_ref().unwrap(),
+                )
+                .await
             }
             Some(id) if id.api_key.is_some() => {
-                let api_key = id.api_key.as_ref().unwrap();
-                self.vend_with_api_key(account, container, path, api_key)
+                self.vend_with_api_key(account, &container, &path, id.api_key.as_ref().unwrap())
                     .await
             }
             Some(_) => Err(NamespaceError::InvalidInput {
@@ -852,19 +936,14 @@ impl CredentialVendor for AzureCredentialVendor {
             }
             .into()),
             None => {
-                // Static credential vending using DefaultAzureCredential
-                // Use directory-scoped SAS when path is provided, container-level otherwise
-                let (sas_token, expires_at_millis) = if path.is_empty() {
-                    self.generate_sas_token(account, container).await?
-                } else {
-                    self.generate_directory_sas_token(
+                let (sas_token, expires_at_millis) = self
+                    .generate_sas_with_static_token(
                         account,
-                        container,
-                        path,
+                        &container,
+                        &path,
                         self.config.permission,
                     )
-                    .await?
-                };
+                    .await?;
 
                 let mut storage_options = HashMap::new();
                 storage_options.insert("azure_storage_sas_token".to_string(), sas_token.clone());
@@ -933,6 +1012,7 @@ mod tests {
             !permissions.delete,
             "Read permission should have delete=false"
         );
+        assert_eq!(permissions.to_string(), "rl");
     }
 
     #[test]
@@ -951,6 +1031,7 @@ mod tests {
             !permissions.delete,
             "Write permission should have delete=false"
         );
+        assert_eq!(permissions.to_string(), "racwl");
     }
 
     #[test]
@@ -969,5 +1050,155 @@ mod tests {
             permissions.delete,
             "Admin permission should have delete=true"
         );
+        assert_eq!(permissions.to_string(), "racwdl");
+    }
+
+    #[test]
+    fn test_parse_user_delegation_key_xml() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<UserDelegationKey>
+    <SignedOid>11111111-1111-1111-1111-111111111111</SignedOid>
+    <SignedTid>22222222-2222-2222-2222-222222222222</SignedTid>
+    <SignedStart>2024-01-01T00:00:00Z</SignedStart>
+    <SignedExpiry>2024-01-02T00:00:00Z</SignedExpiry>
+    <SignedService>b</SignedService>
+    <SignedVersion>2022-11-02</SignedVersion>
+    <Value>YmFzZTY0LXNlY3JldA==</Value>
+</UserDelegationKey>"#;
+
+        let key = AzureCredentialVendor::parse_user_delegation_key_xml(xml).unwrap();
+        assert_eq!(key.signed_oid, "11111111-1111-1111-1111-111111111111");
+        assert_eq!(key.signed_tid, "22222222-2222-2222-2222-222222222222");
+        assert_eq!(key.signed_start, "2024-01-01T00:00:00Z");
+        assert_eq!(key.signed_expiry, "2024-01-02T00:00:00Z");
+        assert_eq!(key.signed_service, "b");
+        assert_eq!(key.signed_version, "2022-11-02");
+        assert_eq!(key.value, "YmFzZTY0LXNlY3JldA==");
+    }
+
+    #[test]
+    fn test_build_directory_sas_query() {
+        let key = AzureUserDelegationKey {
+            signed_oid: "11111111-1111-1111-1111-111111111111".to_string(),
+            signed_tid: "22222222-2222-2222-2222-222222222222".to_string(),
+            signed_start: "2024-01-01T00:00:00Z".to_string(),
+            signed_expiry: "2024-01-08T00:00:00Z".to_string(),
+            signed_service: "b".to_string(),
+            signed_version: "2022-11-02".to_string(),
+            value: "c2VjcmV0LWtleS1mb3ItdGVzdHM=".to_string(),
+        };
+
+        let token = AzureCredentialVendor::build_sas_query(
+            &key,
+            "/blob/account/container/path/to/table",
+            &AzureCredentialVendor::build_sas_permissions(VendedPermission::Read),
+            "2024-01-08T00:00:00Z",
+            AzureSignedResource::Directory,
+            Some(3),
+        )
+        .unwrap();
+
+        assert_eq!(
+            token,
+            "skoid=11111111-1111-1111-1111-111111111111&sktid=22222222-2222-2222-2222-222222222222&skt=2024-01-01T00%3A00%3A00Z&ske=2024-01-08T00%3A00%3A00Z&sks=b&skv=2022-11-02&sv=2022-11-02&sp=rl&sr=d&se=2024-01-08T00%3A00%3A00Z&sdd=3&sig=EjSMl8%2FGXSZ7qPkykdtXiog9DtWdqnec%2Bzrh%2FkU70v0%3D"
+        );
+    }
+
+    #[test]
+    fn test_parse_container_and_path_from_userinfo_uri() {
+        let url = Url::parse("az://container@account.blob.core.windows.net/path/to/table").unwrap();
+        let (container, path) =
+            AzureCredentialVendor::parse_container_and_path(&url, "unused").unwrap();
+        assert_eq!(container, "container");
+        assert_eq!(path, "path/to/table");
+    }
+
+    mod integration_tests {
+        use super::*;
+
+        fn integration_test_enabled() -> bool {
+            matches!(
+                env::var("AZURE_CREDENTIALS_VENDING_INTEG_TEST_ENABLED").as_deref(),
+                Ok("1")
+            )
+        }
+
+        fn maybe_account_name() -> Result<Option<String>> {
+            if !integration_test_enabled() {
+                return Ok(None);
+            }
+
+            let account_name = env::var("AZURE_STORAGE_ACCOUNT_NAME").map_err(|err| {
+                lance_core::Error::from(NamespaceError::InvalidInput {
+                    message: format!(
+                        "AZURE_STORAGE_ACCOUNT_NAME must be set for Azure credentials vending integration tests: {}",
+                        err
+                    ),
+                })
+            })?;
+
+            Ok(Some(account_name))
+        }
+
+        #[tokio::test]
+        async fn test_fetch_static_access_token_with_local_azure_credentials() -> Result<()> {
+            let Some(account_name) = maybe_account_name()? else {
+                return Ok(());
+            };
+
+            let vendor = AzureCredentialVendor::new(
+                AzureCredentialVendorConfig::new().with_account_name(account_name),
+            );
+
+            let token = vendor.fetch_static_access_token().await?;
+            assert!(!token.is_empty(), "Azure access token should not be empty");
+            assert!(
+                token.len() > 100,
+                "Azure access token should look like a JWT"
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_vend_credentials_with_local_azure_credentials() -> Result<()> {
+            let Some(account_name) = maybe_account_name()? else {
+                return Ok(());
+            };
+
+            let vendor = AzureCredentialVendor::new(
+                AzureCredentialVendorConfig::new()
+                    .with_account_name(account_name.clone())
+                    .with_duration_millis(5 * 60 * 1000),
+            );
+
+            let credentials = vendor
+                .vend_credentials("az://integration-test-container/path/to/table", None)
+                .await?;
+
+            assert_eq!(
+                credentials
+                    .storage_options
+                    .get("azure_storage_account_name"),
+                Some(&account_name)
+            );
+
+            let sas_token = credentials
+                .storage_options
+                .get("azure_storage_sas_token")
+                .expect("Azure SAS token should be present");
+
+            assert!(
+                sas_token.contains("sig="),
+                "SAS token should include signature"
+            );
+            assert!(
+                sas_token.contains("sr=d"),
+                "Expected directory-scoped SAS token"
+            );
+            assert!(credentials.expires_at_millis > 0);
+
+            Ok(())
+        }
     }
 }

--- a/rust/lance-namespace-impls/src/credentials/azure.rs
+++ b/rust/lance-namespace-impls/src/credentials/azure.rs
@@ -1140,8 +1140,8 @@ mod tests {
             Ok(Some(account_name))
         }
 
-        const TEST_CONTAINER: &str = "examples";
-        const TEST_PREFIX: &str = "lance-cv-integ-test";
+        const TEST_CONTAINER: &str = "lance-integ-test";
+        const TEST_PREFIX: &str = "cv-test";
 
         #[tokio::test]
         async fn test_fetch_static_access_token() -> Result<()> {
@@ -1216,6 +1216,72 @@ mod tests {
                 .get("azure_storage_sas_token")
                 .expect("Azure SAS token should be present");
             assert!(sas_token.contains("sr=c"), "Expected container-scoped SAS");
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_vended_sas_can_write_read_delete() -> Result<()> {
+            let Some(account_name) = maybe_account_name()? else {
+                return Ok(());
+            };
+
+            let vendor = AzureCredentialVendor::new(
+                AzureCredentialVendorConfig::new()
+                    .with_account_name(account_name.clone())
+                    .with_permission(VendedPermission::Admin)
+                    .with_duration_millis(5 * 60 * 1000),
+            );
+
+            let location = format!("az://{}/{}", TEST_CONTAINER, TEST_PREFIX);
+            let credentials = vendor.vend_credentials(&location, None).await?;
+
+            let sas_token = credentials
+                .storage_options
+                .get("azure_storage_sas_token")
+                .unwrap();
+
+            let blob_url = format!(
+                "https://{}.blob.core.windows.net/{}/{}/e2e-test.txt?{}",
+                account_name, TEST_CONTAINER, TEST_PREFIX, sas_token
+            );
+
+            let client = reqwest::Client::new();
+            let test_content = format!("lance-integ-{}", chrono::Utc::now().timestamp());
+
+            // Write
+            let put_resp = client
+                .put(&blob_url)
+                .header("x-ms-blob-type", "BlockBlob")
+                .header("x-ms-version", SAS_VERSION)
+                .body(test_content.clone())
+                .send()
+                .await
+                .unwrap();
+            assert!(
+                put_resp.status().is_success(),
+                "PUT failed: {}",
+                put_resp.text().await.unwrap_or_default()
+            );
+
+            // Read
+            let get_resp = client
+                .get(&blob_url)
+                .header("x-ms-version", SAS_VERSION)
+                .send()
+                .await
+                .unwrap();
+            assert!(get_resp.status().is_success(), "GET failed");
+            assert_eq!(get_resp.text().await.unwrap(), test_content);
+
+            // Delete
+            let del_resp = client
+                .delete(&blob_url)
+                .header("x-ms-version", SAS_VERSION)
+                .send()
+                .await
+                .unwrap();
+            assert!(del_resp.status().is_success(), "DELETE failed");
 
             Ok(())
         }

--- a/rust/lance-namespace-impls/src/credentials/azure.rs
+++ b/rust/lance-namespace-impls/src/credentials/azure.rs
@@ -306,8 +306,7 @@ impl AzureCredentialVendor {
     /// (matches object_store's credential resolution order):
     /// 1. Workload Identity Federation (AZURE_FEDERATED_TOKEN_FILE + tenant + client ID)
     /// 2. Client Secret OAuth (AZURE_CLIENT_ID + AZURE_CLIENT_SECRET + tenant)
-    /// 3. Azure CLI (`az account get-access-token`)
-    /// 4. Managed Identity (IMDS)
+    /// 3. Managed Identity (IMDS)
     async fn fetch_static_access_token(&self) -> Result<String> {
         if let (Some(tenant_id), Some(client_id), Ok(federated_token_file)) = (
             self.tenant_id_for_static_auth(),
@@ -348,58 +347,8 @@ impl AzureCredentialVendor {
                 .await;
         }
 
-        if let Ok(token) = self.fetch_azure_cli_token().await {
-            debug!("Azure static auth: using Azure CLI access token");
-            return Ok(token);
-        }
-
         debug!("Azure static auth: falling back to managed identity flow");
         self.fetch_managed_identity_token().await
-    }
-
-    async fn fetch_azure_cli_token(&self) -> Result<String> {
-        let output = tokio::process::Command::new("az")
-            .args([
-                "account",
-                "get-access-token",
-                "--resource",
-                AZURE_STORAGE_RESOURCE,
-                "--query",
-                "accessToken",
-                "--output",
-                "tsv",
-            ])
-            .output()
-            .await
-            .map_err(|err| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!(
-                        "Failed to invoke Azure CLI for storage access token: {}",
-                        err
-                    ),
-                })
-            })?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            return Err(NamespaceError::Internal {
-                message: format!(
-                    "Azure CLI failed to fetch storage access token (status={}): {}",
-                    output.status, stderr
-                ),
-            }
-            .into());
-        }
-
-        let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if token.is_empty() {
-            return Err(NamespaceError::Internal {
-                message: "Azure CLI returned an empty storage access token".to_string(),
-            }
-            .into());
-        }
-
-        Ok(token)
     }
 
     async fn exchange_client_secret_for_azure_token(

--- a/rust/lance-namespace-impls/src/credentials/azure.rs
+++ b/rust/lance-namespace-impls/src/credentials/azure.rs
@@ -306,7 +306,8 @@ impl AzureCredentialVendor {
     /// (matches object_store's credential resolution order):
     /// 1. Workload Identity Federation (AZURE_FEDERATED_TOKEN_FILE + tenant + client ID)
     /// 2. Client Secret OAuth (AZURE_CLIENT_ID + AZURE_CLIENT_SECRET + tenant)
-    /// 3. Managed Identity (IMDS)
+    /// 3. Azure CLI (`az account get-access-token`)
+    /// 4. Managed Identity (IMDS)
     async fn fetch_static_access_token(&self) -> Result<String> {
         if let (Some(tenant_id), Some(client_id), Ok(federated_token_file)) = (
             self.tenant_id_for_static_auth(),
@@ -347,8 +348,58 @@ impl AzureCredentialVendor {
                 .await;
         }
 
+        if let Ok(token) = self.fetch_azure_cli_token().await {
+            debug!("Azure static auth: using Azure CLI access token");
+            return Ok(token);
+        }
+
         debug!("Azure static auth: falling back to managed identity flow");
         self.fetch_managed_identity_token().await
+    }
+
+    async fn fetch_azure_cli_token(&self) -> Result<String> {
+        let output = tokio::process::Command::new("az")
+            .args([
+                "account",
+                "get-access-token",
+                "--resource",
+                AZURE_STORAGE_RESOURCE,
+                "--query",
+                "accessToken",
+                "--output",
+                "tsv",
+            ])
+            .output()
+            .await
+            .map_err(|err| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to invoke Azure CLI for storage access token: {}",
+                        err
+                    ),
+                })
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(NamespaceError::Internal {
+                message: format!(
+                    "Azure CLI failed to fetch storage access token (status={}): {}",
+                    output.status, stderr
+                ),
+            }
+            .into());
+        }
+
+        let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if token.is_empty() {
+            return Err(NamespaceError::Internal {
+                message: "Azure CLI returned an empty storage access token".to_string(),
+            }
+            .into());
+        }
+
+        Ok(token)
     }
 
     async fn exchange_client_secret_for_azure_token(
@@ -1140,8 +1191,11 @@ mod tests {
             Ok(Some(account_name))
         }
 
+        const TEST_CONTAINER: &str = "examples";
+        const TEST_PREFIX: &str = "lance-cv-integ-test";
+
         #[tokio::test]
-        async fn test_fetch_static_access_token_with_local_azure_credentials() -> Result<()> {
+        async fn test_fetch_static_access_token() -> Result<()> {
             let Some(account_name) = maybe_account_name()? else {
                 return Ok(());
             };
@@ -1161,7 +1215,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_vend_credentials_with_local_azure_credentials() -> Result<()> {
+        async fn test_vend_directory_scoped_sas() -> Result<()> {
             let Some(account_name) = maybe_account_name()? else {
                 return Ok(());
             };
@@ -1172,9 +1226,8 @@ mod tests {
                     .with_duration_millis(5 * 60 * 1000),
             );
 
-            let credentials = vendor
-                .vend_credentials("az://integration-test-container/path/to/table", None)
-                .await?;
+            let location = format!("az://{}/{}", TEST_CONTAINER, TEST_PREFIX);
+            let credentials = vendor.vend_credentials(&location, None).await?;
 
             assert_eq!(
                 credentials
@@ -1187,16 +1240,82 @@ mod tests {
                 .storage_options
                 .get("azure_storage_sas_token")
                 .expect("Azure SAS token should be present");
+            assert!(sas_token.contains("sig="));
+            assert!(sas_token.contains("sr=d"), "Expected directory-scoped SAS");
+            assert!(credentials.expires_at_millis > 0);
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_vend_container_scoped_sas() -> Result<()> {
+            let Some(account_name) = maybe_account_name()? else {
+                return Ok(());
+            };
+
+            let vendor = AzureCredentialVendor::new(
+                AzureCredentialVendorConfig::new()
+                    .with_account_name(account_name.clone())
+                    .with_duration_millis(5 * 60 * 1000),
+            );
+
+            let location = format!("az://{}", TEST_CONTAINER);
+            let credentials = vendor.vend_credentials(&location, None).await?;
+
+            let sas_token = credentials
+                .storage_options
+                .get("azure_storage_sas_token")
+                .expect("Azure SAS token should be present");
+            assert!(sas_token.contains("sr=c"), "Expected container-scoped SAS");
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn test_read_only_sas_cannot_write() -> Result<()> {
+            let Some(account_name) = maybe_account_name()? else {
+                return Ok(());
+            };
+
+            let vendor = AzureCredentialVendor::new(
+                AzureCredentialVendorConfig::new()
+                    .with_account_name(account_name.clone())
+                    .with_permission(VendedPermission::Read)
+                    .with_duration_millis(5 * 60 * 1000),
+            );
+
+            let location = format!("az://{}/{}", TEST_CONTAINER, TEST_PREFIX);
+            let credentials = vendor.vend_credentials(&location, None).await?;
+
+            let sas_token = credentials
+                .storage_options
+                .get("azure_storage_sas_token")
+                .unwrap();
+
+            let blob_url = format!(
+                "https://{}.blob.core.windows.net/{}/{}/should-not-exist.txt?{}",
+                account_name, TEST_CONTAINER, TEST_PREFIX, sas_token
+            );
+
+            let client = reqwest::Client::new();
+            let put_resp = client
+                .put(&blob_url)
+                .header("x-ms-blob-type", "BlockBlob")
+                .header("x-ms-version", SAS_VERSION)
+                .body("should fail")
+                .send()
+                .await
+                .map_err(|err| {
+                    lance_core::Error::from(NamespaceError::Internal {
+                        message: format!("Failed to send PUT request: {}", err),
+                    })
+                })?;
 
             assert!(
-                sas_token.contains("sig="),
-                "SAS token should include signature"
+                put_resp.status().is_client_error(),
+                "Read-only SAS should not allow writes, got status {}",
+                put_resp.status()
             );
-            assert!(
-                sas_token.contains("sr=d"),
-                "Expected directory-scoped SAS token"
-            );
-            assert!(credentials.expires_at_millis > 0);
 
             Ok(())
         }

--- a/rust/lance-namespace-impls/src/credentials/gcp.rs
+++ b/rust/lance-namespace-impls/src/credentials/gcp.rs
@@ -5,53 +5,26 @@
 //!
 //! This module provides credential vending for GCP Cloud Storage by obtaining
 //! OAuth2 access tokens and downscoping them using Credential Access Boundaries (CAB).
-//!
-//! ## Authentication
-//!
-//! This module uses [Application Default Credentials (ADC)][adc] for authentication.
-//! ADC automatically finds credentials based on the environment:
-//!
-//! 1. **`GOOGLE_APPLICATION_CREDENTIALS` environment variable**: Set this to the path
-//!    of a service account key file (JSON format) before starting the application.
-//! 2. **Well-known file locations**: `~/.config/gcloud/application_default_credentials.json`
-//!    on Linux/macOS, or the equivalent on Windows.
-//! 3. **Metadata server**: When running on GCP (Compute Engine, Cloud Run, GKE, etc.),
-//!    credentials are automatically obtained from the metadata server.
-//!
-//! For production deployments on GCP, using the metadata server (option 3) is recommended
-//! as it doesn't require managing key files.
-//!
-//! [adc]: https://cloud.google.com/docs/authentication/application-default-credentials
-//!
-//! ## Service Account Impersonation
-//!
-//! For multi-tenant scenarios, you can configure `service_account` to impersonate a
-//! different service account. The base credentials (from ADC) must have the
-//! `roles/iam.serviceAccountTokenCreator` role on the target service account.
-//!
-//! ## Permission Scoping
-//!
-//! Permissions are enforced using GCP's Credential Access Boundaries:
-//! - **Read**: `roles/storage.legacyObjectReader` + `roles/storage.objectViewer` (read and list)
-//! - **Write**: Read permissions + `roles/storage.legacyBucketWriter` + `roles/storage.objectCreator`
-//! - **Admin**: Write permissions + `roles/storage.objectAdmin` (includes delete)
-//!
-//! The downscoped token is restricted to the specific bucket and path prefix.
-//!
-//! Note: Legacy roles are used because modern roles like `storage.objectCreator` lack
-//! `storage.buckets.get` which many client libraries require.
 
 use std::collections::HashMap;
+use std::env;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
-use google_cloud_auth::credentials;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use lance_core::Result;
 use lance_io::object_store::uri_to_url;
 use lance_namespace::error::NamespaceError;
 use lance_namespace::models::Identity;
 use log::{debug, info, warn};
 use reqwest::Client;
+use ring::signature::RsaKeyPair;
+use rustls_pki_types::PrivateKeyDer;
+use rustls_pki_types::pem::PemObject;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -59,6 +32,13 @@ use super::{CredentialVendor, VendedCredentials, VendedPermission, redact_creden
 
 /// GCP STS token exchange endpoint for downscoping credentials.
 const STS_TOKEN_EXCHANGE_URL: &str = "https://sts.googleapis.com/v1/token";
+const IAM_GENERATE_ACCESS_TOKEN_URL: &str =
+    "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts";
+const DEFAULT_GOOGLE_TOKEN_URI: &str = "https://oauth2.googleapis.com/token";
+const DEFAULT_METADATA_HOST: &str = "metadata.google.internal";
+const DEFAULT_METADATA_IP: &str = "169.254.169.254";
+const METADATA_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const GOOGLE_CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
 
 /// Configuration for GCP credential vending.
 #[derive(Debug, Clone, Default)]
@@ -67,36 +47,20 @@ pub struct GcpCredentialVendorConfig {
     ///
     /// When set, the vendor will impersonate this service account using the
     /// IAM Credentials API's generateAccessToken endpoint before downscoping.
-    /// This is useful for multi-tenant scenarios where you want to issue tokens
-    /// on behalf of different service accounts.
-    ///
-    /// The base credentials (from ADC) must have the `roles/iam.serviceAccountTokenCreator`
-    /// role on this service account.
-    ///
-    /// Format: `my-sa@project.iam.gserviceaccount.com`
     pub service_account: Option<String>,
 
     /// Permission level for vended credentials.
     /// Default: Read
     /// Permissions are enforced via Credential Access Boundaries (CAB).
-    ///
-    /// Note: GCP token duration cannot be configured; the token lifetime
-    /// is determined by the STS endpoint (typically 1 hour).
     pub permission: VendedPermission,
 
     /// Workload Identity Provider resource name for OIDC token exchange.
     /// Required when using auth_token identity for Workload Identity Federation.
-    ///
-    /// Format: `projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/providers/{provider_id}`
-    ///
-    /// The OIDC token's issuer must match the provider's configuration.
     pub workload_identity_provider: Option<String>,
 
     /// Service account to impersonate after Workload Identity Federation.
     /// Optional - if set, the exchanged token will be used to generate an
     /// access token for this service account.
-    ///
-    /// Format: `my-sa@project.iam.gserviceaccount.com`
     pub impersonation_service_account: Option<String>,
 
     /// Salt for API key hashing.
@@ -117,12 +81,6 @@ impl GcpCredentialVendorConfig {
     }
 
     /// Set the service account to impersonate.
-    ///
-    /// When set, the vendor uses the IAM Credentials API to generate an access
-    /// token for this service account, then downscopes it with CAB.
-    ///
-    /// The base credentials (from ADC) must have the `roles/iam.serviceAccountTokenCreator`
-    /// role on this service account.
     pub fn with_service_account(mut self, service_account: impl Into<String>) -> Self {
         self.service_account = Some(service_account.into());
         self
@@ -166,7 +124,7 @@ impl GcpCredentialVendorConfig {
         self
     }
 
-    /// Set the entire API key hash permissions map.
+    /// Replace all API key hash mappings.
     pub fn with_api_key_hash_permissions(
         mut self,
         permissions: HashMap<String, VendedPermission>,
@@ -176,25 +134,7 @@ impl GcpCredentialVendorConfig {
     }
 }
 
-/// Access boundary rule for a single resource.
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct AccessBoundaryRule {
-    available_resource: String,
-    available_permissions: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    availability_condition: Option<AvailabilityCondition>,
-}
-
-/// Condition for access boundary rule.
-#[derive(Debug, Clone, Serialize)]
-struct AvailabilityCondition {
-    expression: String,
-}
-
-/// Credential Access Boundary structure.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 struct CredentialAccessBoundary {
     access_boundary: AccessBoundaryInner,
 }
@@ -205,12 +145,41 @@ struct AccessBoundaryInner {
     access_boundary_rules: Vec<AccessBoundaryRule>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AccessBoundaryRule {
+    available_resource: String,
+    available_permissions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    availability_condition: Option<AvailabilityCondition>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct AvailabilityCondition {
+    expression: String,
+}
+
 /// Response from STS token exchange.
 #[derive(Debug, Deserialize)]
 struct TokenExchangeResponse {
     access_token: String,
     #[serde(default)]
     expires_in: Option<u64>,
+}
+
+/// Response from refresh-token and service-account OAuth flows.
+#[derive(Debug, Deserialize)]
+struct OAuthAccessTokenResponse {
+    access_token: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    expires_in: Option<u64>,
+}
+
+/// Response from metadata server.
+#[derive(Debug, Deserialize)]
+struct MetadataAccessTokenResponse {
+    access_token: String,
 }
 
 /// Response from IAM generateAccessToken API.
@@ -222,43 +191,341 @@ struct GenerateAccessTokenResponse {
     expire_time: String,
 }
 
+#[derive(Debug, Serialize)]
+struct ServiceAccountClaims<'a> {
+    iss: &'a str,
+    scope: &'a str,
+    aud: &'a str,
+    exp: u64,
+    iat: u64,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct JwtHeader<'a> {
+    alg: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    typ: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kid: Option<&'a str>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum ApplicationDefaultCredentials {
+    #[serde(rename = "service_account")]
+    ServiceAccount(ServiceAccountCredentials),
+    #[serde(rename = "authorized_user")]
+    AuthorizedUser(AuthorizedUserCredentials),
+}
+
+impl ApplicationDefaultCredentials {
+    const CREDENTIALS_PATH: &'static str = if cfg!(windows) {
+        "gcloud/application_default_credentials.json"
+    } else {
+        ".config/gcloud/application_default_credentials.json"
+    };
+
+    fn read(path: Option<&str>) -> Result<Option<Self>> {
+        if let Some(path) = path {
+            return Ok(Some(read_credentials_file(path)?));
+        }
+
+        let home_var = if cfg!(windows) { "APPDATA" } else { "HOME" };
+        if let Some(home) = env::var_os(home_var) {
+            let path = Path::new(&home).join(Self::CREDENTIALS_PATH);
+            if path.exists() {
+                return Ok(Some(read_credentials_file(path)?));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthorizedUserCredentials {
+    client_id: String,
+    client_secret: String,
+    refresh_token: String,
+    #[serde(default)]
+    token_uri: Option<String>,
+}
+
+impl AuthorizedUserCredentials {
+    fn token_uri(&self) -> &str {
+        self.token_uri
+            .as_deref()
+            .unwrap_or(DEFAULT_GOOGLE_TOKEN_URI)
+    }
+
+    async fn fetch_access_token(&self, http_client: &Client) -> Result<String> {
+        let response = http_client
+            .post(self.token_uri())
+            .form(&[
+                ("grant_type", "refresh_token"),
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", self.client_secret.as_str()),
+                ("refresh_token", self.refresh_token.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|err| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to refresh GCP authorized user token from '{}': {}",
+                        self.token_uri(),
+                        err
+                    ),
+                })
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(NamespaceError::Internal {
+                message: format!(
+                    "GCP authorized user token request to '{}' failed with status {}: {}",
+                    self.token_uri(),
+                    status,
+                    body
+                ),
+            }
+            .into());
+        }
+
+        let token_response: OAuthAccessTokenResponse = response.json().await.map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!(
+                    "Failed to parse GCP authorized user token response: {}",
+                    err
+                ),
+            })
+        })?;
+
+        Ok(token_response.access_token)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ServiceAccountCredentials {
+    client_email: String,
+    private_key: String,
+    private_key_id: String,
+    #[serde(default)]
+    token_uri: Option<String>,
+}
+
+struct ServiceAccountKey(RsaKeyPair);
+
+impl std::fmt::Debug for ServiceAccountKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ServiceAccountKey([redacted])")
+    }
+}
+
+impl ServiceAccountKey {
+    fn from_pem(encoded: &[u8]) -> Result<Self> {
+        match PrivateKeyDer::from_pem_slice(encoded).map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Failed to parse GCP service account PEM key: {}", err),
+            })
+        })? {
+            PrivateKeyDer::Pkcs8(key) => Self::from_pkcs8(key.secret_pkcs8_der()),
+            PrivateKeyDer::Pkcs1(key) => Self::from_der(key.secret_pkcs1_der()),
+            _ => Err(NamespaceError::Internal {
+                message: "Unsupported GCP service account private key encoding".to_string(),
+            }
+            .into()),
+        }
+    }
+
+    fn from_pkcs8(key: &[u8]) -> Result<Self> {
+        Ok(Self(RsaKeyPair::from_pkcs8(key).map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Invalid PKCS#8 GCP service account key: {}", err),
+            })
+        })?))
+    }
+
+    fn from_der(key: &[u8]) -> Result<Self> {
+        Ok(Self(RsaKeyPair::from_der(key).map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Invalid RSA GCP service account key: {}", err),
+            })
+        })?))
+    }
+
+    fn sign(&self, message: &str) -> Result<String> {
+        let mut signature = vec![0; self.0.public().modulus_len()];
+        self.0
+            .sign(
+                &ring::signature::RSA_PKCS1_SHA256,
+                &ring::rand::SystemRandom::new(),
+                message.as_bytes(),
+                &mut signature,
+            )
+            .map_err(|err| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!("Failed to sign GCP service account JWT assertion: {}", err),
+                })
+            })?;
+        Ok(URL_SAFE_NO_PAD.encode(signature))
+    }
+}
+
+#[derive(Debug)]
+struct ServiceAccountAuth {
+    client_email: String,
+    private_key_id: String,
+    private_key: ServiceAccountKey,
+    token_uri: String,
+}
+
+impl ServiceAccountAuth {
+    fn from_credentials(credentials: ServiceAccountCredentials) -> Result<Self> {
+        Ok(Self {
+            client_email: credentials.client_email,
+            private_key_id: credentials.private_key_id,
+            private_key: ServiceAccountKey::from_pem(credentials.private_key.as_bytes())?,
+            token_uri: credentials
+                .token_uri
+                .unwrap_or_else(|| DEFAULT_GOOGLE_TOKEN_URI.to_string()),
+        })
+    }
+
+    fn build_jwt_assertion(&self) -> Result<String> {
+        let now = current_unix_epoch_seconds()?;
+        let claims = ServiceAccountClaims {
+            iss: &self.client_email,
+            scope: GOOGLE_CLOUD_PLATFORM_SCOPE,
+            aud: &self.token_uri,
+            iat: now,
+            exp: now + 3600,
+        };
+
+        let header = JwtHeader {
+            alg: "RS256",
+            typ: Some("JWT"),
+            kid: Some(&self.private_key_id),
+        };
+
+        let encoded_header = encode_json_to_base64(&header)?;
+        let encoded_claims = encode_json_to_base64(&claims)?;
+        let message = format!("{}.{}", encoded_header, encoded_claims);
+        let signature = self.private_key.sign(&message)?;
+
+        Ok(format!("{}.{}", message, signature))
+    }
+
+    async fn fetch_access_token(&self, http_client: &Client) -> Result<String> {
+        let assertion = self.build_jwt_assertion()?;
+        let response = http_client
+            .post(&self.token_uri)
+            .form(&[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+                ("assertion", assertion.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|err| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to exchange GCP service account JWT at '{}': {}",
+                        self.token_uri, err
+                    ),
+                })
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(NamespaceError::Internal {
+                message: format!(
+                    "GCP service account token request to '{}' failed with status {}: {}",
+                    self.token_uri, status, body
+                ),
+            }
+            .into());
+        }
+
+        let token_response: OAuthAccessTokenResponse = response.json().await.map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!(
+                    "Failed to parse GCP service account token response: {}",
+                    err
+                ),
+            })
+        })?;
+
+        Ok(token_response.access_token)
+    }
+}
+
+#[derive(Debug)]
+enum GcpAuthSource {
+    ServiceAccount(Box<ServiceAccountAuth>),
+    AuthorizedUser(AuthorizedUserCredentials),
+    MetadataServer,
+}
+
+impl GcpAuthSource {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::ServiceAccount(_) => "service_account",
+            Self::AuthorizedUser(_) => "authorized_user",
+            Self::MetadataServer => "metadata_server",
+        }
+    }
+
+    fn load() -> Result<Self> {
+        let adc_path = env::var("GOOGLE_APPLICATION_CREDENTIALS").ok();
+        if let Some(credentials) = ApplicationDefaultCredentials::read(adc_path.as_deref())? {
+            return match credentials {
+                ApplicationDefaultCredentials::ServiceAccount(credentials) => {
+                    Ok(Self::ServiceAccount(Box::new(
+                        ServiceAccountAuth::from_credentials(credentials)?,
+                    )))
+                }
+                ApplicationDefaultCredentials::AuthorizedUser(credentials) => {
+                    Ok(Self::AuthorizedUser(credentials))
+                }
+            };
+        }
+
+        Ok(Self::MetadataServer)
+    }
+
+    async fn fetch_access_token(&self, http_client: &Client) -> Result<String> {
+        match self {
+            Self::ServiceAccount(credentials) => credentials.fetch_access_token(http_client).await,
+            Self::AuthorizedUser(credentials) => credentials.fetch_access_token(http_client).await,
+            Self::MetadataServer => fetch_metadata_access_token(http_client).await,
+        }
+    }
+}
+
 /// GCP credential vendor that provides downscoped OAuth2 tokens.
 pub struct GcpCredentialVendor {
     config: GcpCredentialVendorConfig,
     http_client: Client,
-    credential: credentials::Credential,
+    auth_source: GcpAuthSource,
 }
 
 impl std::fmt::Debug for GcpCredentialVendor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GcpCredentialVendor")
             .field("config", &self.config)
-            .field("credential", &"[credential]")
+            .field("auth_source", &self.auth_source.name())
             .finish()
     }
 }
 
 impl GcpCredentialVendor {
     /// Create a new GCP credential vendor with the specified configuration.
-    ///
-    /// Uses [Application Default Credentials (ADC)][adc] for authentication.
-    /// To use a service account key file, set the `GOOGLE_APPLICATION_CREDENTIALS`
-    /// environment variable to the file path before starting the application.
-    ///
-    /// [adc]: https://cloud.google.com/docs/authentication/application-default-credentials
-    pub async fn new(config: GcpCredentialVendorConfig) -> Result<Self> {
-        let credential = credentials::create_access_token_credential()
-            .await
-            .map_err(|e| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to create GCP credentials: {}", e),
-                })
-            })?;
-
+    pub fn new(config: GcpCredentialVendorConfig) -> Result<Self> {
         Ok(Self {
             config,
             http_client: Client::new(),
-            credential,
+            auth_source: GcpAuthSource::load()?,
         })
     }
 
@@ -291,43 +558,34 @@ impl GcpCredentialVendor {
     }
 
     /// Get a source token for downscoping.
-    ///
-    /// If service_account is configured, impersonates that service account
-    /// using the IAM Credentials API. Otherwise, uses the configured credential
-    /// directly.
     async fn get_source_token(&self) -> Result<String> {
-        let base_token = self.credential.get_token().await.map_err(|e| {
-            lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to get GCP token: {}", e),
-            })
-        })?;
+        let base_token = self
+            .auth_source
+            .fetch_access_token(&self.http_client)
+            .await?;
 
-        // If service account impersonation is configured, use generateAccessToken API
         if let Some(ref service_account) = self.config.service_account {
             return self
-                .impersonate_service_account(&base_token.token, service_account)
+                .impersonate_service_account(&base_token, service_account)
                 .await;
         }
 
-        Ok(base_token.token)
+        Ok(base_token)
     }
 
     /// Impersonate a service account using the IAM Credentials API.
-    ///
-    /// Uses the base token to call generateAccessToken for the target service account.
     async fn impersonate_service_account(
         &self,
         base_token: &str,
         service_account: &str,
     ) -> Result<String> {
         let url = format!(
-            "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}:generateAccessToken",
-            service_account
+            "{}/{}:generateAccessToken",
+            IAM_GENERATE_ACCESS_TOKEN_URL, service_account
         );
 
-        // Request body with cloud-platform scope (required for GCS access)
         let body = serde_json::json!({
-            "scope": ["https://www.googleapis.com/auth/cloud-platform"]
+            "scope": [GOOGLE_CLOUD_PLATFORM_SCOPE]
         });
 
         let response = self
@@ -337,9 +595,9 @@ impl GcpCredentialVendor {
             .json(&body)
             .send()
             .await
-            .map_err(|e| {
+            .map_err(|err| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to call IAM generateAccessToken: {}", e),
+                    message: format!("Failed to call IAM generateAccessToken: {}", err),
                 })
             })?;
 
@@ -358,9 +616,9 @@ impl GcpCredentialVendor {
             .into());
         }
 
-        let token_response: GenerateAccessTokenResponse = response.json().await.map_err(|e| {
+        let token_response: GenerateAccessTokenResponse = response.json().await.map_err(|err| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to parse generateAccessToken response: {}", e),
+                message: format!("Failed to parse generateAccessToken response: {}", err),
             })
         })?;
 
@@ -377,17 +635,10 @@ impl GcpCredentialVendor {
 
         let mut rules = vec![];
 
-        // Build condition expression for path restriction
         let condition = if prefix.is_empty() {
             None
         } else {
             let prefix_trimmed = prefix.trim_end_matches('/');
-            // CEL expression to restrict access to the specific path prefix.
-            // We append '/' to ensure exact prefix matching - without it, prefix "data"
-            // would incorrectly match "data-other/file.txt".
-            //
-            // For object access: resource.name must start with "prefix/"
-            // For list operations: listPrefix must equal "prefix" OR start with "prefix/"
             let list_prefix_attr =
                 "api.getAttribute('storage.googleapis.com/objectListPrefix', '')";
             let expr = format!(
@@ -401,8 +652,6 @@ impl GcpCredentialVendor {
             Some(AvailabilityCondition { expression: expr })
         };
 
-        // Read permissions: legacyObjectReader for read + objectViewer for list
-        // Using legacy roles because modern roles lack storage.buckets.get
         rules.push(AccessBoundaryRule {
             available_resource: bucket_resource.clone(),
             available_permissions: vec![
@@ -412,7 +661,6 @@ impl GcpCredentialVendor {
             availability_condition: condition.clone(),
         });
 
-        // Write permission: legacyBucketWriter + objectCreator for create/update
         if permission.can_write() {
             rules.push(AccessBoundaryRule {
                 available_resource: bucket_resource.clone(),
@@ -424,7 +672,6 @@ impl GcpCredentialVendor {
             });
         }
 
-        // Admin permission: objectAdmin for delete
         if permission.can_delete() {
             rules.push(AccessBoundaryRule {
                 available_resource: bucket_resource,
@@ -446,9 +693,9 @@ impl GcpCredentialVendor {
         source_token: &str,
         access_boundary: &CredentialAccessBoundary,
     ) -> Result<(String, u64)> {
-        let options_json = serde_json::to_string(access_boundary).map_err(|e| {
+        let options_json = serde_json::to_string(access_boundary).map_err(|err| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to serialize access boundary: {}", e),
+                message: format!("Failed to serialize access boundary: {}", err),
             })
         })?;
 
@@ -475,9 +722,9 @@ impl GcpCredentialVendor {
             .form(&params)
             .send()
             .await
-            .map_err(|e| {
+            .map_err(|err| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to call STS token exchange: {}", e),
+                    message: format!("Failed to call STS token exchange: {}", err),
                 })
             })?;
 
@@ -493,20 +740,14 @@ impl GcpCredentialVendor {
             .into());
         }
 
-        let token_response: TokenExchangeResponse = response.json().await.map_err(|e| {
+        let token_response: TokenExchangeResponse = response.json().await.map_err(|err| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to parse STS response: {}", e),
+                message: format!("Failed to parse STS response: {}", err),
             })
         })?;
 
-        // Calculate expiration time
-        // Use expires_in from response if available, otherwise default to 1 hour
         let expires_in_secs = token_response.expires_in.unwrap_or(3600);
-        let expires_at_millis = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("time went backwards")
-            .as_millis() as u64
-            + expires_in_secs * 1000;
+        let expires_at_millis = current_unix_epoch_millis()? + expires_in_secs * 1000;
 
         Ok((token_response.access_token, expires_at_millis))
     }
@@ -519,57 +760,6 @@ impl GcpCredentialVendor {
         format!("{:x}", hasher.finalize())
     }
 
-    /// Extract a session name from a JWT token (best effort, no validation).
-    /// Decodes the payload and extracts 'sub' or 'email' claim.
-    /// Falls back to "lance-gcp-identity" if parsing fails.
-    fn derive_session_name_from_token(token: &str) -> String {
-        // JWT format: header.payload.signature
-        let parts: Vec<&str> = token.split('.').collect();
-        if parts.len() != 3 {
-            return "lance-gcp-identity".to_string();
-        }
-
-        // Decode the payload (second part)
-        let payload = match URL_SAFE_NO_PAD.decode(parts[1]) {
-            Ok(bytes) => bytes,
-            Err(_) => {
-                // Try standard base64 as fallback
-                match base64::engine::general_purpose::STANDARD_NO_PAD.decode(parts[1]) {
-                    Ok(bytes) => bytes,
-                    Err(_) => return "lance-gcp-identity".to_string(),
-                }
-            }
-        };
-
-        // Parse as JSON and extract 'sub' or 'email'
-        let json: serde_json::Value = match serde_json::from_slice(&payload) {
-            Ok(v) => v,
-            Err(_) => return "lance-gcp-identity".to_string(),
-        };
-
-        let subject = json
-            .get("sub")
-            .or_else(|| json.get("email"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("unknown");
-
-        // Sanitize: keep only alphanumeric, @, -, .
-        let sanitized: String = subject
-            .chars()
-            .filter(|c| c.is_alphanumeric() || *c == '@' || *c == '-' || *c == '.')
-            .collect();
-
-        format!("lance-{}", sanitized)
-    }
-
-    /// Normalize the Workload Identity Provider to the full audience format expected by GCP STS.
-    ///
-    /// GCP STS expects audience in the format:
-    /// `//iam.googleapis.com/projects/{project}/locations/global/workloadIdentityPools/{pool}/providers/{provider}`
-    ///
-    /// This function accepts either:
-    /// - Full format: `//iam.googleapis.com/projects/...`
-    /// - Short format: `projects/...` (will be prefixed with `//iam.googleapis.com/`)
     fn normalize_workload_identity_audience(provider: &str) -> String {
         const IAM_PREFIX: &str = "//iam.googleapis.com/";
         if provider.starts_with(IAM_PREFIX) {
@@ -580,11 +770,6 @@ impl GcpCredentialVendor {
     }
 
     /// Exchange an OIDC token for GCP access token using Workload Identity Federation.
-    ///
-    /// This requires:
-    /// 1. A Workload Identity Pool and Provider configured in GCP
-    /// 2. The OIDC token's issuer to match the provider's configuration
-    /// 3. Optionally, a service account to impersonate after token exchange
     async fn exchange_oidc_for_gcp_token(&self, oidc_token: &str) -> Result<String> {
         let workload_identity_provider = self
             .config
@@ -598,10 +783,8 @@ impl GcpCredentialVendor {
                 })
             })?;
 
-        // Normalize audience to full format expected by GCP STS
         let audience = Self::normalize_workload_identity_audience(workload_identity_provider);
 
-        // Exchange OIDC token for GCP federated token via STS
         let params = [
             (
                 "grant_type",
@@ -614,7 +797,7 @@ impl GcpCredentialVendor {
             ),
             ("subject_token", oidc_token),
             ("audience", audience.as_str()),
-            ("scope", "https://www.googleapis.com/auth/cloud-platform"),
+            ("scope", GOOGLE_CLOUD_PLATFORM_SCOPE),
         ];
 
         let response = self
@@ -623,9 +806,9 @@ impl GcpCredentialVendor {
             .form(&params)
             .send()
             .await
-            .map_err(|e| {
+            .map_err(|err| {
                 lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Failed to exchange OIDC token for GCP token: {}", e),
+                    message: format!("Failed to exchange OIDC token for GCP token: {}", err),
                 })
             })?;
 
@@ -641,15 +824,14 @@ impl GcpCredentialVendor {
             .into());
         }
 
-        let token_response: TokenExchangeResponse = response.json().await.map_err(|e| {
+        let token_response: TokenExchangeResponse = response.json().await.map_err(|err| {
             lance_core::Error::from(NamespaceError::Internal {
-                message: format!("Failed to parse GCP STS token response: {}", e),
+                message: format!("Failed to parse GCP STS token response: {}", err),
             })
         })?;
 
         let federated_token = token_response.access_token;
 
-        // If impersonation is configured, use the federated token to get an impersonated token
         if let Some(ref service_account) = self.config.impersonation_service_account {
             return self
                 .impersonate_service_account(&federated_token, service_account)
@@ -666,16 +848,13 @@ impl GcpCredentialVendor {
         prefix: &str,
         auth_token: &str,
     ) -> Result<VendedCredentials> {
-        let session_name = Self::derive_session_name_from_token(auth_token);
         debug!(
-            "GCP vend_with_web_identity: bucket={}, prefix={}, session={}",
-            bucket, prefix, session_name
+            "GCP vend_with_web_identity: bucket={}, prefix={}",
+            bucket, prefix
         );
 
-        // Exchange OIDC token for GCP token
         let gcp_token = self.exchange_oidc_for_gcp_token(auth_token).await?;
 
-        // Build access boundary and downscope
         let access_boundary = Self::build_access_boundary(bucket, prefix, self.config.permission);
         let (downscoped_token, expires_at_millis) =
             self.downscope_token(&gcp_token, &access_boundary).await?;
@@ -715,7 +894,6 @@ impl GcpCredentialVendor {
 
         let key_hash = Self::hash_api_key(api_key, salt);
 
-        // Look up permission from hash mapping
         let permission = self
             .config
             .api_key_hash_permissions
@@ -736,7 +914,6 @@ impl GcpCredentialVendor {
             bucket, prefix, permission
         );
 
-        // Get source token using ADC and downscope with the API key's permission
         let source_token = self.get_source_token().await?;
         let access_boundary = Self::build_access_boundary(bucket, prefix, permission);
         let (downscoped_token, expires_at_millis) = self
@@ -783,7 +960,6 @@ impl CredentialVendor for GcpCredentialVendor {
 
         let (bucket, prefix) = Self::parse_gcs_uri(table_location)?;
 
-        // Dispatch based on identity
         match identity {
             Some(id) if id.auth_token.is_some() => {
                 let auth_token = id.auth_token.as_ref().unwrap();
@@ -799,7 +975,6 @@ impl CredentialVendor for GcpCredentialVendor {
             }
             .into()),
             None => {
-                // Static credential vending using ADC
                 let source_token = self.get_source_token().await?;
                 let access_boundary =
                     Self::build_access_boundary(&bucket, &prefix, self.config.permission);
@@ -838,9 +1013,160 @@ impl CredentialVendor for GcpCredentialVendor {
     }
 }
 
+fn read_credentials_file<T>(path: impl AsRef<Path>) -> Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let path = path.as_ref().to_owned();
+    let file = File::open(&path).map_err(|err| {
+        lance_core::Error::from(NamespaceError::Internal {
+            message: format!(
+                "Failed to open GCP credentials file '{}': {}",
+                path.display(),
+                err
+            ),
+        })
+    })?;
+
+    serde_json::from_reader(BufReader::new(file)).map_err(|err| {
+        lance_core::Error::from(NamespaceError::Internal {
+            message: format!(
+                "Failed to deserialize GCP credentials file '{}': {}",
+                path.display(),
+                err
+            ),
+        })
+    })
+}
+
+fn encode_json_to_base64<T: Serialize>(value: &T) -> Result<String> {
+    let json = serde_json::to_vec(value).map_err(|err| {
+        lance_core::Error::from(NamespaceError::Internal {
+            message: format!("Failed to serialize GCP JWT payload: {}", err),
+        })
+    })?;
+    Ok(URL_SAFE_NO_PAD.encode(json))
+}
+
+fn current_unix_epoch_seconds() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("System clock is before Unix epoch: {}", err),
+            })
+        })?
+        .as_secs())
+}
+
+fn current_unix_epoch_millis() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("System clock is before Unix epoch: {}", err),
+            })
+        })?
+        .as_millis() as u64)
+}
+
+async fn fetch_metadata_access_token(http_client: &Client) -> Result<String> {
+    let metadata_host = env::var("GCE_METADATA_HOST")
+        .or_else(|_| env::var("GCE_METADATA_ROOT"))
+        .unwrap_or_else(|_| DEFAULT_METADATA_HOST.to_string());
+    let metadata_ip =
+        env::var("GCE_METADATA_IP").unwrap_or_else(|_| DEFAULT_METADATA_IP.to_string());
+
+    let host_error = match request_metadata_access_token(http_client, &metadata_host).await {
+        Ok(token) => return Ok(token),
+        Err(err) => err,
+    };
+
+    request_metadata_access_token(http_client, &metadata_ip)
+        .await
+        .map_err(|fallback_err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!(
+                    "Failed to fetch GCP metadata token from '{}' ({}) and fallback '{}' ({})",
+                    metadata_host, host_error, metadata_ip, fallback_err
+                ),
+            })
+        })
+}
+
+async fn request_metadata_access_token(http_client: &Client, hostname: &str) -> Result<String> {
+    let url = format!(
+        "http://{}/computeMetadata/v1/instance/service-accounts/default/token",
+        hostname
+    );
+    let response = http_client
+        .get(&url)
+        .header("Metadata-Flavor", "Google")
+        .timeout(METADATA_REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|err| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Failed to call GCP metadata server '{}': {}", url, err),
+            })
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(NamespaceError::Internal {
+            message: format!(
+                "GCP metadata server request to '{}' failed with status {}: {}",
+                url, status, body
+            ),
+        }
+        .into());
+    }
+
+    let token_response: MetadataAccessTokenResponse = response.json().await.map_err(|err| {
+        lance_core::Error::from(NamespaceError::Internal {
+            message: format!("Failed to parse GCP metadata token response: {}", err),
+        })
+    })?;
+
+    Ok(token_response.access_token)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const TEST_RSA_PRIVATE_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC/QbkYm6bSbdGm
+IEm5QbgQ52izdzcEpNq2cs0jIXpQ4rklGXThDrScB9krmcZy8prCcBtwQLp+zDfr
+z7iktQ6ZRHitgfRcUqMpd7S9wX30rPpSm6UGlg1+kl0+b90sixZqTI1T+OAfbeNF
+/aXO2gdNdKn2vPMOIelCQFEInHzozWYmx91jpwVtAvSENKDvOImicG7mtiazrGFc
+tbLuKhKGNdnE7RKF4qZRaZ0EX5lgbPDyajkJ/mOd7KI632k1+GbT16eWhegR2Crw
+D8JCNO7w5olk146/mM3EM2gts5jPpbiwEe6rElOSwEDayn9hNPmLStDmHEmmJFZc
+5o4hhnB5AgMBAAECggEADSGCh0V8fRsMF0dFOIJiFEsG/bdUIC3/VCJqohxUzQPb
+6UenpiH/1WyWhO9QWCj+5hWTVLAk/bqgpkCDMU+6+lvgmyz+bW5BBIJS9uo3bxqH
+Ly+/c0XPFF8RJs3AViQQfGjYFSlTneTKA06oWRzP/onhd26+kzxRyvomdhxkWQlO
+tU270fDKUoKi6UO+JPZ+jLRsPYBj3NKAC64avlHLmP8VpUMClS8T76RbiOJ8pVBc
+xeJSXCzu2pZrsZr3PJo8kGNQNzI4j9ryrZd0P5FkQz313cIerpR6CL0L8p3pFyrm
++i01yu4yS1vy0tydN+EwdXmH8MMp+Ku4/b45Jnf1/wKBgQDeILnFrC+n2GHBdnGB
+Rc93jYzIck7FBy7FMEQFIuDWlsAGAzCnUALdVApf1WL+BDoAj1dzR+vawoMr6ToF
+pZvbs0mqbba+2uNl01JgIjWl8ze7Z/a22JqlCaIoO2W4dkO/ocdLjxbsM1p/2V5O
+3MtLopE8yYblnsFDDbqyVcPSkwKBgQDca99RV3MGzFxjnpSIHBMofKrtxvOM9X66
+HmHlEnWz01Cx6bIvvnElQuGatJqaZ34B3kZG959ghGdQBue1kxDHLEgzdyEMBely
+KCPGfKSh2omPgSHK6zj0LH7VZqJwddSqVjmSARmEW4sRGKr4BUkk+z6wki4VjSL5
+SBqnYnDcQwKBgQCc3auT53d4Jx1SDJ03198d5L7JR8BM8DedVeqTXgA+SxOsq1AO
+uDhtqU3yQ7W3AbEceB4f8Wikgr0zo28wUbXxv3mEfBqUSexRGp2P+li8qzhuhor6
+sZj0eAsmMlwxmoNZr5wYxiJACDwfEZjCRLbk4ReEQCWdvzFocyenjV3PNQKBgQCP
+zGQlSdrF7Z68cuFNppstB5/vfaK4LBRf0aBl9FQLW+nCF8bidOiVuXs7FWXjI29G
+Qr8wXy1/pwFLaSXTBD2m4pG72ZUapeS1T9B/FiPFX6/sif8Exc4jJcAc8lc47PYv
+pg7q3ILMIXipT6GCKticIri0MrmT376YSFzzJDqixwKBgBgEX7SFpXe24DFfxRk7
+d1BFAgrF9sVOuALJ4Af40YJ/jGs8e6JEXpSJD+CzUIi5x5Tjb42mHBNsGtgJDGaS
+OdQGUgjzRG0WEXA7DLt8T3TyhC8ZQD/uMpSPjVKVjA5cOwYM82X7tqCMC3Yy7CxP
+4PgiEjqQXha6B8smzs0z0OVO
+-----END PRIVATE KEY-----"#;
 
     #[test]
     fn test_parse_gcs_uri() {
@@ -862,19 +1188,15 @@ mod tests {
 
     #[test]
     fn test_parse_gcs_uri_invalid() {
-        // Wrong scheme - should fail
         let result = GcpCredentialVendor::parse_gcs_uri("s3://bucket/path");
         assert!(result.is_err());
 
-        // Missing bucket
         let result = GcpCredentialVendor::parse_gcs_uri("gs:///path");
         assert!(result.is_err());
 
-        // Invalid URI format
         let result = GcpCredentialVendor::parse_gcs_uri("not-a-uri");
         assert!(result.is_err());
 
-        // Empty string
         let result = GcpCredentialVendor::parse_gcs_uri("");
         assert!(result.is_err());
     }
@@ -922,7 +1244,7 @@ mod tests {
 
         let permissions: Vec<_> = rules
             .iter()
-            .flat_map(|r| r.available_permissions.iter())
+            .flat_map(|rule| rule.available_permissions.iter())
             .collect();
         assert!(permissions.contains(&&"inRole:roles/storage.legacyObjectReader".to_string()));
         assert!(permissions.contains(&&"inRole:roles/storage.objectViewer".to_string()));
@@ -940,32 +1262,25 @@ mod tests {
 
         let rules = &boundary.access_boundary.access_boundary_rules;
         assert_eq!(rules.len(), 3, "Admin should have 3 rules");
-
-        let permissions: Vec<_> = rules
-            .iter()
-            .flat_map(|r| r.available_permissions.iter())
-            .collect();
-        assert!(permissions.contains(&&"inRole:roles/storage.legacyObjectReader".to_string()));
-        assert!(permissions.contains(&&"inRole:roles/storage.objectViewer".to_string()));
-        assert!(permissions.contains(&&"inRole:roles/storage.legacyBucketWriter".to_string()));
-        assert!(permissions.contains(&&"inRole:roles/storage.objectCreator".to_string()));
-        assert!(permissions.contains(&&"inRole:roles/storage.objectAdmin".to_string()));
+        assert_eq!(
+            rules[2].available_permissions,
+            vec!["inRole:roles/storage.objectAdmin".to_string()]
+        );
     }
 
     #[test]
     fn test_build_access_boundary_no_prefix() {
         let boundary =
             GcpCredentialVendor::build_access_boundary("my-bucket", "", VendedPermission::Read);
-
-        let rules = &boundary.access_boundary.access_boundary_rules;
-        assert_eq!(rules.len(), 1);
-        // No condition when prefix is empty (full bucket access)
-        assert!(rules[0].availability_condition.is_none());
+        assert!(
+            boundary.access_boundary.access_boundary_rules[0]
+                .availability_condition
+                .is_none()
+        );
     }
 
     #[test]
     fn test_normalize_workload_identity_audience() {
-        // Short format should be prefixed
         let short =
             "projects/123456/locations/global/workloadIdentityPools/my-pool/providers/my-provider";
         let normalized = GcpCredentialVendor::normalize_workload_identity_audience(short);
@@ -974,14 +1289,113 @@ mod tests {
             "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/my-pool/providers/my-provider"
         );
 
-        // Full format should be unchanged
         let full = "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/my-pool/providers/my-provider";
         let normalized = GcpCredentialVendor::normalize_workload_identity_audience(full);
         assert_eq!(normalized, full);
+    }
 
-        // Edge case: already has prefix (idempotent)
-        let normalized_again =
-            GcpCredentialVendor::normalize_workload_identity_audience(&normalized);
-        assert_eq!(normalized_again, full);
+    #[test]
+    fn test_application_default_credentials_read_from_explicit_path() {
+        let temp_dir = tempdir().unwrap();
+        let credentials_path = temp_dir.path().join("application_default_credentials.json");
+        std::fs::write(
+            &credentials_path,
+            r#"{
+                "type": "authorized_user",
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+                "refresh_token": "refresh-token"
+            }"#,
+        )
+        .unwrap();
+
+        let credentials =
+            ApplicationDefaultCredentials::read(Some(credentials_path.to_str().unwrap())).unwrap();
+        assert!(matches!(
+            credentials,
+            Some(ApplicationDefaultCredentials::AuthorizedUser(_))
+        ));
+    }
+
+    #[test]
+    fn test_service_account_build_jwt_assertion() {
+        let auth = ServiceAccountAuth::from_credentials(ServiceAccountCredentials {
+            client_email: "svc@example.iam.gserviceaccount.com".to_string(),
+            private_key: TEST_RSA_PRIVATE_KEY.to_string(),
+            private_key_id: "key-id-123".to_string(),
+            token_uri: Some("https://oauth2.googleapis.com/token".to_string()),
+        })
+        .unwrap();
+
+        let assertion = auth.build_jwt_assertion().unwrap();
+        let parts: Vec<&str> = assertion.split('.').collect();
+        assert_eq!(parts.len(), 3);
+
+        let header = String::from_utf8(URL_SAFE_NO_PAD.decode(parts[0]).unwrap()).unwrap();
+        assert!(header.contains("\"alg\":\"RS256\""));
+        assert!(header.contains("\"kid\":\"key-id-123\""));
+
+        let claims = String::from_utf8(URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+        assert!(claims.contains("\"iss\":\"svc@example.iam.gserviceaccount.com\""));
+        assert!(claims.contains(&format!("\"aud\":\"{}\"", DEFAULT_GOOGLE_TOKEN_URI)));
+        assert!(claims.contains("\"scope\":\"https://www.googleapis.com/auth/cloud-platform\""));
+    }
+
+    #[tokio::test]
+    async fn test_authorized_user_fetch_access_token_uses_reqwest_form_flow() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("grant_type=refresh_token"))
+            .and(body_string_contains("client_id=client-id"))
+            .and(body_string_contains("client_secret=client-secret"))
+            .and(body_string_contains("refresh_token=refresh-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "ya29.authorized-user-token",
+                "expires_in": 3600
+            })))
+            .mount(&server)
+            .await;
+
+        let credentials = AuthorizedUserCredentials {
+            client_id: "client-id".to_string(),
+            client_secret: "client-secret".to_string(),
+            refresh_token: "refresh-token".to_string(),
+            token_uri: Some(format!("{}/token", server.uri())),
+        };
+
+        let token = credentials
+            .fetch_access_token(&Client::new())
+            .await
+            .unwrap();
+        assert_eq!(token, "ya29.authorized-user-token");
+    }
+
+    #[tokio::test]
+    async fn test_service_account_fetch_access_token_uses_jwt_bearer_flow() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains(
+                "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer",
+            ))
+            .and(body_string_contains("assertion="))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "ya29.service-account-token",
+                "expires_in": 3600
+            })))
+            .mount(&server)
+            .await;
+
+        let auth = ServiceAccountAuth::from_credentials(ServiceAccountCredentials {
+            client_email: "svc@example.iam.gserviceaccount.com".to_string(),
+            private_key: TEST_RSA_PRIVATE_KEY.to_string(),
+            private_key_id: "key-id-123".to_string(),
+            token_uri: Some(format!("{}/token", server.uri())),
+        })
+        .unwrap();
+
+        let token = auth.fetch_access_token(&Client::new()).await.unwrap();
+        assert_eq!(token, "ya29.service-account-token");
     }
 }

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -364,6 +364,8 @@ impl DirectoryNamespaceBuilder {
     ///
     /// GCP-specific properties (for gs:// locations):
     /// - `credential_vendor.gcp_service_account`: Service account to impersonate (optional)
+    /// - `credential_vendor.gcp_workload_identity_provider`: Workload Identity Provider for OIDC token exchange (optional)
+    /// - `credential_vendor.gcp_impersonation_service_account`: Service account to impersonate after workload identity exchange (optional)
     ///
     /// Note: GCP uses Application Default Credentials (ADC). To use a service account key file,
     /// set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable before starting.
@@ -372,6 +374,7 @@ impl DirectoryNamespaceBuilder {
     /// Azure-specific properties (for az:// locations):
     /// - `credential_vendor.azure_account_name`: Azure storage account name (required for Azure)
     /// - `credential_vendor.azure_tenant_id`: Azure tenant ID (optional)
+    /// - `credential_vendor.azure_federated_client_id`: Client ID used for workload identity federation (optional)
     /// - `credential_vendor.azure_duration_millis`: Credential duration in ms (default: 3600000, up to 7 days)
     ///
     /// # Arguments
@@ -569,8 +572,8 @@ impl DirectoryNamespaceBuilder {
     /// Use short property names without the `credential_vendor.` prefix.
     /// Common properties: `enabled`, `permission`.
     /// AWS properties: `aws_role_arn`, `aws_external_id`, `aws_region`, `aws_role_session_name`, `aws_duration_millis`.
-    /// GCP properties: `gcp_service_account`.
-    /// Azure properties: `azure_account_name`, `azure_tenant_id`, `azure_duration_millis`.
+    /// GCP properties: `gcp_service_account`, `gcp_workload_identity_provider`, `gcp_impersonation_service_account`.
+    /// Azure properties: `azure_account_name`, `azure_tenant_id`, `azure_federated_client_id`, `azure_duration_millis`.
     ///
     /// # Arguments
     ///

--- a/rust/lance-namespace-impls/src/lib.rs
+++ b/rust/lance-namespace-impls/src/lib.rs
@@ -46,10 +46,13 @@
 //! # Note: GCP uses ADC; set GOOGLE_APPLICATION_CREDENTIALS env var for service account key
 //! # Note: GCP token duration cannot be configured; it's determined by the STS endpoint
 //! credential_vendor.gcp_service_account = "my-sa@project.iam.gserviceaccount.com"
+//! credential_vendor.gcp_workload_identity_provider = "projects/123456/locations/global/workloadIdentityPools/pool/providers/provider"
+//! credential_vendor.gcp_impersonation_service_account = "my-sa@project.iam.gserviceaccount.com"
 //!
 //! # Azure-specific properties (for az:// locations)
 //! credential_vendor.azure_account_name = "mystorageaccount"  # required for Azure
 //! credential_vendor.azure_tenant_id = "my-tenant-id"
+//! credential_vendor.azure_federated_client_id = "my-app-client-id"
 //! credential_vendor.azure_duration_millis = "3600000"  # 1 hour (default, up to 7 days)
 //! ```
 //!


### PR DESCRIPTION
## Summary

- Replace Azure SDK crates (`azure_core`, `azure_identity`, `azure_storage`, `azure_storage_blobs`, `time`) and `google-cloud-auth` with direct HTTP calls via `reqwest`
- Add `hmac` and `quick-xml` for Azure SAS signing and XML parsing (both already transitive deps, zero compile cost)
- Add `ring` and `rustls-pki-types` for GCP service account JWT signing (both already transitive deps)
- Add Workload Identity Federation (OIDC) support for both Azure and GCP credential vending
- Reduce Cargo.lock by ~500 lines of removed transitive dependencies