### PR TITLE
ci: mark cargo.lock as linguist generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 notebooks/** linguist-vendored
+Cargo.lock linguist-generated
+**/Cargo.lock linguist-generated


### PR DESCRIPTION
This will cause the `Cargo.lock` files to be collapsed by default in github diffs.