### PR TITLE
fix: make vector distance schema nullable

### DIFF
--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -67,7 +67,7 @@ pub trait PartitionSearchControl: Send + Sync {
 
 pub static VECTOR_RESULT_SCHEMA: LazyLock<arrow_schema::SchemaRef> = LazyLock::new(|| {
     arrow_schema::SchemaRef::new(arrow_schema::Schema::new(vec![
-        Field::new(DIST_COL, arrow_schema::DataType::Float32, false),
+        Field::new(DIST_COL, arrow_schema::DataType::Float32, true),
         ROW_ID_FIELD.clone(),
     ]))
 });
@@ -184,7 +184,7 @@ pub trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
     ///
     /// Schema::new(vec![
     ///   Field::new("_rowid", DataType::UInt64, true),
-    ///   Field::new("_distance", DataType::Float32, false),
+    ///   Field::new("_distance", DataType::Float32, true),
     /// ]);
     /// ```
     ///

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/vector.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/vector.rs
@@ -108,7 +108,7 @@ impl VectorIndexExec {
             .iter()
             .map(|f| f.as_ref().clone())
             .collect();
-        fields.push(Field::new(DISTANCE_COLUMN, DataType::Float32, false));
+        fields.push(Field::new(DISTANCE_COLUMN, DataType::Float32, true));
         if with_row_id {
             fields.push(Field::new(lance_core::ROW_ID, DataType::UInt64, true));
         }

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/filter_stale.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/filter_stale.rs
@@ -386,7 +386,7 @@ mod tests {
         Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int32, false),
             Field::new("name", DataType::Utf8, true),
-            Field::new("_distance", DataType::Float32, false),
+            Field::new("_distance", DataType::Float32, true),
             Field::new(MEMTABLE_GEN_COLUMN, DataType::UInt64, false),
         ]))
     }

--- a/rust/lance/src/index/vector/fixture_test.rs
+++ b/rust/lance/src/index/vector/fixture_test.rs
@@ -207,7 +207,7 @@ mod test {
                 assert_query_value: assert_query,
                 ret_val: RecordBatch::new_empty(Arc::new(Schema::new(vec![
                     Field::new("id", DataType::UInt64, false),
-                    Field::new("_distance", DataType::Float32, false),
+                    Field::new("_distance", DataType::Float32, true),
                 ]))),
             });
             IVFIndex::try_new(


### PR DESCRIPTION
## Bug Fix

- What is the bug?
  - Vector search result schemas disagreed on the `_distance` column nullability. The public scanner and KNN schemas already expose `_distance` as nullable, while `VECTOR_RESULT_SCHEMA` and a mem-wal vector path still marked it as non-nullable.
- What issues or incorrect behavior does the bug cause?
  - The mismatch can create inconsistent schemas across vector search execution paths and tests, even though callers should see a single nullable `_distance` contract.
- How does this PR fix the problem?
  - Updates the remaining vector result schema definitions and related test fixtures to mark `_distance` as `Float32` nullable.
  - Updates the `VectorIndex` schema documentation to match the nullable contract.

## Validation

- `rg` check for remaining explicit `_distance` `Float32` `nullable=false` definitions under `rust/lance` and `rust/lance-index`
- `cargo fmt --all --check`
- `cargo test -p lance --lib dataset::mem_wal::scanner::exec::filter_stale::tests:: --no-fail-fast`
- `git diff --check`
