### PR TITLE
feat(wip): support refreshing per-row version metadata for matched rows during Operation::Update with RewriteColumns

### DIFF
--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -45,6 +45,7 @@ pub(crate) struct FragmentMergeResult {
 pub(crate) struct FragmentUpdateResult {
     updated_fragment: Fragment,
     fields_modified: Vec<u32>,
+    matched_offsets: Vec<u32>,
 }
 
 //////////////////
@@ -487,11 +488,14 @@ fn inner_update_column<'local>(
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
     let left_on_str: String = left_on.extract(env)?;
     let right_on_str: String = right_on.extract(env)?;
-    let (updated_fragment, fields_modified) =
+    let (updated_fragment, fields_modified, matched_bitmap) =
         RT.block_on(fragment.update_columns(reader, &left_on_str, &right_on_str))?;
     let result = FragmentUpdateResult {
         updated_fragment,
         fields_modified,
+        matched_offsets: matched_bitmap
+            .map(|bm| bm.iter().collect())
+            .unwrap_or_default(),
     };
     result.into_java(env)
 }
@@ -512,6 +516,7 @@ const FRAGMENT_MERGE_RESULT_CONSTRUCTOR_SIG: &str =
     "(Lorg/lance/FragmentMetadata;Lorg/lance/schema/LanceSchema;)V";
 const FRAGMENT_UPDATE_RESULT_CLASS: &str = "org/lance/fragment/FragmentUpdateResult";
 const FRAGMENT_UPDATE_RESULT_CONSTRUCTOR_SIG: &str = "(Lorg/lance/FragmentMetadata;[J)V";
+const FRAGMENT_UPDATE_RESULT_WITH_OFFSETS_CONSTRUCTOR_SIG: &str = "(Lorg/lance/FragmentMetadata;[J[J)V";
 
 impl IntoJava for &FragmentMergeResult {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
@@ -532,14 +537,37 @@ impl IntoJava for &FragmentUpdateResult {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
         let java_updated_fragment = self.updated_fragment.into_java(env)?;
         let java_fields_modified = JLance(self.fields_modified.clone()).into_java(env)?;
-        Ok(env.new_object(
-            FRAGMENT_UPDATE_RESULT_CLASS,
-            FRAGMENT_UPDATE_RESULT_CONSTRUCTOR_SIG,
-            &[
-                JValueGen::Object(&java_updated_fragment),
-                JValueGen::Object(&java_fields_modified),
-            ],
-        )?)
+
+        // Try with updated row offsets first; then fall back
+        let class = env.find_class(FRAGMENT_UPDATE_RESULT_CLASS)?;
+        let has_new_ctor = env
+            .get_method_id(&class, "<init>", FRAGMENT_UPDATE_RESULT_WITH_OFFSETS_CONSTRUCTOR_SIG)
+            .is_ok();
+        if env.exception_check()? {
+            env.exception_clear()?;
+        }
+        if has_new_ctor {
+            let java_matched_offsets = JLance(self.matched_offsets.clone()).into_java(env)?;
+            Ok(env.new_object(
+                FRAGMENT_UPDATE_RESULT_CLASS,
+                FRAGMENT_UPDATE_RESULT_WITH_OFFSETS_CONSTRUCTOR_SIG,
+                &[
+                    JValueGen::Object(&java_updated_fragment),
+                    JValueGen::Object(&java_fields_modified),
+                    JValueGen::Object(&java_matched_offsets),
+                ],
+            )?)
+        } else {
+            // Old Java jar without matchedOffsets — silently drop the field
+            Ok(env.new_object(
+                FRAGMENT_UPDATE_RESULT_CLASS,
+                FRAGMENT_UPDATE_RESULT_CONSTRUCTOR_SIG,
+                &[
+                    JValueGen::Object(&java_updated_fragment),
+                    JValueGen::Object(&java_fields_modified),
+                ],
+            )?)
+        }
     }
 }
 
@@ -810,5 +838,63 @@ fn convert_to_java_integer<'local>(
             &[JValue::Int(base_index as jint)],
         )?),
         None => Ok(JObject::null()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lance::table::format::Fragment;
+    use roaring::RoaringBitmap;
+
+    #[test]
+    fn test_fragment_update_result_from_some_bitmap() {
+        let mut bitmap = RoaringBitmap::new();
+        bitmap.insert(0);
+        bitmap.insert(2);
+        bitmap.insert(4);
+        bitmap.insert(100);
+
+        let matched_bitmap: Option<RoaringBitmap> = Some(bitmap);
+        let offsets: Vec<u32> = matched_bitmap
+            .map(|bm| bm.iter().collect())
+            .unwrap_or_default();
+
+        let result = FragmentUpdateResult {
+            updated_fragment: Fragment::new(7),
+            fields_modified: vec![1],
+            matched_offsets: offsets,
+        };
+        assert_eq!(result.matched_offsets, vec![0, 2, 4, 100]);
+    }
+
+    #[test]
+    fn test_fragment_update_result_from_none_bitmap() {
+        // When tracking is disabled, matched_bitmap is None -> empty vec
+        let matched_bitmap: Option<RoaringBitmap> = None;
+        let offsets: Vec<u32> = matched_bitmap
+            .map(|bm| bm.iter().collect())
+            .unwrap_or_default();
+
+        let result = FragmentUpdateResult {
+            updated_fragment: Fragment::new(3),
+            fields_modified: vec![2],
+            matched_offsets: offsets,
+        };
+        assert!(result.matched_offsets.is_empty());
+    }
+
+    #[test]
+    fn test_fragment_update_result_large_offsets() {
+        // Verify large offset sets (>5000, the bitmap encoding threshold) work
+        let offsets: Vec<u32> = (0..6000).collect();
+        let result = FragmentUpdateResult {
+            updated_fragment: Fragment::new(99),
+            fields_modified: vec![1, 2],
+            matched_offsets: offsets,
+        };
+        assert_eq!(result.matched_offsets.len(), 6000);
+        assert_eq!(result.matched_offsets[0], 0);
+        assert_eq!(result.matched_offsets[5999], 5999);
     }
 }

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -433,6 +433,7 @@ fn convert_to_java_operation_inner<'local>(
             fields_for_preserving_frag_bitmap,
             update_mode,
             inserted_rows_filter: _,
+            updated_row_offsets,
         } => {
             let removed_ids: Vec<JLance<i64>> = removed_fragment_ids
                 .iter()
@@ -456,9 +457,69 @@ fn convert_to_java_operation_inner<'local>(
                     &[JValue::Object(&update_mode)],
                 )?
                 .l()?;
+
+            let update_class = env.find_class("org/lance/operation/Update")?;
+            let with_offsets_sig = "(Ljava/util/List;Ljava/util/List;Ljava/util/List;[J[JLjava/util/Optional;Ljava/util/Optional;)V";
+            let without_offsets_sig = "(Ljava/util/List;Ljava/util/List;Ljava/util/List;[J[JLjava/util/Optional;)V";
+            let has_new_ctor = env
+                .get_method_id(&update_class, "<init>", with_offsets_sig)
+                .is_ok();
+            if env.exception_check()? {
+                env.exception_clear()?;
+            }
+
+            if !has_new_ctor {
+                return Ok(env.new_object(
+                    "org/lance/operation/Update",
+                    without_offsets_sig,
+                    &[
+                        JValue::Object(&removed_fragment_ids_obj),
+                        JValue::Object(&updated_fragments_obj),
+                        JValue::Object(&new_fragments_obj),
+                        JValueGen::Object(&fields_modified),
+                        JValueGen::Object(&fields_for_preserving_frag_bitmap),
+                        JValue::Object(&update_mode_optional),
+                    ],
+                )?)
+            }
+
+            let java_offsets_map = if let Some(offsets_map) = updated_row_offsets {
+                let hash_map = env.new_object("java/util/HashMap", "()V", &[])?;
+                for (frag_id, offsets) in offsets_map {
+                    let java_frag_id = env.new_object(
+                        "java/lang/Long",
+                        "(J)V",
+                        &[JValue::Long(frag_id as i64)],
+                    )?;
+                    let java_offsets = env.new_long_array(offsets.len() as i32)?;
+                    let offsets_i64: Vec<i64> = offsets.iter().map(|o| *o as i64).collect();
+                    env.set_long_array_region(&java_offsets, 0, &offsets_i64)?;
+                    env.call_method(
+                        &hash_map,
+                        "put",
+                        "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                        &[
+                            JValue::Object(&java_frag_id),
+                            JValue::Object(&java_offsets),
+                        ],
+                    )?;
+                }
+                hash_map
+            } else {
+                JObject::null()
+            };
+            let offsets_optional = env
+                .call_static_method(
+                    "java/util/Optional",
+                    "ofNullable",
+                    "(Ljava/lang/Object;)Ljava/util/Optional;",
+                    &[JValue::Object(&java_offsets_map)],
+                )?
+                .l()?;
+
             Ok(env.new_object(
                 "org/lance/operation/Update",
-                "(Ljava/util/List;Ljava/util/List;Ljava/util/List;[J[JLjava/util/Optional;)V",
+                with_offsets_sig,
                 &[
                     JValue::Object(&removed_fragment_ids_obj),
                     JValue::Object(&updated_fragments_obj),
@@ -466,6 +527,7 @@ fn convert_to_java_operation_inner<'local>(
                     JValueGen::Object(&fields_modified),
                     JValueGen::Object(&fields_for_preserving_frag_bitmap),
                     JValue::Object(&update_mode_optional),
+                    JValue::Object(&offsets_optional),
                 ],
             )?)
         }
