### PR TITLE
fix: propagate update_columns offsets and partial last_updated for RewriteColumns

### DIFF
--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -48,6 +48,8 @@ pub(crate) struct FragmentMergeResult {
 pub(crate) struct FragmentUpdateResult {
     updated_fragment: Fragment,
     fields_modified: Vec<u32>,
+    /// Physical row offsets that received column updates (from `_rowaddr` low bits).
+    updated_row_offsets: Vec<i64>,
 }
 
 //////////////////
@@ -490,11 +492,13 @@ fn inner_update_column<'local>(
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
     let left_on_str: String = left_on.extract(env)?;
     let right_on_str: String = right_on.extract(env)?;
-    let (updated_fragment, fields_modified) =
-        RT.block_on(fragment.update_columns(reader, &left_on_str, &right_on_str))?;
+    let r =
+        RT.block_on(fragment.update_columns_with_offsets(reader, &left_on_str, &right_on_str))?;
+    let updated_row_offsets: Vec<i64> = r.matched_offsets.iter().map(|o| o as i64).collect();
     let result = FragmentUpdateResult {
-        updated_fragment,
-        fields_modified,
+        updated_fragment: r.fragment,
+        fields_modified: r.fields_modified,
+        updated_row_offsets,
     };
     result.into_java(env)
 }
@@ -542,7 +546,7 @@ const FRAGMENT_MERGE_RESULT_CLASS: &str = "org/lance/fragment/FragmentMergeResul
 const FRAGMENT_MERGE_RESULT_CONSTRUCTOR_SIG: &str =
     "(Lorg/lance/FragmentMetadata;Lorg/lance/schema/LanceSchema;)V";
 const FRAGMENT_UPDATE_RESULT_CLASS: &str = "org/lance/fragment/FragmentUpdateResult";
-const FRAGMENT_UPDATE_RESULT_CONSTRUCTOR_SIG: &str = "(Lorg/lance/FragmentMetadata;[J)V";
+const FRAGMENT_UPDATE_RESULT_CONSTRUCTOR_SIG: &str = "(Lorg/lance/FragmentMetadata;[J[J)V";
 
 impl IntoJava for &FragmentMergeResult {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
@@ -563,12 +567,14 @@ impl IntoJava for &FragmentUpdateResult {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
         let java_updated_fragment = self.updated_fragment.into_java(env)?;
         let java_fields_modified = JLance(self.fields_modified.clone()).into_java(env)?;
+        let java_updated_row_offsets = JLance(self.updated_row_offsets.clone()).into_java(env)?;
         Ok(env.new_object(
             FRAGMENT_UPDATE_RESULT_CLASS,
             FRAGMENT_UPDATE_RESULT_CONSTRUCTOR_SIG,
             &[
                 JValueGen::Object(&java_updated_fragment),
                 JValueGen::Object(&java_fields_modified),
+                JValueGen::Object(&java_updated_row_offsets),
             ],
         )?)
     }

--- a/java/lance-jni/src/traits.rs
+++ b/java/lance-jni/src/traits.rs
@@ -202,6 +202,14 @@ impl IntoJava for JLance<Vec<u32>> {
     }
 }
 
