### PR TITLE
perf: avoid O(N^2) version-metadata scan during Update with stable row IDs

### DIFF
--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -1723,6 +1723,14 @@ impl Transaction {
                     let original_frags_map: std::collections::HashMap<u64, &Fragment> =
                         existing_fragments.iter().map(|f| (f.id, f)).collect();
 
+                    // Cache decoded created_at version sequences per original fragment, so we
+                    // only deserialize and walk runs once per source fragment instead of once
+                    // per row (the latter was O(N^2) on Update with stable row IDs).
+                    let mut created_at_seq_cache: std::collections::HashMap<
+                        u64,
+                        Option<lance_table::format::RowDatasetVersionSequence>,
+                    > = std::collections::HashMap::new();
+
                     for fragment in new_fragments.iter_mut() {
                         // For update operations with RewriteRows mode:
                         // - Rows are deleted from old fragments and rewritten to new fragments
@@ -1753,23 +1761,17 @@ impl Transaction {
 
                                 // Look up the original fragment
                                 if let Some(orig_frag) = original_frags_map.get(&orig_frag_id) {
-                                    // Get created_at version from original fragment's metadata
-                                    let created_version = if let Some(created_meta) =
-                                        &orig_frag.created_at_version_meta
-                                    {
-                                        // Load and index into the version sequence
-                                        match created_meta.load_sequence() {
-                                            Ok(seq) => {
-                                                let versions: Vec<u64> = seq.versions().collect();
-                                                versions.get(row_offset).copied().unwrap_or(1)
-                                            }
-                                            Err(_e) => {
-                                                1 // Default to version 1 on error
-                                            }
-                                        }
-                                    } else {
-                                        // No metadata on original fragment, default to version 1
-                                        1
+                                    let cached_seq = created_at_seq_cache
+                                        .entry(orig_frag_id)
+                                        .or_insert_with(|| {
+                                            orig_frag
+                                                .created_at_version_meta
+                                                .as_ref()
+                                                .and_then(|m| m.load_sequence().ok())
+                                        });
+                                    let created_version = match cached_seq {
+                                        Some(seq) => seq.version_at(row_offset).unwrap_or(1),
+                                        None => 1,
                                     };
                                     created_at_versions.push(created_version);
                                 } else {


### PR DESCRIPTION
## Summary

`dataset.update()` on a dataset created with `enable_stable_row_ids=True` was hundreds of times slower than without stable row IDs, scaling roughly linearly with the number of affected rows. Fixes #6404.

The bottleneck is in `Transaction::build_manifest` for `Operation::Update`. For every row in every new fragment, it was:

1. calling `orig_frag.created_at_version_meta.load_sequence()` (deserializes the version run-list), and
2. materializing the entire source fragment's version sequence with `seq.versions().collect::<Vec<u64>>()` just to index into it by `row_offset`.

Both are O(M) in the source fragment's row count, so the loop is O(N × M) — quadratic when the rewritten rows came from a single large fragment.

## Fix

- Hoist the `load_sequence()` call out of the per-row loop: cache the decoded `RowDatasetVersionSequence` in a `HashMap<u64, Option<RowDatasetVersionSequence>>` keyed by the original fragment ID, decoding once per source fragment.
- Replace `versions().collect::<Vec<u64>>()[idx]` with the existing `version_at(idx)` accessor, which walks the run list directly without materializing a `Vec<u64>` per row.

Semantics are unchanged: same fallback to version 1 when metadata is missing or fails to deserialize. The cache uses negligible memory (one entry per source fragment, each holding a small `Vec<RowDatasetVersionRun>`); the old code allocated and freed an N-sized `Vec<u64>` *per row*, so memory usage actually drops.

## Benchmarks

Repro from #6404 (single-fragment dataset, updating 10% of rows):

| N         | before   | after    |
|-----------|---------:|---------:|
| 100,000   |   1.18s  | 0.003s   |
| 200,000   |   4.87s  | 0.004s   |
| 500,000   |  33.0s   | 0.007s   |
| 1,000,000 | 138s     | 0.011s   |

Update with `enable_stable_row_ids=True` is now in the same ballpark as without (which was already ~3ms for 1M).

## Test plan

- [x] Existing update / stable-row-id tests still pass (`test_update_all`, `test_update_conditional`, `test_row_ids_stable_after_update`, `test_row_ids_stable_after_update_odd_id`, `test_stable_row_id_after_deletion_update_and_compaction`, `test_row_ids_update`, `test_update_affects_index_fragment_bitmap`, `test_update_mixed_indexed_unindexed_fragments` — all green).
- [x] Repro from #6404 verified: 1M-row update with stable row IDs drops from ~138s to ~11ms.