@@ -1213,6 +1275,67 @@ fn convert_to_rust_operation(
                     update_mode.extract_object(env)
                 })?;
 
+            // Extract updated_row_offsets: Optional<Map<Long, long[]>>
+            // Use safe fallback for old Java jars that lack updatedRowOffsets() method
+            let updated_row_offsets: Option<HashMap<u64, Vec<u32>>> = {
+                let method_result = env.call_method(
+                    java_operation,
+                    "updatedRowOffsets",
+                    "()Ljava/util/Optional;",
+                    &[],
+                );
+                if env.exception_check().unwrap_or(false) {
+                    env.exception_clear().ok();
+                    None
+                } else if let Ok(jval) = method_result {
+                    let optional_obj = jval.l().ok();
+                    match optional_obj {
+                        Some(opt) => env.get_optional(&opt, |env, offsets_map| {
+                            let entry_set = env
+                                .call_method(offsets_map, "entrySet", "()Ljava/util/Set;", &[])?
+                                .l()?;
+                            let iterator = env
+                                .call_method(&entry_set, "iterator", "()Ljava/util/Iterator;", &[])?
+                                .l()?;
+                            let mut result = HashMap::new();
+                            loop {
+                                let has_next =
+                                    env.call_method(&iterator, "hasNext", "()Z", &[])?.z()?;
+                                if !has_next {
+                                    break;
+                                }
+                                let entry = env
+                                    .call_method(
+                                        &iterator,
+                                        "next",
+                                        "()Ljava/lang/Object;",
+                                        &[],
+                                    )?
+                                    .l()?;
+                                let key = env
+                                    .call_method(&entry, "getKey", "()Ljava/lang/Object;", &[])?
+                                    .l()?;
+                                let frag_id =
+                                    env.call_method(&key, "longValue", "()J", &[])?.j()? as u64;
+                                let value = env
+                                    .call_method(&entry, "getValue", "()Ljava/lang/Object;", &[])?
+                                    .l()?;
+                                let long_array = JLongArray::from(value);
+                                let len = env.get_array_length(&long_array)? as usize;
+                                let mut buf = vec![0i64; len];
+                                env.get_long_array_region(&long_array, 0, &mut buf)?;
+                                let offsets: Vec<u32> = buf.iter().map(|v| *v as u32).collect();
+                                result.insert(frag_id, offsets);
+                            }
+                            Ok(result)
+                        })?,
+                        None => None,
+                    }
+                } else {
+                    None
+                }
+            };
+
             Operation::Update {
                 removed_fragment_ids,
                 updated_fragments,
@@ -1222,6 +1345,7 @@ fn convert_to_rust_operation(
                 fields_for_preserving_frag_bitmap,
                 update_mode,
                 inserted_rows_filter: None,
+                updated_row_offsets,
             }
         }
         "DataReplacement" => {
@@ -1802,5 +1926,98 @@ mod tests {
             schema.metadata,
             HashMap::from([("new_schema_k".to_string(), "new_schema_v".to_string())])
         );
+    }
+
+    #[test]
+    fn test_operation_update_with_row_offsets() {
+        use lance::dataset::transaction::{Operation, UpdateMode};
+
+        let mut offsets_map = HashMap::new();
+        offsets_map.insert(1u64, vec![0u32, 2, 4]);
+        offsets_map.insert(2u64, vec![1u32, 3, 5]);
+
+        let op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![],
+            fields_modified: vec![1],
+            merged_generations: vec![],
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: Some(UpdateMode::RewriteColumns),
+            inserted_rows_filter: None,
+            updated_row_offsets: Some(offsets_map.clone()),
+        };
+
+        if let Operation::Update {
+            updated_row_offsets,
+            update_mode,
+            ..
+        } = &op
+        {
+            assert!(updated_row_offsets.is_some());
+            let map = updated_row_offsets.as_ref().unwrap();
+            assert_eq!(map.len(), 2);
+            assert_eq!(map.get(&1u64).unwrap(), &vec![0u32, 2, 4]);
+            assert_eq!(map.get(&2u64).unwrap(), &vec![1u32, 3, 5]);
+            assert_eq!(*update_mode, Some(UpdateMode::RewriteColumns));
+        } else {
+            panic!("Expected Operation::Update");
+        }
+    }
+
+    #[test]
+    fn test_operation_update_without_row_offsets() {
+        use lance::dataset::transaction::{Operation, UpdateMode};
+
+        let op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![],
+            fields_modified: vec![],
+            merged_generations: vec![],
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: Some(UpdateMode::RewriteColumns),
+            inserted_rows_filter: None,
+            updated_row_offsets: None,
+        };
+
+        if let Operation::Update {
+            updated_row_offsets,
+            ..
+        } = &op
+        {
+            assert!(updated_row_offsets.is_none());
+        } else {
+            panic!("Expected Operation::Update");
+        }
+    }
+
+    #[test]
+    fn test_bitmap_to_offsets_vec_conversion() {
+        use roaring::RoaringBitmap;
+
+        let mut bitmap = RoaringBitmap::new();
+        bitmap.insert(0);
+        bitmap.insert(5);
+        bitmap.insert(10);
+        bitmap.insert(100);
+
+        let offsets: Vec<u32> = bitmap.iter().collect();
+        assert_eq!(offsets, vec![0, 5, 10, 100]);
+
+        let empty_bitmap = RoaringBitmap::new();
+        let empty_offsets: Vec<u32> = empty_bitmap.iter().collect();
+        assert!(empty_offsets.is_empty());
+    }
+
+    #[test]
+    fn test_offsets_i64_u32_conversion() {
+        let java_longs: Vec<i64> = vec![0, 1, 2, 100, 5000];
+        let rust_offsets: Vec<u32> = java_longs.iter().map(|v| *v as u32).collect();
+        assert_eq!(rust_offsets, vec![0u32, 1, 2, 100, 5000]);
+
+        let rust_offsets: Vec<u32> = vec![0, 5, 10, 15, 20];
+        let java_longs: Vec<i64> = rust_offsets.iter().map(|o| *o as i64).collect();
+        assert_eq!(java_longs, vec![0i64, 5, 10, 15, 20]);
     }
 }

