### PR TITLE
refactor!: add NamespaceClientTableContext for cached namespace info

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -19,7 +19,6 @@ use arrow::ffi::FFI_ArrowSchema;
 use arrow::ffi_stream::ArrowArrayStreamReader;
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use arrow::ipc::writer::StreamWriter;
-use arrow::record_batch::RecordBatchIterator;
 use arrow_schema::DataType;
 use arrow_schema::Schema as ArrowSchema;
 use chrono::{DateTime, Utc};
@@ -38,7 +37,6 @@ use lance::dataset::{
     Version, WriteParams,
 };
 use lance::index::DatasetIndexExt;
-use lance::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use lance::io::{ObjectStore, ObjectStoreParams};
 use lance::session::Session as LanceSession;
 use lance::table::format::IndexMetadata;
@@ -51,13 +49,12 @@ use lance_index::progress::noop_progress;
 use lance_index::scalar::btree::BTreeParameters;
 use lance_index::{IndexParams, IndexType};
 use lance_io::object_store::ObjectStoreRegistry;
-use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOptionsProvider};
 use lance_namespace::LanceNamespace;
 use lance_table::io::commit::CommitHandler;
-use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 use std::collections::HashMap;
 use std::future::IntoFuture;
 use std::iter::empty;
+
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
@@ -138,34 +135,24 @@ impl BlockingDataset {
 
     #[allow(clippy::too_many_arguments)]
     pub fn open(
-        uri: &str,
+        uri: Option<&str>,
         version: Option<u64>,
         block_size: Option<i32>,
         index_cache_size_bytes: i64,
         metadata_cache_size_bytes: i64,
         storage_options: HashMap<String, String>,
         serialized_manifest: Option<&[u8]>,
-        storage_options_provider: Option<Arc<dyn StorageOptionsProvider>>,
         session: Option<Arc<LanceSession>>,
         namespace: Option<Arc<dyn LanceNamespace>>,
         table_id: Option<Vec<String>>,
-        namespace_client_managed_versioning: bool,
+        namespace_client_table_context: Option<lance_namespace::NamespaceClientTableContext>,
     ) -> Result<Self> {
-        // Create storage options accessor from storage_options and provider
-        let accessor = match (storage_options.is_empty(), storage_options_provider) {
-            (false, Some(provider)) => Some(Arc::new(
-                lance::io::StorageOptionsAccessor::with_initial_and_provider(
-                    storage_options,
-                    provider,
-                ),
-            )),
-            (false, None) => Some(Arc::new(
+        let accessor = if !storage_options.is_empty() {
+            Some(Arc::new(
                 lance::io::StorageOptionsAccessor::with_static_options(storage_options),
-            )),
-            (true, Some(provider)) => Some(Arc::new(
-                lance::io::StorageOptionsAccessor::with_provider(provider),
-            )),
-            (true, None) => None,
+            ))
+        } else {
+            None
         };
 
         let store_params = ObjectStoreParams {
@@ -181,7 +168,28 @@ impl BlockingDataset {
             ..Default::default()
         };
 
-        let mut builder = DatasetBuilder::from_uri(uri).with_read_params(params);
+        let mut builder = if let (Some(namespace_client), Some(tid)) = (namespace, table_id) {
+            let b = if let Some(namespace_client_table_context) =
+                namespace_client_table_context.clone()
+            {
+                DatasetBuilder::for_namespace(namespace_client, tid)
+                    .with_namespace_client_table_context(namespace_client_table_context)
+            } else {
+                RT.block_on(DatasetBuilder::from_namespace_with_version(
+                    namespace_client,
+                    tid,
+                    version,
+                ))?
+            };
+            b.with_read_params(params)
+        } else {
+            let uri = uri.ok_or_else(|| {
+                Error::input_error(
+                    "uri is required when namespace_client is not provided".to_string(),
+                )
+            })?;
+            DatasetBuilder::from_uri(uri).with_read_params(params)
+        };
 
         if let Some(ver) = version {
             builder = builder.with_version(ver);
@@ -189,17 +197,6 @@ impl BlockingDataset {
 
         if let Some(serialized_manifest) = serialized_manifest {
             builder = builder.with_serialized_manifest(serialized_manifest)?;
-        }
-
-        // Set up namespace commit handler only if namespace manages versioning
-        if namespace_client_managed_versioning
-            && let (Some(namespace_client), Some(tid)) = (namespace, table_id)
-        {
-            let external_store = LanceNamespaceExternalManifestStore::new(namespace_client, tid);
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            builder = builder.with_commit_handler(commit_handler);
         }
 
         let inner = RT.block_on(builder.load())?;
@@ -349,6 +346,8 @@ impl BlockingDataset {
         max_retries: u32,
         skip_auto_cleanup: bool,
         commit_handler: Option<Arc<dyn CommitHandler>>,
+        namespace_info: Option<(Arc<dyn LanceNamespace>, Vec<String>)>,
+        namespace_client_table_context: Option<lance_namespace::NamespaceClientTableContext>,
     ) -> Result<Self> {
         let mut builder = CommitBuilder::new(Arc::new(self.clone().inner))
             .with_store_params(store_params)
@@ -368,6 +367,10 @@ impl BlockingDataset {
         }
         if let Some(handler) = commit_handler {
             builder = builder.with_commit_handler(handler);
+        }
+        if let Some((namespace_client, table_id)) = namespace_info {
+            builder =
+                builder.with_namespace(namespace_client, table_id, namespace_client_table_context);
         }
         let new_dataset = RT.block_on(builder.execute(transaction))?;
         Ok(BlockingDataset { inner: new_dataset })
@@ -394,6 +397,20 @@ impl BlockingDataset {
     pub fn close(&self) {}
 }
 
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_drop<'local>(
+    mut env: JNIEnv<'local>,
+    _obj: JObject,
+    path: JString<'local>,
+    storage_options_obj: JObject<'local>,
+) -> JObject<'local> {
+    let path_str = ok_or_throw!(env, path.extract(&mut env));
+    let storage_options =
+        ok_or_throw!(env, extract_storage_options(&mut env, &storage_options_obj));
+    ok_or_throw!(env, BlockingDataset::drop(&path_str, storage_options));
+    JObject::null()
+}
+
 ///////////////////
 // Write Methods //
 ///////////////////
@@ -403,18 +420,18 @@ pub extern "system" fn Java_org_lance_Dataset_createWithFfiSchema<'local>(
     _obj: JObject,
     arrow_schema_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_stable_row_ids: JObject,    // Optional<Boolean>
-    data_storage_version: JObject,     // Optional<String>
-    enable_v2_manifest_paths: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,
+    max_rows_per_group: JObject,
+    max_bytes_per_file: JObject,
+    mode: JObject,
+    enable_stable_row_ids: JObject,
+    data_storage_version: JObject,
+    enable_v2_manifest_paths: JObject,
+    storage_options_obj: JObject,
     initial_bases: JObject,
     target_bases: JObject,
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    allow_external_blob_outside_bases: JObject,
+    blob_pack_file_size_threshold: JObject,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -443,24 +460,24 @@ fn inner_create_with_ffi_schema<'local>(
     env: &mut JNIEnv<'local>,
     arrow_schema_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_stable_row_ids: JObject,    // Optional<Boolean>
-    data_storage_version: JObject,     // Optional<String>
-    enable_v2_manifest_paths: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,
+    max_rows_per_group: JObject,
+    max_bytes_per_file: JObject,
+    mode: JObject,
+    enable_stable_row_ids: JObject,
+    data_storage_version: JObject,
+    enable_v2_manifest_paths: JObject,
+    storage_options_obj: JObject,
     initial_bases: JObject,
     target_bases: JObject,
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    allow_external_blob_outside_bases: JObject,
+    blob_pack_file_size_threshold: JObject,
 ) -> Result<JObject<'local>> {
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
     let c_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema_ptr) };
-    let schema = Schema::try_from(&c_schema)?;
+    let schema = ArrowSchema::try_from(&c_schema)?;
 
-    let reader = RecordBatchIterator::new(empty(), Arc::new(schema));
+    let reader = arrow::record_batch::RecordBatchIterator::new(empty(), Arc::new(schema));
     create_dataset(
         env,
         path,
@@ -477,23 +494,9 @@ fn inner_create_with_ffi_schema<'local>(
         allow_external_blob_outside_bases,
         blob_pack_file_size_threshold,
         reader,
-        None,  // No namespace for schema-only creation
-        false, // No managed versioning for schema-only creation
+        None,
+        None,
     )
-}
-
-#[unsafe(no_mangle)]
-pub extern "system" fn Java_org_lance_Dataset_drop<'local>(
-    mut env: JNIEnv<'local>,
-    _obj: JObject,
-    path: JString<'local>,
-    storage_options_obj: JObject<'local>,
-) -> JObject<'local> {
-    let path_str = ok_or_throw!(env, path.extract(&mut env));
-    let storage_options =
-        ok_or_throw!(env, extract_storage_options(&mut env, &storage_options_obj));
-    ok_or_throw!(env, BlockingDataset::drop(&path_str, storage_options));
-    JObject::null()
 }
 
 #[unsafe(no_mangle)]
@@ -521,21 +524,21 @@ pub extern "system" fn Java_org_lance_Dataset_createWithFfiStream<'local>(
     _obj: JObject,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,                    // Optional<Integer>
-    max_rows_per_group: JObject,                   // Optional<Integer>
-    max_bytes_per_file: JObject,                   // Optional<Long>
-    mode: JObject,                                 // Optional<String>
-    enable_stable_row_ids: JObject,                // Optional<Boolean>
-    data_storage_version: JObject,                 // Optional<String>
-    enable_v2_manifest_paths: JObject,             // Optional<Boolean>
-    storage_options_obj: JObject,                  // Map<String, String>
-    initial_bases: JObject,                        // Optional<List<BasePath>>
-    target_bases: JObject,                         // Optional<List<String>>
-    allow_external_blob_outside_bases: JObject,    // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,        // Optional<Long>
-    namespace_obj: JObject,                        // LanceNamespace (can be null)
-    table_id_obj: JObject,                         // List<String> (can be null)
-    namespace_client_managed_versioning: jboolean, // Whether namespace manages versioning
+    max_rows_per_file: JObject,                  // Optional<Integer>
+    max_rows_per_group: JObject,                 // Optional<Integer>
+    max_bytes_per_file: JObject,                 // Optional<Long>
+    mode: JObject,                               // Optional<String>
+    enable_stable_row_ids: JObject,              // Optional<Boolean>
+    data_storage_version: JObject,               // Optional<String>
+    enable_v2_manifest_paths: JObject,           // Optional<Boolean>
+    storage_options_obj: JObject,                // Map<String, String>
+    initial_bases: JObject,                      // Optional<List<BasePath>>
+    target_bases: JObject,                       // Optional<List<String>>
+    allow_external_blob_outside_bases: JObject,  // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,      // Optional<Long>
+    namespace_obj: JObject,                      // LanceNamespace (can be null)
+    table_id_obj: JObject,                       // List<String> (can be null)
+    namespace_client_table_context_obj: JObject, // NamespaceClientTableContext (can be null)
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -557,7 +560,7 @@ pub extern "system" fn Java_org_lance_Dataset_createWithFfiStream<'local>(
             blob_pack_file_size_threshold,
             namespace_obj,
             table_id_obj,
-            namespace_client_managed_versioning != 0,
+            namespace_client_table_context_obj,
         )
     )
 }
@@ -567,27 +570,28 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,                 // Optional<Integer>
-    max_rows_per_group: JObject,                // Optional<Integer>
-    max_bytes_per_file: JObject,                // Optional<Long>
-    mode: JObject,                              // Optional<String>
-    enable_stable_row_ids: JObject,             // Optional<Boolean>
-    data_storage_version: JObject,              // Optional<String>
-    enable_v2_manifest_paths: JObject,          // Optional<Boolean>
-    storage_options_obj: JObject,               // Map<String, String>
-    initial_bases: JObject,                     // Optional<List<BasePath>>
-    target_bases: JObject,                      // Optional<List<String>>
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
-    namespace_obj: JObject,                     // LanceNamespace (can be null)
-    table_id_obj: JObject,                      // List<String> (can be null)
-    namespace_client_managed_versioning: bool,  // Whether namespace manages versioning
+    max_rows_per_file: JObject,
+    max_rows_per_group: JObject,
+    max_bytes_per_file: JObject,
+    mode: JObject,
+    enable_stable_row_ids: JObject,
+    data_storage_version: JObject,
+    enable_v2_manifest_paths: JObject,
+    storage_options_obj: JObject,
+    initial_bases: JObject,
+    target_bases: JObject,
+    allow_external_blob_outside_bases: JObject,
+    blob_pack_file_size_threshold: JObject,
+    namespace_obj: JObject,
+    table_id_obj: JObject,
+    namespace_client_table_context_obj: JObject,
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
 
-    // Create the namespace wrapper for commit handling (if provided)
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
 
     create_dataset(
         env,
@@ -606,15 +610,14 @@ fn inner_create_with_ffi_stream<'local>(
         blob_pack_file_size_threshold,
         reader,
         namespace_info,
-        namespace_client_managed_versioning,
+        namespace_client_table_context,
     )
 }
 
 /// Creates a dataset from a record batch reader.
 ///
-/// When `namespace_info` is provided, sets up the storage options provider for
-/// credential refresh. When `namespace_client_managed_versioning` is true, also sets up the
-/// commit handler for namespace-managed versioning.
+/// When `namespace_info` is provided, uses `write_into_namespace` which handles
+/// storage options provider and commit handler setup internally.
 #[allow(clippy::too_many_arguments)]
 fn create_dataset<'local>(
     env: &mut JNIEnv<'local>,
@@ -633,11 +636,9 @@ fn create_dataset<'local>(
     blob_pack_file_size_threshold: JObject,
     reader: impl RecordBatchReader + Send + 'static,
     namespace_info: Option<(Arc<dyn LanceNamespace>, Vec<String>)>,
-    namespace_client_managed_versioning: bool,
+    namespace_client_table_context: Option<lance_namespace::NamespaceClientTableContext>,
 ) -> Result<JObject<'local>> {
-    let path_str = path.extract(env)?;
-
-    let mut write_params = extract_write_params(
+    let write_params = extract_write_params(
         env,
         &max_rows_per_file,
         &max_rows_per_group,
@@ -653,44 +654,19 @@ fn create_dataset<'local>(
         &blob_pack_file_size_threshold,
     )?;
 
-    // Set up namespace commit handler and storage options provider if namespace is provided
-    if let Some((namespace, table_id)) = namespace_info {
-        // Set up commit handler only if namespace manages versioning
-        if namespace_client_managed_versioning {
-            let external_store =
-                LanceNamespaceExternalManifestStore::new(namespace.clone(), table_id.clone());
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            write_params.commit_handler = Some(commit_handler);
-        }
-
-        // Set up storage options provider for credential refresh
-        let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
-            LanceNamespaceStorageOptionsProvider::new(namespace, table_id),
-        );
-
-        // Get existing storage options to combine with provider
-        let storage_options: HashMap<String, String> =
-            extract_storage_options(env, &storage_options_obj)?;
-
-        let accessor = if storage_options.is_empty() {
-            Arc::new(lance::io::StorageOptionsAccessor::with_provider(provider))
-        } else {
-            Arc::new(
-                lance::io::StorageOptionsAccessor::with_initial_and_provider(
-                    storage_options,
-                    provider,
-                ),
-            )
-        };
-        write_params.store_params = Some(ObjectStoreParams {
-            storage_options_accessor: Some(accessor),
-            ..Default::default()
-        });
-    }
-
-    let dataset = BlockingDataset::write(reader, &path_str, Some(write_params))?;
+    let dataset = if let Some((namespace_client, table_id)) = namespace_info {
+        let inner = RT.block_on(Dataset::write_into_namespace(
+            reader,
+            namespace_client,
+            table_id,
+            namespace_client_table_context.as_ref(),
+            Some(write_params),
+        ))?;
+        BlockingDataset { inner }
+    } else {
+        let path_str = path.extract(env)?;
+        BlockingDataset::write(reader, &path_str, Some(write_params))?
+    };
     dataset.into_java(env)
 }
 
@@ -1220,12 +1196,12 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
     block_size_obj: JObject, // Optional<Integer>
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
-    storage_options_obj: JObject,                  // Map<String, String>
-    serialized_manifest: JObject,                  // Optional<ByteBuffer>
-    session_handle: jlong,                         // Session handle, 0 means no session
-    namespace_obj: JObject,                        // LanceNamespace object, null if no namespace
-    table_id_obj: JObject,                         // List<String>, null if no namespace
-    namespace_client_managed_versioning: jboolean, // Whether namespace manages versioning
+    storage_options_obj: JObject,                // Map<String, String>
+    serialized_manifest: JObject,                // Optional<ByteBuffer>
+    session_handle: jlong,                       // Session handle, 0 means no session
+    namespace_obj: JObject,                      // LanceNamespace object, null if no namespace
+    table_id_obj: JObject,                       // List<String>, null if no namespace
+    namespace_client_table_context_obj: JObject, // NamespaceClientTableContext (can be null)
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -1241,7 +1217,7 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
             session_handle,
             namespace_obj,
             table_id_obj,
-            namespace_client_managed_versioning != 0,
+            namespace_client_table_context_obj,
         )
     )
 }
@@ -1250,57 +1226,51 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
 fn inner_open_native<'local>(
     env: &mut JNIEnv<'local>,
     path: JString,
-    version_obj: JObject,    // Optional<Long>
-    block_size_obj: JObject, // Optional<Integer>
+    version_obj: JObject,
+    block_size_obj: JObject,
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
-    storage_options_obj: JObject,              // Map<String, String>
-    serialized_manifest: JObject,              // Optional<ByteBuffer>
-    session_handle: jlong,                     // Session handle, 0 means no session
-    namespace_obj: JObject,                    // LanceNamespace object, null if no namespace
-    table_id_obj: JObject,                     // List<String>, null if no namespace
-    namespace_client_managed_versioning: bool, // Whether namespace manages versioning
+    storage_options_obj: JObject,
+    serialized_manifest: JObject,
+    session_handle: jlong,
+    namespace_obj: JObject,
+    table_id_obj: JObject,
+    namespace_client_table_context_obj: JObject,
 ) -> Result<JObject<'local>> {
-    let path_str: String = path.extract(env)?;
+    let path_str: Option<String> = if path.is_null() {
+        None
+    } else {
+        Some(path.extract(env)?)
+    };
     let version = env.get_u64_opt(&version_obj)?;
     let block_size = env.get_int_opt(&block_size_obj)?;
     let jmap = JMap::from_env(env, &storage_options_obj)?;
     let storage_options = to_rust_map(env, &jmap)?;
 
-    // Extract namespace and table_id if provided (before get_bytes_opt which holds borrow)
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
     let (namespace, table_id) = match namespace_info {
         Some((ns, tid)) => (Some(ns), Some(tid)),
         None => (None, None),
     };
 
-    // When namespace is provided, automatically create a storage options provider
-    // for credential refresh
-    let storage_options_provider_arc: Option<Arc<dyn StorageOptionsProvider>> =
-        if let (Some(ns), Some(tid)) = (namespace.clone(), table_id.clone()) {
-            Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(ns, tid)))
-        } else {
-            None
-        };
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
 
     let serialized_manifest = env.get_bytes_opt(&serialized_manifest)?;
-
-    // Convert session handle to Arc<LanceSession> if provided
     let session = session_from_handle(session_handle);
 
     let dataset = BlockingDataset::open(
-        &path_str,
+        path_str.as_deref(),
         version,
         block_size,
         index_cache_size_bytes,
         metadata_cache_size_bytes,
         storage_options,
         serialized_manifest,
-        storage_options_provider_arc,
         session,
         namespace,
         table_id,
-        namespace_client_managed_versioning,
+        namespace_client_table_context,
     )?;
     dataset.into_java(env)
 }
@@ -1362,6 +1332,48 @@ pub(crate) fn extract_namespace_info(
 
     let table_id = env.get_strings(table_id_obj)?;
     Ok(Some((namespace_client, table_id)))
+}
+
+/// Extract a [`NamespaceClientTableContext`] from a Java
+/// `org.lance.NamespaceClientTableContext` object.
+///
+/// Returns `None` if the object is null.
+pub(crate) fn extract_namespace_client_table_context(
+    env: &mut JNIEnv,
+    ctx_obj: &JObject,
+) -> Result<Option<lance_namespace::NamespaceClientTableContext>> {
+    if ctx_obj.is_null() {
+        return Ok(None);
+    }
+    let location: String = env
+        .call_method(ctx_obj, "getLocation", "()Ljava/lang/String;", &[])?
+        .l()
+        .and_then(|obj| env.get_string(&JString::from(obj)).map(|s| s.into()))
+        .map_err(|e| Error::runtime_error(e.to_string()))?;
+
+    let managed_versioning: bool = env
+        .call_method(ctx_obj, "isManagedVersioning", "()Z", &[])?
+        .z()
+        .map_err(|e| Error::runtime_error(e.to_string()))?;
+
+    let storage_opts_obj = env
+        .call_method(ctx_obj, "getStorageOptions", "()Ljava/util/Map;", &[])?
+        .l()
+        .map_err(|e| Error::runtime_error(e.to_string()))?;
+
+    let storage_options = if storage_opts_obj.is_null() {
+        None
+    } else {
+        let jmap = JMap::from_env(env, &storage_opts_obj)?;
+        let map: HashMap<String, String> = to_rust_map(env, &jmap)?;
+        if map.is_empty() { None } else { Some(map) }
+    };
+
+    Ok(Some(lance_namespace::NamespaceClientTableContext {
+        location,
+        storage_options,
+        managed_versioning,
+    }))
 }
 
 #[unsafe(no_mangle)]

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -169,15 +169,12 @@ impl BlockingDataset {
         };
 
         let mut builder = if let (Some(namespace_client), Some(tid)) = (namespace, table_id) {
-            let b = if let Some(namespace_client_table_context) =
-                namespace_client_table_context.clone()
-            {
-                DatasetBuilder::for_namespace(namespace_client, tid)
-                    .with_namespace_client_table_context(namespace_client_table_context)
-            } else {
-                RT.block_on(DatasetBuilder::from_namespace(namespace_client, tid))?
-            };
-            b.with_read_params(params)
+            RT.block_on(DatasetBuilder::from_namespace(
+                namespace_client,
+                tid,
+                namespace_client_table_context,
+            ))?
+            .with_read_params(params)
         } else {
             let uri = uri.ok_or_else(|| {
                 Error::input_error(

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -175,11 +175,7 @@ impl BlockingDataset {
                 DatasetBuilder::for_namespace(namespace_client, tid)
                     .with_namespace_client_table_context(namespace_client_table_context)
             } else {
-                RT.block_on(DatasetBuilder::from_namespace_with_version(
-                    namespace_client,
-                    tid,
-                    version,
-                ))?
+                RT.block_on(DatasetBuilder::from_namespace(namespace_client, tid))?
             };
             b.with_read_params(params)
         } else {

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -23,11 +23,10 @@ use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOption
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::blocking_dataset::extract_namespace_info;
+use crate::blocking_dataset::{extract_namespace_client_table_context, extract_namespace_info};
 use crate::error::{Error, Result};
 use crate::ffi::JNIEnvExt;
 use crate::traits::{FromJObjectWithEnv, IntoJava, JLance, export_vec, import_vec};
-use crate::utils::extract_storage_options;
 use crate::{
     RT,
     blocking_dataset::{BlockingDataset, NATIVE_DATASET},
@@ -89,17 +88,18 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiArray<'local>(
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    max_rows_per_file: JObject,                 // Optional<Integer>
-    max_rows_per_group: JObject,                // Optional<Integer>
-    max_bytes_per_file: JObject,                // Optional<Long>
-    mode: JObject,                              // Optional<String>
-    enable_stable_row_ids: JObject,             // Optional<Boolean>
-    data_storage_version: JObject,              // Optional<String>
-    storage_options_obj: JObject,               // Map<String, String>
-    namespace_obj: JObject,                     // LanceNamespace (can be null)
-    table_id_obj: JObject,                      // List<String> (can be null)
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    max_rows_per_file: JObject,                  // Optional<Integer>
+    max_rows_per_group: JObject,                 // Optional<Integer>
+    max_bytes_per_file: JObject,                 // Optional<Long>
+    mode: JObject,                               // Optional<String>
+    enable_stable_row_ids: JObject,              // Optional<Boolean>
+    data_storage_version: JObject,               // Optional<String>
+    storage_options_obj: JObject,                // Map<String, String>
+    namespace_obj: JObject,                      // LanceNamespace (can be null)
+    table_id_obj: JObject,                       // List<String> (can be null)
+    namespace_client_table_context_obj: JObject, // NamespaceClientTableContext (can be null)
+    allow_external_blob_outside_bases: JObject,  // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,      // Optional<Long>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -117,6 +117,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiArray<'local>(
             storage_options_obj,
             namespace_obj,
             table_id_obj,
+            namespace_client_table_context_obj,
             allow_external_blob_outside_bases,
             blob_pack_file_size_threshold,
         ),
@@ -130,17 +131,18 @@ fn inner_create_with_ffi_array<'local>(
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    max_rows_per_file: JObject,                 // Optional<Integer>
-    max_rows_per_group: JObject,                // Optional<Integer>
-    max_bytes_per_file: JObject,                // Optional<Long>
-    mode: JObject,                              // Optional<String>
-    enable_stable_row_ids: JObject,             // Optional<Boolean>
-    data_storage_version: JObject,              // Optional<String>
-    storage_options_obj: JObject,               // Map<String, String>
-    namespace_obj: JObject,                     // LanceNamespace (can be null)
-    table_id_obj: JObject,                      // List<String> (can be null)
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    max_rows_per_file: JObject,                  // Optional<Integer>
+    max_rows_per_group: JObject,                 // Optional<Integer>
+    max_bytes_per_file: JObject,                 // Optional<Long>
+    mode: JObject,                               // Optional<String>
+    enable_stable_row_ids: JObject,              // Optional<Boolean>
+    data_storage_version: JObject,               // Optional<String>
+    storage_options_obj: JObject,                // Map<String, String>
+    namespace_obj: JObject,                      // LanceNamespace (can be null)
+    table_id_obj: JObject,                       // List<String> (can be null)
+    namespace_client_table_context_obj: JObject, // NamespaceClientTableContext (can be null)
+    allow_external_blob_outside_bases: JObject,  // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,      // Optional<Long>
 ) -> Result<JObject<'local>> {
     let c_array_ptr = arrow_array_addr as *mut FFI_ArrowArray;
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
@@ -167,6 +169,7 @@ fn inner_create_with_ffi_array<'local>(
         storage_options_obj,
         namespace_obj,
         table_id_obj,
+        namespace_client_table_context_obj,
         allow_external_blob_outside_bases,
         blob_pack_file_size_threshold,
         reader,
@@ -179,17 +182,18 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiStream<'a>(
     _obj: JObject,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    max_rows_per_file: JObject,                 // Optional<Integer>
-    max_rows_per_group: JObject,                // Optional<Integer>
-    max_bytes_per_file: JObject,                // Optional<Long>
-    mode: JObject,                              // Optional<String>
-    enable_stable_row_ids: JObject,             // Optional<Boolean>
-    data_storage_version: JObject,              // Optional<String>
-    storage_options_obj: JObject,               // Map<String, String>
-    namespace_obj: JObject,                     // LanceNamespace (can be null)
-    table_id_obj: JObject,                      // List<String> (can be null)
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    max_rows_per_file: JObject,                  // Optional<Integer>
+    max_rows_per_group: JObject,                 // Optional<Integer>
+    max_bytes_per_file: JObject,                 // Optional<Long>
+    mode: JObject,                               // Optional<String>
+    enable_stable_row_ids: JObject,              // Optional<Boolean>
+    data_storage_version: JObject,               // Optional<String>
+    storage_options_obj: JObject,                // Map<String, String>
+    namespace_obj: JObject,                      // LanceNamespace (can be null)
+    table_id_obj: JObject,                       // List<String> (can be null)
+    namespace_client_table_context_obj: JObject, // NamespaceClientTableContext (can be null)
+    allow_external_blob_outside_bases: JObject,  // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,      // Optional<Long>
 ) -> JObject<'a> {
     ok_or_throw_with_return!(
         env,
@@ -206,6 +210,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiStream<'a>(
             storage_options_obj,
             namespace_obj,
             table_id_obj,
+            namespace_client_table_context_obj,
             allow_external_blob_outside_bases,
             blob_pack_file_size_threshold,
         ),
@@ -218,17 +223,18 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    max_rows_per_file: JObject,                 // Optional<Integer>
-    max_rows_per_group: JObject,                // Optional<Integer>
-    max_bytes_per_file: JObject,                // Optional<Long>
-    mode: JObject,                              // Optional<String>
-    enable_stable_row_ids: JObject,             // Optional<Boolean>
-    data_storage_version: JObject,              // Optional<String>
-    storage_options_obj: JObject,               // Map<String, String>
-    namespace_obj: JObject,                     // LanceNamespace (can be null)
-    table_id_obj: JObject,                      // List<String> (can be null)
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    max_rows_per_file: JObject,                  // Optional<Integer>
+    max_rows_per_group: JObject,                 // Optional<Integer>
+    max_bytes_per_file: JObject,                 // Optional<Long>
+    mode: JObject,                               // Optional<String>
+    enable_stable_row_ids: JObject,              // Optional<Boolean>
+    data_storage_version: JObject,               // Optional<String>
+    storage_options_obj: JObject,                // Map<String, String>
+    namespace_obj: JObject,                      // LanceNamespace (can be null)
+    table_id_obj: JObject,                       // List<String> (can be null)
+    namespace_client_table_context_obj: JObject, // NamespaceClientTableContext (can be null)
+    allow_external_blob_outside_bases: JObject,  // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,      // Optional<Long>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -245,6 +251,7 @@ fn inner_create_with_ffi_stream<'local>(
         storage_options_obj,
         namespace_obj,
         table_id_obj,
+        namespace_client_table_context_obj,
         allow_external_blob_outside_bases,
         blob_pack_file_size_threshold,
         reader,
@@ -255,17 +262,18 @@ fn inner_create_with_ffi_stream<'local>(
 fn create_fragment<'a>(
     env: &mut JNIEnv<'a>,
     dataset_uri: JString,
-    max_rows_per_file: JObject,                 // Optional<Integer>
-    max_rows_per_group: JObject,                // Optional<Integer>
-    max_bytes_per_file: JObject,                // Optional<Long>
-    mode: JObject,                              // Optional<String>
-    enable_stable_row_ids: JObject,             // Optional<Boolean>
-    data_storage_version: JObject,              // Optional<String>
-    storage_options_obj: JObject,               // Map<String, String>
-    namespace_obj: JObject,                     // LanceNamespace (can be null)
-    table_id_obj: JObject,                      // List<String> (can be null)
-    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    max_rows_per_file: JObject,                  // Optional<Integer>
+    max_rows_per_group: JObject,                 // Optional<Integer>
+    max_bytes_per_file: JObject,                 // Optional<Long>
+    mode: JObject,                               // Optional<String>
+    enable_stable_row_ids: JObject,              // Optional<Boolean>
+    data_storage_version: JObject,               // Optional<String>
+    storage_options_obj: JObject,                // Map<String, String>
+    namespace_obj: JObject,                      // LanceNamespace (can be null)
+    table_id_obj: JObject,                       // List<String> (can be null)
+    namespace_client_table_context_obj: JObject, // NamespaceClientTableContext (can be null)
+    allow_external_blob_outside_bases: JObject,  // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,      // Optional<Long>
     source: impl StreamingWriteSource,
 ) -> Result<JObject<'a>> {
     let path_str = dataset_uri.extract(env)?;
@@ -288,27 +296,38 @@ fn create_fragment<'a>(
 
     // Set up storage options provider if namespace is provided
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
     if let Some((namespace, table_id)) = namespace_info {
         let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
             LanceNamespaceStorageOptionsProvider::new(namespace, table_id),
         );
 
-        let storage_options: HashMap<String, String> =
-            extract_storage_options(env, &storage_options_obj)?;
+        let mut merged_storage_options: HashMap<String, String> = write_params
+            .store_params
+            .as_ref()
+            .and_then(|params| params.storage_options().cloned())
+            .unwrap_or_default();
+        if let Some(namespace_client_table_context) = namespace_client_table_context
+            && let Some(context_storage_options) = namespace_client_table_context.storage_options
+        {
+            merged_storage_options.extend(context_storage_options);
+        }
 
-        let accessor = if storage_options.is_empty() {
+        let existing_params = write_params.store_params.take().unwrap_or_default();
+        let accessor = if merged_storage_options.is_empty() {
             Arc::new(lance::io::StorageOptionsAccessor::with_provider(provider))
         } else {
             Arc::new(
                 lance::io::StorageOptionsAccessor::with_initial_and_provider(
-                    storage_options,
+                    merged_storage_options,
                     provider,
                 ),
             )
         };
         write_params.store_params = Some(ObjectStoreParams {
             storage_options_accessor: Some(accessor),
-            ..Default::default()
+            ..existing_params
         });
     }
 

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -4,7 +4,9 @@
 use crate::Error;
 use crate::JNIEnvExt;
 use crate::RT;
-use crate::blocking_dataset::{BlockingDataset, NATIVE_DATASET, extract_namespace_info};
+use crate::blocking_dataset::{
+    BlockingDataset, NATIVE_DATASET, extract_namespace_client_table_context, extract_namespace_info,
+};
 use crate::error::Result;
 use crate::traits::{
     FromJObjectWithEnv, FromJString, IntoJava, JLance, export_vec, import_vec_from_method,
@@ -22,14 +24,10 @@ use lance::dataset::transaction::{
     UpdateMap, UpdateMapEntry, UpdateMode,
 };
 use lance::io::ObjectStoreParams;
-use lance::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use lance::table::format::{Fragment, IndexMetadata};
 use lance_core::datatypes::Field;
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_file::version::LanceFileVersion;
-use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOptionsProvider};
-use lance_table::io::commit::CommitHandler;
-use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 use prost::Message;
 use prost_types::Any;
 use roaring::RoaringBitmap;
@@ -624,7 +622,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
     skip_auto_cleanup: jboolean,
     namespace_obj: JObject,
     table_id_obj: JObject,
-    namespace_client_managed_versioning: jboolean,
+    namespace_client_table_context_obj: JObject,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -641,7 +639,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
             skip_auto_cleanup != 0,
             namespace_obj,
             table_id_obj,
-            namespace_client_managed_versioning != 0,
+            namespace_client_table_context_obj,
         )
     )
 }
@@ -660,7 +658,7 @@ fn inner_commit_to_dataset<'local>(
     skip_auto_cleanup: bool,
     namespace_obj: JObject,
     table_id_obj: JObject,
-    namespace_client_managed_versioning: bool,
+    namespace_client_table_context_obj: JObject,
 ) -> Result<JObject<'local>> {
     let write_param = if write_params_obj.is_null() {
         HashMap::new()
@@ -753,18 +751,9 @@ fn inner_commit_to_dataset<'local>(
         Some(&mut java_blocking_ds),
     )?;
 
-    // Set namespace commit handler only if namespace_client_managed_versioning is true
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
-    let commit_handler = if namespace_client_managed_versioning {
-        namespace_info.map(|(ns, tid)| {
-            let external_store = LanceNamespaceExternalManifestStore::new(ns, tid);
-            Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            }) as Arc<dyn CommitHandler>
-        })
-    } else {
-        None
-    };
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
 
     let new_blocking_ds = {
         let mut dataset_guard =
@@ -778,7 +767,9 @@ fn inner_commit_to_dataset<'local>(
             storage_format,
             max_retries,
             skip_auto_cleanup,
-            commit_handler,
+            None,
+            namespace_info,
+            namespace_client_table_context,
         )?
     };
     new_blocking_ds.into_java(env)
@@ -1372,6 +1363,39 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
     java_transaction: JObject,
     detached_jbool: jboolean,
     enable_v2_manifest_paths: jboolean,
+    allocator_obj: JObject,
+    write_params_obj: JObject,
+    use_stable_row_ids_obj: JObject,
+    storage_format_obj: JObject,
+    max_retries: jint,
+    skip_auto_cleanup: jboolean,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_commit_to_uri(
+            &mut env,
+            uri,
+            java_transaction,
+            detached_jbool != 0,
+            enable_v2_manifest_paths != 0,
+            allocator_obj,
+            write_params_obj,
+            use_stable_row_ids_obj,
+            storage_format_obj,
+            max_retries as u32,
+            skip_auto_cleanup != 0,
+        )
+    )
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToNamespace<'local>(
+    mut env: JNIEnv<'local>,
+    _cls: JObject,
+    java_transaction: JObject,
+    detached_jbool: jboolean,
+    enable_v2_manifest_paths: jboolean,
     namespace_obj: JObject,
     table_id_obj: JObject,
     allocator_obj: JObject,
@@ -1380,13 +1404,12 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
     storage_format_obj: JObject,
     max_retries: jint,
     skip_auto_cleanup: jboolean,
-    namespace_client_managed_versioning: jboolean,
+    namespace_client_table_context_obj: JObject,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
-        inner_commit_to_uri(
+        inner_commit_to_namespace(
             &mut env,
-            uri,
             java_transaction,
             detached_jbool != 0,
             enable_v2_manifest_paths != 0,
@@ -1398,7 +1421,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
             storage_format_obj,
             max_retries as u32,
             skip_auto_cleanup != 0,
-            namespace_client_managed_versioning != 0,
+            namespace_client_table_context_obj,
         )
     )
 }
@@ -1410,15 +1433,12 @@ fn inner_commit_to_uri<'local>(
     java_transaction: JObject,
     detached: bool,
     enable_v2_manifest_paths: bool,
-    namespace_obj: JObject,
-    table_id_obj: JObject,
     allocator_obj: JObject,
     write_params_obj: JObject,
     use_stable_row_ids_obj: JObject,
     storage_format_obj: JObject,
     max_retries: u32,
     skip_auto_cleanup: bool,
-    namespace_client_managed_versioning: bool,
 ) -> Result<JObject<'local>> {
     let uri_str: String = uri.extract(env)?;
 
@@ -1448,63 +1468,35 @@ fn inner_commit_to_uri<'local>(
         Some(parse_storage_format(&format_str)?)
     };
 
-    // Extract namespace info and create storage options provider if namespace is provided
-    let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
-    let storage_options_provider: Option<Arc<dyn StorageOptionsProvider>> =
-        if let Some((ref ns, ref tid)) = namespace_info {
-            Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(
-                ns.clone(),
-                tid.clone(),
-            )))
-        } else {
-            None
-        };
-
-    // Keep a copy of initial options for opening the read dataset.
     let initial_storage_options = write_param.clone();
-
-    let accessor = match (write_param.is_empty(), storage_options_provider.clone()) {
-        (false, Some(provider)) => Some(Arc::new(
-            lance::io::StorageOptionsAccessor::with_initial_and_provider(write_param, provider),
-        )),
-        (false, None) => Some(Arc::new(
+    let accessor = if !write_param.is_empty() {
+        Some(Arc::new(
             lance::io::StorageOptionsAccessor::with_static_options(write_param),
-        )),
-        (true, Some(provider)) => Some(Arc::new(lance::io::StorageOptionsAccessor::with_provider(
-            provider,
-        ))),
-        (true, None) => None,
+        ))
+    } else {
+        None
     };
-
     let store_params = ObjectStoreParams {
         storage_options_accessor: accessor,
         ..Default::default()
     };
 
-    let (open_namespace, open_table_id) = match &namespace_info {
-        Some((namespace_client, tid)) => (Some(namespace_client.clone()), Some(tid.clone())),
-        None => (None, None),
-    };
-
-    // Open the read dataset using the same storage options (and provider, if any) so that
-    // `convert_to_rust_transaction` can derive schema/field ids based on the target dataset.
+    // Open the read dataset so that convert_to_rust_transaction can derive schema/field ids.
     let mut ds = BlockingDataset::open(
-        &uri_str,
+        Some(&*uri_str),
         None,
         None,
         6 * 1024 * 1024,
         1024 * 1024,
         initial_storage_options,
         None,
-        storage_options_provider,
         None,
-        open_namespace,
-        open_table_id,
-        namespace_client_managed_versioning,
+        None,
+        None,
+        None,
     )
     .ok();
 
-    // Convert Java transaction to Rust
     let allocator_ref = if allocator_obj.is_null() {
         None
     } else {
@@ -1513,8 +1505,7 @@ fn inner_commit_to_uri<'local>(
     let transaction =
         convert_to_rust_transaction(env, java_transaction, allocator_ref.as_ref(), ds.as_mut())?;
 
-    // Build CommitBuilder with URI
-    let mut builder = CommitBuilder::new(&*uri_str)
+    let mut builder = CommitBuilder::new(uri_str.as_str())
         .with_store_params(store_params)
         .with_detached(detached)
         .enable_v2_manifest_paths(enable_v2_manifest_paths);
@@ -1532,13 +1523,110 @@ fn inner_commit_to_uri<'local>(
         builder = builder.with_skip_auto_cleanup(true);
     }
 
-    // Set namespace commit handler only if namespace_client_managed_versioning is true
-    if namespace_client_managed_versioning && let Some((namespace_client, tid)) = namespace_info {
-        let external_store = LanceNamespaceExternalManifestStore::new(namespace_client, tid);
-        let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-            external_manifest_store: Arc::new(external_store),
-        });
-        builder = builder.with_commit_handler(commit_handler);
+    let dataset = RT.block_on(builder.execute(transaction))?;
+    let blocking_ds = BlockingDataset { inner: dataset };
+    blocking_ds.into_java(env)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inner_commit_to_namespace<'local>(
+    env: &mut JNIEnv<'local>,
+    java_transaction: JObject,
+    detached: bool,
+    enable_v2_manifest_paths: bool,
+    namespace_obj: JObject,
+    table_id_obj: JObject,
+    allocator_obj: JObject,
+    write_params_obj: JObject,
+    use_stable_row_ids_obj: JObject,
+    storage_format_obj: JObject,
+    max_retries: u32,
+    skip_auto_cleanup: bool,
+    namespace_client_table_context_obj: JObject,
+) -> Result<JObject<'local>> {
+    let write_param = if write_params_obj.is_null() {
+        HashMap::new()
+    } else {
+        let write_param_jmap = JMap::from_env(env, &write_params_obj)?;
+        to_rust_map(env, &write_param_jmap)?
+    };
+
+    let use_stable_row_ids = if use_stable_row_ids_obj.is_null() {
+        None
+    } else {
+        let val = env
+            .call_method(&use_stable_row_ids_obj, "booleanValue", "()Z", &[])?
+            .z()?;
+        Some(val)
+    };
+
+    let storage_format = if storage_format_obj.is_null() {
+        None
+    } else {
+        let format_str: String = JString::from(storage_format_obj).extract(env)?;
+        Some(parse_storage_format(&format_str)?)
+    };
+
+    let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?
+        .ok_or_else(|| Error::input_error("namespace and table id are required".to_string()))?;
+    let namespace_client_table_context =
+        extract_namespace_client_table_context(env, &namespace_client_table_context_obj)?;
+    let initial_storage_options = write_param.clone();
+    let accessor = if !write_param.is_empty() {
+        Some(Arc::new(
+            lance::io::StorageOptionsAccessor::with_static_options(write_param),
+        ))
+    } else {
+        None
+    };
+    let store_params = ObjectStoreParams {
+        storage_options_accessor: accessor,
+        ..Default::default()
+    };
+
+    let mut ds = BlockingDataset::open(
+        None,
+        None,
+        None,
+        6 * 1024 * 1024,
+        1024 * 1024,
+        initial_storage_options,
+        None,
+        None,
+        Some(namespace_info.0.clone()),
+        Some(namespace_info.1.clone()),
+        namespace_client_table_context.clone(),
+    )
+    .ok();
+
+    let allocator_ref = if allocator_obj.is_null() {
+        None
+    } else {
+        Some(allocator_obj)
+    };
+    let transaction =
+        convert_to_rust_transaction(env, java_transaction, allocator_ref.as_ref(), ds.as_mut())?;
+
+    let mut builder = CommitBuilder::new_namespace(
+        namespace_info.0,
+        namespace_info.1,
+        namespace_client_table_context,
+    )
+    .with_store_params(store_params)
+    .with_detached(detached)
+    .enable_v2_manifest_paths(enable_v2_manifest_paths);
+
+    if let Some(use_stable) = use_stable_row_ids {
+        builder = builder.use_stable_row_ids(use_stable);
+    }
+    if let Some(format) = storage_format {
+        builder = builder.with_storage_format(format);
+    }
+    if max_retries > 0 {
+        builder = builder.with_max_retries(max_retries);
+    }
+    if skip_auto_cleanup {
+        builder = builder.with_skip_auto_cleanup(true);
     }
 
     let dataset = RT.block_on(builder.execute(transaction))?;

--- a/java/src/main/java/org/lance/CommitBuilder.java
+++ b/java/src/main/java/org/lance/CommitBuilder.java
@@ -29,6 +29,8 @@ import java.util.Map;
  * <ul>
  *   <li><strong>Dataset-based commit</strong>: commits against an existing dataset.
  *   <li><strong>URI-based commit</strong>: creates or updates a dataset at a URI.
+ *   <li><strong>Namespace-based commit</strong>: creates or updates a table through a namespace
+ *       client.
  * </ul>
  *
  * <p>Example usage (dataset-based):
@@ -53,6 +55,20 @@ import java.util.Map;
  *     // use committed dataset
  * }
  * }</pre>
+ *
+ * <p>Example usage (namespace-based):
+ *
+ * <pre>{@code
+ * try (Transaction txn = new Transaction.Builder()
+ *     .operation(Overwrite.builder().fragments(fragments).schema(schema).build())
+ *     .build();
+ *     Dataset committed = new CommitBuilder(allocator)
+ *         .namespaceClient(namespaceClient)
+ *         .tableId(tableId)
+ *         .execute(txn)) {
+ *     // use committed dataset
+ * }
+ * }</pre>
  */
 public class CommitBuilder {
   static {
@@ -66,7 +82,7 @@ public class CommitBuilder {
   private Map<String, String> writeParams;
   private LanceNamespace namespaceClient;
   private List<String> tableId;
-  private boolean namespaceClientManagedVersioning = false;
+  private NamespaceClientTableContext namespaceClientTableContext;
   private boolean enableV2ManifestPaths = true;
   private boolean detached = false;
   private Boolean useStableRowIds;
@@ -101,6 +117,21 @@ public class CommitBuilder {
   }
 
   /**
+   * Create a commit builder for creating or updating a table through a namespace client.
+   *
+   * <p>Use {@link #namespaceClient(LanceNamespace)} and {@link #tableId(List)} before executing.
+   * The table location is resolved from the namespace client or the cached namespace context.
+   *
+   * @param allocator the Arrow buffer allocator for schema export
+   */
+  public CommitBuilder(BufferAllocator allocator) {
+    Preconditions.checkNotNull(allocator, "Allocator must not be null");
+    this.dataset = null;
+    this.uri = null;
+    this.allocator = allocator;
+  }
+
+  /**
    * Set write parameters (storage options) for the commit.
    *
    * @param writeParams the write parameters
@@ -114,7 +145,7 @@ public class CommitBuilder {
   /**
    * Set the namespace client for managed versioning. When set, commits are routed through the
    * namespace client's {@code createTableVersion} API instead of writing directly to the object
-   * store. This is supported for both dataset-based and URI-based commits.
+   * store. This is supported for dataset-based and namespace-based commits.
    *
    * @param namespaceClient the LanceNamespace client instance
    * @return this builder instance
@@ -138,17 +169,14 @@ public class CommitBuilder {
   }
 
   /**
-   * Set whether namespace manages versioning.
+   * Sets a cached namespace context from a prior {@code describeTable} or {@code declareTable}
+   * call. Rust uses this to determine managed versioning and storage options.
    *
-   * <p>When true and namespaceClient/tableId are set, commits are routed through the namespace
-   * client's create_table_version API. This is typically set based on the managed_versioning field
-   * from describe_table or declare_table responses.
-   *
-   * @param namespaceClientManagedVersioning whether namespace manages versioning
+   * @param context the cached namespace context
    * @return this builder instance
    */
-  public CommitBuilder namespaceClientManagedVersioning(boolean namespaceClientManagedVersioning) {
-    this.namespaceClientManagedVersioning = namespaceClientManagedVersioning;
+  public CommitBuilder namespaceClientTableContext(NamespaceClientTableContext context) {
+    this.namespaceClientTableContext = context;
     return this;
   }
 
@@ -246,6 +274,27 @@ public class CommitBuilder {
    */
   public Dataset execute(Transaction transaction) {
     Preconditions.checkNotNull(transaction, "Transaction must not be null");
+    boolean hasNamespaceFields = namespaceClient != null || tableId != null;
+    boolean hasCompleteNamespace = namespaceClient != null && tableId != null;
+
+    if (uri != null && hasNamespaceFields) {
+      throw new IllegalArgumentException("Cannot specify both URI and namespaceClient+tableId.");
+    }
+
+    if (namespaceClientTableContext != null && !hasCompleteNamespace) {
+      throw new IllegalArgumentException(
+          "namespaceClientTableContext requires namespaceClient and tableId.");
+    }
+
+    if (hasNamespaceFields && !hasCompleteNamespace) {
+      if (namespaceClient == null) {
+        throw new IllegalArgumentException(
+            "tableId is set but namespaceClient is missing. Both must be provided together.");
+      }
+      throw new IllegalArgumentException(
+          "namespaceClient is set but tableId is missing. Both must be provided together.");
+    }
+
     if (dataset != null) {
       Dataset result =
           nativeCommitToDataset(
@@ -260,14 +309,13 @@ public class CommitBuilder {
               skipAutoCleanup,
               namespaceClient,
               tableId,
-              namespaceClientManagedVersioning);
+              namespaceClientTableContext);
       result.setAllocator(dataset.allocator());
       return result;
     }
-    if (uri != null) {
+    if (hasCompleteNamespace) {
       Dataset result =
-          nativeCommitToUri(
-              uri,
+          nativeCommitToNamespace(
               transaction,
               detached,
               enableV2ManifestPaths,
@@ -279,11 +327,28 @@ public class CommitBuilder {
               storageFormat,
               maxRetries,
               skipAutoCleanup,
-              namespaceClientManagedVersioning);
+              namespaceClientTableContext);
       result.setAllocator(allocator);
       return result;
     }
-    throw new IllegalStateException("CommitBuilder requires either a dataset or a URI");
+    if (uri != null) {
+      Dataset result =
+          nativeCommitToUri(
+              uri,
+              transaction,
+              detached,
+              enableV2ManifestPaths,
+              allocator,
+              writeParams,
+              useStableRowIds,
+              storageFormat,
+              maxRetries,
+              skipAutoCleanup);
+      result.setAllocator(allocator);
+      return result;
+    }
+    throw new IllegalStateException(
+        "CommitBuilder requires a dataset, URI, or namespaceClient+tableId");
   }
 
   private static native Dataset nativeCommitToDataset(
@@ -298,10 +363,21 @@ public class CommitBuilder {
       boolean skipAutoCleanup,
       Object namespace,
       Object tableId,
-      boolean namespaceClientManagedVersioning);
+      NamespaceClientTableContext namespaceClientTableContext);
 
   private static native Dataset nativeCommitToUri(
       String uri,
+      Transaction transaction,
+      boolean detached,
+      boolean enableV2ManifestPaths,
+      Object allocator,
+      Map<String, String> writeParams,
+      Boolean useStableRowIds,
+      String storageFormat,
+      int maxRetries,
+      boolean skipAutoCleanup);
+
+  private static native Dataset nativeCommitToNamespace(
       Transaction transaction,
       boolean detached,
       boolean enableV2ManifestPaths,
@@ -313,5 +389,5 @@ public class CommitBuilder {
       String storageFormat,
       int maxRetries,
       boolean skipAutoCleanup,
-      boolean namespaceClientManagedVersioning);
+      NamespaceClientTableContext namespaceClientTableContext);
 }

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -118,7 +118,7 @@ public class Dataset implements Closeable {
   }
 
   /**
-   * Creates an empty dataset.
+   * Creates an empty dataset with the given schema.
    *
    * @param allocator the buffer allocator
    * @param path dataset uri
@@ -159,34 +159,6 @@ public class Dataset implements Closeable {
     }
   }
 
-  /**
-   * Create a dataset with given stream.
-   *
-   * @param allocator buffer allocator
-   * @param stream arrow stream
-   * @param path dataset uri
-   * @param params write parameters
-   * @return Dataset
-   * @deprecated Use {@link #write()} builder instead. For example: {@code
-   *     Dataset.write().allocator(allocator).stream(stream).uri(path)
-   *     .mode(WriteMode.CREATE).execute()}
-   */
-  /**
-   * Create a dataset with given stream.
-   *
-   * @param allocator buffer allocator
-   * @param stream arrow stream
-   * @param path dataset uri
-   * @param params write parameters
-   * @return Dataset
-   * @deprecated Use {@link #write()} builder instead.
-   */
-  @Deprecated
-  public static Dataset create(
-      BufferAllocator allocator, ArrowArrayStream stream, String path, WriteParams params) {
-    return create(allocator, stream, path, params, null, null, false);
-  }
-
   private static native Dataset createWithFfiSchema(
       long arrowSchemaMemoryAddress,
       String path,
@@ -202,6 +174,61 @@ public class Dataset implements Closeable {
       Optional<List<String>> targetBases,
       Optional<Boolean> allowExternalBlobOutsideBases,
       Optional<Long> blobPackFileSizeThreshold);
+
+  /**
+   * Create a dataset with given stream.
+   *
+   * @deprecated Use {@link #write()} builder instead.
+   */
+  @Deprecated
+  public static Dataset create(
+      BufferAllocator allocator, ArrowArrayStream stream, String path, WriteParams params) {
+    return create(allocator, stream, path, params, null, null, null);
+  }
+
+  /**
+   * Open a dataset from the specified path.
+   *
+   * @deprecated Use {@link #open()} builder instead: {@code Dataset.open().uri(path).build()}
+   */
+  @Deprecated
+  public static Dataset open(String path) {
+    return open(
+        new RootAllocator(Long.MAX_VALUE), true, path, new ReadOptions.Builder().build(), null);
+  }
+
+  /**
+   * Open a dataset from the specified path with options.
+   *
+   * @deprecated Use {@link #open()} builder instead: {@code
+   *     Dataset.open().uri(path).readOptions(options).build()}
+   */
+  @Deprecated
+  public static Dataset open(String path, ReadOptions options) {
+    return open(new RootAllocator(Long.MAX_VALUE), true, path, options, null);
+  }
+
+  /**
+   * Open a dataset from the specified path with allocator.
+   *
+   * @deprecated Use {@link #open()} builder instead: {@code
+   *     Dataset.open().allocator(allocator).uri(path).build()}
+   */
+  @Deprecated
+  public static Dataset open(String path, BufferAllocator allocator) {
+    return open(allocator, path, new ReadOptions.Builder().build());
+  }
+
+  /**
+   * Open a dataset from the specified path with allocator and options.
+   *
+   * @deprecated Use {@link #open()} builder instead: {@code
+   *     Dataset.open().allocator(allocator).uri(path).readOptions(options).build()}
+   */
+  @Deprecated
+  public static Dataset open(BufferAllocator allocator, String path, ReadOptions options) {
+    return open(allocator, false, path, options, null);
+  }
 
   /**
    * Creates a dataset from an FFI arrow stream.
@@ -240,15 +267,15 @@ public class Dataset implements Closeable {
       Optional<Long> blobPackFileSizeThreshold,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning);
+      NamespaceClientTableContext namespaceClientTableContext);
 
   /**
    * Creates a dataset with optional namespace client support for managed versioning.
    *
    * <p>When namespaceClient and tableId are provided, the Rust side will automatically create a
-   * storage options provider for credential refresh. When namespaceClientManagedVersioning is true,
-   * the commit handler will use the namespace client's create_table_version method for version
-   * tracking.
+   * storage options provider for credential refresh. When namespaceClientTableContext indicates
+   * managed versioning, the commit handler will use the namespace client's create_table_version
+   * method for version tracking.
    *
    * @param allocator buffer allocator
    * @param stream arrow stream
@@ -257,8 +284,8 @@ public class Dataset implements Closeable {
    * @param namespaceClient optional namespace client for managed versioning and credential refresh
    *     (can be null)
    * @param tableId optional table identifier within the namespace client (can be null)
-   * @param namespaceClientManagedVersioning whether namespace manages versioning (commits go
-   *     through namespace API)
+   * @param namespaceClientTableContext optional cached namespace table context from describe or
+   *     declare table
    * @return Dataset
    */
   static Dataset create(
@@ -268,10 +295,9 @@ public class Dataset implements Closeable {
       WriteParams params,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning) {
+      NamespaceClientTableContext namespaceClientTableContext) {
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(stream);
-    Preconditions.checkNotNull(path);
     Preconditions.checkNotNull(params);
     Dataset dataset =
         createWithFfiStream(
@@ -291,65 +317,9 @@ public class Dataset implements Closeable {
             params.getBlobPackFileSizeThreshold(),
             namespaceClient,
             tableId,
-            namespaceClientManagedVersioning);
+            namespaceClientTableContext);
     dataset.allocator = allocator;
     return dataset;
-  }
-
-  /**
-   * Open a dataset from the specified path.
-   *
-   * @param path file path
-   * @return Dataset
-   * @deprecated Use {@link #open()} builder instead: {@code Dataset.open().uri(path).build()}
-   */
-  @Deprecated
-  public static Dataset open(String path) {
-    return open(
-        new RootAllocator(Long.MAX_VALUE), true, path, new ReadOptions.Builder().build(), null);
-  }
-
-  /**
-   * Open a dataset from the specified path.
-   *
-   * @param path file path
-   * @param options the open options
-   * @return Dataset
-   * @deprecated Use {@link #open()} builder instead: {@code
-   *     Dataset.open().uri(path).readOptions(options).build()}
-   */
-  @Deprecated
-  public static Dataset open(String path, ReadOptions options) {
-    return open(new RootAllocator(Long.MAX_VALUE), true, path, options, null);
-  }
-
-  /**
-   * Open a dataset from the specified path.
-   *
-   * @param path file path
-   * @param allocator Arrow buffer allocator
-   * @return Dataset
-   * @deprecated Use {@link #open()} builder instead: {@code
-   *     Dataset.open().allocator(allocator).uri(path).build()}
-   */
-  @Deprecated
-  public static Dataset open(String path, BufferAllocator allocator) {
-    return open(allocator, path, new ReadOptions.Builder().build());
-  }
-
-  /**
-   * Open a dataset from the specified path with additional options.
-   *
-   * @param allocator Arrow buffer allocator
-   * @param path file path
-   * @param options the open options
-   * @return Dataset
-   * @deprecated Use {@link #open()} builder instead: {@code
-   *     Dataset.open().allocator(allocator).uri(path).readOptions(options).build()}
-   */
-  @Deprecated
-  public static Dataset open(BufferAllocator allocator, String path, ReadOptions options) {
-    return open(allocator, false, path, options, null);
   }
 
   /**
@@ -365,7 +335,7 @@ public class Dataset implements Closeable {
       String path,
       ReadOptions options,
       Session session) {
-    return open(allocator, selfManagedAllocator, path, options, session, null, null, false);
+    return open(allocator, selfManagedAllocator, path, options, session, null, null, null);
   }
 
   /**
@@ -379,8 +349,8 @@ public class Dataset implements Closeable {
    * @param namespaceClient the LanceNamespace to use for managed versioning and credential refresh
    *     (null if not using namespace client)
    * @param tableId table identifier (null if not using namespace client)
-   * @param namespaceClientManagedVersioning whether namespace manages versioning (commits go
-   *     through namespace API)
+   * @param namespaceClientTableContext optional cached namespace table context from describe or
+   *     declare table
    * @return Dataset
    */
   static Dataset open(
@@ -391,8 +361,7 @@ public class Dataset implements Closeable {
       Session session,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning) {
-    Preconditions.checkNotNull(path);
+      NamespaceClientTableContext namespaceClientTableContext) {
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(options);
 
@@ -414,7 +383,7 @@ public class Dataset implements Closeable {
             sessionHandle,
             namespaceClient,
             tableId,
-            namespaceClientManagedVersioning);
+            namespaceClientTableContext);
     dataset.allocator = allocator;
     dataset.selfManagedAllocator = selfManagedAllocator;
     if (effectiveSession != null) {
@@ -437,7 +406,7 @@ public class Dataset implements Closeable {
       long sessionHandle,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning);
+      NamespaceClientTableContext namespaceClientTableContext);
 
   /**
    * Creates a builder for opening a dataset.

--- a/java/src/main/java/org/lance/Fragment.java
+++ b/java/src/main/java/org/lance/Fragment.java
@@ -234,7 +234,7 @@ public class Fragment {
   @Deprecated
   public static List<FragmentMetadata> create(
       String datasetUri, BufferAllocator allocator, VectorSchemaRoot root, WriteParams params) {
-    return create(datasetUri, allocator, root, params, null, null);
+    return create(datasetUri, allocator, root, params, null, null, null);
   }
 
   /**
@@ -249,7 +249,7 @@ public class Fragment {
   @Deprecated
   public static List<FragmentMetadata> create(
       String datasetUri, ArrowArrayStream stream, WriteParams params) {
-    return create(datasetUri, stream, params, null, null);
+    return create(datasetUri, stream, params, null, null, null);
   }
 
   /** Create a fragment from the given arrow array and schema. */
@@ -259,7 +259,8 @@ public class Fragment {
       VectorSchemaRoot root,
       WriteParams params,
       LanceNamespace namespaceClient,
-      List<String> tableId) {
+      List<String> tableId,
+      NamespaceClientTableContext namespaceClientTableContext) {
     Preconditions.checkNotNull(datasetUri);
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(root);
@@ -280,6 +281,7 @@ public class Fragment {
           params.getStorageOptions(),
           namespaceClient,
           tableId,
+          namespaceClientTableContext,
           params.getAllowExternalBlobOutsideBases(),
           params.getBlobPackFileSizeThreshold());
     }
@@ -291,7 +293,8 @@ public class Fragment {
       ArrowArrayStream stream,
       WriteParams params,
       LanceNamespace namespaceClient,
-      List<String> tableId) {
+      List<String> tableId,
+      NamespaceClientTableContext namespaceClientTableContext) {
     Preconditions.checkNotNull(datasetUri);
     Preconditions.checkNotNull(stream);
     Preconditions.checkNotNull(params);
@@ -307,6 +310,7 @@ public class Fragment {
         params.getStorageOptions(),
         namespaceClient,
         tableId,
+        namespaceClientTableContext,
         params.getAllowExternalBlobOutsideBases(),
         params.getBlobPackFileSizeThreshold());
   }
@@ -325,6 +329,7 @@ public class Fragment {
       Map<String, String> storageOptions,
       LanceNamespace namespaceClient,
       List<String> tableId,
+      NamespaceClientTableContext namespaceClientTableContext,
       Optional<Boolean> allowExternalBlobOutsideBases,
       Optional<Long> blobPackFileSizeThreshold);
 
@@ -341,6 +346,7 @@ public class Fragment {
       Map<String, String> storageOptions,
       LanceNamespace namespaceClient,
       List<String> tableId,
+      NamespaceClientTableContext namespaceClientTableContext,
       Optional<Boolean> allowExternalBlobOutsideBases,
       Optional<Long> blobPackFileSizeThreshold);
 }

--- a/java/src/main/java/org/lance/NamespaceClientTableContext.java
+++ b/java/src/main/java/org/lance/NamespaceClientTableContext.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+import org.lance.namespace.model.DeclareTableResponse;
+import org.lance.namespace.model.DescribeTableResponse;
+
+import org.apache.arrow.util.Preconditions;
+
+import java.util.Map;
+
+/**
+ * Cached context from a namespace client's {@code describeTable} or {@code declareTable} response.
+ *
+ * <p>Contains only the resolved table metadata (location, storage options, managed-versioning
+ * flag). The namespace client and table ID are <b>not</b> part of this class; they are still passed
+ * separately.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * DescribeTableResponse response = namespaceClient.describeTable(request);
+ * NamespaceClientTableContext namespaceClientTableContext =
+ *     NamespaceClientTableContext.fromDescribeTableResponse(response);
+ *
+ * Dataset dataset = Dataset.open()
+ *     .namespaceClient(namespaceClient)
+ *     .tableId(tableId)
+ *     .namespaceClientTableContext(namespaceClientTableContext)
+ *     .build();
+ * }</pre>
+ */
+public class NamespaceClientTableContext {
+
+  private final String location;
+  private final Map<String, String> storageOptions;
+  private final boolean managedVersioning;
+
+  /**
+   * Creates a new NamespaceClientTableContext.
+   *
+   * @param location the table's storage location (URI)
+   * @param storageOptions storage options returned by the namespace (e.g. temporary credentials),
+   *     may be null
+   * @param managedVersioning whether commits should go through the namespace's version API
+   */
+  public NamespaceClientTableContext(
+      String location, Map<String, String> storageOptions, boolean managedVersioning) {
+    Preconditions.checkArgument(
+        location != null && !location.isEmpty(), "location must not be null or empty");
+    this.location = location;
+    this.storageOptions = storageOptions;
+    this.managedVersioning = managedVersioning;
+  }
+
+  /**
+   * Build a context from a {@link DescribeTableResponse}.
+   *
+   * @param response the describe table response
+   * @return a new NamespaceClientTableContext
+   * @throws IllegalArgumentException if the response does not contain a location
+   */
+  public static NamespaceClientTableContext fromDescribeTableResponse(
+      DescribeTableResponse response) {
+    String location = response.getLocation();
+    Preconditions.checkArgument(
+        location != null && !location.isEmpty(), "DescribeTableResponse missing location");
+    return new NamespaceClientTableContext(
+        location,
+        response.getStorageOptions(),
+        Boolean.TRUE.equals(response.getManagedVersioning()));
+  }
+
+  /**
+   * Build a context from a {@link DeclareTableResponse}.
+   *
+   * @param response the declare table response
+   * @return a new NamespaceClientTableContext
+   * @throws IllegalArgumentException if the response does not contain a location
+   */
+  public static NamespaceClientTableContext fromDeclareTableResponse(
+      DeclareTableResponse response) {
+    String location = response.getLocation();
+    Preconditions.checkArgument(
+        location != null && !location.isEmpty(), "DeclareTableResponse missing location");
+    return new NamespaceClientTableContext(
+        location,
+        response.getStorageOptions(),
+        Boolean.TRUE.equals(response.getManagedVersioning()));
+  }
+
+  /** Returns the table's storage location (URI). */
+  public String getLocation() {
+    return location;
+  }
+
+  /** Returns the storage options, or null if none were provided. */
+  public Map<String, String> getStorageOptions() {
+    return storageOptions;
+  }
+
+  /** Returns whether commits should go through the namespace's version API. */
+  public boolean isManagedVersioning() {
+    return managedVersioning;
+  }
+}

--- a/java/src/main/java/org/lance/OpenDatasetBuilder.java
+++ b/java/src/main/java/org/lance/OpenDatasetBuilder.java
@@ -14,16 +14,12 @@
 package org.lance;
 
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.model.DescribeTableRequest;
-import org.lance.namespace.model.DescribeTableResponse;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Builder for opening a Dataset.
@@ -56,6 +52,7 @@ public class OpenDatasetBuilder {
   private String uri;
   private LanceNamespace namespaceClient;
   private List<String> tableId;
+  private NamespaceClientTableContext namespaceClientTableContext;
   private ReadOptions options = new ReadOptions.Builder().build();
   private Session session;
 
@@ -117,6 +114,22 @@ public class OpenDatasetBuilder {
   }
 
   /**
+   * Sets a cached namespace context from a prior {@code describeTable} or {@code declareTable}
+   * call. When provided, skips the namespace call and uses the cached location, storage options,
+   * and managed-versioning flag directly.
+   *
+   * <p>Cannot be used with {@code uri()}. Must be used together with {@code namespaceClient()} and
+   * {@code tableId()}.
+   *
+   * @param context the cached namespace context
+   * @return this builder instance
+   */
+  public OpenDatasetBuilder namespaceClientTableContext(NamespaceClientTableContext context) {
+    this.namespaceClientTableContext = context;
+    return this;
+  }
+
+  /**
    * Sets the read options.
    *
    * @param options Read options
@@ -155,93 +168,55 @@ public class OpenDatasetBuilder {
    * @throws IllegalArgumentException if required parameters are missing or invalid
    */
   public Dataset build() {
-    // Validate that exactly one of uri or namespaceClient+tableId is provided
     boolean hasUri = uri != null;
-    boolean hasNamespaceClient = namespaceClient != null && tableId != null;
+    boolean hasNamespaceFields = namespaceClient != null || tableId != null;
+    boolean hasCompleteNamespace = namespaceClient != null && tableId != null;
+    boolean hasContext = namespaceClientTableContext != null;
 
-    if (hasUri && hasNamespaceClient) {
-      throw new IllegalArgumentException(
-          "Cannot specify both uri and namespaceClient+tableId. Use one or the other.");
+    if (hasUri && hasNamespaceFields) {
+      throw new IllegalArgumentException("Cannot specify both uri and namespaceClient+tableId.");
     }
-    if (!hasUri && !hasNamespaceClient) {
-      if (namespaceClient != null) {
+    if (hasContext && !hasCompleteNamespace) {
+      throw new IllegalArgumentException(
+          "namespaceClientTableContext requires namespaceClient and tableId.");
+    }
+    if (!hasUri && !hasNamespaceFields) {
+      throw new IllegalArgumentException("Either uri or namespaceClient+tableId must be provided.");
+    }
+
+    if (hasNamespaceFields && !hasCompleteNamespace) {
+      if (namespaceClient == null) {
         throw new IllegalArgumentException(
-            "namespaceClient is set but tableId is missing. Both namespaceClient and tableId must"
-                + " be provided together.");
-      } else if (tableId != null) {
-        throw new IllegalArgumentException(
-            "tableId is set but namespaceClient is missing. Both namespaceClient and tableId must"
-                + " be provided together.");
+            "tableId is set but namespaceClient is missing. Both must be provided together.");
       } else {
         throw new IllegalArgumentException(
-            "Either uri or namespaceClient+tableId must be provided.");
+            "namespaceClient is set but tableId is missing. Both must be provided together.");
       }
     }
 
     Preconditions.checkNotNull(options, "options must be set");
 
-    // Create allocator if not provided
     if (allocator == null) {
       allocator = new RootAllocator(Long.MAX_VALUE);
       selfManagedAllocator = true;
     }
 
-    // Handle namespace client-based opening
-    if (hasNamespaceClient) {
+    if (hasCompleteNamespace) {
       return buildFromNamespaceClient();
     }
 
-    // Handle URI-based opening
     return Dataset.open(allocator, selfManagedAllocator, uri, options, session);
   }
 
   private Dataset buildFromNamespaceClient() {
-    // Call describe_table to get location and storage options
-    DescribeTableRequest request = new DescribeTableRequest();
-    request.setId(tableId);
-    // Only set version if present
-    options.getVersion().ifPresent(v -> request.setVersion(Long.valueOf(v)));
-
-    DescribeTableResponse response = namespaceClient.describeTable(request);
-
-    String location = response.getLocation();
-    if (location == null || location.isEmpty()) {
-      throw new IllegalArgumentException("Namespace client did not return a table location");
-    }
-
-    // Check if namespace client manages versioning (commits go through namespace client API)
-    Boolean namespaceClientManagedVersioning = response.getManagedVersioning();
-
-    Map<String, String> namespaceStorageOptions = response.getStorageOptions();
-
-    ReadOptions.Builder optionsBuilder =
-        new ReadOptions.Builder()
-            .setIndexCacheSizeBytes(options.getIndexCacheSizeBytes())
-            .setMetadataCacheSizeBytes(options.getMetadataCacheSizeBytes());
-
-    options.getVersion().ifPresent(optionsBuilder::setVersion);
-    options.getBlockSize().ifPresent(optionsBuilder::setBlockSize);
-    options.getSerializedManifest().ifPresent(optionsBuilder::setSerializedManifest);
-
-    Map<String, String> storageOptions = new HashMap<>(options.getStorageOptions());
-    if (namespaceStorageOptions != null) {
-      storageOptions.putAll(namespaceStorageOptions);
-    }
-    optionsBuilder.setStorageOptions(storageOptions);
-
-    // Pass namespaceClient, tableId, and namespaceClientManagedVersioning to Rust
-    // The Rust side will:
-    // - Create a storage options provider when namespaceClient/tableId are non-null for credential
-    // refresh
-    // - Create an external manifest commit handler when namespaceClientManagedVersioning is true
     return Dataset.open(
         allocator,
         selfManagedAllocator,
-        location,
-        optionsBuilder.build(),
+        null,
+        options,
         session,
         namespaceClient,
         tableId,
-        Boolean.TRUE.equals(namespaceClientManagedVersioning));
+        namespaceClientTableContext);
   }
 }

--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -14,19 +14,17 @@
 package org.lance;
 
 import org.lance.namespace.LanceNamespace;
-import org.lance.namespace.model.DeclareTableRequest;
-import org.lance.namespace.model.DeclareTableResponse;
-import org.lance.namespace.model.DescribeTableRequest;
-import org.lance.namespace.model.DescribeTableResponse;
 
 import org.apache.arrow.c.ArrowArrayStream;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,10 +65,10 @@ public class WriteDatasetBuilder {
   private String uri;
   private LanceNamespace namespaceClient;
   private List<String> tableId;
+  private NamespaceClientTableContext namespaceClientTableContext;
   private WriteParams.WriteMode mode = WriteParams.WriteMode.CREATE;
   private Schema schema;
   private Map<String, String> storageOptions = new HashMap<>();
-  private boolean ignoreNamespaceStorageOptions = false;
   private Optional<Integer> maxRowsPerFile = Optional.empty();
   private Optional<Integer> maxRowsPerGroup = Optional.empty();
   private Optional<Long> maxBytesPerFile = Optional.empty();
@@ -171,6 +169,35 @@ public class WriteDatasetBuilder {
   }
 
   /**
+   * Sets a cached namespace context from a prior {@code describeTable} or {@code declareTable}
+   * call. When provided, skips the namespace call and uses the cached location, storage options,
+   * and managed-versioning flag directly.
+   *
+   * <p>Cannot be used with {@code uri()}. Must be used together with {@code namespaceClient()} and
+   * {@code tableId()}.
+   *
+   * @param context the cached namespace context
+   * @return this builder instance
+   */
+  public WriteDatasetBuilder namespaceClientTableContext(NamespaceClientTableContext context) {
+    this.namespaceClientTableContext = context;
+    return this;
+  }
+
+  /**
+   * Sets the schema for the dataset.
+   *
+   * <p>If reader() and stream() are not provided, this creates an empty dataset for URI writes.
+   *
+   * @param schema The dataset schema
+   * @return this builder instance
+   */
+  public WriteDatasetBuilder schema(Schema schema) {
+    this.schema = schema;
+    return this;
+  }
+
+  /**
    * Sets the write mode.
    *
    * @param mode The write mode (CREATE, APPEND, or OVERWRITE)
@@ -183,19 +210,6 @@ public class WriteDatasetBuilder {
   }
 
   /**
-   * Sets the schema for the dataset.
-   *
-   * <p>If the reader and stream not provided, this is used to create an empty dataset
-   *
-   * @param schema The dataset schema
-   * @return this builder instance
-   */
-  public WriteDatasetBuilder schema(Schema schema) {
-    this.schema = schema;
-    return this;
-  }
-
-  /**
    * Sets storage options for the dataset.
    *
    * @param storageOptions Storage configuration options
@@ -203,19 +217,6 @@ public class WriteDatasetBuilder {
    */
   public WriteDatasetBuilder storageOptions(Map<String, String> storageOptions) {
     this.storageOptions = new HashMap<>(storageOptions);
-    return this;
-  }
-
-  /**
-   * Sets whether to ignore storage options from the namespace client's describeTable() or
-   * declareTable().
-   *
-   * @param ignoreNamespaceStorageOptions If true, storage options returned from namespace client
-   *     will be ignored
-   * @return this builder instance
-   */
-  public WriteDatasetBuilder ignoreNamespaceStorageOptions(boolean ignoreNamespaceStorageOptions) {
-    this.ignoreNamespaceStorageOptions = ignoreNamespaceStorageOptions;
     return this;
   }
 
@@ -334,37 +335,42 @@ public class WriteDatasetBuilder {
    * @throws IllegalArgumentException if required parameters are missing or invalid
    */
   public Dataset execute() {
-    // Auto-create allocator if not provided
     if (allocator == null) {
       allocator = new RootAllocator(Long.MAX_VALUE);
     }
 
-    // Validate that exactly one of uri or namespaceClient is provided
     boolean hasUri = uri != null;
-    boolean hasNamespaceClient = namespaceClient != null && tableId != null;
+    boolean hasNamespaceFields = namespaceClient != null || tableId != null;
+    boolean hasCompleteNamespace = namespaceClient != null && tableId != null;
+    boolean hasContext = namespaceClientTableContext != null;
 
-    if (hasUri && hasNamespaceClient) {
+    if (hasUri && hasNamespaceFields) {
       throw new IllegalArgumentException(
-          "Cannot specify both uri() and namespaceClient()+tableId(). Use one or the other.");
+          "Cannot specify both uri() and namespaceClient()+tableId().");
     }
-    if (!hasUri && !hasNamespaceClient) {
-      if (namespaceClient != null) {
-        throw new IllegalArgumentException(
-            "namespaceClient() is set but tableId() is missing. Both must be provided together.");
-      } else if (tableId != null) {
+    if (hasContext && !hasCompleteNamespace) {
+      throw new IllegalArgumentException(
+          "namespaceClientTableContext() requires namespaceClient() and tableId().");
+    }
+    if (!hasUri && !hasNamespaceFields) {
+      throw new IllegalArgumentException(
+          "Either uri() or namespaceClient()+tableId() must be called.");
+    }
+
+    if (hasNamespaceFields && !hasCompleteNamespace) {
+      if (namespaceClient == null) {
         throw new IllegalArgumentException(
             "tableId() is set but namespaceClient() is missing. Both must be provided together.");
       } else {
         throw new IllegalArgumentException(
-            "Either uri() or namespaceClient()+tableId() must be called.");
+            "namespaceClient() is set but tableId() is missing. Both must be provided together.");
       }
     }
 
-    // Validate data source - exactly one of reader, stream, or schema must be provided
     int dataSourceCount = 0;
     if (reader != null) dataSourceCount++;
     if (stream != null) dataSourceCount++;
-    if (schema != null && reader == null && stream == null) dataSourceCount++;
+    if (schema != null) dataSourceCount++;
 
     if (dataSourceCount == 0) {
       throw new IllegalArgumentException(
@@ -375,69 +381,22 @@ public class WriteDatasetBuilder {
           "Cannot specify multiple data sources. "
               + "Use only one of: reader(), stream(), or schema().");
     }
-
-    // Handle namespace client-based writing
-    if (hasNamespaceClient) {
+    if (hasCompleteNamespace) {
       return executeWithNamespaceClient();
     }
 
-    // Handle URI-based writing
     return executeWithUri();
   }
 
   private Dataset executeWithNamespaceClient() {
-    String tableUri;
-    Map<String, String> namespaceStorageOptions = null;
-    boolean namespaceClientManagedVersioning = false;
-
-    // Mode-specific namespace client operations
-    if (mode == WriteParams.WriteMode.CREATE) {
-      DeclareTableRequest declareRequest = new DeclareTableRequest();
-      declareRequest.setId(tableId);
-      DeclareTableResponse declareResponse = namespaceClient.declareTable(declareRequest);
-
-      tableUri = declareResponse.getLocation();
-      if (tableUri == null || tableUri.isEmpty()) {
-        throw new IllegalArgumentException("Namespace client did not return a table location");
-      }
-
-      namespaceClientManagedVersioning =
-          Boolean.TRUE.equals(declareResponse.getManagedVersioning());
-      namespaceStorageOptions =
-          ignoreNamespaceStorageOptions ? null : declareResponse.getStorageOptions();
-    } else {
-      // For APPEND/OVERWRITE modes, call namespaceClient.describeTable()
-      DescribeTableRequest request = new DescribeTableRequest();
-      request.setId(tableId);
-
-      DescribeTableResponse response = namespaceClient.describeTable(request);
-
-      tableUri = response.getLocation();
-      if (tableUri == null || tableUri.isEmpty()) {
-        throw new IllegalArgumentException("Namespace client did not return a table location");
-      }
-
-      namespaceStorageOptions = ignoreNamespaceStorageOptions ? null : response.getStorageOptions();
-      namespaceClientManagedVersioning = Boolean.TRUE.equals(response.getManagedVersioning());
-    }
-
-    // Merge storage options (namespace client options + user options, with namespace client taking
-    // precedence)
-    Map<String, String> mergedStorageOptions = new HashMap<>(storageOptions);
-    if (namespaceStorageOptions != null && !namespaceStorageOptions.isEmpty()) {
-      mergedStorageOptions.putAll(namespaceStorageOptions);
-    }
-
-    // Build WriteParams with merged storage options
     WriteParams.Builder paramsBuilder =
-        new WriteParams.Builder().withMode(mode).withStorageOptions(mergedStorageOptions);
+        new WriteParams.Builder().withMode(mode).withStorageOptions(storageOptions);
 
     maxRowsPerFile.ifPresent(paramsBuilder::withMaxRowsPerFile);
     maxRowsPerGroup.ifPresent(paramsBuilder::withMaxRowsPerGroup);
     maxBytesPerFile.ifPresent(paramsBuilder::withMaxBytesPerFile);
     enableStableRowIds.ifPresent(paramsBuilder::withEnableStableRowIds);
     dataStorageVersion.ifPresent(paramsBuilder::withDataStorageVersion);
-
     initialBases.ifPresent(paramsBuilder::withInitialBases);
     targetBases.ifPresent(paramsBuilder::withTargetBases);
     allowExternalBlobOutsideBases.ifPresent(paramsBuilder::withAllowExternalBlobOutsideBases);
@@ -445,22 +404,55 @@ public class WriteDatasetBuilder {
 
     WriteParams params = paramsBuilder.build();
 
-    // Pass namespaceClient, tableId, and namespaceClientManagedVersioning to JNI
-    // Rust will automatically create a storage options provider when namespaceClient/tableId
-    // are non-null for credential refresh, and will create an external manifest commit handler
-    // when namespaceClientManagedVersioning is true
-    if (namespaceClientManagedVersioning) {
-      return createDatasetWithStreamAndNamespaceClient(
-          tableUri, params, namespaceClient, tableId, true);
-    } else {
-      // Even without managed versioning, pass namespaceClient for credential refresh
-      // when namespace client vends credentials (storage options was non-null)
-      if (!ignoreNamespaceStorageOptions && namespaceStorageOptions != null) {
-        return createDatasetWithStreamAndNamespaceClient(
-            tableUri, params, namespaceClient, tableId, false);
+    if (schema != null) {
+      if (mode != WriteParams.WriteMode.CREATE) {
+        throw new IllegalArgumentException(
+            "schema() with namespaceClient()+tableId() only supports CREATE mode.");
       }
-      return createDatasetWithStream(tableUri, params);
+      try (VectorSchemaRoot emptyRoot = VectorSchemaRoot.create(schema, allocator);
+          ArrowReader emptyReader =
+              new ArrowReader(allocator) {
+                @Override
+                public boolean loadNextBatch() {
+                  return false;
+                }
+
+                @Override
+                public long bytesRead() {
+                  return 0;
+                }
+
+                @Override
+                protected void closeReadSource() {}
+
+                @Override
+                protected Schema readSchema() {
+                  return schema;
+                }
+
+                @Override
+                public VectorSchemaRoot getVectorSchemaRoot() {
+                  return emptyRoot;
+                }
+              };
+          ArrowArrayStream tempStream = ArrowArrayStream.allocateNew(allocator)) {
+        emptyRoot.setRowCount(0);
+        Data.exportArrayStream(allocator, emptyReader, tempStream);
+        return Dataset.create(
+            allocator,
+            tempStream,
+            null,
+            params,
+            namespaceClient,
+            tableId,
+            namespaceClientTableContext);
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to create empty namespace table", e);
+      }
     }
+
+    return createDatasetWithStreamAndNamespaceClient(
+        null, params, namespaceClient, tableId, namespaceClientTableContext);
   }
 
   private Dataset executeWithUri() {
@@ -479,29 +471,11 @@ public class WriteDatasetBuilder {
 
     WriteParams params = paramsBuilder.build();
 
-    return createDatasetWithStream(uri, params);
-  }
-
-  private Dataset createDatasetWithStream(String path, WriteParams params) {
-    // If stream is directly provided, use it
-    if (stream != null) {
-      return Dataset.create(allocator, stream, path, params);
-    }
-
-    // If reader is provided, convert to stream
-    if (reader != null) {
-      try (ArrowArrayStream tempStream = ArrowArrayStream.allocateNew(allocator)) {
-        Data.exportArrayStream(allocator, reader, tempStream);
-        return Dataset.create(allocator, tempStream, path, params);
-      }
-    }
-
-    // If only schema is provided (empty table), use Dataset.create with schema
     if (schema != null) {
-      return Dataset.create(allocator, path, schema, params);
+      return Dataset.create(allocator, uri, schema, params);
     }
 
-    throw new IllegalStateException("No data source provided");
+    return createDatasetWithStreamAndNamespaceClient(uri, params, null, null, null);
   }
 
   private Dataset createDatasetWithStreamAndNamespaceClient(
@@ -509,20 +483,12 @@ public class WriteDatasetBuilder {
       WriteParams params,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      boolean namespaceClientManagedVersioning) {
-    // If stream is directly provided, use it
+      NamespaceClientTableContext namespaceClientTableContext) {
     if (stream != null) {
       return Dataset.create(
-          allocator,
-          stream,
-          path,
-          params,
-          namespaceClient,
-          tableId,
-          namespaceClientManagedVersioning);
+          allocator, stream, path, params, namespaceClient, tableId, namespaceClientTableContext);
     }
 
-    // If reader is provided, convert to stream
     if (reader != null) {
       try (ArrowArrayStream tempStream = ArrowArrayStream.allocateNew(allocator)) {
         Data.exportArrayStream(allocator, reader, tempStream);
@@ -533,14 +499,8 @@ public class WriteDatasetBuilder {
             params,
             namespaceClient,
             tableId,
-            namespaceClientManagedVersioning);
+            namespaceClientTableContext);
       }
-    }
-
-    // If only schema is provided (empty table), use Dataset.create with schema
-    // Note: Schema-only creation doesn't support namespace client-based commit handling
-    if (schema != null) {
-      return Dataset.create(allocator, path, schema, params);
     }
 
     throw new IllegalStateException("No data source provided");

--- a/java/src/main/java/org/lance/WriteFragmentBuilder.java
+++ b/java/src/main/java/org/lance/WriteFragmentBuilder.java
@@ -49,6 +49,7 @@ public class WriteFragmentBuilder {
   private WriteParams.Builder writeParamsBuilder;
   private LanceNamespace namespaceClient;
   private List<String> tableId;
+  private NamespaceClientTableContext namespaceClientTableContext;
 
   WriteFragmentBuilder() {}
 
@@ -128,7 +129,7 @@ public class WriteFragmentBuilder {
    *
    * <p>When provided with `tableId`, a storage options provider will be created automatically to
    * refresh credentials via the namespace client. Must be provided together with `tableId`. The
-   * caller should provide initial/merged storage options via the `storageOptions` method.
+   * caller should provide storage options via the `storageOptions` method.
    *
    * @param namespaceClient the LanceNamespace client instance
    * @return this builder
@@ -148,6 +149,20 @@ public class WriteFragmentBuilder {
    */
   public WriteFragmentBuilder tableId(List<String> tableId) {
     this.tableId = tableId;
+    return this;
+  }
+
+  /**
+   * Sets a cached namespace context from a prior {@code describeTable} or {@code declareTable}
+   * call. When provided, the cached storage options and managed-versioning flag are reused.
+   *
+   * <p>Must be used together with {@code namespaceClient()} and {@code tableId()}.
+   *
+   * @param context the cached namespace context
+   * @return this builder
+   */
+  public WriteFragmentBuilder namespaceClientTableContext(NamespaceClientTableContext context) {
+    this.namespaceClientTableContext = context;
     return this;
   }
 
@@ -231,17 +246,25 @@ public class WriteFragmentBuilder {
   public List<FragmentMetadata> execute() {
     validate();
 
-    // Build the write params
     WriteParams finalWriteParams = buildWriteParams();
 
-    // Pass namespaceClient and tableId to JNI - Rust will automatically create a
-    // storage options provider when these are non-null for credential refresh
     if (vectorSchemaRoot != null) {
       return Fragment.create(
-          datasetUri, allocator, vectorSchemaRoot, finalWriteParams, namespaceClient, tableId);
+          datasetUri,
+          allocator,
+          vectorSchemaRoot,
+          finalWriteParams,
+          namespaceClient,
+          tableId,
+          namespaceClientTableContext);
     } else {
       return Fragment.create(
-          datasetUri, arrowArrayStream, finalWriteParams, namespaceClient, tableId);
+          datasetUri,
+          arrowArrayStream,
+          finalWriteParams,
+          namespaceClient,
+          tableId,
+          namespaceClientTableContext);
     }
   }
 
@@ -279,5 +302,8 @@ public class WriteFragmentBuilder {
         (namespaceClient == null && tableId == null)
             || (namespaceClient != null && tableId != null),
         "Both 'namespaceClient' and 'tableId' must be provided together");
+    Preconditions.checkState(
+        namespaceClientTableContext == null || namespaceClient != null,
+        "namespaceClientTableContext requires namespaceClient and tableId");
   }
 }

--- a/java/src/test/java/org/lance/DirectoryNamespaceIntegrationTest.java
+++ b/java/src/test/java/org/lance/DirectoryNamespaceIntegrationTest.java
@@ -25,6 +25,7 @@ import org.lance.namespace.model.DropTableRequest;
 import org.lance.namespace.model.DropTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
 import org.lance.operation.Append;
+import org.lance.operation.Overwrite;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -60,7 +61,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -1158,15 +1158,11 @@ public class DirectoryNamespaceIntegrationTest {
           0, getDescribeCallCount(innerNamespaceClient), "describeTable should not be called yet");
 
       String tableUri = response.getLocation();
-      Map<String, String> namespaceStorageOptions = response.getStorageOptions();
+      NamespaceClientTableContext namespaceClientTableContext =
+          NamespaceClientTableContext.fromDeclareTableResponse(response);
 
-      // Merge storage options
-      Map<String, String> mergedOptions = new HashMap<>(storageOptions);
-      if (namespaceStorageOptions != null) {
-        mergedOptions.putAll(namespaceStorageOptions);
-      }
-
-      WriteParams writeParams = new WriteParams.Builder().withStorageOptions(mergedOptions).build();
+      WriteParams writeParams =
+          new WriteParams.Builder().withStorageOptions(storageOptions).build();
       List<String> tableId = Arrays.asList(tableName);
 
       // Step 2: Write multiple fragments in parallel (simulated)
@@ -1188,7 +1184,14 @@ public class DirectoryNamespaceIntegrationTest {
         root.setRowCount(2);
 
         List<FragmentMetadata> fragment1 =
-            Fragment.create(tableUri, allocator, root, writeParams, namespaceClient, tableId);
+            Fragment.create(
+                tableUri,
+                allocator,
+                root,
+                writeParams,
+                namespaceClient,
+                tableId,
+                namespaceClientTableContext);
         allFragments.addAll(fragment1);
       }
 
@@ -1208,7 +1211,14 @@ public class DirectoryNamespaceIntegrationTest {
         root.setRowCount(2);
 
         List<FragmentMetadata> fragment2 =
-            Fragment.create(tableUri, allocator, root, writeParams, namespaceClient, tableId);
+            Fragment.create(
+                tableUri,
+                allocator,
+                root,
+                writeParams,
+                namespaceClient,
+                tableId,
+                namespaceClientTableContext);
         allFragments.addAll(fragment2);
       }
 
@@ -1226,16 +1236,29 @@ public class DirectoryNamespaceIntegrationTest {
         root.setRowCount(1);
 
         List<FragmentMetadata> fragment3 =
-            Fragment.create(tableUri, allocator, root, writeParams, namespaceClient, tableId);
+            Fragment.create(
+                tableUri,
+                allocator,
+                root,
+                writeParams,
+                namespaceClient,
+                tableId,
+                namespaceClientTableContext);
         allFragments.addAll(fragment3);
       }
 
       // Step 3: Commit all fragments as one operation
-      FragmentOperation.Overwrite overwriteOp =
-          new FragmentOperation.Overwrite(allFragments, schema);
-
-      try (Dataset dataset =
-          Dataset.commit(allocator, tableUri, overwriteOp, Optional.empty(), mergedOptions)) {
+      try (Transaction transaction =
+              new Transaction.Builder()
+                  .operation(Overwrite.builder().fragments(allFragments).schema(schema).build())
+                  .build();
+          Dataset dataset =
+              new CommitBuilder(allocator)
+                  .writeParams(storageOptions)
+                  .namespaceClient(namespaceClient)
+                  .tableId(tableId)
+                  .namespaceClientTableContext(namespaceClientTableContext)
+                  .execute(transaction)) {
         assertEquals(5, dataset.countRows(), "Should have 5 total rows from all fragments");
         assertEquals(1, dataset.listVersions().size(), "Should have 1 version after commit");
       }
@@ -1285,15 +1308,11 @@ public class DirectoryNamespaceIntegrationTest {
           1, getDeclareCallCount(innerNamespaceClient), "declareTable should be called once");
 
       String tableUri = response.getLocation();
-      Map<String, String> namespaceStorageOptions = response.getStorageOptions();
+      NamespaceClientTableContext namespaceClientTableContext =
+          NamespaceClientTableContext.fromDeclareTableResponse(response);
 
-      // Merge storage options
-      Map<String, String> mergedOptions = new HashMap<>(storageOptions);
-      if (namespaceStorageOptions != null) {
-        mergedOptions.putAll(namespaceStorageOptions);
-      }
-
-      WriteParams writeParams = new WriteParams.Builder().withStorageOptions(mergedOptions).build();
+      WriteParams writeParams =
+          new WriteParams.Builder().withStorageOptions(storageOptions).build();
       List<String> tableId = Arrays.asList(tableName);
 
       try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
@@ -1317,7 +1336,14 @@ public class DirectoryNamespaceIntegrationTest {
 
         // Create fragment with namespace client
         List<FragmentMetadata> fragments1 =
-            Fragment.create(tableUri, allocator, root, writeParams, namespaceClient, tableId);
+            Fragment.create(
+                tableUri,
+                allocator,
+                root,
+                writeParams,
+                namespaceClient,
+                tableId,
+                namespaceClientTableContext);
 
         assertEquals(1, fragments1.size());
 
@@ -1332,22 +1358,45 @@ public class DirectoryNamespaceIntegrationTest {
 
         // Create another fragment with the same namespace client
         List<FragmentMetadata> fragments2 =
-            Fragment.create(tableUri, allocator, root, writeParams, namespaceClient, tableId);
+            Fragment.create(
+                tableUri,
+                allocator,
+                root,
+                writeParams,
+                namespaceClient,
+                tableId,
+                namespaceClientTableContext);
 
         assertEquals(1, fragments2.size());
 
         // Commit first fragment to the dataset using Overwrite (for empty table)
-        FragmentOperation.Overwrite overwriteOp =
-            new FragmentOperation.Overwrite(fragments1, schema);
-        try (Dataset updatedDataset =
-            Dataset.commit(allocator, tableUri, overwriteOp, Optional.empty(), mergedOptions)) {
+        try (Transaction transaction =
+                new Transaction.Builder()
+                    .operation(Overwrite.builder().fragments(fragments1).schema(schema).build())
+                    .build();
+            Dataset updatedDataset =
+                new CommitBuilder(allocator)
+                    .writeParams(storageOptions)
+                    .namespaceClient(namespaceClient)
+                    .tableId(tableId)
+                    .namespaceClientTableContext(namespaceClientTableContext)
+                    .execute(transaction)) {
           assertEquals(1, updatedDataset.version());
           assertEquals(3, updatedDataset.countRows());
 
           // Append second fragment
-          FragmentOperation.Append appendOp2 = new FragmentOperation.Append(fragments2);
-          try (Dataset finalDataset =
-              Dataset.commit(allocator, tableUri, appendOp2, Optional.of(1L), mergedOptions)) {
+          try (Transaction appendTransaction =
+                  new Transaction.Builder()
+                      .readVersion(1L)
+                      .operation(Append.builder().fragments(fragments2).build())
+                      .build();
+              Dataset finalDataset =
+                  new CommitBuilder(allocator)
+                      .writeParams(storageOptions)
+                      .namespaceClient(namespaceClient)
+                      .tableId(tableId)
+                      .namespaceClientTableContext(namespaceClientTableContext)
+                      .execute(appendTransaction)) {
             assertEquals(2, finalDataset.version());
             assertEquals(6, finalDataset.countRows());
           }
@@ -1396,23 +1445,18 @@ public class DirectoryNamespaceIntegrationTest {
       DeclareTableResponse response = namespaceClient.declareTable(request);
 
       String tableUri = response.getLocation();
-      Map<String, String> namespaceStorageOptions = response.getStorageOptions();
-
-      // Merge storage options
-      Map<String, String> mergedOptions = new HashMap<>(storageOptions);
-      if (namespaceStorageOptions != null) {
-        mergedOptions.putAll(namespaceStorageOptions);
-      }
+      NamespaceClientTableContext namespaceClientTableContext =
+          NamespaceClientTableContext.fromDeclareTableResponse(response);
 
       // First, write some initial data using Fragment.create and commit
-      WriteParams writeParams = new WriteParams.Builder().withStorageOptions(mergedOptions).build();
+      WriteParams writeParams =
+          new WriteParams.Builder().withStorageOptions(storageOptions).build();
       List<String> tableId = Arrays.asList(tableName);
 
       List<FragmentMetadata> initialFragments;
       try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
         IntVector idVector = (IntVector) root.getVector("id");
-        org.apache.arrow.vector.VarCharVector nameVector =
-            (org.apache.arrow.vector.VarCharVector) root.getVector("name");
+        VarCharVector nameVector = (VarCharVector) root.getVector("name");
 
         idVector.allocateNew(2);
         nameVector.allocateNew(2);
@@ -1427,35 +1471,48 @@ public class DirectoryNamespaceIntegrationTest {
         root.setRowCount(2);
 
         initialFragments =
-            Fragment.create(tableUri, allocator, root, writeParams, namespaceClient, tableId);
+            Fragment.create(
+                tableUri,
+                allocator,
+                root,
+                writeParams,
+                namespaceClient,
+                tableId,
+                namespaceClientTableContext);
       }
 
       // Commit initial fragments
-      FragmentOperation.Overwrite overwriteOp =
-          new FragmentOperation.Overwrite(initialFragments, schema);
-      try (Dataset dataset =
-          Dataset.commit(allocator, tableUri, overwriteOp, Optional.empty(), mergedOptions)) {
+      try (Transaction transaction =
+              new Transaction.Builder()
+                  .operation(Overwrite.builder().fragments(initialFragments).schema(schema).build())
+                  .build();
+          Dataset dataset =
+              new CommitBuilder(allocator)
+                  .writeParams(storageOptions)
+                  .namespaceClient(namespaceClient)
+                  .tableId(tableId)
+                  .namespaceClientTableContext(namespaceClientTableContext)
+                  .execute(transaction)) {
         assertEquals(1, dataset.version());
         assertEquals(2, dataset.countRows());
       }
 
       // Now test Transaction.commit with namespace client
-      // Open dataset with namespace client using mergedOptions (which has expires_at_millis)
-      ReadOptions readOptions = new ReadOptions.Builder().setStorageOptions(mergedOptions).build();
+      ReadOptions readOptions = new ReadOptions.Builder().setStorageOptions(storageOptions).build();
 
       try (Dataset datasetWithNamespaceClient =
           Dataset.open()
               .allocator(allocator)
               .namespaceClient(namespaceClient)
               .tableId(tableId)
+              .namespaceClientTableContext(namespaceClientTableContext)
               .readOptions(readOptions)
               .build()) {
         // Create more fragments to append
         List<FragmentMetadata> newFragments;
         try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
           IntVector idVector = (IntVector) root.getVector("id");
-          org.apache.arrow.vector.VarCharVector nameVector =
-              (org.apache.arrow.vector.VarCharVector) root.getVector("name");
+          VarCharVector nameVector = (VarCharVector) root.getVector("name");
 
           idVector.allocateNew(2);
           nameVector.allocateNew(2);
@@ -1470,7 +1527,14 @@ public class DirectoryNamespaceIntegrationTest {
           root.setRowCount(2);
 
           newFragments =
-              Fragment.create(tableUri, allocator, root, writeParams, namespaceClient, tableId);
+              Fragment.create(
+                  tableUri,
+                  allocator,
+                  root,
+                  writeParams,
+                  namespaceClient,
+                  tableId,
+                  namespaceClientTableContext);
         }
 
         // Create and commit transaction
@@ -1481,7 +1545,11 @@ public class DirectoryNamespaceIntegrationTest {
                 .operation(appendOp)
                 .build()) {
           try (Dataset committedDataset =
-              new CommitBuilder(datasetWithNamespaceClient).execute(transaction)) {
+              new CommitBuilder(datasetWithNamespaceClient)
+                  .namespaceClient(namespaceClient)
+                  .tableId(tableId)
+                  .namespaceClientTableContext(namespaceClientTableContext)
+                  .execute(transaction)) {
             assertEquals(2, committedDataset.version());
             assertEquals(4, committedDataset.countRows());
           }

--- a/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
+++ b/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
@@ -60,6 +60,7 @@ import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RegisterTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
 import org.lance.operation.Append;
+import org.lance.operation.Overwrite;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -838,6 +839,280 @@ public class DirectoryNamespaceTest {
       }
 
       existingDataset.close();
+      namespaceClient.close();
+    }
+  }
+
+  @Test
+  void testNamespaceCommitBuilderResolvesActualLocation(@TempDir Path managedVersioningTempDir)
+      throws Exception {
+    try (BufferAllocator allocator = new RootAllocator()) {
+      DirectoryNamespace namespaceClient =
+          createManagedVersioningNamespace(managedVersioningTempDir);
+      String tableName = "test_uri_commit_table";
+      List<String> tableId = Arrays.asList(tableName);
+
+      Schema schema =
+          new Schema(
+              Arrays.asList(
+                  new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null),
+                  new Field("name", FieldType.nullable(new ArrowType.Utf8()), null)));
+
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+        IntVector idVector = (IntVector) root.getVector("id");
+        VarCharVector nameVector = (VarCharVector) root.getVector("name");
+
+        idVector.allocateNew(2);
+        nameVector.allocateNew(2);
+        idVector.set(0, 1);
+        idVector.set(1, 2);
+        nameVector.set(0, "Alice".getBytes());
+        nameVector.set(1, "Bob".getBytes());
+        idVector.setValueCount(2);
+        nameVector.setValueCount(2);
+        root.setRowCount(2);
+
+        ArrowReader reader =
+            new ArrowReader(allocator) {
+              boolean firstRead = true;
+
+              @Override
+              public boolean loadNextBatch() {
+                if (firstRead) {
+                  firstRead = false;
+                  return true;
+                }
+                return false;
+              }
+
+              @Override
+              public long bytesRead() {
+                return 0;
+              }
+
+              @Override
+              protected void closeReadSource() {}
+
+              @Override
+              protected Schema readSchema() {
+                return schema;
+              }
+
+              @Override
+              public VectorSchemaRoot getVectorSchemaRoot() {
+                return root;
+              }
+            };
+
+        try (Dataset dataset =
+            Dataset.write()
+                .allocator(allocator)
+                .reader(reader)
+                .namespaceClient(namespaceClient)
+                .tableId(tableId)
+                .mode(WriteParams.WriteMode.CREATE)
+                .execute()) {
+          assertEquals(2, dataset.countRows());
+        }
+      }
+
+      Dataset existingDataset =
+          Dataset.open()
+              .allocator(allocator)
+              .namespaceClient(namespaceClient)
+              .tableId(tableId)
+              .build();
+      String datasetUri = existingDataset.uri();
+
+      List<FragmentMetadata> fragments;
+      try (VectorSchemaRoot appendRoot = VectorSchemaRoot.create(schema, allocator)) {
+        IntVector idVector = (IntVector) appendRoot.getVector("id");
+        VarCharVector nameVector = (VarCharVector) appendRoot.getVector("name");
+
+        idVector.allocateNew(2);
+        nameVector.allocateNew(2);
+        idVector.set(0, 3);
+        idVector.set(1, 4);
+        nameVector.set(0, "Charlie".getBytes());
+        nameVector.set(1, "Diana".getBytes());
+        idVector.setValueCount(2);
+        nameVector.setValueCount(2);
+        appendRoot.setRowCount(2);
+
+        fragments =
+            Fragment.create(datasetUri, allocator, appendRoot, new WriteParams.Builder().build());
+      }
+
+      int createCountBefore = getCreateTableVersionCount(namespaceClient);
+      try (Transaction txn =
+              new Transaction.Builder()
+                  .readVersion(existingDataset.version())
+                  .operation(Append.builder().fragments(fragments).build())
+                  .build();
+          Dataset committed =
+              new CommitBuilder(allocator)
+                  .namespaceClient(namespaceClient)
+                  .tableId(tableId)
+                  .execute(txn)) {
+        assertEquals(2, committed.version());
+        assertEquals(4, committed.countRows());
+        assertEquals(datasetUri, committed.uri());
+      }
+
+      assertEquals(
+          createCountBefore + 1,
+          getCreateTableVersionCount(namespaceClient),
+          "create_table_version should be called for namespace CommitBuilder");
+
+      try (Dataset latestDs =
+          Dataset.open()
+              .allocator(allocator)
+              .namespaceClient(namespaceClient)
+              .tableId(tableId)
+              .build()) {
+        assertEquals(4, latestDs.countRows());
+        assertEquals(2, latestDs.version());
+      }
+
+      existingDataset.close();
+      namespaceClient.close();
+    }
+  }
+
+  @Test
+  void testNamespaceCommitBuilderDeclaresMissingTable(@TempDir Path managedVersioningTempDir)
+      throws Exception {
+    try (BufferAllocator allocator = new RootAllocator()) {
+      DirectoryNamespace namespaceClient =
+          createManagedVersioningNamespace(managedVersioningTempDir);
+      String tableName = "test_uri_commit_declare_table";
+      List<String> tableId = Arrays.asList(tableName);
+
+      Schema schema =
+          new Schema(
+              Arrays.asList(
+                  new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null),
+                  new Field("name", FieldType.nullable(new ArrowType.Utf8()), null)));
+
+      int createCountBefore = getCreateTableVersionCount(namespaceClient);
+      try (Transaction txn =
+              new Transaction.Builder()
+                  .operation(Overwrite.builder().fragments(List.of()).schema(schema).build())
+                  .build();
+          Dataset committed =
+              new CommitBuilder(allocator)
+                  .namespaceClient(namespaceClient)
+                  .tableId(tableId)
+                  .execute(txn)) {
+        assertEquals(1, committed.version());
+        assertEquals(0, committed.countRows());
+      }
+
+      assertEquals(
+          createCountBefore + 1,
+          getCreateTableVersionCount(namespaceClient),
+          "create_table_version should be called for namespace commit creating a missing table");
+
+      try (Dataset latestDs =
+          Dataset.open()
+              .allocator(allocator)
+              .namespaceClient(namespaceClient)
+              .tableId(tableId)
+              .build()) {
+        assertEquals(0, latestDs.countRows());
+        assertEquals(1, latestDs.version());
+      }
+
+      assertThrows(
+          RuntimeException.class,
+          () -> {
+            try (Dataset ignored =
+                Dataset.write()
+                    .allocator(allocator)
+                    .schema(schema)
+                    .namespaceClient(namespaceClient)
+                    .tableId(tableId)
+                    .mode(WriteParams.WriteMode.CREATE)
+                    .execute()) {}
+          });
+
+      namespaceClient.close();
+    }
+  }
+
+  @Test
+  void testWriteDatasetBuilderCreatesEmptyNamespaceTable(@TempDir Path managedVersioningTempDir)
+      throws Exception {
+    try (BufferAllocator allocator = new RootAllocator()) {
+      DirectoryNamespace namespaceClient =
+          createManagedVersioningNamespace(managedVersioningTempDir);
+      List<String> tableId = Arrays.asList("test_write_builder_empty_namespace_table");
+      Schema schema =
+          new Schema(
+              Arrays.asList(
+                  new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null),
+                  new Field("name", FieldType.nullable(new ArrowType.Utf8()), null)));
+
+      int createCountBefore = getCreateTableVersionCount(namespaceClient);
+      try (Dataset dataset =
+          Dataset.write()
+              .allocator(allocator)
+              .schema(schema)
+              .namespaceClient(namespaceClient)
+              .tableId(tableId)
+              .mode(WriteParams.WriteMode.CREATE)
+              .execute()) {
+        assertEquals(1, dataset.version());
+        assertEquals(0, dataset.countRows());
+      }
+
+      assertEquals(
+          createCountBefore + 1,
+          getCreateTableVersionCount(namespaceClient),
+          "create_table_version should be called for empty namespace table creation");
+
+      try (Dataset latestDs =
+          Dataset.open()
+              .allocator(allocator)
+              .namespaceClient(namespaceClient)
+              .tableId(tableId)
+              .build()) {
+        assertEquals(0, latestDs.countRows());
+        assertEquals(1, latestDs.version());
+      }
+
+      namespaceClient.close();
+    }
+  }
+
+  @Test
+  void testCommitBuilderRejectsUriWithNamespace(@TempDir Path managedVersioningTempDir)
+      throws Exception {
+    try (BufferAllocator allocator = new RootAllocator()) {
+      DirectoryNamespace namespaceClient =
+          createManagedVersioningNamespace(managedVersioningTempDir);
+      List<String> tableId = Arrays.asList("test_reject_uri_with_namespace");
+      Schema schema =
+          new Schema(
+              Arrays.asList(
+                  new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+
+      String explicitUri = managedVersioningTempDir.resolve("explicit-target").toUri().toString();
+      try (Transaction txn =
+          new Transaction.Builder()
+              .operation(Overwrite.builder().fragments(List.of()).schema(schema).build())
+              .build()) {
+        IllegalArgumentException error =
+            assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                    new CommitBuilder(explicitUri, allocator)
+                        .namespaceClient(namespaceClient)
+                        .tableId(tableId)
+                        .execute(txn));
+        assertTrue(error.getMessage().contains("Cannot specify both URI and namespaceClient"));
+      }
+
       namespaceClient.close();
     }
   }

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -33,10 +33,7 @@ from .lance import (
     bytes_read_counter,
     iops_counter,
 )
-from .namespace import (
-    DescribeTableRequest,
-    LanceNamespace,
-)
+from .namespace import DescribeTableRequest, LanceNamespace, NamespaceClientTableContext
 from .progress import IndexProgress
 from .schema import json_to_schema, schema_to_json
 from .util import sanitize_ts
@@ -59,6 +56,7 @@ __all__ = [
     "blob_array",
     "blob_field",
     "DatasetBasePath",
+    "DescribeTableRequest",
     "DataStatistics",
     "FieldStatistics",
     "FragmentMetadata",
@@ -66,9 +64,11 @@ __all__ = [
     "IndexFile",
     "LanceDataset",
     "LanceFragment",
+    "LanceNamespace",
     "LanceOperation",
     "LanceScanner",
     "MergeInsertBuilder",
+    "NamespaceClientTableContext",
     "ScanStatistics",
     "Transaction",
     "__version__",
@@ -102,6 +102,7 @@ def dataset(
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
     base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+    namespace_client_table_context: Optional[NamespaceClientTableContext] = None,
 ) -> LanceDataset:
     """
     Opens the Lance dataset from the address specified.
@@ -176,6 +177,12 @@ def dataset(
         of storage options (credentials, endpoint, etc.) for that base.  When a base
         has no explicit entry here, the top-level ``storage_options`` is
         used as a fallback.
+    namespace_client_table_context : optional, NamespaceClientTableContext
+        A cached context from a prior ``describe_table`` or ``declare_table``
+        call.  When provided with ``namespace_client`` + ``table_id``, skips
+        the namespace call and uses the cached location, storage options, and
+        managed-versioning flag directly.  Cannot be used with ``uri``.
+        Must be used together with ``namespace_client`` and ``table_id``.
 
     Notes
     -----
@@ -186,51 +193,29 @@ def dataset(
     - Initial storage options from describe_table() will be merged with
       any provided `storage_options`
     """
-    # Validate that user provides either uri OR (namespace_client + table_id), not both
     has_uri = uri is not None
     has_namespace = namespace_client is not None or table_id is not None
+    has_context = namespace_client_table_context is not None
 
     if has_uri and has_namespace:
+        raise ValueError("Cannot specify both 'uri' and 'namespace_client'/'table_id'.")
+    if has_uri and has_context:
         raise ValueError(
-            "Cannot specify both 'uri' and 'namespace_client/table_id'. "
-            "Please provide either 'uri' or both 'namespace_client' and 'table_id'."
+            "Cannot specify both 'uri' and 'namespace_client_table_context'."
         )
-    elif not has_uri and not has_namespace:
+    if has_context and not has_namespace:
         raise ValueError(
-            "Must specify either 'uri' or both 'namespace_client' and 'table_id'."
+            "'namespace_client_table_context' requires 'namespace_client' and "
+            "'table_id' to be provided."
         )
+    if not has_uri and not has_namespace:
+        raise ValueError("Must specify either 'uri' or 'namespace_client'+'table_id'.")
 
-    # Handle namespace resolution in Python
-    namespace_client_managed_versioning = False
     if namespace_client is not None:
         if table_id is None:
             raise ValueError(
                 "Both 'namespace_client' and 'table_id' must be provided together."
             )
-
-        request = DescribeTableRequest(id=table_id, version=version)
-        response = namespace_client.describe_table(request)
-
-        uri = response.location
-        if uri is None:
-            raise ValueError("Namespace did not return a 'location' for the table")
-
-        # Check if namespace manages versioning (commits go through namespace API)
-        namespace_client_managed_versioning = (
-            getattr(response, "managed_versioning", None) is True
-        )
-
-        namespace_storage_options = response.storage_options
-
-        # Merge namespace storage options with user-provided options
-        # Namespace options take precedence
-        if namespace_storage_options is not None:
-            if storage_options is None:
-                storage_options = namespace_storage_options
-            else:
-                merged_options = dict(storage_options)
-                merged_options.update(namespace_storage_options)
-                storage_options = merged_options
     elif table_id is not None:
         raise ValueError(
             "Both 'namespace_client' and 'table_id' must be provided together."
@@ -250,8 +235,8 @@ def dataset(
         session=session,
         namespace_client=namespace_client,
         table_id=table_id,
-        namespace_client_managed_versioning=namespace_client_managed_versioning,
         base_store_params=base_store_params,
+        namespace_client_table_context=namespace_client_table_context,
     )
     if version is None and asof is not None:
         ts_cutoff = sanitize_ts(asof)
@@ -277,8 +262,8 @@ def dataset(
                 session=session,
                 namespace_client=namespace_client,
                 table_id=table_id,
-                namespace_client_managed_versioning=namespace_client_managed_versioning,
                 base_store_params=base_store_params,
+                namespace_client_table_context=namespace_client_table_context,
             )
     else:
         return ds

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -76,7 +76,7 @@ from .util import _target_partition_size_to_num_partitions, td_to_micros
 if TYPE_CHECKING:
     from pyarrow._compute import Expression
 
-    from lance.namespace import LanceNamespace
+    from lance.namespace import LanceNamespace, NamespaceClientTableContext
 
     from .commit import CommitLock
     from .lance.indices import IndexDescription
@@ -565,7 +565,7 @@ class LanceDataset(pa.dataset.Dataset):
 
     def __init__(
         self,
-        uri: Union[str, Path],
+        uri: Optional[Union[str, Path]] = None,
         version: Optional[int | str] = None,
         block_size: Optional[int] = None,
         index_cache_size: Optional[int] = None,
@@ -580,15 +580,36 @@ class LanceDataset(pa.dataset.Dataset):
         session: Optional[Session] = None,
         namespace_client: Optional[Any] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_managed_versioning: bool = False,
         base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
     ):
         uri = os.fspath(uri) if isinstance(uri, Path) else uri
-        self._uri = uri
+        has_uri = uri is not None
+        has_namespace = namespace_client is not None or table_id is not None
+        has_complete_namespace = namespace_client is not None and table_id is not None
+        has_context = namespace_client_table_context is not None
+
+        if has_uri and has_namespace:
+            raise ValueError(
+                "Cannot specify both 'uri' and 'namespace_client'/'table_id'."
+            )
+        if has_uri and has_context:
+            raise ValueError(
+                "Cannot specify both 'uri' and 'namespace_client_table_context'."
+            )
+        if has_context and not has_complete_namespace:
+            raise ValueError(
+                "'namespace_client_table_context' requires 'namespace_client' and "
+                "'table_id' to be provided."
+            )
+        if has_namespace and not has_complete_namespace:
+            raise ValueError(
+                "Both 'namespace_client' and 'table_id' must be provided together."
+            )
+
         self._storage_options = storage_options
         self._base_store_params = base_store_params
 
-        # Handle deprecation warning for index_cache_size
         if index_cache_size is not None:
             warnings.warn(
                 "The 'index_cache_size' parameter is deprecated. "
@@ -598,13 +619,10 @@ class LanceDataset(pa.dataset.Dataset):
                 stacklevel=2,
             )
 
-        # Store namespace_client and table_id for credential refresh in file operations
         self._namespace_client = namespace_client
         self._table_id = table_id
-        self._namespace_client_managed_versioning = namespace_client_managed_versioning
+        self._namespace_client_table_context = namespace_client_table_context
 
-        # Storage options provider is automatically created in Rust when
-        # namespace_client and table_id are provided
         self._ds = _Dataset(
             uri,
             version,
@@ -620,9 +638,10 @@ class LanceDataset(pa.dataset.Dataset):
             session=session,
             namespace_client=namespace_client,
             table_id=table_id,
-            namespace_client_managed_versioning=namespace_client_managed_versioning,
             base_store_params=base_store_params,
+            namespace_client_table_context=namespace_client_table_context,
         )
+        self._uri = self._ds.uri
         self._default_scan_options = default_scan_options
         self._read_params = read_params
 
@@ -687,7 +706,6 @@ class LanceDataset(pa.dataset.Dataset):
             version,
             storage_options=self._storage_options,
             manifest=manifest,
-            default_scan_options=default_scan_options,
             read_params=read_params,
             base_store_params=base_store_params,
         )
@@ -696,7 +714,7 @@ class LanceDataset(pa.dataset.Dataset):
         self._base_store_params = base_store_params
         self._namespace_client = None
         self._table_id = None
-        self._namespace_client_managed_versioning = False
+        self._namespace_client_table_context = None
 
     def __copy__(self):
         ds = LanceDataset.__new__(LanceDataset)
@@ -705,9 +723,7 @@ class LanceDataset(pa.dataset.Dataset):
         ds._base_store_params = self._base_store_params
         ds._namespace_client = self._namespace_client
         ds._table_id = self._table_id
-        ds._namespace_client_managed_versioning = (
-            self._namespace_client_managed_versioning
-        )
+        ds._namespace_client_table_context = self._namespace_client_table_context
         ds._ds = copy.copy(self._ds)
         ds._default_scan_options = self._default_scan_options
         ds._read_params = self._read_params.copy() if self._read_params else None
@@ -805,6 +821,7 @@ class LanceDataset(pa.dataset.Dataset):
         ds._base_store_params = self._base_store_params
         ds._namespace_client = self._namespace_client
         ds._table_id = self._table_id
+        ds._namespace_client_table_context = self._namespace_client_table_context
         ds._default_scan_options = self._default_scan_options
         ds._read_params = self._read_params
         return ds
@@ -2668,6 +2685,7 @@ class LanceDataset(pa.dataset.Dataset):
             storage_options=self.latest_storage_options(),
             namespace_client=self._namespace_client,
             table_id=self._table_id,
+            namespace_client_table_context=self._namespace_client_table_context,
         )
 
     def checkout_version(
@@ -3937,7 +3955,7 @@ class LanceDataset(pa.dataset.Dataset):
 
     @staticmethod
     def commit(
-        base_uri: Union[str, Path, LanceDataset],
+        base_uri: Union[str, Path, LanceDataset, None],
         operation: Union[LanceOperation.BaseOperation, Transaction],
         read_version: Optional[int] = None,
         commit_lock: Optional[CommitLock] = None,
@@ -3950,8 +3968,8 @@ class LanceDataset(pa.dataset.Dataset):
         enable_stable_row_ids: Optional[bool] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
-        namespace_client_managed_versioning: bool = False,
         base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
     ) -> LanceDataset:
         """Create a new version of dataset
 
@@ -3975,10 +3993,11 @@ class LanceDataset(pa.dataset.Dataset):
 
         Parameters
         ----------
-        base_uri: str, Path, or LanceDataset
-            The base uri of the dataset, or the dataset object itself. Using
-            the dataset object can be more efficient because it can re-use the
-            file metadata cache.
+        base_uri: str, Path, LanceDataset, or None
+            The base uri of the dataset, the dataset object itself, or None
+            when committing through ``namespace_client`` and ``table_id``.
+            Using the dataset object can be more efficient because it can
+            re-use the file metadata cache.
         operation: BaseOperation
             The operation to apply to the dataset.  This describes what changes
             have been made. See available operations under :class:`LanceOperation`.
@@ -4022,6 +4041,10 @@ class LanceDataset(pa.dataset.Dataset):
         table_id : List[str], optional
             The table identifier within the namespace (e.g., ["workspace", "table"]).
             Must be provided together with namespace_client.
+        namespace_client_table_context : optional, NamespaceClientTableContext
+            A cached context from a prior ``describe_table`` or ``declare_table``
+            call. When provided with ``namespace_client`` and ``table_id``, Rust
+            uses the cached location, storage options, and managed-versioning flag.
         base_store_params : dict of str to dict, optional
             Runtime-only object store parameters keyed by base path URI.
 
@@ -4051,6 +4074,34 @@ class LanceDataset(pa.dataset.Dataset):
         2  3  c
         3  4  d
         """
+        has_namespace = namespace_client is not None or table_id is not None
+        has_complete_namespace = namespace_client is not None and table_id is not None
+        has_context = namespace_client_table_context is not None
+        has_explicit_uri = isinstance(base_uri, (str, Path))
+
+        if has_explicit_uri and has_namespace:
+            raise ValueError(
+                "Cannot specify both 'base_uri' and 'namespace_client'/'table_id'."
+            )
+        if has_explicit_uri and has_context:
+            raise ValueError(
+                "Cannot specify both 'base_uri' and 'namespace_client_table_context'."
+            )
+        if has_context and not has_complete_namespace:
+            raise ValueError(
+                "'namespace_client_table_context' requires 'namespace_client' and "
+                "'table_id' to be provided."
+            )
+        if has_namespace and not has_complete_namespace:
+            raise ValueError(
+                "Both 'namespace_client' and 'table_id' must be provided together."
+            )
+        if base_uri is None and not has_complete_namespace:
+            raise ValueError(
+                "base_uri is required unless 'namespace_client' and 'table_id' "
+                "are provided."
+            )
+
         base_store_params = LanceDataset._inherit_base_store_params(
             base_uri, base_store_params
         )
@@ -4059,9 +4110,12 @@ class LanceDataset(pa.dataset.Dataset):
             base_uri = str(base_uri)
         elif isinstance(base_uri, LanceDataset):
             base_uri = base_uri._ds
+        elif base_uri is None and has_complete_namespace:
+            base_uri = ""
         elif not isinstance(base_uri, str):
             raise TypeError(
-                f"base_uri must be str, Path, or LanceDataset, got {type(base_uri)}"
+                "base_uri must be str, Path, LanceDataset, or None when using "
+                f"a namespace, got {type(base_uri)}"
             )
 
         if commit_lock:
@@ -4102,7 +4156,7 @@ class LanceDataset(pa.dataset.Dataset):
                 enable_stable_row_ids=enable_stable_row_ids,
                 namespace_client=namespace_client,
                 table_id=table_id,
-                namespace_client_managed_versioning=namespace_client_managed_versioning,
+                namespace_client_table_context=namespace_client_table_context,
             )
         elif isinstance(operation, LanceOperation.BaseOperation):
             new_ds = _Dataset.commit(
@@ -4118,7 +4172,7 @@ class LanceDataset(pa.dataset.Dataset):
                 enable_stable_row_ids=enable_stable_row_ids,
                 namespace_client=namespace_client,
                 table_id=table_id,
-                namespace_client_managed_versioning=namespace_client_managed_versioning,
+                namespace_client_table_context=namespace_client_table_context,
             )
         else:
             raise TypeError(
@@ -4131,7 +4185,7 @@ class LanceDataset(pa.dataset.Dataset):
         ds._base_store_params = base_store_params
         ds._namespace_client = namespace_client
         ds._table_id = table_id
-        ds._namespace_client_managed_versioning = namespace_client_managed_versioning
+        ds._namespace_client_table_context = namespace_client_table_context
         ds._ds = new_ds
         ds._uri = new_ds.uri
         ds._default_scan_options = None
@@ -6403,6 +6457,7 @@ def write_dataset(
     blob_pack_file_size_threshold: Optional[int] = None,
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
+    namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
 ) -> LanceDataset:
     """Write a given data_obj to the given uri
 
@@ -6524,6 +6579,12 @@ def write_dataset(
     table_id : optional, List[str]
         The table identifier when using a namespace (e.g., ["my_table"]).
         Must be provided together with `namespace_client`. Cannot be used with `uri`.
+    namespace_client_table_context : optional, NamespaceClientTableContext
+        A cached context from a prior ``describe_table`` or ``declare_table``
+        call.  When provided with ``namespace_client`` + ``table_id``, skips
+        the namespace call and uses the cached location, storage options, and
+        managed-versioning flag directly.  Cannot be used with ``uri``.
+        Must be used together with ``namespace_client`` and ``table_id``.
 
     Notes
     -----
@@ -6534,79 +6595,33 @@ def write_dataset(
     - Initial storage options from describe_table() will be merged with
       any provided `storage_options`
     """
-    # Validate that user provides either uri OR (namespace_client + table_id), not both
     has_uri = uri is not None
     has_namespace = namespace_client is not None or table_id is not None
+    has_context = namespace_client_table_context is not None
 
     if has_uri and has_namespace:
+        raise ValueError("Cannot specify both 'uri' and 'namespace_client'/'table_id'.")
+    if has_uri and has_context:
         raise ValueError(
-            "Cannot specify both 'uri' and 'namespace_client/table_id'. "
-            "Please provide either 'uri' or both 'namespace_client' and 'table_id'."
+            "Cannot specify both 'uri' and 'namespace_client_table_context'."
         )
-    elif not has_uri and not has_namespace:
+    if has_context and not has_namespace:
         raise ValueError(
-            "Must specify either 'uri' or both 'namespace_client' and 'table_id'."
+            "'namespace_client_table_context' requires 'namespace_client' and "
+            "'table_id' to be provided."
         )
+    if not has_uri and not has_namespace:
+        raise ValueError("Must specify either 'uri' or 'namespace_client'+'table_id'.")
 
-    # Handle namespace-based dataset writing
     if namespace_client is not None:
         if table_id is None:
             raise ValueError(
                 "Both 'namespace_client' and 'table_id' must be provided together."
             )
-
-        # Implement write_into_namespace logic in Python
-        # This follows the same pattern as the Rust implementation:
-        # - CREATE mode: calls namespace.declare_table()
-        # - APPEND/OVERWRITE mode: calls namespace.describe_table()
-        # - Both modes: create storage options provider and merge storage options
-
-        from .namespace import (
-            DeclareTableRequest,
-            DescribeTableRequest,
-        )
-
-        # Determine which namespace method to call based on mode
-        if mode == "create":
-            declare_request = DeclareTableRequest(id=table_id, location=None)
-            response = namespace_client.declare_table(declare_request)
-        elif mode in ("append", "overwrite"):
-            request = DescribeTableRequest(id=table_id, version=None)
-            response = namespace_client.describe_table(request)
-        else:
-            raise ValueError(f"Invalid mode: {mode}")
-
-        # Get table location from response
-        uri = response.location
-        if not uri:
-            raise ValueError(
-                f"Namespace did not return a table location in {mode} response"
-            )
-
-        # Check if namespace manages versioning (commits go through namespace API)
-        namespace_client_managed_versioning = (
-            getattr(response, "managed_versioning", None) is True
-        )
-
-        # Use namespace storage options
-        namespace_storage_options = response.storage_options
-
-        # Merge namespace storage options with any existing options
-        # Namespace options take precedence (same as Rust implementation)
-        # Storage options provider will be created automatically in Rust
-        if namespace_storage_options is not None:
-            if storage_options is None:
-                storage_options = dict(namespace_storage_options)
-            else:
-                merged_options = dict(storage_options)
-                merged_options.update(namespace_storage_options)
-                storage_options = merged_options
     elif table_id is not None:
         raise ValueError(
             "Both 'namespace_client' and 'table_id' must be provided together."
         )
-    else:
-        namespace_client_managed_versioning = False
 
     if use_legacy_format is not None:
         warnings.warn(
@@ -6653,9 +6668,7 @@ def write_dataset(
     if namespace_client is not None and table_id is not None:
         params["namespace_client"] = namespace_client
         params["table_id"] = table_id
-        params["namespace_client_managed_versioning"] = (
-            namespace_client_managed_versioning
-        )
+        params["namespace_client_table_context"] = namespace_client_table_context
 
     if commit_lock:
         if not callable(commit_lock):
@@ -6666,7 +6679,7 @@ def write_dataset(
         uri = os.fspath(uri)
     elif isinstance(uri, LanceDataset):
         uri = uri._ds
-    elif not isinstance(uri, str):
+    elif uri is not None and not isinstance(uri, str):
         raise TypeError(f"dest must be a str, Path, or LanceDataset. Got {type(uri)}")
 
     inner_ds = _write_dataset(reader, uri, params)
@@ -6676,7 +6689,7 @@ def write_dataset(
     ds._base_store_params = base_store_params
     ds._namespace_client = namespace_client
     ds._table_id = table_id
-    ds._namespace_client_managed_versioning = namespace_client_managed_versioning
+    ds._namespace_client_table_context = namespace_client_table_context
     ds._ds = inner_ds
     ds._uri = inner_ds.uri
     ds._default_scan_options = None

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4290,6 +4290,7 @@ class LanceDataset(pa.dataset.Dataset):
         ds._base_store_params = base_store_params
         ds._namespace_client = None
         ds._table_id = None
+        ds._namespace_client_table_context = None
         ds._default_scan_options = None
         ds._read_params = None
         return BulkCommitResult(

--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -25,7 +25,27 @@ from .lance import (
 )
 
 if TYPE_CHECKING:
-    from .namespace import LanceNamespace
+    from .namespace import LanceNamespace, NamespaceClientTableContext
+
+
+def _validate_namespace_client_args(
+    namespace_client: Optional["LanceNamespace"],
+    table_id: Optional[List[str]],
+    namespace_client_table_context: Optional["NamespaceClientTableContext"],
+) -> None:
+    if namespace_client is not None and table_id is None:
+        raise ValueError(
+            "Both 'namespace_client' and 'table_id' must be provided together."
+        )
+    if table_id is not None and namespace_client is None:
+        raise ValueError(
+            "Both 'namespace_client' and 'table_id' must be provided together."
+        )
+    if namespace_client_table_context is not None and namespace_client is None:
+        raise ValueError(
+            "'namespace_client_table_context' requires 'namespace_client' and "
+            "'table_id' to be provided."
+        )
 
 
 class ReaderResults:
@@ -71,6 +91,7 @@ class LanceFileReader:
         *,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
         _inner_reader: Optional[_LanceFileReader] = None,
     ):
         """
@@ -91,13 +112,24 @@ class LanceFileReader:
         table_id : optional, List[str]
             The table identifier within the namespace.
             Must be provided together with namespace_client.
+        namespace_client_table_context : optional, NamespaceClientTableContext
+            Cached context from a prior namespace call. The native layer uses
+            this cached metadata together with ``namespace_client`` and
+            ``table_id`` to avoid redundant namespace lookups while keeping
+            credential refresh support.
         columns: list of str, default None
             List of column names to be fetched.
             All columns are fetched if None or unspecified.
         """
+
         if _inner_reader is not None:
             self._reader = _inner_reader
         else:
+            _validate_namespace_client_args(
+                namespace_client,
+                table_id,
+                namespace_client_table_context,
+            )
             if isinstance(path, Path):
                 path = str(path)
             self._reader = _LanceFileReader(
@@ -105,6 +137,7 @@ class LanceFileReader:
                 storage_options=storage_options,
                 namespace_client=namespace_client,
                 table_id=table_id,
+                namespace_client_table_context=namespace_client_table_context,
                 columns=columns,
             )
 
@@ -222,6 +255,7 @@ class LanceFileSession:
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
     ):
         """
         Creates a new file session
@@ -241,14 +275,26 @@ class LanceFileSession:
         table_id : optional, List[str]
             The table identifier within the namespace.
             Must be provided together with namespace_client.
+        namespace_client_table_context : optional, NamespaceClientTableContext
+            Cached context from a prior namespace call. The native layer uses
+            this cached metadata together with ``namespace_client`` and
+            ``table_id`` to avoid redundant namespace lookups while keeping
+            credential refresh support.
         """
+
         if isinstance(base_path, Path):
             base_path = str(base_path)
+        _validate_namespace_client_args(
+            namespace_client,
+            table_id,
+            namespace_client_table_context,
+        )
         self._session = _LanceFileSession(
             base_path,
             storage_options=storage_options,
             namespace_client=namespace_client,
             table_id=table_id,
+            namespace_client_table_context=namespace_client_table_context,
         )
 
     def open_reader(
@@ -394,6 +440,7 @@ class LanceFileWriter:
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
         max_page_bytes: Optional[int] = None,
         _inner_writer: Optional[_LanceFileWriter] = None,
         **kwargs,
@@ -426,14 +473,25 @@ class LanceFileWriter:
         table_id : optional, List[str]
             The table identifier within the namespace.
             Must be provided together with namespace_client.
+        namespace_client_table_context : optional, NamespaceClientTableContext
+            Cached context from a prior namespace call. The native layer uses
+            this cached metadata together with ``namespace_client`` and
+            ``table_id`` to avoid redundant namespace lookups while keeping
+            credential refresh support.
         max_page_bytes : optional, int
             The maximum size of a page in bytes, if a single array would create a
             page larger than this then it will be split into multiple pages. The
             default value is 32MB.
         """
+
         if _inner_writer is not None:
             self._writer = _inner_writer
         else:
+            _validate_namespace_client_args(
+                namespace_client,
+                table_id,
+                namespace_client_table_context,
+            )
             if isinstance(path, Path):
                 path = str(path)
             self._writer = _LanceFileWriter(
@@ -444,6 +502,7 @@ class LanceFileWriter:
                 storage_options=storage_options,
                 namespace_client=namespace_client,
                 table_id=table_id,
+                namespace_client_table_context=namespace_client_table_context,
                 max_page_bytes=max_page_bytes,
                 **kwargs,
             )

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
         Transaction,
     )
     from .lance import LanceSchema
-    from .namespace import LanceNamespace
+    from .namespace import LanceNamespace, NamespaceClientTableContext
 
 
 DEFAULT_MAX_BYTES_PER_FILE = 90 * 1024 * 1024 * 1024
@@ -348,6 +348,7 @@ class LanceFragment(pa.dataset.Fragment):
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional["LanceNamespace"] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
     ) -> FragmentMetadata:
         """Create a :class:`FragmentMetadata` from the given data.
 
@@ -391,11 +392,15 @@ class LanceFragment(pa.dataset.Fragment):
             A namespace client for automatic credential refresh. When provided with
             `table_id`, a storage options provider will be created automatically to
             refresh credentials via the namespace. Must be provided together with
-            `table_id`. The caller should provide initial/merged storage options via
-            the `storage_options` parameter.
+            `table_id`.
         table_id : optional, List[str]
             The table identifier when using a namespace (e.g., ["my_table"]).
             Must be provided together with `namespace_client`.
+        namespace_client_table_context : optional, NamespaceClientTableContext
+            Cached context from a prior namespace call. The native layer uses
+            this cached metadata together with ``namespace_client`` and
+            ``table_id`` to avoid redundant namespace lookups while keeping
+            credential refresh support.
 
         See Also
         --------
@@ -411,7 +416,6 @@ class LanceFragment(pa.dataset.Fragment):
         -------
         FragmentMetadata
         """
-        # Validate namespace_client and table_id are provided together
         if namespace_client is not None and table_id is None:
             raise ValueError(
                 "Both 'namespace_client' and 'table_id' must be provided together."
@@ -419,6 +423,11 @@ class LanceFragment(pa.dataset.Fragment):
         elif table_id is not None and namespace_client is None:
             raise ValueError(
                 "Both 'namespace_client' and 'table_id' must be provided together."
+            )
+        if namespace_client_table_context is not None and namespace_client is None:
+            raise ValueError(
+                "'namespace_client_table_context' requires 'namespace_client' and "
+                "'table_id' to be provided."
             )
 
         if use_legacy_format is not None:
@@ -449,6 +458,7 @@ class LanceFragment(pa.dataset.Fragment):
             storage_options=storage_options,
             namespace_client=namespace_client,
             table_id=table_id,
+            namespace_client_table_context=namespace_client_table_context,
         )
 
     @property
@@ -1008,6 +1018,7 @@ if TYPE_CHECKING:
         initial_bases: Optional[List["DatasetBasePath"]] = None,
         namespace_client: Optional[LanceNamespace] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional[NamespaceClientTableContext] = None,
     ) -> Transaction: ...
 
     @overload
@@ -1030,6 +1041,7 @@ if TYPE_CHECKING:
         initial_bases: Optional[List["DatasetBasePath"]] = None,
         namespace_client: Optional[LanceNamespace] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional[NamespaceClientTableContext] = None,
     ) -> List[FragmentMetadata]: ...
 
 
@@ -1052,6 +1064,7 @@ def write_fragments(
     initial_bases: Optional[List["DatasetBasePath"]] = None,
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
+    namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
 ) -> List[FragmentMetadata] | Transaction:
     """
     Write data into one or more fragments.
@@ -1136,6 +1149,11 @@ def write_fragments(
     table_id : optional, List[str]
         The table identifier when using a namespace (e.g., ["my_table"]).
         Must be provided together with `namespace_client`.
+    namespace_client_table_context : optional, NamespaceClientTableContext
+        Cached context from a prior namespace call. The native layer uses
+        this cached metadata together with ``namespace_client`` and
+        ``table_id`` to avoid redundant namespace lookups while keeping
+        credential refresh support.
 
     Returns
     -------
@@ -1153,7 +1171,6 @@ def write_fragments(
     """
     from .dataset import LanceDataset
 
-    # Validate namespace_client and table_id are provided together
     if namespace_client is not None and table_id is None:
         raise ValueError(
             "Both 'namespace_client' and 'table_id' must be provided together."
@@ -1161,6 +1178,11 @@ def write_fragments(
     elif table_id is not None and namespace_client is None:
         raise ValueError(
             "Both 'namespace_client' and 'table_id' must be provided together."
+        )
+    if namespace_client_table_context is not None and namespace_client is None:
+        raise ValueError(
+            "'namespace_client_table_context' requires 'namespace_client' and "
+            "'table_id' to be provided."
         )
 
     reader = _coerce_reader(data, schema)
@@ -1196,6 +1218,7 @@ def write_fragments(
         storage_options=storage_options,
         namespace_client=namespace_client,
         table_id=table_id,
+        namespace_client_table_context=namespace_client_table_context,
         enable_stable_row_ids=enable_stable_row_ids,
         target_bases=target_bases,
         initial_bases=initial_bases,

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -47,6 +47,7 @@ from ..fragment import (
     DataFile,
     FragmentMetadata,
 )
+from ..namespace import NamespaceClientTableContext
 from ..progress import FragmentWriteProgress as FragmentWriteProgress
 from ..progress import IndexProgress as IndexProgress
 from ..types import ReaderLike as ReaderLike
@@ -103,6 +104,7 @@ class LanceFileWriter:
         storage_options: Optional[Dict[str, str]],
         namespace_client: Optional[LanceNamespace],
         table_id: Optional[List[str]],
+        namespace_client_table_context: Optional[NamespaceClientTableContext],
         keep_original_array: Optional[bool],
         max_page_bytes: Optional[int],
     ): ...
@@ -118,6 +120,7 @@ class LanceFileSession:
         storage_options: Optional[Dict[str, str]] = None,
         namespace_client: Optional[LanceNamespace] = None,
         table_id: Optional[List[str]] = None,
+        namespace_client_table_context: Optional[NamespaceClientTableContext] = None,
     ): ...
     def open_reader(
         self, path: str, columns: Optional[List[str]] = None
@@ -143,6 +146,7 @@ class LanceFileReader:
         storage_options: Optional[Dict[str, str]],
         namespace_client: Optional[LanceNamespace],
         table_id: Optional[List[str]],
+        namespace_client_table_context: Optional[NamespaceClientTableContext],
         columns: Optional[List[str]] = None,
     ): ...
     def read_all(
@@ -538,7 +542,10 @@ def _write_fragments(
     storage_options: Optional[Dict[str, str]],
     namespace_client: Optional[LanceNamespace],
     table_id: Optional[List[str]],
+    namespace_client_table_context: Optional[NamespaceClientTableContext],
     enable_stable_row_ids: bool,
+    target_bases: Optional[List[str]],
+    initial_bases: Optional[List[DatasetBasePath]],
 ): ...
 def _write_fragments_transaction(
     dataset_uri: str | Path | _Dataset,
@@ -552,7 +559,10 @@ def _write_fragments_transaction(
     storage_options: Optional[Dict[str, str]],
     namespace_client: Optional[LanceNamespace],
     table_id: Optional[List[str]],
+    namespace_client_table_context: Optional[NamespaceClientTableContext],
     enable_stable_row_ids: bool,
+    target_bases: Optional[List[str]],
+    initial_bases: Optional[List[DatasetBasePath]],
 ) -> Transaction: ...
 def _json_to_schema(schema_json: str) -> pa.Schema: ...
 def _schema_to_json(schema: pa.Schema) -> str: ...

--- a/python/python/lance/namespace.py
+++ b/python/python/lance/namespace.py
@@ -106,10 +106,81 @@ except ImportError:
 
 __all__ = [
     "DirectoryNamespace",
+    "NamespaceClientTableContext",
     "RestNamespace",
     "RestAdapter",
     "DynamicContextProvider",
 ]
+
+
+# =============================================================================
+# Cached Table Context
+# =============================================================================
+
+
+class NamespaceClientTableContext:
+    """Cached context from a namespace client's ``describe_table`` or
+    ``declare_table`` response.
+
+    Contains only the resolved table metadata (location, storage options,
+    managed-versioning flag).  The namespace client and table ID are **not**
+    part of this class; they are still passed separately.
+
+    Parameters
+    ----------
+    location : str
+        The table's storage location (URI).
+    storage_options : Optional[Dict[str, str]]
+        Storage options returned by the namespace (e.g. temporary credentials).
+    managed_versioning : bool
+        Whether commits should go through the namespace's version API.
+    """
+
+    def __init__(
+        self,
+        location: str,
+        storage_options: Optional[Dict[str, str]] = None,
+        managed_versioning: bool = False,
+    ):
+        self.location = location
+        self.storage_options = storage_options
+        self.managed_versioning = managed_versioning
+
+    @classmethod
+    def from_describe_table_response(
+        cls,
+        response: DescribeTableResponse,
+    ) -> "NamespaceClientTableContext":
+        """Build a context from a ``DescribeTableResponse``.
+
+        Raises ``ValueError`` if the response does not contain a location.
+        """
+        location = response.location
+        if not location:
+            raise ValueError("DescribeTableResponse missing location")
+        return cls(
+            location=location,
+            storage_options=response.storage_options,
+            managed_versioning=getattr(response, "managed_versioning", None) is True,
+        )
+
+    @classmethod
+    def from_declare_table_response(
+        cls,
+        response: DeclareTableResponse,
+    ) -> "NamespaceClientTableContext":
+        """Build a context from a ``DeclareTableResponse``.
+
+        Raises ``ValueError`` if the response does not contain a location.
+        """
+        location = response.location
+        if not location:
+            raise ValueError("DeclareTableResponse missing location")
+        return cls(
+            location=location,
+            storage_options=response.storage_options,
+            managed_versioning=getattr(response, "managed_versioning", None) is True,
+        )
 
 
 # =============================================================================

--- a/python/python/lance/tf/data.py
+++ b/python/python/lance/tf/data.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from lance import LanceNamespace
+    from lance.namespace import NamespaceClientTableContext
 
 
 def arrow_data_type_to_tf(dt: pa.DataType) -> tf.DType:
@@ -143,7 +144,7 @@ def from_lance(
     output_signature: Optional[Dict[str, tf.TypeSpec]] = None,
     namespace_client: Optional["LanceNamespace"] = None,
     table_id: Optional[List[str]] = None,
-    ignore_namespace_table_storage_options: bool = False,
+    namespace_client_table_context: Optional["NamespaceClientTableContext"] = None,
 ) -> tf.data.Dataset:
     """Create a ``tf.data.Dataset`` from a Lance dataset.
 
@@ -171,9 +172,10 @@ def from_lance(
     table_id : Optional[List[str]], optional
         Table identifier used together with ``namespace_client`` to locate
         the table.
-    ignore_namespace_table_storage_options : bool, default False
-        When using ``namespace_client``/``table_id``, ignore storage options
-        returned by the namespace.
+    namespace_client_table_context : optional, NamespaceClientTableContext
+        Cached context from a prior namespace call. When provided with
+        ``namespace_client`` and ``table_id``, skips the namespace lookup and
+        uses the cached location, storage options, and managed-versioning flag.
 
     Examples
     --------
@@ -214,9 +216,14 @@ def from_lance(
 
     """
     if isinstance(dataset, LanceDataset):
-        if namespace_client is not None or table_id is not None:
+        if (
+            namespace_client is not None
+            or table_id is not None
+            or namespace_client_table_context is not None
+        ):
             raise ValueError(
-                "Cannot specify 'namespace_client' or 'table_id' when passing "
+                "Cannot specify 'namespace_client', 'table_id', or "
+                "'namespace_client_table_context' when passing "
                 "a LanceDataset instance"
             )
     else:
@@ -224,7 +231,7 @@ def from_lance(
             dataset,
             namespace_client=namespace_client,
             table_id=table_id,
-            ignore_namespace_table_storage_options=ignore_namespace_table_storage_options,
+            namespace_client_table_context=namespace_client_table_context,
         )
 
     if isinstance(fragments, tf.data.Dataset):

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1647,6 +1647,8 @@ def test_commit_batch_append():
     result = lance.LanceDataset.commit_batch(dataset, [txn2, txn3])
     dataset = result["dataset"]
     assert dataset.version == 2
+    assert dataset._namespace_client_table_context is None
+    assert dataset.__copy__()._namespace_client_table_context is None
     assert len(dataset.get_fragments()) == 3
     assert dataset.to_table() == pa.concat_tables([data1, data2, data3])
     merged_txn = result["merged"]

--- a/python/python/tests/test_file.py
+++ b/python/python/tests/test_file.py
@@ -9,7 +9,116 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
 import pytest
+from lance.dataset import LanceDataset
 from lance.file import LanceFileReader, LanceFileSession, LanceFileWriter
+from lance.namespace import NamespaceClientTableContext
+
+
+def test_file_wrappers_forward_namespace_context(monkeypatch):
+    calls = {}
+
+    def fake_reader(path, **kwargs):
+        calls["reader"] = (path, kwargs)
+        return object()
+
+    def fake_session(base_path, **kwargs):
+        calls["session"] = (base_path, kwargs)
+        return object()
+
+    def fake_writer(path, *args, **kwargs):
+        calls["writer"] = (path, args, kwargs)
+        return object()
+
+    monkeypatch.setattr("lance.file._LanceFileReader", fake_reader)
+    monkeypatch.setattr("lance.file._LanceFileSession", fake_session)
+    monkeypatch.setattr("lance.file._LanceFileWriter", fake_writer)
+
+    context = NamespaceClientTableContext(
+        "s3://bucket/table",
+        {"from_context": "value"},
+        False,
+    )
+    namespace_client = object()
+    table_id = ["workspace", "table"]
+
+    LanceFileReader(
+        "s3://bucket/file.lance",
+        storage_options={"from_user": "value"},
+        namespace_client=namespace_client,
+        table_id=table_id,
+        namespace_client_table_context=context,
+    )
+    LanceFileSession(
+        "s3://bucket/session",
+        storage_options={"from_user": "value"},
+        namespace_client=namespace_client,
+        table_id=table_id,
+        namespace_client_table_context=context,
+    )
+    LanceFileWriter(
+        "s3://bucket/file.lance",
+        storage_options={"from_user": "value"},
+        namespace_client=namespace_client,
+        table_id=table_id,
+        namespace_client_table_context=context,
+    )
+
+    assert calls["reader"][1]["storage_options"] == {"from_user": "value"}
+    assert calls["reader"][1]["namespace_client"] is namespace_client
+    assert calls["reader"][1]["table_id"] == table_id
+    assert calls["reader"][1]["namespace_client_table_context"] is context
+    assert calls["session"][1]["storage_options"] == {"from_user": "value"}
+    assert calls["session"][1]["namespace_client"] is namespace_client
+    assert calls["session"][1]["table_id"] == table_id
+    assert calls["session"][1]["namespace_client_table_context"] is context
+    assert calls["writer"][2]["storage_options"] == {"from_user": "value"}
+    assert calls["writer"][2]["namespace_client"] is namespace_client
+    assert calls["writer"][2]["table_id"] == table_id
+    assert calls["writer"][2]["namespace_client_table_context"] is context
+
+
+def test_file_wrappers_reject_context_without_namespace(tmp_path):
+    context = NamespaceClientTableContext(str(tmp_path), None, False)
+
+    for cls, args in [
+        (LanceFileReader, (str(tmp_path / "file.lance"),)),
+        (LanceFileSession, (str(tmp_path),)),
+        (LanceFileWriter, (str(tmp_path / "file.lance"),)),
+    ]:
+        with pytest.raises(ValueError, match="namespace_client_table_context"):
+            cls(*args, namespace_client_table_context=context)
+
+
+def test_dataset_new_file_session_forwards_namespace_context(monkeypatch):
+    calls = {}
+
+    def fake_session(**kwargs):
+        calls.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("lance.file.LanceFileSession", fake_session)
+
+    context = NamespaceClientTableContext(
+        "s3://bucket/table",
+        {"from_context": "value"},
+        False,
+    )
+    namespace_client = object()
+    table_id = ["workspace", "table"]
+    ds = LanceDataset.__new__(LanceDataset)
+    ds._uri = "s3://bucket/table"
+    ds._namespace_client = namespace_client
+    ds._table_id = table_id
+    ds._namespace_client_table_context = context
+    ds.latest_storage_options = lambda: {"from_latest": "value"}
+
+    ds.new_file_session()
+
+    assert calls["base_path"] == "s3://bucket/table"
+    assert calls["storage_options"] == {"from_latest": "value"}
+    assert calls["namespace_client"] is namespace_client
+    assert calls["table_id"] == table_id
+    assert calls["namespace_client_table_context"] is context
 
 
 def test_file_read_projection(tmp_path):

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -23,7 +23,84 @@ from lance import (
 from lance.debug import format_fragment
 from lance.file import LanceFileWriter
 from lance.fragment import write_fragments
+from lance.namespace import NamespaceClientTableContext
 from lance.progress import FileSystemFragmentWriteProgress
+
+
+def test_fragment_wrappers_forward_namespace_context(monkeypatch, tmp_path: Path):
+    calls = {}
+
+    class FakeFragmentApi:
+        @staticmethod
+        def create(dataset_uri, fragment_id, reader, **kwargs):
+            calls["create"] = {
+                "dataset_uri": dataset_uri,
+                "fragment_id": fragment_id,
+                "kwargs": kwargs,
+            }
+            return "created"
+
+    def fake_write_fragments(dataset_uri, reader, **kwargs):
+        calls["write_fragments"] = {
+            "dataset_uri": dataset_uri,
+            "kwargs": kwargs,
+        }
+        return []
+
+    monkeypatch.setattr("lance.fragment._Fragment", FakeFragmentApi)
+    monkeypatch.setattr("lance.fragment._write_fragments", fake_write_fragments)
+
+    context = NamespaceClientTableContext(
+        str(tmp_path),
+        {"from_context": "value"},
+        False,
+    )
+    namespace_client = object()
+    table_id = ["workspace", "table"]
+
+    assert (
+        LanceFragment.create(
+            tmp_path,
+            pa.table({"a": [1]}),
+            storage_options={"from_user": "value"},
+            namespace_client=namespace_client,
+            table_id=table_id,
+            namespace_client_table_context=context,
+        )
+        == "created"
+    )
+
+    write_fragments(
+        pa.table({"a": [1]}),
+        str(tmp_path),
+        storage_options={"from_user": "value"},
+        namespace_client=namespace_client,
+        table_id=table_id,
+        namespace_client_table_context=context,
+    )
+
+    assert calls["create"]["kwargs"]["storage_options"] == {"from_user": "value"}
+    assert calls["create"]["kwargs"]["namespace_client"] is namespace_client
+    assert calls["create"]["kwargs"]["table_id"] == table_id
+    assert calls["create"]["kwargs"]["namespace_client_table_context"] is context
+    assert calls["write_fragments"]["kwargs"]["storage_options"] == {
+        "from_user": "value"
+    }
+    assert calls["write_fragments"]["kwargs"]["namespace_client"] is namespace_client
+    assert calls["write_fragments"]["kwargs"]["table_id"] == table_id
+    assert (
+        calls["write_fragments"]["kwargs"]["namespace_client_table_context"] is context
+    )
+
+
+def test_fragment_create_rejects_context_without_namespace(tmp_path: Path):
+    context = NamespaceClientTableContext(str(tmp_path), None, False)
+    with pytest.raises(ValueError, match="namespace_client_table_context"):
+        LanceFragment.create(
+            tmp_path,
+            pa.table({"a": [1]}),
+            namespace_client_table_context=context,
+        )
 
 
 def test_write_fragment(tmp_path: Path):

--- a/python/python/tests/test_namespace_dir.py
+++ b/python/python/tests/test_namespace_dir.py
@@ -1077,7 +1077,7 @@ def test_namespace_entry_points_reject_explicit_uri_with_context(tmp_path):
         )
 
 
-def test_namespace_open_passes_requested_version_to_describe(tmp_path):
+def test_namespace_open_version_uses_lance_checkout(tmp_path):
     inner = connect(
         "dir",
         {
@@ -1119,7 +1119,7 @@ def test_namespace_open_passes_requested_version_to_describe(tmp_path):
     ds = lance.dataset(namespace_client=ns_client, table_id=table_id, version=1)
 
     assert ds.version == 1
-    assert ns_client.describe_versions[-1] == 1
+    assert ns_client.describe_versions[-1] is None
 
 
 @pytest.mark.skipif(

--- a/python/python/tests/test_namespace_dir.py
+++ b/python/python/tests/test_namespace_dir.py
@@ -979,6 +979,149 @@ def test_external_manifest_store_invokes_namespace_apis(use_custom):
         ), "describe_table_version should be called once when opening version 1"
 
 
+@pytest.mark.parametrize("use_custom", [False, True], ids=["DirectoryNS", "CustomNS"])
+def test_cached_context_skips_namespace_lookup_for_open_and_append(use_custom):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        inner_ns_client = lance.namespace.DirectoryNamespace(
+            root=tmpdir,
+            table_version_tracking_enabled="true",
+            manifest_enabled="true",
+            ops_metrics_enabled="true",
+        )
+        ns_client = _wrap_if_custom(inner_ns_client, use_custom)
+
+        ns_client.create_namespace(CreateNamespaceRequest(id=["workspace"]))
+
+        table_id = ["workspace", "cached_context_table"]
+        table1 = pa.Table.from_pylist([{"a": 1, "b": 2}, {"a": 10, "b": 20}])
+        ds = lance.write_dataset(
+            table1, namespace_client=ns_client, table_id=table_id, mode="create"
+        )
+        assert ds.count_rows() == 2
+
+        describe_resp = ns_client.describe_table(DescribeTableRequest(id=table_id))
+        context = (
+            lance.namespace.NamespaceClientTableContext.from_describe_table_response(
+                describe_resp
+            )
+        )
+
+        describe_count_before_open = _get_ops_metric(inner_ns_client, "describe_table")
+        ds_from_context = lance.dataset(
+            namespace_client=ns_client,
+            table_id=table_id,
+            namespace_client_table_context=context,
+        )
+        assert ds_from_context.count_rows() == 2
+        assert (
+            _get_ops_metric(inner_ns_client, "describe_table")
+            == describe_count_before_open
+        ), "describe_table should not be called when opening with cached context"
+
+        create_count_before_append = _get_ops_metric(
+            inner_ns_client, "create_table_version"
+        )
+        describe_count_before_append = _get_ops_metric(
+            inner_ns_client, "describe_table"
+        )
+
+        table2 = pa.Table.from_pylist([{"a": 100, "b": 200}, {"a": 1000, "b": 2000}])
+        appended = lance.write_dataset(
+            table2,
+            namespace_client=ns_client,
+            table_id=table_id,
+            mode="append",
+            namespace_client_table_context=context,
+        )
+        assert appended.count_rows() == 4
+        assert (
+            _get_ops_metric(inner_ns_client, "describe_table")
+            == describe_count_before_append
+        ), "describe_table should not be called when appending with cached context"
+        assert (
+            _get_ops_metric(inner_ns_client, "create_table_version")
+            == create_count_before_append + 1
+        ), "create_table_version should still be called for the append commit"
+
+
+def test_namespace_entry_points_reject_explicit_uri_with_context(tmp_path):
+    context = lance.namespace.NamespaceClientTableContext(
+        str(tmp_path / "table.lance"),
+        None,
+        False,
+    )
+    namespace_client = object()
+    table_id = ["workspace", "table"]
+    operation = lance.LanceOperation.Overwrite(
+        pa.schema([pa.field("a", pa.int64())]), []
+    )
+
+    with pytest.raises(ValueError, match="Cannot specify both 'uri'"):
+        lance.LanceDataset(
+            str(tmp_path / "explicit.lance"),
+            namespace_client=namespace_client,
+            table_id=table_id,
+            namespace_client_table_context=context,
+        )
+
+    with pytest.raises(ValueError, match="namespace_client_table_context"):
+        lance.LanceDataset(namespace_client_table_context=context)
+
+    with pytest.raises(ValueError, match="Cannot specify both 'base_uri'"):
+        lance.LanceDataset.commit(
+            str(tmp_path / "explicit.lance"),
+            operation,
+            namespace_client=namespace_client,
+            table_id=table_id,
+            namespace_client_table_context=context,
+        )
+
+
+def test_namespace_open_passes_requested_version_to_describe(tmp_path):
+    inner = connect(
+        "dir",
+        {
+            "root": str(tmp_path / "ns"),
+            "table_storage_root": str(tmp_path / "tables"),
+        },
+    )
+    table_id = ["workspace", "versioned_open"]
+    lance.write_dataset(
+        pa.table({"a": [1]}),
+        namespace_client=inner,
+        table_id=table_id,
+        mode="create",
+    )
+    lance.write_dataset(
+        pa.table({"a": [2]}),
+        namespace_client=inner,
+        table_id=table_id,
+        mode="append",
+    )
+
+    class RecordingNamespace(CustomNamespace):
+        def __init__(self, wrapped):
+            super().__init__(wrapped)
+            self.describe_versions = []
+
+        def describe_table(
+            self, request: DescribeTableRequest
+        ) -> DescribeTableResponse:
+            version = (
+                request.version
+                if hasattr(request, "version")
+                else request.get("version")
+            )
+            self.describe_versions.append(version)
+            return super().describe_table(request)
+
+    ns_client = RecordingNamespace(inner)
+    ds = lance.dataset(namespace_client=ns_client, table_id=table_id, version=1)
+
+    assert ds.version == 1
+    assert ns_client.describe_versions[-1] == 1
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Windows file locking prevents reliable concurrent filesystem operations",

--- a/python/python/tests/test_namespace_integration.py
+++ b/python/python/tests/test_namespace_integration.py
@@ -27,6 +27,7 @@ from lance.namespace import (
     DescribeTableRequest,
     DirectoryNamespace,
     LanceNamespace,
+    NamespaceClientTableContext,
 )
 from lance_namespace import (
     CreateNamespaceRequest,
@@ -586,8 +587,7 @@ def test_namespace_distributed_write(s3_bucket: str, use_custom: bool):
     ns_client_storage_options = response.storage_options
     assert ns_client_storage_options is not None
 
-    merged_options = dict(storage_options)
-    merged_options.update(ns_client_storage_options)
+    context = NamespaceClientTableContext.from_declare_table_response(response)
 
     from lance.fragment import write_fragments
 
@@ -595,27 +595,30 @@ def test_namespace_distributed_write(s3_bucket: str, use_custom: bool):
     fragment1 = write_fragments(
         fragment1_data,
         table_uri,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
 
     fragment2_data = pa.Table.from_pylist([{"a": 10, "b": 20}, {"a": 30, "b": 40}])
     fragment2 = write_fragments(
         fragment2_data,
         table_uri,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
 
     fragment3_data = pa.Table.from_pylist([{"a": 100, "b": 200}])
     fragment3 = write_fragments(
         fragment3_data,
         table_uri,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
 
     all_fragments = fragment1 + fragment2 + fragment3
@@ -623,11 +626,12 @@ def test_namespace_distributed_write(s3_bucket: str, use_custom: bool):
     operation = lance.LanceOperation.Overwrite(fragment1_data.schema, all_fragments)
 
     ds = lance.LanceDataset.commit(
-        table_uri,
+        None,
         operation,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
 
     assert ds.count_rows() == 5
@@ -688,9 +692,9 @@ def test_file_writer_with_namespace_client(s3_bucket: str, use_custom: bool):
     describe_response = ns_client.describe_table(
         DescribeTableRequest(id=table_id, version=None)
     )
-    merged_options = dict(storage_options)
-    if describe_response.storage_options:
-        merged_options.update(describe_response.storage_options)
+    context = NamespaceClientTableContext.from_describe_table_response(
+        describe_response
+    )
 
     initial_describe_count = get_describe_call_count(inner_ns_client)
 
@@ -700,9 +704,10 @@ def test_file_writer_with_namespace_client(s3_bucket: str, use_custom: bool):
     writer = LanceFileWriter(
         file_uri,
         schema=schema,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
 
     batch = pa.RecordBatch.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]}, schema=schema)
@@ -719,9 +724,10 @@ def test_file_writer_with_namespace_client(s3_bucket: str, use_custom: bool):
 
     reader = LanceFileReader(
         file_uri,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
     result = reader.read_all(batch_size=1024)
     result_table = result.to_table()
@@ -739,9 +745,10 @@ def test_file_writer_with_namespace_client(s3_bucket: str, use_custom: bool):
     writer2 = LanceFileWriter(
         file_uri2,
         schema=schema,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
 
     batch3 = pa.RecordBatch.from_pydict(
@@ -755,9 +762,10 @@ def test_file_writer_with_namespace_client(s3_bucket: str, use_custom: bool):
 
     reader2 = LanceFileReader(
         file_uri2,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
     result2 = reader2.read_all(batch_size=1024)
     result_table2 = result2.to_table()
@@ -797,18 +805,20 @@ def test_file_reader_with_namespace_client(s3_bucket: str, use_custom: bool):
     describe_response = ns_client.describe_table(
         DescribeTableRequest(id=table_id, version=None)
     )
-    merged_options = dict(storage_options)
-    if describe_response.storage_options:
-        merged_options.update(describe_response.storage_options)
+    context = NamespaceClientTableContext.from_describe_table_response(
+        describe_response
+    )
 
     file_uri = f"s3://{s3_bucket}/{table_name}_file_reader_test.lance"
     schema = pa.schema([pa.field("x", pa.int64()), pa.field("y", pa.int64())])
 
-    # Write a file first (without namespace_client to keep it simple)
     writer = LanceFileWriter(
         file_uri,
         schema=schema,
-        storage_options=merged_options,
+        storage_options=storage_options,
+        namespace_client=ns_client,
+        table_id=table_id,
+        namespace_client_table_context=context,
     )
     batch = pa.RecordBatch.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]}, schema=schema)
     writer.write_batch(batch)
@@ -818,18 +828,19 @@ def test_file_reader_with_namespace_client(s3_bucket: str, use_custom: bool):
     describe_response = ns_client.describe_table(
         DescribeTableRequest(id=table_id, version=None)
     )
-    merged_options = dict(storage_options)
-    if describe_response.storage_options:
-        merged_options.update(describe_response.storage_options)
+    context = NamespaceClientTableContext.from_describe_table_response(
+        describe_response
+    )
 
     initial_describe_count = get_describe_call_count(inner_ns_client)
 
     # First read should work without needing refresh
     reader = LanceFileReader(
         file_uri,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
     result = reader.read_all(batch_size=1024)
     result_table = result.to_table()
@@ -847,7 +858,7 @@ def test_file_reader_with_namespace_client(s3_bucket: str, use_custom: bool):
     writer2 = LanceFileWriter(
         file_uri2,
         schema=schema,
-        storage_options=merged_options,
+        storage_options=storage_options,
     )
     batch2 = pa.RecordBatch.from_pydict(
         {"x": [100, 200], "y": [300, 400]}, schema=schema
@@ -858,9 +869,10 @@ def test_file_reader_with_namespace_client(s3_bucket: str, use_custom: bool):
     # Second read should trigger credential refresh
     reader2 = LanceFileReader(
         file_uri2,
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
     result2 = reader2.read_all(batch_size=1024)
     result_table2 = result2.to_table()
@@ -903,18 +915,19 @@ def test_file_session_with_namespace_client(s3_bucket: str, use_custom: bool):
     describe_response = ns_client.describe_table(
         DescribeTableRequest(id=table_id, version=None)
     )
-    merged_options = dict(storage_options)
-    if describe_response.storage_options:
-        merged_options.update(describe_response.storage_options)
+    context = NamespaceClientTableContext.from_describe_table_response(
+        describe_response
+    )
 
     initial_describe_count = get_describe_call_count(inner_ns_client)
 
     # Create session with namespace_client
     session = LanceFileSession(
         f"s3://{s3_bucket}/{table_name}_session",
-        storage_options=merged_options,
+        storage_options=storage_options,
         namespace_client=ns_client,
         table_id=table_id,
+        namespace_client_table_context=context,
     )
 
     # Test contains method

--- a/python/python/tests/test_tf.py
+++ b/python/python/tests/test_tf.py
@@ -118,12 +118,11 @@ def test_namespace_table_id(monkeypatch):
         None,
         namespace_client=ns,
         table_id=["tbl"],
-        ignore_namespace_table_storage_options=True,
     )
 
     assert calls["kwargs"]["namespace_client"] is ns
     assert calls["kwargs"]["table_id"] == ["tbl"]
-    assert calls["kwargs"]["ignore_namespace_table_storage_options"] is True
+    assert calls["kwargs"]["namespace_client_table_context"] is None
 
     batches = list(ds)
     assert [b["a"].numpy().tolist() for b in batches] == [[1, 2]]

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -615,17 +615,16 @@ impl Dataset {
             let namespace_client_table_context = namespace_client_table_context
                 .map(|c| extract_namespace_client_table_context(c))
                 .transpose()?;
-            let mut b =
-                if let Some(namespace_client_table_context) = namespace_client_table_context {
-                    DatasetBuilder::for_namespace(ns_client, tid.clone())
-                        .with_namespace_client_table_context(namespace_client_table_context)
-                } else {
-                    rt().block_on(
-                        Some(py),
-                        DatasetBuilder::from_namespace(ns_client, tid.clone()),
-                    )?
-                    .map_err(|err| PyIOError::new_err(err.to_string()))?
-                }
+            let mut b = rt()
+                .block_on(
+                    Some(py),
+                    DatasetBuilder::from_namespace(
+                        ns_client,
+                        tid.clone(),
+                        namespace_client_table_context,
+                    ),
+                )?
+                .map_err(|err| PyIOError::new_err(err.to_string()))?
                 .with_index_cache_size_bytes(params.index_cache_size_bytes)
                 .with_metadata_cache_size_bytes(params.metadata_cache_size_bytes);
             b = b.with_read_params(params);

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -610,14 +610,6 @@ impl Dataset {
         }
 
         // Create builder: namespace path or URI path
-        let namespace_describe_version = if let Some(ver) = &version
-            && let Ok(i) = ver.downcast::<PyInt>()
-        {
-            Some(i.extract::<u64>()?)
-        } else {
-            None
-        };
-
         let mut builder = if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
             let ns_client = extract_namespace_arc(py, ns_client)?;
             let namespace_client_table_context = namespace_client_table_context
@@ -630,11 +622,7 @@ impl Dataset {
                 } else {
                     rt().block_on(
                         Some(py),
-                        DatasetBuilder::from_namespace_with_version(
-                            ns_client,
-                            tid.clone(),
-                            namespace_describe_version,
-                        ),
+                        DatasetBuilder::from_namespace(ns_client, tid.clone()),
                     )?
                     .map_err(|err| PyIOError::new_err(err.to_string()))?
                 }
@@ -3159,10 +3147,10 @@ pub enum PyWriteDest {
 }
 
 impl PyWriteDest {
-    pub fn as_dest(&self) -> WriteDestination<'_> {
+    pub fn as_dest(&self) -> WriteDestination {
         match self {
             Self::Dataset(ds) => WriteDestination::Dataset(ds.ds.clone()),
-            Self::Uri(uri) => WriteDestination::Uri(uri),
+            Self::Uri(uri) => WriteDestination::Uri(uri.to_string()),
         }
     }
 }

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -82,19 +82,16 @@ use lance_index::{
 use lance_index::{
     infer_system_index_type, metrics::NoOpMetricsCollector, scalar::inverted::query::Occur,
 };
-use lance_io::object_store::{
-    LanceNamespaceStorageOptionsProvider, ObjectStoreParams, StorageOptionsAccessor,
-};
+use lance_io::object_store::{ObjectStoreParams, StorageOptionsAccessor};
 use lance_linalg::distance::MetricType;
 use lance_table::format::{BasePath, Fragment, IndexMetadata};
 use lance_table::io::commit::CommitHandler;
-use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 
 use crate::error::PythonErrorExt;
 use crate::file::object_store_from_uri_or_path;
 use crate::fragment::FileFragment;
 use crate::indices::{PyIndexConfig, PyIndexDescription};
-use crate::namespace::extract_namespace_arc;
+use crate::namespace::{extract_namespace_arc, extract_namespace_client_table_context};
 use crate::rt;
 use crate::scanner::ScanStatistics;
 use crate::schema::{LanceSchema, logical_schema_from_lance};
@@ -102,7 +99,6 @@ use crate::session::Session;
 use crate::storage_options::PyStorageOptionsAccessor;
 use crate::utils::PyLance;
 use crate::{LanceReader, Scanner};
-use lance::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 
 use self::cleanup::CleanupStats;
 use self::commit::PyCommitLock;
@@ -514,10 +510,10 @@ impl Dataset {
     #[allow(clippy::too_many_arguments)]
     #[allow(deprecated)]
     #[new]
-    #[pyo3(signature=(uri, version=None, block_size=None, index_cache_size=None, metadata_cache_size=None, commit_handler=None, storage_options=None, manifest=None, metadata_cache_size_bytes=None, index_cache_size_bytes=None, read_params=None, session=None, namespace_client=None, table_id=None, namespace_client_managed_versioning=false, base_store_params=None))]
+    #[pyo3(signature=(uri=None, version=None, block_size=None, index_cache_size=None, metadata_cache_size=None, commit_handler=None, storage_options=None, manifest=None, metadata_cache_size_bytes=None, index_cache_size_bytes=None, read_params=None, session=None, namespace_client=None, table_id=None, namespace_client_table_context=None, base_store_params=None))]
     fn new(
         py: Python,
-        uri: String,
+        uri: Option<String>,
         version: Option<Bound<PyAny>>,
         block_size: Option<usize>,
         index_cache_size: Option<usize>,
@@ -531,9 +527,35 @@ impl Dataset {
         session: Option<Session>,
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
-        namespace_client_managed_versioning: bool,
+        namespace_client_table_context: Option<&Bound<'_, PyAny>>,
         base_store_params: Option<HashMap<String, HashMap<String, String>>>,
     ) -> PyResult<Self> {
+        let has_uri = uri.is_some();
+        let has_namespace = namespace_client.is_some() || table_id.is_some();
+        let has_complete_namespace = namespace_client.is_some() && table_id.is_some();
+        let has_context = namespace_client_table_context.is_some();
+
+        if has_uri && has_namespace {
+            return Err(PyValueError::new_err(
+                "Cannot specify both 'uri' and 'namespace_client'/'table_id'.",
+            ));
+        }
+        if has_uri && has_context {
+            return Err(PyValueError::new_err(
+                "Cannot specify both 'uri' and 'namespace_client_table_context'.",
+            ));
+        }
+        if has_context && !has_complete_namespace {
+            return Err(PyValueError::new_err(
+                "'namespace_client_table_context' requires 'namespace_client' and 'table_id'.",
+            ));
+        }
+        if has_namespace && !has_complete_namespace {
+            return Err(PyValueError::new_err(
+                "Both 'namespace_client' and 'table_id' must be provided together.",
+            ));
+        }
+
         let mut params = ReadParams::default();
         if let Some(metadata_cache_size_bytes) = metadata_cache_size_bytes {
             params.metadata_cache_size_bytes(metadata_cache_size_bytes);
@@ -587,7 +609,45 @@ impl Dataset {
             params.file_reader_options = Some(file_reader_options);
         }
 
-        let mut builder = DatasetBuilder::from_uri(&uri).with_read_params(params);
+        // Create builder: namespace path or URI path
+        let namespace_describe_version = if let Some(ver) = &version
+            && let Ok(i) = ver.downcast::<PyInt>()
+        {
+            Some(i.extract::<u64>()?)
+        } else {
+            None
+        };
+
+        let mut builder = if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
+            let ns_client = extract_namespace_arc(py, ns_client)?;
+            let namespace_client_table_context = namespace_client_table_context
+                .map(|c| extract_namespace_client_table_context(c))
+                .transpose()?;
+            let mut b =
+                if let Some(namespace_client_table_context) = namespace_client_table_context {
+                    DatasetBuilder::for_namespace(ns_client, tid.clone())
+                        .with_namespace_client_table_context(namespace_client_table_context)
+                } else {
+                    rt().block_on(
+                        Some(py),
+                        DatasetBuilder::from_namespace_with_version(
+                            ns_client,
+                            tid.clone(),
+                            namespace_describe_version,
+                        ),
+                    )?
+                    .map_err(|err| PyIOError::new_err(err.to_string()))?
+                }
+                .with_index_cache_size_bytes(params.index_cache_size_bytes)
+                .with_metadata_cache_size_bytes(params.metadata_cache_size_bytes);
+            b = b.with_read_params(params);
+            b
+        } else {
+            let uri = uri.ok_or_else(|| {
+                PyValueError::new_err("uri is required when namespace_client is not provided")
+            })?;
+            DatasetBuilder::from_uri(&uri).with_read_params(params)
+        };
 
         if let Some(ver) = version {
             if let Ok(i) = ver.cast::<PyInt>() {
@@ -602,8 +662,6 @@ impl Dataset {
                 ));
             };
         }
-        // Save a copy of storage options for potential namespace-based credential refresh
-        let initial_storage_options = storage_options.clone();
 
         if let Some(mut storage_options) = storage_options {
             if let Some(user_agent) = storage_options.get_mut("user_agent") {
@@ -625,36 +683,6 @@ impl Dataset {
             builder = builder.with_session(session.inner.clone());
         }
 
-        // Set up namespace-based features if namespace_client and table_id are provided
-        if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
-            let ns_client = extract_namespace_arc(py, ns_client)?;
-
-            // Auto-create storage options provider from namespace client
-            // when storage_options are present (meaning credentials came from namespace.describe_table)
-            if initial_storage_options.is_some() {
-                let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
-                    LanceNamespaceStorageOptionsProvider::new(ns_client.clone(), tid.clone()),
-                );
-                // Create accessor with initial options and provider for credential refresh
-                let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                    initial_storage_options.clone().unwrap_or_default(),
-                    provider,
-                ));
-                builder = builder.with_storage_options_accessor(accessor);
-            }
-
-            // Set up commit handler only if namespace manages versioning
-            if namespace_client_managed_versioning {
-                let external_store =
-                    LanceNamespaceExternalManifestStore::new(ns_client, tid.clone());
-                let commit_handler: Arc<dyn CommitHandler> =
-                    Arc::new(ExternalManifestCommitHandler {
-                        external_manifest_store: Arc::new(external_store),
-                    });
-                builder = builder.with_commit_handler(commit_handler);
-            }
-        }
-
         if let Some(base_store_params) = base_store_params {
             for (base_path, opts) in base_store_params {
                 let accessor = Arc::new(StorageOptionsAccessor::with_static_options(opts));
@@ -669,10 +697,13 @@ impl Dataset {
         let dataset = rt().block_on(Some(py), builder.load())?;
 
         match dataset {
-            Ok(ds) => Ok(Self {
-                uri,
-                ds: Arc::new(ds),
-            }),
+            Ok(ds) => {
+                let resolved_uri = ds.uri().to_string();
+                Ok(Self {
+                    uri: resolved_uri,
+                    ds: Arc::new(ds),
+                })
+            }
             Err(err) => Err(PyValueError::new_err(err.to_string())),
         }
     }
@@ -2361,7 +2392,7 @@ impl Dataset {
 
     #[allow(clippy::too_many_arguments)]
     #[staticmethod]
-    #[pyo3(signature = (dest, operation, read_version = None, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, commit_message = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_managed_versioning = false))]
+    #[pyo3(signature = (dest, operation, read_version = None, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, commit_message = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_table_context = None))]
     fn commit(
         dest: PyWriteDest,
         operation: PyLance<Operation>,
@@ -2375,7 +2406,7 @@ impl Dataset {
         enable_stable_row_ids: Option<bool>,
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
-        namespace_client_managed_versioning: bool,
+        namespace_client_table_context: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         let mut transaction = Transaction::new(read_version.unwrap_or_default(), operation.0, None);
 
@@ -2397,14 +2428,14 @@ impl Dataset {
             enable_stable_row_ids,
             namespace_client,
             table_id,
-            namespace_client_managed_versioning,
+            namespace_client_table_context,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     #[allow(deprecated)]
     #[staticmethod]
-    #[pyo3(signature = (dest, transaction, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_managed_versioning = false))]
+    #[pyo3(signature = (dest, transaction, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_table_context = None))]
     fn commit_transaction(
         dest: PyWriteDest,
         transaction: PyLance<Transaction>,
@@ -2416,7 +2447,7 @@ impl Dataset {
         enable_stable_row_ids: Option<bool>,
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
-        namespace_client_managed_versioning: bool,
+        namespace_client_table_context: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         let accessor =
             crate::storage_options::create_accessor_from_storage_options(storage_options.clone())?;
@@ -2430,34 +2461,55 @@ impl Dataset {
             None
         };
 
-        // Create commit_handler: prefer user-provided commit_lock, then namespace client-based handler
-        // (only if namespace_client_managed_versioning is true)
+        let namespace_client_table_context = namespace_client_table_context
+            .map(|c| extract_namespace_client_table_context(c))
+            .transpose()?;
+        if namespace_client_table_context.is_some()
+            && (namespace_client.is_none() || table_id.is_none())
+        {
+            return Err(PyValueError::new_err(
+                "'namespace_client_table_context' requires 'namespace_client' and 'table_id'.",
+            ));
+        }
+        if namespace_client.is_some() != table_id.is_some() {
+            return Err(PyValueError::new_err(
+                "Both 'namespace_client' and 'table_id' must be provided together.",
+            ));
+        }
+        if (namespace_client.is_some() || table_id.is_some())
+            && matches!(&dest, PyWriteDest::Uri(uri) if !uri.is_empty())
+        {
+            return Err(PyValueError::new_err(
+                "Cannot specify both 'dest' and 'namespace_client'/'table_id'.",
+            ));
+        }
+
         let commit_handler: Option<Arc<dyn CommitHandler>> =
             if let Some(commit_lock) = commit_lock.as_ref() {
-                // User provided a commit_lock
                 Some(
                     commit_lock
                         .into_py_any(commit_lock.py())
                         .map(|cl| Arc::new(PyCommitLock::new(cl)) as Arc<dyn CommitHandler>)?,
                 )
-            } else if namespace_client_managed_versioning
-                && let (Some(ns_client), Some(tid)) = (namespace_client, table_id)
-            {
-                // Create ExternalManifestCommitHandler from namespace client and table_id
-                // only when namespace manages versioning
-                let ns_client = extract_namespace_arc(ns_client.py(), ns_client)?;
-                let external_store = LanceNamespaceExternalManifestStore::new(ns_client, tid);
-                Some(Arc::new(ExternalManifestCommitHandler {
-                    external_manifest_store: Arc::new(external_store),
-                }) as Arc<dyn CommitHandler>)
             } else {
                 None
             };
 
-        let mut builder = CommitBuilder::new(dest.as_dest())
-            .enable_v2_manifest_paths(enable_v2_manifest_paths.unwrap_or(true))
-            .with_detached(detached.unwrap_or(false))
-            .with_max_retries(max_retries.unwrap_or(20));
+        let mut builder = if let (Some(ns_client), Some(tid)) = (namespace_client, table_id) {
+            let ns_client = extract_namespace_arc(ns_client.py(), ns_client)?;
+            match dest {
+                PyWriteDest::Dataset(dataset) => CommitBuilder::new(dataset.ds.clone())
+                    .with_namespace(ns_client, tid, namespace_client_table_context),
+                PyWriteDest::Uri(_) => {
+                    CommitBuilder::new_namespace(ns_client, tid, namespace_client_table_context)
+                }
+            }
+        } else {
+            CommitBuilder::new(dest.as_dest())
+        }
+        .enable_v2_manifest_paths(enable_v2_manifest_paths.unwrap_or(true))
+        .with_detached(detached.unwrap_or(false))
+        .with_max_retries(max_retries.unwrap_or(20));
 
         if let Some(enable) = enable_stable_row_ids {
             builder = builder.use_stable_row_ids(enable);
@@ -3452,29 +3504,95 @@ impl Dataset {
 #[pyfunction(name = "_write_dataset")]
 pub fn write_dataset(
     reader: &Bound<'_, PyAny>,
-    dest: PyWriteDest,
+    dest: Option<PyWriteDest>,
     options: &Bound<'_, PyDict>,
 ) -> PyResult<Dataset> {
     let params = get_write_params(options)?;
     let py = options.py();
-    let ds = if reader.is_instance_of::<Scanner>() {
-        let scanner: Scanner = reader.extract()?;
-        let batches = rt()
-            .block_on(Some(py), scanner.to_reader())?
-            .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
-        rt().block_on(
-            Some(py),
-            LanceDataset::write(batches, dest.as_dest(), params),
-        )?
-        .map_err(|err| PyIOError::new_err(err.to_string()))?
+    let namespace_client_opt = get_dict_opt::<Bound<PyAny>>(options, "namespace_client")?;
+    let table_id_opt = get_dict_opt::<Vec<String>>(options, "table_id")?;
+    let namespace_client_table_context_opt =
+        get_dict_opt::<Bound<PyAny>>(options, "namespace_client_table_context")?;
+    let has_namespace = namespace_client_opt.is_some() || table_id_opt.is_some();
+    let has_complete_namespace = namespace_client_opt.is_some() && table_id_opt.is_some();
+
+    if has_namespace && dest.is_some() {
+        return Err(PyValueError::new_err(
+            "Cannot specify both 'dest' and 'namespace_client'/'table_id'.",
+        ));
+    }
+    if namespace_client_table_context_opt.is_some() && !has_complete_namespace {
+        return Err(PyValueError::new_err(
+            "'namespace_client_table_context' requires 'namespace_client' and 'table_id'.",
+        ));
+    }
+    if has_namespace && !has_complete_namespace {
+        return Err(PyValueError::new_err(
+            "Both 'namespace_client' and 'table_id' must be provided together.",
+        ));
+    }
+
+    let ds = if let (Some(ns_client), Some(table_id)) =
+        (namespace_client_opt.as_ref(), table_id_opt.as_ref())
+    {
+        let ns_client = extract_namespace_arc(py, ns_client)?;
+        let namespace_client_table_context = namespace_client_table_context_opt
+            .map(|c| extract_namespace_client_table_context(&c))
+            .transpose()?;
+
+        if reader.is_instance_of::<Scanner>() {
+            let scanner: Scanner = reader.extract()?;
+            let batches = rt()
+                .block_on(Some(py), scanner.to_reader())?
+                .map_err(|err| PyValueError::new_err(err.to_string()))?;
+            rt().block_on(
+                Some(py),
+                LanceDataset::write_into_namespace(
+                    batches,
+                    ns_client,
+                    table_id.clone(),
+                    namespace_client_table_context.as_ref(),
+                    params,
+                ),
+            )?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?
+        } else {
+            let batches = ArrowArrayStreamReader::from_pyarrow_bound(reader)?;
+            rt().block_on(
+                Some(py),
+                LanceDataset::write_into_namespace(
+                    batches,
+                    ns_client,
+                    table_id.clone(),
+                    namespace_client_table_context.as_ref(),
+                    params,
+                ),
+            )?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?
+        }
     } else {
-        let batches = ArrowArrayStreamReader::from_pyarrow_bound(reader)?;
-        rt().block_on(
-            Some(py),
-            LanceDataset::write(batches, dest.as_dest(), params),
-        )?
-        .map_err(|err| PyIOError::new_err(err.to_string()))?
+        let dest = dest.ok_or_else(|| {
+            PyValueError::new_err("dest is required when namespace_client is not provided")
+        })?;
+        if reader.is_instance_of::<Scanner>() {
+            let scanner: Scanner = reader.extract()?;
+            let batches = rt()
+                .block_on(Some(py), scanner.to_reader())?
+                .map_err(|err| PyValueError::new_err(err.to_string()))?;
+            rt().block_on(
+                Some(py),
+                LanceDataset::write(batches, dest.as_dest(), params),
+            )?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?
+        } else {
+            let batches = ArrowArrayStreamReader::from_pyarrow_bound(reader)?;
+            rt().block_on(
+                Some(py),
+                LanceDataset::write(batches, dest.as_dest(), params),
+            )?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?
+        }
     };
     Ok(Dataset {
         uri: ds.uri().to_string(),
@@ -3552,34 +3670,12 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
 
         let storage_options = get_dict_opt::<HashMap<String, String>>(options, "storage_options")?;
 
-        // Extract namespace_client and table_id for storage options provider creation
-        let namespace_client_opt = get_dict_opt::<Bound<PyAny>>(options, "namespace_client")?;
-        let table_id_opt = get_dict_opt::<Vec<String>>(options, "table_id")?;
-
-        if let Some(so) = storage_options.clone() {
-            // If namespace_client and table_id are provided, create storage options provider from them
-            if let (Some(ns_client), Some(table_id)) =
-                (namespace_client_opt.as_ref(), table_id_opt.as_ref())
-            {
-                let ns_client = extract_namespace_arc(options.py(), ns_client)?;
-                let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
-                    LanceNamespaceStorageOptionsProvider::new(ns_client, table_id.clone()),
-                );
-                let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                    so, provider,
-                ));
-                p.store_params = Some(ObjectStoreParams {
-                    storage_options_accessor: Some(accessor),
-                    ..Default::default()
-                });
-            } else {
-                // No namespace, just use storage options directly
-                let accessor = Arc::new(StorageOptionsAccessor::with_static_options(so));
-                p.store_params = Some(ObjectStoreParams {
-                    storage_options_accessor: Some(accessor),
-                    ..Default::default()
-                });
-            }
+        if let Some(so) = storage_options {
+            let accessor = Arc::new(StorageOptionsAccessor::with_static_options(so));
+            p.store_params = Some(ObjectStoreParams {
+                storage_options_accessor: Some(accessor),
+                ..Default::default()
+            });
         }
 
         if let Some(enable_stable_row_ids) = get_dict_opt::<bool>(options, "enable_stable_row_ids")?
@@ -3684,24 +3780,6 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
                 new_props.insert(key, value);
             }
             p.transaction_properties = Some(Arc::new(new_props));
-        }
-
-        // Handle namespace_client and table_id for managed versioning (external manifest store)
-        // Only set if commit_handler is not already set by user and namespace_client_managed_versioning is true
-        let namespace_client_managed_versioning =
-            get_dict_opt::<bool>(options, "namespace_client_managed_versioning")?.unwrap_or(false);
-        if p.commit_handler.is_none()
-            && namespace_client_managed_versioning
-            && let (Some(ns_client), Some(table_id)) =
-                (namespace_client_opt.as_ref(), table_id_opt.as_ref())
-        {
-            let ns_client = extract_namespace_arc(options.py(), ns_client)?;
-            let external_store =
-                LanceNamespaceExternalManifestStore::new(ns_client, table_id.clone());
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            p.commit_handler = Some(commit_handler);
         }
 
         Some(p)

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::namespace::extract_namespace_arc;
+use crate::namespace::{extract_namespace_arc, extract_namespace_client_table_context};
 use crate::{error::PythonErrorExt, rt};
 use arrow::pyarrow::PyArrowType;
 use arrow_array::{RecordBatch, RecordBatchReader, UInt32Array};
@@ -39,7 +39,7 @@ use lance_io::{
 use object_store::path::Path;
 use pyo3::{
     Bound, IntoPyObjectExt, Py, PyErr, PyResult, Python,
-    exceptions::{PyIOError, PyRuntimeError},
+    exceptions::{PyIOError, PyRuntimeError, PyValueError},
     pyclass, pyfunction, pymethods,
     types::PyAny,
 };
@@ -48,6 +48,56 @@ use std::collections::HashMap;
 use std::{pin::Pin, sync::Arc};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
+
+type StorageOptionsProvider = Arc<dyn lance_io::object_store::StorageOptionsProvider>;
+type StorageOptionsAndProvider = (
+    Option<HashMap<String, String>>,
+    Option<StorageOptionsProvider>,
+);
+
+fn resolve_storage_options_and_provider(
+    storage_options: Option<HashMap<String, String>>,
+    namespace_client: Option<&Bound<'_, PyAny>>,
+    table_id: Option<&Vec<String>>,
+    namespace_client_table_context: Option<&Bound<'_, PyAny>>,
+) -> PyResult<StorageOptionsAndProvider> {
+    if namespace_client.is_some() != table_id.is_some() {
+        return Err(PyValueError::new_err(
+            "Both 'namespace_client' and 'table_id' must be provided together.",
+        ));
+    }
+    if namespace_client_table_context.is_some() && namespace_client.is_none() {
+        return Err(PyValueError::new_err(
+            "'namespace_client_table_context' requires 'namespace_client' and 'table_id'.",
+        ));
+    }
+
+    let provider = if let (Some(ns_client), Some(tid)) = (namespace_client, table_id) {
+        let ns_client = extract_namespace_arc(ns_client.py(), ns_client)?;
+        Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(
+            ns_client,
+            tid.clone(),
+        )) as StorageOptionsProvider)
+    } else {
+        None
+    };
+
+    let merged_storage_options = if let Some(context) = namespace_client_table_context {
+        let context = extract_namespace_client_table_context(context)?;
+        match context.storage_options {
+            Some(context_storage_options) => {
+                let mut merged_storage_options = storage_options.unwrap_or_default();
+                merged_storage_options.extend(context_storage_options);
+                Some(merged_storage_options)
+            }
+            None => storage_options,
+        }
+    } else {
+        storage_options
+    };
+
+    Ok((merged_storage_options, provider))
+}
 #[pyclass(get_all, skip_from_py_object)]
 #[derive(Clone, Debug, Serialize)]
 pub struct LanceBufferDescriptor {
@@ -299,7 +349,7 @@ impl LanceFileWriter {
 #[pymethods]
 impl LanceFileWriter {
     #[new]
-    #[pyo3(signature=(path, schema=None, data_cache_bytes=None, version=None, storage_options=None, namespace_client=None, table_id=None, keep_original_array=None, max_page_bytes=None))]
+    #[pyo3(signature=(path, schema=None, data_cache_bytes=None, version=None, storage_options=None, namespace_client=None, table_id=None, namespace_client_table_context=None, keep_original_array=None, max_page_bytes=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         path: String,
@@ -309,20 +359,16 @@ impl LanceFileWriter {
         storage_options: Option<HashMap<String, String>>,
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
+        namespace_client_table_context: Option<&Bound<'_, PyAny>>,
         keep_original_array: Option<bool>,
         max_page_bytes: Option<u64>,
     ) -> PyResult<Self> {
-        // Create storage options provider from namespace_client and table_id if both are provided
-        let provider = if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
-            let ns_client = extract_namespace_arc(ns_client.py(), ns_client)?;
-            Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(
-                ns_client,
-                tid.clone(),
-            ))
-                as Arc<dyn lance_io::object_store::StorageOptionsProvider>)
-        } else {
-            None
-        };
+        let (storage_options, provider) = resolve_storage_options_and_provider(
+            storage_options,
+            namespace_client,
+            table_id.as_ref(),
+            namespace_client_table_context,
+        )?;
 
         rt().block_on(
             None,
@@ -456,24 +502,20 @@ impl LanceFileSession {
 #[pymethods]
 impl LanceFileSession {
     #[new]
-    #[pyo3(signature=(uri_or_path, storage_options=None, namespace_client=None, table_id=None))]
+    #[pyo3(signature=(uri_or_path, storage_options=None, namespace_client=None, table_id=None, namespace_client_table_context=None))]
     pub fn new(
         uri_or_path: String,
         storage_options: Option<HashMap<String, String>>,
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
+        namespace_client_table_context: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
-        // Create storage options provider from namespace_client and table_id if both are provided
-        let provider = if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
-            let ns_client = extract_namespace_arc(ns_client.py(), ns_client)?;
-            Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(
-                ns_client,
-                tid.clone(),
-            ))
-                as Arc<dyn lance_io::object_store::StorageOptionsProvider>)
-        } else {
-            None
-        };
+        let (storage_options, provider) = resolve_storage_options_and_provider(
+            storage_options,
+            namespace_client,
+            table_id.as_ref(),
+            namespace_client_table_context,
+        )?;
         rt().block_on(None, Self::try_new(uri_or_path, storage_options, provider))?
     }
 
@@ -754,25 +796,21 @@ impl LanceFileReader {
 #[pymethods]
 impl LanceFileReader {
     #[new]
-    #[pyo3(signature=(path, storage_options=None, namespace_client=None, table_id=None, columns=None))]
+    #[pyo3(signature=(path, storage_options=None, namespace_client=None, table_id=None, namespace_client_table_context=None, columns=None))]
     pub fn new(
         path: String,
         storage_options: Option<HashMap<String, String>>,
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
+        namespace_client_table_context: Option<&Bound<'_, PyAny>>,
         columns: Option<Vec<String>>,
     ) -> PyResult<Self> {
-        // Create storage options provider from namespace_client and table_id if both are provided
-        let provider = if let (Some(ns_client), Some(tid)) = (&namespace_client, &table_id) {
-            let ns_client = extract_namespace_arc(ns_client.py(), ns_client)?;
-            Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(
-                ns_client,
-                tid.clone(),
-            ))
-                as Arc<dyn lance_io::object_store::StorageOptionsProvider>)
-        } else {
-            None
-        };
+        let (storage_options, provider) = resolve_storage_options_and_provider(
+            storage_options,
+            namespace_client,
+            table_id.as_ref(),
+            namespace_client_table_context,
+        )?;
         rt().block_on(None, Self::open(path, storage_options, provider, columns))?
     }
 

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::sync::Arc;
 
@@ -23,8 +24,12 @@ use lance::Error;
 use lance::dataset::fragment::FileFragment as LanceFragment;
 use lance::dataset::scanner::ColumnOrdering;
 use lance::dataset::transaction::{Operation, Transaction};
-use lance::dataset::{InsertBuilder, NewColumnTransform};
+use lance::dataset::{InsertBuilder, NewColumnTransform, WriteParams};
 use lance_core::datatypes::BlobHandling;
+use lance_io::object_store::{
+    LanceNamespaceStorageOptionsProvider, ObjectStoreParams, StorageOptionsAccessor,
+    StorageOptionsProvider,
+};
 use lance_io::utils::CachedFileSize;
 use lance_table::format::{
     DataFile, DeletionFile, DeletionFileType, Fragment, RowDatasetVersionMeta, RowIdMeta,
@@ -38,9 +43,96 @@ use pyo3::{intern, prelude::*};
 
 use crate::dataset::{PyWriteDest, get_write_params, transforms_from_python};
 use crate::error::PythonErrorExt;
+use crate::namespace::{extract_namespace_arc, extract_namespace_client_table_context};
 use crate::schema::{LanceSchema, logical_schema_from_lance};
 use crate::utils::{PyLance, export_vec, extract_vec};
 use crate::{Dataset, Scanner, rt};
+
+fn get_non_none_kwarg<'py>(
+    kwargs: &Bound<'py, PyDict>,
+    key: &str,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    let Some(value) = kwargs.get_item(key)? else {
+        return Ok(None);
+    };
+    if value.is_none() {
+        Ok(None)
+    } else {
+        Ok(Some(value))
+    }
+}
+
+fn resolve_write_params(
+    params: Option<WriteParams>,
+    kwargs: Option<&Bound<'_, PyDict>>,
+) -> PyResult<Option<WriteParams>> {
+    let Some(kwargs) = kwargs else {
+        return Ok(params);
+    };
+
+    let namespace_client_table_context =
+        get_non_none_kwarg(kwargs, "namespace_client_table_context")?
+            .map(|context| extract_namespace_client_table_context(&context))
+            .transpose()?;
+
+    let namespace_client = get_non_none_kwarg(kwargs, "namespace_client")?;
+    let table_id: Option<Vec<String>> = get_non_none_kwarg(kwargs, "table_id")?
+        .map(|table_id| table_id.extract())
+        .transpose()?;
+
+    if namespace_client.is_some() != table_id.is_some() {
+        return Err(PyValueError::new_err(
+            "Both 'namespace_client' and 'table_id' must be provided together.",
+        ));
+    }
+    if namespace_client_table_context.is_some() && namespace_client.is_none() {
+        return Err(PyValueError::new_err(
+            "'namespace_client_table_context' requires 'namespace_client' and 'table_id'.",
+        ));
+    }
+
+    let provider = if let (Some(namespace_client), Some(table_id)) =
+        (namespace_client.as_ref(), table_id.as_ref())
+    {
+        let namespace_client = extract_namespace_arc(namespace_client.py(), namespace_client)?;
+        Some(Arc::new(LanceNamespaceStorageOptionsProvider::new(
+            namespace_client,
+            table_id.clone(),
+        )) as Arc<dyn StorageOptionsProvider>)
+    } else {
+        None
+    };
+
+    let mut params = params.unwrap_or_default();
+    let mut merged_storage_options: HashMap<String, String> = params
+        .store_params
+        .as_ref()
+        .and_then(|store_params| store_params.storage_options().cloned())
+        .unwrap_or_default();
+    if let Some(namespace_client_table_context) = namespace_client_table_context
+        && let Some(context_storage_options) = namespace_client_table_context.storage_options
+    {
+        merged_storage_options.extend(context_storage_options);
+    }
+
+    let existing_store_params = params.store_params.take().unwrap_or_default();
+    let storage_options_accessor = match (merged_storage_options.is_empty(), provider) {
+        (false, Some(provider)) => Some(Arc::new(
+            StorageOptionsAccessor::with_initial_and_provider(merged_storage_options, provider),
+        )),
+        (false, None) => Some(Arc::new(StorageOptionsAccessor::with_static_options(
+            merged_storage_options,
+        ))),
+        (true, Some(provider)) => Some(Arc::new(StorageOptionsAccessor::with_provider(provider))),
+        (true, None) => None,
+    };
+    params.store_params = Some(ObjectStoreParams {
+        storage_options_accessor,
+        ..existing_store_params
+    });
+
+    Ok(Some(params))
+}
 
 #[pyclass(name = "_Fragment", module = "_lib", from_py_object)]
 #[derive(Clone)]
@@ -123,6 +215,7 @@ impl FileFragment {
         } else {
             None
         };
+        let params = resolve_write_params(params, kwargs)?;
 
         let batches = convert_reader(reader)?;
 
@@ -437,8 +530,8 @@ fn do_write_fragments(
 
     let params = kwargs
         .and_then(|params| get_write_params(params).transpose())
-        .transpose()?
-        .unwrap_or_default();
+        .transpose()?;
+    let params = resolve_write_params(params, kwargs)?.unwrap_or_default();
 
     rt().block_on(
         Some(reader.py()),

--- a/python/src/namespace.rs
+++ b/python/src/namespace.rs
@@ -1512,6 +1512,13 @@ impl LanceNamespaceTrait for PyLanceNamespace {
         call_py_method(self.py_namespace.clone(), "describe_table", request).await
     }
 
+    async fn declare_table(
+        &self,
+        request: lance_namespace::models::DeclareTableRequest,
+    ) -> lance_core::Result<lance_namespace::models::DeclareTableResponse> {
+        call_py_method(self.py_namespace.clone(), "declare_table", request).await
+    }
+
     async fn describe_table_version(
         &self,
         request: DescribeTableVersionRequest,
@@ -1579,6 +1586,24 @@ pub fn extract_namespace_arc(
 
     // Custom Python implementation or subclass - wrap with PyLanceNamespace
     PyLanceNamespace::create_arc(py, namespace_client)
+}
+
+/// Extract a [`NamespaceClientTableContext`] from a Python object.
+///
+/// Reads the `location`, `storage_options`, and `managed_versioning`
+/// attributes from the Python `NamespaceClientTableContext` instance.
+pub fn extract_namespace_client_table_context(
+    ctx: &Bound<'_, PyAny>,
+) -> PyResult<lance_namespace::NamespaceClientTableContext> {
+    let location: String = ctx.getattr("location")?.extract()?;
+    let storage_options: Option<HashMap<String, String>> =
+        ctx.getattr("storage_options")?.extract()?;
+    let managed_versioning: bool = ctx.getattr("managed_versioning")?.extract()?;
+    Ok(lance_namespace::NamespaceClientTableContext {
+        location,
+        storage_options,
+        managed_versioning,
+    })
 }
 
 /// Python wrapper for REST adapter server

--- a/rust/lance-namespace-datafusion/src/namespace_level.rs
+++ b/rust/lance-namespace-datafusion/src/namespace_level.rs
@@ -119,6 +119,7 @@ impl NamespaceLevel {
         DatasetBuilder::from_namespace(
             Arc::clone(&self.root),
             self.child_id(table_name.to_string()),
+            None,
         )
         .await?
         .load()

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -7605,7 +7605,7 @@ mod tests {
 
         // Open the dataset using from_namespace to get proper object_store and paths
         let table_id = vec!["test_table".to_string()];
-        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone(), None)
             .await
             .unwrap()
             .load()
@@ -7717,7 +7717,7 @@ mod tests {
 
         // Open the dataset using from_namespace to get proper object_store and paths
         let table_id = vec!["test_table".to_string()];
-        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+        let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone(), None)
             .await
             .unwrap()
             .load()
@@ -8122,7 +8122,7 @@ mod tests {
 
             // checkout_latest should call list_table_versions exactly once
             let initial_list_calls = tracking_ns.list_table_versions_calls();
-            let latest_dataset = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            let latest_dataset = DatasetBuilder::from_namespace(ns.clone(), table_id.clone(), None)
                 .await
                 .unwrap()
                 .load()
@@ -8137,7 +8137,7 @@ mod tests {
 
             // checkout to specific version should call describe_table_version exactly once
             let initial_describe_calls = tracking_ns.describe_table_version_calls();
-            let v1_dataset = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            let v1_dataset = DatasetBuilder::from_namespace(ns.clone(), table_id.clone(), None)
                 .await
                 .unwrap()
                 .with_version(1)
@@ -9082,7 +9082,7 @@ mod tests {
                 .unwrap();
 
             let table_id = vec![table_name.to_string()];
-            let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+            let dataset = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone(), None)
                 .await
                 .unwrap()
                 .load()

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -6163,7 +6163,7 @@ mod tests {
 
         let reader1 = RecordBatchIterator::new(vec![data1].into_iter().map(Ok), schema.clone());
         let dataset =
-            Dataset::write_into_namespace(reader1, namespace.clone(), table_id.clone(), None)
+            Dataset::write_into_namespace(reader1, namespace.clone(), table_id.clone(), None, None)
                 .await
                 .unwrap();
 
@@ -6190,6 +6190,7 @@ mod tests {
             reader2,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(params_append),
         )
         .await
@@ -6218,6 +6219,7 @@ mod tests {
             reader3,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(params_overwrite),
         )
         .await
@@ -7305,6 +7307,7 @@ mod tests {
             batches,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(write_params),
         )
         .await
@@ -7421,6 +7424,7 @@ mod tests {
             batches,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(write_params),
         )
         .await
@@ -7535,6 +7539,7 @@ mod tests {
             batches,
             namespace.clone(),
             table_id.clone(),
+            None,
             Some(write_params),
         )
         .await
@@ -8083,6 +8088,7 @@ mod tests {
                 batches,
                 ns.clone(),
                 table_id.clone(),
+                None,
                 Some(write_params),
             )
             .await
@@ -8197,6 +8203,7 @@ mod tests {
                 batches,
                 tracking_ns.clone(),
                 table_id.clone(),
+                None,
                 Some(write_params),
             )
             .await
@@ -8221,6 +8228,7 @@ mod tests {
                 batches,
                 tracking_ns.clone(),
                 table_id.clone(),
+                None,
                 Some(write_params),
             )
             .await

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -2848,10 +2848,15 @@ mod tests {
             .unwrap();
 
             let reader1 = RecordBatchIterator::new(vec![data1].into_iter().map(Ok), schema.clone());
-            let dataset =
-                Dataset::write_into_namespace(reader1, namespace.clone(), table_id.clone(), None)
-                    .await
-                    .unwrap();
+            let dataset = Dataset::write_into_namespace(
+                reader1,
+                namespace.clone(),
+                table_id.clone(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
 
             assert_eq!(dataset.count_rows(None).await.unwrap(), 3);
             assert_eq!(dataset.version().version, 1);
@@ -2876,6 +2881,7 @@ mod tests {
                 reader2,
                 namespace.clone(),
                 table_id.clone(),
+                None,
                 Some(params_append),
             )
             .await
@@ -2904,6 +2910,7 @@ mod tests {
                 reader3,
                 namespace.clone(),
                 table_id.clone(),
+                None,
                 Some(params_overwrite),
             )
             .await

--- a/rust/lance-namespace/src/context.rs
+++ b/rust/lance-namespace/src/context.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Cached table context from a namespace client.
+//!
+//! [`NamespaceClientTableContext`] holds the information that was returned by a
+//! prior `describe_table` or `declare_table` call (location, storage options,
+//! managed-versioning flag).
+//!
+//! Passing this struct avoids repeating the same parameters across every API
+//! entry-point and makes it explicit that the values are cached from a prior
+//! namespace call rather than user-provided overrides.  The namespace client
+//! and table ID are **not** part of this struct; they are still passed
+//! separately.
+
+use std::collections::HashMap;
+
+use lance_namespace_reqwest_client::models::{DeclareTableResponse, DescribeTableResponse};
+
+use crate::{Error, Result};
+
+/// Cached context from a namespace client's `describe_table` or `declare_table`
+/// response.
+///
+/// Contains only the resolved table metadata (location, storage options,
+/// managed-versioning flag).  The namespace client and table ID remain
+/// separate parameters.
+#[derive(Debug, Clone)]
+pub struct NamespaceClientTableContext {
+    /// The table's storage location (URI).
+    pub location: String,
+    /// Storage options returned by the namespace (e.g. temporary credentials).
+    pub storage_options: Option<HashMap<String, String>>,
+    /// Whether commits should go through the namespace's version API.
+    pub managed_versioning: bool,
+}
+
+impl NamespaceClientTableContext {
+    /// Build a context from a `DescribeTableResponse`.
+    ///
+    /// Returns an error if the response does not contain a `location`.
+    pub fn from_describe_table_response(response: DescribeTableResponse) -> Result<Self> {
+        let location = response
+            .location
+            .ok_or_else(|| Error::invalid_input("DescribeTableResponse missing location"))?;
+        Ok(Self {
+            location,
+            storage_options: response.storage_options,
+            managed_versioning: response.managed_versioning == Some(true),
+        })
+    }
+
+    /// Build a context from a `DeclareTableResponse`.
+    ///
+    /// Returns an error if the response does not contain a `location`.
+    pub fn from_declare_table_response(response: DeclareTableResponse) -> Result<Self> {
+        let location = response
+            .location
+            .ok_or_else(|| Error::invalid_input("DeclareTableResponse missing location"))?;
+        Ok(Self {
+            location,
+            storage_options: response.storage_options,
+            managed_versioning: response.managed_versioning == Some(true),
+        })
+    }
+}

--- a/rust/lance-namespace/src/lib.rs
+++ b/rust/lance-namespace/src/lib.rs
@@ -15,11 +15,13 @@
 //! See [`error::ErrorCode`] for the list of error codes and
 //! [`error::NamespaceError`] for the error types.
 
+pub mod context;
 pub mod error;
 pub mod namespace;
 pub mod schema;
 
 // Re-export the trait at the crate root
+pub use context::NamespaceClientTableContext;
 pub use lance_core::{Error, Result};
 pub use namespace::LanceNamespace;
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -40,7 +40,7 @@ use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::utils::{
     CachedFileSize, read_last_block, read_message, read_metadata_offset, read_struct,
 };
-use lance_namespace::LanceNamespace;
+use lance_namespace::{LanceNamespace, NamespaceClientTableContext};
 use lance_table::format::{
     DataFile, DataStorageFormat, DeletionFile, Fragment, IndexMetadata, Manifest, RowIdMeta, pb,
 };
@@ -760,149 +760,108 @@ impl Dataset {
 
     /// Write into a namespace client-managed table with automatic credential vending.
     ///
-    /// For CREATE mode, calls declare_table() to initialize the table.
-    /// For other modes, calls describe_table() and opens dataset with namespace client credentials.
-    ///
-    /// # Arguments
-    ///
-    /// * `batches` - The record batches to write
-    /// * `namespace_client` - The namespace client to use for table management
-    /// * `table_id` - The table identifier
-    /// * `params` - Write parameters
+    /// When `namespace_client_table_context` is `None`, calls `declare_table()`
+    /// (CREATE) or `describe_table()` (APPEND/OVERWRITE) to resolve table info.
+    /// When provided, uses the cached values directly.
     pub async fn write_into_namespace(
         batches: impl RecordBatchReader + Send + 'static,
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
+        namespace_client_table_context: Option<&NamespaceClientTableContext>,
         mut params: Option<WriteParams>,
     ) -> Result<Self> {
         let mut write_params = params.take().unwrap_or_default();
 
+        let owned_context;
+        let namespace_client_table_context = match namespace_client_table_context {
+            Some(c) => c,
+            None => {
+                owned_context = match write_params.mode {
+                    WriteMode::Create => {
+                        let declare_request = DeclareTableRequest {
+                            id: Some(table_id.clone()),
+                            ..Default::default()
+                        };
+                        let response = namespace_client.declare_table(declare_request).await?;
+                        NamespaceClientTableContext::from_declare_table_response(response)?
+                    }
+                    WriteMode::Append | WriteMode::Overwrite => {
+                        let request = DescribeTableRequest {
+                            id: Some(table_id.clone()),
+                            ..Default::default()
+                        };
+                        let response = namespace_client.describe_table(request).await?;
+                        NamespaceClientTableContext::from_describe_table_response(response)?
+                    }
+                };
+                &owned_context
+            }
+        };
+
+        if namespace_client_table_context.managed_versioning {
+            let external_store = LanceNamespaceExternalManifestStore::new(
+                namespace_client.clone(),
+                table_id.clone(),
+            );
+            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
+                external_manifest_store: Arc::new(external_store),
+            });
+            write_params.commit_handler = Some(commit_handler);
+        }
+
+        let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
+            LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
+        );
+
+        let mut merged_options = write_params
+            .store_params
+            .as_ref()
+            .and_then(|p| p.storage_options().cloned())
+            .unwrap_or_default();
+        if let Some(ref namespace_storage_options) = namespace_client_table_context.storage_options
+        {
+            merged_options.extend(
+                namespace_storage_options
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            );
+        }
+        let accessor = if merged_options.is_empty() {
+            Arc::new(StorageOptionsAccessor::with_provider(provider))
+        } else {
+            Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                merged_options,
+                provider,
+            ))
+        };
+
+        let existing_params = write_params.store_params.take().unwrap_or_default();
+        write_params.store_params = Some(ObjectStoreParams {
+            storage_options_accessor: Some(accessor),
+            ..existing_params
+        });
+
         match write_params.mode {
             WriteMode::Create => {
-                let declare_request = DeclareTableRequest {
-                    id: Some(table_id.clone()),
-                    ..Default::default()
-                };
-                let response = namespace_client
-                    .declare_table(declare_request)
-                    .await
-                    .map_err(|e| Error::namespace_source(Box::new(e)))?;
-
-                let uri = response.location.ok_or_else(|| {
-                    Error::namespace_source(Box::new(std::io::Error::other(
-                        "Table location not found in declare_table response",
-                    )))
-                })?;
-
-                // Set up commit handler when managed_versioning is enabled
-                if response.managed_versioning == Some(true) {
-                    let external_store = LanceNamespaceExternalManifestStore::new(
-                        namespace_client.clone(),
-                        table_id.clone(),
-                    );
-                    let commit_handler: Arc<dyn CommitHandler> =
-                        Arc::new(ExternalManifestCommitHandler {
-                            external_manifest_store: Arc::new(external_store),
-                        });
-                    write_params.commit_handler = Some(commit_handler);
-                }
-
-                // Set initial credentials and provider from namespace_client
-                if let Some(namespace_storage_options) = response.storage_options {
-                    let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
-                        LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
-                    );
-
-                    // Merge namespace client storage options with any existing options
-                    let mut merged_options = write_params
-                        .store_params
-                        .as_ref()
-                        .and_then(|p| p.storage_options().cloned())
-                        .unwrap_or_default();
-                    merged_options.extend(namespace_storage_options);
-
-                    let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                        merged_options,
-                        provider,
-                    ));
-
-                    let existing_params = write_params.store_params.take().unwrap_or_default();
-                    write_params.store_params = Some(ObjectStoreParams {
-                        storage_options_accessor: Some(accessor),
-                        ..existing_params
-                    });
-                }
-
-                Self::write(batches, uri.as_str(), Some(write_params)).await
+                Self::write(
+                    batches,
+                    namespace_client_table_context.location.as_str(),
+                    Some(write_params),
+                )
+                .await
             }
             WriteMode::Append | WriteMode::Overwrite => {
-                let request = DescribeTableRequest {
-                    id: Some(table_id.clone()),
-                    ..Default::default()
-                };
-                let response = namespace_client
-                    .describe_table(request)
-                    .await
-                    .map_err(|e| Error::namespace_source(Box::new(e)))?;
-
-                let uri = response.location.ok_or_else(|| {
-                    Error::namespace_source(Box::new(std::io::Error::other(
-                        "Table location not found in describe_table response",
-                    )))
-                })?;
-
-                // Set up commit handler when managed_versioning is enabled
-                if response.managed_versioning == Some(true) {
-                    let external_store = LanceNamespaceExternalManifestStore::new(
-                        namespace_client.clone(),
-                        table_id.clone(),
-                    );
-                    let commit_handler: Arc<dyn CommitHandler> =
-                        Arc::new(ExternalManifestCommitHandler {
-                            external_manifest_store: Arc::new(external_store),
-                        });
-                    write_params.commit_handler = Some(commit_handler);
-                }
-
-                // Set initial credentials and provider from namespace_client
-                if let Some(namespace_storage_options) = response.storage_options {
-                    let provider: Arc<dyn StorageOptionsProvider> =
-                        Arc::new(LanceNamespaceStorageOptionsProvider::new(
-                            namespace_client.clone(),
-                            table_id.clone(),
-                        ));
-
-                    // Merge namespace client storage options with any existing options
-                    let mut merged_options = write_params
-                        .store_params
-                        .as_ref()
-                        .and_then(|p| p.storage_options().cloned())
-                        .unwrap_or_default();
-                    merged_options.extend(namespace_storage_options);
-
-                    let accessor = Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                        merged_options,
-                        provider,
-                    ));
-
-                    let existing_params = write_params.store_params.take().unwrap_or_default();
-                    write_params.store_params = Some(ObjectStoreParams {
-                        storage_options_accessor: Some(accessor),
-                        ..existing_params
-                    });
-                }
-
-                // For APPEND/OVERWRITE modes, we must open the existing dataset first
-                // and pass it to InsertBuilder. If we pass just the URI, InsertBuilder
-                // assumes no dataset exists and converts the mode to CREATE.
-                let mut builder = DatasetBuilder::from_uri(uri.as_str());
+                let mut builder =
+                    DatasetBuilder::from_uri(namespace_client_table_context.location.as_str());
                 if let Some(ref store_params) = write_params.store_params
                     && let Some(accessor) = &store_params.storage_options_accessor
                 {
                     builder = builder.with_storage_options_accessor(accessor.clone());
                 }
+                if let Some(ref commit_handler) = write_params.commit_handler {
+                    builder = builder.with_commit_handler(commit_handler.clone());
+                }
                 let dataset = Arc::new(builder.load().await?);
-
                 Self::write(batches, dataset, Some(write_params)).await
             }
         }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -33,8 +33,7 @@ use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::LanceFileVersion;
 use lance_index::{IndexType, progress::IndexBuildProgress};
 use lance_io::object_store::{
-    LanceNamespaceStorageOptionsProvider, ObjectStore, ObjectStoreParams, StorageOptions,
-    StorageOptionsAccessor, StorageOptionsProvider,
+    ObjectStore, ObjectStoreParams, StorageOptions, StorageOptionsAccessor,
 };
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::utils::{
@@ -46,11 +45,9 @@ use lance_table::format::{
 };
 use lance_table::io::commit::{
     CommitConfig, CommitError, CommitHandler, CommitLock, ManifestLocation, ManifestNamingScheme,
-    VERSIONS_DIR, external_manifest::ExternalManifestCommitHandler, migrate_scheme_to_v2,
-    write_manifest_file_to_path,
+    VERSIONS_DIR, migrate_scheme_to_v2, write_manifest_file_to_path,
 };
 
-use crate::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use lance_table::io::manifest::{read_manifest, read_manifest_indexes};
 use object_store::path::Path;
 use prost::Message;
@@ -118,7 +115,6 @@ use hash_joiner::HashJoiner;
 pub use lance_core::ROW_ID;
 use lance_core::box_error;
 use lance_index::scalar::lance_format::LanceIndexStore;
-use lance_namespace::models::{DeclareTableRequest, DescribeTableRequest};
 use lance_table::feature_flags::{apply_feature_flags, can_read_dataset};
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
 pub use schema_evolution::{
@@ -135,7 +131,8 @@ pub use write::update::{UpdateBuilder, UpdateJob};
 #[allow(deprecated)]
 pub use write::{
     AutoCleanupParams, CommitBuilder, DeleteBuilder, DeleteResult, ExternalBlobMode, InsertBuilder,
-    WriteDestination, WriteMode, WriteParams, WriteProgressFn, WriteStats, write_fragments,
+    NamespaceTableDestination, WriteDestination, WriteMode, WriteParams, WriteProgressFn,
+    WriteStats, write_fragments,
 };
 
 pub(crate) const INDICES_DIR: &str = "_indices";
@@ -503,7 +500,7 @@ impl Dataset {
         };
         let transaction = Transaction::new(version_number, clone_op, None);
 
-        let builder = CommitBuilder::new(WriteDestination::Uri(branch_location.uri.as_str()))
+        let builder = CommitBuilder::new(WriteDestination::Uri(branch_location.uri.clone()))
             .with_store_params(store_params.unwrap_or_default())
             .with_object_store(Arc::new(self.object_store().clone()))
             .with_commit_handler(self.commit_handler.clone())
@@ -747,7 +744,7 @@ impl Dataset {
     ///
     pub async fn write(
         batches: impl RecordBatchReader + Send + 'static,
-        dest: impl Into<WriteDestination<'_>>,
+        dest: impl Into<WriteDestination>,
         params: Option<WriteParams>,
     ) -> Result<Self> {
         let mut builder = InsertBuilder::new(dest);
@@ -768,103 +765,19 @@ impl Dataset {
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
         namespace_client_table_context: Option<&NamespaceClientTableContext>,
-        mut params: Option<WriteParams>,
+        params: Option<WriteParams>,
     ) -> Result<Self> {
-        let mut write_params = params.take().unwrap_or_default();
-
-        let owned_context;
-        let namespace_client_table_context = match namespace_client_table_context {
-            Some(c) => c,
-            None => {
-                owned_context = match write_params.mode {
-                    WriteMode::Create => {
-                        let declare_request = DeclareTableRequest {
-                            id: Some(table_id.clone()),
-                            ..Default::default()
-                        };
-                        let response = namespace_client.declare_table(declare_request).await?;
-                        NamespaceClientTableContext::from_declare_table_response(response)?
-                    }
-                    WriteMode::Append | WriteMode::Overwrite => {
-                        let request = DescribeTableRequest {
-                            id: Some(table_id.clone()),
-                            ..Default::default()
-                        };
-                        let response = namespace_client.describe_table(request).await?;
-                        NamespaceClientTableContext::from_describe_table_response(response)?
-                    }
-                };
-                &owned_context
-            }
-        };
-
-        if namespace_client_table_context.managed_versioning {
-            let external_store = LanceNamespaceExternalManifestStore::new(
-                namespace_client.clone(),
-                table_id.clone(),
-            );
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            write_params.commit_handler = Some(commit_handler);
-        }
-
-        let provider: Arc<dyn StorageOptionsProvider> = Arc::new(
-            LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
+        let namespace_table = NamespaceTableDestination::new(
+            namespace_client,
+            table_id,
+            namespace_client_table_context.cloned(),
         );
-
-        let mut merged_options = write_params
-            .store_params
-            .as_ref()
-            .and_then(|p| p.storage_options().cloned())
-            .unwrap_or_default();
-        if let Some(ref namespace_storage_options) = namespace_client_table_context.storage_options
-        {
-            merged_options.extend(
-                namespace_storage_options
-                    .iter()
-                    .map(|(key, value)| (key.clone(), value.clone())),
-            );
-        }
-        let accessor = if merged_options.is_empty() {
-            Arc::new(StorageOptionsAccessor::with_provider(provider))
-        } else {
-            Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                merged_options,
-                provider,
-            ))
-        };
-
-        let existing_params = write_params.store_params.take().unwrap_or_default();
-        write_params.store_params = Some(ObjectStoreParams {
-            storage_options_accessor: Some(accessor),
-            ..existing_params
-        });
-
-        match write_params.mode {
-            WriteMode::Create => {
-                Self::write(
-                    batches,
-                    namespace_client_table_context.location.as_str(),
-                    Some(write_params),
-                )
-                .await
-            }
-            WriteMode::Append | WriteMode::Overwrite => {
-                let mut builder =
-                    DatasetBuilder::from_uri(namespace_client_table_context.location.as_str());
-                if let Some(ref store_params) = write_params.store_params
-                    && let Some(accessor) = &store_params.storage_options_accessor
-                {
-                    builder = builder.with_storage_options_accessor(accessor.clone());
-                }
-                if let Some(ref commit_handler) = write_params.commit_handler {
-                    builder = builder.with_commit_handler(commit_handler.clone());
-                }
-                let dataset = Arc::new(builder.load().await?);
-                Self::write(batches, dataset, Some(write_params)).await
-            }
-        }
+        Self::write(
+            batches,
+            WriteDestination::NamespaceTable(namespace_table),
+            params,
+        )
+        .await
     }
 
     /// Append to existing [Dataset] with a stream of [RecordBatch]s
@@ -1160,7 +1073,7 @@ impl Dataset {
 
     #[allow(clippy::too_many_arguments)]
     async fn do_commit(
-        base_uri: WriteDestination<'_>,
+        base_uri: WriteDestination,
         operation: Operation,
         read_version: Option<u64>,
         store_params: Option<ObjectStoreParams>,
@@ -1232,7 +1145,7 @@ impl Dataset {
     ///   this on will make the dataset unreadable for older versions of Lance
     ///   (prior to 0.17.0). Default is False.
     pub async fn commit(
-        dest: impl Into<WriteDestination<'_>>,
+        dest: impl Into<WriteDestination>,
         operation: Operation,
         read_version: Option<u64>,
         store_params: Option<ObjectStoreParams>,
@@ -1262,7 +1175,7 @@ impl Dataset {
     /// This can be used to stage changes or to handle "secondary" datasets whose
     /// lineage is tracked elsewhere.
     pub async fn commit_detached(
-        dest: impl Into<WriteDestination<'_>>,
+        dest: impl Into<WriteDestination>,
         operation: Operation,
         read_version: Option<u64>,
         store_params: Option<ObjectStoreParams>,
@@ -2376,7 +2289,7 @@ impl Dataset {
         };
         let transaction = Transaction::new(version_number, clone_op, None);
 
-        let builder = CommitBuilder::new(WriteDestination::Uri(target_path))
+        let builder = CommitBuilder::new(WriteDestination::Uri(target_path.to_string()))
             .with_store_params(
                 store_params.unwrap_or(self.store_params.as_deref().cloned().unwrap_or_default()),
             )
@@ -2470,7 +2383,7 @@ impl Dataset {
             branch_name: None,
         };
         let txn = Transaction::new(ref_version, clone_op, None);
-        let builder = CommitBuilder::new(WriteDestination::Uri(target_path))
+        let builder = CommitBuilder::new(WriteDestination::Uri(target_path.to_string()))
             .with_store_params(store_params.clone().unwrap_or_default())
             .with_object_store(target_store.clone())
             .with_commit_handler(self.commit_handler.clone())

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -55,8 +55,6 @@ pub struct DatasetBuilder {
     /// Runtime-only exact object store bindings keyed by base path URI.
     base_store_params: HashMap<String, ObjectStoreParams>,
     namespace_info: Option<(Arc<dyn LanceNamespace>, Vec<String>)>,
-    uri_was_explicitly_set: bool,
-    validation_error: Option<String>,
 }
 
 impl std::fmt::Debug for DatasetBuilder {
@@ -76,14 +74,12 @@ impl std::fmt::Debug for DatasetBuilder {
             )
             .field("base_store_params", &!self.base_store_params.is_empty())
             .field("namespace_info", &self.namespace_info.is_some())
-            .field("uri_was_explicitly_set", &self.uri_was_explicitly_set)
-            .field("validation_error", &self.validation_error)
             .finish()
     }
 }
 
 impl DatasetBuilder {
-    fn from_uri_impl<T: AsRef<str>>(table_uri: T, uri_was_explicitly_set: bool) -> Self {
+    fn from_uri_impl<T: AsRef<str>>(table_uri: T) -> Self {
         Self {
             index_cache_size_bytes: DEFAULT_INDEX_CACHE_SIZE,
             metadata_cache_size_bytes: DEFAULT_METADATA_CACHE_SIZE,
@@ -98,120 +94,91 @@ impl DatasetBuilder {
             storage_options_override: None,
             base_store_params: HashMap::new(),
             namespace_info: None,
-            uri_was_explicitly_set,
-            validation_error: None,
         }
     }
 
     pub fn from_uri<T: AsRef<str>>(table_uri: T) -> Self {
-        Self::from_uri_impl(table_uri, true)
-    }
-
-    pub fn for_namespace(namespace_client: Arc<dyn LanceNamespace>, table_id: Vec<String>) -> Self {
-        Self::from_uri_impl("", false).with_namespace(namespace_client, table_id)
+        Self::from_uri_impl(table_uri)
     }
 
     /// Create a DatasetBuilder from a LanceNamespace client.
     ///
-    /// Calls `describe_table()` to fetch the table location, storage options,
-    /// and managed-versioning flag.
+    /// When `namespace_client_table_context` is `None`, calls `describe_table()`
+    /// to fetch the table location, storage options, and managed-versioning flag.
+    /// When provided, uses the cached context directly and does not call the
+    /// namespace.
     #[allow(deprecated)]
     pub async fn from_namespace(
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
+        namespace_client_table_context: Option<NamespaceClientTableContext>,
     ) -> Result<Self> {
-        let request = DescribeTableRequest {
-            id: Some(table_id.clone()),
-            ..Default::default()
-        };
-        let response = namespace_client.describe_table(request).await?;
         let namespace_client_table_context =
-            NamespaceClientTableContext::from_describe_table_response(response)?;
+            if let Some(namespace_client_table_context) = namespace_client_table_context {
+                namespace_client_table_context
+            } else {
+                let request = DescribeTableRequest {
+                    id: Some(table_id.clone()),
+                    ..Default::default()
+                };
+                let response = namespace_client.describe_table(request).await?;
+                NamespaceClientTableContext::from_describe_table_response(response)?
+            };
 
-        Ok(Self::for_namespace(namespace_client, table_id)
-            .with_namespace_client_table_context(namespace_client_table_context))
+        Self::from_resolved_namespace(namespace_client, table_id, namespace_client_table_context)
+    }
+
+    fn from_resolved_namespace(
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        namespace_client_table_context: NamespaceClientTableContext,
+    ) -> Result<Self> {
+        if namespace_client_table_context.location.is_empty() {
+            return Err(Error::invalid_input(
+                "NamespaceClientTableContext missing location",
+            ));
+        }
+
+        let mut builder = Self::from_uri_impl(&namespace_client_table_context.location);
+        builder.namespace_info = Some((namespace_client.clone(), table_id.clone()));
+        builder.storage_options_override = namespace_client_table_context.storage_options.clone();
+
+        if namespace_client_table_context.managed_versioning {
+            let external_store = LanceNamespaceExternalManifestStore::new(
+                namespace_client.clone(),
+                table_id.clone(),
+            );
+            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
+                external_manifest_store: Arc::new(external_store),
+            });
+            builder.commit_handler = Some(commit_handler);
+        }
+
+        let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
+            LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
+        );
+        let mut merged_storage_options = builder
+            .options
+            .storage_options()
+            .cloned()
+            .unwrap_or_default();
+        if let Some(storage_options) = &namespace_client_table_context.storage_options {
+            merged_storage_options.extend(storage_options.clone());
+        }
+        let accessor = if merged_storage_options.is_empty() {
+            StorageOptionsAccessor::with_provider(provider)
+        } else {
+            StorageOptionsAccessor::with_initial_and_provider(merged_storage_options, provider)
+        };
+        builder.options.storage_options_accessor = Some(Arc::new(accessor));
+
+        Ok(builder)
     }
 }
 
 // Much of this builder is directly inspired from the to delta-rs table builder implementation
 // https://github.com/delta-io/delta-rs/main/crates/deltalake-core/src/table/builder.rs
 impl DatasetBuilder {
-    /// Associate a namespace client and table id with this builder.
-    pub fn with_namespace(
-        mut self,
-        namespace_client: Arc<dyn LanceNamespace>,
-        table_id: Vec<String>,
-    ) -> Self {
-        if self.uri_was_explicitly_set {
-            self.validation_error = Some(
-                "namespace clients cannot be combined with an explicit uri/location".to_string(),
-            );
-            return self;
-        }
-        self.namespace_info = Some((namespace_client, table_id));
-        self
-    }
-
-    /// Apply a cached namespace table context to this builder.
-    ///
-    /// For full namespace behavior (credential refresh and managed-versioning
-    /// commit handling), call [`Self::with_namespace`] first.
-    pub fn with_namespace_client_table_context(
-        mut self,
-        namespace_client_table_context: NamespaceClientTableContext,
-    ) -> Self {
-        if self.uri_was_explicitly_set {
-            self.validation_error = Some(
-                "namespace_client_table_context cannot be combined with an explicit uri/location"
-                    .to_string(),
-            );
-            return self;
-        }
-        if self.namespace_info.is_none() {
-            self.validation_error = Some(
-                "namespace_client_table_context requires with_namespace() to be set first"
-                    .to_string(),
-            );
-            return self;
-        }
-
-        self.table_uri = namespace_client_table_context.location.clone();
-        self.storage_options_override = namespace_client_table_context.storage_options.clone();
-
-        if let Some((namespace_client, table_id)) = &self.namespace_info {
-            if namespace_client_table_context.managed_versioning {
-                let external_store = LanceNamespaceExternalManifestStore::new(
-                    namespace_client.clone(),
-                    table_id.clone(),
-                );
-                let commit_handler: Arc<dyn CommitHandler> =
-                    Arc::new(ExternalManifestCommitHandler {
-                        external_manifest_store: Arc::new(external_store),
-                    });
-                self.commit_handler = Some(commit_handler);
-            }
-
-            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> =
-                Arc::new(LanceNamespaceStorageOptionsProvider::new(
-                    namespace_client.clone(),
-                    table_id.clone(),
-                ));
-            let mut merged_storage_options =
-                self.options.storage_options().cloned().unwrap_or_default();
-            if let Some(storage_options) = &namespace_client_table_context.storage_options {
-                merged_storage_options.extend(storage_options.clone());
-            }
-            let accessor = if merged_storage_options.is_empty() {
-                StorageOptionsAccessor::with_provider(provider)
-            } else {
-                StorageOptionsAccessor::with_initial_and_provider(merged_storage_options, provider)
-            };
-            self.options.storage_options_accessor = Some(Arc::new(accessor));
-        }
-
-        self
-    }
-
     /// Set the cache size for indices. Set to zero, to disable the cache.
     pub fn with_index_cache_size_bytes(mut self, cache_size: usize) -> Self {
         self.index_cache_size_bytes = cache_size;
@@ -354,6 +321,7 @@ impl DatasetBuilder {
                 StorageOptionsAccessor::with_static_options(storage_options),
             ));
         }
+        self.apply_storage_options_override();
         self
     }
 
@@ -384,6 +352,7 @@ impl DatasetBuilder {
                 StorageOptionsAccessor::with_static_options(storage_options),
             ));
         }
+        self.apply_storage_options_override();
         self
     }
 
@@ -537,6 +506,7 @@ impl DatasetBuilder {
                 (None, None) => None,
             };
             self.options = options;
+            self.apply_storage_options_override();
         }
 
         if let Some(session) = read_params.session {
@@ -589,6 +559,7 @@ impl DatasetBuilder {
                 (None, None) => None,
             };
             self.options = options;
+            self.apply_storage_options_override();
         }
 
         if let Some(commit_handler) = write_params.commit_handler {
@@ -618,12 +589,9 @@ impl DatasetBuilder {
     pub async fn build_object_store(
         self,
     ) -> Result<(Arc<ObjectStore>, Path, Arc<dyn CommitHandler>)> {
-        if let Some(validation_error) = self.validation_error.clone() {
-            return Err(Error::invalid_input(validation_error));
-        }
         if self.namespace_info.is_some() && self.table_uri.is_empty() {
             return Err(Error::invalid_input(
-                "namespace dataset opens require from_namespace() or namespace_client_table_context",
+                "namespace dataset opens require from_namespace() to resolve a table location",
             ));
         }
         let commit_handler = match self.commit_handler {
@@ -720,6 +688,13 @@ impl DatasetBuilder {
         };
         merged_params.storage_options_accessor = Some(storage_options_accessor);
         merged_params
+    }
+
+    fn apply_storage_options_override(&mut self) {
+        if let Some(override_opts) = &self.storage_options_override {
+            self.options =
+                Self::merge_store_params_with_storage_options(&self.options, override_opts);
+        }
     }
 
     async fn load_impl(mut self) -> Result<Dataset> {
@@ -938,11 +913,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn namespace_context_attaches_provider_without_initial_storage_options() {
-        let builder =
-            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
-                .with_namespace_client_table_context(namespace_context(None));
+    #[tokio::test]
+    async fn namespace_context_attaches_provider_without_initial_storage_options() {
+        let builder = DatasetBuilder::from_namespace(
+            Arc::new(DummyNamespace),
+            vec!["table".to_string()],
+            Some(namespace_context(None)),
+        )
+        .await
+        .unwrap();
 
         let accessor = builder
             .options
@@ -952,14 +931,16 @@ mod tests {
         assert!(accessor.initial_storage_options().is_none());
     }
 
-    #[test]
-    fn namespace_context_uses_cached_location_and_initial_storage_options() {
+    #[tokio::test]
+    async fn namespace_context_uses_cached_location_and_initial_storage_options() {
         let storage_options = HashMap::from([("token".to_string(), "cached".to_string())]);
-        let builder =
-            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
-                .with_namespace_client_table_context(namespace_context(Some(
-                    storage_options.clone(),
-                )));
+        let builder = DatasetBuilder::from_namespace(
+            Arc::new(DummyNamespace),
+            vec!["table".to_string()],
+            Some(namespace_context(Some(storage_options.clone()))),
+        )
+        .await
+        .unwrap();
 
         let accessor = builder
             .options
@@ -970,8 +951,8 @@ mod tests {
         assert_eq!(accessor.initial_storage_options(), Some(&storage_options));
     }
 
-    #[test]
-    fn namespace_context_merges_existing_storage_options() {
+    #[tokio::test]
+    async fn namespace_context_merges_existing_storage_options() {
         let user_storage_options = HashMap::from([
             ("user_token".to_string(), "user".to_string()),
             ("token".to_string(), "user".to_string()),
@@ -986,12 +967,14 @@ mod tests {
             ("expires_at_millis".to_string(), "123".to_string()),
         ]);
 
-        let builder =
-            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
-                .with_storage_options(user_storage_options)
-                .with_namespace_client_table_context(namespace_context(Some(
-                    namespace_storage_options,
-                )));
+        let builder = DatasetBuilder::from_namespace(
+            Arc::new(DummyNamespace),
+            vec!["table".to_string()],
+            Some(namespace_context(Some(namespace_storage_options))),
+        )
+        .await
+        .unwrap()
+        .with_storage_options(user_storage_options);
 
         let accessor = builder
             .options
@@ -1004,23 +987,25 @@ mod tests {
         );
     }
 
-    #[test]
-    fn namespace_context_provider_survives_write_params() {
+    #[tokio::test]
+    async fn namespace_context_provider_survives_write_params() {
         let user_storage_options = HashMap::from([("user_token".to_string(), "user".to_string())]);
-        let builder =
-            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
-                .with_namespace_client_table_context(namespace_context(None))
-                .with_write_params(WriteParams {
-                    store_params: Some(ObjectStoreParams {
-                        storage_options_accessor: Some(Arc::new(
-                            StorageOptionsAccessor::with_static_options(
-                                user_storage_options.clone(),
-                            ),
-                        )),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                });
+        let builder = DatasetBuilder::from_namespace(
+            Arc::new(DummyNamespace),
+            vec!["table".to_string()],
+            Some(namespace_context(None)),
+        )
+        .await
+        .unwrap()
+        .with_write_params(WriteParams {
+            store_params: Some(ObjectStoreParams {
+                storage_options_accessor: Some(Arc::new(
+                    StorageOptionsAccessor::with_static_options(user_storage_options.clone()),
+                )),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
 
         let accessor = builder
             .options
@@ -1034,14 +1019,47 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn for_namespace_requires_context_before_load() {
-        let err =
-            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
-                .load()
-                .await
-                .unwrap_err();
+    async fn namespace_context_overrides_write_params_storage_options() {
+        let user_storage_options = HashMap::from([
+            ("user_token".to_string(), "user".to_string()),
+            ("token".to_string(), "user".to_string()),
+        ]);
+        let namespace_storage_options = HashMap::from([
+            ("token".to_string(), "cached".to_string()),
+            ("expires_at_millis".to_string(), "123".to_string()),
+        ]);
+        let expected_storage_options = HashMap::from([
+            ("user_token".to_string(), "user".to_string()),
+            ("token".to_string(), "cached".to_string()),
+            ("expires_at_millis".to_string(), "123".to_string()),
+        ]);
 
-        assert!(err.to_string().contains("namespace_client_table_context"));
+        let builder = DatasetBuilder::from_namespace(
+            Arc::new(DummyNamespace),
+            vec!["table".to_string()],
+            Some(namespace_context(Some(namespace_storage_options))),
+        )
+        .await
+        .unwrap()
+        .with_write_params(WriteParams {
+            store_params: Some(ObjectStoreParams {
+                storage_options_accessor: Some(Arc::new(
+                    StorageOptionsAccessor::with_static_options(user_storage_options),
+                )),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+
+        let accessor = builder
+            .options
+            .storage_options_accessor
+            .expect("namespace context should override write params storage options");
+        assert!(accessor.provider().is_some());
+        assert_eq!(
+            accessor.initial_storage_options(),
+            Some(&expected_storage_options)
+        );
     }
 
     #[derive(Debug)]
@@ -1075,6 +1093,7 @@ mod tests {
                 describe_version: describe_version.clone(),
             }),
             vec!["table".to_string()],
+            None,
         )
         .await
         .unwrap()

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -126,36 +126,28 @@ impl DatasetBuilder {
     /// Create a DatasetBuilder from a LanceNamespace client for an optional table version.
     ///
     /// Calls `describe_table()` to fetch the table location, storage options,
-    /// and managed-versioning flag. When `version` is provided, it is passed to
-    /// the namespace so version-scoped locations or vended credentials can be
-    /// resolved before the dataset is opened.
+    /// and managed-versioning flag. When `version` is provided, it is applied to
+    /// the returned dataset builder using normal Lance version checkout.
     #[allow(deprecated)]
     pub async fn from_namespace_with_version(
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
         version: Option<u64>,
     ) -> Result<Self> {
-        let version = version
-            .map(|version| {
-                i64::try_from(version).map_err(|_| {
-                    Error::invalid_input(format!(
-                        "table version {} exceeds namespace request range",
-                        version
-                    ))
-                })
-            })
-            .transpose()?;
         let request = DescribeTableRequest {
             id: Some(table_id.clone()),
-            version,
             ..Default::default()
         };
         let response = namespace_client.describe_table(request).await?;
         let namespace_client_table_context =
             NamespaceClientTableContext::from_describe_table_response(response)?;
 
-        Ok(Self::for_namespace(namespace_client, table_id)
-            .with_namespace_client_table_context(namespace_client_table_context))
+        let mut builder = Self::for_namespace(namespace_client, table_id)
+            .with_namespace_client_table_context(namespace_client_table_context);
+        if let Some(version) = version {
+            builder = builder.with_version(version);
+        }
+        Ok(builder)
     }
 }
 
@@ -582,7 +574,38 @@ impl DatasetBuilder {
 
     /// Set options based on [WriteParams].
     pub fn with_write_params(mut self, write_params: WriteParams) -> Self {
-        if let Some(options) = write_params.store_params {
+        if let Some(mut options) = write_params.store_params {
+            options.storage_options_accessor = match (
+                self.options.storage_options_accessor.as_ref(),
+                options.storage_options_accessor.as_ref(),
+            ) {
+                (Some(existing), Some(incoming)) => {
+                    let mut merged_storage_options = existing
+                        .initial_storage_options()
+                        .cloned()
+                        .unwrap_or_default();
+                    if let Some(incoming_storage_options) = incoming.initial_storage_options() {
+                        merged_storage_options.extend(incoming_storage_options.clone());
+                    }
+                    let provider = existing
+                        .provider()
+                        .cloned()
+                        .or_else(|| incoming.provider().cloned());
+                    Some(if let Some(provider) = provider {
+                        Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                            merged_storage_options,
+                            provider,
+                        ))
+                    } else {
+                        Arc::new(StorageOptionsAccessor::with_static_options(
+                            merged_storage_options,
+                        ))
+                    })
+                }
+                (Some(existing), None) => Some(existing.clone()),
+                (None, Some(incoming)) => Some(incoming.clone()),
+                (None, None) => None,
+            };
             self.options = options;
         }
 
@@ -999,6 +1022,35 @@ mod tests {
         );
     }
 
+    #[test]
+    fn namespace_context_provider_survives_write_params() {
+        let user_storage_options = HashMap::from([("user_token".to_string(), "user".to_string())]);
+        let builder =
+            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
+                .with_namespace_client_table_context(namespace_context(None))
+                .with_write_params(WriteParams {
+                    store_params: Some(ObjectStoreParams {
+                        storage_options_accessor: Some(Arc::new(
+                            StorageOptionsAccessor::with_static_options(
+                                user_storage_options.clone(),
+                            ),
+                        )),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                });
+
+        let accessor = builder
+            .options
+            .storage_options_accessor
+            .expect("namespace provider should survive write params");
+        assert!(accessor.provider().is_some());
+        assert_eq!(
+            accessor.initial_storage_options(),
+            Some(&user_storage_options)
+        );
+    }
+
     #[tokio::test]
     async fn for_namespace_requires_context_before_load() {
         let err =
@@ -1034,9 +1086,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn from_namespace_with_version_passes_version_to_describe_table() {
+    async fn from_namespace_with_version_sets_dataset_version_target() {
         let describe_version = Arc::new(std::sync::Mutex::new(None));
-        DatasetBuilder::from_namespace_with_version(
+        let builder = DatasetBuilder::from_namespace_with_version(
             Arc::new(RecordingNamespace {
                 describe_version: describe_version.clone(),
             }),
@@ -1046,6 +1098,10 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(*describe_version.lock().unwrap(), Some(7));
+        assert_eq!(*describe_version.lock().unwrap(), None);
+        assert!(matches!(
+            builder.version,
+            Some(crate::dataset::refs::Ref::VersionNumber(7))
+        ));
     }
 }

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -120,20 +120,6 @@ impl DatasetBuilder {
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
     ) -> Result<Self> {
-        Self::from_namespace_with_version(namespace_client, table_id, None).await
-    }
-
-    /// Create a DatasetBuilder from a LanceNamespace client for an optional table version.
-    ///
-    /// Calls `describe_table()` to fetch the table location, storage options,
-    /// and managed-versioning flag. When `version` is provided, it is applied to
-    /// the returned dataset builder using normal Lance version checkout.
-    #[allow(deprecated)]
-    pub async fn from_namespace_with_version(
-        namespace_client: Arc<dyn LanceNamespace>,
-        table_id: Vec<String>,
-        version: Option<u64>,
-    ) -> Result<Self> {
         let request = DescribeTableRequest {
             id: Some(table_id.clone()),
             ..Default::default()
@@ -142,12 +128,8 @@ impl DatasetBuilder {
         let namespace_client_table_context =
             NamespaceClientTableContext::from_describe_table_response(response)?;
 
-        let mut builder = Self::for_namespace(namespace_client, table_id)
-            .with_namespace_client_table_context(namespace_client_table_context);
-        if let Some(version) = version {
-            builder = builder.with_version(version);
-        }
-        Ok(builder)
+        Ok(Self::for_namespace(namespace_client, table_id)
+            .with_namespace_client_table_context(namespace_client_table_context))
     }
 }
 
@@ -1086,17 +1068,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn from_namespace_with_version_sets_dataset_version_target() {
+    async fn from_namespace_leaves_version_as_builder_option() {
         let describe_version = Arc::new(std::sync::Mutex::new(None));
-        let builder = DatasetBuilder::from_namespace_with_version(
+        let builder = DatasetBuilder::from_namespace(
             Arc::new(RecordingNamespace {
                 describe_version: describe_version.clone(),
             }),
             vec!["table".to_string()],
-            Some(7),
         )
         .await
-        .unwrap();
+        .unwrap()
+        .with_version(7);
 
         assert_eq!(*describe_version.lock().unwrap(), None);
         assert!(matches!(

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -18,6 +18,7 @@ use lance_io::object_store::{
     ObjectStoreParams, StorageOptions, StorageOptionsAccessor,
 };
 use lance_namespace::LanceNamespace;
+use lance_namespace::NamespaceClientTableContext;
 use lance_namespace::models::DescribeTableRequest;
 use lance_table::{
     format::Manifest,
@@ -53,6 +54,9 @@ pub struct DatasetBuilder {
     storage_options_override: Option<HashMap<String, String>>,
     /// Runtime-only exact object store bindings keyed by base path URI.
     base_store_params: HashMap<String, ObjectStoreParams>,
+    namespace_info: Option<(Arc<dyn LanceNamespace>, Vec<String>)>,
+    uri_was_explicitly_set: bool,
+    validation_error: Option<String>,
 }
 
 impl std::fmt::Debug for DatasetBuilder {
@@ -71,12 +75,15 @@ impl std::fmt::Debug for DatasetBuilder {
                 &self.storage_options_override.is_some(),
             )
             .field("base_store_params", &!self.base_store_params.is_empty())
+            .field("namespace_info", &self.namespace_info.is_some())
+            .field("uri_was_explicitly_set", &self.uri_was_explicitly_set)
+            .field("validation_error", &self.validation_error)
             .finish()
     }
 }
 
 impl DatasetBuilder {
-    pub fn from_uri<T: AsRef<str>>(table_uri: T) -> Self {
+    fn from_uri_impl<T: AsRef<str>>(table_uri: T, uri_was_explicitly_set: bool) -> Self {
         Self {
             index_cache_size_bytes: DEFAULT_INDEX_CACHE_SIZE,
             metadata_cache_size_bytes: DEFAULT_METADATA_CACHE_SIZE,
@@ -90,98 +97,147 @@ impl DatasetBuilder {
             file_reader_options: None,
             storage_options_override: None,
             base_store_params: HashMap::new(),
+            namespace_info: None,
+            uri_was_explicitly_set,
+            validation_error: None,
         }
     }
 
-    /// Create a DatasetBuilder from a LanceNamespace client
+    pub fn from_uri<T: AsRef<str>>(table_uri: T) -> Self {
+        Self::from_uri_impl(table_uri, true)
+    }
+
+    pub fn for_namespace(namespace_client: Arc<dyn LanceNamespace>, table_id: Vec<String>) -> Self {
+        Self::from_uri_impl("", false).with_namespace(namespace_client, table_id)
+    }
+
+    /// Create a DatasetBuilder from a LanceNamespace client.
     ///
-    /// This will automatically fetch the table location and storage options from the namespace
-    /// client via `describe_table()`.
-    ///
-    /// Storage options from the namespace client will override any user-provided storage options
-    /// set via `.with_storage_options()`. This ensures the namespace client is always the source
-    /// of truth for storage options.
-    ///
-    /// # Arguments
-    /// * `namespace_client` - The namespace client implementation to fetch table info from
-    /// * `table_id` - The table identifier (e.g., vec!["my_table"])
-    ///
-    /// # Example
-    /// ```ignore
-    /// use lance_namespace_impls::ConnectBuilder;
-    /// use lance::dataset::DatasetBuilder;
-    ///
-    /// // Connect to a REST namespace
-    /// let namespace_client = ConnectBuilder::new("rest")
-    ///     .property("uri", "http://localhost:8080")
-    ///     .connect()
-    ///     .await?;
-    ///
-    /// // Load a dataset using storage options from namespace client
-    /// let dataset = DatasetBuilder::from_namespace(
-    ///     namespace_client,
-    ///     vec!["my_table".to_string()],
-    /// )
-    /// .await?
-    /// .load()
-    /// .await?;
-    /// ```
+    /// Calls `describe_table()` to fetch the table location, storage options,
+    /// and managed-versioning flag.
     #[allow(deprecated)]
     pub async fn from_namespace(
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
     ) -> Result<Self> {
+        Self::from_namespace_with_version(namespace_client, table_id, None).await
+    }
+
+    /// Create a DatasetBuilder from a LanceNamespace client for an optional table version.
+    ///
+    /// Calls `describe_table()` to fetch the table location, storage options,
+    /// and managed-versioning flag. When `version` is provided, it is passed to
+    /// the namespace so version-scoped locations or vended credentials can be
+    /// resolved before the dataset is opened.
+    #[allow(deprecated)]
+    pub async fn from_namespace_with_version(
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        version: Option<u64>,
+    ) -> Result<Self> {
+        let version = version
+            .map(|version| {
+                i64::try_from(version).map_err(|_| {
+                    Error::invalid_input(format!(
+                        "table version {} exceeds namespace request range",
+                        version
+                    ))
+                })
+            })
+            .transpose()?;
         let request = DescribeTableRequest {
             id: Some(table_id.clone()),
+            version,
             ..Default::default()
         };
+        let response = namespace_client.describe_table(request).await?;
+        let namespace_client_table_context =
+            NamespaceClientTableContext::from_describe_table_response(response)?;
 
-        let response = namespace_client
-            .describe_table(request)
-            .await
-            .map_err(|e| Error::namespace_source(Box::new(e)))?;
-
-        let table_uri = response.location.ok_or_else(|| {
-            Error::namespace_source(Box::new(std::io::Error::other(
-                "Table location not found in namespace response",
-            )))
-        })?;
-
-        let mut builder = Self::from_uri(&table_uri);
-
-        // Check managed_versioning flag to determine if namespace-managed commits should be used
-        if response.managed_versioning == Some(true) {
-            let external_store = LanceNamespaceExternalManifestStore::new(
-                namespace_client.clone(),
-                table_id.clone(),
-            );
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            builder.commit_handler = Some(commit_handler);
-        }
-
-        // Use namespace storage options if available
-        let namespace_storage_options = response.storage_options;
-
-        builder.storage_options_override = namespace_storage_options.clone();
-
-        if let Some(initial_opts) = namespace_storage_options {
-            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> = Arc::new(
-                LanceNamespaceStorageOptionsProvider::new(namespace_client, table_id),
-            );
-            builder.options.storage_options_accessor = Some(Arc::new(
-                StorageOptionsAccessor::with_initial_and_provider(initial_opts, provider),
-            ));
-        }
-
-        Ok(builder)
+        Ok(Self::for_namespace(namespace_client, table_id)
+            .with_namespace_client_table_context(namespace_client_table_context))
     }
 }
 
 // Much of this builder is directly inspired from the to delta-rs table builder implementation
 // https://github.com/delta-io/delta-rs/main/crates/deltalake-core/src/table/builder.rs
 impl DatasetBuilder {
+    /// Associate a namespace client and table id with this builder.
+    pub fn with_namespace(
+        mut self,
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+    ) -> Self {
+        if self.uri_was_explicitly_set {
+            self.validation_error = Some(
+                "namespace clients cannot be combined with an explicit uri/location".to_string(),
+            );
+            return self;
+        }
+        self.namespace_info = Some((namespace_client, table_id));
+        self
+    }
+
+    /// Apply a cached namespace table context to this builder.
+    ///
+    /// For full namespace behavior (credential refresh and managed-versioning
+    /// commit handling), call [`Self::with_namespace`] first.
+    pub fn with_namespace_client_table_context(
+        mut self,
+        namespace_client_table_context: NamespaceClientTableContext,
+    ) -> Self {
+        if self.uri_was_explicitly_set {
+            self.validation_error = Some(
+                "namespace_client_table_context cannot be combined with an explicit uri/location"
+                    .to_string(),
+            );
+            return self;
+        }
+        if self.namespace_info.is_none() {
+            self.validation_error = Some(
+                "namespace_client_table_context requires with_namespace() to be set first"
+                    .to_string(),
+            );
+            return self;
+        }
+
+        self.table_uri = namespace_client_table_context.location.clone();
+        self.storage_options_override = namespace_client_table_context.storage_options.clone();
+
+        if let Some((namespace_client, table_id)) = &self.namespace_info {
+            if namespace_client_table_context.managed_versioning {
+                let external_store = LanceNamespaceExternalManifestStore::new(
+                    namespace_client.clone(),
+                    table_id.clone(),
+                );
+                let commit_handler: Arc<dyn CommitHandler> =
+                    Arc::new(ExternalManifestCommitHandler {
+                        external_manifest_store: Arc::new(external_store),
+                    });
+                self.commit_handler = Some(commit_handler);
+            }
+
+            let provider: Arc<dyn lance_io::object_store::StorageOptionsProvider> =
+                Arc::new(LanceNamespaceStorageOptionsProvider::new(
+                    namespace_client.clone(),
+                    table_id.clone(),
+                ));
+            let mut merged_storage_options =
+                self.options.storage_options().cloned().unwrap_or_default();
+            if let Some(storage_options) = &namespace_client_table_context.storage_options {
+                merged_storage_options.extend(storage_options.clone());
+            }
+            let accessor = if merged_storage_options.is_empty() {
+                StorageOptionsAccessor::with_provider(provider)
+            } else {
+                StorageOptionsAccessor::with_initial_and_provider(merged_storage_options, provider)
+            };
+            self.options.storage_options_accessor = Some(Arc::new(accessor));
+        }
+
+        self
+    }
+
     /// Set the cache size for indices. Set to zero, to disable the cache.
     pub fn with_index_cache_size_bytes(mut self, cache_size: usize) -> Self {
         self.index_cache_size_bytes = cache_size;
@@ -474,7 +530,38 @@ impl DatasetBuilder {
             .with_index_cache_size_bytes(read_params.index_cache_size_bytes)
             .with_metadata_cache_size_bytes(read_params.metadata_cache_size_bytes);
 
-        if let Some(options) = read_params.store_options {
+        if let Some(mut options) = read_params.store_options {
+            options.storage_options_accessor = match (
+                self.options.storage_options_accessor.as_ref(),
+                options.storage_options_accessor.as_ref(),
+            ) {
+                (Some(existing), Some(incoming)) => {
+                    let mut merged_storage_options = existing
+                        .initial_storage_options()
+                        .cloned()
+                        .unwrap_or_default();
+                    if let Some(incoming_storage_options) = incoming.initial_storage_options() {
+                        merged_storage_options.extend(incoming_storage_options.clone());
+                    }
+                    let provider = existing
+                        .provider()
+                        .cloned()
+                        .or_else(|| incoming.provider().cloned());
+                    Some(if let Some(provider) = provider {
+                        Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                            merged_storage_options,
+                            provider,
+                        ))
+                    } else {
+                        Arc::new(StorageOptionsAccessor::with_static_options(
+                            merged_storage_options,
+                        ))
+                    })
+                }
+                (Some(existing), None) => Some(existing.clone()),
+                (None, Some(incoming)) => Some(incoming.clone()),
+                (None, None) => None,
+            };
             self.options = options;
         }
 
@@ -526,6 +613,14 @@ impl DatasetBuilder {
     pub async fn build_object_store(
         self,
     ) -> Result<(Arc<ObjectStore>, Path, Arc<dyn CommitHandler>)> {
+        if let Some(validation_error) = self.validation_error.clone() {
+            return Err(Error::invalid_input(validation_error));
+        }
+        if self.namespace_info.is_some() && self.table_uri.is_empty() {
+            return Err(Error::invalid_input(
+                "namespace dataset opens require from_namespace() or namespace_client_table_context",
+            ));
+        }
         let commit_handler = match self.commit_handler {
             Some(commit_handler) => Ok(commit_handler),
             None => commit_handler_from_url(&self.table_uri, &Some(self.options.clone())).await,
@@ -811,5 +906,146 @@ impl DatasetBuilder {
             store_params,
             base_store_params,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lance_namespace::models::DescribeTableResponse;
+
+    #[derive(Debug)]
+    struct DummyNamespace;
+
+    impl LanceNamespace for DummyNamespace {
+        fn namespace_id(&self) -> String {
+            "dummy".to_string()
+        }
+    }
+
+    fn namespace_context(
+        storage_options: Option<HashMap<String, String>>,
+    ) -> NamespaceClientTableContext {
+        NamespaceClientTableContext {
+            location: "memory://table".to_string(),
+            storage_options,
+            managed_versioning: false,
+        }
+    }
+
+    #[test]
+    fn namespace_context_attaches_provider_without_initial_storage_options() {
+        let builder =
+            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
+                .with_namespace_client_table_context(namespace_context(None));
+
+        let accessor = builder
+            .options
+            .storage_options_accessor
+            .expect("namespace context should attach a storage options accessor");
+        assert!(accessor.provider().is_some());
+        assert!(accessor.initial_storage_options().is_none());
+    }
+
+    #[test]
+    fn namespace_context_uses_cached_location_and_initial_storage_options() {
+        let storage_options = HashMap::from([("token".to_string(), "cached".to_string())]);
+        let builder =
+            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
+                .with_namespace_client_table_context(namespace_context(Some(
+                    storage_options.clone(),
+                )));
+
+        let accessor = builder
+            .options
+            .storage_options_accessor
+            .expect("namespace context should attach a storage options accessor");
+        assert_eq!(builder.table_uri, "memory://table");
+        assert!(accessor.provider().is_some());
+        assert_eq!(accessor.initial_storage_options(), Some(&storage_options));
+    }
+
+    #[test]
+    fn namespace_context_merges_existing_storage_options() {
+        let user_storage_options = HashMap::from([
+            ("user_token".to_string(), "user".to_string()),
+            ("token".to_string(), "user".to_string()),
+        ]);
+        let namespace_storage_options = HashMap::from([
+            ("token".to_string(), "cached".to_string()),
+            ("expires_at_millis".to_string(), "123".to_string()),
+        ]);
+        let expected_storage_options = HashMap::from([
+            ("user_token".to_string(), "user".to_string()),
+            ("token".to_string(), "cached".to_string()),
+            ("expires_at_millis".to_string(), "123".to_string()),
+        ]);
+
+        let builder =
+            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
+                .with_storage_options(user_storage_options)
+                .with_namespace_client_table_context(namespace_context(Some(
+                    namespace_storage_options,
+                )));
+
+        let accessor = builder
+            .options
+            .storage_options_accessor
+            .expect("namespace context should attach a storage options accessor");
+        assert!(accessor.provider().is_some());
+        assert_eq!(
+            accessor.initial_storage_options(),
+            Some(&expected_storage_options)
+        );
+    }
+
+    #[tokio::test]
+    async fn for_namespace_requires_context_before_load() {
+        let err =
+            DatasetBuilder::for_namespace(Arc::new(DummyNamespace), vec!["table".to_string()])
+                .load()
+                .await
+                .unwrap_err();
+
+        assert!(err.to_string().contains("namespace_client_table_context"));
+    }
+
+    #[derive(Debug)]
+    struct RecordingNamespace {
+        describe_version: Arc<std::sync::Mutex<Option<i64>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LanceNamespace for RecordingNamespace {
+        fn namespace_id(&self) -> String {
+            "recording".to_string()
+        }
+
+        async fn describe_table(
+            &self,
+            request: DescribeTableRequest,
+        ) -> Result<DescribeTableResponse> {
+            *self.describe_version.lock().unwrap() = request.version;
+            Ok(DescribeTableResponse {
+                location: Some("memory://table".to_string()),
+                ..Default::default()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn from_namespace_with_version_passes_version_to_describe_table() {
+        let describe_version = Arc::new(std::sync::Mutex::new(None));
+        DatasetBuilder::from_namespace_with_version(
+            Arc::new(RecordingNamespace {
+                describe_version: describe_version.clone(),
+            }),
+            vec!["table".to_string()],
+            Some(7),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(*describe_version.lock().unwrap(), Some(7));
     }
 }

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1097,7 +1097,7 @@ async fn test_shallow_clone_multiple_times(
 
     // Async dataset writer function
     async fn write_dataset(
-        dest: impl Into<WriteDestination<'_>>,
+        dest: impl Into<WriteDestination>,
         row_count: u64,
         mode: WriteMode,
         version: LanceFileVersion,

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -44,9 +44,68 @@ use lance_index::IndexType;
 use lance_index::scalar::ScalarIndexParams;
 use lance_io::object_store::{ObjectStore, ObjectStoreParams, StorageOptionsAccessor};
 use lance_io::utils::tracking_store::IOTracker;
+use lance_namespace::{LanceNamespace, NamespaceClientTableContext};
 use lance_table::io::manifest::read_manifest;
 use object_store::path::Path;
 use rstest::rstest;
+
+#[derive(Debug)]
+struct DummyNamespace;
+
+impl LanceNamespace for DummyNamespace {
+    fn namespace_id(&self) -> String {
+        "dummy".to_string()
+    }
+}
+
+#[tokio::test]
+async fn test_write_into_namespace_preserves_user_storage_options_without_cached_options() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let table_path = tmpdir.path().join("table");
+    let table_uri = table_path.to_str().unwrap().to_string();
+
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "i",
+        DataType::Int32,
+        false,
+    )]));
+    let batch =
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))]).unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+
+    let user_storage_options = HashMap::from([("user_token".to_string(), "user".to_string())]);
+    let write_params = WriteParams {
+        mode: WriteMode::Create,
+        store_params: Some(ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                user_storage_options.clone(),
+            ))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let context = NamespaceClientTableContext {
+        location: table_uri,
+        storage_options: None,
+        managed_versioning: false,
+    };
+
+    let dataset = Dataset::write_into_namespace(
+        reader,
+        Arc::new(DummyNamespace),
+        vec!["table".to_string()],
+        Some(&context),
+        Some(write_params),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        dataset.initial_storage_options(),
+        Some(&user_storage_options)
+    );
+    assert!(dataset.storage_options_provider().is_some());
+}
 
 #[tokio::test]
 async fn test_truncate_table() {

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -22,8 +22,16 @@ use lance_file::previous::writer::{
 };
 use lance_file::version::LanceFileVersion;
 use lance_file::writer::{self as current_writer, FileWriterOptions};
-use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
+use lance_io::object_store::{
+    LanceNamespaceStorageOptionsProvider, ObjectStore, ObjectStoreParams, ObjectStoreRegistry,
+    StorageOptionsAccessor, StorageOptionsProvider,
+};
+use lance_namespace::{
+    ErrorCode as NamespaceErrorCode, LanceNamespace, NamespaceClientTableContext,
+    models::{DeclareTableRequest, DescribeTableRequest},
+};
 use lance_table::format::{BasePath, DataFile, Fragment};
+use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 use lance_table::io::commit::{CommitHandler, commit_handler_from_url};
 use lance_table::io::manifest::ManifestDescribing;
 use object_store::path::Path;
@@ -37,6 +45,8 @@ use crate::Dataset;
 use crate::dataset::blob::{
     BlobPreprocessor, ExternalBaseCandidate, ExternalBaseResolver, preprocess_blob_batches,
 };
+use crate::dataset::transaction::Operation;
+use crate::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use crate::session::Session;
 
 use super::DATA_DIR;
@@ -57,52 +67,255 @@ pub use commit::CommitBuilder;
 pub use delete::{DeleteBuilder, DeleteResult};
 pub use insert::InsertBuilder;
 
+/// A namespace table destination to write data to.
+///
+/// This keeps user-provided namespace inputs and cached namespace table context
+/// together so write and commit paths do not encode unresolved namespace tables
+/// as placeholder URIs.
+#[derive(Debug, Clone)]
+pub struct NamespaceTableDestination {
+    pub(crate) namespace_client: Arc<dyn LanceNamespace>,
+    pub(crate) table_id: Vec<String>,
+    pub(crate) namespace_client_table_context: Option<NamespaceClientTableContext>,
+    pub(crate) dataset: Option<Arc<Dataset>>,
+}
+
+impl NamespaceTableDestination {
+    pub fn new(
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        namespace_client_table_context: Option<NamespaceClientTableContext>,
+    ) -> Self {
+        Self {
+            namespace_client,
+            table_id,
+            namespace_client_table_context,
+            dataset: None,
+        }
+    }
+
+    pub fn with_dataset(mut self, dataset: Arc<Dataset>) -> Self {
+        self.dataset = Some(dataset);
+        self
+    }
+
+    pub(crate) fn with_optional_dataset(mut self, dataset: Option<Arc<Dataset>>) -> Self {
+        self.dataset = dataset;
+        self
+    }
+
+    pub(crate) fn dataset(&self) -> Option<&Dataset> {
+        self.dataset.as_deref()
+    }
+
+    fn error_chain_contains_namespace_table_not_found(
+        err: &(dyn std::error::Error + 'static),
+    ) -> bool {
+        if let Some(err) = err.downcast_ref::<lance_namespace::NamespaceError>() {
+            return err.code() == NamespaceErrorCode::TableNotFound;
+        }
+        if let Some(err) = err.downcast_ref::<Error>() {
+            return Self::is_namespace_table_not_found(err);
+        }
+        if let Some(source) = err.source() {
+            return Self::error_chain_contains_namespace_table_not_found(source);
+        }
+        false
+    }
+
+    fn is_namespace_table_not_found(err: &Error) -> bool {
+        match err {
+            Error::Namespace { source, .. } => {
+                Self::error_chain_contains_namespace_table_not_found(source.as_ref())
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) async fn resolve_context_for_write(
+        &self,
+        mode: WriteMode,
+    ) -> Result<NamespaceClientTableContext> {
+        if let Some(namespace_client_table_context) = &self.namespace_client_table_context {
+            return Ok(namespace_client_table_context.clone());
+        }
+
+        match mode {
+            WriteMode::Create => {
+                let declare_request = DeclareTableRequest {
+                    id: Some(self.table_id.clone()),
+                    ..Default::default()
+                };
+                let response = self.namespace_client.declare_table(declare_request).await?;
+                NamespaceClientTableContext::from_declare_table_response(response)
+            }
+            WriteMode::Append | WriteMode::Overwrite => {
+                let describe_request = DescribeTableRequest {
+                    id: Some(self.table_id.clone()),
+                    ..Default::default()
+                };
+                let response = self
+                    .namespace_client
+                    .describe_table(describe_request)
+                    .await?;
+                NamespaceClientTableContext::from_describe_table_response(response)
+            }
+        }
+    }
+
+    pub(crate) async fn resolve_context_for_commit(
+        &self,
+        transaction: &Transaction,
+    ) -> Result<NamespaceClientTableContext> {
+        if let Some(namespace_client_table_context) = &self.namespace_client_table_context {
+            return Ok(namespace_client_table_context.clone());
+        }
+
+        let describe_request = DescribeTableRequest {
+            id: Some(self.table_id.clone()),
+            ..Default::default()
+        };
+        match self.namespace_client.describe_table(describe_request).await {
+            Ok(response) => NamespaceClientTableContext::from_describe_table_response(response),
+            Err(err)
+                if Self::is_namespace_table_not_found(&err)
+                    && matches!(
+                        transaction.operation,
+                        Operation::Overwrite { .. } | Operation::Clone { .. }
+                    ) =>
+            {
+                let declare_request = DeclareTableRequest {
+                    id: Some(self.table_id.clone()),
+                    ..Default::default()
+                };
+                let response = self.namespace_client.declare_table(declare_request).await?;
+                NamespaceClientTableContext::from_declare_table_response(response)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    pub(crate) fn store_params_with_context(
+        &self,
+        existing_store_params: ObjectStoreParams,
+        namespace_client_table_context: &NamespaceClientTableContext,
+    ) -> ObjectStoreParams {
+        let provider: Arc<dyn StorageOptionsProvider> =
+            Arc::new(LanceNamespaceStorageOptionsProvider::new(
+                self.namespace_client.clone(),
+                self.table_id.clone(),
+            ));
+        let mut merged_storage_options = existing_store_params
+            .storage_options()
+            .cloned()
+            .unwrap_or_default();
+        if let Some(storage_options) = &namespace_client_table_context.storage_options {
+            merged_storage_options.extend(storage_options.clone());
+        }
+        ObjectStoreParams {
+            storage_options_accessor: Some(if merged_storage_options.is_empty() {
+                Arc::new(StorageOptionsAccessor::with_provider(provider))
+            } else {
+                Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                    merged_storage_options,
+                    provider,
+                ))
+            }),
+            ..existing_store_params
+        }
+    }
+
+    pub(crate) fn managed_commit_handler(
+        &self,
+        namespace_client_table_context: &NamespaceClientTableContext,
+    ) -> Option<Arc<dyn CommitHandler>> {
+        if namespace_client_table_context.managed_versioning {
+            let external_store = LanceNamespaceExternalManifestStore::new(
+                self.namespace_client.clone(),
+                self.table_id.clone(),
+            );
+            Some(Arc::new(ExternalManifestCommitHandler {
+                external_manifest_store: Arc::new(external_store),
+            }) as Arc<dyn CommitHandler>)
+        } else {
+            None
+        }
+    }
+}
+
 /// The destination to write data to.
 #[derive(Debug, Clone)]
-pub enum WriteDestination<'a> {
+pub enum WriteDestination {
     /// An existing dataset to write to.
     Dataset(Arc<Dataset>),
     /// A URI to write to.
-    Uri(&'a str),
+    Uri(String),
+    /// A namespace table to resolve through a Lance namespace client.
+    NamespaceTable(NamespaceTableDestination),
 }
 
-impl WriteDestination<'_> {
+impl WriteDestination {
     pub fn dataset(&self) -> Option<&Dataset> {
         match self {
-            WriteDestination::Dataset(dataset) => Some(dataset.as_ref()),
-            WriteDestination::Uri(_) => None,
+            Self::Dataset(dataset) => Some(dataset.as_ref()),
+            Self::Uri(_) => None,
+            Self::NamespaceTable(table) => table.dataset(),
         }
     }
 
     pub fn uri(&self) -> String {
         match self {
-            WriteDestination::Dataset(dataset) => dataset.uri.clone(),
-            WriteDestination::Uri(uri) => uri.to_string(),
+            Self::Dataset(dataset) => dataset.uri.clone(),
+            Self::Uri(uri) => uri.clone(),
+            Self::NamespaceTable(table) => table
+                .dataset
+                .as_ref()
+                .map(|dataset| dataset.uri.clone())
+                .or_else(|| {
+                    table
+                        .namespace_client_table_context
+                        .as_ref()
+                        .map(|context| context.location.clone())
+                })
+                .unwrap_or_else(|| format!("namespace:{}", table.table_id.join("."))),
+        }
+    }
+
+    pub(crate) fn namespace_table(&self) -> Option<&NamespaceTableDestination> {
+        match self {
+            Self::NamespaceTable(table) => Some(table),
+            _ => None,
         }
     }
 }
 
-impl From<Arc<Dataset>> for WriteDestination<'_> {
+impl From<Arc<Dataset>> for WriteDestination {
     fn from(dataset: Arc<Dataset>) -> Self {
-        WriteDestination::Dataset(dataset)
+        Self::Dataset(dataset)
     }
 }
 
-impl<'a> From<&'a str> for WriteDestination<'a> {
-    fn from(uri: &'a str) -> Self {
-        WriteDestination::Uri(uri)
+impl From<String> for WriteDestination {
+    fn from(uri: String) -> Self {
+        Self::Uri(uri)
     }
 }
 
-impl<'a> From<&'a String> for WriteDestination<'a> {
-    fn from(uri: &'a String) -> Self {
-        WriteDestination::Uri(uri.as_str())
+impl From<&str> for WriteDestination {
+    fn from(uri: &str) -> Self {
+        Self::Uri(uri.to_string())
     }
 }
 
-impl<'a> From<&'a Path> for WriteDestination<'a> {
-    fn from(path: &'a Path) -> Self {
-        WriteDestination::Uri(path.as_ref())
+impl From<&String> for WriteDestination {
+    fn from(uri: &String) -> Self {
+        Self::Uri(uri.clone())
+    }
+}
+
+impl From<&Path> for WriteDestination {
+    fn from(path: &Path) -> Self {
+        Self::Uri(path.as_ref().to_string())
     }
 }
 
@@ -463,7 +676,7 @@ impl WriteParams {
     note = "Use [`InsertBuilder::execute_uncommitted_stream`] instead"
 )]
 pub async fn write_fragments(
-    dest: impl Into<WriteDestination<'_>>,
+    dest: impl Into<WriteDestination>,
     data: impl StreamingWriteSource,
     params: WriteParams,
 ) -> Result<Transaction> {

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -6,14 +6,8 @@ use std::sync::Arc;
 
 use lance_core::utils::mask::RowAddrTreeMap;
 use lance_file::version::LanceFileVersion;
-use lance_io::object_store::{
-    LanceNamespaceStorageOptionsProvider, ObjectStore, ObjectStoreParams, StorageOptionsAccessor,
-    StorageOptionsProvider,
-};
-use lance_namespace::{
-    ErrorCode as NamespaceErrorCode, LanceNamespace, NamespaceClientTableContext,
-    models::{DeclareTableRequest, DescribeTableRequest},
-};
+use lance_io::object_store::{ObjectStore, ObjectStoreParams};
+use lance_namespace::{LanceNamespace, NamespaceClientTableContext};
 use lance_table::{
     format::{DataStorageFormat, is_detached_version},
     io::commit::{CommitConfig, CommitHandler, ManifestNamingScheme},
@@ -31,40 +25,19 @@ use crate::{
     session::Session,
 };
 
-use super::{WriteDestination, resolve_commit_handler};
+use super::{NamespaceTableDestination, WriteDestination, resolve_commit_handler};
 use crate::dataset::branch_location::BranchLocation;
 use crate::dataset::transaction::validate_operation;
-use crate::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use lance_core::utils::tracing::{DATASET_COMMITTED_EVENT, TRACE_DATASET_EVENTS};
-use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 use tracing::info;
-
-#[derive(Clone)]
-struct NamespaceCommitInfo {
-    namespace_client: Arc<dyn LanceNamespace>,
-    table_id: Vec<String>,
-    namespace_client_table_context: Option<NamespaceClientTableContext>,
-}
-
-impl std::fmt::Debug for NamespaceCommitInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("NamespaceCommitInfo")
-            .field("table_id", &self.table_id)
-            .field(
-                "namespace_client_table_context",
-                &self.namespace_client_table_context,
-            )
-            .finish()
-    }
-}
 
 /// Create a new commit from a [`Transaction`].
 ///
 /// Transactions can be created using a write method like [`super::InsertBuilder::execute_uncommitted`].
 #[derive(Debug, Clone)]
-pub struct CommitBuilder<'a> {
-    dest: WriteDestination<'a>,
-    uri_was_explicitly_set: bool,
+pub struct CommitBuilder {
+    dest: WriteDestination,
+    validation_error: Option<String>,
     use_stable_row_ids: Option<bool>,
     enable_v2_manifest_paths: bool,
     storage_format: Option<LanceFileVersion>,
@@ -76,39 +49,14 @@ pub struct CommitBuilder<'a> {
     commit_config: CommitConfig,
     affected_rows: Option<RowAddrTreeMap>,
     transaction_properties: Option<Arc<HashMap<String, String>>>,
-    namespace_commit_info: Option<NamespaceCommitInfo>,
 }
 
-impl<'a> CommitBuilder<'a> {
-    fn error_chain_contains_namespace_table_not_found(
-        err: &(dyn std::error::Error + 'static),
-    ) -> bool {
-        if let Some(err) = err.downcast_ref::<lance_namespace::NamespaceError>() {
-            return err.code() == NamespaceErrorCode::TableNotFound;
-        }
-        if let Some(err) = err.downcast_ref::<Error>() {
-            return Self::is_namespace_table_not_found(err);
-        }
-        if let Some(source) = err.source() {
-            return Self::error_chain_contains_namespace_table_not_found(source);
-        }
-        false
-    }
-
-    fn is_namespace_table_not_found(err: &Error) -> bool {
-        match err {
-            Error::Namespace { source, .. } => {
-                Self::error_chain_contains_namespace_table_not_found(source.as_ref())
-            }
-            _ => false,
-        }
-    }
-
-    pub fn new(dest: impl Into<WriteDestination<'a>>) -> Self {
+impl CommitBuilder {
+    pub fn new(dest: impl Into<WriteDestination>) -> Self {
         let dest = dest.into();
         Self {
-            uri_was_explicitly_set: matches!(dest, WriteDestination::Uri(_)),
             dest,
+            validation_error: None,
             use_stable_row_ids: None,
             enable_v2_manifest_paths: true,
             storage_format: None,
@@ -120,7 +68,6 @@ impl<'a> CommitBuilder<'a> {
             commit_config: Default::default(),
             affected_rows: None,
             transaction_properties: None,
-            namespace_commit_info: None,
         }
     }
 
@@ -129,26 +76,13 @@ impl<'a> CommitBuilder<'a> {
         table_id: Vec<String>,
         namespace_client_table_context: Option<NamespaceClientTableContext>,
     ) -> Self {
-        Self {
-            dest: WriteDestination::Uri(""),
-            uri_was_explicitly_set: false,
-            use_stable_row_ids: None,
-            enable_v2_manifest_paths: true,
-            storage_format: None,
-            commit_handler: None,
-            store_params: None,
-            object_store: None,
-            session: None,
-            detached: false,
-            commit_config: Default::default(),
-            affected_rows: None,
-            transaction_properties: None,
-            namespace_commit_info: Some(NamespaceCommitInfo {
+        Self::new(WriteDestination::NamespaceTable(
+            NamespaceTableDestination::new(
                 namespace_client,
                 table_id,
                 namespace_client_table_context,
-            }),
-        }
+            ),
+        ))
     }
 
     pub fn with_namespace(
@@ -157,11 +91,25 @@ impl<'a> CommitBuilder<'a> {
         table_id: Vec<String>,
         namespace_client_table_context: Option<NamespaceClientTableContext>,
     ) -> Self {
-        self.namespace_commit_info = Some(NamespaceCommitInfo {
+        let namespace_table = NamespaceTableDestination::new(
             namespace_client,
             table_id,
             namespace_client_table_context,
-        });
+        );
+        let current_dest = std::mem::replace(&mut self.dest, WriteDestination::Uri(String::new()));
+        self.dest = match current_dest {
+            WriteDestination::Dataset(dataset) => {
+                WriteDestination::NamespaceTable(namespace_table.with_dataset(dataset))
+            }
+            WriteDestination::NamespaceTable(existing) => WriteDestination::NamespaceTable(
+                namespace_table.with_optional_dataset(existing.dataset),
+            ),
+            uri @ WriteDestination::Uri(_) => {
+                self.validation_error =
+                    Some("namespace clients cannot be combined with an explicit uri".to_string());
+                uri
+            }
+        };
         self
     }
 
@@ -278,173 +226,110 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
-    async fn resolve_namespace_client_table_context(
-        &self,
-        transaction: &Transaction,
-    ) -> Result<Option<NamespaceClientTableContext>> {
-        let Some(namespace_commit_info) = &self.namespace_commit_info else {
-            return Ok(None);
-        };
-
-        if let Some(namespace_client_table_context) =
-            &namespace_commit_info.namespace_client_table_context
-        {
-            return Ok(Some(namespace_client_table_context.clone()));
-        }
-
-        let describe_request = DescribeTableRequest {
-            id: Some(namespace_commit_info.table_id.clone()),
-            ..Default::default()
-        };
-        match namespace_commit_info
-            .namespace_client
-            .describe_table(describe_request)
-            .await
-        {
-            Ok(response) => {
-                NamespaceClientTableContext::from_describe_table_response(response).map(Some)
-            }
-            Err(err)
-                if Self::is_namespace_table_not_found(&err)
-                    && matches!(
-                        transaction.operation,
-                        Operation::Overwrite { .. } | Operation::Clone { .. }
-                    ) =>
-            {
-                let declare_request = DeclareTableRequest {
-                    id: Some(namespace_commit_info.table_id.clone()),
-                    ..Default::default()
-                };
-                let response = namespace_commit_info
-                    .namespace_client
-                    .declare_table(declare_request)
-                    .await?;
-                NamespaceClientTableContext::from_declare_table_response(response).map(Some)
-            }
-            Err(err) => Err(err),
-        }
-    }
-
     pub async fn execute(self, transaction: Transaction) -> Result<Dataset> {
-        if self.uri_was_explicitly_set && self.namespace_commit_info.is_some() {
-            return Err(Error::invalid_input(
-                "namespace clients cannot be combined with an explicit uri",
-            ));
+        if let Some(validation_error) = &self.validation_error {
+            return Err(Error::invalid_input(validation_error.clone()));
         }
 
-        let namespace_client_table_context = self
-            .resolve_namespace_client_table_context(&transaction)
-            .await?;
+        let namespace_client_table_context =
+            if let Some(namespace_table) = self.dest.namespace_table() {
+                Some(
+                    namespace_table
+                        .resolve_context_for_commit(&transaction)
+                        .await?,
+                )
+            } else {
+                None
+            };
         let session = self
             .session
             .or_else(|| self.dest.dataset().map(|ds| ds.session.clone()))
             .unwrap_or_default();
 
         let effective_uri = match (&self.dest, &namespace_client_table_context) {
-            (WriteDestination::Uri(_), Some(namespace_client_table_context)) => {
+            (WriteDestination::Uri(uri), _) => Some(uri.clone()),
+            (WriteDestination::NamespaceTable(_), Some(namespace_client_table_context)) => {
                 Some(namespace_client_table_context.location.clone())
             }
-            (WriteDestination::Uri(uri), None) => Some((*uri).to_string()),
+            (WriteDestination::NamespaceTable(_), None) => {
+                return Err(Error::invalid_input(
+                    "namespace table destination requires resolved table context",
+                ));
+            }
             (WriteDestination::Dataset(_), _) => None,
         };
 
         let mut effective_store_params = self.store_params.clone();
         let mut effective_commit_handler = self.commit_handler.clone();
-        if let (Some(namespace_commit_info), Some(namespace_client_table_context)) =
-            (&self.namespace_commit_info, &namespace_client_table_context)
+        if let (Some(namespace_table), Some(namespace_client_table_context)) =
+            (self.dest.namespace_table(), &namespace_client_table_context)
         {
-            if effective_commit_handler.is_none()
-                && namespace_client_table_context.managed_versioning
-            {
-                let external_store = LanceNamespaceExternalManifestStore::new(
-                    namespace_commit_info.namespace_client.clone(),
-                    namespace_commit_info.table_id.clone(),
-                );
-                effective_commit_handler = Some(Arc::new(ExternalManifestCommitHandler {
-                    external_manifest_store: Arc::new(external_store),
-                }) as Arc<dyn CommitHandler>);
+            if effective_commit_handler.is_none() {
+                effective_commit_handler =
+                    namespace_table.managed_commit_handler(namespace_client_table_context);
             }
-
-            let provider: Arc<dyn StorageOptionsProvider> =
-                Arc::new(LanceNamespaceStorageOptionsProvider::new(
-                    namespace_commit_info.namespace_client.clone(),
-                    namespace_commit_info.table_id.clone(),
-                ));
             let existing_store_params = effective_store_params.take().unwrap_or_default();
-            let mut merged_storage_options = existing_store_params
-                .storage_options()
-                .cloned()
-                .unwrap_or_default();
-            if let Some(storage_options) = &namespace_client_table_context.storage_options {
-                merged_storage_options.extend(storage_options.clone());
-            }
-            effective_store_params = Some(ObjectStoreParams {
-                storage_options_accessor: Some(if merged_storage_options.is_empty() {
-                    Arc::new(StorageOptionsAccessor::with_provider(provider))
-                } else {
-                    Arc::new(StorageOptionsAccessor::with_initial_and_provider(
-                        merged_storage_options,
-                        provider,
-                    ))
-                }),
-                ..existing_store_params
-            });
+            effective_store_params =
+                Some(namespace_table.store_params_with_context(
+                    existing_store_params,
+                    namespace_client_table_context,
+                ));
         }
 
-        let resolved_uri = if matches!(self.dest, WriteDestination::Uri(_)) {
-            Some(
-                effective_uri
-                    .as_deref()
-                    .ok_or_else(|| Error::invalid_input("uri is required"))?,
-            )
-        } else {
-            None
-        };
+        let resolved_uri = effective_uri;
 
-        let (object_store, base_path, commit_handler) = match &self.dest {
-            WriteDestination::Dataset(dataset) => (
+        let (object_store, base_path, commit_handler) = if let Some(dataset) = self.dest.dataset() {
+            (
                 dataset.object_store.clone(),
                 dataset.base.clone(),
                 effective_commit_handler
                     .clone()
                     .or_else(|| Some(dataset.commit_handler.clone()))
                     .unwrap(),
-            ),
-            WriteDestination::Uri(_) => {
-                let uri = resolved_uri.expect("uri destinations must have a resolved uri");
-                let commit_handler = if let (Some(_), Some(commit_handler)) =
-                    (&self.object_store, &effective_commit_handler)
-                {
-                    commit_handler.clone()
-                } else {
-                    resolve_commit_handler(
-                        uri,
-                        effective_commit_handler.clone(),
-                        &effective_store_params,
-                    )
-                    .await?
-                };
-                let (object_store, base_path) = if let Some(passed_store) = self.object_store {
-                    (
-                        passed_store,
-                        ObjectStore::extract_path_from_uri(session.store_registry(), uri)?,
-                    )
-                } else {
-                    ObjectStore::from_uri_and_params(
-                        session.store_registry(),
-                        uri,
-                        &effective_store_params.clone().unwrap_or_default(),
-                    )
-                    .await?
-                };
-                (object_store, base_path, commit_handler)
-            }
+            )
+        } else {
+            let uri = resolved_uri
+                .as_deref()
+                .ok_or_else(|| Error::invalid_input("uri is required"))?;
+            let commit_handler = if let (Some(_), Some(commit_handler)) =
+                (&self.object_store, &effective_commit_handler)
+            {
+                commit_handler.clone()
+            } else {
+                resolve_commit_handler(
+                    uri,
+                    effective_commit_handler.clone(),
+                    &effective_store_params,
+                )
+                .await?
+            };
+            let (object_store, base_path) = if let Some(passed_store) = self.object_store {
+                (
+                    passed_store,
+                    ObjectStore::extract_path_from_uri(session.store_registry(), uri)?,
+                )
+            } else {
+                ObjectStore::from_uri_and_params(
+                    session.store_registry(),
+                    uri,
+                    &effective_store_params.clone().unwrap_or_default(),
+                )
+                .await?
+            };
+            (object_store, base_path, commit_handler)
         };
 
         let dest = match &self.dest {
             WriteDestination::Dataset(dataset) => WriteDestination::Dataset(dataset.clone()),
-            WriteDestination::Uri(_) => {
-                let uri = resolved_uri.expect("uri destinations must have a resolved uri");
+            WriteDestination::NamespaceTable(namespace_table)
+                if namespace_table.dataset.is_some() =>
+            {
+                self.dest.clone()
+            }
+            WriteDestination::Uri(_) | WriteDestination::NamespaceTable(_) => {
+                let uri = resolved_uri
+                    .as_deref()
+                    .expect("uri destinations must have a resolved uri");
                 // Check if it already exists.
                 let mut builder = DatasetBuilder::from_uri(uri)
                     .with_read_params(ReadParams {
@@ -462,9 +347,27 @@ impl<'a> CommitBuilder<'a> {
                 }
 
                 match builder.load().await {
-                    Ok(dataset) => WriteDestination::Dataset(Arc::new(dataset)),
+                    Ok(dataset) => match &self.dest {
+                        WriteDestination::NamespaceTable(namespace_table) => {
+                            WriteDestination::NamespaceTable(
+                                namespace_table.clone().with_dataset(Arc::new(dataset)),
+                            )
+                        }
+                        _ => WriteDestination::Dataset(Arc::new(dataset)),
+                    },
                     Err(Error::DatasetNotFound { .. } | Error::NotFound { .. }) => {
-                        WriteDestination::Uri(uri)
+                        match (&self.dest, &namespace_client_table_context) {
+                            (
+                                WriteDestination::NamespaceTable(namespace_table),
+                                Some(namespace_client_table_context),
+                            ) => {
+                                let mut namespace_table = namespace_table.clone();
+                                namespace_table.namespace_client_table_context =
+                                    Some(namespace_client_table_context.clone());
+                                WriteDestination::NamespaceTable(namespace_table)
+                            }
+                            _ => WriteDestination::Uri(uri.to_string()),
+                        }
                     }
                     Err(e) => return Err(e),
                 }
@@ -491,12 +394,14 @@ impl<'a> CommitBuilder<'a> {
             validate_operation(None, &transaction.operation)?;
         }
 
-        let (metadata_cache, index_cache) = match &dest {
-            WriteDestination::Dataset(ds) => (ds.metadata_cache.clone(), ds.index_cache.clone()),
-            WriteDestination::Uri(uri) => (
-                Arc::new(session.metadata_cache.for_dataset(uri)),
-                Arc::new(session.index_cache.for_dataset(uri)),
-            ),
+        let (metadata_cache, index_cache) = if let Some(ds) = dest.dataset() {
+            (ds.metadata_cache.clone(), ds.index_cache.clone())
+        } else {
+            let uri = dest.uri();
+            (
+                Arc::new(session.metadata_cache.for_dataset(&uri)),
+                Arc::new(session.index_cache.for_dataset(&uri)),
+            )
         };
 
         let manifest_naming_scheme = if let Some(ds) = dest.dataset() {
@@ -595,42 +500,42 @@ impl<'a> CommitBuilder<'a> {
 
         let fragment_bitmap = Arc::new(manifest.fragments.iter().map(|f| f.id as u32).collect());
 
-        match &dest {
-            WriteDestination::Dataset(dataset) => Ok(Dataset {
+        if let Some(dataset) = dest.dataset() {
+            Ok(Dataset {
                 manifest: Arc::new(manifest),
                 manifest_location,
                 session,
                 fragment_bitmap,
-                ..dataset.as_ref().clone()
-            }),
-            WriteDestination::Uri(uri) => {
-                let refs = Refs::new(
-                    object_store.clone(),
-                    commit_handler.clone(),
-                    BranchLocation {
-                        path: base_path.clone(),
-                        uri: uri.to_string(),
-                        branch: manifest.branch.clone(),
-                    },
-                );
+                ..dataset.clone()
+            })
+        } else {
+            let uri = dest.uri();
+            let refs = Refs::new(
+                object_store.clone(),
+                commit_handler.clone(),
+                BranchLocation {
+                    path: base_path.clone(),
+                    uri: uri.clone(),
+                    branch: manifest.branch.clone(),
+                },
+            );
 
-                Ok(Dataset {
-                    object_store,
-                    base: base_path,
-                    uri: uri.to_string(),
-                    manifest: Arc::new(manifest),
-                    manifest_location,
-                    session,
-                    commit_handler,
-                    refs,
-                    index_cache,
-                    fragment_bitmap,
-                    metadata_cache,
-                    file_reader_options: None,
-                    store_params: effective_store_params.clone().map(Box::new),
-                    base_store_params: None,
-                })
-            }
+            Ok(Dataset {
+                object_store,
+                base: base_path,
+                uri,
+                manifest: Arc::new(manifest),
+                manifest_location,
+                session,
+                commit_handler,
+                refs,
+                index_cache,
+                fragment_bitmap,
+                metadata_cache,
+                file_reader_options: None,
+                store_params: effective_store_params.clone().map(Box::new),
+                base_store_params: None,
+            })
         }
     }
 
@@ -736,6 +641,59 @@ mod tests {
             tag: None,
             transaction_properties: None,
         }
+    }
+
+    #[derive(Debug)]
+    struct DummyNamespace;
+
+    impl LanceNamespace for DummyNamespace {
+        fn namespace_id(&self) -> String {
+            "dummy".to_string()
+        }
+    }
+
+    fn namespace_context() -> NamespaceClientTableContext {
+        NamespaceClientTableContext {
+            location: "memory://namespace-table".to_string(),
+            storage_options: None,
+            managed_versioning: false,
+        }
+    }
+
+    #[test]
+    fn new_namespace_uses_namespace_table_destination() {
+        let context = namespace_context();
+        let builder = CommitBuilder::new_namespace(
+            Arc::new(DummyNamespace),
+            vec!["table".to_string()],
+            Some(context.clone()),
+        );
+
+        let WriteDestination::NamespaceTable(namespace_table) = builder.dest else {
+            panic!("new_namespace should use WriteDestination::NamespaceTable");
+        };
+        assert!(namespace_table.dataset.is_none());
+        assert_eq!(namespace_table.table_id, vec!["table".to_string()]);
+        let cached_context = namespace_table
+            .namespace_client_table_context
+            .expect("namespace context should be cached");
+        assert_eq!(cached_context.location, context.location);
+        assert_eq!(
+            cached_context.managed_versioning,
+            context.managed_versioning
+        );
+    }
+
+    #[test]
+    fn with_namespace_rejects_explicit_uri_destination() {
+        let builder = CommitBuilder::new("memory://explicit").with_namespace(
+            Arc::new(DummyNamespace),
+            vec!["table".to_string()],
+            Some(namespace_context()),
+        );
+
+        assert!(builder.validation_error.is_some());
+        assert!(matches!(builder.dest, WriteDestination::Uri(_)));
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -6,7 +6,14 @@ use std::sync::Arc;
 
 use lance_core::utils::mask::RowAddrTreeMap;
 use lance_file::version::LanceFileVersion;
-use lance_io::object_store::{ObjectStore, ObjectStoreParams};
+use lance_io::object_store::{
+    LanceNamespaceStorageOptionsProvider, ObjectStore, ObjectStoreParams, StorageOptionsAccessor,
+    StorageOptionsProvider,
+};
+use lance_namespace::{
+    ErrorCode as NamespaceErrorCode, LanceNamespace, NamespaceClientTableContext,
+    models::{DeclareTableRequest, DescribeTableRequest},
+};
 use lance_table::{
     format::{DataStorageFormat, is_detached_version},
     io::commit::{CommitConfig, CommitHandler, ManifestNamingScheme},
@@ -27,8 +34,29 @@ use crate::{
 use super::{WriteDestination, resolve_commit_handler};
 use crate::dataset::branch_location::BranchLocation;
 use crate::dataset::transaction::validate_operation;
+use crate::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use lance_core::utils::tracing::{DATASET_COMMITTED_EVENT, TRACE_DATASET_EVENTS};
+use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
 use tracing::info;
+
+#[derive(Clone)]
+struct NamespaceCommitInfo {
+    namespace_client: Arc<dyn LanceNamespace>,
+    table_id: Vec<String>,
+    namespace_client_table_context: Option<NamespaceClientTableContext>,
+}
+
+impl std::fmt::Debug for NamespaceCommitInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NamespaceCommitInfo")
+            .field("table_id", &self.table_id)
+            .field(
+                "namespace_client_table_context",
+                &self.namespace_client_table_context,
+            )
+            .finish()
+    }
+}
 
 /// Create a new commit from a [`Transaction`].
 ///
@@ -36,6 +64,7 @@ use tracing::info;
 #[derive(Debug, Clone)]
 pub struct CommitBuilder<'a> {
     dest: WriteDestination<'a>,
+    uri_was_explicitly_set: bool,
     use_stable_row_ids: Option<bool>,
     enable_v2_manifest_paths: bool,
     storage_format: Option<LanceFileVersion>,
@@ -47,12 +76,39 @@ pub struct CommitBuilder<'a> {
     commit_config: CommitConfig,
     affected_rows: Option<RowAddrTreeMap>,
     transaction_properties: Option<Arc<HashMap<String, String>>>,
+    namespace_commit_info: Option<NamespaceCommitInfo>,
 }
 
 impl<'a> CommitBuilder<'a> {
+    fn error_chain_contains_namespace_table_not_found(
+        err: &(dyn std::error::Error + 'static),
+    ) -> bool {
+        if let Some(err) = err.downcast_ref::<lance_namespace::NamespaceError>() {
+            return err.code() == NamespaceErrorCode::TableNotFound;
+        }
+        if let Some(err) = err.downcast_ref::<Error>() {
+            return Self::is_namespace_table_not_found(err);
+        }
+        if let Some(source) = err.source() {
+            return Self::error_chain_contains_namespace_table_not_found(source);
+        }
+        false
+    }
+
+    fn is_namespace_table_not_found(err: &Error) -> bool {
+        match err {
+            Error::Namespace { source, .. } => {
+                Self::error_chain_contains_namespace_table_not_found(source.as_ref())
+            }
+            _ => false,
+        }
+    }
+
     pub fn new(dest: impl Into<WriteDestination<'a>>) -> Self {
+        let dest = dest.into();
         Self {
-            dest: dest.into(),
+            uri_was_explicitly_set: matches!(dest, WriteDestination::Uri(_)),
+            dest,
             use_stable_row_ids: None,
             enable_v2_manifest_paths: true,
             storage_format: None,
@@ -64,7 +120,49 @@ impl<'a> CommitBuilder<'a> {
             commit_config: Default::default(),
             affected_rows: None,
             transaction_properties: None,
+            namespace_commit_info: None,
         }
+    }
+
+    pub fn new_namespace(
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        namespace_client_table_context: Option<NamespaceClientTableContext>,
+    ) -> Self {
+        Self {
+            dest: WriteDestination::Uri(""),
+            uri_was_explicitly_set: false,
+            use_stable_row_ids: None,
+            enable_v2_manifest_paths: true,
+            storage_format: None,
+            commit_handler: None,
+            store_params: None,
+            object_store: None,
+            session: None,
+            detached: false,
+            commit_config: Default::default(),
+            affected_rows: None,
+            transaction_properties: None,
+            namespace_commit_info: Some(NamespaceCommitInfo {
+                namespace_client,
+                table_id,
+                namespace_client_table_context,
+            }),
+        }
+    }
+
+    pub fn with_namespace(
+        mut self,
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        namespace_client_table_context: Option<NamespaceClientTableContext>,
+    ) -> Self {
+        self.namespace_commit_info = Some(NamespaceCommitInfo {
+            namespace_client,
+            table_id,
+            namespace_client_table_context,
+        });
+        self
     }
 
     /// Whether to use stable row ids. This makes the `_rowid` column stable
@@ -180,26 +278,151 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
+    async fn resolve_namespace_client_table_context(
+        &self,
+        transaction: &Transaction,
+    ) -> Result<Option<NamespaceClientTableContext>> {
+        let Some(namespace_commit_info) = &self.namespace_commit_info else {
+            return Ok(None);
+        };
+
+        if let Some(namespace_client_table_context) =
+            &namespace_commit_info.namespace_client_table_context
+        {
+            return Ok(Some(namespace_client_table_context.clone()));
+        }
+
+        let describe_request = DescribeTableRequest {
+            id: Some(namespace_commit_info.table_id.clone()),
+            ..Default::default()
+        };
+        match namespace_commit_info
+            .namespace_client
+            .describe_table(describe_request)
+            .await
+        {
+            Ok(response) => {
+                NamespaceClientTableContext::from_describe_table_response(response).map(Some)
+            }
+            Err(err)
+                if Self::is_namespace_table_not_found(&err)
+                    && matches!(
+                        transaction.operation,
+                        Operation::Overwrite { .. } | Operation::Clone { .. }
+                    ) =>
+            {
+                let declare_request = DeclareTableRequest {
+                    id: Some(namespace_commit_info.table_id.clone()),
+                    ..Default::default()
+                };
+                let response = namespace_commit_info
+                    .namespace_client
+                    .declare_table(declare_request)
+                    .await?;
+                NamespaceClientTableContext::from_declare_table_response(response).map(Some)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
     pub async fn execute(self, transaction: Transaction) -> Result<Dataset> {
+        if self.uri_was_explicitly_set && self.namespace_commit_info.is_some() {
+            return Err(Error::invalid_input(
+                "namespace clients cannot be combined with an explicit uri",
+            ));
+        }
+
+        let namespace_client_table_context = self
+            .resolve_namespace_client_table_context(&transaction)
+            .await?;
         let session = self
             .session
             .or_else(|| self.dest.dataset().map(|ds| ds.session.clone()))
             .unwrap_or_default();
 
+        let effective_uri = match (&self.dest, &namespace_client_table_context) {
+            (WriteDestination::Uri(_), Some(namespace_client_table_context)) => {
+                Some(namespace_client_table_context.location.clone())
+            }
+            (WriteDestination::Uri(uri), None) => Some((*uri).to_string()),
+            (WriteDestination::Dataset(_), _) => None,
+        };
+
+        let mut effective_store_params = self.store_params.clone();
+        let mut effective_commit_handler = self.commit_handler.clone();
+        if let (Some(namespace_commit_info), Some(namespace_client_table_context)) =
+            (&self.namespace_commit_info, &namespace_client_table_context)
+        {
+            if effective_commit_handler.is_none()
+                && namespace_client_table_context.managed_versioning
+            {
+                let external_store = LanceNamespaceExternalManifestStore::new(
+                    namespace_commit_info.namespace_client.clone(),
+                    namespace_commit_info.table_id.clone(),
+                );
+                effective_commit_handler = Some(Arc::new(ExternalManifestCommitHandler {
+                    external_manifest_store: Arc::new(external_store),
+                }) as Arc<dyn CommitHandler>);
+            }
+
+            let provider: Arc<dyn StorageOptionsProvider> =
+                Arc::new(LanceNamespaceStorageOptionsProvider::new(
+                    namespace_commit_info.namespace_client.clone(),
+                    namespace_commit_info.table_id.clone(),
+                ));
+            let existing_store_params = effective_store_params.take().unwrap_or_default();
+            let mut merged_storage_options = existing_store_params
+                .storage_options()
+                .cloned()
+                .unwrap_or_default();
+            if let Some(storage_options) = &namespace_client_table_context.storage_options {
+                merged_storage_options.extend(storage_options.clone());
+            }
+            effective_store_params = Some(ObjectStoreParams {
+                storage_options_accessor: Some(if merged_storage_options.is_empty() {
+                    Arc::new(StorageOptionsAccessor::with_provider(provider))
+                } else {
+                    Arc::new(StorageOptionsAccessor::with_initial_and_provider(
+                        merged_storage_options,
+                        provider,
+                    ))
+                }),
+                ..existing_store_params
+            });
+        }
+
+        let resolved_uri = if matches!(self.dest, WriteDestination::Uri(_)) {
+            Some(
+                effective_uri
+                    .as_deref()
+                    .ok_or_else(|| Error::invalid_input("uri is required"))?,
+            )
+        } else {
+            None
+        };
+
         let (object_store, base_path, commit_handler) = match &self.dest {
             WriteDestination::Dataset(dataset) => (
                 dataset.object_store.clone(),
                 dataset.base.clone(),
-                dataset.commit_handler.clone(),
+                effective_commit_handler
+                    .clone()
+                    .or_else(|| Some(dataset.commit_handler.clone()))
+                    .unwrap(),
             ),
-            WriteDestination::Uri(uri) => {
+            WriteDestination::Uri(_) => {
+                let uri = resolved_uri.expect("uri destinations must have a resolved uri");
                 let commit_handler = if let (Some(_), Some(commit_handler)) =
-                    (&self.object_store, &self.commit_handler)
+                    (&self.object_store, &effective_commit_handler)
                 {
                     commit_handler.clone()
                 } else {
-                    resolve_commit_handler(uri, self.commit_handler.clone(), &self.store_params)
-                        .await?
+                    resolve_commit_handler(
+                        uri,
+                        effective_commit_handler.clone(),
+                        &effective_store_params,
+                    )
+                    .await?
                 };
                 let (object_store, base_path) = if let Some(passed_store) = self.object_store {
                     (
@@ -210,7 +433,7 @@ impl<'a> CommitBuilder<'a> {
                     ObjectStore::from_uri_and_params(
                         session.store_registry(),
                         uri,
-                        &self.store_params.clone().unwrap_or_default(),
+                        &effective_store_params.clone().unwrap_or_default(),
                     )
                     .await?
                 };
@@ -220,12 +443,13 @@ impl<'a> CommitBuilder<'a> {
 
         let dest = match &self.dest {
             WriteDestination::Dataset(dataset) => WriteDestination::Dataset(dataset.clone()),
-            WriteDestination::Uri(uri) => {
+            WriteDestination::Uri(_) => {
+                let uri = resolved_uri.expect("uri destinations must have a resolved uri");
                 // Check if it already exists.
                 let mut builder = DatasetBuilder::from_uri(uri)
                     .with_read_params(ReadParams {
-                        store_options: self.store_params.clone(),
-                        commit_handler: self.commit_handler.clone(),
+                        store_options: effective_store_params.clone(),
+                        commit_handler: effective_commit_handler.clone(),
                         ..Default::default()
                     })
                     .with_session(session.clone());
@@ -371,7 +595,7 @@ impl<'a> CommitBuilder<'a> {
 
         let fragment_bitmap = Arc::new(manifest.fragments.iter().map(|f| f.id as u32).collect());
 
-        match &self.dest {
+        match &dest {
             WriteDestination::Dataset(dataset) => Ok(Dataset {
                 manifest: Arc::new(manifest),
                 manifest_location,
@@ -403,7 +627,7 @@ impl<'a> CommitBuilder<'a> {
                     fragment_bitmap,
                     metadata_cache,
                     file_reader_options: None,
-                    store_params: self.store_params.clone().map(Box::new),
+                    store_params: effective_store_params.clone().map(Box::new),
                     base_store_params: None,
                 })
             }

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -452,8 +452,14 @@ impl<'a> InsertBuilder<'a> {
                 }
             }
             WriteDestination::NamespaceTable(namespace_table) => {
+                let mut namespace_table = namespace_table.clone();
+                if namespace_table.namespace_client_table_context.is_none() {
+                    namespace_table.namespace_client_table_context =
+                        namespace_table_context.clone();
+                }
+
                 if namespace_table.dataset.is_some() {
-                    self.dest.clone()
+                    WriteDestination::NamespaceTable(namespace_table)
                 } else {
                     let context = namespace_table_context
                         .as_ref()
@@ -468,10 +474,9 @@ impl<'a> InsertBuilder<'a> {
 
                     match builder.load().await {
                         Ok(dataset) => WriteDestination::NamespaceTable(
-                            namespace_table.clone().with_dataset(Arc::new(dataset)),
+                            namespace_table.with_dataset(Arc::new(dataset)),
                         ),
                         Err(Error::DatasetNotFound { .. } | Error::NotFound { .. }) => {
-                            let mut namespace_table = namespace_table.clone();
                             namespace_table.namespace_client_table_context = Some(context.clone());
                             WriteDestination::NamespaceTable(namespace_table)
                         }

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -45,14 +45,14 @@ use crate::dataset::progress::{WriteProgressFn, WriteStats};
 /// they are passed to the [`CommitBuilder`].
 #[derive(Debug, Clone)]
 pub struct InsertBuilder<'a> {
-    dest: WriteDestination<'a>,
+    dest: WriteDestination,
     // TODO: make these parameters a part of the builder, and add specific methods.
     params: Option<&'a WriteParams>,
     write_progress: Option<WriteProgressFn>,
 }
 
 impl<'a> InsertBuilder<'a> {
-    pub fn new(dest: impl Into<WriteDestination<'a>>) -> Self {
+    pub fn new(dest: impl Into<WriteDestination>) -> Self {
         Self {
             dest: dest.into(),
             params: None,
@@ -130,7 +130,7 @@ impl<'a> InsertBuilder<'a> {
         self.write_uncommitted_impl(data).await.map(|(t, _)| t)
     }
 
-    async fn do_commit(context: &WriteContext<'_>, transaction: Transaction) -> Result<Dataset> {
+    async fn do_commit(context: &WriteContext, transaction: Transaction) -> Result<Dataset> {
         let mut commit_builder = CommitBuilder::new(context.dest.clone())
             .use_stable_row_ids(context.params.enable_stable_row_ids)
             .with_storage_format(context.storage_version)
@@ -153,7 +153,7 @@ impl<'a> InsertBuilder<'a> {
     async fn write_uncommitted_impl(
         &self,
         data: Vec<RecordBatch>,
-    ) -> Result<(Transaction, WriteContext<'_>)> {
+    ) -> Result<(Transaction, WriteContext)> {
         // TODO: This should be able to split the data up based on max_rows_per_file
         // and write in parallel. https://github.com/lance-format/lance/issues/1980
         if data.is_empty() {
@@ -188,7 +188,7 @@ impl<'a> InsertBuilder<'a> {
         &self,
         stream: SendableRecordBatchStream,
         schema: Schema,
-    ) -> Result<(Transaction, WriteContext<'_>)> {
+    ) -> Result<(Transaction, WriteContext)> {
         let mut context = self.resolve_context().await?;
 
         info!(
@@ -223,7 +223,7 @@ impl<'a> InsertBuilder<'a> {
     fn build_transaction(
         schema: Schema,
         fragments: Vec<Fragment>,
-        context: &WriteContext<'_>,
+        context: &WriteContext,
     ) -> Result<Transaction> {
         let operation = match context.params.mode {
             WriteMode::Create => {
@@ -281,20 +281,26 @@ impl<'a> InsertBuilder<'a> {
 
     fn validate_write(&self, context: &mut WriteContext, data_schema: &Schema) -> Result<()> {
         // Write mode
-        match (&context.params.mode, &context.dest) {
-            (WriteMode::Create, WriteDestination::Dataset(ds)) => {
-                return Err(Error::dataset_already_exists(ds.uri.clone()));
+        match context.params.mode {
+            WriteMode::Create => {
+                if let Some(ds) = context.dest.dataset() {
+                    return Err(Error::dataset_already_exists(ds.uri.clone()));
+                }
             }
-            (WriteMode::Append | WriteMode::Overwrite, WriteDestination::Uri(uri)) => {
-                log::warn!("No existing dataset at {uri}, it will be created");
-                context.params.mode = WriteMode::Create;
+            WriteMode::Append | WriteMode::Overwrite => {
+                if context.dest.dataset().is_none() {
+                    log::warn!(
+                        "No existing dataset at {}, it will be created",
+                        context.dest.uri()
+                    );
+                    context.params.mode = WriteMode::Create;
+                }
             }
-            _ => {}
         }
 
         // Validate schema
         if matches!(context.params.mode, WriteMode::Append)
-            && let WriteDestination::Dataset(dataset) = &context.dest
+            && let Some(dataset) = context.dest.dataset()
         {
             // If the dataset is already using (or not using) stable row ids, we need to match
             // and ignore whatever the user provided as input
@@ -332,7 +338,7 @@ impl<'a> InsertBuilder<'a> {
         }
 
         // Feature flags
-        if let WriteDestination::Dataset(dataset) = &context.dest
+        if let Some(dataset) = context.dest.dataset()
             && !can_write_dataset(dataset.manifest.writer_feature_flags)
         {
             let message = format!(
@@ -346,11 +352,25 @@ impl<'a> InsertBuilder<'a> {
         Ok(())
     }
 
-    async fn resolve_context(&self) -> Result<WriteContext<'a>> {
+    async fn resolve_context(&self) -> Result<WriteContext> {
         let mut params = self.params.cloned().unwrap_or_default();
         if let Some(cb) = self.write_progress.clone() {
             params.write_progress = Some(cb);
         }
+        let mut namespace_table_context = None;
+        if let Some(namespace_table) = self.dest.namespace_table() {
+            let context = namespace_table
+                .resolve_context_for_write(params.mode)
+                .await?;
+            let existing_store_params = params.store_params.take().unwrap_or_default();
+            params.store_params =
+                Some(namespace_table.store_params_with_context(existing_store_params, &context));
+            if params.commit_handler.is_none() {
+                params.commit_handler = namespace_table.managed_commit_handler(&context);
+            }
+            namespace_table_context = Some(context);
+        }
+
         let (object_store, base_path, commit_handler) = match &self.dest {
             WriteDestination::Dataset(dataset) => (
                 dataset.object_store.clone(),
@@ -377,6 +397,40 @@ impl<'a> InsertBuilder<'a> {
                 .await?;
                 (object_store, base_path, commit_handler)
             }
+            WriteDestination::NamespaceTable(namespace_table) => {
+                if let Some(dataset) = &namespace_table.dataset {
+                    (
+                        dataset.object_store.clone(),
+                        dataset.base.clone(),
+                        params
+                            .commit_handler
+                            .clone()
+                            .unwrap_or_else(|| dataset.commit_handler.clone()),
+                    )
+                } else {
+                    let context = namespace_table_context
+                        .as_ref()
+                        .expect("namespace table context was resolved above");
+                    let registry = params
+                        .session
+                        .as_ref()
+                        .map(|s| s.store_registry())
+                        .unwrap_or_else(|| Arc::new(Default::default()));
+                    let (object_store, base_path) = ObjectStore::from_uri_and_params(
+                        registry,
+                        &context.location,
+                        &params.store_params.clone().unwrap_or_default(),
+                    )
+                    .await?;
+                    let commit_handler = resolve_commit_handler(
+                        &context.location,
+                        params.commit_handler.clone(),
+                        &params.store_params,
+                    )
+                    .await?;
+                    (object_store, base_path, commit_handler)
+                }
+            }
         };
         let dest = match &self.dest {
             WriteDestination::Dataset(dataset) => WriteDestination::Dataset(dataset.clone()),
@@ -392,15 +446,43 @@ impl<'a> InsertBuilder<'a> {
                 match builder.load().await {
                     Ok(dataset) => WriteDestination::Dataset(Arc::new(dataset)),
                     Err(Error::DatasetNotFound { .. } | Error::NotFound { .. }) => {
-                        WriteDestination::Uri(uri)
+                        WriteDestination::Uri(uri.clone())
                     }
                     Err(e) => return Err(e),
                 }
             }
+            WriteDestination::NamespaceTable(namespace_table) => {
+                if namespace_table.dataset.is_some() {
+                    self.dest.clone()
+                } else {
+                    let context = namespace_table_context
+                        .as_ref()
+                        .expect("namespace table context was resolved above");
+                    let builder =
+                        DatasetBuilder::from_uri(&context.location).with_read_params(ReadParams {
+                            store_options: params.store_params.clone(),
+                            commit_handler: params.commit_handler.clone(),
+                            session: params.session.clone(),
+                            ..Default::default()
+                        });
+
+                    match builder.load().await {
+                        Ok(dataset) => WriteDestination::NamespaceTable(
+                            namespace_table.clone().with_dataset(Arc::new(dataset)),
+                        ),
+                        Err(Error::DatasetNotFound { .. } | Error::NotFound { .. }) => {
+                            let mut namespace_table = namespace_table.clone();
+                            namespace_table.namespace_client_table_context = Some(context.clone());
+                            WriteDestination::NamespaceTable(namespace_table)
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
         };
 
-        let storage_version = match (&params.mode, &dest) {
-            (WriteMode::Overwrite, WriteDestination::Dataset(dataset)) => {
+        let storage_version = match (&params.mode, dest.dataset()) {
+            (WriteMode::Overwrite, Some(dataset)) => {
                 // If overwriting an existing dataset, allow the user to specify but use
                 // the existing version if they don't
                 params.data_storage_version.map(Ok).unwrap_or_else(|| {
@@ -408,13 +490,13 @@ impl<'a> InsertBuilder<'a> {
                     m.data_storage_format.lance_file_version()
                 })?
             }
-            (_, WriteDestination::Dataset(dataset)) => {
+            (_, Some(dataset)) => {
                 // If appending to an existing dataset, always use the dataset version
                 let m = dataset.manifest.as_ref();
                 m.data_storage_format.lance_file_version()?
             }
             // Otherwise (no existing dataset) fallback to the default if the user didn't specify
-            (_, WriteDestination::Uri(_)) => params.storage_version_or_default(),
+            (_, None) => params.storage_version_or_default(),
         };
 
         Ok(WriteContext {
@@ -429,9 +511,9 @@ impl<'a> InsertBuilder<'a> {
 }
 
 #[derive(Debug)]
-struct WriteContext<'a> {
+struct WriteContext {
     params: WriteParams,
-    dest: WriteDestination<'a>,
+    dest: WriteDestination,
     object_store: Arc<ObjectStore>,
     base_path: Path,
     commit_handler: Arc<dyn CommitHandler>,

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -717,9 +717,9 @@ mod tests {
         }
     }
 
-    impl<'a> From<&'a TempStrDir> for WriteDestination<'a> {
-        fn from(value: &'a TempStrDir) -> Self {
-            WriteDestination::Uri(value.as_str())
+    impl From<&TempStrDir> for WriteDestination {
+        fn from(value: &TempStrDir) -> Self {
+            Self::Uri(value.as_str().to_string())
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce explicit NamespaceClientTableContext across Rust, Python, and Java namespace paths
- centralize namespace location, storage option merge, and managed-versioning handling in Rust
- update namespace distributed write, file, fragment, commit, and integration coverage for cached table context