### PR TITLE
feat!: make dataset object store access base-aware

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3455,6 +3455,7 @@ fn inner_get_zonemap_stats<'local>(
                     for index in &indices {
                         let index_store = Arc::new(
                             LanceIndexStore::from_dataset_for_existing(&dataset, index)
+                                .await
                                 .map_err(Error::from)?,
                         );
                         let index_file = index_store

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2508,15 +2508,21 @@ impl Dataset {
     }
 
     /// Get a snapshot of current IO statistics without resetting counters
-    fn io_stats_snapshot(&self) -> IoStats {
-        let stats = self.ds.object_store().io_stats_snapshot();
-        IoStats::from_lance(stats)
+    fn io_stats_snapshot(&self) -> PyResult<IoStats> {
+        let object_store = rt()
+            .block_on(None, self.ds.object_store(None))?
+            .infer_error()?;
+        let stats = object_store.io_stats_snapshot();
+        Ok(IoStats::from_lance(stats))
     }
 
     /// Get incremental IO statistics for this dataset
-    fn io_stats_incremental(&self) -> IoStats {
-        let stats = self.ds.object_store().io_stats_incremental();
-        IoStats::from_lance(stats)
+    fn io_stats_incremental(&self) -> PyResult<IoStats> {
+        let object_store = rt()
+            .block_on(None, self.ds.object_store(None))?
+            .infer_error()?;
+        let stats = object_store.io_stats_incremental();
+        Ok(IoStats::from_lance(stats))
     }
 
     #[staticmethod]

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -526,7 +526,8 @@ async fn do_load_shuffled_vectors(
 
     let mut ds = dataset.ds.as_ref().clone();
     let index_dir = ds.indices_dir().child(index_id.to_string());
-    let files = list_index_files_with_sizes(ds.object_store(), &index_dir)
+    let object_store = ds.object_store(None).await.infer_error()?;
+    let files = list_index_files_with_sizes(object_store.as_ref(), &index_dir)
         .await
         .infer_error()?;
     let metadata = IndexMetadata {

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -7610,7 +7610,9 @@ mod tests {
         // Use dataset's object_store to find and copy the manifest
         let versions_path = dataset.versions_dir();
         let manifest_metas: Vec<_> = dataset
-            .object_store()
+            .object_store(None)
+            .await
+            .unwrap()
             .inner
             .list(Some(&versions_path))
             .try_collect()
@@ -7629,7 +7631,9 @@ mod tests {
 
         // Read the existing manifest data
         let manifest_data = dataset
-            .object_store()
+            .object_store(None)
+            .await
+            .unwrap()
             .inner
             .get(&manifest_meta.location)
             .await
@@ -7641,7 +7645,9 @@ mod tests {
         // Write to a staging location using the dataset's object_store
         let staging_path = dataset.versions_dir().child("staging_manifest");
         dataset
-            .object_store()
+            .object_store(None)
+            .await
+            .unwrap()
             .inner
             .put(&staging_path, manifest_data.into())
             .await
@@ -7666,7 +7672,13 @@ mod tests {
             .version
             .expect("response should contain version info");
         let version_2_path = Path::parse(&version_info.manifest_path).unwrap();
-        let head_result = dataset.object_store().inner.head(&version_2_path).await;
+        let head_result = dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .head(&version_2_path)
+            .await;
         assert!(
             head_result.is_ok(),
             "Version 2 manifest should exist at {}",
@@ -7674,7 +7686,13 @@ mod tests {
         );
 
         // Verify the staging file has been deleted
-        let staging_head_result = dataset.object_store().inner.head(&staging_path).await;
+        let staging_head_result = dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .head(&staging_path)
+            .await;
         assert!(
             staging_head_result.is_err(),
             "Staging manifest should have been deleted after create_table_version"
@@ -7722,7 +7740,9 @@ mod tests {
         // Use dataset's object_store to find and copy the manifest
         let versions_path = dataset.versions_dir();
         let manifest_metas: Vec<_> = dataset
-            .object_store()
+            .object_store(None)
+            .await
+            .unwrap()
             .inner
             .list(Some(&versions_path))
             .try_collect()
@@ -7741,7 +7761,9 @@ mod tests {
 
         // Read the existing manifest data
         let manifest_data = dataset
-            .object_store()
+            .object_store(None)
+            .await
+            .unwrap()
             .inner
             .get(&manifest_meta.location)
             .await
@@ -7753,7 +7775,9 @@ mod tests {
         // Write to a staging location using the dataset's object_store
         let staging_path = dataset.versions_dir().child("staging_manifest");
         dataset
-            .object_store()
+            .object_store(None)
+            .await
+            .unwrap()
             .inner
             .put(&staging_path, manifest_data.into())
             .await
@@ -7792,7 +7816,13 @@ mod tests {
         );
 
         // Verify version 2 still exists using the dataset's object_store
-        let head_result = dataset.object_store().inner.head(&version_2_path).await;
+        let head_result = dataset
+            .object_store(None)
+            .await
+            .unwrap()
+            .inner
+            .head(&version_2_path)
+            .await;
         assert!(
             head_result.is_ok(),
             "Version 2 manifest should still exist at {}",
@@ -8229,7 +8259,9 @@ mod tests {
             // Verify version 2 was created using the dataset's object_store
             // List manifests in the versions directory to find the V2 named manifest
             let manifest_metas: Vec<_> = dataset
-                .object_store()
+                .object_store(None)
+                .await
+                .unwrap()
                 .inner
                 .list(Some(&dataset.versions_dir()))
                 .try_collect()
@@ -9084,7 +9116,9 @@ mod tests {
             // Find existing manifest and create a staging copy
             let versions_path = dataset.versions_dir();
             let manifest_metas: Vec<_> = dataset
-                .object_store()
+                .object_store(None)
+                .await
+                .unwrap()
                 .inner
                 .list(Some(&versions_path))
                 .try_collect()
@@ -9102,7 +9136,9 @@ mod tests {
                 .expect("No manifest file found");
 
             let manifest_data = dataset
-                .object_store()
+                .object_store(None)
+                .await
+                .unwrap()
                 .inner
                 .get(&manifest_meta.location)
                 .await
@@ -9115,7 +9151,9 @@ mod tests {
                 .versions_dir()
                 .child(format!("staging_{}", table_name));
             dataset
-                .object_store()
+                .object_store(None)
+                .await
+                .unwrap()
                 .inner
                 .put(&staging_path, manifest_data.into())
                 .await

--- a/rust/lance/benches/take.rs
+++ b/rust/lance/benches/take.rs
@@ -226,10 +226,8 @@ fn file_reader_take(
 
 async fn create_file_reader(dataset: &Dataset, file_path: &Path) -> FileReader {
     // Create file reader v2.
-    let scheduler = ScanScheduler::new(
-        dataset.object_store.clone(),
-        SchedulerConfig::new(2 * 1024 * 1024 * 1024),
-    );
+    let object_store = dataset.object_store(None).await.unwrap();
+    let scheduler = ScanScheduler::new(object_store, SchedulerConfig::new(2 * 1024 * 1024 * 1024));
     let file = scheduler
         .open_file(file_path, &CachedFileSize::unknown())
         .await

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -33,8 +33,9 @@ use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::LanceFileVersion;
 use lance_index::{IndexType, progress::IndexBuildProgress};
 use lance_io::object_store::{
-    LanceNamespaceStorageOptionsProvider, ObjectStore, ObjectStoreParams, StorageOptions,
-    StorageOptionsAccessor, StorageOptionsProvider,
+    ChainedWrappingObjectStore, LanceNamespaceStorageOptionsProvider, ObjectStore,
+    ObjectStoreParams, StorageOptions, StorageOptionsAccessor, StorageOptionsProvider,
+    WrappingObjectStore,
 };
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::utils::{
@@ -153,7 +154,9 @@ pub const DEFAULT_METADATA_CACHE_SIZE: usize = 1024 * 1024 * 1024;
 /// Lance Dataset
 #[derive(Clone)]
 pub struct Dataset {
-    pub object_store: Arc<ObjectStore>,
+    /// The primary dataset object store. Use [`Self::object_store`] when
+    /// resolving files that may carry a base id.
+    pub(crate) object_store: Arc<ObjectStore>,
     pub(crate) commit_handler: Arc<dyn CommitHandler>,
     /// Uri of the dataset.
     ///
@@ -505,7 +508,7 @@ impl Dataset {
 
         let builder = CommitBuilder::new(WriteDestination::Uri(branch_location.uri.as_str()))
             .with_store_params(store_params.unwrap_or_default())
-            .with_object_store(Arc::new(self.object_store().clone()))
+            .with_object_store(Arc::new(self.object_store.as_ref().clone()))
             .with_commit_handler(self.commit_handler.clone())
             .with_storage_format(self.manifest.data_storage_format.lance_file_version()?);
         let dataset = builder.execute(transaction).await?;
@@ -1332,7 +1335,7 @@ impl Dataset {
     ) -> Result<()> {
         let (manifest, manifest_location) = commit_transaction(
             self,
-            self.object_store(),
+            self.object_store.as_ref(),
             self.commit_handler.as_ref(),
             &transaction,
             write_config,
@@ -1654,10 +1657,6 @@ impl Dataset {
             .await
     }
 
-    pub fn object_store(&self) -> &ObjectStore {
-        &self.object_store
-    }
-
     /// Clone this dataset with a different object store binding.
     ///
     /// The returned dataset shares metadata, session state, and caches with the
@@ -1674,6 +1673,73 @@ impl Dataset {
             cloned.store_params = Some(Box::new(store_params));
         }
         cloned
+    }
+
+    /// Clone this dataset with extra object store wrappers applied to all read stores.
+    ///
+    /// The returned dataset uses the wrappers for the already-open primary object
+    /// store and appends the same wrappers to the dataset-level and base-specific
+    /// object store params used when additional base stores are opened later.
+    pub fn with_object_store_wrappers(
+        &self,
+        wrappers: impl IntoIterator<Item = Arc<dyn WrappingObjectStore>>,
+    ) -> Self {
+        let wrappers = wrappers.into_iter().collect::<Vec<_>>();
+        if wrappers.is_empty() {
+            return self.clone();
+        }
+
+        let mut cloned = self.clone();
+        let mut object_store = self.object_store.as_ref().clone();
+        for wrapper in &wrappers {
+            object_store.inner =
+                wrapper.wrap(&object_store.store_prefix, object_store.inner.clone());
+        }
+        cloned.object_store = Arc::new(object_store);
+        cloned.refs = Refs::new(
+            cloned.object_store.clone(),
+            cloned.commit_handler.clone(),
+            cloned.branch_location(),
+        );
+
+        let store_params = self.store_params.as_deref().cloned().unwrap_or_default();
+        cloned.store_params = Some(Box::new(Self::append_object_store_wrappers(
+            store_params,
+            &wrappers,
+        )));
+        cloned.base_store_params = self.base_store_params.as_ref().map(|base_store_params| {
+            Arc::new(
+                base_store_params
+                    .iter()
+                    .map(|(base_path, store_params)| {
+                        (
+                            base_path.clone(),
+                            Self::append_object_store_wrappers(store_params.clone(), &wrappers),
+                        )
+                    })
+                    .collect(),
+            )
+        });
+        cloned
+    }
+
+    fn append_object_store_wrappers(
+        mut store_params: ObjectStoreParams,
+        wrappers: &[Arc<dyn WrappingObjectStore>],
+    ) -> ObjectStoreParams {
+        let mut all_wrappers = Vec::with_capacity(
+            store_params.object_store_wrapper.as_ref().map_or(0, |_| 1) + wrappers.len(),
+        );
+        if let Some(wrapper) = store_params.object_store_wrapper.take() {
+            all_wrappers.push(wrapper);
+        }
+        all_wrappers.extend(wrappers.iter().cloned());
+        store_params.object_store_wrapper = match all_wrappers.len() {
+            0 => None,
+            1 => all_wrappers.pop(),
+            _ => Some(Arc::new(ChainedWrappingObjectStore::new(all_wrappers))),
+        };
+        store_params
     }
 
     fn store_params_for_base(
@@ -1794,12 +1860,14 @@ impl Dataset {
         let data_dir = self.data_file_dir_for_base(base_id)?;
         let filepath = data_dir.child(path);
 
+        let object_store = self.object_store(base_id).await?;
+
         // Get file size
-        let file_size = self.object_store().size(&filepath).await?;
+        let file_size = object_store.size(&filepath).await?;
 
         // Read file metadata
         let scheduler = ScanScheduler::new(
-            self.object_store.clone(),
+            object_store.clone(),
             SchedulerConfig::new(2 * 1024 * 1024 * 1024),
         );
         let file = scheduler
@@ -1898,8 +1966,7 @@ impl Dataset {
         }
     }
 
-    /// Get the ObjectStore for a specific path based on base_id
-    pub(crate) async fn object_store_for_base(&self, base_id: u32) -> Result<Arc<ObjectStore>> {
+    async fn base_object_store(&self, base_id: u32) -> Result<Arc<ObjectStore>> {
         let base_path = self.manifest.base_paths.get(&base_id).ok_or_else(|| {
             Error::invalid_input(format!("Dataset base path with ID {} not found", base_id))
         })?;
@@ -1913,6 +1980,38 @@ impl Dataset {
         .await?;
 
         Ok(store)
+    }
+
+    /// Resolve the object store for the primary dataset or an additional base.
+    ///
+    /// Pass `None` to get the primary dataset object store. Pass `Some(base_id)`
+    /// when resolving a file whose metadata references an additional base.
+    pub async fn object_store(&self, base_id: Option<u32>) -> Result<Arc<ObjectStore>> {
+        match base_id {
+            Some(base_id) => self.base_object_store(base_id).await,
+            None => Ok(self.object_store.clone()),
+        }
+    }
+
+    pub(crate) async fn object_store_for_data_file(
+        &self,
+        data_file: &DataFile,
+    ) -> Result<Arc<ObjectStore>> {
+        self.object_store(data_file.base_id).await
+    }
+
+    pub(crate) async fn object_store_for_deletion(
+        &self,
+        deletion_file: &DeletionFile,
+    ) -> Result<Arc<ObjectStore>> {
+        self.object_store(deletion_file.base_id).await
+    }
+
+    pub(crate) async fn object_store_for_index(
+        &self,
+        index: &IndexMetadata,
+    ) -> Result<Arc<ObjectStore>> {
+        self.object_store(index.base_id).await
     }
 
     pub(crate) fn dataset_dir_for_deletion(&self, deletion_file: &DeletionFile) -> Result<Path> {
@@ -2390,7 +2489,7 @@ impl Dataset {
     /// # tokio::runtime::Runtime::new().unwrap().block_on(fut);
     /// ```
     pub async fn migrate_manifest_paths_v2(&mut self) -> Result<()> {
-        migrate_scheme_to_v2(self.object_store(), &self.base).await?;
+        migrate_scheme_to_v2(self.object_store.as_ref(), &self.base).await?;
         // We need to re-open.
         let latest_version = self.latest_version_id().await?;
         *self = self.checkout_version(latest_version).await?;
@@ -2421,7 +2520,7 @@ impl Dataset {
             .with_store_params(
                 store_params.unwrap_or(self.store_params.as_deref().cloned().unwrap_or_default()),
             )
-            .with_object_store(Arc::new(self.object_store().clone()))
+            .with_object_store(Arc::new(self.object_store.as_ref().clone()))
             .with_commit_handler(self.commit_handler.clone())
             .with_storage_format(self.manifest.data_storage_format.lance_file_version()?);
         builder.execute(transaction).await
@@ -2658,11 +2757,11 @@ pub(crate) struct NewTransactionResult<'a> {
 pub(crate) fn load_new_transactions(dataset: &Dataset) -> NewTransactionResult<'_> {
     // Re-use the same list call for getting the latest manifest and the metadata
     // for all manifests in between.
-    let io_parallelism = dataset.object_store().io_parallelism();
+    let io_parallelism = dataset.object_store.as_ref().io_parallelism();
     let latest_version = dataset.manifest.version;
     let locations = dataset
         .commit_handler
-        .list_manifest_locations(&dataset.base, dataset.object_store(), true)
+        .list_manifest_locations(&dataset.base, dataset.object_store.as_ref(), true)
         .try_take_while(move |location| {
             futures::future::ready(Ok(location.version > latest_version))
         });
@@ -2686,7 +2785,7 @@ pub(crate) fn load_new_transactions(dataset: &Dataset) -> NewTransactionResult<'
                 } else {
                     let loaded = Arc::new(
                         Dataset::load_manifest(
-                            dataset.object_store(),
+                            dataset.object_store.as_ref(),
                             &location,
                             &dataset.uri,
                             dataset.session.as_ref(),
@@ -2941,7 +3040,7 @@ impl Dataset {
             IndexType::Inverted => {
                 // Call merge_index_files function for inverted index
                 lance_index::scalar::inverted::builder::merge_index_files(
-                    self.object_store(),
+                    self.object_store.as_ref(),
                     &index_dir,
                     Arc::new(store),
                     progress,
@@ -2951,7 +3050,7 @@ impl Dataset {
             IndexType::BTree => {
                 // Call merge_index_files function for btree index
                 lance_index::scalar::btree::merge_index_files(
-                    self.object_store(),
+                    self.object_store.as_ref(),
                     &index_dir,
                     Arc::new(store),
                     batch_readhead,
@@ -2961,7 +3060,7 @@ impl Dataset {
             }
             IndexType::Bitmap => {
                 lance_index::scalar::bitmap::merge_index_files(
-                    self.object_store(),
+                    self.object_store.as_ref(),
                     &index_dir,
                     Arc::new(store),
                     progress,

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -1946,7 +1946,7 @@ async fn collect_blob_entries_v2(
                     let object_store = if let Some(store) = store_cache.get(&base_id) {
                         store.clone()
                     } else {
-                        let store = dataset.object_store_for_base(base_id).await?;
+                        let store = dataset.object_store(Some(base_id)).await?;
                         store_cache.insert(base_id, store.clone());
                         store
                     };
@@ -2047,7 +2047,7 @@ async fn resolve_blob_read_location(
         if let Some(store) = store_cache.get(&base_id) {
             store.clone()
         } else {
-            let store = dataset.object_store_for_base(base_id).await?;
+            let store = dataset.object_store(Some(base_id)).await?;
             store_cache.insert(base_id, store.clone());
             store
         }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1535,11 +1535,13 @@ mod tests {
     async fn write_dummy_index_artifact(dataset: &Dataset, uuid: Uuid) -> Result<()> {
         let index_dir = dataset.indices_dir().child(uuid.to_string());
         dataset
-            .object_store()
+            .object_store
+            .as_ref()
             .put(&index_dir.child("index.idx"), b"idx")
             .await?;
         dataset
-            .object_store()
+            .object_store
+            .as_ref()
             .put(&index_dir.child("auxiliary.idx"), b"aux")
             .await?;
         Ok(())
@@ -1555,11 +1557,13 @@ mod tests {
             .child(staging_uuid.to_string())
             .child(format!("partial_{}", shard_uuid));
         dataset
-            .object_store()
+            .object_store
+            .as_ref()
             .put(&shard_dir.child("index.idx"), b"idx")
             .await?;
         dataset
-            .object_store()
+            .object_store
+            .as_ref()
             .put(&shard_dir.child("auxiliary.idx"), b"aux")
             .await?;
         Ok(())
@@ -2291,7 +2295,8 @@ mod tests {
         assert_eq!(removed.index_files_removed, 2);
         assert!(
             !dataset
-                .object_store()
+                .object_store
+                .as_ref()
                 .exists(
                     &dataset
                         .indices_dir()
@@ -2303,7 +2308,8 @@ mod tests {
         );
         assert!(
             dataset
-                .object_store()
+                .object_store
+                .as_ref()
                 .exists(
                     &dataset
                         .indices_dir()
@@ -2315,7 +2321,8 @@ mod tests {
         );
         assert!(
             dataset
-                .object_store()
+                .object_store
+                .as_ref()
                 .exists(
                     &dataset
                         .indices_dir()
@@ -2355,7 +2362,8 @@ mod tests {
         assert_eq!(removed.index_files_removed, 4);
         assert!(
             !dataset
-                .object_store()
+                .object_store
+                .as_ref()
                 .exists(
                     &dataset
                         .indices_dir()
@@ -2368,7 +2376,8 @@ mod tests {
         );
         assert!(
             !dataset
-                .object_store()
+                .object_store
+                .as_ref()
                 .exists(
                     &dataset
                         .indices_dir()

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -932,9 +932,10 @@ impl FileFragment {
                     .dataset
                     .data_file_dir(data_file)?
                     .child(data_file.path.as_str());
+                let object_store = self.dataset.object_store_for_data_file(data_file).await?;
                 let field_id_offset = Self::get_field_id_offset(data_file);
                 let reader = PreviousFileReader::try_new_with_fragment_id(
-                    &self.dataset.object_store,
+                    &object_store,
                     &path,
                     self.schema().clone(),
                     self.id() as u32,
@@ -963,7 +964,7 @@ impl FileFragment {
             let (store_scheduler, reader_priority) = if let Some(base_id) = data_file.base_id {
                 // TODO: make object stores for non-default bases reuse the same scan scheduler
                 //  currently we always create a new one
-                let object_store = self.dataset.object_store_for_base(base_id).await?;
+                let object_store = self.dataset.object_store(Some(base_id)).await?;
                 let config = SchedulerConfig::max_bandwidth(&object_store);
                 (
                     ScanScheduler::new(object_store, config),
@@ -1248,7 +1249,7 @@ impl FileFragment {
         }
 
         for data_file in &self.metadata.files {
-            data_file.validate(&self.dataset.data_file_dir(&self.metadata.files[0])?)?;
+            data_file.validate(&self.dataset.data_file_dir(data_file)?)?;
         }
 
         let get_lengths = self.metadata.files.iter().map(|data_file| async move {
@@ -1831,7 +1832,7 @@ impl FileFragment {
             self.metadata.id,
             self.dataset.version().version,
             &deletion_vector,
-            self.dataset.object_store(),
+            self.dataset.object_store.as_ref(),
         )
         .await?;
 
@@ -3954,7 +3955,7 @@ mod tests {
 
         // Assert file is small (< 4300 bytes)
         {
-            let stats = dataset.object_store().io_stats_incremental();
+            let stats = dataset.object_store.as_ref().io_stats_incremental();
             assert_io_eq!(stats, write_iops, 3);
             assert_io_lt!(stats, written_bytes, 4300);
         }
@@ -3979,7 +3980,7 @@ mod tests {
         assert_eq!(data.num_rows(), 1);
         assert_eq!(data.num_columns(), 7);
 
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(stats, read_iops, 1);
         assert_io_lt!(stats, read_bytes, 4096);
     }

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -118,6 +118,7 @@ impl IndexRemapper for DatasetIndexRemapper {
     }
 }
 
+#[async_trait]
 pub trait LanceIndexStoreExt {
     /// Create an index store for a new index (will always be absolute with no base id)
     fn from_dataset_for_new(dataset: &Dataset, uuid: &str) -> Result<Self>
@@ -125,7 +126,7 @@ pub trait LanceIndexStoreExt {
         Self: Sized;
 
     /// Open an index store for an existing index (might be relative or absolute)
-    fn from_dataset_for_existing(dataset: &Dataset, index: &IndexMetadata) -> Result<Self>
+    async fn from_dataset_for_existing(dataset: &Dataset, index: &IndexMetadata) -> Result<Self>
     where
         Self: Sized;
 }
@@ -144,6 +145,7 @@ pub(crate) fn dataset_format_version(dataset: &Dataset) -> LanceFileVersion {
         .unwrap_or(LanceFileVersion::V2_0)
 }
 
+#[async_trait]
 impl LanceIndexStoreExt for LanceIndexStore {
     fn from_dataset_for_new(dataset: &Dataset, uuid: &str) -> Result<Self> {
         let index_dir = dataset.indices_dir().child(uuid);
@@ -157,18 +159,15 @@ impl LanceIndexStoreExt for LanceIndexStore {
         ))
     }
 
-    fn from_dataset_for_existing(dataset: &Dataset, index: &IndexMetadata) -> Result<Self> {
+    async fn from_dataset_for_existing(dataset: &Dataset, index: &IndexMetadata) -> Result<Self> {
         let index_dir = dataset
             .indice_files_dir(index)?
             .child(index.uuid.to_string());
         let cache = dataset.metadata_cache.file_metadata_cache(&index_dir);
         let format_version = dataset_format_version(dataset);
-        let store = Self::with_format_version(
-            dataset.object_store.clone(),
-            index_dir,
-            Arc::new(cache),
-            format_version,
-        );
+        let object_store = dataset.object_store_for_index(index).await?;
+        let store =
+            Self::with_format_version(object_store, index_dir, Arc::new(cache), format_version);
         Ok(store.with_file_sizes(index.file_size_map()))
     }
 }
@@ -232,7 +231,8 @@ mod tests {
         let second_segment_dir = dataset.indices_dir().child(second_segment_uuid.to_string());
         for file_name in ["index.idx", "auxiliary.idx"] {
             dataset
-                .object_store()
+                .object_store
+                .as_ref()
                 .copy(
                     &first_segment_dir.child(file_name),
                     &second_segment_dir.child(file_name),

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -502,7 +502,7 @@ async fn can_use_binary_copy_impl(
 
             // check file global buffer
             let object_store = match data_file.base_id {
-                Some(base_id) => dataset.object_store_for_base(base_id).await?,
+                Some(base_id) => dataset.object_store(Some(base_id)).await?,
                 None => dataset.object_store.clone(),
             };
             let full_path = dataset
@@ -617,7 +617,7 @@ impl CompactionPlanner for DefaultCompactionPlanner {
                     Err(e) => Err(e),
                 }
             })
-            .buffered(dataset.object_store().io_parallelism());
+            .buffered(dataset.object_store.as_ref().io_parallelism());
 
         let index_fragmaps = load_index_fragmaps(dataset).await?;
         let indices_containing_frag = |frag_id: u32| {
@@ -1096,7 +1096,7 @@ async fn reserve_fragment_ids(
 
     let (manifest, _) = commit_transaction(
         dataset,
-        dataset.object_store(),
+        dataset.object_store.as_ref(),
         dataset.commit_handler.as_ref(),
         &transaction,
         &Default::default(),

--- a/rust/lance/src/dataset/optimize/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/binary_copy.rs
@@ -250,7 +250,7 @@ pub async fn rewrite_files_binary_copy(
     for frag in fragments.iter() {
         for df in frag.files.iter() {
             let object_store = if let Some(base_id) = df.base_id {
-                dataset.object_store_for_base(base_id).await?
+                dataset.object_store(Some(base_id)).await?
             } else {
                 dataset.object_store.clone()
             };

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1094,7 +1094,7 @@ impl Scanner {
         get_default_batch_size().unwrap_or_else(|| {
             self.batch_size.unwrap_or_else(|| {
                 std::cmp::max(
-                    self.dataset.object_store().block_size() / 4,
+                    self.dataset.object_store.as_ref().block_size() / 4,
                     BATCH_SIZE_FALLBACK,
                 )
             })
@@ -2208,7 +2208,7 @@ impl Scanner {
                 }
 
                 let byte_width = field.data_type().byte_width_opt();
-                let is_cloud = self.dataset.object_store().is_cloud();
+                let is_cloud = self.dataset.object_store.as_ref().is_cloud();
                 if is_cloud {
                     byte_width.is_some_and(|bw| bw < 1000)
                 } else {
@@ -8500,9 +8500,9 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             .unwrap();
 
         // First run a full scan to get a baseline
-        let _ = dataset.object_store().io_stats_incremental(); // reset
+        let _ = dataset.object_store.as_ref().io_stats_incremental(); // reset
         dataset.scan().try_into_batch().await.unwrap();
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         let full_scan_bytes = io_stats.read_bytes;
 
         // Next do a scan without pushdown, we should still see a benefit from late materialization
@@ -8514,7 +8514,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             .try_into_batch()
             .await
             .unwrap();
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_lt!(io_stats, read_bytes, full_scan_bytes);
         let filtered_scan_bytes = io_stats.read_bytes;
 
@@ -8528,7 +8528,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
                 .try_into_batch()
                 .await
                 .unwrap();
-            let io_stats = dataset.object_store().io_stats_incremental();
+            let io_stats = dataset.object_store.as_ref().io_stats_incremental();
             assert_io_lt!(io_stats, read_bytes, filtered_scan_bytes);
         }
 
@@ -8542,7 +8542,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             .try_into_batch()
             .await
             .unwrap();
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_lt!(io_stats, read_bytes, full_scan_bytes);
         let index_scan_bytes = io_stats.read_bytes;
 
@@ -8555,7 +8555,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             .try_into_batch()
             .await
             .unwrap();
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_lt!(io_stats, read_bytes, index_scan_bytes);
     }
 
@@ -9726,7 +9726,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             .unwrap();
 
         // First pass will need to perform some IOPs to determine what scalar indices are available
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_gt!(io_stats, read_iops, 0);
 
         // Second planning cycle should not perform any I/O
@@ -9739,7 +9739,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             .await
             .unwrap();
 
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 0);
 
         dataset
@@ -9751,7 +9751,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             .await
             .unwrap();
 
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 0);
 
         dataset
@@ -9764,7 +9764,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             .await
             .unwrap();
 
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 0);
 
         dataset
@@ -9777,7 +9777,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             .await
             .unwrap();
 
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 0);
     }
 

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -42,11 +42,20 @@ use crate::index::DatasetIndexExt;
 use futures::TryStreamExt;
 use lance_index::IndexType;
 use lance_index::scalar::ScalarIndexParams;
-use lance_io::object_store::{ObjectStore, ObjectStoreParams, StorageOptionsAccessor};
+use lance_io::object_store::{
+    ObjectStore, ObjectStoreParams, StorageOptionsAccessor, WrappingObjectStore,
+};
 use lance_io::utils::tracking_store::IOTracker;
 use lance_table::io::manifest::read_manifest;
+use object_store::ObjectStore as _;
 use object_store::path::Path;
 use rstest::rstest;
+
+fn file_object_store_uri(path: &std::path::Path) -> String {
+    let path = path.to_str().unwrap().replace('\\', "/");
+    let path_prefix = if path.starts_with('/') { "" } else { "/" };
+    format!("file-object-store://{path_prefix}{path}")
+}
 
 #[tokio::test]
 async fn test_truncate_table() {
@@ -110,8 +119,8 @@ async fn test_with_object_store_clone_preserves_shared_state_and_overrides_store
     let wrapped_dataset = dataset.with_object_store(wrapped_store, Some(store_params));
     assert!(Arc::ptr_eq(&dataset.session(), &wrapped_dataset.session()));
     assert!(!Arc::ptr_eq(
-        &dataset.object_store().inner,
-        &wrapped_dataset.object_store().inner
+        &dataset.object_store.as_ref().inner,
+        &wrapped_dataset.object_store.as_ref().inner
     ));
 }
 
@@ -169,9 +178,240 @@ async fn test_with_object_store_enables_isolated_per_request_io_tracking() {
     assert_eq!(tracker_b.incremental_stats().read_iops, 0);
 }
 
+#[tokio::test]
+async fn test_with_object_store_wrappers_wraps_primary_store() {
+    let test_dir = TempStdDir::default();
+    create_file(&test_dir, WriteMode::Create, LanceFileVersion::Stable).await;
+    let uri = test_dir.to_str().unwrap();
+    let dataset = Dataset::open(uri).await.unwrap();
+
+    let tracker = Arc::new(IOTracker::default());
+    let wrapped =
+        dataset.with_object_store_wrappers(vec![tracker.clone() as Arc<dyn WrappingObjectStore>]);
+
+    let _ = tracker.incremental_stats();
+    drain_scan(&wrapped).await;
+    assert!(tracker.incremental_stats().read_iops > 0);
+}
+
+#[tokio::test]
+async fn test_with_object_store_wrappers_wraps_base_store_params() {
+    let test_dir = TempStdDir::default();
+    create_file(&test_dir, WriteMode::Create, LanceFileVersion::Stable).await;
+    let uri = test_dir.to_str().unwrap();
+    let dataset = Arc::new(Dataset::open(uri).await.unwrap());
+
+    let base_dir = tempfile::tempdir().unwrap();
+    let base_uri = file_object_store_uri(base_dir.path());
+    let base = BasePath::new(1, base_uri, Some("base".to_string()), true);
+    dataset.add_bases(vec![base.clone()], None).await.unwrap();
+
+    let existing_tracker = Arc::new(IOTracker::default());
+    let base_store_params = ObjectStoreParams {
+        object_store_wrapper: Some(existing_tracker.clone()),
+        ..Default::default()
+    };
+    let dataset = DatasetBuilder::from_uri(uri)
+        .with_base_store_params(&base.path, base_store_params)
+        .load()
+        .await
+        .unwrap();
+
+    let request_tracker = Arc::new(IOTracker::default());
+    let wrapped = dataset
+        .with_object_store_wrappers(vec![request_tracker.clone() as Arc<dyn WrappingObjectStore>]);
+    let base_store = wrapped.object_store(Some(1)).await.unwrap();
+    let base_location = base
+        .extract_path(wrapped.session().store_registry())
+        .unwrap()
+        .child("data")
+        .child("probe.lance");
+
+    base_store.put(&base_location, b"hello").await.unwrap();
+    let _ = existing_tracker.incremental_stats();
+    let _ = request_tracker.incremental_stats();
+
+    base_store
+        .inner
+        .get_range(&base_location, 0..1)
+        .await
+        .unwrap();
+
+    assert!(existing_tracker.incremental_stats().read_iops > 0);
+    assert!(request_tracker.incremental_stats().read_iops > 0);
+}
+
+#[tokio::test]
+async fn test_with_object_store_wrappers_wraps_refs_store() {
+    let test_dir = tempfile::tempdir().unwrap();
+    let uri = file_object_store_uri(test_dir.path());
+    let batch = gen_batch()
+        .col("i", array::step::<Int32Type>())
+        .into_batch_rows(RowCount::from(2))
+        .unwrap();
+    let dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema()),
+        &uri,
+        None,
+    )
+    .await
+    .unwrap();
+    dataset
+        .tags()
+        .create("v1", dataset.manifest().version)
+        .await
+        .unwrap();
+
+    let tracker = Arc::new(IOTracker::default());
+    let wrapped =
+        dataset.with_object_store_wrappers(vec![tracker.clone() as Arc<dyn WrappingObjectStore>]);
+
+    let _ = tracker.incremental_stats();
+    wrapped.tags().get("v1").await.unwrap();
+    assert!(tracker.incremental_stats().read_iops > 0);
+}
+
+#[tokio::test]
+async fn test_create_data_file_uses_base_object_store() {
+    let primary_dir = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    let primary_uri = file_object_store_uri(primary_dir.path());
+    let source_uri = file_object_store_uri(source_dir.path());
+
+    let source_batch = gen_batch()
+        .col("id", array::step::<Int32Type>())
+        .into_batch_rows(RowCount::from(8))
+        .unwrap();
+    let source = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(source_batch.clone())], source_batch.schema()),
+        &source_uri,
+        None,
+    )
+    .await
+    .unwrap();
+    let primary = Arc::new(
+        Dataset::write(
+            RecordBatchIterator::new(vec![Ok(source_batch.clone())], source_batch.schema()),
+            &primary_uri,
+            None,
+        )
+        .await
+        .unwrap(),
+    );
+
+    let base = BasePath::new(1, source_uri.clone(), Some("source".to_string()), true);
+    primary.add_bases(vec![base.clone()], None).await.unwrap();
+
+    let tracker = Arc::new(IOTracker::default());
+    let dataset = DatasetBuilder::from_uri(&primary_uri)
+        .with_base_store_params(
+            &base.path,
+            ObjectStoreParams {
+                object_store_wrapper: Some(tracker.clone()),
+                ..Default::default()
+            },
+        )
+        .with_session(Arc::new(Session::default()))
+        .load()
+        .await
+        .unwrap();
+    let source_file = &source.manifest().fragments[0].files[0];
+
+    let _ = tracker.incremental_stats();
+    let data_file = dataset
+        .create_data_file(&source_file.path, Some(base.id))
+        .await
+        .unwrap();
+
+    assert_eq!(data_file.base_id, Some(base.id));
+    assert!(tracker.incremental_stats().read_iops > 0);
+}
+
+#[tokio::test]
+async fn test_shallow_clone_base_artifacts_use_base_object_store() {
+    let source_dir = tempfile::tempdir().unwrap();
+    let clone_dir = tempfile::tempdir().unwrap();
+    let source_uri = file_object_store_uri(source_dir.path());
+    let clone_uri = file_object_store_uri(clone_dir.path());
+
+    let batch = gen_batch()
+        .col("id", array::step::<Int32Type>())
+        .into_batch_rows(RowCount::from(64))
+        .unwrap();
+    let mut source = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema()),
+        &source_uri,
+        None,
+    )
+    .await
+    .unwrap();
+    source
+        .create_index(
+            &["id"],
+            IndexType::Scalar,
+            Some("id_idx".to_string()),
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+    source.delete("id < 4").await.unwrap();
+    source
+        .tags()
+        .create("with_artifacts", source.version().version)
+        .await
+        .unwrap();
+
+    let cloned = source
+        .shallow_clone(&clone_uri, "with_artifacts", None)
+        .await
+        .unwrap();
+    let base = cloned
+        .manifest()
+        .base_paths
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    let tracker = Arc::new(IOTracker::default());
+    let cloned = DatasetBuilder::from_uri(&clone_uri)
+        .with_base_store_params(
+            &base.path,
+            ObjectStoreParams {
+                object_store_wrapper: Some(tracker.clone()),
+                ..Default::default()
+            },
+        )
+        .with_session(Arc::new(Session::default()))
+        .load()
+        .await
+        .unwrap();
+
+    let fragment = cloned
+        .get_fragments()
+        .into_iter()
+        .find(|fragment| fragment.metadata.deletion_file.is_some())
+        .unwrap();
+    assert_eq!(
+        fragment.metadata.deletion_file.as_ref().unwrap().base_id,
+        Some(base.id)
+    );
+
+    let _ = tracker.incremental_stats();
+    fragment.get_deletion_vector().await.unwrap().unwrap();
+    assert!(tracker.incremental_stats().read_iops > 0);
+
+    let indices = cloned.load_indices().await.unwrap();
+    assert_eq!(indices[0].base_id, Some(base.id));
+
+    let _ = tracker.incremental_stats();
+    cloned.index_statistics("id_idx").await.unwrap();
+    assert!(tracker.incremental_stats().read_iops > 0);
+}
+
 #[cfg(feature = "azure")]
 #[tokio::test]
-async fn test_object_store_for_base_uses_runtime_base_store_params() {
+async fn test_object_store_uses_runtime_base_store_params() {
     let test_dir = TempStdDir::default();
     create_file(&test_dir, WriteMode::Create, LanceFileVersion::Stable).await;
     let uri = test_dir.to_str().unwrap();
@@ -220,9 +460,9 @@ async fn test_object_store_for_base_uses_runtime_base_store_params() {
         .await
         .unwrap();
 
-    let store_a = dataset.object_store_for_base(1).await.unwrap();
-    let store_a_again = dataset.object_store_for_base(1).await.unwrap();
-    let store_b = dataset.object_store_for_base(2).await.unwrap();
+    let store_a = dataset.object_store(Some(1)).await.unwrap();
+    let store_a_again = dataset.object_store(Some(1)).await.unwrap();
+    let store_b = dataset.object_store(Some(2)).await.unwrap();
 
     assert!(Arc::ptr_eq(&store_a, &store_a_again));
     assert!(!Arc::ptr_eq(&store_a, &store_b));
@@ -444,7 +684,7 @@ async fn test_load_manifest_iops() {
     .await
     .unwrap();
 
-    let _ = _original_ds.object_store().io_stats_incremental(); //reset
+    let _ = _original_ds.object_store.as_ref().io_stats_incremental(); //reset
 
     let _dataset = DatasetBuilder::from_uri("memory://test")
         .with_session(session)
@@ -456,7 +696,7 @@ async fn test_load_manifest_iops() {
     // 1. List _versions directory to get the latest manifest location
     // 2. Read the manifest file. (The manifest is small enough to be read in one go.
     //    Larger manifests would result in more IOPS.)
-    let io_stats = _dataset.object_store().io_stats_incremental();
+    let io_stats = _dataset.object_store.as_ref().io_stats_incremental();
     assert_io_eq!(io_stats, read_iops, 2);
 }
 
@@ -555,10 +795,10 @@ async fn test_write_manifest(
 
     // Check it has no flags
     let manifest = read_manifest(
-        dataset.object_store(),
+        dataset.object_store.as_ref(),
         &dataset
             .commit_handler
-            .resolve_latest_location(&dataset.base, dataset.object_store())
+            .resolve_latest_location(&dataset.base, dataset.object_store.as_ref())
             .await
             .unwrap()
             .path,
@@ -579,10 +819,10 @@ async fn test_write_manifest(
 
     // Check it set the flag
     let mut manifest = read_manifest(
-        dataset.object_store(),
+        dataset.object_store.as_ref(),
         &dataset
             .commit_handler
-            .resolve_latest_location(&dataset.base, dataset.object_store())
+            .resolve_latest_location(&dataset.base, dataset.object_store.as_ref())
             .await
             .unwrap()
             .path,
@@ -604,7 +844,7 @@ async fn test_write_manifest(
     manifest.reader_feature_flags |= FLAG_UNKNOWN;
     manifest.version += 1;
     write_manifest_file(
-        dataset.object_store(),
+        dataset.object_store.as_ref(),
         dataset.commit_handler.as_ref(),
         &dataset.base,
         &mut manifest,
@@ -813,7 +1053,7 @@ async fn test_deep_clone(
     assert!(cloned_dataset.manifest().base_paths.is_empty());
 
     // Validate internal file counts are equal between source and cloned datasets
-    let store = branch.object_store();
+    let store = branch.object_store.as_ref();
     let src_root = dataset.base.clone();
     let branch_root = branch.base.clone();
     let dst_root = cloned_dataset.base.clone();
@@ -865,7 +1105,7 @@ async fn test_deep_clone(
         .deep_clone(cloned_ds, ("branch", original_version - 1), None)
         .await
         .unwrap();
-    let store = branch.object_store();
+    let store = branch.object_store.as_ref();
     let dst_root = cloned_dataset.base.clone();
 
     // Validate target dataset rows

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -1078,7 +1078,11 @@ async fn test_replace_dataset() {
         .await
         .unwrap();
 
-    ds.object_store().remove_dir_all(test_path).await.unwrap();
+    ds.object_store
+        .as_ref()
+        .remove_dir_all(test_path)
+        .await
+        .unwrap();
 
     let ds2 = InsertBuilder::new(&test_uri)
         .execute(vec![data2.clone()])

--- a/rust/lance/src/dataset/tests/dataset_transactions.rs
+++ b/rust/lance/src/dataset/tests/dataset_transactions.rs
@@ -175,8 +175,8 @@ async fn test_session_store_registry() {
         .unwrap();
     assert_eq!(registry.active_stores().len(), 1);
     assert_eq!(
-        Arc::as_ptr(&dataset.object_store().inner),
-        Arc::as_ptr(&dataset2.object_store().inner)
+        Arc::as_ptr(&dataset.object_store.as_ref().inner),
+        Arc::as_ptr(&dataset2.object_store.as_ref().inner)
     );
 
     // If we create another with **different parameters**, it should create a new store.
@@ -195,8 +195,8 @@ async fn test_session_store_registry() {
         .unwrap();
     assert_eq!(registry.active_stores().len(), 2);
     assert_ne!(
-        Arc::as_ptr(&dataset.object_store().inner),
-        Arc::as_ptr(&dataset3.object_store().inner)
+        Arc::as_ptr(&dataset.object_store.as_ref().inner),
+        Arc::as_ptr(&dataset3.object_store.as_ref().inner)
     );
 
     // Remove both datasets
@@ -331,12 +331,12 @@ async fn test_inline_transaction() {
         .load()
         .await
         .unwrap();
-    let stats = read_ds2.object_store().io_stats_incremental(); // Reset
+    let stats = read_ds2.object_store.as_ref().io_stats_incremental(); // Reset
     assert!(stats.read_bytes < 64 * 1024);
     // Because the manifest is so small, we should have opportunistically
     // cached the transaction in memory already.
     let inline_tx = read_ds2.read_transaction().await.unwrap().unwrap();
-    let stats = read_ds2.object_store().io_stats_incremental();
+    let stats = read_ds2.object_store.as_ref().io_stats_incremental();
     assert_eq!(stats.read_iops, 0);
     assert_eq!(stats.read_bytes, 0);
     assert_eq!(inline_tx, tx);
@@ -344,9 +344,10 @@ async fn test_inline_transaction() {
     // Case 3: manifest does not contain inline transaction, read should fall back to external transaction file
     let ds = create_dataset(2).await;
     let tx = make_tx(ds.manifest().version);
-    let tx_file = crate::io::commit::write_transaction_file(ds.object_store(), &ds.base, &tx)
-        .await
-        .unwrap();
+    let tx_file =
+        crate::io::commit::write_transaction_file(ds.object_store.as_ref(), &ds.base, &tx)
+            .await
+            .unwrap();
     let (mut manifest, indices) = tx
         .build_manifest(
             Some(ds.manifest.as_ref()),
@@ -356,7 +357,7 @@ async fn test_inline_transaction() {
         )
         .unwrap();
     let location = write_manifest_file(
-        ds.object_store(),
+        ds.object_store.as_ref(),
         ds.commit_handler.as_ref(),
         &ds.base,
         &mut manifest,

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -540,7 +540,7 @@ mod tests {
             .unwrap();
         let dataset = Arc::new(dataset);
 
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_gt!(io_stats, read_iops, 0);
         assert_io_gt!(io_stats, write_iops, 0);
 
@@ -556,7 +556,7 @@ mod tests {
             // we shouldn't need to read anything from disk. Except we do need
             // to check for the latest version to see if we need to do conflict
             // resolution.
-            let io_stats = dataset.object_store().io_stats_incremental();
+            let io_stats = dataset.object_store.as_ref().io_stats_incremental();
             assert_io_eq!(io_stats, read_iops, 1, "check latest version, i = {} ", i);
             // Should see 2 IOPs:
             // 1. Write the transaction files
@@ -574,7 +574,7 @@ mod tests {
         // Session should still be re-used
         // However, the dataset needs to be loaded and the read version checked out,
         // so an additional 4 IOPs are needed.
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 5, "load dataset + check version");
         assert_io_eq!(io_stats, write_iops, 2, "write txn + manifest");
 
@@ -589,7 +589,7 @@ mod tests {
         assert_eq!(new_ds.manifest().version, 8);
         // Now we have to load all previous transactions.
 
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_gt!(io_stats, read_iops, 10);
         assert_io_eq!(io_stats, write_iops, 2, "write txn + manifest");
     }
@@ -619,7 +619,7 @@ mod tests {
             .await
             .unwrap();
 
-        dataset.object_store().io_stats_incremental(); // Reset the stats
+        dataset.object_store.as_ref().io_stats_incremental(); // Reset the stats
         let read_version = dataset.manifest().version;
         let new_ds = CommitBuilder::new(Arc::new(dataset))
             .execute(sample_transaction(read_version))
@@ -627,7 +627,7 @@ mod tests {
             .unwrap();
 
         // Assert io requests
-        let io_stats = new_ds.object_store().io_stats_incremental();
+        let io_stats = new_ds.object_store.as_ref().io_stats_incremental();
         // This could be zero, if we decided to be optimistic. However, that
         // would mean two wasted write requests (txn + manifest) if there was
         // a conflict. We choose to be pessimistic for more consistent performance.
@@ -685,14 +685,14 @@ mod tests {
                 .await
                 .unwrap();
         }
-        dataset.object_store().io_stats_incremental();
+        dataset.object_store.as_ref().io_stats_incremental();
 
         let new_ds = CommitBuilder::new(original_dataset.clone())
             .execute(sample_transaction(original_dataset.manifest().version))
             .await
             .unwrap();
 
-        let io_stats = new_ds.object_store().io_stats_incremental();
+        let io_stats = new_ds.object_store.as_ref().io_stats_incremental();
 
         // If there is a conflict with two transaction, the retry should require io requests:
         // * 1 list version

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -938,7 +938,7 @@ impl MergeInsertJob {
         let updated_fragments = Arc::new(Mutex::new(Vec::new()));
         let new_fragments = Arc::new(Mutex::new(Vec::new()));
         let mut tasks = JoinSet::new();
-        let task_limit = dataset.object_store().io_parallelism();
+        let task_limit = dataset.object_store.as_ref().io_parallelism();
         let reservation =
             MemoryConsumer::new("MergeInsert").register(session_ctx.task_ctx().memory_pool());
 
@@ -4579,7 +4579,7 @@ mod tests {
             .await
             .unwrap();
         let tx_path = committed.manifest().transaction_file.clone().unwrap();
-        let tx_read = read_transaction_file(dataset.object_store(), &dataset.base, &tx_path)
+        let tx_read = read_transaction_file(dataset.object_store.as_ref(), &dataset.base, &tx_path)
             .await
             .unwrap();
         // Check that inserted_rows_filter is present in the Operation::Update

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1028,7 +1028,7 @@ impl DatasetIndexExt for Dataset {
         }
 
         let mut merged_segment = crate::index::vector::ivf::merge_segments(
-            self.object_store(),
+            self.object_store.as_ref(),
             &self.indices_dir(),
             source_segments,
         )
@@ -1440,7 +1440,7 @@ async fn collect_regular_indices_statistics(
     let mut index_uri: Option<String> = None;
 
     for meta in metadatas.iter() {
-        let index_store = Arc::new(LanceIndexStore::from_dataset_for_existing(ds, meta)?);
+        let index_store = Arc::new(LanceIndexStore::from_dataset_for_existing(ds, meta).await?);
         let index_details = scalar::fetch_index_details(ds, field_path, meta).await?;
         if index_uri.is_none() {
             index_uri = Some(index_details.type_url.clone());
@@ -1659,7 +1659,8 @@ impl DatasetIndexInternalExt for Dataset {
             // Fall back to file existence check for older indices without file metadata
             let index_dir = self.indice_files_dir(&index_meta)?;
             let index_file = index_dir.child(uuid).child(INDEX_FILE_NAME);
-            self.object_store.exists(&index_file).await?
+            let object_store = self.object_store_for_index(&index_meta).await?;
+            object_store.exists(&index_file).await?
         };
 
         if is_vector_index {
@@ -1707,6 +1708,11 @@ impl DatasetIndexInternalExt for Dataset {
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn VectorIndex>> {
         let frag_reuse_uuid = self.frag_reuse_index_uuid().await;
+        let index_meta = self
+            .load_index(uuid)
+            .await?
+            .ok_or_else(|| Error::index(format!("Index with id {} does not exist", uuid)))?;
+        let object_store = self.object_store_for_index(&index_meta).await?;
 
         // Check sized cache first (v2+ indices with serializable state).
         let state_key = IvfIndexStateCacheKey::new(uuid, frag_reuse_uuid.as_ref());
@@ -1715,11 +1721,7 @@ impl DatasetIndexInternalExt for Dataset {
             let partition_cache = self.index_cache.with_key_prefix(&state_key.key());
             return entry
                 .0
-                .reconstruct(
-                    self.object_store.clone(),
-                    self.metadata_cache.as_ref(),
-                    partition_cache,
-                )
+                .reconstruct(object_store, self.metadata_cache.as_ref(), partition_cache)
                 .await;
         }
 
@@ -1730,13 +1732,9 @@ impl DatasetIndexInternalExt for Dataset {
         }
 
         let frag_reuse_index = self.open_frag_reuse_index(metrics).await?;
-        let index_meta = self
-            .load_index(uuid)
-            .await?
-            .ok_or_else(|| Error::index(format!("Index with id {} does not exist", uuid)))?;
         let index_dir = self.indice_files_dir(&index_meta)?;
         let index_file = index_dir.child(uuid).child(INDEX_FILE_NAME);
-        let reader: Arc<dyn Reader> = self.object_store.open(&index_file).await?.into();
+        let reader: Arc<dyn Reader> = object_store.open(&index_file).await?.into();
 
         let tailing_bytes = read_last_block(reader.as_ref()).await?;
         let (major_version, minor_version) = read_version(&tailing_bytes)?;
@@ -2429,7 +2427,8 @@ mod tests {
             .child(uuid.to_string())
             .child(INDEX_FILE_NAME);
         dataset
-            .object_store()
+            .object_store
+            .as_ref()
             .put(&index_path, payload)
             .await
             .unwrap();
@@ -2926,7 +2925,7 @@ mod tests {
         let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
 
         let mut dataset = Dataset::write(reader, &test_dir, None).await.unwrap();
-        let io_tracker = dataset.object_store().io_tracker().clone();
+        let io_tracker = dataset.object_store.as_ref().io_tracker().clone();
 
         let params = ScalarIndexParams::for_builtin(BuiltinIndexType::Bitmap);
         dataset
@@ -3688,10 +3687,10 @@ mod tests {
             )
             .await
             .unwrap();
-        dataset.object_store().io_stats_incremental(); // Reset
+        dataset.object_store.as_ref().io_stats_incremental(); // Reset
 
         let indices = dataset.load_indices().await.unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         // We should already have this cached since we just wrote it.
         assert_io_eq!(stats, read_iops, 0);
         assert_io_eq!(stats, read_bytes, 0);
@@ -3704,13 +3703,13 @@ mod tests {
             .load()
             .await
             .unwrap();
-        let stats = dataset2.object_store().io_stats_incremental(); // Reset
+        let stats = dataset2.object_store.as_ref().io_stats_incremental(); // Reset
         assert_io_lt!(stats, read_bytes, 64 * 1024);
 
         // Because the manifest is so small, we should have opportunistically
         // cached the indices in memory already.
         let indices2 = dataset2.load_indices().await.unwrap();
-        let stats = dataset2.object_store().io_stats_incremental();
+        let stats = dataset2.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(stats, read_iops, 0);
         assert_io_eq!(stats, read_bytes, 0);
         assert_eq!(indices2.len(), 1);
@@ -6836,7 +6835,7 @@ mod tests {
             .unwrap();
 
         // Reset IO stats before query
-        let _ = dataset.object_store().io_stats_incremental();
+        let _ = dataset.object_store.as_ref().io_stats_incremental();
 
         // Query using the BTree index
         let results = dataset
@@ -6849,7 +6848,7 @@ mod tests {
         assert!(results.num_rows() > 0);
 
         // Verify IOPs - should be minimal (no HEAD requests)
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         // We expect reads for: index metadata + index pages + data files
         // The key assertion is that we don't have extra HEAD requests
         assert_io_lt!(
@@ -6903,7 +6902,7 @@ mod tests {
             .unwrap();
 
         // Reset IO stats before query
-        let _ = dataset.object_store().io_stats_incremental();
+        let _ = dataset.object_store.as_ref().io_stats_incremental();
 
         // Query using the Bitmap index
         let results = dataset
@@ -6916,7 +6915,7 @@ mod tests {
         assert!(results.num_rows() > 0);
 
         // Verify IOPs
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_lt!(
             stats,
             read_iops,
@@ -6976,7 +6975,7 @@ mod tests {
             .unwrap();
 
         // Reset IO stats before query
-        let _ = dataset.object_store().io_stats_incremental();
+        let _ = dataset.object_store.as_ref().io_stats_incremental();
 
         // Query using the Inverted index (full-text search)
         let results = dataset
@@ -6989,7 +6988,7 @@ mod tests {
         assert!(results.num_rows() > 0);
 
         // Verify IOPs
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_lt!(
             stats,
             read_iops,
@@ -7064,7 +7063,7 @@ mod tests {
         let _ = dataset.scan().try_into_batch().await.unwrap();
 
         // Reset IO stats before query
-        let _ = dataset.object_store().io_stats_incremental();
+        let _ = dataset.object_store.as_ref().io_stats_incremental();
 
         // Query using the IVF_PQ index (KNN search)
         let query_vector: Vec<f32> = (0..dimension).map(|i| i as f32 / 1000.0).collect();
@@ -7079,7 +7078,7 @@ mod tests {
         assert!(results.num_rows() > 0);
 
         // Verify IOPs
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_lt!(
             stats,
             read_iops,

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -83,7 +83,8 @@ async fn metadata_is_vector_index(dataset: &Dataset, index: &IndexMetadata) -> R
     let index_file = index_dir
         .child(index.uuid.to_string())
         .child(INDEX_FILE_NAME);
-    dataset.object_store.exists(&index_file).await
+    let object_store = dataset.object_store_for_index(index).await?;
+    object_store.exists(&index_file).await
 }
 
 /// Merge in-inflight unindexed data, with a specific number of previous indices
@@ -567,7 +568,7 @@ mod tests {
         );
 
         // There should be two indices directories existed.
-        let object_store = dataset.object_store();
+        let object_store = dataset.object_store.as_ref();
         let index_dirs = object_store.read_dir(dataset.indices_dir()).await.unwrap();
         assert_eq!(index_dirs.len(), 2);
 

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -724,7 +724,7 @@ impl<'a> IndexSegmentBuilder<'a> {
             | IndexType::IvfHnswPq
             | IndexType::IvfHnswSq => {
                 crate::index::vector::ivf::build_segment(
-                    self.dataset.object_store(),
+                    self.dataset.object_store.as_ref(),
                     &self.dataset.indices_dir(),
                     plan,
                 )
@@ -1449,7 +1449,7 @@ mod tests {
         committed_index_metadata.fragment_bitmap = Some(fragment_ids.iter().copied().collect());
         committed_index_metadata.files = Some(
             list_index_files_with_sizes(
-                dataset.object_store(),
+                dataset.object_store.as_ref(),
                 &dataset.indices_dir().child(shared_uuid.clone()),
             )
             .await
@@ -1564,7 +1564,14 @@ mod tests {
                 .indices_dir()
                 .child(segment.uuid.to_string())
                 .child(crate::index::INDEX_FILE_NAME);
-            assert!(dataset.object_store().exists(&segment_index).await.unwrap());
+            assert!(
+                dataset
+                    .object_store
+                    .as_ref()
+                    .exists(&segment_index)
+                    .await
+                    .unwrap()
+            );
             input_segments.push(segment);
         }
 
@@ -1826,7 +1833,14 @@ mod tests {
                 .indices_dir()
                 .child(segment.uuid().to_string())
                 .child(lance_index::scalar::inverted::METADATA_FILE);
-            assert!(dataset.object_store().exists(&metadata_path).await.unwrap());
+            assert!(
+                dataset
+                    .object_store
+                    .as_ref()
+                    .exists(&metadata_path)
+                    .await
+                    .unwrap()
+            );
         }
 
         dataset

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -140,7 +140,7 @@ impl DatasetPreFilter {
                     let (row_ids, deletion_vector) = join!(row_ids, deletion_vector);
                     Ok::<_, crate::Error>((row_ids?, deletion_vector?))
                 })
-                .buffer_unordered(dataset.object_store().io_parallelism())
+                .buffer_unordered(dataset.object_store.as_ref().io_parallelism())
                 .try_collect::<Vec<_>>()
                 .await
         }

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -381,7 +381,7 @@ pub async fn open_scalar_index(
     metrics: &dyn MetricsCollector,
 ) -> Result<Arc<dyn ScalarIndex>> {
     let uuid_str = index.uuid.to_string();
-    let index_store = Arc::new(LanceIndexStore::from_dataset_for_existing(dataset, index)?);
+    let index_store = Arc::new(LanceIndexStore::from_dataset_for_existing(dataset, index).await?);
 
     let index_details = fetch_index_details(dataset, column, index).await?;
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_details(index_details.as_ref())?;
@@ -424,16 +424,19 @@ pub(crate) async fn infer_scalar_index_details(
     let bitmap_page_lookup = index_dir.child(BITMAP_LOOKUP_NAME);
     let inverted_list_lookup = index_dir.child(METADATA_FILE);
     let legacy_inverted_list_lookup = index_dir.child(INVERT_LIST_FILE);
+    let object_store = dataset.object_store_for_index(index).await?;
     let index_details = if let DataType::List(_) = col.data_type() {
         prost_types::Any::from_msg(&LabelListIndexDetails::default()).unwrap()
-    } else if dataset.object_store.exists(&bitmap_page_lookup).await? {
+    } else if object_store.exists(&bitmap_page_lookup).await? {
         prost_types::Any::from_msg(&BitmapIndexDetails::default()).unwrap()
-    } else if dataset.object_store.exists(&inverted_list_lookup).await? {
+    } else if object_store.exists(&inverted_list_lookup).await? {
         // Try to infer inverted index details from metadata file to capture with_position and other params
         // Fall back to defaults if anything goes wrong
         let default_details = prost_types::Any::from_msg(&InvertedIndexDetails::default()).unwrap();
         let parse_params = async || {
-            let index_store = LanceIndexStore::from_dataset_for_existing(dataset, index).ok()?;
+            let index_store = LanceIndexStore::from_dataset_for_existing(dataset, index)
+                .await
+                .ok()?;
             let reader = index_store.open_index_file(METADATA_FILE).await.ok()?;
             let params_str = reader.schema().metadata.get("params")?;
             let params = ::serde_json::from_str::<InvertedIndexParams>(params_str).ok()?;
@@ -441,11 +444,7 @@ pub(crate) async fn infer_scalar_index_details(
             Some(prost_types::Any::from_msg(&details).unwrap())
         };
         parse_params().await.unwrap_or(default_details)
-    } else if dataset
-        .object_store
-        .exists(&legacy_inverted_list_lookup)
-        .await?
-    {
+    } else if object_store.exists(&legacy_inverted_list_lookup).await? {
         prost_types::Any::from_msg(&InvertedIndexDetails::default()).unwrap()
     } else {
         prost_types::Any::from_msg(&BTreeIndexDetails::default()).unwrap()

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -100,7 +100,7 @@ pub(crate) async fn build_segment(
 
     let index_dir = dataset.indices_dir().child(source_segment.uuid.to_string());
     let metadata_path = index_dir.child(lance_index::scalar::inverted::METADATA_FILE);
-    if dataset.object_store().exists(&metadata_path).await? {
+    if dataset.object_store.as_ref().exists(&metadata_path).await? {
         return Ok(built_segment);
     }
 
@@ -109,7 +109,7 @@ pub(crate) async fn build_segment(
         &source_segment.uuid.to_string(),
     )?);
     lance_index::scalar::inverted::builder::merge_index_files(
-        dataset.object_store(),
+        dataset.object_store.as_ref(),
         &index_dir,
         store,
         lance_index::progress::noop_progress(),

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -1582,11 +1582,12 @@ pub(crate) async fn open_vector_index_v2(
         .await?
         .ok_or_else(|| Error::index(format!("Index with id {} does not exist", uuid)))?;
     let index_dir = dataset.indice_files_dir(&index_meta)?;
+    let object_store = dataset.object_store_for_index(&index_meta).await?;
 
     let index: Arc<dyn VectorIndex> = match index_metadata.index_type.as_str() {
         "IVF_HNSW_PQ" => {
             let aux_path = index_dir.child(uuid).child(INDEX_AUXILIARY_FILE_NAME);
-            let aux_reader = dataset.object_store().open(&aux_path).await?;
+            let aux_reader = object_store.open(&aux_path).await?;
 
             let ivf_data = IvfModel::load(&reader).await?;
             let options = HNSWIndexOptions { use_residual: true };
@@ -1613,7 +1614,7 @@ pub(crate) async fn open_vector_index_v2(
 
         "IVF_HNSW_SQ" => {
             let aux_path = index_dir.child(uuid).child(INDEX_AUXILIARY_FILE_NAME);
-            let aux_reader = dataset.object_store().open(&aux_path).await?;
+            let aux_reader = object_store.open(&aux_path).await?;
 
             let ivf_data = IvfModel::load(&reader).await?;
             let options = HNSWIndexOptions {
@@ -2552,7 +2553,12 @@ mod tests {
         let out_base = dataset.indices_dir().child(&*uuid);
         let training_path = out_base.child("global_training.idx");
 
-        let writer = dataset.object_store().create(&training_path).await.unwrap();
+        let writer = dataset
+            .object_store
+            .as_ref()
+            .create(&training_path)
+            .await
+            .unwrap();
         let arrow_schema = ArrowSchema::new(vec![Field::new("dummy", ArrowDataType::Int32, true)]);
         let mut v2w = lance_file::writer::FileWriter::try_new(
             writer,

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -157,7 +157,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let temp_dir_path = Path::from_filesystem_path(&temp_dir)?;
         let format_version = dataset_format_version(&dataset);
         Ok(Self {
-            store: dataset.object_store().clone(),
+            store: dataset.object_store.as_ref().clone(),
             column,
             index_dir,
             distance_type,
@@ -224,7 +224,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let temp_dir_path = Path::from_filesystem_path(&temp_dir)?;
         let format_version = dataset_format_version(&dataset);
         Ok(Self {
-            store: dataset.object_store().clone(),
+            store: dataset.object_store.as_ref().clone(),
             column,
             index_dir,
             distance_type: ivf_index.metric_type(),

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -407,7 +407,7 @@ pub(crate) async fn optimize_vector_indices(
     }
 
     let new_uuid = Uuid::new_v4();
-    let object_store = dataset.object_store();
+    let object_store = dataset.object_store.as_ref();
     let index_file = dataset
         .indices_dir()
         .child(new_uuid.to_string())
@@ -1565,7 +1565,7 @@ pub async fn build_ivf_pq_index(
     let precomputed_partitions = load_precomputed_partitions_if_available(ivf_params).await?;
 
     write_ivf_pq_file(
-        dataset.object_store(),
+        dataset.object_store.as_ref(),
         dataset.indices_dir(),
         column,
         index_name,
@@ -1795,7 +1795,7 @@ pub(crate) async fn remap_index_file(
     column: String,
     transforms: Vec<pb::Transform>,
 ) -> Result<()> {
-    let object_store = dataset.object_store();
+    let object_store = dataset.object_store.as_ref();
     let old_path = dataset.indices_dir().child(old_uuid).child(INDEX_FILE_NAME);
     let new_path = dataset.indices_dir().child(new_uuid).child(INDEX_FILE_NAME);
 
@@ -1915,7 +1915,7 @@ pub async fn write_ivf_pq_file_from_existing_index(
     pq: ProductQuantizer,
     streams: Vec<impl Stream<Item = Result<RecordBatch>>>,
 ) -> Result<()> {
-    let obj_store = dataset.object_store();
+    let obj_store = dataset.object_store.as_ref();
     let path = dataset
         .indices_dir()
         .child(index_id.to_string())
@@ -1957,7 +1957,7 @@ async fn write_ivf_hnsw_file(
     shuffle_partition_concurrency: usize,
     precomputed_shuffle_buffers: Option<(Path, Vec<String>)>,
 ) -> Result<()> {
-    let object_store = dataset.object_store();
+    let object_store = dataset.object_store.as_ref();
     let path = dataset.indices_dir().child(uuid).child(INDEX_FILE_NAME);
     let writer = object_store.create(&path).await?;
 
@@ -4392,11 +4392,11 @@ mod tests {
             .unwrap();
 
         // Reset IO stats after index creation
-        dataset.object_store().io_stats_incremental();
+        dataset.object_store.as_ref().io_stats_incremental();
 
         // Prewarm should perform IO to load all partitions into cache
         dataset.prewarm_index("my_idx").await.unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert!(
             stats.read_iops > 0,
             "prewarm should have read from disk, but read_iops was 0"
@@ -4413,7 +4413,7 @@ mod tests {
             .try_into_batch()
             .await
             .unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(
             stats,
             read_iops,
@@ -4423,7 +4423,7 @@ mod tests {
 
         // Second prewarm should not need IO (already cached)
         dataset.prewarm_index("my_idx").await.unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(stats, read_iops, 0, "second prewarm should not perform IO");
     }
 
@@ -4467,11 +4467,11 @@ mod tests {
             .clone();
 
         // Reset IO stats after migration and sampling.
-        dataset.object_store().io_stats_incremental();
+        dataset.object_store.as_ref().io_stats_incremental();
 
         // Prewarm should perform IO to load all index deltas into cache.
         dataset.prewarm_index("vector_idx").await.unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert!(
             stats.read_iops > 0,
             "prewarm should have read from disk, but read_iops was 0"
@@ -4487,7 +4487,7 @@ mod tests {
             .try_into_batch()
             .await
             .unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(
             stats,
             read_iops,
@@ -4497,7 +4497,7 @@ mod tests {
 
         // Second prewarm should not need IO (already cached).
         dataset.prewarm_index("vector_idx").await.unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(stats, read_iops, 0, "second prewarm should not perform IO");
     }
 

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -2863,7 +2863,8 @@ mod tests {
                 .child(crate::index::INDEX_FILE_NAME);
             assert!(
                 ds_split
-                    .object_store()
+                    .object_store
+                    .as_ref()
                     .exists(&segment_index)
                     .await
                     .unwrap(),
@@ -3244,7 +3245,7 @@ mod tests {
 
         let progress = Arc::new(RecordingProgress::default());
         let merged_segment = crate::index::vector::ivf::merge_segments_with_progress(
-            dataset.object_store(),
+            dataset.object_store.as_ref(),
             &dataset.indices_dir(),
             segments,
             progress.clone(),
@@ -3385,7 +3386,7 @@ mod tests {
             .unwrap();
 
         let scheduler = ScanScheduler::new(
-            Arc::new(dataset.object_store().clone()),
+            Arc::new(dataset.object_store.as_ref().clone()),
             SchedulerConfig::default_for_testing(),
         );
         let sq_meta = get_sq_metadata(&dataset, scheduler, &segment.uuid.to_string()).await;
@@ -5367,11 +5368,11 @@ mod tests {
             .unwrap();
 
         // Reset IO stats after index creation
-        dataset.object_store().io_stats_incremental();
+        dataset.object_store.as_ref().io_stats_incremental();
 
         // Prewarm should perform IO to load all partitions into cache
         dataset.prewarm_index("my_idx").await.unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert!(
             stats.read_iops > 0,
             "prewarm should have read from disk, but read_iops was 0"
@@ -5388,7 +5389,7 @@ mod tests {
             .try_into_batch()
             .await
             .unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(
             stats,
             read_iops,
@@ -5398,7 +5399,7 @@ mod tests {
 
         // Second prewarm should not need IO (already cached)
         dataset.prewarm_index("my_idx").await.unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(stats, read_iops, 0, "second prewarm should not perform IO");
     }
 
@@ -5482,11 +5483,11 @@ mod tests {
         assert_eq!(unique_uuids.len(), 2, "expected two unique index UUIDs");
 
         // Reset IO stats after index creation
-        dataset.object_store().io_stats_incremental();
+        dataset.object_store.as_ref().io_stats_incremental();
 
         // Prewarm should perform IO to load all index deltas into cache
         dataset.prewarm_index(INDEX_NAME).await.unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert!(
             stats.read_iops > 0,
             "prewarm should have read from disk, but read_iops was 0"
@@ -5503,7 +5504,7 @@ mod tests {
             .try_into_batch()
             .await
             .unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(
             stats,
             read_iops,
@@ -5513,7 +5514,7 @@ mod tests {
 
         // Second prewarm should not need IO (already cached)
         dataset.prewarm_index(INDEX_NAME).await.unwrap();
-        let stats = dataset.object_store().io_stats_incremental();
+        let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(stats, read_iops, 0, "second prewarm should not perform IO");
     }
 

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -490,12 +490,12 @@ fn sample_training_data_scan(
     num_rows: usize,
     byte_width: usize,
 ) -> Result<crate::dataset::scanner::DatasetRecordBatchStream> {
-    let block_size = dataset.object_store().block_size();
+    let block_size = dataset.object_store.as_ref().block_size();
     let ranges = random_ranges(num_rows, sample_size_hint, block_size, byte_width);
     Ok(dataset.take_scan(
         Box::pin(futures::stream::iter(ranges).map(Ok)),
         Arc::new(dataset.schema().project(&[column])?),
-        dataset.object_store().io_parallelism(),
+        dataset.object_store.as_ref().io_parallelism(),
     ))
 }
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -581,7 +581,7 @@ pub(crate) async fn migrate_fragments(
             let mut data_files = fragment.files.clone();
 
             // For each of the data files in the fragment, we need to get the file size
-            let object_store = dataset.object_store();
+            let object_store = dataset.object_store.as_ref();
             let get_sizes = data_files
                 .iter()
                 .map(|file| {
@@ -699,7 +699,8 @@ async fn migrate_indices(dataset: &Dataset, indices: &mut [IndexMetadata]) -> Re
                 let index_dir = dataset
                     .indice_files_dir(index)?
                     .child(index.uuid.to_string());
-                list_index_files_with_sizes(&dataset.object_store, &index_dir).await
+                let object_store = dataset.object_store_for_index(index).await?;
+                list_index_files_with_sizes(&object_store, &index_dir).await
             }
             .await;
             match result {
@@ -908,7 +909,7 @@ pub(crate) async fn commit_transaction(
     manifest_naming_scheme: ManifestNamingScheme,
     affected_rows: Option<&RowAddrTreeMap>,
 ) -> Result<(Manifest, ManifestLocation)> {
-    // Note: object_store has been configured with WriteParams, but dataset.object_store()
+    // Note: object_store has been configured with WriteParams, but dataset.object_store.as_ref()
     // has not necessarily. So for anything involving writing, use `object_store`.
     let read_version = transaction.read_version;
     let mut target_version = read_version + 1;

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1364,7 +1364,7 @@ impl<'a> TransactionRebase<'a> {
                         .await
                         .map(|dv| (fragment_id, dv))
                     })
-                    .buffered(dataset.object_store().io_parallelism())
+                    .buffered(dataset.object_store.as_ref().io_parallelism())
                     .try_collect::<Vec<_>>()
                     .await?;
 
@@ -1420,7 +1420,7 @@ impl<'a> TransactionRebase<'a> {
                         *fragment_id,
                         dataset.manifest.version,
                         &dv,
-                        dataset.object_store(),
+                        dataset.object_store.as_ref(),
                     )
                     .await?;
 
@@ -1849,12 +1849,12 @@ mod tests {
             .await
             .unwrap();
 
-        dataset.object_store().io_stats_incremental(); // reset
+        dataset.object_store.as_ref().io_stats_incremental(); // reset
         for (other_version, other_transaction) in other_transactions.iter().enumerate() {
             rebase
                 .check_txn(other_transaction, other_version as u64)
                 .unwrap();
-            let io_stats = dataset.object_store().io_stats_incremental();
+            let io_stats = dataset.object_store.as_ref().io_stats_incremental();
             assert_io_eq!(io_stats, read_iops, 0);
             assert_io_eq!(io_stats, write_iops, 0);
         }
@@ -1868,7 +1868,7 @@ mod tests {
         let rebased_transaction = rebase.finish(&dataset).await.unwrap();
         assert_eq!(rebased_transaction, expected_transaction);
         // We didn't need to do any IO, so the stats should be 0.
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 0);
         assert_io_eq!(io_stats, write_iops, 0);
     }
@@ -1884,7 +1884,7 @@ mod tests {
                 deletion_file,
                 // Reference deletion file should never enter this apply_deletion. So base path is fine.
                 &dataset.base,
-                dataset.object_store(),
+                dataset.object_store.as_ref(),
             )
             .await
             .unwrap()
@@ -1899,7 +1899,7 @@ mod tests {
             fragment.id,
             dataset.manifest.version,
             &current_deletions,
-            dataset.object_store(),
+            dataset.object_store.as_ref(),
         )
         .await
         .unwrap();
@@ -1973,12 +1973,12 @@ mod tests {
                     .await
                     .unwrap();
 
-            dataset.object_store().io_stats_incremental(); // reset
+            dataset.object_store.as_ref().io_stats_incremental(); // reset
             for (other_version, other_transaction) in previous_transactions.iter().enumerate() {
                 rebase
                     .check_txn(other_transaction, other_version as u64)
                     .unwrap();
-                let io_stats = dataset.object_store().io_stats_incremental();
+                let io_stats = dataset.object_store.as_ref().io_stats_incremental();
                 assert_io_eq!(io_stats, read_iops, 0);
                 assert_io_eq!(io_stats, write_iops, 0);
             }
@@ -1989,7 +1989,7 @@ mod tests {
             let rebased_transaction = rebase.finish(&dataset).await.unwrap();
             assert_eq!(rebased_transaction.read_version, dataset.manifest.version);
 
-            let io_stats = dataset.object_store().io_stats_incremental();
+            let io_stats = dataset.object_store.as_ref().io_stats_incremental();
             if expected_rewrite {
                 // Read the current deletion file, and write the new one.
                 assert_io_eq!(io_stats, read_iops, 0, "deletion file should be cached");
@@ -2014,7 +2014,7 @@ mod tests {
                 //     original_fragment.id,
                 //     original_fragment.deletion_file.as_ref().unwrap(),
                 // );
-                // assert!(!dataset.object_store().exists(&old_path).await.unwrap());
+                // assert!(!dataset.object_store.as_ref().exists(&old_path).await.unwrap());
                 // The new deletion file should exist.
                 let final_fragment = match &rebased_transaction.operation {
                     Operation::Update {
@@ -2032,7 +2032,14 @@ mod tests {
                     final_fragment.id,
                     final_fragment.deletion_file.as_ref().unwrap(),
                 );
-                assert!(dataset.object_store().exists(&new_path).await.unwrap());
+                assert!(
+                    dataset
+                        .object_store
+                        .as_ref()
+                        .exists(&new_path)
+                        .await
+                        .unwrap()
+                );
 
                 assert_io_eq!(io_stats, num_stages, 1);
             } else {
@@ -2138,12 +2145,12 @@ mod tests {
 
         let affected_rows = RowAddrTreeMap::from_iter([0]);
 
-        dataset.object_store().io_stats_incremental(); // reset
+        dataset.object_store.as_ref().io_stats_incremental(); // reset
         let mut rebase = TransactionRebase::try_new(&dataset, txn.clone(), Some(&affected_rows))
             .await
             .unwrap();
 
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 0);
         assert_io_eq!(io_stats, write_iops, 0);
 
@@ -2168,7 +2175,7 @@ mod tests {
             vec![(0, true)],
         );
 
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 0);
         assert_io_eq!(io_stats, write_iops, 0);
 
@@ -2178,7 +2185,7 @@ mod tests {
             Err(crate::Error::RetryableCommitConflict { .. })
         ));
 
-        let io_stats = dataset.object_store().io_stats_incremental();
+        let io_stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(io_stats, read_iops, 0, "deletion file should be cached");
         assert_io_eq!(io_stats, write_iops, 0, "failed before writing");
     }

--- a/rust/lance/src/io/commit/s3_test.rs
+++ b/rust/lance/src/io/commit/s3_test.rs
@@ -217,7 +217,7 @@ async fn test_concurrent_writers() {
         .await
         .unwrap();
     // Commit: 2 IOPs. 1 for transaction file, 1 for manifest file
-    let io_stats = dataset.object_store().io_stats_incremental();
+    let io_stats = dataset.object_store.as_ref().io_stats_incremental();
     assert_io_eq!(io_stats, write_iops, 2);
     let dataset = Arc::new(dataset);
     let old_version = dataset.manifest().version;
@@ -304,7 +304,7 @@ async fn test_ddb_open_iops() {
     //    * write staged file
     //    * copy to final file
     //    * delete staged file
-    let io_stats = committed_ds.object_store().io_stats_incremental();
+    let io_stats = committed_ds.object_store.as_ref().io_stats_incremental();
     assert_io_eq!(io_stats, write_iops, 4);
     assert_io_eq!(io_stats, read_iops, 1);
 
@@ -316,7 +316,7 @@ async fn test_ddb_open_iops() {
         .load()
         .await
         .unwrap();
-    let io_stats = dataset.object_store().io_stats_incremental();
+    let io_stats = dataset.object_store.as_ref().io_stats_incremental();
     // Open dataset can be read with 1 IOP, just to read the manifest.
     // Looking up latest manifest is handled in dynamodb.
     assert_io_eq!(io_stats, read_iops, 1);
@@ -331,7 +331,7 @@ async fn test_ddb_open_iops() {
         .execute(vec![data.clone()])
         .await
         .unwrap();
-    let io_stats = dataset.object_store().io_stats_incremental();
+    let io_stats = dataset.object_store.as_ref().io_stats_incremental();
     // Append: 5 IOPS: data file, transaction file, 3x manifest file
     assert_io_eq!(io_stats, write_iops, 5);
     // TODO: we can reduce this by implementing a specialized CommitHandler::list_manifest_locations()
@@ -340,7 +340,7 @@ async fn test_ddb_open_iops() {
 
     // Checkout original version
     dataset.checkout_version(1).await.unwrap();
-    let io_stats = dataset.object_store().io_stats_incremental();
+    let io_stats = dataset.object_store.as_ref().io_stats_incremental();
     // Checkout: 1 IOPS: manifest file
     assert_io_eq!(io_stats, read_iops, 1);
     assert_io_eq!(io_stats, write_iops, 0);

--- a/rust/lance/src/io/deletion.rs
+++ b/rust/lance/src/io/deletion.rs
@@ -22,12 +22,13 @@ pub async fn read_dataset_deletion_file(
     if let Some(cached) = dataset.metadata_cache.get_with_key(&key).await {
         Ok(cached)
     } else {
+        let object_store = dataset.object_store_for_deletion(deletion_file).await?;
         let deletion_vector = Arc::new(
             read_deletion_file(
                 fragment_id,
                 deletion_file,
                 &dataset_dir,
-                dataset.object_store.as_ref(),
+                object_store.as_ref(),
             )
             .await?,
         );

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -657,7 +657,10 @@ impl FilteredReadStream {
     ) -> Vec<ScopedFragmentRead> {
         let default_batch_size = options.batch_size.unwrap_or_else(|| {
             get_default_batch_size().unwrap_or_else(|| {
-                std::cmp::max(dataset.object_store().block_size() / 4, BATCH_SIZE_FALLBACK)
+                std::cmp::max(
+                    dataset.object_store.as_ref().block_size() / 4,
+                    BATCH_SIZE_FALLBACK,
+                )
             }) as u32
         });
         let projection = Arc::new(options.projection.clone());


### PR DESCRIPTION
Make dataset object-store access explicit for multi-base datasets. The public `Dataset::object_store` accessor now takes an `Option<u32>` base id: pass `None` for the primary dataset store, or `Some(base_id)` for an additional base referenced by dataset metadata. This is a breaking change from the previous zero-argument accessor.

Adds `Dataset::with_object_store_wrappers(...)` to clone datasets with wrappers propagated to the primary object store, refs store, primary store params, and every base store params entry. When a fragment, deletion file, or index references a base id, Lance resolves both the correct path location and the corresponding wrapped object store, so wrappers such as caching and instrumentation apply to multi-base reads without changing page cache keys.

Also fixes base-aware read paths that resolved a `base_id` path but still used the primary dataset object store. Data-file metadata creation, deletion file reads, scalar/vector index opens, index detail inference, index stats, and index migration now resolve the correct base object store before reading.