--- a/java/src/main/java/org/lance/fragment/FragmentUpdateResult.java
+++ b/java/src/main/java/org/lance/fragment/FragmentUpdateResult.java
@@ -25,10 +25,16 @@ import org.apache.arrow.c.ArrowArrayStream;
 public class FragmentUpdateResult {
   private final FragmentMetadata updatedFragment;
   private final long[] fieldsModified;
+  private final long[] matchedOffsets;
 
-  public FragmentUpdateResult(FragmentMetadata updatedFragment, long[] updatedFieldIds) {
+  public FragmentUpdateResult(FragmentMetadata updatedFragment, long[] updatedFieldIds, long[] matchedOffsets) {
     this.updatedFragment = updatedFragment;
     this.fieldsModified = updatedFieldIds;
+    this.matchedOffsets = matchedOffsets;
+  }
+
+  public FragmentUpdateResult(FragmentMetadata updatedFragment, long[] updatedFieldIds) {
+    this(updatedFragment, updatedFieldIds, new long[0]);
   }
 
   public FragmentMetadata getUpdatedFragment() {
@@ -39,11 +45,21 @@ public class FragmentUpdateResult {
     return fieldsModified;
   }
 
+  /**
+   * Physical row offsets within the fragment that were matched (updated) by the join.
+   * These are 0-based indices and can be passed as {@code updatedRowOffsets} when
+   * committing with {@link org.lance.operation.Update}.
+   */
+  public long[] getMatchedOffsets() {
+    return matchedOffsets;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("fragmentMetadata", updatedFragment)
         .add("updatedFieldIds", fieldsModified)
+        .add("matchedOffsets", matchedOffsets)
         .toString();
   }
 }

--- a/java/src/main/java/org/lance/operation/Update.java
+++ b/java/src/main/java/org/lance/operation/Update.java
@@ -20,6 +20,7 @@ import com.google.common.base.MoreObjects;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -30,6 +31,7 @@ public class Update implements Operation {
   private final long[] fieldsModified;
   private final long[] fieldsForPreservingFragBitmap;
   private final Optional<UpdateMode> updateMode;
+  private final Optional<Map<Long, long[]>> updatedRowOffsets;
 
   private Update(
       List<Long> removedFragmentIds,
@@ -37,13 +39,15 @@ public class Update implements Operation {
       List<FragmentMetadata> newFragments,
       long[] fieldsModified,
       long[] fieldsForPreservingFragBitmap,
-      Optional<UpdateMode> updateMode) {
+      Optional<UpdateMode> updateMode,
+      Optional<Map<Long, long[]>> updatedRowOffsets) {
     this.removedFragmentIds = removedFragmentIds;
     this.updatedFragments = updatedFragments;
     this.newFragments = newFragments;
     this.fieldsModified = fieldsModified;
     this.fieldsForPreservingFragBitmap = fieldsForPreservingFragBitmap;
     this.updateMode = updateMode;
+    this.updatedRowOffsets = updatedRowOffsets;
   }
 
   public static Builder builder() {
@@ -74,6 +78,16 @@ public class Update implements Operation {
     return updateMode;
   }
 
+  /**
+   * Optional per-fragment map of updated row offsets (physical row indices within each fragment).
+   * Used for RewriteColumns mode to selectively update _row_last_updated_at_version.
+   * Key: fragment ID, Value: sorted, deduplicated local physical row offsets that were updated.
+   * If empty, all rows in updated_fragments are assumed to be updated.
+   */
+  public Optional<Map<Long, long[]>> updatedRowOffsets() {
+    return updatedRowOffsets;
+  }
+
   @Override
   public String name() {
     return "Update";
@@ -87,6 +101,7 @@ public class Update implements Operation {
         .add("fieldsModified", fieldsModified)
         .add("fieldsForPreservingFragBitmap", fieldsForPreservingFragBitmap)
         .add("updateMode", updateMode)
+        .add("updatedRowOffsets", updatedRowOffsets)
         .toString();
   }
 
@@ -100,7 +115,8 @@ public class Update implements Operation {
         && Objects.equals(newFragments, that.newFragments)
         && Arrays.equals(fieldsModified, that.fieldsModified)
         && Arrays.equals(fieldsForPreservingFragBitmap, that.fieldsForPreservingFragBitmap)
-        && Objects.equals(updateMode, that.updateMode);
+        && Objects.equals(updateMode, that.updateMode)
+        && Objects.equals(updatedRowOffsets, that.updatedRowOffsets);
   }
 
   public enum UpdateMode {
@@ -115,6 +131,7 @@ public class Update implements Operation {
     private long[] fieldsModified = new long[0];
     private long[] fieldsForPreservingFragBitmap = new long[0];
     private Optional<UpdateMode> updateMode = Optional.empty();
+    private Optional<Map<Long, long[]>> updatedRowOffsets = Optional.empty();
 
     private Builder() {}
 
@@ -148,6 +165,15 @@ public class Update implements Operation {
       return this;
     }
 
+    /**
+     * Set per-fragment updated row offsets for RewriteColumns mode.
+     * @param updatedRowOffsets Map from fragment ID to sorted physical row offsets that were updated.
+     */
+    public Builder updatedRowOffsets(Optional<Map<Long, long[]>> updatedRowOffsets) {
+      this.updatedRowOffsets = updatedRowOffsets;
+      return this;
+    }
+
     public Update build() {
       return new Update(
           removedFragmentIds,
@@ -155,7 +181,8 @@ public class Update implements Operation {
           newFragments,
           fieldsModified,
           fieldsForPreservingFragBitmap,
-          updateMode);
+          updateMode,
+          updatedRowOffsets);
     }
   }
 }

--- a/java/src/test/java/org/lance/operation/UpdateTest.java
+++ b/java/src/test/java/org/lance/operation/UpdateTest.java
@@ -36,11 +36,16 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UpdateTest extends OperationTestBase {
 
@@ -200,6 +205,323 @@ public class UpdateTest extends OperationTestBase {
             assertEquals(expectNames, actualNames);
             assertEquals(expectTimeStamps, actualTimeStamps);
           }
+        }
+      }
+    }
+  }
+
+
+  @Test
+  void testUpdateColumnsReturnsMatchedOffsets(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("testUpdateColumnsMatchedOffsets").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.UpdateColumnTestDataset testDataset =
+          new TestUtils.UpdateColumnTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+
+      int rowCount = 6;
+      FragmentMetadata fragmentMeta = testDataset.createNewFragment(rowCount);
+      try (Transaction appendTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Append.builder().fragments(Collections.singletonList(fragmentMeta)).build())
+              .build()) {
+        try (Dataset ds = new CommitBuilder(this.dataset).execute(appendTxn)) {
+          assertEquals(rowCount, ds.countRows());
+        }
+      }
+
+      dataset = Dataset.open(datasetPath, allocator);
+      Fragment targetFragment = dataset.getFragments().get(0);
+      int updateRowCount = 4;
+      FragmentUpdateResult updateResult = testDataset.updateColumn(targetFragment, updateRowCount);
+
+      // Verify matchedOffsets is populated
+      long[] matchedOffsets = updateResult.getMatchedOffsets();
+      assertNotNull(matchedOffsets, "matchedOffsets should not be null");
+      // The update sends _rowid [0,1,2,3] for a 6-row fragment.
+      // Rows 0,1,2,3 all exist, so all 4 should be matched.
+      assertTrue(matchedOffsets.length > 0, "matchedOffsets should not be empty");
+      assertEquals(updateRowCount, matchedOffsets.length,
+          "All update rows should match");
+    }
+  }
+
+  @Test
+  void testUpdateWithUpdatedRowOffsets(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("testUpdateWithOffsets").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.UpdateColumnTestDataset testDataset =
+          new TestUtils.UpdateColumnTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+
+      int rowCount = 6;
+      FragmentMetadata fragmentMeta = testDataset.createNewFragment(rowCount);
+      try (Transaction appendTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Append.builder().fragments(Collections.singletonList(fragmentMeta)).build())
+              .build()) {
+        try (Dataset ds = new CommitBuilder(this.dataset).execute(appendTxn)) {
+          assertEquals(rowCount, ds.countRows());
+        }
+      }
+
+      dataset = Dataset.open(datasetPath, allocator);
+      Fragment targetFragment = dataset.getFragments().get(0);
+      int updateRowCount = 4;
+      FragmentUpdateResult updateResult = testDataset.updateColumn(targetFragment, updateRowCount);
+
+      // Build updatedRowOffsets map from matchedOffsets
+      long fragmentId = dataset.getFragments().get(0).getId();
+      long[] matchedOffsets = updateResult.getMatchedOffsets();
+      Map<Long, long[]> offsetsMap = new HashMap<>();
+      offsetsMap.put(fragmentId, matchedOffsets);
+
+      // Commit with updatedRowOffsets via RewriteColumns mode
+      try (Transaction updateTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Update.builder()
+                      .updatedFragments(
+                          Collections.singletonList(updateResult.getUpdatedFragment()))
+                      .fieldsModified(updateResult.getFieldsModified())
+                      .updateMode(Optional.of(UpdateMode.RewriteColumns))
+                      .updatedRowOffsets(Optional.of(offsetsMap))
+                      .build())
+              .build()) {
+        try (Dataset ds = new CommitBuilder(this.dataset).execute(updateTxn)) {
+          assertEquals(3, ds.version());
+          assertEquals(rowCount, ds.countRows());
+        }
+      }
+    }
+  }
+
+  @Test
+  void testUpdateBuilderDefaultsEmptyOffsets() {
+    // Verify builder default is Optional.empty()
+    Update update = Update.builder()
+        .removedFragmentIds(Collections.emptyList())
+        .build();
+    assertEquals(Optional.empty(), update.updatedRowOffsets());
+  }
+
+  @Test
+  void testUpdateBuilderWithOffsets() {
+    Map<Long, long[]> offsets = new HashMap<>();
+    offsets.put(1L, new long[]{0, 2, 4});
+    offsets.put(2L, new long[]{1, 3, 5});
+
+    Update update = Update.builder()
+        .removedFragmentIds(Collections.emptyList())
+        .updateMode(Optional.of(UpdateMode.RewriteColumns))
+        .updatedRowOffsets(Optional.of(offsets))
+        .build();
+
+    assertTrue(update.updatedRowOffsets().isPresent());
+    Map<Long, long[]> got = update.updatedRowOffsets().get();
+    assertEquals(2, got.size());
+    assertArrayEquals(new long[]{0, 2, 4}, got.get(1L));
+    assertArrayEquals(new long[]{1, 3, 5}, got.get(2L));
+  }
+
+  /**
+   * Backward compatibility: old Java code builds Update without updatedRowOffsets.
+   * The builder default is Optional.empty(), and commit should succeed without offsets.
+   * This is the RewriteRows path where offsets are not needed.
+   */
+  @Test
+  void testBackwardCompatUpdateWithoutOffsets_RewriteRows(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("testBackwardCompatRewriteRows").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+
+      int rowCount = 20;
+      FragmentMetadata fragmentMeta = testDataset.createNewFragment(rowCount);
+      try (Transaction appendTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Append.builder().fragments(Collections.singletonList(fragmentMeta)).build())
+              .build()) {
+        dataset = new CommitBuilder(this.dataset).execute(appendTxn);
+      }
+
+      // Old-style Update: no updatedRowOffsets parameter at all
+      int newRowCount = 30;
+      FragmentMetadata newFragment = testDataset.createNewFragment(newRowCount);
+      try (Transaction updateTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Update.builder()
+                      .removedFragmentIds(
+                          Collections.singletonList(
+                              Long.valueOf(dataset.getFragments().get(0).getId())))
+                      .newFragments(Collections.singletonList(newFragment))
+                      .updateMode(Optional.of(UpdateMode.RewriteRows))
+                      // no .updatedRowOffsets() call — old code never set this
+                      .build())
+              .build()) {
+        try (Dataset ds = new CommitBuilder(this.dataset).execute(updateTxn)) {
+          assertEquals(3, ds.version());
+          assertEquals(newRowCount, ds.countRows());
+        }
+      }
+    }
+  }
+
+  /**
+   * Backward compatibility: old Java code builds Update with RewriteColumns mode
+   * but without updatedRowOffsets. This was the only available path before the
+   * offsets feature was added. Commit should still succeed.
+   */
+  @Test
+  void testBackwardCompatUpdateWithoutOffsets_RewriteColumns(@TempDir Path tempDir)
+      throws Exception {
+    String datasetPath = tempDir.resolve("testBackwardCompatRewriteColumns").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.UpdateColumnTestDataset testDataset =
+          new TestUtils.UpdateColumnTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+
+      int rowCount = 6;
+      FragmentMetadata fragmentMeta = testDataset.createNewFragment(rowCount);
+      try (Transaction appendTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Append.builder().fragments(Collections.singletonList(fragmentMeta)).build())
+              .build()) {
+        dataset = new CommitBuilder(this.dataset).execute(appendTxn);
+      }
+
+      dataset = Dataset.open(datasetPath, allocator);
+      Fragment targetFragment = dataset.getFragments().get(0);
+      int updateRowCount = 4;
+      FragmentUpdateResult updateResult = testDataset.updateColumn(targetFragment, updateRowCount);
+
+      // Old-style commit: RewriteColumns but without updatedRowOffsets
+      try (Transaction updateTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Update.builder()
+                      .updatedFragments(
+                          Collections.singletonList(updateResult.getUpdatedFragment()))
+                      .fieldsModified(updateResult.getFieldsModified())
+                      .updateMode(Optional.of(UpdateMode.RewriteColumns))
+                      // no .updatedRowOffsets() — old code path
+                      .build())
+              .build()) {
+        try (Dataset ds = new CommitBuilder(this.dataset).execute(updateTxn)) {
+          assertEquals(3, ds.version());
+          assertEquals(rowCount, ds.countRows());
+        }
+      }
+    }
+  }
+
+  /**
+   * Backward compatibility: old Java code builds Update without updateMode at all.
+   * This was the default before UpdateMode was introduced.
+   */
+  @Test
+  void testBackwardCompatUpdateWithoutUpdateMode(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("testBackwardCompatNoMode").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+
+      int rowCount = 20;
+      FragmentMetadata fragmentMeta = testDataset.createNewFragment(rowCount);
+      try (Transaction appendTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Append.builder().fragments(Collections.singletonList(fragmentMeta)).build())
+              .build()) {
+        dataset = new CommitBuilder(this.dataset).execute(appendTxn);
+      }
+
+      int newRowCount = 30;
+      FragmentMetadata newFragment = testDataset.createNewFragment(newRowCount);
+      // Old-style: no updateMode, no updatedRowOffsets
+      try (Transaction updateTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Update.builder()
+                      .removedFragmentIds(
+                          Collections.singletonList(
+                              Long.valueOf(dataset.getFragments().get(0).getId())))
+                      .newFragments(Collections.singletonList(newFragment))
+                      // no .updateMode() — defaults to Optional.empty()
+                      // no .updatedRowOffsets() — defaults to Optional.empty()
+                      .build())
+              .build()) {
+        assertEquals(Optional.empty(), ((Update) updateTxn.getOperation()).updateMode());
+        assertEquals(Optional.empty(), ((Update) updateTxn.getOperation()).updatedRowOffsets());
+        try (Dataset ds = new CommitBuilder(this.dataset).execute(updateTxn)) {
+          assertEquals(3, ds.version());
+          assertEquals(newRowCount, ds.countRows());
+        }
+      }
+    }
+  }
+
+  /**
+   * Backward compatibility: explicitly passing Optional.empty() for updatedRowOffsets
+   * should behave identically to not setting it at all.
+   */
+  @Test
+  void testBackwardCompatExplicitEmptyOffsets(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("testExplicitEmptyOffsets").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.UpdateColumnTestDataset testDataset =
+          new TestUtils.UpdateColumnTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+
+      int rowCount = 6;
+      FragmentMetadata fragmentMeta = testDataset.createNewFragment(rowCount);
+      try (Transaction appendTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Append.builder().fragments(Collections.singletonList(fragmentMeta)).build())
+              .build()) {
+        dataset = new CommitBuilder(this.dataset).execute(appendTxn);
+      }
+
+      dataset = Dataset.open(datasetPath, allocator);
+      Fragment targetFragment = dataset.getFragments().get(0);
+      int updateRowCount = 4;
+      FragmentUpdateResult updateResult = testDataset.updateColumn(targetFragment, updateRowCount);
+
+      // Explicitly pass Optional.empty() — same as not calling the method
+      try (Transaction updateTxn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Update.builder()
+                      .updatedFragments(
+                          Collections.singletonList(updateResult.getUpdatedFragment()))
+                      .fieldsModified(updateResult.getFieldsModified())
+                      .updateMode(Optional.of(UpdateMode.RewriteColumns))
+                      .updatedRowOffsets(Optional.empty())
+                      .build())
+              .build()) {
+        assertEquals(Optional.empty(), ((Update) updateTxn.getOperation()).updatedRowOffsets());
+        try (Dataset ds = new CommitBuilder(this.dataset).execute(updateTxn)) {
+          assertEquals(3, ds.version());
+          assertEquals(rowCount, ds.countRows());
         }
       }
     }

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -227,6 +227,25 @@ message Transaction {
     }
   }
 