+impl IntoJava for JLance<Vec<i64>> {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        let arr = env.new_long_array(self.0.len() as i32)?;
+        env.set_long_array_region(&arr, 0, &self.0)?;
+        Ok(arr.into())
+    }
+}
+
 impl IntoJava for JLance<usize> {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
         Ok(env.new_object("java/lang/Long", "(J)V", &[JValueGen::Long(self.0 as i64)])?)

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -433,6 +433,7 @@ fn convert_to_java_operation_inner<'local>(
             fields_for_preserving_frag_bitmap,
             update_mode,
             inserted_rows_filter: _,
+            updated_fragment_offsets: _,
         } => {
             let removed_ids: Vec<JLance<i64>> = removed_fragment_ids
                 .iter()
@@ -1222,6 +1223,7 @@ fn convert_to_rust_operation(
                 fields_for_preserving_frag_bitmap,
                 update_mode,
                 inserted_rows_filter: None,
+                updated_fragment_offsets: None,
             }
         }
         "DataReplacement" => {

--- a/java/src/main/java/org/lance/fragment/FragmentUpdateResult.java
+++ b/java/src/main/java/org/lance/fragment/FragmentUpdateResult.java
@@ -26,9 +26,19 @@ public class FragmentUpdateResult {
   private final FragmentMetadata updatedFragment;
   private final long[] fieldsModified;
 
+  /** Local physical row offsets within the fragment that received updates (see RowAddress). */
+  private final long[] updatedRowOffsets;
+
+  /** Two-argument form for callers that do not track per-row offsets; offsets default to empty. */
   public FragmentUpdateResult(FragmentMetadata updatedFragment, long[] updatedFieldIds) {
+    this(updatedFragment, updatedFieldIds, new long[0]);
+  }
+
+  public FragmentUpdateResult(
+      FragmentMetadata updatedFragment, long[] updatedFieldIds, long[] updatedRowOffsets) {
     this.updatedFragment = updatedFragment;
     this.fieldsModified = updatedFieldIds;
+    this.updatedRowOffsets = updatedRowOffsets;
   }
 
   public FragmentMetadata getUpdatedFragment() {
@@ -39,11 +49,17 @@ public class FragmentUpdateResult {
     return fieldsModified;
   }
 
+  /** Physical row offsets (0-based within the fragment) whose columns were rewritten. */
+  public long[] getUpdatedRowOffsets() {
+    return updatedRowOffsets;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("fragmentMetadata", updatedFragment)
         .add("updatedFieldIds", fieldsModified)
+        .add("updatedRowOffsets", updatedRowOffsets)
         .toString();
   }
 }

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -227,6 +227,11 @@ message Transaction {
     }
   }
 
+  // Serialized as sorted distinct local physical row offsets within the fragment (0-based).
+  message UInt32List {
+    repeated uint32 values = 1;
+  }
+
   // An operation that updates rows but does not add or remove rows.
   message Update {
     // The fragments that have been removed. These are fragments where all rows
@@ -248,6 +253,8 @@ message Transaction {
     // Filter for checking existence of keys in newly inserted rows, used for conflict detection.
     // Only tracks keys from INSERT operations during merge insert, not updates.
     optional KeyExistenceFilter inserted_rows = 8;
+    // Per-fragment physical row offsets that matched an update_columns hash join (RewriteColumns).
+    map<uint64, UInt32List> updated_fragment_offsets = 9;
   }
 
   // The mode of update operation

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -299,6 +299,7 @@ impl FromPyObject<'_, '_> for PyLance<Operation> {
                     fields_for_preserving_frag_bitmap,
                     update_mode,
                     inserted_rows_filter: None,
+                    updated_fragment_offsets: None,
                 };
                 Ok(Self(op))
             }

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1701,8 +1701,8 @@ impl FileFragment {
             let matched = joiner.matched_join_rows(index_column.clone())?;
             if let Some(addr_col) = batch.column_by_name(ROW_ADDR) {
                 let addrs = as_primitive_array::<UInt64Type>(addr_col.as_ref());
-                for row_idx in 0..batch.num_rows() {
-                    if !matched[row_idx] || addrs.is_null(row_idx) {
+                for (row_idx, &is_matched) in matched.iter().enumerate().take(batch.num_rows()) {
+                    if !is_matched || addrs.is_null(row_idx) {
                         continue;
                     }
                     let addr = RowAddress::from(addrs.value(row_idx));

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -13,8 +13,9 @@ use std::sync::Arc;
 
 use arrow::compute::concat_batches;
 use arrow_array::cast::as_primitive_array;
+use arrow_array::types::UInt64Type;
 use arrow_array::{
-    RecordBatch, RecordBatchReader, StructArray, UInt32Array, UInt64Array, new_null_array,
+    Array, RecordBatch, RecordBatchReader, StructArray, UInt32Array, UInt64Array, new_null_array,
 };
 use arrow_schema::Schema as ArrowSchema;
 use datafusion::logical_expr::Expr;
@@ -23,6 +24,7 @@ use futures::future::try_join_all;
 use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, join, stream};
 use lance_arrow::{RecordBatchExt, SchemaExt};
 use lance_core::datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions};
+use lance_core::utils::address::RowAddress;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::{Error, Result, cache::CacheKey, datatypes::Schema};
@@ -48,6 +50,7 @@ use lance_table::utils::stream::{
     ReadBatchFutStream, ReadBatchTask, ReadBatchTaskStream, RowIdAndDeletesConfig,
     wrap_with_row_id_and_delete,
 };
+use roaring::RoaringBitmap;
 
 use self::write::FragmentCreateBuilder;
 
@@ -60,6 +63,16 @@ use super::{NewColumnTransform, WriteParams, schema_evolution};
 use crate::dataset::Dataset;
 use crate::dataset::fragment::session::FragmentSession;
 use crate::io::deletion::read_dataset_deletion_file;
+
+/// Result of [`FileFragment::update_columns_with_offsets`]: updated fragment metadata, modified field ids,
+/// and physical row offsets that matched the join (for stable row-id version metadata).
+#[derive(Debug, Clone)]
+pub struct FragmentUpdateColumnsResult {
+    pub fragment: Fragment,
+    pub fields_modified: Vec<u32>,
+    /// Physical row offsets (0-based within this fragment) whose columns were rewritten from the right-hand stream.
+    pub matched_offsets: RoaringBitmap,
+}
 
 /// A Fragment of a Lance [`Dataset`].
 ///
@@ -1602,12 +1615,27 @@ impl FileFragment {
         Ok(self)
     }
 
+    /// Same as [`Self::update_columns_with_offsets`] but discards the matched row offsets.
+    /// Use [`Self::update_columns_with_offsets`] if you need per-row version metadata for stable row IDs.
     pub async fn update_columns(
         &mut self,
         right_stream: impl RecordBatchReader + Send + 'static,
         left_on: &str,
         right_on: &str,
     ) -> Result<(Fragment, Vec<u32>)> {
+        let r = self
+            .update_columns_with_offsets(right_stream, left_on, right_on)
+            .await?;
+        Ok((r.fragment, r.fields_modified))
+    }
+
+    /// Same operation as [`Self::update_columns`], and also returns matched physical row offsets for stable row IDs.
+    pub async fn update_columns_with_offsets(
+        &mut self,
+        right_stream: impl RecordBatchReader + Send + 'static,
+        left_on: &str,
+        right_on: &str,
+    ) -> Result<FragmentUpdateColumnsResult> {
         if self.schema().field(left_on).is_none() && left_on != ROW_ID && left_on != ROW_ADDR {
             return Err(Error::invalid_input(format!(
                 "Column {} does not exist in the left side fragment",
@@ -1647,6 +1675,11 @@ impl FileFragment {
         let mut read_columns: Vec<String> =
             write_schema.fields.iter().map(|f| f.name.clone()).collect();
         read_columns.push(left_on.to_string());
+        // Physical positions for matched rows are taken from `_rowaddr` (fragment id + row offset).
+        // The updater scans live rows in physical order; `_rowaddr` encodes the slot index used by row-level version metadata.
+        if !read_columns.iter().any(|n| n.as_str() == ROW_ADDR) {
+            read_columns.push(ROW_ADDR.to_string());
+        }
         let mut updater = self
             .updater(
                 Some(&read_columns),
@@ -1654,11 +1687,32 @@ impl FileFragment {
                 None,
             )
             .await?;
-        // Hash join
+        // Hash join: rows matched on the right-hand stream rewrite columns; track physical offsets via `_rowaddr`.
         let joiner = Arc::new(HashJoiner::try_new(right_stream, right_on).await?);
+        let mut matched_offsets = RoaringBitmap::new();
+        let frag_id_u32 = u32::try_from(self.metadata.id).map_err(|_| {
+            Error::invalid_input(format!(
+                "Fragment id {} does not fit RowAddress fragment id",
+                self.metadata.id
+            ))
+        })?;
         while let Some(batch) = updater.next().await? {
+            let index_column = batch[left_on].clone();
+            let matched = joiner.matched_join_rows(index_column.clone())?;
+            if let Some(addr_col) = batch.column_by_name(ROW_ADDR) {
+                let addrs = as_primitive_array::<UInt64Type>(addr_col.as_ref());
+                for row_idx in 0..batch.num_rows() {
+                    if !matched[row_idx] || addrs.is_null(row_idx) {
+                        continue;
+                    }
+                    let addr = RowAddress::from(addrs.value(row_idx));
+                    if addr.fragment_id() == frag_id_u32 {
+                        matched_offsets.insert(addr.row_offset());
+                    }
+                }
+            }
             let updated_batch = joiner
-                .collect_with_fallback(batch, batch[left_on].clone(), self.dataset())
+                .collect_with_fallback(batch, index_column, self.dataset())
                 .await?;
             updater.update(updated_batch).await?;
         }
@@ -1689,8 +1743,11 @@ impl FileFragment {
             .iter()
             .filter_map(|&i| u32::try_from(i).ok())
             .collect();
-        // Note: updated field should be returned when committing, waiting to be done
-        Ok((updated_fragment, updated_fields))
+        Ok(FragmentUpdateColumnsResult {
+            fragment: updated_fragment,
+            fields_modified: updated_fields,
+            matched_offsets,
+        })
     }
 
     /// Append new columns to the fragment
@@ -2647,12 +2704,13 @@ mod tests {
     use lance_io::{assert_io_eq, assert_io_lt, object_store::ObjectStore};
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+    use std::collections::HashMap;
 
     use super::*;
     use crate::{
         dataset::{
             InsertBuilder,
-            transaction::{Operation, UpdateMode},
+            transaction::{Operation, UpdateMode, UpdatedFragmentOffsets},
         },
         session::Session,
         utils::test::TestDatasetGenerator,
@@ -2851,19 +2909,29 @@ mod tests {
             vec![Ok(update_batch1)].into_iter(),
             schema1,
         ));
-        let (updated_fragment1, fields_modified1) = fragment1
-            .update_columns(right_stream1, ROW_ID, ROW_ID)
+        let u1 = fragment1
+            .update_columns_with_offsets(right_stream1, ROW_ID, ROW_ID)
             .await
             .unwrap();
+        assert_eq!(u1.matched_offsets.iter().count(), 38);
+        assert!(!u1.matched_offsets.contains(0));
+        assert!(!u1.matched_offsets.contains(3));
+        assert!(u1.matched_offsets.contains(1));
+        assert!(u1.matched_offsets.contains(39));
+        let frag_id_1 = u1.fragment.id;
+        let matched_1 = u1.matched_offsets;
         let op1 = Operation::Update {
             removed_fragment_ids: vec![],
-            updated_fragments: vec![updated_fragment1],
+            updated_fragments: vec![u1.fragment],
             new_fragments: vec![],
-            fields_modified: fields_modified1,
+            fields_modified: u1.fields_modified,
             merged_generations: Vec::new(),
             fields_for_preserving_frag_bitmap: vec![],
             update_mode: Some(UpdateMode::RewriteColumns),
             inserted_rows_filter: None,
+            updated_fragment_offsets: Some(UpdatedFragmentOffsets(HashMap::from([(
+                frag_id_1, matched_1,
+            )]))),
         };
         let mut dataset1 = Dataset::commit(
             test_uri,
@@ -2924,19 +2992,27 @@ mod tests {
             vec![Ok(update_batch2)].into_iter(),
             schema2,
         ));
-        let (updated_fragment2, fields_modified2) = fragment2
-            .update_columns(right_stream2, "i", "i1")
+        let u2 = fragment2
+            .update_columns_with_offsets(right_stream2, "i", "i1")
             .await
             .unwrap();
+        assert_eq!(u2.matched_offsets.iter().count(), 38);
+        assert!(!u2.matched_offsets.contains(0));
+        assert!(!u2.matched_offsets.contains(3));
+        let frag_id_2 = u2.fragment.id;
+        let matched_2 = u2.matched_offsets;
         let op = Operation::Update {
             removed_fragment_ids: vec![],
-            updated_fragments: vec![updated_fragment2],
+            updated_fragments: vec![u2.fragment],
             new_fragments: vec![],
-            fields_modified: fields_modified2,
+            fields_modified: u2.fields_modified,
             merged_generations: Vec::new(),
             fields_for_preserving_frag_bitmap: vec![],
             update_mode: Some(UpdateMode::RewriteColumns),
             inserted_rows_filter: None,
+            updated_fragment_offsets: Some(UpdatedFragmentOffsets(HashMap::from([(
+                frag_id_2, matched_2,
+            )]))),
         };
         let dataset2 = Dataset::commit(
             test_uri,

--- a/rust/lance/src/dataset/hash_joiner.rs
+++ b/rust/lance/src/dataset/hash_joiner.rs
@@ -278,6 +278,16 @@ impl HashJoiner {
             .await?;
         Ok(RecordBatch::try_new(self.batches[0].schema(), columns)?)
     }
+
+    /// Returns `true` for each row where [collect_with_fallback] would take values from the
+    /// right-hand stream (hash hit); `false` where it falls back to the left batch row.
+    pub(super) fn matched_join_rows(&self, index_column: ArrayRef) -> Result<Vec<bool>> {
+        let rows = column_to_rows(index_column)?;
+        Ok(rows
+            .iter()
+            .map(|row| self.index_map.get(&row.owned()).is_some())
+            .collect())
+    }
 }
 
 #[cfg(test)]
@@ -354,6 +364,44 @@ mod tests {
         );
 
         assert_eq!(results.num_columns(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_matched_join_rows() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("i", DataType::Int32, true),
+            Field::new("s", DataType::Utf8, true),
+        ]));
+
+        let batches: Vec<RecordBatch> = (0..2)
+            .map(|v| {
+                let values = (v * 10..v * 10 + 10).collect::<Vec<_>>();
+                RecordBatch::try_new(
+                    schema.clone(),
+                    vec![
+                        Arc::new(Int32Array::from_iter(values.iter().copied())),
+                        Arc::new(StringArray::from_iter_values(
+                            values.iter().map(|val| format!("str_{}", val)),
+                        )),
+                    ],
+                )
+                .unwrap()
+            })
+            .collect();
+        let reader: Box<dyn RecordBatchReader + Send> = Box::new(RecordBatchIterator::new(
+            batches.into_iter().map(Ok),
+            schema,
+        ));
+        let joiner = HashJoiner::try_new(reader, "i").await.unwrap();
+
+        let index = Arc::new(Int32Array::from(vec![
+            Some(5),  // present in first RHS batch
+            Some(15), // present in second RHS batch
+            Some(99), // absent from RHS
+            None,     // null join key — no RHS entry
+        ]));
+        let matched = joiner.matched_join_rows(index).unwrap();
+        assert_eq!(matched, vec![true, true, false, false]);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -14,7 +14,7 @@
 
 use super::ManifestWriteConfig;
 use super::write::merge_insert::inserted_rows::KeyExistenceFilter;
-use crate::dataset::transaction::UpdateMode::RewriteRows;
+use crate::dataset::transaction::UpdateMode::{RewriteColumns, RewriteRows};
 use crate::index::mem_wal::update_mem_wal_index_merged_generations;
 use crate::utils::temporal::timestamp_to_nanos;
 use deepsize::DeepSizeOf;
@@ -396,6 +396,9 @@ pub enum Operation {
         /// Optional filter for detecting conflicts on inserted row keys.
         /// Only tracks keys from INSERT operations during merge insert, not updates.
         inserted_rows_filter: Option<KeyExistenceFilter>,
+        /// Physical row offsets (per fragment) that matched `update_columns` for RewriteColumns.
+        /// `None` means callers did not supply offsets; [`build_manifest`] skips partial refresh then.
+        updated_fragment_offsets: Option<UpdatedFragmentOffsets>,
     },
 
     /// Project to a new schema. This only changes the schema, not the data.
@@ -442,6 +445,28 @@ pub enum UpdateMode {
     /// Old versions of columns are tombstoned. This is most optimal when most rows are affected
     /// but a small subset of columns are affected.
     RewriteColumns,
+}
+
+/// Matched physical row offsets per fragment for a partial [`UpdateMode::RewriteColumns`] update.
+///
+/// Used with stable row IDs so [`Transaction::build_manifest`] can refresh row-level version
+/// metadata only for rows that were rewritten.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdatedFragmentOffsets(pub HashMap<u64, RoaringBitmap>);
+
+impl Default for UpdatedFragmentOffsets {
+    fn default() -> Self {
+        Self(HashMap::new())
+    }
+}
+
+impl DeepSizeOf for UpdatedFragmentOffsets {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.0.iter().fold(0_usize, |acc, (frag_id, bitmap)| {
+            acc + frag_id.deep_size_of_children(context)
+                + (bitmap.len() as usize).saturating_mul(std::mem::size_of::<u32>())
+        })
+    }
 }
 
 impl std::fmt::Display for Operation {
@@ -595,6 +620,7 @@ impl PartialEq for Operation {
                     fields_for_preserving_frag_bitmap: a_fields_for_preserving_frag_bitmap,
                     update_mode: a_update_mode,
                     inserted_rows_filter: a_inserted_rows_filter,
+                    updated_fragment_offsets: a_updated_fragment_offsets,
                 },
                 Self::Update {
                     removed_fragment_ids: b_removed,
@@ -605,6 +631,7 @@ impl PartialEq for Operation {
                     fields_for_preserving_frag_bitmap: b_fields_for_preserving_frag_bitmap,
                     update_mode: b_update_mode,
                     inserted_rows_filter: b_inserted_rows_filter,
+                    updated_fragment_offsets: b_updated_fragment_offsets,
                 },
             ) => {
                 compare_vec(a_removed, b_removed)
@@ -618,6 +645,7 @@ impl PartialEq for Operation {
                     )
                     && a_update_mode == b_update_mode
                     && a_inserted_rows_filter == b_inserted_rows_filter
+                    && a_updated_fragment_offsets == b_updated_fragment_offsets
             }
             (Self::Project { schema: a }, Self::Project { schema: b }) => a == b,
             (
@@ -1840,6 +1868,7 @@ impl Transaction {
                 merged_generations,
                 fields_for_preserving_frag_bitmap,
                 update_mode,
+                updated_fragment_offsets,
                 ..
             } => {
                 // Extract existing fragments once for reuse
@@ -1869,6 +1898,31 @@ impl Transaction {
                 }
 
                 final_fragments.extend(updated_frags);
+
+                if next_row_id.is_some() && matches!(update_mode, Some(RewriteColumns)) {
+                    if let Some(UpdatedFragmentOffsets(off_map)) = updated_fragment_offsets {
+                        if !off_map.is_empty() {
+                            let new_version = current_manifest.map(|m| m.version + 1).unwrap_or(1);
+                            let prev_version = current_manifest.map(|m| m.version).unwrap_or(0);
+                            for fragment in final_fragments.iter_mut() {
+                                let Some(bitmap) = off_map.get(&fragment.id) else {
+                                    continue;
+                                };
+                                if bitmap.is_empty() {
+                                    continue;
+                                }
+                                let offsets: Vec<usize> =
+                                    bitmap.iter().map(|o| o as usize).collect();
+                                lance_table::rowids::version::refresh_row_latest_update_meta_for_partial_frag_rewrite_cols(
+                                    fragment,
+                                    &offsets,
+                                    new_version,
+                                    prev_version,
+                                )?;
+                            }
+                        }
+                    }
+                }
 
                 // If we updated any fields, remove those fragments from indices covering those fields
                 Self::prune_updated_fields_from_indices(
@@ -2918,6 +2972,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                 fields_for_preserving_frag_bitmap,
                 update_mode,
                 inserted_rows,
+                updated_fragment_offsets,
             })) => Operation::Update {
                 removed_fragment_ids,
                 updated_fragments: updated_fragments
@@ -2942,6 +2997,18 @@ impl TryFrom<pb::Transaction> for Transaction {
                 inserted_rows_filter: inserted_rows
                     .map(|ik| KeyExistenceFilter::try_from(&ik))
                     .transpose()?,
+                updated_fragment_offsets: {
+                    let m: HashMap<u64, RoaringBitmap> = updated_fragment_offsets
+                        .into_iter()
+                        .filter(|(_, list)| !list.values.is_empty())
+                        .map(|(id, list)| (id, RoaringBitmap::from_iter(list.values)))
+                        .collect();
+                    if m.is_empty() {
+                        None
+                    } else {
+                        Some(UpdatedFragmentOffsets(m))
+                    }
+                },
             },
             Some(pb::transaction::Operation::Project(pb::transaction::Project { schema })) => {
                 Operation::Project {
@@ -3244,6 +3311,7 @@ impl From<&Transaction> for pb::Transaction {
                 fields_for_preserving_frag_bitmap,
                 update_mode,
                 inserted_rows_filter,
+                updated_fragment_offsets,
             } => pb::transaction::Operation::Update(pb::transaction::Update {
                 removed_fragment_ids: removed_fragment_ids.clone(),
                 updated_fragments: updated_fragments
@@ -3265,6 +3333,18 @@ impl From<&Transaction> for pb::Transaction {
                     })
                     .unwrap_or(0),
                 inserted_rows: inserted_rows_filter.as_ref().map(|ik| ik.into()),
+                updated_fragment_offsets: updated_fragment_offsets
+                    .as_ref()
+                    .map(|UpdatedFragmentOffsets(m)| {
+                        m.iter()
+                            .filter(|(_, b)| !b.is_empty())
+                            .map(|(frag_id, b)| {
+                                let values: Vec<u32> = b.iter().collect();
+                                (*frag_id, pb::transaction::UInt32List { values })
+                            })
+                            .collect::<HashMap<_, _>>()
+                    })
+                    .unwrap_or_default(),
             }),
             Operation::Project { schema } => {
                 pb::transaction::Operation::Project(pb::transaction::Project {
@@ -3546,17 +3626,30 @@ fn merge_fragments_valid(manifest: &Manifest, new_fragments: &[Fragment]) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow_array::cast::AsArray;
+    use arrow_array::types::UInt64Type;
+    use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use chrono::Utc;
+    use futures::TryStreamExt;
     use lance_core::datatypes::Schema as LanceSchema;
+    use lance_core::utils::address::RowAddress;
+    use lance_core::utils::tempfile::TempStrDir;
+    use lance_core::{ROW_ADDR, ROW_CREATED_AT_VERSION, ROW_LAST_UPDATED_AT_VERSION};
+    use lance_file::version::LanceFileVersion;
     use lance_io::utils::CachedFileSize;
     use lance_table::format::{
         RowDatasetVersionMeta, RowDatasetVersionRun, RowDatasetVersionSequence, RowIdMeta,
     };
     use lance_table::rowids::segment::U64Segment;
     use lance_table::rowids::write_row_ids;
+    use std::collections::HashMap;
     use std::sync::Arc;
     use uuid::Uuid;
+
+    use crate::Dataset;
+    use crate::dataset::write::WriteParams;
+    use crate::session::Session;
 
     fn sample_manifest() -> Manifest {
         let schema = ArrowSchema::new(vec![ArrowField::new("id", DataType::Int32, false)]);
@@ -4529,6 +4622,186 @@ mod tests {
         assert!(indices.is_empty());
     }
 
+    /// Partial RewriteColumns refresh in `build_manifest`: only matched physical
+    /// rows get `last_updated_at_version` bumped; same-fragment unmatched rows and
+    /// untouched fragments keep both version sequences.
+    #[tokio::test]
+    async fn test_build_manifest_partial_last_updated_rewrite_columns_stable_row_ids() {
+        let dir = TempStrDir::default();
+        let uri = dir.as_str();
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("x", DataType::Int32, false),
+        ]));
+        let batch0 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..8)),
+                Arc::new(Int32Array::from(vec![0_i32; 8])),
+            ],
+        )
+        .unwrap();
+        let reader0 = RecordBatchIterator::new(vec![Ok(batch0)], schema.clone());
+        let write_params = WriteParams {
+            enable_stable_row_ids: true,
+            data_storage_version: Some(LanceFileVersion::Stable),
+            ..Default::default()
+        };
+        let mut dataset = Dataset::write(reader0, uri, Some(write_params))
+            .await
+            .unwrap();
+
+        let batch1 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(100..108)),
+                Arc::new(Int32Array::from(vec![0_i32; 8])),
+            ],
+        )
+        .unwrap();
+        let reader1 = RecordBatchIterator::new(vec![Ok(batch1)], schema.clone());
+        dataset.append(reader1, None).await.unwrap();
+
+        let frags = dataset.get_fragments();
+        assert_eq!(
+            frags.len(),
+            2,
+            "expected two fragments (append creates a new fragment)"
+        );
+
+        async fn scan_row_versions(ds: &Dataset) -> HashMap<(u32, u32), (u64, u64)> {
+            let mut scanner = ds.scan();
+            scanner
+                .project(&[
+                    ROW_ADDR,
+                    ROW_LAST_UPDATED_AT_VERSION,
+                    ROW_CREATED_AT_VERSION,
+                ])
+                .unwrap();
+            let batches = scanner
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let mut out = HashMap::new();
+            for batch in batches {
+                let addrs = batch
+                    .column_by_name(ROW_ADDR)
+                    .unwrap()
+                    .as_primitive::<UInt64Type>();
+                let last = batch
+                    .column_by_name(ROW_LAST_UPDATED_AT_VERSION)
+                    .unwrap()
+                    .as_primitive::<UInt64Type>();
+                let created = batch
+                    .column_by_name(ROW_CREATED_AT_VERSION)
+                    .unwrap()
+                    .as_primitive::<UInt64Type>();
+                for row in 0..batch.num_rows() {
+                    let addr = RowAddress::from(addrs.value(row));
+                    out.insert(
+                        (addr.fragment_id(), addr.row_offset()),
+                        (last.value(row), created.value(row)),
+                    );
+                }
+            }
+            out
+        }
+
+        let before = scan_row_versions(&dataset).await;
+        assert_eq!(before.len(), 16);
+
+        // Update only rows i in {2, 4, 6} within fragment 0 (physical offsets 2, 4, 6).
+        let update_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("x", DataType::Int32, false),
+        ]));
+        let update_batch = RecordBatch::try_new(
+            update_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![2, 4, 6])),
+                Arc::new(Int32Array::from(vec![99, 99, 99])),
+            ],
+        )
+        .unwrap();
+        let right: Box<dyn arrow_array::RecordBatchReader + Send> = Box::new(
+            RecordBatchIterator::new(vec![Ok(update_batch)].into_iter(), update_schema),
+        );
+
+        let mut frag0 = dataset.get_fragment(0).unwrap();
+        let u = frag0
+            .update_columns_with_offsets(right, "i", "i")
+            .await
+            .unwrap();
+        assert_eq!(u.matched_offsets.iter().count(), 3);
+        for off in [2_u32, 4, 6] {
+            assert!(u.matched_offsets.contains(off));
+        }
+
+        let updated_fragment_offsets = Some(UpdatedFragmentOffsets(HashMap::from([(
+            u.fragment.id,
+            u.matched_offsets,
+        )])));
+
+        let op = Operation::Update {
+            removed_fragment_ids: vec![],
+            updated_fragments: vec![u.fragment],
+            new_fragments: vec![],
+            fields_modified: u.fields_modified,
+            merged_generations: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: Some(UpdateMode::RewriteColumns),
+            inserted_rows_filter: None,
+            updated_fragment_offsets,
+        };
+
+        let read_v = dataset.version().version;
+        let dataset = Dataset::commit(
+            uri,
+            op,
+            Some(read_v),
+            None,
+            None,
+            Arc::new(Session::default()),
+            true,
+        )
+        .await
+        .unwrap();
+
+        let new_v = dataset.version().version;
+        assert_eq!(new_v, read_v + 1);
+
+        let after = scan_row_versions(&dataset).await;
+        for off in 0..8_u32 {
+            let key = (0, off);
+            let (last_before, created_before) = before[&key];
+            let (last_after, created_after) = after[&key];
+            assert_eq!(created_after, created_before);
+            if off == 2 || off == 4 || off == 6 {
+                assert_eq!(
+                    last_after, new_v,
+                    "matched row offset {off} should advance last_updated to new version"
+                );
+            } else {
+                assert_eq!(
+                    last_after, last_before,
+                    "unmatched row offset {off} in fragment 0 should keep last_updated"
+                );
+            }
+        }
+
+        for off in 0..8_u32 {
+            let key = (1, off);
+            assert_eq!(
+                after[&key], before[&key],
+                "fragment 1 row offset {off}: both version columns unchanged"
+            );
+        }
+    }
+
     /// Regression test for https://github.com/lance-format/lance/issues/6417
     ///
     /// When overwriting a LEGACY dataset with STABLE-format fragments, the
@@ -4622,6 +4895,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_fragment_offsets: None,
             },
             None,
         )

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -397,7 +397,7 @@ pub enum Operation {
         /// Only tracks keys from INSERT operations during merge insert, not updates.
         inserted_rows_filter: Option<KeyExistenceFilter>,
         /// Physical row offsets (per fragment) that matched `update_columns` for RewriteColumns.
-        /// `None` means callers did not supply offsets; [`build_manifest`] skips partial refresh then.
+        /// `None` means callers did not supply offsets; `build_manifest` skips partial refresh then.
         updated_fragment_offsets: Option<UpdatedFragmentOffsets>,
     },
 
