### PR TITLE
fix(java-jni): make dispatcher thread a daemon to allow jvm to exit

### DIFF
--- a/java/lance-jni/src/dispatcher.rs
+++ b/java/lance-jni/src/dispatcher.rs
@@ -31,9 +31,11 @@ impl Dispatcher {
         std::thread::Builder::new()
             .name("lance-jni-dispatcher".to_string())
             .spawn(move || {
-                // Attach ONCE and never detach - this is the key optimization
+                // Attach as daemon thread so it won't prevent JVM from exiting.
+                // The thread stays attached for the entire lifetime (never detach),
+                // but being a daemon thread means JVM won't wait for it on shutdown.
                 let mut env = jvm
-                    .attach_current_thread_permanently()
+                    .attach_current_thread_as_daemon()
                     .expect("Failed to attach dispatcher to JVM");
 
                 log::info!("JNI dispatcher thread started");


### PR DESCRIPTION
The JNI dispatcher thread was attached via `attach_current_thread_permanently`, which registers it as a non-daemon JVM thread. This prevented the JVM from exiting naturally on shutdown because it waits for all non-daemon threads to finish, but the dispatcher loop only ends when its channel is dropped. Switching to `attach_current_thread_as_daemon` keeps the thread attached for its whole lifetime while allowing the JVM to terminate without waiting on it.

## Behavior

- Dispatcher functionality (receiving messages, invoking JNI callbacks)
  is unchanged — `attach_current_thread_as_daemon` produces a fully
  functional `JNIEnv`.
- On JVM exit, any in-flight callback on the dispatcher may be
  interrupted, but at that point there is no Java-side consumer left to
  observe the result.
- `GlobalRef`s still held in the channel at shutdown are not explicitly
  dropped, but the JVM reclaims all Java objects on process exit anyway.

## Why not a full shutdown mechanism?

A more thorough solution would either:

1. implement `JNI_OnUnload` to drop the global `DISPATCHER` / `RT`, or
2. expose a `shutdown()` on `Dispatcher` and call it from Java `close()`.

Both are more invasive and require handling reference counting across
multiple namespace instances that share the same dispatcher. Since
daemon semantics already resolve the user-visible hang with a one-line
change, this PR stays minimal and leaves a proper lifecycle API for a
follow-up.

## Testing

- Reproduced the hang on `main` with the Java snippet above; verified
  with `jstack` that `lance-jni-dispatcher` was the only remaining
  non-daemon thread.
- After applying this patch (rebuilt `liblance_jni`), the same program
  exits cleanly without `System.exit(0)`.
- Ran existing `java/` unit tests — no regressions observed.

## Risks

Low. The change is a single JNI API swap with equivalent semantics
except for the daemon flag. No public API, no behavior change during
normal operation, only shutdown behavior is affected.