+  // Per-fragment row offsets that were updated during a RewriteColumns operation.
+  // Used to selectively update _row_last_updated_at_version for only the matched rows.
+  message FragmentRowOffsets {
+    // The fragment ID.
+    uint64 fragment_id = 1;
+    // The matched row offsets, encoded either as a sorted array or a Roaring bitmap.
+    oneof offsets {
+      // Sorted, deduplicated local physical row offsets (used when sparse).
+      FragmentRowOffsetArray array = 2;
+      // Roaring bitmap of local physical row offsets (used when dense).
+      bytes bitmap = 3;
+    }
+  }
+
+  // An array of row offsets within a fragment.
+  message FragmentRowOffsetArray {
+    repeated uint32 offsets = 1;
+  }
+
   // An operation that updates rows but does not add or remove rows.
   message Update {
     // The fragments that have been removed. These are fragments where all rows
@@ -248,6 +267,13 @@ message Transaction {
     // Filter for checking existence of keys in newly inserted rows, used for conflict detection.
     // Only tracks keys from INSERT operations during merge insert, not updates.
     optional KeyExistenceFilter inserted_rows = 8;
+    // Per-fragment updated row offsets for RewriteColumns mode.
+    // When present, only the specified rows in each fragment will have their
+    // _row_last_updated_at_version advanced to the new dataset version.
+    // Fragments not listed here are not partially refreshed.
+    // If empty, the caller has already set version metadata on the fragments,
+    // or all rows in updated_fragments are assumed updated.
+    repeated FragmentRowOffsets updated_row_offsets = 9;
   }
 
   // The mode of update operation

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5033,6 +5033,12 @@ class LanceOperation:
             default_factory=list
         )
         update_mode: str = ""
+        updated_row_offsets: Optional[Dict[int, List[int]]] = None
+        """Optional per-fragment map of updated row offsets (physical row indices
+        within each fragment). Used for RewriteColumns mode to selectively
+        update ``_row_last_updated_at_version``. Key: fragment ID, Value:
+        sorted, deduplicated local physical row offsets that were updated.
+        If None, all rows in updated_fragments are assumed to be updated."""
 
         def __post_init__(self):
             LanceOperation._validate_fragments(self.updated_fragments)

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -794,10 +794,14 @@ class LanceFragment(pa.dataset.Fragment):
 
         Returns
         -------
-        Tuple[FragmentMetadata, List[int]]
+        Tuple[FragmentMetadata, List[int], List[int]]
             A tuple of:
             - FragmentMetadata: The updated fragment metadata
             - List[int]: The list of field IDs that were modified
+            - List[int]: The list of physical row offsets that were matched
+              (updated). These are 0-based indices within the fragment and
+              can be passed as ``updated_row_offsets`` when committing with
+              ``LanceOperation.Update``.
 
         Examples
         --------
@@ -854,10 +858,10 @@ class LanceFragment(pa.dataset.Fragment):
             right_on = left_on
 
         reader = _coerce_reader(data_obj, schema)
-        metadata, fields_modified = self._fragment.update_columns(
+        metadata, fields_modified, matched_offsets = self._fragment.update_columns(
             reader, left_on, right_on
         )
-        return metadata, fields_modified
+        return metadata, fields_modified, matched_offsets
 
     def merge_columns(
         self,

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -362,15 +362,16 @@ impl FileFragment {
         reader: PyArrowType<ArrowArrayStreamReader>,
         left_on: String,
         right_on: String,
-    ) -> PyResult<(PyLance<Fragment>, Vec<u32>)> {
+    ) -> PyResult<(PyLance<Fragment>, Vec<u32>, Option<Vec<u32>>)> {
         let mut fragment = self.fragment.clone();
-        let (updated_fragment, fields_modified) = rt()
+        let (updated_fragment, fields_modified, matched_bitmap) = rt()
             .spawn(None, async move {
                 fragment.update_columns(reader.0, &left_on, &right_on).await
             })?
             .infer_error()?;
 
-        Ok((PyLance(updated_fragment), fields_modified))
+        let matched_offsets = matched_bitmap.map(|bm| bm.iter().collect());
+        Ok((PyLance(updated_fragment), fields_modified, matched_offsets))
     }
 
     fn delete(&self, predicate: &str) -> PyResult<Option<Self>> {

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -299,6 +299,17 @@ impl FromPyObject<'_, '_> for PyLance<Operation> {
                     fields_for_preserving_frag_bitmap,
                     update_mode,
                     inserted_rows_filter: None,
+                    updated_row_offsets: ob
+                        .getattr("updated_row_offsets")
+                        .ok()
+                        .and_then(|attr| {
+                            if attr.is_none() {
+                                None
+                            } else {
+                                attr.extract::<std::collections::HashMap<u64, Vec<u32>>>()
+                                    .ok()
+                            }
+                        }),
                 };
                 Ok(Self(op))
             }
@@ -450,6 +461,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
                 fields_modified,
                 fields_for_preserving_frag_bitmap,
                 update_mode,
+                updated_row_offsets,
                 ..
             } => {
                 let removed_fragment_ids = removed_fragment_ids.into_pyobject(py)?;
@@ -467,6 +479,16 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
                     },
                     None => "rewrite_rows",
                 };