@@ -449,16 +449,10 @@ pub enum UpdateMode {
 
 /// Matched physical row offsets per fragment for a partial [`UpdateMode::RewriteColumns`] update.
 ///
-/// Used with stable row IDs so [`Transaction::build_manifest`] can refresh row-level version
+/// Used with stable row IDs so `build_manifest` can refresh row-level version
 /// metadata only for rows that were rewritten.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct UpdatedFragmentOffsets(pub HashMap<u64, RoaringBitmap>);
-
-impl Default for UpdatedFragmentOffsets {
-    fn default() -> Self {
-        Self(HashMap::new())
-    }
-}
 
 impl DeepSizeOf for UpdatedFragmentOffsets {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
@@ -1899,28 +1893,33 @@ impl Transaction {
 
                 final_fragments.extend(updated_frags);
 
-                if next_row_id.is_some() && matches!(update_mode, Some(RewriteColumns)) {
-                    if let Some(UpdatedFragmentOffsets(off_map)) = updated_fragment_offsets {
-                        if !off_map.is_empty() {
-                            let new_version = current_manifest.map(|m| m.version + 1).unwrap_or(1);
-                            let prev_version = current_manifest.map(|m| m.version).unwrap_or(0);
-                            for fragment in final_fragments.iter_mut() {
-                                let Some(bitmap) = off_map.get(&fragment.id) else {
-                                    continue;
-                                };
-                                if bitmap.is_empty() {
-                                    continue;
-                                }
-                                let offsets: Vec<usize> =
-                                    bitmap.iter().map(|o| o as usize).collect();
-                                lance_table::rowids::version::refresh_row_latest_update_meta_for_partial_frag_rewrite_cols(
-                                    fragment,
-                                    &offsets,
-                                    new_version,
-                                    prev_version,
-                                )?;
-                            }
+                if next_row_id.is_some()
+                    && matches!(update_mode, Some(RewriteColumns))
+                    && let Some(UpdatedFragmentOffsets(off_map)) = updated_fragment_offsets
+                    && !off_map.is_empty()
+                {
+                    let new_version = current_manifest.map(|m| m.version + 1).unwrap_or(1);
+                    let prev_version = current_manifest.map(|m| m.version).unwrap_or(0);
+                    for fragment in final_fragments.iter_mut() {
+                        let Some(bitmap) = off_map.get(&fragment.id) else {
+                            continue;
+                        };
+                        if bitmap.is_empty() {
+                            continue;
                         }
+                        // Skip fragments with no existing version metadata: the helper
+                        // would fill unmatched rows with prev_version, fabricating a
+                        // last_updated stamp for rows that never had one.
+                        if fragment.last_updated_at_version_meta.is_none() {
+                            continue;
+                        }
+                        let offsets: Vec<usize> = bitmap.iter().map(|o| o as usize).collect();
+                        lance_table::rowids::version::refresh_row_latest_update_meta_for_partial_frag_rewrite_cols(
+                            fragment,
+                            &offsets,
+                            new_version,
+                            prev_version,
+                        )?;
                     }
                 }
 
@@ -4620,6 +4619,62 @@ mod tests {
         let result = Transaction::handle_rewrite_indices(&mut indices, &rewritten_indices, &[]);
         assert!(result.is_ok());
         assert!(indices.is_empty());
+    }
+
+    /// When a fragment has no existing last_updated_at_version_meta (None), a
+    /// partial RewriteColumns refresh must leave it as None rather than fabricating
+    /// prev_version for unmatched rows.
+    #[test]
+    fn test_partial_rewrite_skips_fragment_with_no_version_meta() {
+        let row_ids = RowIdSequence::from([10u64, 11, 12, 13, 14].as_slice());
+        let row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&row_ids)));
+
+        let (major, minor) = lance_file::version::LanceFileVersion::Stable.to_numbers();
+        let data_file = DataFile::new("data.lance", vec![0], vec![0], major, minor, None, None);
+
+        let fragment = Fragment {
+            id: 1,
+            files: vec![data_file],
+            deletion_file: None,
+            row_id_meta,
+            physical_rows: Some(5),
+            last_updated_at_version_meta: None,
+            created_at_version_meta: None,
+        };
+
+        let manifest = make_stable_row_id_manifest(vec![fragment.clone()]);
+
+        // Simulate a RewriteColumns update that matched offsets 1 and 3
+        let off_map = HashMap::from([(1u64, RoaringBitmap::from_iter([1u32, 3]))]);
+        let tx = Transaction::new(
+            manifest.version,
+            Operation::Update {
+                removed_fragment_ids: vec![],
+                updated_fragments: vec![fragment],
+                new_fragments: vec![],
+                fields_modified: vec![],
+                merged_generations: vec![],
+                fields_for_preserving_frag_bitmap: vec![],
+                update_mode: Some(UpdateMode::RewriteColumns),
+                inserted_rows_filter: None,
+                updated_fragment_offsets: Some(UpdatedFragmentOffsets(off_map)),
+            },
+            None,
+        );
+
+        let (out, _) = tx
+            .build_manifest(
+                Some(&manifest),
+                vec![],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap();
+
+        assert!(
+            out.fragments[0].last_updated_at_version_meta.is_none(),
+            "fragment with no prior version metadata must not have fabricated prev_version stamped on unmatched rows"
+        );
     }
 
     /// Partial RewriteColumns refresh in `build_manifest`: only matched physical

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -755,6 +755,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_fragment_offsets: None,
             },
             read_version: 1,
             tag: None,

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1650,6 +1650,7 @@ impl MergeInsertJob {
                 fields_for_preserving_frag_bitmap: vec![], // in-place update do not affect preserving frag bitmap
                 update_mode: Some(RewriteColumns),
                 inserted_rows_filter: None, // not implemented for v1
+                updated_fragment_offsets: None,
             };
             // We have rewritten the fragments, not just the deletion files, so
             // we can't use affected rows here.
@@ -1724,6 +1725,7 @@ impl MergeInsertJob {
                     .collect(),
                 update_mode: Some(RewriteRows),
                 inserted_rows_filter: None, // not implemented for v1
+                updated_fragment_offsets: None,
             };
 
             let affected_rows = Some(RowAddrTreeMap::from(removed_row_addrs));

--- a/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
@@ -284,6 +284,7 @@ impl ExecutionPlan for DeleteOnlyMergeInsertExec {
                     .collect(),
                 update_mode: None,
                 inserted_rows_filter: None, // Delete-only operations don't insert rows
+                updated_fragment_offsets: None,
             };
 
             let transaction = Transaction::new(dataset.manifest.version, operation, None);

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -928,6 +928,7 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
                     .collect(),
                 update_mode: Some(RewriteRows),
                 inserted_rows_filter: inserted_rows_filter.clone(),
+                updated_fragment_offsets: None,
             };
 
             // Step 5: Create and store the transaction

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -377,6 +377,7 @@ impl UpdateJob {
             fields_for_preserving_frag_bitmap,
             update_mode: Some(RewriteRows),
             inserted_rows_filter: None,
+            updated_fragment_offsets: None,
         };
 
         let transaction = Transaction::new(dataset.manifest.version, operation, None);

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1815,6 +1815,7 @@ mod tests {
             fields_for_preserving_frag_bitmap: vec![],
             update_mode: None,
             inserted_rows_filter: None,
+            updated_fragment_offsets: None,
         };
         let transaction = Transaction::new_from_version(1, operation);
         let other_operations = [
@@ -1827,6 +1828,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_fragment_offsets: None,
             },
             Operation::Delete {
                 deleted_fragment_ids: vec![3],
@@ -1842,6 +1844,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_fragment_offsets: None,
             },
         ];
         let other_transactions = other_operations.map(|op| Transaction::new_from_version(2, op));
@@ -1944,6 +1947,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_fragment_offsets: None,
             },
             Operation::Delete {
                 updated_fragments: vec![apply_deletion(&[1], &mut fragment, &dataset).await],
@@ -1959,6 +1963,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_fragment_offsets: None,
             },
         ];
         let transactions =
