### PR TITLE
fix: drop stale has_all_zeros guard so block bitpack engages on rep/def

### DIFF
--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -302,13 +302,12 @@ fn try_bitpack_for_block(
 
     let bit_widths = data.expect_stat(Stat::BitWidth);
     let widths = bit_widths.as_primitive::<UInt64Type>();
-    let has_all_zeros = widths.values().contains(&0);
     let max_bit_width = *widths.values().iter().max().unwrap();
 
     let too_small =
         widths.len() == 1 && InlineBitpacking::min_size_bytes(widths.value(0)) >= data.data_size();
 
-    if has_all_zeros || too_small {
+    if too_small {
         return None;
     }
 
@@ -1261,6 +1260,34 @@ mod tests {
         let compressor = strategy.create_miniblock_compressor(&field, &data).unwrap();
         // Should use RLE due to very low threshold
         assert!(format!("{:?}", compressor).contains("RleEncoder"));
+    }
+
+    // Regression for #6626: an all-zero stat segment (e.g. rep/def for a long
+    // run of empty lists) used to disable block bitpacking entirely.
+    #[test]
+    #[cfg(feature = "bitpacking")]
+    fn test_block_bitpacks_with_zero_segment() {
+        let strategy = DefaultCompressionStrategy::new();
+        let field = create_test_field("levels", DataType::UInt16);
+
+        // First 1024 zeros, then 1024 ones; max bit width is 1.
+        let mut values: Vec<u16> = vec![0; 1024];
+        values.extend(std::iter::repeat_n(1u16, 1024));
+        let mut block = FixedWidthDataBlock {
+            bits_per_value: 16,
+            data: LanceBuffer::reinterpret_vec(values),
+            num_values: 2048,
+            block_info: BlockInfo::default(),
+        };
+        block.compute_stat();
+        let data = DataBlock::FixedWidth(block);
+
+        let (compressor, _encoding) = strategy.create_block_compressor(&field, &data).unwrap();
+        let debug_str = format!("{:?}", compressor);
+        assert!(
+            debug_str.contains("OutOfLineBitpacking"),
+            "expected OutOfLineBitpacking, got: {debug_str}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`write_dataset` panics on v2.1 (the current default) when a list column has a single very long row of incompressible primitives surrounded by empty lists. Fixes #6626.

The repro from the issue:

```python
import random, lance, pyarrow as pa
rng = random.Random(0)
rows = [[] for _ in range(50_000)]
rows[25_000] = [rng.getrandbits(64) for _ in range(50_000)]
table = pa.table({"ids": pa.array(rows, type=pa.list_(pa.uint64()))})
lance.write_dataset(table, "/tmp/repro.lance", data_storage_version="2.1")
```

surfaces as

```
thread 'lance-cpu' panicked at .../primitive.rs:3973:13:
assertion failed: chunk_bytes <= max_chunk_size
```

(or the sibling `Definition buffer size (NN bytes) too large` error at the same call site, depending on the data shape).

## Root cause

In this shape both rep and def levels contain a long run of zeros for the empty-list rows. `try_bitpack_for_block` rejects any buffer whose 1024-element bit-width statistic segments contain a 0, falling through to identity (raw u16) for both rep and def. The level slicer then dumps the entire run of "invisible" levels into the chunk that brackets the next visible value, blowing the per-chunk 32KiB ceiling.

A debug print in `serialize_miniblocks` confirms this:

```
[mb-overflow] chunk_bytes=106152 max=32768 log_nv=9 buf_sizes=[4096] rep_data=51024 def_data=51024 rep_levels=25512 def_levels=25512
```

(25,512 levels × 16 bits × two buffers ≈ 100 KiB just for rep+def.)

## History of `has_all_zeros`

- #3102: original report that bitpacking panics on chunks with width 0 ("Unsupported width: 0" inside fastlanes).
- #4537 added `try_bitpack_for_block` (and its sibling `try_bitpack_for_mini_block`), each guarded by `has_all_zeros` to dodge that panic.
- #4694 fixed the underlying fastlanes pack/unpack so that `width == 0` is now valid — pack writes nothing, unpack fills zeros — and removed the guard from the miniblock path. The block path was missed at that time.

## Fix

Drop the `has_all_zeros` short-circuit from `try_bitpack_for_block` so the block path matches the miniblock path (and matches what fastlanes already supports). The block bitpacker then compresses these buffers at 1 bit per value instead of 16, keeping each chunk well under the budget without changing the encoding-selection logic.

The change is intentionally minimal: I am not relaxing or expanding any of the other gates (`too_small`, `bits in {8, 16, 32, 64}`, etc.).

## Tests

- New unit test `test_block_bitpacks_with_zero_segment` confirms that a u16 buffer whose first 1024-element stat segment is all-zero now picks `OutOfLineBitpacking` from `create_block_compressor`. This mirrors the test pattern used by #4694 for the miniblock path.
- The repro from #6626 succeeds end-to-end at v2.0/2.1/2.2 (verified with a small `cargo run --example`).
- Existing list / bitpacking tests still pass (370/370), including `test_sparse_large_string_list` from #6234 and `test_miniblock_bitpack_zero_chunk_selection` from #4694.