+                let updated_row_offsets_py = match updated_row_offsets {
+                    Some(map) => {
+                        let dict = pyo3::types::PyDict::new(py);
+                        for (frag_id, offsets) in map {
+                            dict.set_item(frag_id, offsets)?;
+                        }
+                        dict.into_any()
+                    }
+                    None => py.None().into_bound(py),
+                };
                 let cls = namespace
                     .getattr("Update")
                     .expect("Failed to get Update class");
@@ -477,6 +499,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
                     fields_modified,
                     fields_for_preserving_frag_bitmap,
                     update_mode,
+                    updated_row_offsets_py,
                 ))
             }
             Operation::DataReplacement { replacements } => {

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -11,6 +11,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Range;
 use std::sync::Arc;
 
+use roaring::RoaringBitmap;
+
 use arrow::compute::concat_batches;
 use arrow_array::cast::as_primitive_array;
 use arrow_array::{
@@ -1601,12 +1603,38 @@ impl FileFragment {
         Ok(self)
     }
 
+    /// If you need to opt out of offset tracking to save memory, use
+    /// [`update_columns_with_tracking`] with `track_matched_offsets = false`.
     pub async fn update_columns(
         &mut self,
         right_stream: impl RecordBatchReader + Send + 'static,
         left_on: &str,
         right_on: &str,
-    ) -> Result<(Fragment, Vec<u32>)> {
+    ) -> Result<(Fragment, Vec<u32>, Option<RoaringBitmap>)> {
+        self.update_columns_impl(right_stream, left_on, right_on, true)
+            .await
+    }
+
+
+    pub async fn update_columns_with_tracking(
+        &mut self,
+        right_stream: impl RecordBatchReader + Send + 'static,
+        left_on: &str,
+        right_on: &str,
+        track_matched_offsets: bool,
+    ) -> Result<(Fragment, Vec<u32>, Option<RoaringBitmap>)> {
+        self.update_columns_impl(right_stream, left_on, right_on, track_matched_offsets)
+            .await
+    }
+
+    /// Internal implementation of update_columns with configurable offset tracking.
+    async fn update_columns_impl(
+        &mut self,
+        right_stream: impl RecordBatchReader + Send + 'static,
+        left_on: &str,
+        right_on: &str,
+        track_matched_offsets: bool,
+    ) -> Result<(Fragment, Vec<u32>, Option<RoaringBitmap>)> {
         if self.schema().field(left_on).is_none() && left_on != ROW_ID && left_on != ROW_ADDR {
             return Err(Error::invalid_input(format!(
                 "Column {} does not exist in the left side fragment",
@@ -1655,11 +1683,35 @@ impl FileFragment {
             .await?;
         // Hash join
         let joiner = Arc::new(HashJoiner::try_new(right_stream, right_on).await?);
+        let mut matched_bitmap: Option<RoaringBitmap> = if track_matched_offsets {
+            Some(RoaringBitmap::new())
+        } else {
+            None
+        };
+        let mut physical_offset: u32 = 0;
         while let Some(batch) = updater.next().await? {
-            let updated_batch = joiner
-                .collect_with_fallback(batch, batch[left_on].clone(), self.dataset())
-                .await?;
-            updater.update(updated_batch).await?;
+            let batch_len = batch.num_rows() as u32;
+            if track_matched_offsets {
+                let (updated_batch, batch_matched) = joiner
+                    .collect_with_fallback_reporting(
+                        batch,
+                        batch[left_on].clone(),
+                        self.dataset(),
+                    )
+                    .await?;
+                if let Some(ref mut bm) = matched_bitmap {
+                    for local_idx in batch_matched {
+                        bm.insert(physical_offset + local_idx);
+                    }
+                }
+                updater.update(updated_batch).await?;
+                physical_offset += batch_len;
+            } else {
+                let updated_batch = joiner
+                    .collect_with_fallback(batch, batch[left_on].clone(), self.dataset())
+                    .await?;
+                updater.update(updated_batch).await?;
+            }
         }
 
         let mut updated_fragment = updater.finish().await?;
@@ -1689,7 +1741,7 @@ impl FileFragment {
             .filter_map(|&i| u32::try_from(i).ok())
             .collect();
         // Note: updated field should be returned when committing, waiting to be done
-        Ok((updated_fragment, updated_fields))
+        Ok((updated_fragment, updated_fields, matched_bitmap))
     }
 
     /// Append new columns to the fragment
@@ -2850,7 +2902,7 @@ mod tests {
             vec![Ok(update_batch1)].into_iter(),
             schema1,
         ));
-        let (updated_fragment1, fields_modified1) = fragment1
+        let (updated_fragment1, fields_modified1, _matched_offsets1) = fragment1
             .update_columns(right_stream1, ROW_ID, ROW_ID)
             .await
             .unwrap();
@@ -2863,6 +2915,7 @@ mod tests {
             fields_for_preserving_frag_bitmap: vec![],
             update_mode: Some(UpdateMode::RewriteColumns),
             inserted_rows_filter: None,
+            updated_row_offsets: None,
         };
         let mut dataset1 = Dataset::commit(
             test_uri,
@@ -2923,7 +2976,7 @@ mod tests {
             vec![Ok(update_batch2)].into_iter(),
             schema2,
         ));
-        let (updated_fragment2, fields_modified2) = fragment2
+        let (updated_fragment2, fields_modified2, _matched_offsets2) = fragment2
             .update_columns(right_stream2, "i", "i1")
             .await
             .unwrap();
@@ -2936,6 +2989,7 @@ mod tests {
             fields_for_preserving_frag_bitmap: vec![],
             update_mode: Some(UpdateMode::RewriteColumns),
             inserted_rows_filter: None,
+            updated_row_offsets: None,
         };
         let dataset2 = Dataset::commit(
             test_uri,
@@ -3631,7 +3685,7 @@ mod tests {
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
-        let batch = concat_batches(&schema, &batches).unwrap();
+        let batch = arrow_select::concat::concat_batches(&schema, &batches).unwrap();
 
         let mut row_id: i32 = 0;
         let mut i: usize = 0;
@@ -3982,5 +4036,232 @@ mod tests {
         let stats = dataset.object_store().io_stats_incremental();
         assert_io_eq!(stats, read_iops, 1);
         assert_io_lt!(stats, read_bytes, 4096);
+    }
+
+    #[tokio::test]
+    async fn test_update_columns_returns_matched_offsets() {
+        let test_dir = TempStrDir::default();
+        let test_uri = &test_dir;
+        let mut dataset = create_dataset_v2(test_uri).await;
+
+        let _ = dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![("col1".into(), "-1".into())]),
+                None,
+                None,
+            )
+            .await;
+        let mut fragment = dataset.get_fragment(0).unwrap();
+
+        // Fragment 0 has rows with i = 0..40
+        // Update only even rows (0, 2, 4, ..., 38) via ROW_ID join
+        let row_ids: Vec<u64> = (0..40u64).filter(|v| v % 2 == 0).collect();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(ROW_ID, DataType::UInt64, false),
+            ArrowField::new("col1", DataType::Int64, true),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from(row_ids.clone())),
+                Arc::new(Int64Array::from(vec![42i64; 20])),
+            ],
+        )
+            .unwrap();
+        let right_stream: Box<dyn RecordBatchReader + Send> = Box::new(RecordBatchIterator::new(
+            vec![Ok(update_batch)].into_iter(),
+            schema,
+        ));
+
+        let (_updated_fragment, _fields_modified, matched_offsets) = fragment
+            .update_columns(right_stream, ROW_ID, ROW_ID)
+            .await
+            .unwrap();
+
+        // update_columns always tracks offsets (hardcoded true)
+        let bitmap = matched_offsets.expect("update_columns should always return Some(bitmap)");
+        let matched: Vec<u32> = bitmap.iter().collect();
+        // Even row indices: 0, 2, 4, ..., 38
+        let expected: Vec<u32> = (0..40u32).filter(|v| v % 2 == 0).collect();
+        assert_eq!(matched, expected);
+    }
+
+    #[tokio::test]
+    async fn test_update_columns_large_offsets_bitmap_encoding() {
+        // Create a dataset with a single fragment containing >5000 rows to
+        // exercise the RoaringBitmap path (proto serialization uses bitmap
+        // encoding when offsets.len() > 5000).
+        let test_dir = TempStrDir::default();
+        let test_uri = &test_dir;
+
+        let num_rows: i32 = 8000;
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "i",
+            DataType::Int32,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..num_rows))],
+        )
+            .unwrap();
+        let write_params = WriteParams {
+            max_rows_per_file: num_rows as usize, // single fragment
+            max_rows_per_group: 1024,
+            data_storage_version: Some(LanceFileVersion::Stable),
+            ..Default::default()
+        };
+        let batches = RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema.clone());
+        Dataset::write(batches, test_uri, Some(write_params))
+            .await
+            .unwrap();
+        let mut dataset = Dataset::open(test_uri).await.unwrap();
+        assert_eq!(dataset.get_fragments().len(), 1);
+
+        // Add a column to update
+        let _ = dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![("col1".into(), "-1".into())]),
+                None,
+                None,
+            )
+            .await;
+        let mut fragment = dataset.get_fragment(0).unwrap();
+
+        // Update 6000 rows (offsets 0..6000) — exceeds the 5000 threshold
+        let update_count = 6000usize;
+        let row_ids: Vec<u64> = (0..update_count as u64).collect();
+        let update_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(ROW_ID, DataType::UInt64, false),
+            ArrowField::new("col1", DataType::Int64, true),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            update_schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from(row_ids)),
+                Arc::new(Int64Array::from(vec![42i64; update_count])),
+            ],
+        )
+            .unwrap();
+        let right_stream: Box<dyn RecordBatchReader + Send> = Box::new(RecordBatchIterator::new(
+            vec![Ok(update_batch)].into_iter(),
+            update_schema,
+        ));
+
+        let (updated_fragment, fields_modified, matched_offsets) = fragment
+            .update_columns(right_stream, ROW_ID, ROW_ID)
+            .await
+            .unwrap();
+
+        // ---- Verify the RoaringBitmap returned by update_columns ----
+        let bitmap = matched_offsets.expect("should always return Some(bitmap)");
+        assert_eq!(bitmap.len(), update_count as u64);
+        let matched: Vec<u32> = bitmap.iter().collect();
+        let expected: Vec<u32> = (0..update_count as u32).collect();
+        assert_eq!(matched, expected);
+
+        // ---- Verify protobuf round-trip uses bitmap encoding for >5000 offsets ----
+        use crate::dataset::transaction::{Operation, UpdateMode};
+        use lance_table::format::pb;
+        use std::collections::HashMap;
+
+        let mut offsets_map = HashMap::new();
+        offsets_map.insert(
+            updated_fragment.id,
+            bitmap.iter().collect::<Vec<u32>>(),
+        );
+        let op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![updated_fragment],
+            new_fragments: vec![],
+            fields_modified,
+            merged_generations: vec![],
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: Some(UpdateMode::RewriteColumns),
+            inserted_rows_filter: None,
+            updated_row_offsets: Some(offsets_map.clone()),
+        };
+
+        let txn = crate::dataset::transaction::Transaction {
+            read_version: dataset.version().version,
+            uuid: uuid::Uuid::new_v4().to_string(),
+            operation: op,
+            tag: None,
+            transaction_properties: None,
+        };
+
+        // Serialize to protobuf and verify bitmap encoding is used
+        let pb_txn: pb::Transaction = pb::Transaction::from(&txn);
+        if let Some(pb::transaction::Operation::Update(ref update)) = pb_txn.operation {
+            assert_eq!(update.updated_row_offsets.len(), 1);
+            let fro = &update.updated_row_offsets[0];
+            assert!(
+                matches!(
+                    fro.offsets,
+                    Some(pb::transaction::fragment_row_offsets::Offsets::Bitmap(_))
+                ),
+                "Expected bitmap encoding for >5000 offsets, got array encoding"
+            );
+        } else {
+            panic!("Expected Update operation in protobuf");
+        }
+
+        // Deserialize back and verify offsets are preserved
+        let round_tripped =
+            crate::dataset::transaction::Transaction::try_from(pb_txn).unwrap();
+        if let Operation::Update {
+            updated_row_offsets: Some(rt_map),
+            ..
+        } = &round_tripped.operation
+        {
+            let (_, rt_offsets) = rt_map.iter().next().unwrap();
+            assert_eq!(rt_offsets.len(), update_count);
+            assert_eq!(*rt_offsets, expected);
+        } else {
+            panic!("Expected Update with Some(updated_row_offsets)");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_columns_with_tracking_false_returns_none() {
+        let test_dir = TempStrDir::default();
+        let test_uri = &test_dir;
+        let mut dataset = create_dataset_v2(test_uri).await;
+
+        let _ = dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![("col1".into(), "-1".into())]),
+                None,
+                None,
+            )
+            .await;
+        let mut fragment = dataset.get_fragment(0).unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new(ROW_ID, DataType::UInt64, false),
+            ArrowField::new("col1", DataType::Int64, true),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from(vec![0u64, 1, 2])),
+                Arc::new(Int64Array::from(vec![99i64; 3])),
+            ],
+        )
+            .unwrap();
+        let right_stream: Box<dyn RecordBatchReader + Send> = Box::new(RecordBatchIterator::new(
+            vec![Ok(update_batch)].into_iter(),
+            schema,
+        ));
+
+        let (_updated_fragment, _fields_modified, matched_offsets) = fragment
+            .update_columns_with_tracking(right_stream, ROW_ID, ROW_ID, false)
+            .await
+            .unwrap();
+
+        assert!(
+            matched_offsets.is_none(),
+            "update_columns_with_tracking(false) should return None"
+        );
     }
 }

