### PR TITLE
fix(core): map DataFusion SchemaError to InvalidInput

### DIFF
--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -602,10 +602,10 @@ impl From<datafusion_common::DataFusionError> for Error {
         match e {
             datafusion_common::DataFusionError::SQL(..)
             | datafusion_common::DataFusionError::Plan(..)
-            | datafusion_common::DataFusionError::Configuration(..) => {
+            | datafusion_common::DataFusionError::Configuration(..)
+            | datafusion_common::DataFusionError::SchemaError(..) => {
                 Self::invalid_input_source(box_error(e))
             }
-            datafusion_common::DataFusionError::SchemaError(..) => Self::schema(e.to_string()),
             datafusion_common::DataFusionError::ArrowError(arrow_err, _) => Self::from(*arrow_err),
             datafusion_common::DataFusionError::NotImplemented(..) => {
                 Self::not_supported_source(box_error(e))
@@ -796,6 +796,34 @@ mod test {
                 assert_eq!(recovered.code, 999);
             }
             _ => panic!("Expected ExternalError variant"),
+        }
+    }
+
+    #[cfg(feature = "datafusion")]
+    #[test]
+    fn test_datafusion_schema_error_is_invalid_input() {
+        // Schema errors from DataFusion (e.g., a filter referencing an unknown
+        // column) are user-input failures, not internal lance failures. They
+        // must surface as `Error::InvalidInput` so downstream FFI/Python
+        // bindings can map them to the right user-facing error code.
+        use datafusion_common::Column;
+
+        let schema_err = datafusion_common::SchemaError::FieldNotFound {
+            field: Box::new(Column::from_name("missing_col")),
+            valid_fields: vec![],
+        };
+        let df_err =
+            datafusion_common::DataFusionError::SchemaError(Box::new(schema_err), Box::new(None));
+        let lance_err: Error = df_err.into();
+
+        match lance_err {
+            Error::InvalidInput { .. } => {
+                assert!(
+                    lance_err.to_string().contains("missing_col"),
+                    "expected the column name to survive in the error message, got: {lance_err}"
+                );
+            }
+            _ => panic!("Expected InvalidInput variant, got {:?}", lance_err),
         }
     }
 


### PR DESCRIPTION
## Summary

Schema errors from DataFusion (e.g. a filter referencing an unknown column, a projection naming a missing field) are user-input failures, not internal lance failures. Today they're mapped to `Error::Schema`, which makes downstream consumers that pattern-match on `Error::InvalidInput` for user-facing error classification report them as "internal."

This PR moves `DataFusionError::SchemaError` into the same bucket as `SQL`/`Plan`/`Configuration`, all of which already route to `Error::InvalidInput`. Behaviorally these are the same kind of error — bad input from the caller — and they should classify the same way.

## Concrete impact

The C/C++ FFI binding ([`lance-format/lance-c`](https://github.com/lance-format/lance-c)) maps `Error::Schema` to its `Internal` error code (catch-all), so a caller doing:

```c
lance_dataset_delete(ds, "no_such_column = 1", NULL);
```

sees `LANCE_ERR_INTERNAL` instead of `LANCE_ERR_INVALID_ARGUMENT`. Any binding doing the same kind of variant-based mapping (Python, Java, …) hits the same problem. lance-c [#31](https://github.com/lance-format/lance-c/pull/31) currently asserts the wrong code in its tests as a workaround — once this lands, that PR can flip its assertions to `InvalidArgument` and the wart goes away.

The path that produces this is straightforward: `Scanner::filter` parses the SQL via `Planner::parse_filter` → `filter.to_field(&df_schema)?` → DataFusion returns `DataFusionError::SchemaError` for unknown fields → today, `Error::Schema { .. }`. With this fix → `Error::InvalidInput { .. }`, with the column name preserved in the boxed source.

## Risk

Any code that pattern-matches on `Error::Schema` to handle DataFusion-derived schema errors will no longer match.

A grep across `rust/lance`, `rust/lance-index`, and `rust/lance-datafusion` finds two such matches, both in `lance-index/src/scalar/inverted/index.rs` (lines 1862, 1878). Both are fed by **`lance-io`'s** internal `Error::schema(...)` calls (not by the DataFusion conversion), and continue to behave unchanged.

External consumers (Python bindings, Java bindings, lance-c) that classify `Error::Schema` as "internal" today will start classifying these errors as "invalid input" — which is the desired direction.

## Test plan

Adds a unit test (`test_datafusion_schema_error_is_invalid_input`) that constructs a `DataFusionError::SchemaError(SchemaError::FieldNotFound { ... })` directly and asserts:

1. The converted `Error` is `InvalidInput`.
2. The offending column name (`"missing_col"`) is preserved in the displayed error message.

```
$ cargo test -p lance-core --features datafusion test_datafusion_schema_error_is_invalid_input
test error::test::test_datafusion_schema_error_is_invalid_input ... ok
test result: ok. 1 passed; 0 failed
```

`cargo fmt -p lance-core --check` clean.