### PR TITLE
feat: add write ahead log appender and tailer primitives

### DIFF
--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -45,13 +45,14 @@ A table has at most one MemWAL index. It stores:
 - **Configuration**: Shard specs defining how rows map to shards, and which indexes to maintain
 - **Merge progress**: Last generation merged to base table for each shard
 - **Index catchup progress**: Which merged generation each base table index has been rebuilt to cover
-- **Shard snapshots**: Snapshot of all shard states for read optimization
+- **Shard snapshots**: Point-in-time snapshot of shard states for read optimization
 
 The index is the source of truth for **configuration**, **merge progress** and **index catchup progress**
 Writers and mergers read the MemWAL index to get these configurations before writing.
 
 Each [shard's manifest](#shard-manifest) is authoritative for its own state.
-Readers use **shard snapshots** is a read-only optimization to see a point-in-time view of all shards without the need to open each shard manifest.
+Readers may use **shard snapshots** as a read-only optimization to see a point-in-time view of shards without opening each shard manifest.
+Readers that need the latest shard set must discover shard directories in storage and read each shard's latest manifest.
 
 See [MemWAL Index Details](#memwal-index-details) for the complete structure.
 
@@ -173,6 +174,7 @@ Each shard has a manifest file. This is the source of truth for the state of a s
 The manifest contains:
 
 - **Fencing state**: `writer_epoch` as the latest writer fencing token, see [Writer Fencing](#writer-fencing) for more details.
+- **Shard assignment**: `shard_spec_id`, `shard_field_values`, and `shard_field_string_values` record how this shard maps to its shard spec. `shard_field_values` stores int32-valued shard fields and `shard_field_string_values` stores UTF-8 shard fields.
 - **WAL pointers**: `replay_after_wal_entry_position` (last entry position flushed to MemTable, 0-based), `wal_entry_position_last_seen` (last entry position seen at manifest update, 0-based)
 - **Generation trackers**: `current_generation` (next generation to flush), `flushed_generations` list of generation number and directory path pairs (e.g., generation 1 at `a1b2c3d4_gen_1`)
 
@@ -258,8 +260,17 @@ The `index_details` field in `IndexMetadata` contains a `MemWalIndexDetails` pro
 
 ### Shard Identifier
 
-Each shard has a unique identifier across all shards following UUID v4 standard.
-When a new shard is created, it is assigned a new identifier.
+Each shard has a unique UUID identifier within the table.
+When a new shard is created, implementations may assign either a random UUID or
+a deterministic UUID derived from the shard assignment when deterministic
+writer fencing is required.
+
+### Shard Discovery
+
+The MemWAL index can store shard snapshots for read optimization, but those snapshots may lag the latest shard set.
+Implementations that need to discover the current shard set should list `_mem_wal/` shard directories and read each shard's latest [shard manifest](#shard-manifest).
+
+Each shard manifest records the shard UUID, shard spec ID, and computed shard field values needed to map the shard back to a shard spec assignment.
 
 ### Shard Spec
 
@@ -342,28 +353,26 @@ This file uses standard Lance format with the shard snapshot schema, enabling ef
 ### Shard Snapshot Arrow Schema
 
 Shard snapshots are stored as a Lance file with one row per shard.
-The schema has one column per `ShardManifest` field plus shard spec columns:
+The snapshot schema is optimized for shard discovery. Full mutable shard state
+remains in the authoritative shard manifest files.
 
-| Column                            | Type                                             | Description                                              |
-| --------------------------------- | ------------------------------------------------ | -------------------------------------------------------- |
-| `shard_id`                       | `fixed_size_binary(16)`                          | Shard UUID bytes                                        |
-| `version`                         | `uint64`                                         | Shard manifest version                                  |
-| `shard_spec_id`                  | `uint32`                                         | Shard spec ID (0 if manual)                             |
-| `writer_epoch`                    | `uint64`                                         | Writer fencing token                                     |
-| `replay_after_wal_entry_position` | `uint64`                                         | Last WAL entry position (0-based) flushed to MemTable    |
-| `wal_entry_position_last_seen`    | `uint64`                                         | Last WAL entry position (0-based) seen (hint)            |
-| `current_generation`              | `uint64`                                         | Next generation to flush                                 |
-| `flushed_generations`             | `list<struct<generation: uint64, path: string>>` | Flushed MemTable paths                                   |
-| `region_field_{field_id}`         | varies                                           | Shard field value (one column per field in shard spec) |
+| Column                           | Type     | Description                                              |
+| -------------------------------- | -------- | -------------------------------------------------------- |
+| `shard_id`                       | `utf8`   | Shard UUID string                                       |
+| `shard_spec_id`                  | `uint32` | Shard spec ID (0 if manual)                             |
+| `shard_field_{field_id}`         | `int32`  | Int32 shard field value (one column per int shard field) |
+| `shard_string_field_{field_id}`  | `utf8`   | Utf8 shard field value (one column per string field)     |
 
 For example, with a shard spec containing a field `user_bucket` of type `int32`:
 
 | Column                     | Type    | Description                  |
 | -------------------------- | ------- | ---------------------------- |
 | ...                        | ...     | (base columns above)         |
-| `region_field_user_bucket` | `int32` | Bucket value for this shard |
+| `shard_field_user_bucket`  | `int32` | Bucket value for this shard |
 
-This schema directly corresponds to the fields in the `ShardManifest` protobuf message plus the computed shard field values.
+This schema records the fields needed to map each shard back to its shard spec
+assignment. Readers that need fencing epochs, WAL positions, or flushed
+generation state must read the latest shard manifests directly.
 
 ## Storage Layout
 

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -174,7 +174,7 @@ Each shard has a manifest file. This is the source of truth for the state of a s
 The manifest contains:
 
 - **Fencing state**: `writer_epoch` as the latest writer fencing token, see [Writer Fencing](#writer-fencing) for more details.
-- **Shard assignment**: `shard_spec_id`, `shard_field_values`, and `shard_field_string_values` record how this shard maps to its shard spec. `shard_field_values` stores int32-valued shard fields and `shard_field_string_values` stores UTF-8 shard fields.
+- **Shard assignment**: `shard_spec_id` and `shard_field_values` record how this shard maps to its shard spec. `shard_field_values` is a map from shard field id to the raw Arrow scalar bytes of the computed value; the matching `ShardField.result_type` in the `ShardSpec` determines how to interpret each entry (e.g., 4 little-endian bytes for int32, raw UTF-8 bytes for utf8).
 - **WAL pointers**: `replay_after_wal_entry_position` (last entry position flushed to MemTable, 0-based), `wal_entry_position_last_seen` (last entry position seen at manifest update, 0-based)
 - **Generation trackers**: `current_generation` (next generation to flush), `flushed_generations` list of generation number and directory path pairs (e.g., generation 1 at `a1b2c3d4_gen_1`)
 
@@ -356,12 +356,11 @@ Shard snapshots are stored as a Lance file with one row per shard.
 The snapshot schema is optimized for shard discovery. Full mutable shard state
 remains in the authoritative shard manifest files.
 
-| Column                           | Type     | Description                                              |
-| -------------------------------- | -------- | -------------------------------------------------------- |
-| `shard_id`                       | `utf8`   | Shard UUID string                                       |
-| `shard_spec_id`                  | `uint32` | Shard spec ID (0 if manual)                             |
-| `shard_field_{field_id}`         | `int32`  | Int32 shard field value (one column per int shard field) |
-| `shard_string_field_{field_id}`  | `utf8`   | Utf8 shard field value (one column per string field)     |
+| Column                   | Type          | Description                                                                                                |
+| ------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------- |
+| `shard_id`               | `utf8`        | Shard UUID string                                                                                          |
+| `shard_spec_id`          | `uint32`      | Shard spec ID (0 if manual)                                                                                |
+| `shard_field_{field_id}` | varies        | One column per shard field defined in the shard spec, typed to match the field's `ShardField.result_type`. |
 
 For example, with a shard spec containing a field `user_bucket` of type `int32`:
 

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -622,8 +622,7 @@ message IndexCatchupProgress {
 // authoritative in the shard manifest files.
 //   shard_id: utf8
 //   shard_spec_id: uint32
-//   shard_field_{field_id}: int32
-//   shard_string_field_{field_id}: utf8
+//   shard_field_{field_id}: typed per the matching ShardField.result_type
 message MemWalIndexDetails {
   // Snapshot timestamp (Unix timestamp in milliseconds).
   int64 snapshot_ts_millis = 1;

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -537,6 +537,12 @@ message ShardManifest {
   // A value of 0 indicates a manually-created shard not governed by any spec.
   uint32 shard_spec_id = 10;
 
+  // Computed shard field values as raw Arrow scalar bytes, keyed by shard
+  // field id. The byte encoding follows Arrow's little-endian convention:
+  // int32 is 4 LE bytes, utf8 is raw UTF-8 bytes, etc. The receiver looks
+  // up the result_type from the ShardSpec to interpret each value.
+  repeated ShardFieldEntry shard_field_entries = 14;
+
   // Writer fencing token - monotonically increasing.
   // A writer must increment this when claiming the shard.
   uint64 writer_epoch = 2;
@@ -557,6 +563,16 @@ message ShardManifest {
 
   // List of flushed MemTable generations and their directory paths.
   repeated FlushedGeneration flushed_generations = 8;
+}
+
+// A shard field value stored as raw Arrow scalar bytes.
+message ShardFieldEntry {
+  // Shard field id (matches ShardField.field_id in the ShardSpec).
+  string field_id = 1;
+
+  // Raw Arrow scalar value bytes in little-endian encoding.
+  // The data type is determined by the result_type of the matching ShardField.
+  bytes value = 2;
 }
 
 // A flushed MemTable generation and its storage location.
@@ -596,20 +612,18 @@ message IndexCatchupProgress {
 // - Shard state snapshots
 //
 // Writers read this index to get configuration before writing.
-// Readers read this index to discover shards and their state.
+// Readers may use shard snapshots in this index as a point-in-time
+// optimization. Readers that need the latest shard set should list shard
+// directories in storage and read each shard's latest manifest.
 // A background process updates the index periodically to keep shard snapshots current.
 //
 // Shard snapshots are stored as a Lance file with one row per shard.
-// The schema has one column per ShardManifest field, with shard fields as columns:
-//   shard_id: fixed_size_binary(16)  -- UUID bytes
-//   version: uint64
+// The schema records shard discovery fields. Full mutable shard state remains
+// authoritative in the shard manifest files.
+//   shard_id: utf8
 //   shard_spec_id: uint32
-//   writer_epoch: uint64
-//   replay_after_wal_entry_position: uint64
-//   wal_entry_position_last_seen: uint64
-//   current_generation: uint64
-//   merged_generation: uint64
-//   flushed_generations: list<struct<generation: uint64, path: string>>
+//   shard_field_{field_id}: int32
+//   shard_string_field_{field_id}: utf8
 message MemWalIndexDetails {
   // Snapshot timestamp (Unix timestamp in milliseconds).
   int64 snapshot_ts_millis = 1;
@@ -690,4 +704,3 @@ message ShardField {
   // Transform parameters (e.g., num_buckets for bucket transform).
   map<string, string> parameters = 6;
 }
-

--- a/rust/lance-index/src/mem_wal.rs
+++ b/rust/lance-index/src/mem_wal.rs
@@ -153,6 +153,11 @@ pub struct ShardManifest {
     pub shard_id: Uuid,
     pub version: u64,
     pub shard_spec_id: u32,
+    /// Computed shard field values as raw Arrow scalar bytes, keyed by field id.
+    /// The byte encoding follows Arrow's little-endian convention: int32 is 4 LE
+    /// bytes, utf8 is raw UTF-8 bytes, etc. The result_type in the corresponding
+    /// ShardField from the ShardSpec determines how to interpret each value.
+    pub shard_field_values: HashMap<String, Vec<u8>>,
     pub writer_epoch: u64,
     /// The most recent WAL entry position (0-based) flushed to a MemTable.
     /// Recovery replays from `replay_after_wal_entry_position + 1`.
@@ -165,7 +170,8 @@ pub struct ShardManifest {
 
 impl DeepSizeOf for ShardManifest {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        self.flushed_generations.deep_size_of_children(context)
+        self.shard_field_values.deep_size_of_children(context)
+            + self.flushed_generations.deep_size_of_children(context)
     }
 }
 
@@ -175,6 +181,14 @@ impl From<&ShardManifest> for pb::ShardManifest {
             shard_id: Some((&rm.shard_id).into()),
             version: rm.version,
             shard_spec_id: rm.shard_spec_id,
+            shard_field_entries: rm
+                .shard_field_values
+                .iter()
+                .map(|(k, v)| pb::ShardFieldEntry {
+                    field_id: k.clone(),
+                    value: v.clone(),
+                })
+                .collect(),
             writer_epoch: rm.writer_epoch,
             replay_after_wal_entry_position: rm.replay_after_wal_entry_position,
             wal_entry_position_last_seen: rm.wal_entry_position_last_seen,
@@ -193,10 +207,16 @@ impl TryFrom<pb::ShardManifest> for ShardManifest {
             .as_ref()
             .map(Uuid::try_from)
             .ok_or_else(|| Error::invalid_input("Missing shard_id in ShardManifest"))??;
+        let shard_field_values = rm
+            .shard_field_entries
+            .into_iter()
+            .map(|e| (e.field_id, e.value))
+            .collect();
         Ok(Self {
             shard_id,
             version: rm.version,
             shard_spec_id: rm.shard_spec_id,
+            shard_field_values,
             writer_epoch: rm.writer_epoch,
             replay_after_wal_entry_position: rm.replay_after_wal_entry_position,
             wal_entry_position_last_seen: rm.wal_entry_position_last_seen,

--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -41,9 +41,10 @@ mod util;
 mod wal;
 pub mod write;
 
-pub use api::{DatasetMemWalExt, MemWalConfig};
+pub use api::{DatasetMemWalExt, MemWalConfig, MemWalShardConfig};
 pub use manifest::ShardManifestStore;
 pub use memtable::scanner::MemTableScanner;
 pub use scanner::{LsmDataSource, LsmGeneration, LsmScanner, ShardSnapshot};
+pub use wal::{WalAppendResult, WalAppender, WalReadEntry, WalTailer};
 pub use write::ShardWriter;
 pub use write::ShardWriterConfig;

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -22,7 +22,7 @@ use crate::Dataset;
 use crate::dataset::CommitBuilder;
 use crate::dataset::transaction::{Operation, Transaction};
 use crate::index::DatasetIndexInternalExt;
-use crate::index::mem_wal::new_mem_wal_index_meta;
+use crate::index::mem_wal::{load_mem_wal_index_details, new_mem_wal_index_meta};
 
 use super::ShardWriterConfig;
 use super::write::MemIndexConfig;
@@ -42,6 +42,13 @@ pub struct MemWalConfig {
     pub maintained_indexes: Vec<String>,
 }
 
+/// Shard initialization options for MemWAL.
+#[derive(Debug, Clone, Default)]
+pub struct MemWalShardConfig {
+    /// Number of shards managed by the MemWAL index.
+    pub num_shards: u32,
+}
+
 /// Extension trait for Dataset to support MemWAL operations.
 #[async_trait]
 pub trait DatasetMemWalExt {
@@ -55,11 +62,40 @@ pub trait DatasetMemWalExt {
     /// ```ignore
     /// let mut dataset = Dataset::open("s3://bucket/dataset").await?;
     /// dataset.initialize_mem_wal(MemWalConfig {
-    ///     shard_specs: vec![],
+    ///     shard_spec: None,
     ///     maintained_indexes: vec!["id_btree".to_string()],
     /// }).await?;
     /// ```
     async fn initialize_mem_wal(&mut self, config: MemWalConfig) -> Result<()>;
+
+    /// Initialize MemWAL with explicit shard state.
+    ///
+    /// This preserves [`MemWalConfig`] struct-literal compatibility while
+    /// allowing callers that need precomputed shard mappings to initialize the
+    /// MemWAL index with inline shard snapshots.
+    async fn initialize_mem_wal_with_shards(
+        &mut self,
+        config: MemWalConfig,
+        shard_config: MemWalShardConfig,
+    ) -> Result<()> {
+        if shard_config.num_shards == 0 {
+            self.initialize_mem_wal(config).await
+        } else {
+            Err(Error::invalid_input(
+                "initialize_mem_wal_with_shards is not implemented for this DatasetMemWalExt implementer",
+            ))
+        }
+    }
+
+    /// Return the MemWAL index details for this dataset, if MemWAL is initialized.
+    async fn mem_wal_index_details(&self) -> Result<Option<MemWalIndexDetails>> {
+        Ok(None)
+    }
+
+    /// List current MemWAL shard IDs from object storage directory listing.
+    async fn list_mem_wal_latest_shard_ids(&self) -> Result<Vec<Uuid>> {
+        Ok(Vec::new())
+    }
 
     /// Get a ShardWriter for the specified shard.
     ///
@@ -90,61 +126,48 @@ pub trait DatasetMemWalExt {
 #[async_trait]
 impl DatasetMemWalExt for Dataset {
     async fn initialize_mem_wal(&mut self, config: MemWalConfig) -> Result<()> {
-        // Validate that the dataset has a primary key (required for MemWAL)
-        let pk_fields = self.schema().unenforced_primary_key();
-        if pk_fields.is_empty() {
-            return Err(Error::invalid_input(
-                "MemWAL requires a primary key on the dataset. \
-             Define a primary key using the 'lance-schema:unenforced-primary-key' Arrow field metadata.",
-            ));
-        }
+        initialize_mem_wal_impl(self, config, MemWalShardConfig::default()).await
+    }
 
-        // Validate that all maintained_indexes exist on the dataset
-        let indices = self.load_indices().await?;
-        for index_name in &config.maintained_indexes {
-            if !indices.iter().any(|idx| &idx.name == index_name) {
-                return Err(Error::invalid_input(format!(
-                    "Index '{}' not found on dataset. maintained_indexes must reference existing indexes.",
-                    index_name
-                )));
-            }
-        }
+    async fn initialize_mem_wal_with_shards(
+        &mut self,
+        config: MemWalConfig,
+        shard_config: MemWalShardConfig,
+    ) -> Result<()> {
+        initialize_mem_wal_impl(self, config, shard_config).await
+    }
 
-        // Check if MemWAL index already exists
-        if indices.iter().any(|idx| idx.name == MEM_WAL_INDEX_NAME) {
-            return Err(Error::invalid_input(
-                "MemWAL is already initialized on this dataset. Use update methods instead.",
-            ));
-        }
-
-        // Create MemWalIndexDetails
-        let details = MemWalIndexDetails {
-            shard_specs: config.shard_spec.into_iter().collect(),
-            maintained_indexes: config.maintained_indexes,
-            ..Default::default()
+    async fn mem_wal_index_details(&self) -> Result<Option<MemWalIndexDetails>> {
+        let Some(index_meta) = self.load_index_by_name(MEM_WAL_INDEX_NAME).await? else {
+            return Ok(None);
         };
 
-        // Create the index metadata
-        let index_meta = new_mem_wal_index_meta(self.manifest.version, details)?;
+        load_mem_wal_index_details(index_meta).map(Some)
+    }
 
-        // Commit as CreateIndex transaction
-        let transaction = Transaction::new(
-            self.manifest.version,
-            Operation::CreateIndex {
-                new_indices: vec![index_meta],
-                removed_indices: vec![],
-            },
-            None,
-        );
-
-        let new_dataset = CommitBuilder::new(Arc::new(self.clone()))
-            .execute(transaction)
-            .await?;
-
-        // Update self to point to new version
-        *self = new_dataset;
-
-        Ok(())
+    async fn list_mem_wal_latest_shard_ids(&self) -> Result<Vec<Uuid>> {
+        let prefix = super::util::mem_wal_path(&self.branch_location().path);
+        let object_store = self.object_store(None).await?;
+        let list_result = object_store
+            .inner
+            .list_with_delimiter(Some(&prefix))
+            .await
+            .map_err(|e| {
+                Error::io(format!(
+                    "failed to list MemWAL shard directories at {}: {}",
+                    prefix, e
+                ))
+            })?;
+        let mut ids = Vec::new();
+        for shard_prefix in list_result.common_prefixes {
+            if let Some(name) = shard_prefix.filename()
+                && let Ok(shard_id) = Uuid::parse_str(name)
+            {
+                ids.push(shard_id);
+            }
+        }
+        ids.sort();
+        Ok(ids)
     }
 
     async fn mem_wal_writer(
@@ -232,6 +255,62 @@ impl DatasetMemWalExt for Dataset {
         )
         .await
     }
+}
+
+async fn initialize_mem_wal_impl(
+    dataset: &mut Dataset,
+    config: MemWalConfig,
+    shard_config: MemWalShardConfig,
+) -> Result<()> {
+    let pk_fields = dataset.schema().unenforced_primary_key();
+    if pk_fields.is_empty() {
+        return Err(Error::invalid_input(
+            "MemWAL requires a primary key on the dataset. \
+             Define a primary key using the 'lance-schema:unenforced-primary-key' Arrow field metadata.",
+        ));
+    }
+
+    let indices = dataset.load_indices().await?;
+    for index_name in &config.maintained_indexes {
+        if !indices.iter().any(|idx| &idx.name == index_name) {
+            return Err(Error::invalid_input(format!(
+                "Index '{}' not found on dataset. maintained_indexes must reference existing indexes.",
+                index_name
+            )));
+        }
+    }
+
+    if indices.iter().any(|idx| idx.name == MEM_WAL_INDEX_NAME) {
+        return Err(Error::invalid_input(
+            "MemWAL is already initialized on this dataset. Use update methods instead.",
+        ));
+    }
+
+    let details = MemWalIndexDetails {
+        num_shards: shard_config.num_shards,
+        inline_snapshots: None,
+        shard_specs: config.shard_spec.into_iter().collect(),
+        maintained_indexes: config.maintained_indexes,
+        ..Default::default()
+    };
+
+    let index_meta = new_mem_wal_index_meta(dataset.manifest.version, details)?;
+    let transaction = Transaction::new(
+        dataset.manifest.version,
+        Operation::CreateIndex {
+            new_indices: vec![index_meta],
+            removed_indices: vec![],
+        },
+        None,
+    );
+
+    let new_dataset = CommitBuilder::new(Arc::new(dataset.clone()))
+        .execute(transaction)
+        .await?;
+
+    *dataset = new_dataset;
+
+    Ok(())
 }
 
 /// Load vector index configuration from the base table's IVF-PQ index.

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -397,9 +397,12 @@ impl ShardManifestStore {
     /// 2. Incrementing the writer epoch
     /// 3. Atomically writing the new manifest
     ///
-    /// If another writer has already claimed the shard (version conflict),
-    /// this fails immediately rather than retrying. This prevents "epoch wars"
-    /// where multiple writers keep fencing each other.
+    /// On version conflict, re-reads the manifest and only fails if another
+    /// writer has actually claimed an equal-or-higher epoch. Benign conflicts
+    /// where the version was bumped without claiming a new epoch (for
+    /// example, a tailer cursor update or a concurrent `initialize_shard`)
+    /// trigger a retry rather than a misleading "another writer" error.
+    /// This preserves the no-epoch-war guarantee for real claimants.
     ///
     /// # Returns
     ///
@@ -408,49 +411,73 @@ impl ShardManifestStore {
     ///
     /// # Errors
     ///
-    /// Returns an error if another writer already claimed the shard.
+    /// Returns an error if another writer already claimed an equal-or-higher
+    /// epoch, or if the manifest stays contended past the retry budget.
     #[instrument(name = "manifest_claim_epoch", level = "info", skip_all, fields(shard_id = %self.shard_id, shard_spec_id))]
     pub async fn claim_epoch(&self, shard_spec_id: u32) -> Result<(u64, ShardManifest)> {
-        let current = self.read_latest().await?;
+        const MAX_CLAIM_RETRIES: usize = 16;
+        let mut last_write_err: Option<Error> = None;
+        for _ in 0..MAX_CLAIM_RETRIES {
+            let current = self.read_latest().await?;
 
-        let (next_version, next_epoch, base_manifest) = match current {
-            Some(m) => (m.version + 1, m.writer_epoch + 1, Some(m)),
-            None => (1, 1, None),
-        };
+            let (next_version, next_epoch, base_manifest) = match current {
+                Some(m) => (m.version + 1, m.writer_epoch + 1, Some(m)),
+                None => (1, 1, None),
+            };
 
-        let new_manifest = if let Some(base) = base_manifest {
-            ShardManifest {
-                version: next_version,
-                writer_epoch: next_epoch,
-                ..base
+            let new_manifest = if let Some(base) = base_manifest {
+                ShardManifest {
+                    version: next_version,
+                    writer_epoch: next_epoch,
+                    ..base
+                }
+            } else {
+                ShardManifest {
+                    shard_id: self.shard_id,
+                    version: next_version,
+                    shard_spec_id,
+                    shard_field_values: HashMap::new(),
+                    writer_epoch: next_epoch,
+                    replay_after_wal_entry_position: 0,
+                    wal_entry_position_last_seen: 0,
+                    current_generation: 1,
+                    flushed_generations: vec![],
+                }
+            };
+
+            match self.write(&new_manifest).await {
+                Ok(_) => {
+                    info!(
+                        "Claimed shard {} with epoch {} (version {})",
+                        self.shard_id, next_epoch, next_version
+                    );
+                    return Ok((next_epoch, new_manifest));
+                }
+                Err(write_err) => {
+                    let latest_epoch = self
+                        .read_latest()
+                        .await?
+                        .map(|m| m.writer_epoch)
+                        .unwrap_or(0);
+                    if latest_epoch >= next_epoch {
+                        return Err(Error::io(format!(
+                            "Failed to claim shard {} (version {}): another writer claimed epoch {} (>= our target {}): {}",
+                            self.shard_id, next_version, latest_epoch, next_epoch, write_err
+                        )));
+                    }
+                    last_write_err = Some(write_err);
+                }
             }
-        } else {
-            ShardManifest {
-                shard_id: self.shard_id,
-                version: next_version,
-                shard_spec_id,
-                shard_field_values: HashMap::new(),
-                writer_epoch: next_epoch,
-                replay_after_wal_entry_position: 0,
-                wal_entry_position_last_seen: 0,
-                current_generation: 1,
-                flushed_generations: vec![],
-            }
-        };
+        }
 
-        self.write(&new_manifest).await.map_err(|e| {
-            Error::io(format!(
-                "Failed to claim shard {} (version {}): another writer may have claimed it: {}",
-                self.shard_id, next_version, e
-            ))
-        })?;
-
-        info!(
-            "Claimed shard {} with epoch {} (version {})",
-            self.shard_id, next_epoch, next_version
-        );
-
-        Ok((next_epoch, new_manifest))
+        Err(Error::io(format!(
+            "Failed to claim shard {} after {} retries due to manifest contention: {}",
+            self.shard_id,
+            MAX_CLAIM_RETRIES,
+            last_write_err
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        )))
     }
 
     /// Check if the given epoch has been fenced by a newer writer.
@@ -693,6 +720,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn test_claim_epoch_retries_through_benign_cursor_update() {
+        // Reproduces a tailer cursor update racing with claim_epoch on the
+        // same versioned manifest filename. The cursor update bumps the
+        // version without claiming an epoch; claim_epoch must retry rather
+        // than surface a misleading "another writer claimed it" error.
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+        let manifest_store = ShardManifestStore::new(store, &base_path, shard_id, 2);
+
+        // Initial claim establishes epoch 1 at version 1.
+        let (first_epoch, first) = manifest_store.claim_epoch(0).await.unwrap();
+        assert_eq!(first_epoch, 1);
+        assert_eq!(first.version, 1);
+
+        // Simulate a tailer cursor update bumping the version but leaving
+        // the writer epoch unchanged.
+        let mut cursor_update = first.clone();
+        cursor_update.version += 1;
+        cursor_update.wal_entry_position_last_seen = 42;
+        manifest_store.write(&cursor_update).await.unwrap();
+
+        // Now an appender claims again. Without retry it would see the v2
+        // cursor update as a contention failure; with retry it observes the
+        // unchanged epoch and proceeds to v3 / epoch 2.
+        let (second_epoch, second) = manifest_store.claim_epoch(0).await.unwrap();
+        assert_eq!(second_epoch, 2);
+        assert_eq!(second.version, 3);
+        assert_eq!(second.wal_entry_position_last_seen, 42);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -397,12 +397,15 @@ impl ShardManifestStore {
     /// 2. Incrementing the writer epoch
     /// 3. Atomically writing the new manifest
     ///
-    /// On version conflict, re-reads the manifest and only fails if another
-    /// writer has claimed a strictly higher epoch than the one we were
-    /// targeting. Equal-or-lower conflicts (for example, a tailer cursor
-    /// update, a concurrent `initialize_shard`, or another claimant racing
-    /// us at the same target epoch) trigger a retry; the next iteration
-    /// observes the new state and bumps to the next epoch.
+    /// On version conflict, re-reads the manifest and only retries when
+    /// the latest writer_epoch is strictly less than the epoch we were
+    /// targeting — meaning the version was bumped by something other than
+    /// a real claim (a tailer cursor update or a concurrent
+    /// `initialize_shard` writing epoch 0). If the latest writer_epoch
+    /// is equal to or greater than our target, the target epoch is
+    /// already claimed and this call fails. This preserves the
+    /// no-epoch-war guarantee for real claimants while tolerating benign
+    /// version bumps.
     ///
     /// # Returns
     ///
@@ -411,9 +414,9 @@ impl ShardManifestStore {
     ///
     /// # Errors
     ///
-    /// Returns an error if another writer claimed a strictly higher epoch
-    /// than our target, or if the manifest stays contended past the retry
-    /// budget.
+    /// Returns an error if another writer claimed an equal-or-higher
+    /// epoch than our target, or if the manifest stays contended past
+    /// the retry budget.
     #[instrument(name = "manifest_claim_epoch", level = "info", skip_all, fields(shard_id = %self.shard_id, shard_spec_id))]
     pub async fn claim_epoch(&self, shard_spec_id: u32) -> Result<(u64, ShardManifest)> {
         const MAX_CLAIM_RETRIES: usize = 16;
@@ -460,9 +463,9 @@ impl ShardManifestStore {
                         .await?
                         .map(|m| m.writer_epoch)
                         .unwrap_or(0);
-                    if latest_epoch > next_epoch {
+                    if latest_epoch >= next_epoch {
                         return Err(Error::io(format!(
-                            "Failed to claim shard {} (version {}): another writer claimed epoch {} (> our target {}): {}",
+                            "Failed to claim shard {} (version {}): another writer claimed epoch {} (>= our target {}): {}",
                             self.shard_id, next_version, latest_epoch, next_epoch, write_err
                         )));
                     }
@@ -746,30 +749,6 @@ mod tests {
         assert_eq!(second_epoch, 2);
         assert_eq!(second.version, 3);
         assert_eq!(second.wal_entry_position_last_seen, 42);
-    }
-
-    #[tokio::test]
-    async fn test_concurrent_claim_epoch_both_succeed_with_distinct_epochs() {
-        // Two concurrent claim_epoch calls must both eventually succeed
-        // with distinct epochs. At least one is guaranteed to take the
-        // AlreadyExists retry path, exercising the conflict branch.
-        let (store, base_path, _temp_dir) = create_local_store().await;
-        let shard_id = Uuid::new_v4();
-        let manifest_store = Arc::new(ShardManifestStore::new(store, &base_path, shard_id, 4));
-
-        let s1 = manifest_store.clone();
-        let s2 = manifest_store.clone();
-        let (r1, r2) = tokio::join!(
-            tokio::spawn(async move { s1.claim_epoch(0).await }),
-            tokio::spawn(async move { s2.claim_epoch(0).await }),
-        );
-
-        let (e1, _) = r1.unwrap().unwrap();
-        let (e2, _) = r2.unwrap().unwrap();
-        assert_ne!(e1, e2, "concurrent claims must end up with distinct epochs");
-        let mut epochs = [e1, e2];
-        epochs.sort();
-        assert_eq!(epochs, [1, 2]);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -27,6 +27,7 @@
 //! 3. Continue until a version is not found
 //! 4. Return the last found version
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -123,6 +124,42 @@ impl ShardManifestStore {
             .map_err(|e| Error::io(format!("Failed to decode manifest protobuf: {}", e)))?;
 
         ShardManifest::try_from(pb_manifest)
+    }
+
+    /// Write an initial manifest for a newly-created shard.
+    ///
+    /// `shard_field_values` maps field_id to raw Arrow scalar bytes.
+    /// Initial manifests use writer epoch 0. A writer that claims the shard
+    /// will write a new manifest with epoch 1 before appending WAL entries.
+    pub async fn initialize_shard(
+        &self,
+        shard_spec_id: u32,
+        shard_field_values: HashMap<String, Vec<u8>>,
+    ) -> Result<ShardManifest> {
+        let manifest = ShardManifest {
+            shard_id: self.shard_id,
+            version: 1,
+            shard_spec_id,
+            shard_field_values,
+            writer_epoch: 0,
+            replay_after_wal_entry_position: 0,
+            wal_entry_position_last_seen: 0,
+            current_generation: 1,
+            flushed_generations: vec![],
+        };
+
+        match self.write(&manifest).await {
+            Ok(_) => Ok(manifest),
+            Err(error) => match self.read_latest().await? {
+                Some(existing)
+                    if existing.shard_spec_id == manifest.shard_spec_id
+                        && existing.shard_field_values == manifest.shard_field_values =>
+                {
+                    Ok(existing)
+                }
+                _ => Err(error),
+            },
+        }
     }
 
     /// Write a new manifest version atomically.
@@ -392,6 +429,7 @@ impl ShardManifestStore {
                 shard_id: self.shard_id,
                 version: next_version,
                 shard_spec_id,
+                shard_field_values: HashMap::new(),
                 writer_epoch: next_epoch,
                 replay_after_wal_entry_position: 0,
                 wal_entry_position_last_seen: 0,
@@ -527,6 +565,7 @@ mod tests {
             shard_id,
             version,
             shard_spec_id: 0,
+            shard_field_values: HashMap::new(),
             writer_epoch: epoch,
             replay_after_wal_entry_position: 0,
             wal_entry_position_last_seen: 0,
@@ -611,5 +650,68 @@ mod tests {
         let manifest2 = create_test_manifest(shard_id, 1, 2);
         let result = manifest_store.write(&manifest2).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_initialize_shard_writes_v1_with_epoch_zero() {
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+        let manifest_store = ShardManifestStore::new(store, &base_path, shard_id, 2);
+
+        let mut field_values = HashMap::new();
+        field_values.insert("user_bucket".to_string(), 7i32.to_le_bytes().to_vec());
+
+        let manifest = manifest_store
+            .initialize_shard(3, field_values.clone())
+            .await
+            .unwrap();
+        assert_eq!(manifest.shard_id, shard_id);
+        assert_eq!(manifest.version, 1);
+        assert_eq!(manifest.writer_epoch, 0);
+        assert_eq!(manifest.shard_spec_id, 3);
+        assert_eq!(manifest.shard_field_values, field_values);
+
+        let loaded = manifest_store.read_latest().await.unwrap().unwrap();
+        assert_eq!(loaded, manifest);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_shard_idempotent_on_match() {
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+        let manifest_store = ShardManifestStore::new(store, &base_path, shard_id, 2);
+
+        let mut field_values = HashMap::new();
+        field_values.insert("k".to_string(), b"v".to_vec());
+
+        let first = manifest_store
+            .initialize_shard(1, field_values.clone())
+            .await
+            .unwrap();
+        let second = manifest_store
+            .initialize_shard(1, field_values)
+            .await
+            .unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_shard_rejects_conflict_with_mismatch() {
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+        let manifest_store = ShardManifestStore::new(store, &base_path, shard_id, 2);
+
+        manifest_store
+            .initialize_shard(1, HashMap::new())
+            .await
+            .unwrap();
+
+        let mut other = HashMap::new();
+        other.insert("k".to_string(), b"v".to_vec());
+        let result = manifest_store.initialize_shard(1, other).await;
+        assert!(
+            result.is_err(),
+            "second initialize_shard with different fields must fail"
+        );
     }
 }

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -398,11 +398,11 @@ impl ShardManifestStore {
     /// 3. Atomically writing the new manifest
     ///
     /// On version conflict, re-reads the manifest and only fails if another
-    /// writer has actually claimed an equal-or-higher epoch. Benign conflicts
-    /// where the version was bumped without claiming a new epoch (for
-    /// example, a tailer cursor update or a concurrent `initialize_shard`)
-    /// trigger a retry rather than a misleading "another writer" error.
-    /// This preserves the no-epoch-war guarantee for real claimants.
+    /// writer has claimed a strictly higher epoch than the one we were
+    /// targeting. Equal-or-lower conflicts (for example, a tailer cursor
+    /// update, a concurrent `initialize_shard`, or another claimant racing
+    /// us at the same target epoch) trigger a retry; the next iteration
+    /// observes the new state and bumps to the next epoch.
     ///
     /// # Returns
     ///
@@ -411,8 +411,9 @@ impl ShardManifestStore {
     ///
     /// # Errors
     ///
-    /// Returns an error if another writer already claimed an equal-or-higher
-    /// epoch, or if the manifest stays contended past the retry budget.
+    /// Returns an error if another writer claimed a strictly higher epoch
+    /// than our target, or if the manifest stays contended past the retry
+    /// budget.
     #[instrument(name = "manifest_claim_epoch", level = "info", skip_all, fields(shard_id = %self.shard_id, shard_spec_id))]
     pub async fn claim_epoch(&self, shard_spec_id: u32) -> Result<(u64, ShardManifest)> {
         const MAX_CLAIM_RETRIES: usize = 16;
@@ -459,9 +460,9 @@ impl ShardManifestStore {
                         .await?
                         .map(|m| m.writer_epoch)
                         .unwrap_or(0);
-                    if latest_epoch >= next_epoch {
+                    if latest_epoch > next_epoch {
                         return Err(Error::io(format!(
-                            "Failed to claim shard {} (version {}): another writer claimed epoch {} (>= our target {}): {}",
+                            "Failed to claim shard {} (version {}): another writer claimed epoch {} (> our target {}): {}",
                             self.shard_id, next_version, latest_epoch, next_epoch, write_err
                         )));
                     }
@@ -723,34 +724,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_claim_epoch_retries_through_benign_cursor_update() {
-        // Reproduces a tailer cursor update racing with claim_epoch on the
-        // same versioned manifest filename. The cursor update bumps the
-        // version without claiming an epoch; claim_epoch must retry rather
-        // than surface a misleading "another writer claimed it" error.
+    async fn test_claim_epoch_after_cursor_update() {
+        // After a tailer cursor update bumps the manifest version without
+        // claiming an epoch, the next claim_epoch should observe the new
+        // state and produce the next epoch — this guards against treating
+        // a cursor update as a real claimant.
         let (store, base_path, _temp_dir) = create_local_store().await;
         let shard_id = Uuid::new_v4();
         let manifest_store = ShardManifestStore::new(store, &base_path, shard_id, 2);
 
-        // Initial claim establishes epoch 1 at version 1.
         let (first_epoch, first) = manifest_store.claim_epoch(0).await.unwrap();
         assert_eq!(first_epoch, 1);
         assert_eq!(first.version, 1);
 
-        // Simulate a tailer cursor update bumping the version but leaving
-        // the writer epoch unchanged.
         let mut cursor_update = first.clone();
         cursor_update.version += 1;
         cursor_update.wal_entry_position_last_seen = 42;
         manifest_store.write(&cursor_update).await.unwrap();
 
-        // Now an appender claims again. Without retry it would see the v2
-        // cursor update as a contention failure; with retry it observes the
-        // unchanged epoch and proceeds to v3 / epoch 2.
         let (second_epoch, second) = manifest_store.claim_epoch(0).await.unwrap();
         assert_eq!(second_epoch, 2);
         assert_eq!(second.version, 3);
         assert_eq!(second.wal_entry_position_last_seen, 42);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_claim_epoch_both_succeed_with_distinct_epochs() {
+        // Two concurrent claim_epoch calls must both eventually succeed
+        // with distinct epochs. At least one is guaranteed to take the
+        // AlreadyExists retry path, exercising the conflict branch.
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+        let manifest_store = Arc::new(ShardManifestStore::new(store, &base_path, shard_id, 4));
+
+        let s1 = manifest_store.clone();
+        let s2 = manifest_store.clone();
+        let (r1, r2) = tokio::join!(
+            tokio::spawn(async move { s1.claim_epoch(0).await }),
+            tokio::spawn(async move { s2.claim_epoch(0).await }),
+        );
+
+        let (e1, _) = r1.unwrap().unwrap();
+        let (e2, _) = r2.unwrap().unwrap();
+        assert_ne!(e1, e2, "concurrent claims must end up with distinct epochs");
+        let mut epochs = [e1, e2];
+        epochs.sort();
+        assert_eq!(epochs, [1, 2]);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/util.rs
+++ b/rust/lance/src/dataset/mem_wal/util.rs
@@ -126,13 +126,18 @@ pub fn parse_bit_reversed_filename(filename: &str) -> Option<u64> {
     Some(bit_reverse_u64(reversed))
 }
 
+/// Path to the MemWAL root directory.
+///
+/// Returns: `{base_path}/_mem_wal/`
+pub fn mem_wal_path(base_path: &Path) -> Path {
+    base_path.child("_mem_wal")
+}
+
 /// Base path for a shard within the MemWAL directory.
 ///
 /// Returns: `{base_path}/_mem_wal/{shard_id}/`
 pub fn shard_base_path(base_path: &Path, shard_id: &Uuid) -> Path {
-    base_path
-        .child("_mem_wal")
-        .child(shard_id.as_hyphenated().to_string())
+    mem_wal_path(base_path).child(shard_id.as_hyphenated().to_string())
 }
 
 /// Path to the WAL directory for a shard.
@@ -238,6 +243,15 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn test_mem_wal_path() {
+        let base_path = Path::from("my/dataset");
+        assert_eq!(mem_wal_path(&base_path).as_ref(), "my/dataset/_mem_wal");
+
+        let empty_base = Path::from("");
+        assert_eq!(mem_wal_path(&empty_base).as_ref(), "_mem_wal");
     }
 
     #[test]

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -16,15 +16,20 @@ use arrow_ipc::reader::StreamReader;
 use arrow_ipc::writer::StreamWriter;
 use arrow_schema::Schema as ArrowSchema;
 use bytes::Bytes;
+use futures::StreamExt;
 use lance_core::{Error, Result};
 use lance_io::object_store::ObjectStore;
 use object_store::path::Path;
-use tokio::sync::{mpsc, watch};
+use object_store::{PutMode, PutOptions};
+use tokio::sync::{Mutex, mpsc, watch};
 
 use tracing::instrument;
 use uuid::Uuid;
 
-use super::util::{WatchableOnceCell, shard_wal_path, wal_entry_filename};
+use super::manifest::ShardManifestStore;
+use super::util::{
+    WatchableOnceCell, parse_bit_reversed_filename, shard_wal_path, wal_entry_filename,
+};
 
 use super::index::IndexStore;
 use super::memtable::batch_store::{BatchStore, StoredBatch};
@@ -541,6 +546,496 @@ impl WalEntryData {
     }
 }
 
+// ============================================================================
+// Generic WAL Appender and Tailer
+// ============================================================================
+
+const FIRST_WAL_ENTRY_POSITION: u64 = 1;
+const MAX_APPEND_CREATE_CONFLICTS: usize = 1024;
+const APPEND_CONFLICT_REFRESH_INTERVAL: usize = 16;
+const MAX_CURSOR_PROBE: u64 = 4096;
+
+/// Result of appending a WAL entry.
+#[derive(Debug, Clone)]
+pub struct WalAppendResult {
+    pub shard_id: Uuid,
+    pub entry_position: u64,
+    pub num_batches: usize,
+    pub num_rows: usize,
+    pub wal_bytes: usize,
+}
+
+/// A WAL entry read from storage.
+#[derive(Debug, Clone)]
+pub struct WalReadEntry {
+    pub shard_id: Uuid,
+    pub entry_position: u64,
+    /// Writer epoch recorded in the WAL entry's IPC schema metadata.
+    /// Replay logic uses this to fence-check against the current epoch.
+    pub writer_epoch: u64,
+    pub batches: Vec<RecordBatch>,
+}
+
+/// WAL appender for a single MemWAL shard with epoch fencing.
+///
+/// Writes Arrow IPC entries atomically using put-if-not-exists. On conflict,
+/// retries with the next position. Checks fencing on conflict or PUT failure.
+#[derive(Debug)]
+pub struct WalAppender {
+    object_store: Arc<ObjectStore>,
+    wal_dir: Path,
+    manifest_store: Arc<ShardManifestStore>,
+    shard_id: Uuid,
+    writer_epoch: u64,
+    next_entry_position: Mutex<Option<u64>>,
+}
+
+impl WalAppender {
+    /// Open a WAL appender and claim a new writer epoch.
+    pub async fn open(
+        object_store: Arc<ObjectStore>,
+        base_path: Path,
+        shard_id: Uuid,
+        shard_spec_id: u32,
+    ) -> Result<Self> {
+        let manifest_store = Arc::new(ShardManifestStore::new(
+            object_store.clone(),
+            &base_path,
+            shard_id,
+            2,
+        ));
+        let (writer_epoch, _) = manifest_store.claim_epoch(shard_spec_id).await?;
+        Ok(Self {
+            object_store,
+            wal_dir: shard_wal_path(&base_path, &shard_id),
+            manifest_store,
+            shard_id,
+            writer_epoch,
+            next_entry_position: Mutex::new(None),
+        })
+    }
+
+    /// Shard id.
+    pub fn shard_id(&self) -> Uuid {
+        self.shard_id
+    }
+
+    /// Writer epoch recorded in the shard manifest.
+    pub fn writer_epoch(&self) -> u64 {
+        self.writer_epoch
+    }
+
+    /// Append batches as one durable WAL entry.
+    pub async fn append(&self, batches: Vec<RecordBatch>) -> Result<WalAppendResult> {
+        validate_appender_batches(&batches)?;
+        let wal_data = Bytes::from(serialize_appender_batches(&batches, self.writer_epoch)?);
+        let wal_bytes = wal_data.len();
+        let num_batches = batches.len();
+        let num_rows = batches.iter().map(RecordBatch::num_rows).sum();
+
+        let mut next_pos = self.next_entry_position.lock().await;
+        if next_pos.is_none() {
+            *next_pos = Some(self.scan_next_position().await?);
+        }
+
+        let mut conflicts = 0;
+        loop {
+            let pos = next_pos.ok_or_else(|| {
+                Error::internal(format!(
+                    "missing cached WAL position for shard {}",
+                    self.shard_id
+                ))
+            })?;
+            match atomic_put(
+                self.object_store.as_ref(),
+                &self.wal_dir,
+                &wal_entry_filename(pos),
+                wal_data.clone(),
+            )
+            .await
+            {
+                Ok(()) => {
+                    *next_pos = Some(pos.checked_add(1).ok_or_else(|| {
+                        Error::io(format!("WAL position overflow for shard {}", self.shard_id))
+                    })?);
+                    return Ok(WalAppendResult {
+                        shard_id: self.shard_id,
+                        entry_position: pos,
+                        num_batches,
+                        num_rows,
+                        wal_bytes,
+                    });
+                }
+                Err(AtomicPutError::AlreadyExists) => {
+                    self.check_fenced().await?;
+                    conflicts += 1;
+                    if conflicts >= MAX_APPEND_CREATE_CONFLICTS {
+                        return Err(Error::io(format!(
+                            "WAL append for shard {} failed after {} conflicts",
+                            self.shard_id, conflicts
+                        )));
+                    }
+                    if conflicts % APPEND_CONFLICT_REFRESH_INTERVAL == 0 {
+                        *next_pos = Some(self.scan_next_position().await?);
+                    } else {
+                        *next_pos = Some(pos.checked_add(1).ok_or_else(|| {
+                            Error::io(format!("WAL position overflow for shard {}", self.shard_id))
+                        })?);
+                    }
+                }
+                Err(AtomicPutError::Other(error)) => {
+                    self.check_fenced().await?;
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    /// Check that this writer's epoch has not been fenced.
+    pub async fn check_fenced(&self) -> Result<()> {
+        self.manifest_store.check_fenced(self.writer_epoch).await
+    }
+
+    async fn scan_next_position(&self) -> Result<u64> {
+        scan_next_position(self.object_store.as_ref(), &self.wal_dir, self.shard_id).await
+    }
+}
+
+/// Ordered reader for MemWAL entries from a single shard.
+///
+/// Uses `wal_entry_position_last_seen` from the shard manifest as a cursor
+/// hint for `next_position()`, probing forward from the hint to find the true
+/// tip before falling back to a full directory listing.
+#[derive(Debug, Clone)]
+pub struct WalTailer {
+    object_store: Arc<ObjectStore>,
+    wal_dir: Path,
+    manifest_store: Arc<ShardManifestStore>,
+    shard_id: Uuid,
+    update_cursor: bool,
+}
+
+impl WalTailer {
+    /// Create a WAL tailer for a shard.
+    pub fn new(object_store: Arc<ObjectStore>, base_path: Path, shard_id: Uuid) -> Self {
+        let manifest_store = Arc::new(ShardManifestStore::new(
+            object_store.clone(),
+            &base_path,
+            shard_id,
+            2,
+        ));
+        Self {
+            object_store,
+            wal_dir: shard_wal_path(&base_path, &shard_id),
+            manifest_store,
+            shard_id,
+            update_cursor: false,
+        }
+    }
+
+    /// Enable async best-effort cursor updates on read.
+    ///
+    /// When enabled, successful `read_entry` calls asynchronously update
+    /// `wal_entry_position_last_seen` in the shard manifest.
+    pub fn with_cursor_updates(mut self, enabled: bool) -> Self {
+        self.update_cursor = enabled;
+        self
+    }
+
+    /// Read a WAL entry at the given position. Returns `None` if no entry exists.
+    pub async fn read_entry(&self, entry_position: u64) -> Result<Option<WalReadEntry>> {
+        let path = self.wal_dir.child(wal_entry_filename(entry_position));
+        let data = match self.object_store.inner.get(&path).await {
+            Ok(data) => data,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(e) => {
+                return Err(Error::io(format!(
+                    "failed to read WAL entry {} for shard {}: {}",
+                    entry_position, self.shard_id, e
+                )));
+            }
+        };
+        let bytes = data.bytes().await.map_err(|e| {
+            Error::io(format!(
+                "failed to read WAL entry bytes at {} for shard {}: {}",
+                path, self.shard_id, e
+            ))
+        })?;
+        let (writer_epoch, batches) = deserialize_appender_batches(bytes)?;
+
+        if self.update_cursor {
+            let ms = self.manifest_store.clone();
+            tokio::spawn(async move {
+                let _ = best_effort_cursor_update(&ms, entry_position).await;
+            });
+        }
+
+        Ok(Some(WalReadEntry {
+            shard_id: self.shard_id,
+            entry_position,
+            writer_epoch,
+            batches,
+        }))
+    }
+
+    /// Find the next append position (one past the latest entry).
+    pub async fn next_position(&self) -> Result<u64> {
+        if let Some(hint) = self.manifest_cursor_hint().await
+            && hint >= FIRST_WAL_ENTRY_POSITION
+            && let Some(tip) = self.probe_forward(hint).await?
+        {
+            return Ok(tip);
+        }
+        scan_next_position(self.object_store.as_ref(), &self.wal_dir, self.shard_id).await
+    }
+
+    /// Find the earliest listed WAL position.
+    pub async fn first_position(&self) -> Result<u64> {
+        scan_first_position(self.object_store.as_ref(), &self.wal_dir, self.shard_id).await
+    }
+
+    async fn manifest_cursor_hint(&self) -> Option<u64> {
+        let manifest = self.manifest_store.read_latest().await.ok()??;
+        let hint = manifest.wal_entry_position_last_seen;
+        if hint > 0 { Some(hint) } else { None }
+    }
+
+    async fn probe_forward(&self, hint: u64) -> Result<Option<u64>> {
+        let path = self.wal_dir.child(wal_entry_filename(hint));
+        match self.object_store.inner.head(&path).await {
+            Ok(_) => {}
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(e) => {
+                return Err(Error::io(format!(
+                    "failed to check WAL entry {} for shard {}: {}",
+                    hint, self.shard_id, e
+                )));
+            }
+        }
+        let mut pos = hint + 1;
+        while pos - hint <= MAX_CURSOR_PROBE {
+            let p = self.wal_dir.child(wal_entry_filename(pos));
+            match self.object_store.inner.head(&p).await {
+                Ok(_) => pos += 1,
+                Err(object_store::Error::NotFound { .. }) => return Ok(Some(pos)),
+                Err(e) => {
+                    return Err(Error::io(format!(
+                        "failed to check WAL entry {} for shard {}: {}",
+                        pos, self.shard_id, e
+                    )));
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
+// --- helpers ---
+
+fn validate_appender_batches(batches: &[RecordBatch]) -> Result<()> {
+    if batches.is_empty() {
+        return Err(Error::invalid_input(
+            "cannot append an empty batch list to WAL",
+        ));
+    }
+    let schema = batches[0].schema();
+    for (idx, batch) in batches.iter().enumerate() {
+        if batch.num_rows() == 0 {
+            return Err(Error::invalid_input(format!(
+                "cannot append empty batch at index {} to WAL",
+                idx
+            )));
+        }
+        if batch.schema_ref().fields() != schema.fields() {
+            return Err(Error::invalid_input(format!(
+                "batch at index {} has a different schema from the first batch",
+                idx
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn serialize_appender_batches(batches: &[RecordBatch], writer_epoch: u64) -> Result<Vec<u8>> {
+    let schema = batches[0].schema();
+    let mut metadata = schema.metadata().clone();
+    metadata.insert(WRITER_EPOCH_KEY.to_string(), writer_epoch.to_string());
+    let ipc_schema = Arc::new(ArrowSchema::new_with_metadata(
+        schema.fields().to_vec(),
+        metadata,
+    ));
+    let mut buffer = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut buffer, &ipc_schema)
+            .map_err(|e| Error::io(format!("failed to create Arrow IPC stream writer: {}", e)))?;
+        for batch in batches {
+            writer.write(batch).map_err(|e| {
+                Error::io(format!("failed to write batch to WAL IPC stream: {}", e))
+            })?;
+        }
+        writer
+            .finish()
+            .map_err(|e| Error::io(format!("failed to finish WAL IPC stream: {}", e)))?;
+    }
+    Ok(buffer)
+}
+
+fn deserialize_appender_batches(bytes: Bytes) -> Result<(u64, Vec<RecordBatch>)> {
+    let cursor = Cursor::new(bytes);
+    let reader = StreamReader::try_new(cursor, None)
+        .map_err(|e| Error::io(format!("failed to open WAL IPC stream reader: {}", e)))?;
+    let schema = reader.schema();
+    let writer_epoch = schema
+        .metadata()
+        .get(WRITER_EPOCH_KEY)
+        .ok_or_else(|| Error::io(format!("WAL entry missing {} metadata", WRITER_EPOCH_KEY)))?
+        .parse::<u64>()
+        .map_err(|e| {
+            Error::io(format!(
+                "WAL entry has malformed {} metadata: {}",
+                WRITER_EPOCH_KEY, e
+            ))
+        })?;
+    let mut clean_metadata = schema.metadata().clone();
+    clean_metadata.remove(WRITER_EPOCH_KEY);
+    let logical_schema = Arc::new(ArrowSchema::new_with_metadata(
+        schema.fields().to_vec(),
+        clean_metadata,
+    ));
+    let mut batches = Vec::new();
+    for batch in reader {
+        let batch =
+            batch.map_err(|e| Error::io(format!("failed to read WAL IPC stream batch: {}", e)))?;
+        let clean = RecordBatch::try_new(logical_schema.clone(), batch.columns().to_vec())
+            .map_err(|e| Error::io(format!("failed to strip WAL metadata: {}", e)))?;
+        batches.push(clean);
+    }
+    Ok((writer_epoch, batches))
+}
+
+enum AtomicPutError {
+    AlreadyExists,
+    Other(Error),
+}
+
+async fn atomic_put(
+    object_store: &ObjectStore,
+    dir: &Path,
+    filename: &str,
+    bytes: Bytes,
+) -> std::result::Result<(), AtomicPutError> {
+    let path = dir.child(filename);
+    if object_store.is_local() {
+        let temp = dir.child(format!("{}.tmp.{}", filename, Uuid::new_v4()));
+        object_store
+            .inner
+            .put(&temp, bytes.into())
+            .await
+            .map_err(|e| {
+                AtomicPutError::Other(Error::io(format!("failed to write temp file: {}", e)))
+            })?;
+        match object_store.inner.rename_if_not_exists(&temp, &path).await {
+            Ok(()) => Ok(()),
+            Err(object_store::Error::AlreadyExists { .. }) => {
+                let _ = object_store.delete(&temp).await;
+                Err(AtomicPutError::AlreadyExists)
+            }
+            Err(e) => {
+                let _ = object_store.delete(&temp).await;
+                Err(AtomicPutError::Other(Error::io(format!(
+                    "failed to create {} atomically: {}",
+                    path, e
+                ))))
+            }
+        }
+    } else {
+        object_store
+            .inner
+            .put_opts(
+                &path,
+                bytes.into(),
+                PutOptions {
+                    mode: PutMode::Create,
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| match e {
+                object_store::Error::AlreadyExists { .. }
+                | object_store::Error::Precondition { .. } => AtomicPutError::AlreadyExists,
+                _ => AtomicPutError::Other(Error::io(format!(
+                    "failed to create {} atomically: {}",
+                    path, e
+                ))),
+            })?;
+        Ok(())
+    }
+}
+
+async fn scan_next_position(
+    object_store: &ObjectStore,
+    wal_dir: &Path,
+    shard_id: Uuid,
+) -> Result<u64> {
+    let mut max_position = None::<u64>;
+    let mut stream = object_store.inner.list(Some(wal_dir));
+    while let Some(item) = stream.next().await {
+        let meta = item.map_err(|e| {
+            Error::io(format!(
+                "failed to list WAL directory for shard {}: {}",
+                shard_id, e
+            ))
+        })?;
+        if let Some(filename) = meta.location.filename()
+            && let Some(position) = parse_bit_reversed_filename(filename)
+        {
+            max_position = Some(max_position.map_or(position, |max| max.max(position)));
+        }
+    }
+    match max_position {
+        Some(pos) => pos
+            .checked_add(1)
+            .ok_or_else(|| Error::io(format!("WAL position overflow for shard {}", shard_id))),
+        None => Ok(FIRST_WAL_ENTRY_POSITION),
+    }
+}
+
+async fn scan_first_position(
+    object_store: &ObjectStore,
+    wal_dir: &Path,
+    shard_id: Uuid,
+) -> Result<u64> {
+    let mut min_position = None::<u64>;
+    let mut stream = object_store.inner.list(Some(wal_dir));
+    while let Some(item) = stream.next().await {
+        let meta = item.map_err(|e| {
+            Error::io(format!(
+                "failed to list WAL directory for shard {}: {}",
+                shard_id, e
+            ))
+        })?;
+        if let Some(filename) = meta.location.filename()
+            && let Some(position) = parse_bit_reversed_filename(filename)
+        {
+            min_position = Some(min_position.map_or(position, |min| min.min(position)));
+        }
+    }
+    Ok(min_position.unwrap_or(FIRST_WAL_ENTRY_POSITION))
+}
+
+async fn best_effort_cursor_update(manifest_store: &ShardManifestStore, entry_position: u64) {
+    let Ok(Some(manifest)) = manifest_store.read_latest().await else {
+        return;
+    };
+    if entry_position <= manifest.wal_entry_position_last_seen {
+        return;
+    }
+    let mut updated = manifest;
+    updated.version += 1;
+    updated.wal_entry_position_last_seen = entry_position;
+    let _ = manifest_store.write(&updated).await;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -698,5 +1193,147 @@ mod tests {
         assert_eq!(wal_data.batches.len(), 2);
         assert_eq!(wal_data.batches[0].num_rows(), 10);
         assert_eq!(wal_data.batches[1].num_rows(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_wal_appender_and_tailer_round_trip() {
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+
+        let appender = WalAppender::open(store.clone(), base_path.clone(), shard_id, 0)
+            .await
+            .unwrap();
+        assert_eq!(appender.shard_id(), shard_id);
+        assert_eq!(appender.writer_epoch(), 1);
+
+        let schema = create_test_schema();
+        let batch_a = create_test_batch(&schema, 4);
+        let batch_b = create_test_batch(&schema, 2);
+
+        let first = appender.append(vec![batch_a.clone()]).await.unwrap();
+        assert_eq!(first.entry_position, FIRST_WAL_ENTRY_POSITION);
+        assert_eq!(first.num_rows, 4);
+        assert_eq!(first.num_batches, 1);
+        assert!(first.wal_bytes > 0);
+
+        let second = appender.append(vec![batch_b.clone()]).await.unwrap();
+        assert_eq!(second.entry_position, FIRST_WAL_ENTRY_POSITION + 1);
+
+        let tailer = WalTailer::new(store, base_path, shard_id);
+        assert_eq!(tailer.first_position().await.unwrap(), first.entry_position);
+        assert_eq!(
+            tailer.next_position().await.unwrap(),
+            second.entry_position + 1
+        );
+
+        let read = tailer
+            .read_entry(first.entry_position)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(read.shard_id, shard_id);
+        assert_eq!(read.writer_epoch, appender.writer_epoch());
+        assert_eq!(read.batches.len(), 1);
+        assert_eq!(read.batches[0].num_rows(), 4);
+        // Writer-epoch IPC metadata must be stripped from logical batches.
+        assert!(
+            !read.batches[0]
+                .schema()
+                .metadata()
+                .contains_key(WRITER_EPOCH_KEY)
+        );
+
+        assert!(tailer.read_entry(999).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_wal_appender_fenced_by_newer_writer() {
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+
+        let first = WalAppender::open(store.clone(), base_path.clone(), shard_id, 0)
+            .await
+            .unwrap();
+        assert_eq!(first.writer_epoch(), 1);
+
+        let schema = create_test_schema();
+        let batch = create_test_batch(&schema, 1);
+        first.append(vec![batch.clone()]).await.unwrap();
+
+        let second = WalAppender::open(store, base_path, shard_id, 0)
+            .await
+            .unwrap();
+        assert_eq!(second.writer_epoch(), 2);
+        // Newer writer races first to position 2.
+        second.append(vec![batch.clone()]).await.unwrap();
+
+        let err = first.check_fenced().await.unwrap_err();
+        assert!(
+            err.to_string().contains("Writer fenced"),
+            "expected fence error, got: {err}"
+        );
+
+        // Fenced writer's cached next_pos still points at 2; the conflict path
+        // must surface the fence error rather than silently advance.
+        let err = first.append(vec![batch]).await.unwrap_err();
+        assert!(
+            err.to_string().contains("Writer fenced"),
+            "expected fence error from append, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wal_appender_rejects_invalid_input() {
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+        let appender = WalAppender::open(store, base_path, shard_id, 0)
+            .await
+            .unwrap();
+        let err = appender.append(vec![]).await.unwrap_err();
+        assert!(err.to_string().contains("empty batch list"));
+
+        let schema = create_test_schema();
+        let zero = RecordBatch::new_empty(schema);
+        let err = appender.append(vec![zero]).await.unwrap_err();
+        assert!(err.to_string().contains("empty batch"));
+    }
+
+    #[tokio::test]
+    async fn test_wal_tailer_uses_manifest_cursor_hint() {
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+        let appender = WalAppender::open(store.clone(), base_path.clone(), shard_id, 0)
+            .await
+            .unwrap();
+
+        let schema = create_test_schema();
+        for _ in 0..3 {
+            appender
+                .append(vec![create_test_batch(&schema, 1)])
+                .await
+                .unwrap();
+        }
+
+        let tailer =
+            WalTailer::new(store.clone(), base_path.clone(), shard_id).with_cursor_updates(true);
+        let entry = tailer.read_entry(2).await.unwrap().unwrap();
+        assert_eq!(entry.entry_position, 2);
+
+        // Best-effort cursor update is async; poll briefly until it lands.
+        let manifest_store = ShardManifestStore::new(store, &base_path, shard_id, 2);
+        let mut hint = 0u64;
+        for _ in 0..50 {
+            if let Some(m) = manifest_store.read_latest().await.unwrap() {
+                hint = m.wal_entry_position_last_seen;
+                if hint >= 2 {
+                    break;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(hint >= 2, "cursor hint never updated, last={hint}");
+
+        // next_position must still resolve to one past the last appended entry.
+        assert_eq!(tailer.next_position().await.unwrap(), 4);
     }
 }


### PR DESCRIPTION
## Summary

Surface a generic read/write surface for MemWAL shards so callers can drive a shard directly without going through the existing flusher.

- **Shard self-description.** `ShardManifest` now records the `(shard_spec_id, field_id -> bytes)` assignment that produced the shard, so a manifest found on disk can be mapped back to a shard spec without consulting the inline index. Proto adds `ShardFieldEntry`; manifest carries `shard_field_values: HashMap<String, Vec<u8>>`.
- **Idempotent shard initialization.** `ShardManifestStore::initialize_shard()` writes manifest v1 at writer epoch 0 and treats `AlreadyExists` as success when the existing manifest matches.
- **Generic WAL primitives.**
    - `WalAppender::open()` claims a writer epoch via the manifest store; `append(batches)` serializes Arrow IPC and writes with put-if-not-exists, retrying on conflict and fencing on PUT failure.
    - `WalTailer::read_entry`, `next_position`, `first_position` use `wal_entry_position_last_seen` as a probe hint with a listing fallback. `WalReadEntry` includes the `writer_epoch` recorded in the entry so callers can fence-check on replay.
- **Index discovery helpers.** New `Dataset` methods `mem_wal_index_details()` and `list_mem_wal_latest_shard_ids()` (object-storage directory listing). The inline shard snapshot is positioned as a stale read-optimization rather than the source of truth; `docs/src/format/table/mem_wal.md` is updated to match.

## Tests

Added unit tests for:
- `ShardManifestStore::initialize_shard` happy path, idempotent on match, rejects mismatched conflict.
- `WalAppender` / `WalTailer` round-trip including `writer_epoch` propagation; position increment.
- Writer-epoch fencing: a stale appender hits the conflict path on append and surfaces the fence error.
- Input validation: empty batch list and zero-row batches are rejected.
- `WalTailer::with_cursor_updates(true)` updates `wal_entry_position_last_seen` asynchronously, and `next_position()` still resolves correctly.
- `mem_wal_path()` helper.

cc @jackye1995 for review.