--- a/rust/lance/src/dataset/hash_joiner.rs
+++ b/rust/lance/src/dataset/hash_joiner.rs
@@ -278,6 +278,71 @@ impl HashJoiner {
             .await?;
         Ok(RecordBatch::try_new(self.batches[0].schema(), columns)?)
     }
+    /// Like [`collect_with_fallback`], but also reports which row indices in the
+    /// left batch were matched (i.e. found in the right table).
+    ///
+    /// Returns `(result_batch, matched_left_indices)` where `matched_left_indices`
+    /// contains the 0-based positions within the left batch that had a match.
+    pub(super) async fn collect_with_fallback_reporting(
+        &self,
+        left_batch: &RecordBatch,
+        index_column: ArrayRef,
+        dataset: &Dataset,
+    ) -> Result<(RecordBatch, Vec<u32>)> {
+        if index_column.data_type() != &self.index_type {
+            return Err(Error::invalid_input(format!(
+                "Index column type mismatch: expected {}, got {}",
+                self.index_type,
+                index_column.data_type()
+            )));
+        }
+        let left_batch_index = self.batches.len();
+        let mut matched_indices = Vec::new();
+        let indices = column_to_rows(index_column)?
+            .into_iter()
+            .enumerate()
+            .map(|(left_rowi, row)| {
+                self.index_map
+                    .get(&row.owned())
+                    .map(|(batch_i, row_i)| {
+                        matched_indices.push(left_rowi as u32);
+                        (*batch_i, *row_i)
+                    })
+                    .unwrap_or((left_batch_index, left_rowi))
+            })
+            .collect::<Vec<_>>();
+        let indices = Arc::new(indices);
+        let columns = futures::stream::iter(0..self.batches[0].num_columns())
+            .map(|column_i| {
+                let mut arrays = Vec::with_capacity(self.batches.len() + 1);
+                for batch in &self.batches {
+                    arrays.push(batch.column(column_i).clone());
+                }
+                arrays.push(left_batch.column(column_i).clone());
+                let indices = indices.clone();
+                async move {
+                    let task_result = task::spawn_blocking(move || {
+                        let array_refs = arrays.iter().map(|x| x.as_ref()).collect::<Vec<_>>();
+                        interleave(array_refs.as_ref(), indices.as_ref())
+                            .map_err(|err| Error::invalid_input(format!("HashJoiner: {}", err)))
+                    })
+                    .await;
+                    match task_result {
+                        Ok(Ok(array)) => {
+                            Self::check_lance_support_null(&array, dataset)?;
+                            Ok(array)
+                        }
+                        Ok(Err(err)) => Err(err),
+                        Err(err) => Err(Error::invalid_input(format!("HashJoiner: {}", err))),
+                    }
+                }
+            })
+            .buffered(get_num_compute_intensive_cpus())
+            .try_collect::<Vec<_>>()
+            .await?;
+        let result = RecordBatch::try_new(self.batches[0].schema(), columns)?;
+        Ok((result, matched_indices))
+    }
 }
 
 #[cfg(test)]
