### PR TITLE
fix: allow concurrent UpdateConfig transactions to overwrite each other

### DIFF
--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -1392,36 +1392,6 @@ impl Operation {
         }
     }
 
-    pub(crate) fn modifies_same_metadata(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                Self::UpdateConfig {
-                    schema_metadata_updates,
-                    field_metadata_updates,
-                    ..
-                },
-                Self::UpdateConfig {
-                    schema_metadata_updates: other_schema_metadata,
-                    field_metadata_updates: other_field_metadata,
-                    ..
-                },
-            ) => {
-                if schema_metadata_updates.is_some() && other_schema_metadata.is_some() {
-                    return true;
-                }
-                if !field_metadata_updates.is_empty() && !other_field_metadata.is_empty() {
-                    for field in field_metadata_updates.keys() {
-                        if other_field_metadata.contains_key(field) {
-                            return true;
-                        }
-                    }
-                }
-                false
-            }
-            _ => false,
-        }
-    }
-
     /// Check whether another operation upserts a key that is referenced by another operation
     pub(crate) fn upsert_key_conflict(&self, other: &Self) -> bool {
         let self_upsert_keys = self.get_upsert_config_keys();

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1120,19 +1120,11 @@ impl<'a> TransactionRebase<'a> {
                     }
                 }
                 Operation::UpdateConfig { .. } => {
-                    if self
-                        .transaction
-                        .operation
-                        .upsert_key_conflict(&other_transaction.operation)
-                        || self
-                            .transaction
-                            .operation
-                            .modifies_same_metadata(&other_transaction.operation)
-                    {
-                        Err(self.incompatible_conflict_err(other_transaction, other_version))
-                    } else {
-                        Ok(())
-                    }
+                    // Concurrent UpdateConfig transactions are allowed to overwrite
+                    // one another; the later commit wins for any overlapping keys
+                    // or metadata. This avoids spurious conflicts on independent
+                    // metadata edits and matches a last-writer-wins semantics.
+                    Ok(())
                 }
                 Operation::Append { .. }
                 | Operation::Clone { .. }
@@ -2487,7 +2479,8 @@ mod tests {
                 [Compatible; 9],
             ),
             (
-                // Update config that conflicts with key being upserted by other UpdateConfig operation
+                // Update config overlapping with another UpdateConfig is allowed:
+                // last-writer-wins, so concurrent UpdateConfig commits no longer conflict.
                 create_update_config_for_test(
                     Some(HashMap::from_iter(vec![(
                         "lance.test".to_string(),
@@ -2497,20 +2490,10 @@ mod tests {
                     None,
                     None,
                 ),
-                [
-                    Compatible,    // append
-                    Compatible,    // create index
-                    Compatible,    // delete
-                    Compatible,    // merge
-                    Compatible,    // overwrite
-                    Compatible,    // rewrite
-                    Compatible,    // reserve
-                    Compatible,    // update
-                    NotCompatible, // update config
-                ],
+                [Compatible; 9],
             ),
             (
-                // Update config that conflicts with key being deleted by other UpdateConfig operation
+                // Same overlap with the other UpdateConfig's deleted key — still allowed.
                 create_update_config_for_test(
                     Some(HashMap::from_iter(vec![(
                         "remove-key".to_string(),
@@ -2520,17 +2503,7 @@ mod tests {
                     None,
                     None,
                 ),
-                [
-                    Compatible,    // append
-                    Compatible,    // create index
-                    Compatible,    // delete
-                    Compatible,    // merge
-                    Compatible,    // overwrite
-                    Compatible,    // rewrite
-                    Compatible,    // reserve
-                    Compatible,    // update
-                    NotCompatible, // update config
-                ],
+                [Compatible; 9],
             ),
             (
                 // Delete config keys currently being deleted by other UpdateConfig operation
@@ -2543,28 +2516,18 @@ mod tests {
                 [Compatible; 9],
             ),
             (
-                // Delete config keys currently being upserted by other UpdateConfig operation
+                // Delete config keys currently being upserted by other UpdateConfig — allowed.
                 create_update_config_for_test(
                     None,
                     Some(vec!["lance.test".to_string()]),
                     None,
                     None,
                 ),
-                [
-                    Compatible,    // append
-                    Compatible,    // create index
-                    Compatible,    // delete
-                    Compatible,    // merge
-                    Compatible,    // overwrite
-                    Compatible,    // rewrite
-                    Compatible,    // reserve
-                    Compatible,    // update
-                    NotCompatible, // update config
-                ],
+                [Compatible; 9],
             ),
             (
-                // Changing schema metadata conflicts with another update changing schema
-                // metadata or with an overwrite
+                // Changing schema metadata still conflicts with an overwrite, but no
+                // longer conflicts with another UpdateConfig changing schema metadata.
                 create_update_config_for_test(
                     None,
                     None,
@@ -2583,12 +2546,12 @@ mod tests {
                     Compatible,    // rewrite
                     Compatible,    // reserve
                     Compatible,    // update
-                    NotCompatible, // update config
+                    Compatible,    // update config
                 ],
             ),
             (
-                // Changing field metadata conflicts with another update changing same field
-                // metadata or overwrite
+                // Changing field metadata still conflicts with overwrite, but
+                // concurrent UpdateConfigs against the same field are allowed.
                 create_update_config_for_test(
                     None,
                     None,
@@ -2610,7 +2573,7 @@ mod tests {
                     Compatible,    // rewrite
                     Compatible,    // reserve
                     Compatible,    // update
-                    NotCompatible, // update config
+                    Compatible,    // update config
                 ],
             ),
             (


### PR DESCRIPTION
Previously, two concurrent `UpdateConfig` transactions would conflict if they upserted/deleted the same config key, or if they modified the same schema or field metadata. This forced callers to retry even though config updates have no data dependency on one another.

This PR makes `UpdateConfig` vs `UpdateConfig` always compatible, with last-writer-wins semantics. `UpdateConfig` vs `Overwrite` behavior is unchanged.

## Test plan
- [x] Updated the conflict matrix cases in `conflict_resolver.rs` so the previously `NotCompatible` `UpdateConfig`-vs-`UpdateConfig` cells are now `Compatible`.
- [x] `cargo test -p lance --lib io::commit::conflict_resolver` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)