### PR TITLE
perf: cache per-fragment reader templates

### DIFF
--- a/rust/lance-file/src/io.rs
+++ b/rust/lance-file/src/io.rs
@@ -9,6 +9,37 @@ use lance_io::scheduler::FileScheduler;
 
 use super::reader::DEFAULT_READ_CHUNK_SIZE;
 
+/// A placeholder [`EncodingsIo`] used by cached / unbound [`crate::reader::FileReader`]
+/// instances.
+///
+/// A `FileReader` opened via [`crate::reader::FileReader::try_open_unbound_with_file_metadata`]
+/// holds this sentinel in its scheduler slot. The caller MUST call
+/// [`crate::reader::FileReader::with_scheduler`] to bind a real scheduler before
+/// performing any reads — invoking I/O against the sentinel panics.
+///
+/// This exists to let callers cache an immutable, fully-projected `FileReader`
+/// across requests without baking in per-request object stores or open file
+/// handles. Each request rebinds the cached reader to its own scheduler.
+#[derive(Debug)]
+pub struct SentinelEncodingsIo;
+
+impl EncodingsIo for SentinelEncodingsIo {
+    fn with_bypass_backpressure(&self) -> Option<Arc<dyn EncodingsIo>> {
+        None
+    }
+
+    fn submit_request(
+        &self,
+        _ranges: Vec<std::ops::Range<u64>>,
+        _priority: u64,
+    ) -> BoxFuture<'static, lance_core::Result<Vec<bytes::Bytes>>> {
+        panic!(
+            "SentinelEncodingsIo::submit_request called — this FileReader was opened \
+             without a scheduler; bind one with FileReader::with_scheduler before reading"
+        );
+    }
+}
+
 #[derive(Debug)]
 pub struct LanceEncodingsIo {
     scheduler: FileScheduler,

--- a/rust/lance-file/src/lib.rs
+++ b/rust/lance-file/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub mod datatypes;
 pub mod format;
-pub(crate) mod io;
+pub mod io;
 pub mod reader;
 pub mod testing;
 pub mod version;
@@ -13,7 +13,7 @@ pub mod writer;
 #[cfg(test)]
 mod compatibility_tests;
 
-pub use io::LanceEncodingsIo;
+pub use io::{LanceEncodingsIo, SentinelEncodingsIo};
 
 use format::MAGIC;
 use lance_core::{Error, Result};

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -46,7 +46,7 @@ use lance_io::{
 use crate::{
     datatypes::{Fields, FieldsWithMeta},
     format::{MAGIC, MAJOR_VERSION, MINOR_VERSION, pb, pbfile},
-    io::LanceEncodingsIo,
+    io::{LanceEncodingsIo, SentinelEncodingsIo},
     version::ConcreteFileVersion,
     writer::PAGE_BUFFER_ALIGNMENT,
 };
@@ -509,6 +509,32 @@ pub struct FileReader {
     core: FileReadCore,
     metadata: Arc<CachedFileMetadata>,
 }
+
+impl DeepSizeOf for FileReader {
+    fn deep_size_of_children(&self, ctx: &mut Context) -> usize {
+        // Only count the metadata, which is the bulk of the reader's
+        // footprint and has DeepSizeOf. The other Arcs we hold are either
+        // back-references that would cause us to over-count (the `cache`
+        // points back into the very LanceCache we may be inserted into,
+        // which would inflate our reported size with the entire cache and
+        // recursively grow as more entries are inserted) or types without a
+        // DeepSizeOf impl (`scheduler`, `decoder_plugins`, `options`).
+        self.metadata.deep_size_of_children(ctx)
+    }
+}
+
+impl DeepSizeOf for ProjectedFileReader {
+    fn deep_size_of_children(&self, ctx: &mut Context) -> usize {
+        // Same rationale as FileReader: only count the metadata. For Indexed
+        // providers, FileMetadataIndex does not implement DeepSizeOf so we
+        // conservatively report 0 for that variant.
+        match &self.core.metadata_provider {
+            FileMetadataProvider::Full(metadata) => metadata.deep_size_of_children(ctx),
+            FileMetadataProvider::Indexed(_) => 0,
+        }
+    }
+}
+
 #[derive(Debug)]
 struct Footer {
     #[allow(dead_code)]
@@ -689,6 +715,18 @@ impl FileReader {
         match self.core.scheduler.with_io_stats(stats) {
             Some(scheduler) => self.with_scheduler(scheduler),
             None => self.clone(),
+        }
+    }
+
+    /// Return a clone of this reader with a different [`FileReaderOptions`].
+    ///
+    /// Used when a reader is cached with the dataset's default options but a
+    /// specific read needs to override them (e.g. a per-scan decoder config or
+    /// batch size).
+    pub fn with_options(&self, options: FileReaderOptions) -> Self {
+        Self {
+            core: self.core.with_options(options),
+            metadata: self.metadata.clone(),
         }
     }
 
@@ -1398,6 +1436,39 @@ impl FileReader {
         let cache = Arc::new(cache.with_key_prefix(path.as_ref()));
         let core = FileReadCore::try_new(
             scheduler,
+            base_projection,
+            decoder_plugins,
+            FileMetadataProvider::Full(file_metadata.clone()),
+            cache,
+            options,
+        )?;
+        Ok(Self {
+            core,
+            metadata: file_metadata,
+        })
+    }
+
+    /// Build a [`FileReader`] without binding it to a real I/O scheduler.
+    ///
+    /// The returned reader holds a [`SentinelEncodingsIo`] in its scheduler
+    /// slot, so it cannot serve reads as-is — the caller MUST call
+    /// [`FileReader::with_scheduler`] to bind a real scheduler before any
+    /// read. Calling a read against the sentinel panics.
+    ///
+    /// This exists so that callers can cache a fully-projected, validated
+    /// `FileReader` across requests without the cache holding object stores
+    /// or open file handles.
+    pub fn try_open_unbound_with_file_metadata(
+        path: Path,
+        base_projection: Option<ReaderProjection>,
+        decoder_plugins: Arc<DecoderPlugins>,
+        file_metadata: Arc<CachedFileMetadata>,
+        cache: &LanceCache,
+        options: FileReaderOptions,
+    ) -> Result<Self> {
+        let cache = Arc::new(cache.with_key_prefix(path.as_ref()));
+        let core = FileReadCore::try_new(
+            Arc::new(SentinelEncodingsIo),
             base_projection,
             decoder_plugins,
             FileMetadataProvider::Full(file_metadata.clone()),
@@ -2155,6 +2226,17 @@ impl FileReadCore {
         }
     }
 
+    fn with_options(&self, options: FileReaderOptions) -> Self {
+        Self {
+            scheduler: self.scheduler.clone(),
+            base_projection: self.base_projection.clone(),
+            metadata_provider: self.metadata_provider.clone(),
+            decoder_plugins: self.decoder_plugins.clone(),
+            cache: self.cache.clone(),
+            options,
+        }
+    }
+
     fn version(&self) -> LanceFileVersion {
         self.metadata_provider.version()
     }
@@ -2512,6 +2594,13 @@ impl ProjectedFileReader {
     pub fn with_scheduler(&self, scheduler: Arc<dyn EncodingsIo>) -> Self {
         Self {
             core: self.core.with_scheduler(scheduler),
+        }
+    }
+
+    /// Returns a clone of this reader with different [`FileReaderOptions`].
+    pub fn with_options(&self, options: FileReaderOptions) -> Self {
+        Self {
+            core: self.core.with_options(options),
         }
     }
 

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -732,6 +732,21 @@ enum MetadataMode {
     Full,
 }
 
+/// Returns true when `LANCE_CACHE_FRAGMENT_READERS` is set to any non-empty value.
+///
+/// When enabled, [`FileFragment::open`] caches a projection-independent
+/// [`FragmentReaderTemplate`] per (manifest_version, fragment_id) so that
+/// repeated opens of the same fragment skip per-file metadata work.  The
+/// trade-off is that the first open always reads metadata for every data file
+/// regardless of the projection, which defeats the lazy column-metadata
+/// optimisation.  The default is therefore **disabled**; set the variable to
+/// opt in.
+fn is_fragment_reader_cache_enabled() -> bool {
+    std::env::var("LANCE_CACHE_FRAGMENT_READERS")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
 impl FileFragment {
     /// Creates a new FileFragment.
     pub fn new(dataset: Arc<Dataset>, metadata: Fragment) -> Self {
@@ -917,43 +932,163 @@ impl FileFragment {
         projection: &Schema,
         read_config: FragReadConfig,
     ) -> Result<FragmentReader> {
-        // For each v2 data file, open a `FileScheduler` once. We use the same
-        // scheduler for both populating the cache (on miss) and binding the
-        // cached reader (always), so the IO cost matches the pre-cache path.
-        // v1 data files are not cached and re-opened inside the legacy path.
-        let mut v2_schedulers: Vec<Option<(FileScheduler, u32)>> =
-            Vec::with_capacity(self.metadata.files.len());
-        for data_file in &self.metadata.files {
-            if data_file.is_legacy_file() {
-                v2_schedulers.push(None);
-                continue;
+        // Fast path: if no data file contributes to the projection, skip
+        // scheduler setup and the template cache entirely.  Deletion vectors
+        // and row counts come from the manifest and require no file IO on
+        // modern datasets.
+        let full_schema = self.dataset.schema();
+        let any_file_needed = self.metadata.files.iter().any(|data_file| {
+            let file_schema = data_file.schema(full_schema);
+            projection
+                .intersection_ignore_types(&file_schema)
+                .map(|s| !s.fields.is_empty())
+                .unwrap_or(true) // on error, fall through to the main path
+        });
+
+        if !any_file_needed {
+            if !read_config.has_system_cols() {
+                return Err(Error::not_found(format!(
+                    "No data files found for schema: {}, fragment_id={}",
+                    projection,
+                    self.id()
+                )));
             }
-            let path = self
-                .dataset
-                .data_file_dir(data_file)?
-                .join(data_file.path.as_str());
-            let (store_scheduler, reader_priority) = self
-                .resolve_store_scheduler(data_file, &read_config)
-                .await?;
-            let file_scheduler = store_scheduler
-                .open_file_with_priority(&path, reader_priority as u64, &data_file.file_size_bytes)
-                .await?;
-            v2_schedulers.push(Some((file_scheduler, reader_priority)));
+            let deletion_vec_load = self.get_deletion_vector();
+            let row_id_load = if self.dataset.manifest.uses_stable_row_ids() {
+                futures::future::Either::Left(
+                    load_row_id_sequence(&self.dataset, &self.metadata).map_ok(Some),
+                )
+            } else {
+                futures::future::Either::Right(futures::future::ready(Ok(None)))
+            };
+            let physical_rows_load = self.physical_rows();
+            let (deletion_vec, row_id_sequence, num_physical_rows) =
+                join!(deletion_vec_load, row_id_load, physical_rows_load);
+            let deletion_vec = deletion_vec?;
+            let row_id_sequence = row_id_sequence?;
+            let num_physical_rows = num_physical_rows?;
+            let num_deleted = deletion_vec.as_ref().map(|dv| dv.len()).unwrap_or(0);
+            let num_rows = num_physical_rows - num_deleted;
+
+            let mut reader = FragmentReader::try_new(
+                self.id(),
+                deletion_vec,
+                row_id_sequence,
+                vec![],
+                ArrowSchema::from(projection),
+                num_rows,
+                num_physical_rows,
+                Arc::new(self.metadata.clone()),
+            )?;
+
+            if !self.metadata.overlays.is_empty() {
+                let planner = plan_overlays(self, projection)?;
+                if !planner.is_empty() {
+                    reader.overlay = Some(OverlayReadState {
+                        planner: Arc::new(planner),
+                        fragment: Arc::new(self.clone()),
+                        read_config: Arc::new(read_config.clone()),
+                    });
+                }
+            }
+
+            if read_config.with_row_id {
+                reader.with_row_id();
+            }
+            if read_config.with_row_address {
+                reader.with_row_address();
+            }
+            if read_config.with_row_last_updated_at_version {
+                reader.with_row_last_updated_at_version();
+            }
+            if read_config.with_row_created_at_version {
+                reader.with_row_created_at_version();
+            }
+
+            return Ok(reader);
         }
 
-        let key = crate::session::caches::FragmentReaderTemplateKey {
-            manifest_version: self.dataset.manifest.version,
-            fragment_id: self.id() as u64,
-        };
-        let template = self
-            .dataset
-            .metadata_cache
-            .get_or_insert_with_key(key, || self.load_fragment_reader_template(&v2_schedulers))
-            .await?;
+        let (opened_files, deletion_vec, row_id_sequence, num_rows, num_physical_rows) =
+            if is_fragment_reader_cache_enabled() {
+                // Caching path: open a FileScheduler for every v2 data file once,
+                // then get-or-build a projection-independent FragmentReaderTemplate.
+                // Subsequent opens of the same fragment reuse the template and skip
+                // all per-file metadata work.
+                let mut v2_schedulers: Vec<Option<(FileScheduler, u32)>> =
+                    Vec::with_capacity(self.metadata.files.len());
+                for data_file in &self.metadata.files {
+                    if data_file.is_legacy_file() {
+                        v2_schedulers.push(None);
+                        continue;
+                    }
+                    let path = self
+                        .dataset
+                        .data_file_dir(data_file)?
+                        .join(data_file.path.as_str());
+                    let (store_scheduler, reader_priority) = self
+                        .resolve_store_scheduler(data_file, &read_config)
+                        .await?;
+                    let file_scheduler = store_scheduler
+                        .open_file_with_priority(
+                            &path,
+                            reader_priority as u64,
+                            &data_file.file_size_bytes,
+                        )
+                        .await?;
+                    v2_schedulers.push(Some((file_scheduler, reader_priority)));
+                }
 
-        let opened_files = self
-            .bind_readers(&template, &v2_schedulers, projection, &read_config)
-            .await?;
+                let key = crate::session::caches::FragmentReaderTemplateKey {
+                    manifest_version: self.dataset.manifest.version,
+                    fragment_id: self.id() as u64,
+                };
+                let template = self
+                    .dataset
+                    .metadata_cache
+                    .get_or_insert_with_key(key, || {
+                        self.load_fragment_reader_template(&v2_schedulers)
+                    })
+                    .await?;
+
+                let opened_files = self
+                    .bind_readers(&template, &v2_schedulers, projection, &read_config)
+                    .await?;
+
+                (
+                    opened_files,
+                    template.deletion_vec.clone(),
+                    template.row_id_sequence.clone(),
+                    template.num_rows,
+                    template.num_physical_rows,
+                )
+            } else {
+                // Legacy uncached path: open only the data files that overlap the
+                // projection (preserving lazy column-metadata behaviour), and
+                // derive row counts directly from the manifest.
+                let open_files = self.open_readers(projection, &read_config);
+                let deletion_vec_load = self.get_deletion_vector();
+                let row_id_load = if self.dataset.manifest.uses_stable_row_ids() {
+                    futures::future::Either::Left(
+                        load_row_id_sequence(&self.dataset, &self.metadata).map_ok(Some),
+                    )
+                } else {
+                    futures::future::Either::Right(futures::future::ready(Ok(None)))
+                };
+                let (opened_files, deletion_vec, row_id_sequence) =
+                    join!(open_files, deletion_vec_load, row_id_load);
+                let opened_files = opened_files?;
+                let deletion_vec = deletion_vec?;
+                let row_id_sequence = row_id_sequence?;
+                let num_physical_rows = self.physical_rows().await?;
+                let num_rows = self.count_rows(None).await?;
+                (
+                    opened_files,
+                    deletion_vec,
+                    row_id_sequence,
+                    num_rows,
+                    num_physical_rows,
+                )
+            };
 
         if opened_files.is_empty() && !read_config.has_system_cols() {
             return Err(Error::not_found(format!(
@@ -965,12 +1100,12 @@ impl FileFragment {
 
         let mut reader = FragmentReader::try_new(
             self.id(),
-            template.deletion_vec.clone(),
-            template.row_id_sequence.clone(),
+            deletion_vec,
+            row_id_sequence,
             opened_files,
             ArrowSchema::from(projection),
-            template.num_rows,
-            template.num_physical_rows,
+            num_rows,
+            num_physical_rows,
             Arc::new(self.metadata.clone()),
         )?;
 
@@ -1441,7 +1576,6 @@ impl FileFragment {
         .boxed()
     }
 
-    #[cfg(test)]
     async fn open_readers(
         &self,
         projection: &Schema,
@@ -6254,10 +6388,17 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_fragment_reader_template_is_cached(
         #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)]
         data_storage_version: LanceFileVersion,
     ) {
+        // SAFETY: #[serial] ensures no other thread touches this env var
+        // concurrently.  We save and restore so sibling serial tests see the
+        // default (unset) value.
+        const ENV_KEY: &str = "LANCE_CACHE_FRAGMENT_READERS";
+        let original_env = std::env::var(ENV_KEY).ok();
+        unsafe { std::env::set_var(ENV_KEY, "1") };
         use crate::session::caches::FragmentReaderTemplateKey;
 
         let test_dir = TempStrDir::default();
@@ -6355,6 +6496,13 @@ mod tests {
             cached_after.num_physical_rows,
             "new template should reflect the post-delete deletion vector",
         );
+
+        unsafe {
+            match original_env {
+                Some(v) => std::env::set_var(ENV_KEY, v),
+                None => std::env::remove_var(ENV_KEY),
+            }
+        }
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -25,6 +25,7 @@ use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, join, stream};
 use lance_arrow::json::{convert_json_columns, has_json_fields, is_arrow_json_field};
 use lance_arrow::{RecordBatchExt, SchemaExt};
 use lance_core::datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions};
+use lance_core::deepsize::{Context, DeepSizeOf};
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
@@ -44,7 +45,7 @@ use lance_file::reader::{
 };
 use lance_file::version::{ConcreteFileVersion, LanceFileVersion};
 use lance_file::versions::v1::reader::{FileReader as V1FileReader, read_batch as v1_read_batch};
-use lance_file::{LanceEncodingsIo, determine_file_version};
+use lance_file::{LanceEncodingsIo, SentinelEncodingsIo, determine_file_version};
 use lance_io::ReadBatchParams;
 use lance_io::scheduler::{FileScheduler, ScanScheduler, SchedulerConfig};
 use lance_io::utils::CachedFileSize;
@@ -916,22 +917,43 @@ impl FileFragment {
         projection: &Schema,
         read_config: FragReadConfig,
     ) -> Result<FragmentReader> {
-        let open_files = self.open_readers(projection, &read_config);
-        let deletion_vec_load = self.get_deletion_vector();
+        // For each v2 data file, open a `FileScheduler` once. We use the same
+        // scheduler for both populating the cache (on miss) and binding the
+        // cached reader (always), so the IO cost matches the pre-cache path.
+        // v1 data files are not cached and re-opened inside the legacy path.
+        let mut v2_schedulers: Vec<Option<(FileScheduler, u32)>> =
+            Vec::with_capacity(self.metadata.files.len());
+        for data_file in &self.metadata.files {
+            if data_file.is_legacy_file() {
+                v2_schedulers.push(None);
+                continue;
+            }
+            let path = self
+                .dataset
+                .data_file_dir(data_file)?
+                .join(data_file.path.as_str());
+            let (store_scheduler, reader_priority) = self
+                .resolve_store_scheduler(data_file, &read_config)
+                .await?;
+            let file_scheduler = store_scheduler
+                .open_file_with_priority(&path, reader_priority as u64, &data_file.file_size_bytes)
+                .await?;
+            v2_schedulers.push(Some((file_scheduler, reader_priority)));
+        }
 
-        let row_id_load = if self.dataset.manifest.uses_stable_row_ids() {
-            futures::future::Either::Left(
-                load_row_id_sequence(&self.dataset, &self.metadata).map_ok(Some),
-            )
-        } else {
-            futures::future::Either::Right(futures::future::ready(Ok(None)))
+        let key = crate::session::caches::FragmentReaderTemplateKey {
+            manifest_version: self.dataset.manifest.version,
+            fragment_id: self.id() as u64,
         };
+        let template = self
+            .dataset
+            .metadata_cache
+            .get_or_insert_with_key(key, || self.load_fragment_reader_template(&v2_schedulers))
+            .await?;
 
-        let (opened_files, deletion_vec, row_id_sequence) =
-            join!(open_files, deletion_vec_load, row_id_load);
-        let opened_files = opened_files?;
-        let deletion_vec = deletion_vec?;
-        let row_id_sequence = row_id_sequence?;
+        let opened_files = self
+            .bind_readers(&template, &v2_schedulers, projection, &read_config)
+            .await?;
 
         if opened_files.is_empty() && !read_config.has_system_cols() {
             return Err(Error::not_found(format!(
@@ -941,16 +963,14 @@ impl FileFragment {
             )));
         }
 
-        let num_physical_rows = self.physical_rows().await?;
-
         let mut reader = FragmentReader::try_new(
             self.id(),
-            deletion_vec,
-            row_id_sequence,
+            template.deletion_vec.clone(),
+            template.row_id_sequence.clone(),
             opened_files,
             ArrowSchema::from(projection),
-            self.count_rows(None).await?,
-            num_physical_rows,
+            template.num_rows,
+            template.num_physical_rows,
             Arc::new(self.metadata.clone()),
         )?;
 
@@ -981,6 +1001,222 @@ impl FileFragment {
         }
 
         Ok(reader)
+    }
+
+    /// Resolve the [`ScanScheduler`] and reader priority a v2 data file should
+    /// use, honoring `read_config` overrides and per-base bindings.
+    async fn resolve_store_scheduler(
+        &self,
+        data_file: &DataFile,
+        read_config: &FragReadConfig,
+    ) -> Result<(Arc<ScanScheduler>, u32)> {
+        if let Some(base_id) = data_file.base_id {
+            // TODO: make object stores for non-default bases reuse the same scan scheduler
+            //  currently we always create a new one
+            let object_store = self.dataset.object_store(Some(base_id)).await?;
+            let config = SchedulerConfig::max_bandwidth(&object_store);
+            Ok((
+                ScanScheduler::new(object_store, config),
+                read_config.reader_priority.unwrap_or(0),
+            ))
+        } else if let Some(scan_scheduler) = read_config.scan_scheduler.as_ref() {
+            Ok((
+                scan_scheduler.clone(),
+                read_config.reader_priority.unwrap_or(0),
+            ))
+        } else {
+            Ok((
+                ScanScheduler::new(
+                    self.dataset.object_store.clone(),
+                    SchedulerConfig::max_bandwidth(&self.dataset.object_store),
+                ),
+                0,
+            ))
+        }
+    }
+
+    async fn load_fragment_reader_template(
+        &self,
+        v2_schedulers: &[Option<(FileScheduler, u32)>],
+    ) -> Result<FragmentReaderTemplate> {
+        let deletion_vec_load = self.get_deletion_vector();
+        let row_id_load = if self.dataset.manifest.uses_stable_row_ids() {
+            futures::future::Either::Left(
+                load_row_id_sequence(&self.dataset, &self.metadata).map_ok(Some),
+            )
+        } else {
+            futures::future::Either::Right(futures::future::ready(Ok(None)))
+        };
+        let physical_rows_load = self.physical_rows();
+
+        let (deletion_vec, row_id_sequence, num_physical_rows) =
+            join!(deletion_vec_load, row_id_load, physical_rows_load);
+        let deletion_vec = deletion_vec?;
+        let row_id_sequence = row_id_sequence?;
+        let num_physical_rows = num_physical_rows?;
+
+        let num_deleted = deletion_vec.as_ref().map(|dv| dv.len()).unwrap_or(0);
+        let num_rows = num_physical_rows - num_deleted;
+
+        let mut data_files = Vec::with_capacity(self.metadata.files.len());
+        for (data_file, scheduler) in self.metadata.files.iter().zip(v2_schedulers.iter()) {
+            data_files.push(match scheduler {
+                Some((file_scheduler, _)) => Some(
+                    self.build_cached_data_file(data_file, file_scheduler)
+                        .await?,
+                ),
+                None => None,
+            });
+        }
+
+        Ok(FragmentReaderTemplate {
+            data_files,
+            deletion_vec,
+            row_id_sequence,
+            num_rows,
+            num_physical_rows,
+        })
+    }
+
+    async fn build_cached_data_file(
+        &self,
+        data_file: &DataFile,
+        file_scheduler: &FileScheduler,
+    ) -> Result<CachedDataFile> {
+        let full_schema = self.dataset.schema();
+        let data_file_schema = Arc::new(data_file.schema(full_schema));
+        let path = file_scheduler.reader().path().clone();
+        let file_metadata = self.get_file_metadata(file_scheduler).await?;
+        let metadata_cache = self.dataset.metadata_cache.file_metadata_cache(&path);
+        let file_reader = Arc::new(
+            ProjectedFileReader::try_open_with_file_metadata(
+                Arc::new(SentinelEncodingsIo),
+                path,
+                None,
+                Arc::<DecoderPlugins>::default(),
+                file_metadata,
+                &metadata_cache,
+                self.dataset.file_reader_options.clone().unwrap_or_default(),
+            )
+            .await?,
+        );
+
+        let field_id_to_column_idx = Arc::new(BTreeMap::from_iter(
+            data_file
+                .fields
+                .iter()
+                .copied()
+                .zip(data_file.column_indices.iter().copied())
+                .filter_map(|(field_id, column_index)| {
+                    if column_index < 0 {
+                        None
+                    } else {
+                        Some((field_id as u32, column_index as u32))
+                    }
+                }),
+        ));
+
+        Ok(CachedDataFile {
+            file_reader,
+            data_file_schema,
+            field_id_to_column_idx,
+        })
+    }
+
+    /// Build the per-data-file readers for one `open()` call by rebinding
+    /// each cached template entry against the file scheduler we already opened.
+    async fn bind_readers(
+        &self,
+        template: &FragmentReaderTemplate,
+        v2_schedulers: &[Option<(FileScheduler, u32)>],
+        projection: &Schema,
+        read_config: &FragReadConfig,
+    ) -> Result<Vec<Box<dyn GenericFileReader>>> {
+        let mut opened_files: Vec<Box<dyn GenericFileReader>> = Vec::new();
+        for ((data_file, cached), scheduler) in self
+            .metadata
+            .files
+            .iter()
+            .zip(template.data_files.iter())
+            .zip(v2_schedulers.iter())
+        {
+            let reader = match (cached, scheduler) {
+                (Some(cached), Some((file_scheduler, reader_priority))) => self.bind_v2_reader(
+                    cached,
+                    file_scheduler.clone(),
+                    *reader_priority,
+                    projection,
+                    read_config,
+                )?,
+                _ => {
+                    // v1 (or any uncached entry): fall back to the per-call open path.
+                    self.open_reader(data_file, Some(projection), read_config)
+                        .await?
+                }
+            };
+            if let Some(reader) = reader {
+                opened_files.push(reader);
+            }
+        }
+
+        // Pad with NullReader if the projection asks for fields that no data
+        // file contains.
+        let field_ids_in_files = opened_files
+            .iter()
+            .flat_map(|r| r.projection().fields_pre_order().map(|f| f.id))
+            .filter(|id| *id >= 0)
+            .collect::<HashSet<_>>();
+        let mut missing_fields = projection.field_ids();
+        missing_fields.retain(|f| !field_ids_in_files.contains(f) && *f >= 0);
+        if !missing_fields.is_empty() {
+            let missing_projection = projection.project_by_ids(&missing_fields, true);
+            let null_reader = NullReader::new(
+                Arc::new(missing_projection),
+                template.num_physical_rows as u32,
+            );
+            opened_files.push(Box::new(null_reader));
+        }
+
+        Ok(opened_files)
+    }
+
+    fn bind_v2_reader(
+        &self,
+        cached: &CachedDataFile,
+        file_scheduler: FileScheduler,
+        reader_priority: u32,
+        projection: &Schema,
+        read_config: &FragReadConfig,
+    ) -> Result<Option<Box<dyn GenericFileReader>>> {
+        let schema_per_file =
+            Arc::new(projection.intersection_ignore_types(&cached.data_file_schema)?);
+        if schema_per_file.fields.is_empty() {
+            return Ok(None);
+        }
+
+        // Resolve per-call FileReaderOptions: read_config overrides dataset
+        // default. The cached FileReader was built with the dataset default,
+        // so swap in the resolved options if they differ.
+        let resolved_options = read_config
+            .file_reader_options
+            .clone()
+            .or_else(|| self.dataset.file_reader_options.clone())
+            .unwrap_or_default();
+        let read_chunk_size = resolved_options.read_chunk_size;
+        let mut bound = cached.file_reader.with_scheduler(Arc::new(
+            LanceEncodingsIo::new(file_scheduler.clone()).with_read_chunk_size(read_chunk_size),
+        ));
+        if read_config.file_reader_options.is_some() {
+            bound = bound.with_options(resolved_options);
+        }
+        let reader = v2_adapter::Reader::new(
+            Arc::new(bound),
+            schema_per_file,
+            cached.field_id_to_column_idx.clone(),
+            reader_priority,
+            file_scheduler,
+        );
+        Ok(Some(Box::new(reader)))
     }
 
     fn get_field_id_offset(data_file: &DataFile) -> u32 {
@@ -1205,6 +1441,7 @@ impl FileFragment {
         .boxed()
     }
 
+    #[cfg(test)]
     async fn open_readers(
         &self,
         projection: &Schema,
@@ -2298,6 +2535,59 @@ struct OverlayReadState {
     planner: Arc<OverlayReadPlanner>,
     fragment: Arc<FileFragment>,
     read_config: Arc<FragReadConfig>,
+}
+
+/// Cached, projection-independent shape of one v2 data file.
+///
+/// Holds the pre-computed schema work and a fully-projected
+/// [`ProjectedFileReader`] whose scheduler slot is a
+/// [`lance_file::io::SentinelEncodingsIo`]. Each `FileFragment::open` call
+/// rebinds this reader to a fresh [`FileScheduler`] against the caller's
+/// scheduler via `ProjectedFileReader::with_scheduler` — that's the only
+/// per-call work (besides opening the file handle), so the expensive bits —
+/// `data_file.schema`, the field-id→column-idx map,
+/// `ReaderProjection::from_whole_schema`, and `validate_projection` — run once.
+#[derive(Debug, Clone)]
+pub struct CachedDataFile {
+    /// ProjectedFileReader with `SentinelEncodingsIo` in its scheduler slot. Always
+    /// rebind via `with_scheduler` before issuing reads.
+    file_reader: Arc<ProjectedFileReader>,
+    /// Pre-computed `data_file.schema(dataset_schema)`. Intersect with the
+    /// caller's projection to get the per-file schema for the v2 adapter.
+    data_file_schema: Arc<Schema>,
+    field_id_to_column_idx: Arc<BTreeMap<u32, u32>>,
+}
+
+impl DeepSizeOf for CachedDataFile {
+    fn deep_size_of_children(&self, ctx: &mut Context) -> usize {
+        self.file_reader.deep_size_of_children(ctx)
+            + self.data_file_schema.deep_size_of_children(ctx)
+            + self.field_id_to_column_idx.deep_size_of_children(ctx)
+    }
+}
+
+/// Cached, projection- and scheduler-independent state of a fragment that
+/// backs [`FragmentReader`].
+///
+/// One entry per data file in `fragment.files`, in the same order. v1
+/// (legacy) data files are not cacheable (they own an `Arc<dyn Reader>`
+/// directly with no scheduler-swap method) and are stored as `None` — the
+/// `open()` path opens those per call.
+#[derive(Debug, Clone)]
+pub struct FragmentReaderTemplate {
+    pub(crate) data_files: Vec<Option<CachedDataFile>>,
+    pub(crate) deletion_vec: Option<Arc<DeletionVector>>,
+    pub(crate) row_id_sequence: Option<Arc<RowIdSequence>>,
+    pub(crate) num_rows: usize,
+    pub(crate) num_physical_rows: usize,
+}
+
+impl DeepSizeOf for FragmentReaderTemplate {
+    fn deep_size_of_children(&self, ctx: &mut Context) -> usize {
+        self.data_files.deep_size_of_children(ctx)
+            + self.deletion_vec.deep_size_of_children(ctx)
+            + self.row_id_sequence.deep_size_of_children(ctx)
+    }
 }
 
 // Custom clone impl needed because it is not easy to clone Box<dyn GenericFileReader>
@@ -5959,6 +6249,111 @@ mod tests {
                 .await
                 .unwrap(),
             256
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_fragment_reader_template_is_cached(
+        #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)]
+        data_storage_version: LanceFileVersion,
+    ) {
+        use crate::session::caches::FragmentReaderTemplateKey;
+
+        let test_dir = TempStrDir::default();
+        let dataset = create_dataset(&test_dir, data_storage_version).await;
+        // Use the first fragment so the `delete("i < 10")` below actually
+        // touches rows in this fragment (rows 0..40).
+        let fragment = dataset.get_fragments().into_iter().next().unwrap();
+        let projection = dataset.schema().project::<&str>(&["i"]).unwrap();
+
+        let key = FragmentReaderTemplateKey {
+            manifest_version: dataset.manifest.version,
+            fragment_id: fragment.id() as u64,
+        };
+
+        // Cold cache: no entry yet.
+        assert!(
+            dataset.metadata_cache.get_with_key(&key).await.is_none(),
+            "template should not be cached before first open"
+        );
+
+        let _reader1 = fragment
+            .open(&projection, FragReadConfig::default().with_row_id(true))
+            .await
+            .unwrap();
+        let cached = dataset
+            .metadata_cache
+            .get_with_key(&key)
+            .await
+            .expect("template should be cached after first open");
+        // For v2 datasets, the per-data-file shape (FileReader + schema +
+        // field-id map) is included in the cached template; for v1 the
+        // entries are `None` because v1 readers can't be rebound.
+        if data_storage_version == LanceFileVersion::Stable {
+            assert!(
+                cached.data_files.iter().all(|d| d.is_some()),
+                "v2 data files should each have a cached shape"
+            );
+        } else {
+            assert!(
+                cached.data_files.iter().all(|d| d.is_none()),
+                "v1 data files are not cacheable"
+            );
+        }
+
+        // Re-opening, even with different projections or flags, should reuse
+        // the template since it's projection- and flag-independent.
+        let hits_before = dataset.session().metadata_cache_stats().await.hits;
+        let _reader2 = fragment
+            .open(&projection, FragReadConfig::default())
+            .await
+            .unwrap();
+        let _reader3 = fragment
+            .open(dataset.schema(), FragReadConfig::default())
+            .await
+            .unwrap();
+        let hits_after = dataset.session().metadata_cache_stats().await.hits;
+        assert!(
+            hits_after > hits_before,
+            "subsequent opens should hit the template cache (before={hits_before}, after={hits_after})"
+        );
+
+        // After a commit that mutates fragments (delete), the cache must not
+        // hand back the stale template from the previous version.
+        let mut dataset = dataset;
+        dataset.delete("i < 10").await.unwrap();
+        let new_fragment = dataset
+            .get_fragments()
+            .into_iter()
+            .find(|f| f.id() == fragment.id())
+            .unwrap();
+        let new_key = FragmentReaderTemplateKey {
+            manifest_version: dataset.manifest.version,
+            fragment_id: new_fragment.id() as u64,
+        };
+        assert_ne!(new_key.manifest_version, key.manifest_version);
+        assert!(
+            dataset
+                .metadata_cache
+                .get_with_key(&new_key)
+                .await
+                .is_none(),
+            "post-commit template must not be in the cache before re-open"
+        );
+        let _ = new_fragment
+            .open(&projection, FragReadConfig::default().with_row_id(true))
+            .await
+            .unwrap();
+        let cached_after = dataset
+            .metadata_cache
+            .get_with_key(&new_key)
+            .await
+            .expect("post-commit template should be cached after re-open");
+        assert_eq!(
+            cached_after.num_rows + cached_after.deletion_vec.as_ref().unwrap().len(),
+            cached_after.num_physical_rows,
+            "new template should reflect the post-delete deletion vector",
         );
     }
 

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -932,20 +932,16 @@ impl FileFragment {
         projection: &Schema,
         read_config: FragReadConfig,
     ) -> Result<FragmentReader> {
-        // Fast path: if no data file contributes to the projection, skip
-        // scheduler setup and the template cache entirely.  Deletion vectors
-        // and row counts come from the manifest and require no file IO on
-        // modern datasets.
-        let full_schema = self.dataset.schema();
-        let any_file_needed = self.metadata.files.iter().any(|data_file| {
-            let file_schema = data_file.schema(full_schema);
-            projection
-                .intersection_ignore_types(&file_schema)
-                .map(|s| !s.fields.is_empty())
-                .unwrap_or(true) // on error, fall through to the main path
-        });
-
-        if !any_file_needed {
+        // Fast path: if the projection contains no schema fields at all (e.g. a
+        // system-column-only scan such as `project(&[ROW_ID])`), skip scheduler
+        // setup and the template cache entirely.  Deletion vectors and row counts
+        // come from the manifest and require no file IO on modern datasets.
+        //
+        // We intentionally check `projection.fields.is_empty()` rather than
+        // "no data file intersects the projection" so that schema-evolved
+        // AllNull columns — which have real field IDs but are absent from every
+        // data file — still reach the NullReader synthesis path below.
+        if projection.fields.is_empty() {
             if !read_config.has_system_cols() {
                 return Err(Error::not_found(format!(
                     "No data files found for schema: {}, fragment_id={}",

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -24,6 +24,7 @@ use lance_table::{
 };
 use object_store::path::Path;
 
+use crate::dataset::fragment::FragmentReaderTemplate;
 use crate::dataset::transaction::Transaction;
 
 /// A type-safe wrapper around a LanceCache that enforces namespaces for dataset metadata.
@@ -240,6 +241,45 @@ impl CacheKey for RowIdSequenceKey {
 
     fn write_key(&self, builder: &mut KeyBuilder) {
         builder.write_u64(self.fragment_id);
+    }
+}
+
+/// Cache key for the [`FragmentReaderTemplate`] that backs an opened
+/// [`crate::dataset::fragment::FragmentReader`].
+///
+/// The template holds metadata (deletion vector, row id sequence, row counts)
+/// plus pre-built per-data-file shapes (an unbound [`lance_file::reader::FileReader`],
+/// the data-file schema, and the field-id-to-column-index map). It is invariant
+/// to the projection or system column flags requested at open time, so the key
+/// only needs to identify the fragment within a manifest version.
+///
+/// Per-request bindings — the object store, scan scheduler, and open file
+/// handles — are intentionally **not** part of the cached value. Each
+/// `FileFragment::open` call rebinds the cached `FileReader` to a fresh
+/// `FileScheduler` against the caller's `ScanScheduler`, so per-request
+/// `with_object_store` wrappers and scan-scoped schedulers keep their
+/// isolation guarantees.
+///
+/// `manifest_version` is part of the key because a fragment's deletion file,
+/// row-id metadata, and data files can change between commits even though the
+/// fragment id stays the same — without it, callers would see stale data
+/// after operations like `delete`.
+#[derive(Debug)]
+pub struct FragmentReaderTemplateKey {
+    pub manifest_version: u64,
+    pub fragment_id: u64,
+}
+
+impl CacheKey for FragmentReaderTemplateKey {
+    type ValueType = FragmentReaderTemplate;
+    fn key(&self) -> Cow<'_, str> {
+        Cow::Owned(format!(
+            "fragment_reader_template/{}/{}",
+            self.manifest_version, self.fragment_id,
+        ))
+    }
+    fn type_name() -> &'static str {
+        "FragmentReaderTemplate"
     }
 }
 


### PR DESCRIPTION
## Summary

Cache per-fragment reader state in the dataset metadata cache so that the hot `FileFragment::open` path can skip the projection-independent setup work — `data_file.schema(...)`, `Schema::intersection_ignore_types`, the field-id→column-idx `BTreeMap`, `ReaderProjection::from_whole_schema`, and `validate_projection` — and reuse a fully-built `FileReader` across opens.

## Motivation

Opening a `FragmentReader` had non-trivial overhead even when file metadata was already in the cache: every call rebuilt the per-data-file schema intersection, the field id map, and the `FileReader` (which itself ran projection setup + validation). For workloads that open the same fragment repeatedly (take queries, repeated scans), this work was a measurable cost.

## What's cached

A `FragmentReaderTemplate` keyed on `(manifest_version, fragment_id)` and stored in the dataset's metadata cache:

- **Bundle:** `deletion_vec`, `row_id_sequence`, `num_rows`, `num_physical_rows`.
- **Per v2 data file (`CachedDataFile`):**
  - `Arc<FileReader>` whose scheduler slot is a `SentinelEncodingsIo` (panics if read; never used directly — always rebound).
  - The pre-computed `data_file.schema(dataset_schema)` (per-call we only intersect with the user's projection).
  - The `field_id → column_idx` `BTreeMap`.

## What's not cached, and why

Object stores, `ScanScheduler`s, and open file handles. These are per-call. The split exists because two correctness invariants depend on it:

- **`test_with_object_store_enables_isolated_per_request_io_tracking`** — `with_object_store` wrappers create per-request datasets that share a session/cache but use different object stores. A cached reader bound to one store would route subsequent requests through the wrong wrapper.
- **`test_scan_finishes_all_tasks`** — when a scan is dropped, its `ScanScheduler` must drop too so background I/O tasks observe the signal. Caching a reader that holds the scheduler keeps it alive indefinitely.

v1 (legacy) data files are not cacheable — `PreviousFileReader` owns its `Arc<dyn Reader>` open handle directly with no scheduler-swap method. They fall through to the unchanged per-call open path.

## Design

`FileFragment::open` does the following:

1. For each v2 data file, opens **one** `FileScheduler` against the resolved `ScanScheduler` (per-call binding).
2. Cache get-or-insert the template. On miss, the loader uses the schedulers we just opened to read file metadata — so cache-miss IOPs match the pre-cache path. Verified by `test_iops_read_small` (still asserts a single GET).
3. For each cached data file, rebinds via `cached.file_reader.with_scheduler(LanceEncodingsIo::new(file_scheduler))` and applies per-call `FileReaderOptions` (`with_options`) when `read_config.file_reader_options` is set.
4. Constructs the `v2_adapter::Reader` and assembles the `FragmentReader`.

`manifest_version` in the key means commits that mutate a fragment (e.g. `delete()`) automatically invalidate cached templates with no explicit cache invalidation needed.

## New `lance-file` API

- `SentinelEncodingsIo` — placeholder `EncodingsIo` whose `submit_request` panics. Used as the scheduler slot in unbound cached `FileReader`s.
- `FileReader::try_open_unbound_with_file_metadata` — constructs a `FileReader` with the sentinel scheduler. Caller must call `with_scheduler` before any read; documented contract, panic message tells you what's wrong if you forget.
- `FileReader::with_options` — companion to `with_scheduler` for swapping `FileReaderOptions` (clone-and-replace).
- `impl DeepSizeOf for FileReader` — counts only `metadata` (the bulk of the footprint). The `cache: Arc<LanceCache>` field is excluded because it's a back-reference to the cache the reader is being inserted into; including it would inflate every entry's size with the whole cache and overflow `usize` after a few hundred fragments.

## Test plan

- [x] `cargo test -p lance --lib dataset::fragment::` — 49 passed. Includes new `test_fragment_reader_template_is_cached` (parameterized over `Legacy` and `Stable` storage versions) which verifies:
    - Cold cache → entry absent.
    - First `open()` → entry present; v2 templates have a `CachedDataFile` per data file, v1 templates have `None` per data file.
    - Subsequent opens with different projections / flags hit the cache (template is projection- and flag-independent).
    - Post-`delete()` re-open does not see a stale template (key includes `manifest_version`).
- [x] `cargo test -p lance --lib dataset::` — 1083 passed. Confirms:
    - `test_with_object_store_enables_isolated_per_request_io_tracking` — per-request store wrappers stay isolated.
    - `test_scan_finishes_all_tasks` — abandoned scans still drop their schedulers and clean up tasks.
    - `test_defer_index_remap_large_external_file` — wide-fragment compaction (caught a `DeepSizeOf` back-reference bug during development; fixed before merge).
    - `test_binary_copy_compaction_with_complex_schema` — complex-schema compaction.
    - `test_iops_read_small` — single GET for small-file open + read.
- [x] `cargo test -p lance --lib io::exec::` — 70 passed.
- [x] `cargo clippy -p lance -p lance-file --all --tests --benches -- -D warnings` — clean.
- [x] `cargo fmt -p lance -p lance-file --check` — clean.