@@ -389,6 +454,145 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("Index column type mismatch: expected Int32, got UInt32")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_with_fallback_reporting() {
+        let right_schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("val", DataType::Utf8, false),
+        ]));
+        let right_batch = RecordBatch::try_new(
+            right_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![10, 20, 30])),
+                Arc::new(StringArray::from(vec!["ten", "twenty", "thirty"])),
+            ],
+        )
+            .unwrap();
+        let right_reader: Box<dyn RecordBatchReader + Send> = Box::new(
+            RecordBatchIterator::new(vec![Ok(right_batch)], right_schema.clone()),
+        );
+        let joiner = HashJoiner::try_new(right_reader, "key").await.unwrap();
+
+        let dataset = create_dataset().await;
+
+        // Left batch schema must match joiner output schema: [val] only.
+        let left_schema = Arc::new(Schema::new(vec![
+            Field::new("val", DataType::Utf8, false),
+        ]));
+        let left_batch = RecordBatch::try_new(
+            left_schema.clone(),
+            vec![Arc::new(StringArray::from(vec![
+                "old_10", "old_99", "old_20", "old_88", "old_30",
+            ]))],
+        )
+            .unwrap();
+        // Index column passed separately (keys [10, 99, 20, 88, 30]).
+        let index_col: ArrayRef = Arc::new(Int32Array::from(vec![10, 99, 20, 88, 30]));
+
+        let (result, matched) = joiner
+            .collect_with_fallback_reporting(&left_batch, index_col, &dataset)
+            .await
+            .unwrap();
+
+        // Matches at local indices 0, 2, 4
+        assert_eq!(matched, vec![0u32, 2, 4]);
+
+        // Matched rows get right-table values; unmatched keep left-table values
+        assert_eq!(
+            result.column_by_name("val").unwrap().as_ref(),
+            &StringArray::from(vec!["ten", "old_99", "twenty", "old_88", "thirty"])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_with_fallback_reporting_no_matches() {
+        let right_schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("val", DataType::Utf8, false),
+        ]));
+        let right_batch = RecordBatch::try_new(
+            right_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![100, 200])),
+                Arc::new(StringArray::from(vec!["a", "b"])),
+            ],
+        )
+            .unwrap();
+        let right_reader: Box<dyn RecordBatchReader + Send> = Box::new(
+            RecordBatchIterator::new(vec![Ok(right_batch)], right_schema.clone()),
+        );
+        let joiner = HashJoiner::try_new(right_reader, "key").await.unwrap();
+
+        let dataset = create_dataset().await;
+
+        // Left batch with only the non-key column
+        let left_schema = Arc::new(Schema::new(vec![
+            Field::new("val", DataType::Utf8, false),
+        ]));
+        let left_batch = RecordBatch::try_new(
+            left_schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["x", "y", "z"]))],
+        )
+            .unwrap();
+        let index_col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+
+        let (result, matched) = joiner
+            .collect_with_fallback_reporting(&left_batch, index_col, &dataset)
+            .await
+            .unwrap();
+
+        // No matches
+        assert!(matched.is_empty());
+        // All values from left
+        assert_eq!(
+            result.column_by_name("val").unwrap().as_ref(),
+            &StringArray::from(vec!["x", "y", "z"])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_with_fallback_reporting_all_matches() {
+        let right_schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::Int32, false),
+            Field::new("val", DataType::Utf8, false),
+        ]));
+        let right_batch = RecordBatch::try_new(
+            right_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["new_1", "new_2", "new_3"])),
+            ],
+        )
+            .unwrap();
+        let right_reader: Box<dyn RecordBatchReader + Send> = Box::new(
+            RecordBatchIterator::new(vec![Ok(right_batch)], right_schema.clone()),
+        );
+        let joiner = HashJoiner::try_new(right_reader, "key").await.unwrap();
+
+        let dataset = create_dataset().await;
+
+        let left_schema = Arc::new(Schema::new(vec![
+            Field::new("val", DataType::Utf8, false),
+        ]));
+        let left_batch = RecordBatch::try_new(
+            left_schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["old_1", "old_2", "old_3"]))],
+        )
+            .unwrap();
+        let index_col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+
+        let (result, matched) = joiner
+            .collect_with_fallback_reporting(&left_batch, index_col, &dataset)
+            .await
+            .unwrap();
+
+        assert_eq!(matched, vec![0u32, 1, 2]);
+        assert_eq!(
+            result.column_by_name("val").unwrap().as_ref(),
+            &StringArray::from(vec!["new_1", "new_2", "new_3"])
         );
     }
 }

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -222,6 +222,12 @@ pub enum Operation {
         /// Optional filter for detecting conflicts on inserted row keys.
         /// Only tracks keys from INSERT operations during merge insert, not updates.
         inserted_rows_filter: Option<KeyExistenceFilter>,
+        /// Optional per-fragment map of updated row offsets (physical row indices within each fragment).
+        /// Used for RewriteColumns mode to selectively update `_row_last_updated_at_version`.
+        /// Key: fragment ID, Value: sorted local physical row offsets that were updated.
+        /// Callers can construct this from `RoaringBitmap` via `.iter().collect()`.
+        /// If None, all rows in updated_fragments are assumed to be updated (or caller already set metadata).
+        updated_row_offsets: Option<HashMap<u64, Vec<u32>>>,
     },
 
     /// Project to a new schema. This only changes the schema, not the data.