@@ -2088,6 +2093,7 @@ mod tests {
                     fields_for_preserving_frag_bitmap: vec![],
                     update_mode: None,
                     inserted_rows_filter: None,
+                    updated_fragment_offsets: None,
                 },
             ),
             (
@@ -2101,6 +2107,7 @@ mod tests {
                     fields_for_preserving_frag_bitmap: vec![],
                     update_mode: None,
                     inserted_rows_filter: None,
+                    updated_fragment_offsets: None,
                 },
             ),
             (
@@ -2261,6 +2268,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_fragment_offsets: None,
             },
             create_update_config_for_test(
                 Some(HashMap::from_iter(vec![(
@@ -2467,6 +2475,7 @@ mod tests {
                     fields_for_preserving_frag_bitmap: vec![],
                     update_mode: None,
                     inserted_rows_filter: None,
+                    updated_fragment_offsets: None,
                 },
                 [
                     Compatible,    // append
@@ -2989,6 +2998,7 @@ mod tests {
                 fields_for_preserving_frag_bitmap: vec![],
                 update_mode: None,
                 inserted_rows_filter: None,
+                updated_fragment_offsets: None,
             },
         ];
 


### PR DESCRIPTION
## Summary

* Fixes https://github.com/lance-format/lance/issues/6505
* `FileFragment::update_columns` returns `Result<(Fragment, Vec<u32>)>` (unchanged
  public shape). `update_columns_with_offsets` returns `FragmentUpdateColumnsResult`
  (fragment, `fields_modified`, `matched_offsets: RoaringBitmap`) for callers that need
  physical row indices for stable row-id metadata.
* `HashJoiner::matched_join_rows` — boolean mask for hash hits; used by
  `update_columns_with_offsets` and covered by `test_matched_join_rows`.
* `Operation::Update`: optional `updated_fragment_offsets: Option<UpdatedFragmentOffsets>`
  where `UpdatedFragmentOffsets` wraps `HashMap<u64, RoaringBitmap>` (newtype with
  `Default`, `PartialEq`, manual `DeepSizeOf`). `None` means the caller did not supply
  offsets.
* Proto (`transaction.proto`): backward-compatible `map<uint64, UInt32List> updated_fragment_offsets = 9`
  on `Update`; serde round-trip preserves semantics.
* `build_manifest`: when stable row IDs are enabled, `update_mode == RewriteColumns`,
  and `Some(UpdatedFragmentOffsets(..))` includes a non-empty bitmap for a fragment,
  calls `refresh_row_latest_update_meta_for_partial_frag_rewrite_cols` for those offsets
  only — unmatched rows and untouched fragments are left unchanged.
* JNI / Java: `FragmentUpdateResult` includes matched row offsets; the 2-arg constructor
  `(FragmentMetadata, long[])` delegates to the 3-arg form with an empty offset array for
  compatibility. JNI uses `update_columns_with_offsets`.
* Python: `update_columns` binding correctly destructures the `(Fragment, Vec<u32>)` tuple.


## Root cause

For `Operation::Update` with `RewriteColumns`, commits could advance the dataset version
without advancing `_row_last_updated_at_version` for the rows that were actually rewritten.
`update_columns` did not report which physical offsets matched, and `build_manifest` had no
per-fragment offset map to drive the partial refresh. Without that information the transaction
layer cannot distinguish which rows changed, so the version metadata is not updated.


## Implementation notes

* `RoaringBitmap` iteration is ascending and duplicate-free; redundant `sort` / `dedup`
  when building proto lists or offset vectors from bitmaps were removed.
* Call sites that do not populate offsets use `updated_fragment_offsets: None`.


## Why the protobuf field exists

lance-spark passes `Transaction` through JNI as a protobuf blob: Java builds a `Transaction`
proto, Rust deserializes it and runs `build_manifest`. Without `updated_fragment_offsets` on
the wire, the decoded `Operation::Update` would always have `updated_fragment_offsets: None`
even when matched offsets were computed on the JVM side, and the partial refresh in
`build_manifest` would silently do nothing.


## Test plan

* `cargo test -p lance test_matched_join_rows` — `HashJoiner::matched_join_rows`.
* `cargo test -p lance test_build_manifest_partial_last_updated_rewrite_columns_stable_row_ids`
  — `Dataset::commit` -> `build_manifest`: two fragments, partial
  `update_columns_with_offsets`, `Operation::Update` with `RewriteColumns` and an offset
  map; asserts matched vs unmatched vs untouched row version metadata.
* `cargo test -p lance test_fragment_update` — fragment path with `Operation::Update` and
  offsets.
* `cargo test -p lance --tests` (or at least `cargo check -p lance --tests`) and
  `cargo check --manifest-path java/lance-jni/Cargo.toml`.

The `pylance` crate is excluded from the root workspace; validate Python bindings in the
usual `maturin` / CI flow if you touch `python/`.


## Compatibility

* Rust: `update_columns` signature unchanged; `update_columns_with_offsets` is additive.
* Java: 2-arg `FragmentUpdateResult` constructor preserved.
* Proto: field 9; older clients ignore unknown fields.
