### PR TITLE
feat(io): bypass backpressure for io_buffer_size=0 and 2.0 indirect I/O

### DIFF
--- a/rust/lance-encoding/src/lib.rs
+++ b/rust/lance-encoding/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::ops::Range;
+use std::{ops::Range, sync::Arc};
 
 use bytes::Bytes;
 use futures::{FutureExt, TryFutureExt, future::BoxFuture};
@@ -74,6 +74,17 @@ pub trait EncodingsIo: std::fmt::Debug + Send + Sync {
         self.submit_request(vec![range], priority)
             .map_ok(|mut v| v.pop().unwrap())
             .boxed()
+    }
+
+    /// Returns a version of this I/O service that bypasses backpressure for all requests.
+    ///
+    /// This is intended for indirect I/O (e.g. fetching items after decoding offsets) where
+    /// blocking on backpressure could cause deadlocks or excessive latency.
+    ///
+    /// Returns `None` if this implementation does not support bypass (e.g. in-memory or test
+    /// schedulers), in which case the caller should fall back to using self.
+    fn with_bypass_backpressure(&self) -> Option<Arc<dyn EncodingsIo>> {
+        None
     }
 }
 

--- a/rust/lance-encoding/src/previous/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/list.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{collections::VecDeque, ops::Range, sync::Arc};
+use std::{collections::VecDeque, ops::Range, sync::{Arc, OnceLock}};
 
 use arrow_array::{
     Array, ArrayRef, BooleanArray, Int32Array, Int64Array, LargeListArray, ListArray, UInt64Array,
@@ -34,6 +34,17 @@ use crate::{
     repdef::RepDefBuilder,
     utils::accumulation::AccumulationQueue,
 };
+
+/// When set, indirect I/O in the 2.0 list scheduler bypasses the backpressure system.
+///
+/// This can be useful when indirect I/O is blocking on backpressure and causing latency or
+/// deadlocks.  Set LANCE_BYPASS_INDIRECT_IO_BACKPRESSURE=1 to enable.
+static BYPASS_INDIRECT_IO_BACKPRESSURE: OnceLock<bool> = OnceLock::new();
+
+fn bypass_indirect_io_backpressure() -> bool {
+    *BYPASS_INDIRECT_IO_BACKPRESSURE
+        .get_or_init(|| std::env::var("LANCE_BYPASS_INDIRECT_IO_BACKPRESSURE").is_ok())
+}
 
 // Scheduling lists is tricky.  Imagine the following scenario:
 //
@@ -454,7 +465,14 @@ impl SchedulingJob for ListFieldSchedulingJob<'_> {
 
         let items_scheduler = self.scheduler.items_scheduler.clone();
         let items_type = self.scheduler.items_field.data_type().clone();
-        let io = context.io().clone();
+        let base_io = context.io().clone();
+        let io = if bypass_indirect_io_backpressure() {
+            base_io
+                .with_bypass_backpressure()
+                .unwrap_or(base_io)
+        } else {
+            base_io
+        };
         let cache = context.cache().clone();
 
         // Immediately spawn the indirect scheduling

--- a/rust/lance-encoding/src/previous/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/list.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{collections::VecDeque, ops::Range, sync::{Arc, OnceLock}};
+use std::{
+    collections::VecDeque,
+    ops::Range,
+    sync::{Arc, OnceLock},
+};
 
 use arrow_array::{
     Array, ArrayRef, BooleanArray, Int32Array, Int64Array, LargeListArray, ListArray, UInt64Array,
@@ -467,9 +471,7 @@ impl SchedulingJob for ListFieldSchedulingJob<'_> {
         let items_type = self.scheduler.items_field.data_type().clone();
         let base_io = context.io().clone();
         let io = if bypass_indirect_io_backpressure() {
-            base_io
-                .with_bypass_backpressure()
-                .unwrap_or(base_io)
+            base_io.with_bypass_backpressure().unwrap_or(base_io)
         } else {
             base_io
         };

--- a/rust/lance-encoding/src/previous/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/list.rs
@@ -41,8 +41,8 @@ use crate::{
 
 /// When set, indirect I/O in the 2.0 list scheduler bypasses the backpressure system.
 ///
-/// This can be useful when indirect I/O is blocking on backpressure and causing latency or
-/// deadlocks.  Set LANCE_BYPASS_INDIRECT_IO_BACKPRESSURE=1 to enable.
+/// This can be a blunt instrument to avoid deadlocks in 2.0 scenarios
+/// Set LANCE_BYPASS_INDIRECT_IO_BACKPRESSURE=1 to enable.
 static BYPASS_INDIRECT_IO_BACKPRESSURE: OnceLock<bool> = OnceLock::new();
 
 fn bypass_indirect_io_backpressure() -> bool {

--- a/rust/lance-encoding/src/previous/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/list.rs
@@ -16,7 +16,7 @@ use arrow_array::{
 use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, Buffer, NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field, Fields};
 use futures::{FutureExt, future::BoxFuture};
-use lance_core::{Error, Result, cache::LanceCache};
+use lance_core::{Error, Result, cache::LanceCache, utils::parse::str_is_truthy};
 use log::trace;
 use tokio::task::JoinHandle;
 
@@ -46,8 +46,11 @@ use crate::{
 static BYPASS_INDIRECT_IO_BACKPRESSURE: OnceLock<bool> = OnceLock::new();
 
 fn bypass_indirect_io_backpressure() -> bool {
-    *BYPASS_INDIRECT_IO_BACKPRESSURE
-        .get_or_init(|| std::env::var("LANCE_BYPASS_INDIRECT_IO_BACKPRESSURE").is_ok())
+    *BYPASS_INDIRECT_IO_BACKPRESSURE.get_or_init(|| {
+        std::env::var("LANCE_BYPASS_INDIRECT_IO_BACKPRESSURE")
+            .map(|val| str_is_truthy(&val))
+            .unwrap_or(false)
+    })
 }
 
 // Scheduling lists is tricky.  Imagine the following scenario:

--- a/rust/lance-file/src/io.rs
+++ b/rust/lance-file/src/io.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::sync::Arc;
+
 use futures::{FutureExt, future::BoxFuture};
 use lance_encoding::EncodingsIo;
 use lance_io::scheduler::FileScheduler;
@@ -29,6 +31,13 @@ impl LanceEncodingsIo {
 }
 
 impl EncodingsIo for LanceEncodingsIo {
+    fn with_bypass_backpressure(&self) -> Option<Arc<dyn EncodingsIo>> {
+        Some(Arc::new(LanceEncodingsIo {
+            scheduler: self.scheduler.with_bypass_backpressure(),
+            read_chunk_size: self.read_chunk_size,
+        }))
+    }
+
     fn submit_request(
         &self,
         ranges: Vec<std::ops::Range<u64>>,

--- a/rust/lance-file/src/io.rs
+++ b/rust/lance-file/src/io.rs
@@ -32,7 +32,7 @@ impl LanceEncodingsIo {
 
 impl EncodingsIo for LanceEncodingsIo {
     fn with_bypass_backpressure(&self) -> Option<Arc<dyn EncodingsIo>> {
-        Some(Arc::new(LanceEncodingsIo {
+        Some(Arc::new(Self {
             scheduler: self.scheduler.with_bypass_backpressure(),
             read_chunk_size: self.read_chunk_size,
         }))

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -1049,10 +1049,7 @@ mod tests {
             .map(|t| (t.priority, t.bypass_backpressure))
             .collect();
 
-        assert_eq!(
-            order,
-            vec![(5, true), (20, true), (1, false), (10, false)]
-        );
+        assert_eq!(order, vec![(5, true), (20, true), (1, false), (10, false)]);
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -309,7 +309,11 @@ impl<F: FnOnce(Response) + Send> Drop for MutableBatch<F> {
         let response = Response {
             data: result,
             // Report 0 bytes for bypass tasks so the backpressure budget is unaffected
-            num_bytes: if self.bypass_backpressure { 0 } else { self.num_bytes },
+            num_bytes: if self.bypass_backpressure {
+                0
+            } else {
+                self.num_bytes
+            },
             priority: self.priority,
             num_reqs: self.num_reqs,
         };
@@ -768,9 +772,15 @@ impl ScanScheduler {
         bypass_backpressure: bool,
     ) -> impl Future<Output = Result<Vec<Bytes>>> + Send + use<> {
         match &self.io_queue {
-            IoQueueType::Standard(io_queue) => futures::future::Either::Left(
-                self.submit_request_standard(reader, request, priority, io_queue, bypass_backpressure),
-            ),
+            IoQueueType::Standard(io_queue) => {
+                futures::future::Either::Left(self.submit_request_standard(
+                    reader,
+                    request,
+                    priority,
+                    io_queue,
+                    bypass_backpressure,
+                ))
+            }
             IoQueueType::Lite(io_queue) => futures::future::Either::Right(
                 self.submit_request_lite(reader, request, priority, io_queue, bypass_backpressure),
             ),

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -98,6 +98,8 @@ struct IoQueueState {
     start: Instant,
     // Last time we warned about backpressure
     last_warn: AtomicU64,
+    // When true, skip all byte-based backpressure checks (set when io_buffer_size == 0)
+    no_backpressure: bool,
 }
 
 impl IoQueueState {
@@ -110,6 +112,7 @@ impl IoQueueState {
             done_scheduling: false,
             start: Instant::now(),
             last_warn: AtomicU64::from(0),
+            no_backpressure: io_buffer_size == 0,
         }
     }
 
@@ -134,7 +137,10 @@ impl IoQueueState {
     fn can_deliver(&self, task: &IoTask) -> bool {
         if self.iops_avail == 0 {
             false
-        } else if task.priority <= self.priorities_in_flight.min_in_flight() {
+        } else if self.no_backpressure
+            || task.bypass_backpressure
+            || task.priority <= self.priorities_in_flight.min_in_flight()
+        {
             true
         } else if task.num_bytes() as i64 > self.bytes_avail {
             self.warn_if_needed();
@@ -147,15 +153,18 @@ impl IoQueueState {
     fn next_task(&mut self) -> Option<IoTask> {
         let task = self.pending_requests.peek()?;
         if self.can_deliver(task) {
+            let skip_bytes_accounting = self.no_backpressure || task.bypass_backpressure;
             self.priorities_in_flight.push(task.priority);
             self.iops_avail -= 1;
-            self.bytes_avail -= task.num_bytes() as i64;
-            if self.bytes_avail < 0 {
-                // This can happen when we admit special priority requests
-                log::debug!(
-                    "Backpressure throttle temporarily exceeded by {} bytes due to priority I/O",
-                    -self.bytes_avail
-                );
+            if !skip_bytes_accounting {
+                self.bytes_avail -= task.num_bytes() as i64;
+                if self.bytes_avail < 0 {
+                    // This can happen when we admit special priority requests
+                    log::debug!(
+                        "Backpressure throttle temporarily exceeded by {} bytes due to priority I/O",
+                        -self.bytes_avail
+                    );
+                }
             }
             Some(self.pending_requests.pop().unwrap())
         } else {
@@ -257,10 +266,18 @@ struct MutableBatch<F: FnOnce(Response) + Send> {
     priority: u128,
     num_reqs: usize,
     err: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    // When true, report 0 bytes consumed so the backpressure budget is unaffected
+    bypass_backpressure: bool,
 }
 
 impl<F: FnOnce(Response) + Send> MutableBatch<F> {
-    fn new(when_done: F, num_data_buffers: u32, priority: u128, num_reqs: usize) -> Self {
+    fn new(
+        when_done: F,
+        num_data_buffers: u32,
+        priority: u128,
+        num_reqs: usize,
+        bypass_backpressure: bool,
+    ) -> Self {
         Self {
             when_done: Some(when_done),
             data_buffers: vec![Bytes::default(); num_data_buffers as usize],
@@ -268,6 +285,7 @@ impl<F: FnOnce(Response) + Send> MutableBatch<F> {
             priority,
             num_reqs,
             err: None,
+            bypass_backpressure,
         }
     }
 }
@@ -290,7 +308,8 @@ impl<F: FnOnce(Response) + Send> Drop for MutableBatch<F> {
         // the result go out of scope and get cleaned up
         let response = Response {
             data: result,
-            num_bytes: self.num_bytes,
+            // Report 0 bytes for bypass tasks so the backpressure budget is unaffected
+            num_bytes: if self.bypass_backpressure { 0 } else { self.num_bytes },
             priority: self.priority,
             num_reqs: self.num_reqs,
         };
@@ -329,6 +348,7 @@ struct IoTask {
     to_read: Range<u64>,
     when_done: Box<dyn FnOnce(Result<Bytes>) + Send>,
     priority: u128,
+    bypass_backpressure: bool,
 }
 
 impl Eq for IoTask {}
@@ -618,6 +638,7 @@ impl ScanScheduler {
             root: self.clone(),
             base_priority,
             max_iop_size,
+            bypass_backpressure: false,
         })
     }
 
@@ -639,6 +660,7 @@ impl ScanScheduler {
         tx: oneshot::Sender<Response>,
         priority: u128,
         io_queue: &Arc<IoQueue>,
+        bypass_backpressure: bool,
     ) {
         let num_iops = request.len() as u32;
 
@@ -652,6 +674,7 @@ impl ScanScheduler {
             num_iops,
             priority,
             request.len(),
+            bypass_backpressure,
         ))));
 
         for (task_idx, iop) in request.into_iter().enumerate() {
@@ -662,6 +685,7 @@ impl ScanScheduler {
                 reader: reader.clone(),
                 to_read: iop,
                 priority,
+                bypass_backpressure,
                 when_done: Box::new(move |data| {
                     io_queue_clone.on_iop_complete();
                     let mut dest = dest.lock().unwrap();
@@ -683,10 +707,11 @@ impl ScanScheduler {
         request: Vec<Range<u64>>,
         priority: u128,
         io_queue: &Arc<IoQueue>,
+        bypass_backpressure: bool,
     ) -> impl Future<Output = Result<Vec<Bytes>>> + Send + use<> {
         let (tx, rx) = oneshot::channel::<Response>();
 
-        self.do_submit_request(reader, request, tx, priority, io_queue);
+        self.do_submit_request(reader, request, tx, priority, io_queue, bypass_backpressure);
 
         let io_queue_clone = io_queue.clone();
 
@@ -705,6 +730,7 @@ impl ScanScheduler {
         request: Vec<Range<u64>>,
         priority: u128,
         io_queue: &Arc<lite::IoQueue>,
+        bypass_backpressure: bool,
     ) -> impl Future<Output = Result<Vec<Bytes>>> + Send + use<> {
         // It's important that we submit all requests _before_ we await anything
         let maybe_tasks = request
@@ -718,7 +744,7 @@ impl ScanScheduler {
                         .map_err(Error::from)
                         .boxed()
                 });
-                queue.submit(task, priority, run_fn)
+                queue.submit(task, priority, run_fn, bypass_backpressure)
             })
             .collect::<Result<Vec<_>>>();
         match maybe_tasks {
@@ -739,13 +765,14 @@ impl ScanScheduler {
         reader: Arc<dyn Reader>,
         request: Vec<Range<u64>>,
         priority: u128,
+        bypass_backpressure: bool,
     ) -> impl Future<Output = Result<Vec<Bytes>>> + Send + use<> {
         match &self.io_queue {
             IoQueueType::Standard(io_queue) => futures::future::Either::Left(
-                self.submit_request_standard(reader, request, priority, io_queue),
+                self.submit_request_standard(reader, request, priority, io_queue, bypass_backpressure),
             ),
             IoQueueType::Lite(io_queue) => futures::future::Either::Right(
-                self.submit_request_lite(reader, request, priority, io_queue),
+                self.submit_request_lite(reader, request, priority, io_queue, bypass_backpressure),
             ),
         }
     }
@@ -788,6 +815,7 @@ pub struct FileScheduler {
     block_size: u64,
     base_priority: u64,
     max_iop_size: u64,
+    bypass_backpressure: bool,
 }
 
 fn is_close_together(range1: &Range<u64>, range2: &Range<u64>, block_size: u64) -> bool {
@@ -859,9 +887,12 @@ impl FileScheduler {
 
         self.root.stats.record_request(&updated_requests);
 
-        let bytes_vec_fut =
-            self.root
-                .submit_request(self.reader.clone(), updated_requests.clone(), priority);
+        let bytes_vec_fut = self.root.submit_request(
+            self.reader.clone(),
+            updated_requests.clone(),
+            priority,
+            self.bypass_backpressure,
+        );
 
         let mut updated_index = 0;
         let mut final_bytes = Vec::with_capacity(request.len());
@@ -919,6 +950,18 @@ impl FileScheduler {
             block_size: self.block_size,
             max_iop_size: self.max_iop_size,
             base_priority: priority,
+            bypass_backpressure: self.bypass_backpressure,
+        }
+    }
+
+    /// Returns a copy of this scheduler that bypasses backpressure for all requests.
+    ///
+    /// This should be used for indirect I/O (e.g. fetching items after decoding offsets) where
+    /// blocking on backpressure could cause a deadlock or excessive latency.
+    pub fn with_bypass_backpressure(&self) -> Self {
+        Self {
+            bypass_backpressure: true,
+            ..self.clone()
         }
     }
 
@@ -1376,9 +1419,9 @@ mod tests {
 
         // Submit several requests. The lite scheduler should call get_range
         // eagerly during submit (before the returned future is polled).
-        let fut1 = scheduler.submit_request(reader.clone(), vec![0..100], 0);
-        let fut2 = scheduler.submit_request(reader.clone(), vec![100..200], 10);
-        let fut3 = scheduler.submit_request(reader.clone(), vec![200..300], 20);
+        let fut1 = scheduler.submit_request(reader.clone(), vec![0..100], 0, false);
+        let fut2 = scheduler.submit_request(reader.clone(), vec![100..200], 10, false);
+        let fut3 = scheduler.submit_request(reader.clone(), vec![200..300], 20, false);
 
         // get_range must have been called for all 3 requests already.
         assert_eq!(get_range_count.load(Ordering::Acquire), 3);

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -1523,4 +1523,125 @@ mod tests {
             fut.await.unwrap();
         }
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_zero_buffer_size_no_backpressure() {
+        // With io_buffer_size_bytes=0 (no_backpressure=true), reads at any priority go
+        // through without blocking, even though a zero budget would normally halt all I/O.
+        let obj_store = Arc::new(ObjectStore::memory());
+        let config = SchedulerConfig {
+            io_buffer_size_bytes: 0,
+            use_lite_scheduler: Some(false),
+        };
+        let scheduler = ScanScheduler::new(obj_store, config);
+
+        let get_range_count = Arc::new(AtomicU64::new(0));
+        let reader: Arc<dyn Reader> = Arc::new(TrackingReader {
+            get_range_count: get_range_count.clone(),
+            path: Path::parse("test").unwrap(),
+        });
+
+        // Submit three reads at increasing priorities without awaiting any first.
+        // Priority 1 and 2 would deadlock under a real 0-byte budget without no_backpressure.
+        let fut1 = scheduler.submit_request(reader.clone(), vec![0..1000], 0, false);
+        let fut2 = scheduler.submit_request(reader.clone(), vec![1000..2000], 1, false);
+        let fut3 = scheduler.submit_request(reader.clone(), vec![2000..3000], 2, false);
+
+        let bytes1 = timeout(Duration::from_secs(5), fut1).await.unwrap().unwrap();
+        let bytes2 = timeout(Duration::from_secs(5), fut2).await.unwrap().unwrap();
+        let bytes3 = timeout(Duration::from_secs(5), fut3).await.unwrap().unwrap();
+        assert_eq!(bytes1[0].len(), 1000);
+        assert_eq!(bytes2[0].len(), 1000);
+        assert_eq!(bytes3[0].len(), 1000);
+        assert_eq!(get_range_count.load(Ordering::Acquire), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_file_scheduler_bypass_backpressure() {
+        // A FileScheduler obtained via with_bypass_backpressure() submits reads that bypass
+        // the byte budget, allowing them to proceed even when the budget is exhausted.
+        let some_path = Path::parse("foo").unwrap();
+        let base_store = Arc::new(InMemory::new());
+        base_store
+            .put(&some_path, vec![0u8; 1000].into())
+            .await
+            .unwrap();
+
+        let bytes_dispatched = Arc::new(AtomicU64::from(0));
+        let mut obj_store = MockObjectStore::default();
+        let bytes_dispatched_copy = bytes_dispatched.clone();
+        obj_store
+            .expect_get_opts()
+            .returning(move |location, options| {
+                let range = options.range.as_ref().unwrap();
+                let num_bytes = match range {
+                    GetRange::Bounded(bounded) => bounded.end - bounded.start,
+                    _ => panic!(),
+                };
+                bytes_dispatched_copy.fetch_add(num_bytes, Ordering::Release);
+                let location = location.clone();
+                let base_store = base_store.clone();
+                async move { base_store.get_opts(&location, options).await }.boxed()
+            });
+        let obj_store = Arc::new(ObjectStore::new(
+            Arc::new(obj_store),
+            Url::parse("mem://").unwrap(),
+            Some(500),
+            None,
+            false,
+            false,
+            1,
+            DEFAULT_DOWNLOAD_RETRY_COUNT,
+            None,
+        ));
+
+        // Budget = 10 bytes.
+        let config = SchedulerConfig {
+            io_buffer_size_bytes: 10,
+            use_lite_scheduler: Some(false),
+        };
+        let scan_scheduler = ScanScheduler::new(obj_store, config);
+        let file_scheduler = scan_scheduler
+            .open_file(&Path::parse("foo").unwrap(), &CachedFileSize::new(1000))
+            .await
+            .unwrap();
+        let bypass_scheduler = file_scheduler.with_bypass_backpressure();
+
+        // Fill the 10-byte budget with a priority-0 read.
+        let blocker_fut = file_scheduler.submit_single(0..10, 0);
+        while bytes_dispatched.load(Ordering::Acquire) < 10 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        // A normal read at priority 2 is blocked: budget = 0, priority 2 > min-in-flight 0.
+        // A bypass read at priority 1 (higher priority in the queue) bypasses the budget check.
+        let normal_fut = file_scheduler.submit_single(0..10, 2);
+        let bypass_fut = bypass_scheduler.submit_single(0..10, 1);
+
+        // Bypass read is dispatched; normal read is still blocked.
+        while bytes_dispatched.load(Ordering::Acquire) < 20 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            bytes_dispatched.load(Ordering::Acquire),
+            20,
+            "normal read should still be blocked while budget is exhausted"
+        );
+
+        // Consuming the blocker releases its 10-byte budget → normal read can proceed.
+        timeout(Duration::from_secs(5), blocker_fut)
+            .await
+            .unwrap()
+            .unwrap();
+        timeout(Duration::from_secs(5), bypass_fut)
+            .await
+            .unwrap()
+            .unwrap();
+        timeout(Duration::from_secs(5), normal_fut)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(bytes_dispatched.load(Ordering::Acquire), 30);
+    }
 }

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -359,7 +359,7 @@ impl Eq for IoTask {}
 
 impl PartialEq for IoTask {
     fn eq(&self, other: &Self) -> bool {
-        self.priority == other.priority
+        self.bypass_backpressure == other.bypass_backpressure && self.priority == other.priority
     }
 }
 
@@ -371,8 +371,11 @@ impl PartialOrd for IoTask {
 
 impl Ord for IoTask {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // This is intentionally inverted.  We want a min-heap
-        other.priority.cmp(&self.priority)
+        // Bypass tasks are always delivered before normal tasks.
+        // Within the same bypass class, this is a min-heap on priority.
+        self.bypass_backpressure
+            .cmp(&other.bypass_backpressure)
+            .then(other.priority.cmp(&self.priority))
     }
 }
 
@@ -1018,6 +1021,39 @@ mod tests {
     };
 
     use super::*;
+
+    fn make_task(priority: u128, bypass_backpressure: bool) -> IoTask {
+        IoTask {
+            reader: Arc::new(TrackingReader {
+                get_range_count: Arc::new(AtomicU64::new(0)),
+                path: Path::parse("test").unwrap(),
+            }),
+            to_read: 0..1,
+            when_done: Box::new(|_| {}),
+            priority,
+            bypass_backpressure,
+        }
+    }
+
+    #[test]
+    fn test_iotask_ordering() {
+        // Bypass tasks must come out of the heap before non-bypass tasks.
+        // Within each group, lower priority number (= higher priority) comes first.
+        let mut heap = BinaryHeap::new();
+        heap.push(make_task(10, false)); // non-bypass, low priority
+        heap.push(make_task(1, false)); // non-bypass, high priority
+        heap.push(make_task(20, true)); // bypass, low priority
+        heap.push(make_task(5, true)); // bypass, high priority
+
+        let order: Vec<(u128, bool)> = std::iter::from_fn(|| heap.pop())
+            .map(|t| (t.priority, t.bypass_backpressure))
+            .collect();
+
+        assert_eq!(
+            order,
+            vec![(5, true), (20, true), (1, false), (10, false)]
+        );
+    }
 
     #[tokio::test]
     async fn test_full_seq_read() {

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -1547,9 +1547,18 @@ mod tests {
         let fut2 = scheduler.submit_request(reader.clone(), vec![1000..2000], 1, false);
         let fut3 = scheduler.submit_request(reader.clone(), vec![2000..3000], 2, false);
 
-        let bytes1 = timeout(Duration::from_secs(5), fut1).await.unwrap().unwrap();
-        let bytes2 = timeout(Duration::from_secs(5), fut2).await.unwrap().unwrap();
-        let bytes3 = timeout(Duration::from_secs(5), fut3).await.unwrap().unwrap();
+        let bytes1 = timeout(Duration::from_secs(5), fut1)
+            .await
+            .unwrap()
+            .unwrap();
+        let bytes2 = timeout(Duration::from_secs(5), fut2)
+            .await
+            .unwrap()
+            .unwrap();
+        let bytes3 = timeout(Duration::from_secs(5), fut3)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(bytes1[0].len(), 1000);
         assert_eq!(bytes2[0].len(), 1000);
         assert_eq!(bytes3[0].len(), 1000);

--- a/rust/lance-io/src/scheduler/lite.rs
+++ b/rust/lance-io/src/scheduler/lite.rs
@@ -301,7 +301,6 @@ impl SimpleBackpressureThrottle {
         }
     }
 
-
     fn warn_if_needed(&self) {
         let seconds_elapsed = self.start.elapsed().as_secs();
         let last_warn = self.last_warn.load(Ordering::Acquire);
@@ -346,7 +345,10 @@ impl BackpressureThrottle for SimpleBackpressureThrottle {
 
     fn force_acquire(&mut self, priority: u128) -> BackpressureReservation {
         self.priorities_in_flight.push(priority);
-        BackpressureReservation { num_bytes: 0, priority }
+        BackpressureReservation {
+            num_bytes: 0,
+            priority,
+        }
     }
 }
 
@@ -611,7 +613,12 @@ mod tests {
         let (blocker_tx, blocker_rx) = oneshot::channel();
         let blocker = queue
             .clone()
-            .submit(0..10, 0, make_run_fn(0, blocker_rx, start_order.clone()), false)
+            .submit(
+                0..10,
+                0,
+                make_run_fn(0, blocker_rx, start_order.clone()),
+                false,
+            )
             .unwrap();
 
         // Submit four tasks with out-of-order priorities.
@@ -619,25 +626,45 @@ mod tests {
         let (tx_30, rx_30) = oneshot::channel();
         let h30 = queue
             .clone()
-            .submit(0..10, 30, make_run_fn(30, rx_30, start_order.clone()), false)
+            .submit(
+                0..10,
+                30,
+                make_run_fn(30, rx_30, start_order.clone()),
+                false,
+            )
             .unwrap();
 
         let (tx_10, rx_10) = oneshot::channel();
         let h10 = queue
             .clone()
-            .submit(0..10, 10, make_run_fn(10, rx_10, start_order.clone()), false)
+            .submit(
+                0..10,
+                10,
+                make_run_fn(10, rx_10, start_order.clone()),
+                false,
+            )
             .unwrap();
 
         let (tx_50, rx_50) = oneshot::channel();
         let h50 = queue
             .clone()
-            .submit(0..10, 50, make_run_fn(50, rx_50, start_order.clone()), false)
+            .submit(
+                0..10,
+                50,
+                make_run_fn(50, rx_50, start_order.clone()),
+                false,
+            )
             .unwrap();
 
         let (tx_20, rx_20) = oneshot::channel();
         let h20 = queue
             .clone()
-            .submit(0..10, 20, make_run_fn(20, rx_20, start_order.clone()), false)
+            .submit(
+                0..10,
+                20,
+                make_run_fn(20, rx_20, start_order.clone()),
+                false,
+            )
             .unwrap();
 
         // Only the blocker has started so far.

--- a/rust/lance-io/src/scheduler/lite.rs
+++ b/rust/lance-io/src/scheduler/lite.rs
@@ -119,6 +119,8 @@ struct IoTask {
     priority: u128,
     /// The current state of the task
     state: TaskState,
+    /// When true, the task bypasses backpressure and is always scheduled immediately
+    bypass_backpressure: bool,
 }
 
 impl IoTask {
@@ -232,6 +234,9 @@ struct BackpressureReservation {
 trait BackpressureThrottle: Send {
     fn try_acquire(&mut self, num_bytes: u64, priority: u128) -> Option<BackpressureReservation>;
     fn release(&mut self, reservation: BackpressureReservation);
+    /// Unconditionally acquire a zero-cost reservation, tracking only the priority.
+    /// Used for bypass tasks that must never be blocked by backpressure.
+    fn force_acquire(&mut self, priority: u128) -> BackpressureReservation;
 }
 
 // We want to allow requests that have a lower priority than any
@@ -277,6 +282,8 @@ struct SimpleBackpressureThrottle {
     last_warn: AtomicU64,
     bytes_available: i64,
     priorities_in_flight: PrioritiesInFlight,
+    // When true, skip all byte-based backpressure checks (set when max_bytes == 0)
+    no_backpressure: bool,
 }
 
 impl SimpleBackpressureThrottle {
@@ -290,8 +297,10 @@ impl SimpleBackpressureThrottle {
             last_warn: AtomicU64::new(0),
             bytes_available: max_bytes as i64,
             priorities_in_flight: PrioritiesInFlight::new(max_concurrency),
+            no_backpressure: max_bytes == 0,
         }
     }
+
 
     fn warn_if_needed(&self) {
         let seconds_elapsed = self.start.elapsed().as_secs();
@@ -314,7 +323,8 @@ impl SimpleBackpressureThrottle {
 
 impl BackpressureThrottle for SimpleBackpressureThrottle {
     fn try_acquire(&mut self, num_bytes: u64, priority: u128) -> Option<BackpressureReservation> {
-        if self.bytes_available >= num_bytes as i64
+        if self.no_backpressure
+            || self.bytes_available >= num_bytes as i64
             || self.priorities_in_flight.min_in_flight() >= priority
         {
             self.bytes_available -= num_bytes as i64;
@@ -332,6 +342,11 @@ impl BackpressureThrottle for SimpleBackpressureThrottle {
     fn release(&mut self, reservation: BackpressureReservation) {
         self.bytes_available += reservation.num_bytes as i64;
         self.priorities_in_flight.remove(reservation.priority);
+    }
+
+    fn force_acquire(&mut self, priority: u128) -> BackpressureReservation {
+        self.priorities_in_flight.push(priority);
+        BackpressureReservation { num_bytes: 0, priority }
     }
 }
 
@@ -435,10 +450,14 @@ impl IoQueue {
 
     fn push(&self, mut task: IoTask, mut state: MutexGuard<IoQueueState>) -> Result<()> {
         let task_id = task.id;
-        if let Some(reservation) = state
-            .backpressure_throttle
-            .try_acquire(task.num_bytes, task.priority)
-        {
+        let maybe_reservation = if task.bypass_backpressure {
+            Some(state.backpressure_throttle.force_acquire(task.priority))
+        } else {
+            state
+                .backpressure_throttle
+                .try_acquire(task.num_bytes, task.priority)
+        };
+        if let Some(reservation) = maybe_reservation {
             state.handle_result(task.reserve(reservation))?;
             state.handle_result(task.start())?;
             state.tasks.insert(task_id, task);
@@ -459,6 +478,7 @@ impl IoQueue {
         range: Range<u64>,
         priority: u128,
         run_fn: RunFn,
+        bypass_backpressure: bool,
     ) -> Result<TaskHandle> {
         log::trace!(
             "Submitting I/O task with range {:?}, priority {:?}",
@@ -473,6 +493,7 @@ impl IoQueue {
             id: task_id,
             num_bytes: range.end - range.start,
             priority,
+            bypass_backpressure,
             state: TaskState::Initial {
                 idle_waker: None,
                 run_fn,
@@ -590,7 +611,7 @@ mod tests {
         let (blocker_tx, blocker_rx) = oneshot::channel();
         let blocker = queue
             .clone()
-            .submit(0..10, 0, make_run_fn(0, blocker_rx, start_order.clone()))
+            .submit(0..10, 0, make_run_fn(0, blocker_rx, start_order.clone()), false)
             .unwrap();
 
         // Submit four tasks with out-of-order priorities.
@@ -598,25 +619,25 @@ mod tests {
         let (tx_30, rx_30) = oneshot::channel();
         let h30 = queue
             .clone()
-            .submit(0..10, 30, make_run_fn(30, rx_30, start_order.clone()))
+            .submit(0..10, 30, make_run_fn(30, rx_30, start_order.clone()), false)
             .unwrap();
 
         let (tx_10, rx_10) = oneshot::channel();
         let h10 = queue
             .clone()
-            .submit(0..10, 10, make_run_fn(10, rx_10, start_order.clone()))
+            .submit(0..10, 10, make_run_fn(10, rx_10, start_order.clone()), false)
             .unwrap();
 
         let (tx_50, rx_50) = oneshot::channel();
         let h50 = queue
             .clone()
-            .submit(0..10, 50, make_run_fn(50, rx_50, start_order.clone()))
+            .submit(0..10, 50, make_run_fn(50, rx_50, start_order.clone()), false)
             .unwrap();
 
         let (tx_20, rx_20) = oneshot::channel();
         let h20 = queue
             .clone()
-            .submit(0..10, 20, make_run_fn(20, rx_20, start_order.clone()))
+            .submit(0..10, 20, make_run_fn(20, rx_20, start_order.clone()), false)
             .unwrap();
 
         // Only the blocker has started so far.

--- a/rust/lance-io/src/scheduler/lite.rs
+++ b/rust/lance-io/src/scheduler/lite.rs
@@ -695,4 +695,111 @@ mod tests {
         h50.await.unwrap();
         assert_eq!(*start_order.lock().unwrap(), vec![0, 10, 20, 30, 50]);
     }
+
+    #[tokio::test]
+    async fn test_zero_buffer_bypasses_backpressure() {
+        // Budget = 0 sets no_backpressure = true, so all tasks start immediately
+        // regardless of how many bytes are "outstanding".
+        let queue = Arc::new(IoQueue::new(128, 0));
+        let start_order: Arc<Mutex<Vec<u128>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let make_run_fn =
+            |prio: u128, rx: oneshot::Receiver<Bytes>, order: Arc<Mutex<Vec<u128>>>| -> RunFn {
+                Box::new(move || {
+                    order.lock().unwrap().push(prio);
+                    Box::pin(async move { Ok(rx.await.unwrap()) })
+                })
+            };
+
+        let (tx0, rx0) = oneshot::channel();
+        let h0 = queue
+            .clone()
+            .submit(0..10, 0, make_run_fn(0, rx0, start_order.clone()), false)
+            .unwrap();
+        let (tx1, rx1) = oneshot::channel();
+        let h1 = queue
+            .clone()
+            .submit(0..10, 1, make_run_fn(1, rx1, start_order.clone()), false)
+            .unwrap();
+        let (tx2, rx2) = oneshot::channel();
+        let h2 = queue
+            .clone()
+            .submit(0..10, 2, make_run_fn(2, rx2, start_order.clone()), false)
+            .unwrap();
+
+        // All three tasks start immediately — no backpressure budget check when max_bytes=0.
+        assert_eq!(*start_order.lock().unwrap(), vec![0, 1, 2]);
+
+        tx0.send(Bytes::from_static(b"done")).unwrap();
+        tx1.send(Bytes::from_static(b"done")).unwrap();
+        tx2.send(Bytes::from_static(b"done")).unwrap();
+        h0.await.unwrap();
+        h1.await.unwrap();
+        h2.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bypass_flag_proceeds_past_exhausted_budget() {
+        // Budget of 10 bytes. A blocker task fills it. A task with bypass=true starts
+        // immediately despite the exhausted budget; a normal task stays queued.
+        let queue = Arc::new(IoQueue::new(128, 10));
+        let start_order: Arc<Mutex<Vec<u128>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let make_run_fn =
+            |prio: u128, rx: oneshot::Receiver<Bytes>, order: Arc<Mutex<Vec<u128>>>| -> RunFn {
+                Box::new(move || {
+                    order.lock().unwrap().push(prio);
+                    Box::pin(async move { Ok(rx.await.unwrap()) })
+                })
+            };
+
+        // Blocker (priority 0, 10 bytes): fills the budget.
+        let (blocker_tx, blocker_rx) = oneshot::channel();
+        let blocker = queue
+            .clone()
+            .submit(
+                0..10,
+                0,
+                make_run_fn(0, blocker_rx, start_order.clone()),
+                false,
+            )
+            .unwrap();
+
+        // Normal (priority 1, 10 bytes): blocked — budget exhausted, no priority bypass.
+        let (normal_tx, normal_rx) = oneshot::channel();
+        let normal = queue
+            .clone()
+            .submit(
+                0..10,
+                1,
+                make_run_fn(1, normal_rx, start_order.clone()),
+                false,
+            )
+            .unwrap();
+
+        // Bypass (priority 2, 10 bytes): starts immediately via force_acquire.
+        let (bypass_tx, bypass_rx) = oneshot::channel();
+        let bypass = queue
+            .clone()
+            .submit(
+                0..10,
+                2,
+                make_run_fn(2, bypass_rx, start_order.clone()),
+                true,
+            )
+            .unwrap();
+
+        // Blocker (0) and bypass (2) have started; normal (1) is still queued.
+        assert_eq!(*start_order.lock().unwrap(), vec![0, 2]);
+
+        // Completing the blocker frees the budget and unblocks the normal task.
+        blocker_tx.send(Bytes::from_static(b"done")).unwrap();
+        blocker.await.unwrap();
+        assert_eq!(*start_order.lock().unwrap(), vec![0, 2, 1]);
+
+        bypass_tx.send(Bytes::from_static(b"done")).unwrap();
+        bypass.await.unwrap();
+        normal_tx.send(Bytes::from_static(b"done")).unwrap();
+        normal.await.unwrap();
+    }
 }

--- a/rust/lance-io/src/scheduler/lite.rs
+++ b/rust/lance-io/src/scheduler/lite.rs
@@ -119,7 +119,7 @@ struct IoTask {
     priority: u128,
     /// The current state of the task
     state: TaskState,
-    /// When true, the task bypasses backpressure and is always scheduled immediately
+    /// When true, the task bypasses backpressure
     bypass_backpressure: bool,
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
- When `SchedulerConfig` is created with `io_buffer_size_bytes = 0`, the byte-based backpressure system is disabled entirely — all I/O proceeds without waiting for budget. Previously a    
zero buffer size would deadlock (every read exceeds a zero budget).                                                                                                                         
- New env var `LANCE_BYPASS_INDIRECT_IO_BACKPRESSURE`: when set, indirect I/O in the **2.0 list scheduler** (`indirect_schedule_task` — items fetched after decoding offsets) bypasses the  
backpressure budget. This is surfaced via a new `EncodingsIo::with_bypass_backpressure()` method implemented by `LanceEncodingsIo`.                                                         
                                                                                                                                                                                              
Both the standard and lite schedulers are updated consistently. The IOPS concurrency limit is unaffected; only the byte-budget gate is bypassed.                                            
                                                                                                                                                                                              
## Changed files                                                                                                                                                                            
                                                                                                                                                                                              
| File | Change |                                                                                                                                                                           
|------|--------|                                                                                                                                                                           
| `rust/lance-io/src/scheduler.rs` | `no_backpressure` on `IoQueueState`; `bypass_backpressure` on `IoTask`/`MutableBatch`; `FileScheduler::with_bypass_backpressure()` |                   
| `rust/lance-io/src/scheduler/lite.rs` | `no_backpressure` on `SimpleBackpressureThrottle`; `force_acquire` on `BackpressureThrottle` trait; `bypass_backpressure` on lite `IoTask` |      
| `rust/lance-encoding/src/lib.rs` | `EncodingsIo::with_bypass_backpressure()` default method |                                                                                             
| `rust/lance-file/src/io.rs` | `LanceEncodingsIo` override of `with_bypass_backpressure()` |                                                                                               
| `rust/lance-encoding/src/previous/encodings/logical/list.rs` | `LANCE_BYPASS_INDIRECT_IO_BACKPRESSURE` env var + bypass io wrapping in indirect schedule |                                
                                                                                                                                                                                              
## Test plan                                                                                                                                                                                
                                                                                                                                                                                              
- [ ] `cargo test -p lance-io --lib` — 155 tests pass (io_uring tests excluded, require kernel support)                                                                                     
- [ ] `cargo test -p lance-encoding --lib` — 369 tests pass                                                                                                                                 
- [ ] `cargo check --workspace --tests` — clean