@@ -421,6 +427,7 @@ impl PartialEq for Operation {
                     fields_for_preserving_frag_bitmap: a_fields_for_preserving_frag_bitmap,
                     update_mode: a_update_mode,
                     inserted_rows_filter: a_inserted_rows_filter,
+                    updated_row_offsets: a_updated_row_offsets,
                 },
                 Self::Update {
                     removed_fragment_ids: b_removed,
@@ -431,6 +438,7 @@ impl PartialEq for Operation {
                     fields_for_preserving_frag_bitmap: b_fields_for_preserving_frag_bitmap,
                     update_mode: b_update_mode,
                     inserted_rows_filter: b_inserted_rows_filter,
+                    updated_row_offsets: b_updated_row_offsets,
                 },
             ) => {
                 compare_vec(a_removed, b_removed)
@@ -444,6 +452,7 @@ impl PartialEq for Operation {
                     )
                     && a_update_mode == b_update_mode
                     && a_inserted_rows_filter == b_inserted_rows_filter
+                    && a_updated_row_offsets == b_updated_row_offsets
             }
             (Self::Project { schema: a }, Self::Project { schema: b }) => a == b,
             (
@@ -1667,13 +1676,14 @@ impl Transaction {
                 merged_generations,
                 fields_for_preserving_frag_bitmap,
                 update_mode,
+                updated_row_offsets,
                 ..
             } => {
                 // Extract existing fragments once for reuse
                 let existing_fragments = maybe_existing_fragments?;
 
                 // Apply updates to existing fragments
-                let updated_frags: Vec<Fragment> = existing_fragments
+                let mut updated_frags: Vec<Fragment> = existing_fragments
                     .iter()
                     .filter_map(|f| {
                         if removed_fragment_ids.contains(&f.id) {
@@ -1691,8 +1701,30 @@ impl Transaction {
                 // Note: We don't update version metadata for fragments with deletion vectors
                 // because the version sequences are indexed by physical row position, not logical position.
                 // Version metadata for deleted rows will be filtered out during scan using the deletion vector.
-                if next_row_id.is_some() {
-                    // Version metadata will be properly set during compaction when deletions are materialized
+                // For RewriteColumns mode with stable row IDs, selectively update
+                // _row_last_updated_at_version for only the matched rows in each fragment.
+                if next_row_id.is_some() && update_mode == &Some(UpdateMode::RewriteColumns) {
+                    let new_version = current_manifest.map(|m| m.version + 1).unwrap_or(1);
+                    let prev_version = current_manifest.map(|m| m.version).unwrap_or(0);
+
+                    if let Some(offsets_map) = updated_row_offsets {
+                        for frag in updated_frags.iter_mut() {
+                            if let Some(offsets) = offsets_map.get(&frag.id) {
+                                // Selectively refresh only matched rows
+                                let offsets_usize: Vec<usize> =
+                                    offsets.iter().map(|o| *o as usize).collect();
+                                lance_table::rowids::version::refresh_row_latest_update_meta_for_partial_frag_rewrite_cols(
+                                    frag,
+                                    &offsets_usize,
+                                    new_version,
+                                    prev_version,
+                                )?;
+                            }
+                            // Fragments not in the map: don't touch their version metadata (guard)
+                        }
+                    }
+                    // If updated_row_offsets is None, the caller (e.g., merge_insert) has already
+                    // set version metadata directly on the fragments before constructing the operation.
                 }
 
                 final_fragments.extend(updated_frags);
@@ -2857,6 +2889,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                 fields_for_preserving_frag_bitmap,
                 update_mode,
                 inserted_rows,
+                updated_row_offsets,
             })) => Operation::Update {
                 removed_fragment_ids,
                 updated_fragments: updated_fragments
@@ -2881,6 +2914,28 @@ impl TryFrom<pb::Transaction> for Transaction {
                 inserted_rows_filter: inserted_rows
                     .map(|ik| KeyExistenceFilter::try_from(&ik))
                     .transpose()?,
+                updated_row_offsets: if updated_row_offsets.is_empty() {
+                    None
+                } else {
+                    Some(
+                        updated_row_offsets
+                            .into_iter()
+                            .map(|fro| {
+                                let offsets: Vec<u32> = match fro.offsets {
+                                    Some(pb::transaction::fragment_row_offsets::Offsets::Array(arr)) => {
+                                        arr.offsets
+                                    }
+                                    Some(pb::transaction::fragment_row_offsets::Offsets::Bitmap(buf)) => {
+                                        let bitmap = RoaringBitmap::deserialize_from(&buf[..]).unwrap();
+                                        bitmap.iter().collect()
+                                    }
+                                    None => Vec::new(),
+                                };
+                                (fro.fragment_id, offsets)
+                            })
+                            .collect(),
+                    )
+                },
             },
             Some(pb::transaction::Operation::Project(pb::transaction::Project { schema })) => {
                 Operation::Project {
@@ -3183,6 +3238,7 @@ impl From<&Transaction> for pb::Transaction {
                 fields_for_preserving_frag_bitmap,
                 update_mode,
                 inserted_rows_filter,
+                updated_row_offsets,
             } => pb::transaction::Operation::Update(pb::transaction::Update {
                 removed_fragment_ids: removed_fragment_ids.clone(),
                 updated_fragments: updated_fragments
@@ -3204,6 +3260,33 @@ impl From<&Transaction> for pb::Transaction {
                     })
                     .unwrap_or(0),
                 inserted_rows: inserted_rows_filter.as_ref().map(|ik| ik.into()),
+                updated_row_offsets: updated_row_offsets
+                    .as_ref()
+                    .map(|map| {
+                        map.iter()
+                            .map(|(frag_id, offsets)| {
+                                // Use bitmap encoding when dense (>5000 offsets),
+                                // array encoding when sparse.
+                                let proto_offsets = if offsets.len() > 5000 {
+                                    let bitmap: RoaringBitmap = offsets.iter().copied().collect();
+                                    let mut buf = Vec::new();
+                                    bitmap.serialize_into(&mut buf).unwrap();
+                                    Some(pb::transaction::fragment_row_offsets::Offsets::Bitmap(buf))
+                                } else {
+                                    Some(pb::transaction::fragment_row_offsets::Offsets::Array(
+                                        pb::transaction::FragmentRowOffsetArray {
+                                            offsets: offsets.iter().copied().collect(),
+                                        },
+                                    ))
+                                };
+                                pb::transaction::FragmentRowOffsets {
+                                    fragment_id: *frag_id,
+                                    offsets: proto_offsets,
+                                }
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
             }),
             Operation::Project { schema } => {
                 pb::transaction::Operation::Project(pb::transaction::Project {
@@ -4526,5 +4609,174 @@ mod tests {
         // This should succeed — the old manifest's LEGACY format should not
         // cause strict validation of the new STABLE fragments.
         validate_operation(Some(&legacy_manifest), &operation).unwrap();
+    }
+
+    #[test]
+    fn test_updated_row_offsets_pb_roundtrip_array_encoding() {
+        // Small number of offsets -> array encoding
+        let mut offsets_map = HashMap::new();
+        offsets_map.insert(1u64, vec![0u32, 5, 10]);
+        offsets_map.insert(3u64, vec![2u32, 7]);
+
+        let transaction = Transaction {
+            read_version: 1,
+            uuid: Uuid::new_v4().to_string(),
+            operation: Operation::Update {
+                removed_fragment_ids: vec![],
+                updated_fragments: vec![Fragment::new(1), Fragment::new(3)],
+                new_fragments: vec![],
+                fields_modified: vec![1],
+                merged_generations: vec![],
+                fields_for_preserving_frag_bitmap: vec![],
+                update_mode: Some(UpdateMode::RewriteColumns),
+                inserted_rows_filter: None,
+                updated_row_offsets: Some(offsets_map.clone()),
+            },
+            tag: None,
+            transaction_properties: None,
+        };
+
+        let pb_txn: pb::Transaction = pb::Transaction::from(&transaction);
+        let round_tripped = Transaction::try_from(pb_txn).unwrap();
+
+        assert_eq!(transaction.operation, round_tripped.operation);
+        if let Operation::Update {
+            updated_row_offsets,
+            ..
+        } = &round_tripped.operation
+        {
+            let got = updated_row_offsets.as_ref().unwrap();
+            assert_eq!(got.get(&1u64).unwrap(), &vec![0u32, 5, 10]);
+            assert_eq!(got.get(&3u64).unwrap(), &vec![2u32, 7]);
+        } else {
+            panic!("Expected Operation::Update");
+        }
+    }
+
+    #[test]
+    fn test_updated_row_offsets_pb_roundtrip_bitmap_encoding() {
+        // >5000 offsets -> bitmap encoding
+        let large_offsets: Vec<u32> = (0..6000).collect();
+        let mut offsets_map = HashMap::new();
+        offsets_map.insert(42u64, large_offsets.clone());
+
+        let transaction = Transaction {
+            read_version: 2,
+            uuid: Uuid::new_v4().to_string(),
+            operation: Operation::Update {
+                removed_fragment_ids: vec![],
+                updated_fragments: vec![Fragment::new(42)],
+                new_fragments: vec![],
+                fields_modified: vec![1],
+                merged_generations: vec![],
+                fields_for_preserving_frag_bitmap: vec![],
+                update_mode: Some(UpdateMode::RewriteColumns),
+                inserted_rows_filter: None,
+                updated_row_offsets: Some(offsets_map),
+            },
+            tag: None,
+            transaction_properties: None,
+        };
+
+        let pb_txn: pb::Transaction = pb::Transaction::from(&transaction);
+        let round_tripped = Transaction::try_from(pb_txn).unwrap();
+
+        if let Operation::Update {
+            updated_row_offsets,
+            ..
+        } = &round_tripped.operation
+        {
+            let got = updated_row_offsets.as_ref().unwrap();
+            assert_eq!(got.get(&42u64).unwrap(), &large_offsets);
+        } else {
+            panic!("Expected Operation::Update");
+        }
+    }
+
+    #[test]
+    fn test_updated_row_offsets_none_roundtrip() {
+        let transaction = Transaction {
+            read_version: 1,
+            uuid: Uuid::new_v4().to_string(),
+            operation: Operation::Update {
+                removed_fragment_ids: vec![],
+                updated_fragments: vec![Fragment::new(0)],
+                new_fragments: vec![],
+                fields_modified: vec![1],
+                merged_generations: vec![],
+                fields_for_preserving_frag_bitmap: vec![],
+                update_mode: Some(UpdateMode::RewriteColumns),
+                inserted_rows_filter: None,
+                updated_row_offsets: None,
+            },
+            tag: None,
+            transaction_properties: None,
+        };
+
+        let pb_txn: pb::Transaction = pb::Transaction::from(&transaction);
+        let round_tripped = Transaction::try_from(pb_txn).unwrap();
+
+        if let Operation::Update {
+            updated_row_offsets,
+            ..
+        } = &round_tripped.operation
+        {
+            assert!(updated_row_offsets.is_none());
+        } else {
+            panic!("Expected Operation::Update");
+        }
+    }
+
+    #[test]
+    fn test_updated_row_offsets_equality() {
+        let mut map_a = HashMap::new();
+        map_a.insert(1u64, vec![0u32, 1, 2]);
+
+        let mut map_b = HashMap::new();
+        map_b.insert(1u64, vec![0u32, 1, 2]);
+
+        let op_a = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![],
+            fields_modified: vec![],
+            merged_generations: vec![],
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: Some(UpdateMode::RewriteColumns),
+            inserted_rows_filter: None,
+            updated_row_offsets: Some(map_a),
+        };
+
+        let op_b = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![],
+            fields_modified: vec![],
+            merged_generations: vec![],
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: Some(UpdateMode::RewriteColumns),
+            inserted_rows_filter: None,
+            updated_row_offsets: Some(map_b),
+        };
+
+        assert_eq!(op_a, op_b);
+
+        // Different offsets should not be equal
+        let mut map_c = HashMap::new();
+        map_c.insert(1u64, vec![0u32, 1, 3]);
+
+        let op_c = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![],
+            new_fragments: vec![],
+            fields_modified: vec![],
+            merged_generations: vec![],
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: Some(UpdateMode::RewriteColumns),
+            inserted_rows_filter: None,
+            updated_row_offsets: Some(map_c),
+        };
+
+        assert_ne!(op_a, op_c);
     }
 }

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -755,6 +755,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_row_offsets: None,
             },
             read_version: 1,
             tag: None,

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1650,6 +1650,7 @@ impl MergeInsertJob {
                 fields_for_preserving_frag_bitmap: vec![], // in-place update do not affect preserving frag bitmap
                 update_mode: Some(RewriteColumns),
                 inserted_rows_filter: None, // not implemented for v1
+                updated_row_offsets: None, // metadata already set on fragments by update_fragments
             };
             // We have rewritten the fragments, not just the deletion files, so
             // we can't use affected rows here.
@@ -1724,6 +1725,7 @@ impl MergeInsertJob {
                     .collect(),
                 update_mode: Some(RewriteRows),
                 inserted_rows_filter: None, // not implemented for v1
+                updated_row_offsets: None,
             };
 
             let affected_rows = Some(RowAddrTreeMap::from(removed_row_addrs));

--- a/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
@@ -284,6 +284,7 @@ impl ExecutionPlan for DeleteOnlyMergeInsertExec {
                     .collect(),
                 update_mode: None,
                 inserted_rows_filter: None, // Delete-only operations don't insert rows
+                updated_row_offsets: None,
             };
 
             let transaction = Transaction::new(dataset.manifest.version, operation, None);

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -928,6 +928,7 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
                     .collect(),
                 update_mode: Some(RewriteRows),
                 inserted_rows_filter: inserted_rows_filter.clone(),
+                updated_row_offsets: None,
             };
 
             // Step 5: Create and store the transaction

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -377,6 +377,7 @@ impl UpdateJob {
             fields_for_preserving_frag_bitmap,
             update_mode: Some(RewriteRows),
             inserted_rows_filter: None,
+            updated_row_offsets: None,
         };
 
         let transaction = Transaction::new(dataset.manifest.version, operation, None);

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1815,6 +1815,7 @@ mod tests {
             fields_for_preserving_frag_bitmap: vec![],
             update_mode: None,
             inserted_rows_filter: None,
+            updated_row_offsets: None,
         };
         let transaction = Transaction::new_from_version(1, operation);
         let other_operations = [
@@ -1827,6 +1828,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_row_offsets: None,
             },
             Operation::Delete {
                 deleted_fragment_ids: vec![3],
@@ -1842,6 +1844,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_row_offsets: None,
             },
         ];
         let other_transactions = other_operations.map(|op| Transaction::new_from_version(2, op));
@@ -1944,6 +1947,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_row_offsets: None,
             },
             Operation::Delete {
                 updated_fragments: vec![apply_deletion(&[1], &mut fragment, &dataset).await],
@@ -1959,6 +1963,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_row_offsets: None,
             },
         ];
         let transactions =
@@ -2081,6 +2086,7 @@ mod tests {
                     fields_for_preserving_frag_bitmap: vec![],
                     update_mode: None,
                     inserted_rows_filter: None,
+                    updated_row_offsets: None,
                 },
             ),
             (
@@ -2094,6 +2100,7 @@ mod tests {
                     fields_for_preserving_frag_bitmap: vec![],
                     update_mode: None,
                     inserted_rows_filter: None,
+                    updated_row_offsets: None,
                 },
             ),
             (
@@ -2254,6 +2261,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_row_offsets: None,
             },
             create_update_config_for_test(
                 Some(HashMap::from_iter(vec![(
@@ -2460,6 +2468,7 @@ mod tests {
                     fields_for_preserving_frag_bitmap: vec![],
                     update_mode: None,
                     inserted_rows_filter: None,
+                    updated_row_offsets: None,
                 },
                 [
                     Compatible,    // append
@@ -2982,6 +2991,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_row_offsets: None,
             },
         ];
 


### PR DESCRIPTION
wip, trying to fix issue: https://github.com/lance-format/lance/issues/6505