### PR TITLE
feat: support tracking deleted rows between versions

### DIFF
--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -777,6 +777,7 @@ impl FromJObjectWithEnv<Fragment> for JObject<'_> {
             row_id_meta,
             created_at_version_meta,
             last_updated_at_version_meta,
+            deleted_at_version_meta: None,
         })
     }
 }

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -342,6 +342,13 @@ message DataFragment {
     ExternalFile external_created_at_versions = 10;
   } // created_at_version_sequence
 
+  oneof deleted_at_version_sequence {
+    // If small (< 200KB), the row deleted at versions are stored inline.
+    bytes inline_deleted_at_versions = 21;
+    // Otherwise, stored as part of a file.
+    ExternalFile external_deleted_at_versions = 22;
+  } // deleted_at_version_sequence
+
   // Number of original rows in the fragment, this includes rows that are now marked with
   // deletion tombstones. To compute the current number of rows, subtract
   // `deletion_file.num_deleted_rows` from this value.

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -77,6 +77,8 @@ class FragmentMetadata:
         The row created at version metadata, if any.
     last_updated_at_version_meta : Optional[RowDatasetVersionMeta]
         The row last updated at version metadata, if any.
+    deleted_at_version_meta : Optional[RowDatasetVersionMeta]
+        The row deleted at version metadata, if any.
     """
 
     id: int
@@ -86,6 +88,7 @@ class FragmentMetadata:
     row_id_meta: Optional[RowIdMeta] = None
     created_at_version_meta: Optional[RowDatasetVersionMeta] = None
     last_updated_at_version_meta: Optional[RowDatasetVersionMeta] = None
+    deleted_at_version_meta: Optional[RowDatasetVersionMeta] = None
 
     @property
     def num_deletions(self) -> int:
@@ -132,6 +135,11 @@ class FragmentMetadata:
                 if self.last_updated_at_version_meta is not None
                 else None
             ),
+            deleted_at_version_meta=(
+                json.loads(self.deleted_at_version_meta.json())
+                if self.deleted_at_version_meta is not None
+                else None
+            ),
         )
 
     @staticmethod
@@ -158,6 +166,12 @@ class FragmentMetadata:
                 json.dumps(last_updated_at_version_meta)
             )
 
+        deleted_at_version_meta = json_data.get("deleted_at_version_meta")
+        if deleted_at_version_meta is not None:
+            deleted_at_version_meta = RowDatasetVersionMeta.from_json(
+                json.dumps(deleted_at_version_meta)
+            )
+
         return FragmentMetadata(
             id=json_data["id"],
             files=[DataFile(**f) for f in json_data["files"]],
@@ -166,6 +180,7 @@ class FragmentMetadata:
             row_id_meta=row_id_meta,
             created_at_version_meta=created_at_version_meta,
             last_updated_at_version_meta=last_updated_at_version_meta,
+            deleted_at_version_meta=deleted_at_version_meta,
         )
 
 

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -279,7 +279,8 @@ def test_fragment_meta():
         "file_size_bytes=100), DataFile(path='1.lance', fields=[1], column_indices=[], "
         "file_major_version=0, file_minor_version=0, file_size_bytes=None)], "
         "physical_rows=100, deletion_file=None, row_id_meta=None, "
-        "created_at_version_meta=None, last_updated_at_version_meta=None)"
+        "created_at_version_meta=None, last_updated_at_version_meta=None, "
+        "deleted_at_version_meta=None)"
     )
 
 

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -784,6 +784,9 @@ impl FromPyObject<'_, '_> for PyLance<Fragment> {
         let created_at_version_meta: Option<PyRef<PyRowDatasetVersionMeta>> =
             ob.getattr("created_at_version_meta")?.extract()?;
         let created_at_version_meta = created_at_version_meta.map(|r| r.0.clone());
+        let deleted_at_version_meta: Option<PyRef<PyRowDatasetVersionMeta>> =
+            ob.getattr("deleted_at_version_meta")?.extract()?;
+        let deleted_at_version_meta = deleted_at_version_meta.map(|r| r.0.clone());
 
         Ok(Self(Fragment {
             id: ob.getattr("id")?.extract()?,
@@ -793,6 +796,7 @@ impl FromPyObject<'_, '_> for PyLance<Fragment> {
             row_id_meta,
             last_updated_at_version_meta,
             created_at_version_meta,
+            deleted_at_version_meta,
         }))
     }
 }
@@ -825,6 +829,11 @@ impl<'py> IntoPyObject<'py> for PyLance<&Fragment> {
             .created_at_version_meta
             .as_ref()
             .map(|r| PyRowDatasetVersionMeta(r.clone()));
+        let deleted_at_version_meta = self
+            .0
+            .deleted_at_version_meta
+            .as_ref()
+            .map(|r| PyRowDatasetVersionMeta(r.clone()));
 
         cls.call1((
             self.0.id,
@@ -834,6 +843,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Fragment> {
             row_id_meta,
             created_at_version_meta,
             last_updated_at_version_meta,
+            deleted_at_version_meta,
         ))
     }
 }

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -1069,6 +1069,7 @@ pub struct Projection {
     pub with_row_addr: bool,
     pub with_row_last_updated_at_version: bool,
     pub with_row_created_at_version: bool,
+    pub with_row_deleted_at_version: bool,
     pub blob_handling: BlobHandling,
 }
 
@@ -1086,6 +1087,10 @@ impl Debug for Projection {
                 "with_row_created_at_version",
                 &self.with_row_created_at_version,
             )
+            .field(
+                "with_row_deleted_at_version",
+                &self.with_row_deleted_at_version,
+            )
             .field("blob_handling", &self.blob_handling)
             .finish()
     }
@@ -1101,6 +1106,7 @@ impl Projection {
             with_row_addr: false,
             with_row_last_updated_at_version: false,
             with_row_created_at_version: false,
+            with_row_deleted_at_version: false,
             blob_handling: BlobHandling::default(),
         }
     }
@@ -1127,6 +1133,11 @@ impl Projection {
 
     pub fn with_row_created_at_version(mut self) -> Self {
         self.with_row_created_at_version = true;
+        self
+    }
+
+    pub fn with_row_deleted_at_version(mut self) -> Self {
+        self.with_row_deleted_at_version = true;
         self
     }
 
@@ -1161,6 +1172,9 @@ impl Projection {
             return Ok(self);
         } else if column == crate::ROW_CREATED_AT_VERSION {
             self.with_row_created_at_version = true;
+            return Ok(self);
+        } else if column == crate::ROW_DELETED_AT_VERSION {
+            self.with_row_deleted_at_version = true;
             return Ok(self);
         }
 
@@ -1228,6 +1242,8 @@ impl Projection {
             self.with_row_last_updated_at_version && other.with_row_last_updated_at_version;
         self.with_row_created_at_version =
             self.with_row_created_at_version && other.with_row_created_at_version;
+        self.with_row_deleted_at_version =
+            self.with_row_deleted_at_version && other.with_row_deleted_at_version;
         self
     }
 
@@ -1267,6 +1283,8 @@ impl Projection {
             self.with_row_last_updated_at_version || other.with_row_last_updated_at_version;
         self.with_row_created_at_version =
             self.with_row_created_at_version || other.with_row_created_at_version;
+        self.with_row_deleted_at_version =
+            self.with_row_deleted_at_version || other.with_row_deleted_at_version;
         self
     }
 
@@ -1290,6 +1308,10 @@ impl Projection {
             .fields()
             .iter()
             .any(|f| f.name() == crate::ROW_CREATED_AT_VERSION);
+        self.with_row_deleted_at_version |= other
+            .fields()
+            .iter()
+            .any(|f| f.name() == crate::ROW_DELETED_AT_VERSION);
         let other =
             self.base
                 .schema()
@@ -1317,6 +1339,10 @@ impl Projection {
             .fields()
             .iter()
             .any(|f| f.name() == crate::ROW_CREATED_AT_VERSION);
+        self.with_row_deleted_at_version &= !other
+            .fields()
+            .iter()
+            .any(|f| f.name() == crate::ROW_DELETED_AT_VERSION);
         let other =
             self.base
                 .schema()
@@ -1358,6 +1384,8 @@ impl Projection {
                 self.with_row_last_updated_at_version = false;
             } else if field.name == crate::ROW_CREATED_AT_VERSION {
                 self.with_row_created_at_version = false;
+            } else if field.name == crate::ROW_DELETED_AT_VERSION {
+                self.with_row_deleted_at_version = false;
             } else {
                 debug_assert_eq!(field.id, -1);
             }
@@ -1372,6 +1400,7 @@ impl Projection {
             && !self.with_row_id
             && !self.with_row_last_updated_at_version
             && !self.with_row_created_at_version
+            && !self.with_row_deleted_at_version
     }
 
     /// True if the projection is only the row_id or row_addr columns
@@ -1382,7 +1411,8 @@ impl Projection {
             && (self.with_row_addr
                 || self.with_row_id
                 || self.with_row_last_updated_at_version
-                || self.with_row_created_at_version)
+                || self.with_row_created_at_version
+                || self.with_row_deleted_at_version)
     }
 
     /// True if the projection has at least one non-metadata column
@@ -1412,6 +1442,9 @@ impl Projection {
         }
         if self.with_row_created_at_version {
             extra_fields.push(crate::ROW_CREATED_AT_VERSION_FIELD.clone());
+        }
+        if self.with_row_deleted_at_version {
+            extra_fields.push(crate::ROW_DELETED_AT_VERSION_FIELD.clone());
         }
         schema.extend(&extra_fields).unwrap();
         schema

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -27,6 +27,8 @@ pub const ROW_OFFSET: &str = "_rowoffset";
 pub const ROW_LAST_UPDATED_AT_VERSION: &str = "_row_last_updated_at_version";
 /// Column name for the row's created at dataset version.
 pub const ROW_CREATED_AT_VERSION: &str = "_row_created_at_version";
+/// Column name for the row's deleted at dataset version.
+pub const ROW_DELETED_AT_VERSION: &str = "_row_deleted_at_version";
 
 /// Row ID field. This is nullable because its validity bitmap is sometimes used
 /// as a selection vector.
@@ -46,6 +48,9 @@ pub static ROW_LAST_UPDATED_AT_VERSION_FIELD: LazyLock<ArrowField> =
 /// Row created at version field.
 pub static ROW_CREATED_AT_VERSION_FIELD: LazyLock<ArrowField> =
     LazyLock::new(|| ArrowField::new(ROW_CREATED_AT_VERSION, DataType::UInt64, true));
+/// Row deleted at version field.
+pub static ROW_DELETED_AT_VERSION_FIELD: LazyLock<ArrowField> =
+    LazyLock::new(|| ArrowField::new(ROW_DELETED_AT_VERSION, DataType::UInt64, true));
 
 /// Check if a column name is a system column.
 ///
@@ -59,6 +64,11 @@ pub static ROW_CREATED_AT_VERSION_FIELD: LazyLock<ArrowField> =
 pub fn is_system_column(column_name: &str) -> bool {
     matches!(
         column_name,
-        ROW_ID | ROW_ADDR | ROW_OFFSET | ROW_LAST_UPDATED_AT_VERSION | ROW_CREATED_AT_VERSION
+        ROW_ID
+            | ROW_ADDR
+            | ROW_OFFSET
+            | ROW_LAST_UPDATED_AT_VERSION
+            | ROW_CREATED_AT_VERSION
+            | ROW_DELETED_AT_VERSION
     )
 }

--- a/rust/lance-datafusion/src/projection.rs
+++ b/rust/lance-datafusion/src/projection.rs
@@ -14,8 +14,8 @@ use std::{
 use tracing::instrument;
 
 use lance_core::{
-    Error, ROW_ADDR, ROW_CREATED_AT_VERSION, ROW_ID, ROW_LAST_UPDATED_AT_VERSION, ROW_OFFSET,
-    Result, WILDCARD,
+    Error, ROW_ADDR, ROW_CREATED_AT_VERSION, ROW_DELETED_AT_VERSION, ROW_ID,
+    ROW_LAST_UPDATED_AT_VERSION, ROW_OFFSET, Result, WILDCARD,
     datatypes::{OnMissing, Projectable, Projection, Schema},
 };
 
@@ -35,6 +35,7 @@ struct ProjectionBuilder {
     needs_row_addr: bool,
     needs_row_last_updated_at: bool,
     needs_row_created_at: bool,
+    needs_row_deleted_at: bool,
     must_add_row_offset: bool,
     has_wildcard: bool,
 }
@@ -56,6 +57,7 @@ impl ProjectionBuilder {
             needs_row_addr: false,
             needs_row_created_at: false,
             needs_row_last_updated_at: false,
+            needs_row_deleted_at: false,
             must_add_row_offset: false,
             has_wildcard: false,
         }
@@ -93,6 +95,8 @@ impl ProjectionBuilder {
                 self.needs_row_last_updated_at = true;
             } else if name == ROW_CREATED_AT_VERSION {
                 self.needs_row_created_at = true;
+            } else if name == ROW_DELETED_AT_VERSION {
+                self.needs_row_deleted_at = true;
             }
         }
 
@@ -150,6 +154,7 @@ impl ProjectionBuilder {
         physical_projection.with_row_addr = self.needs_row_addr || self.must_add_row_offset;
         physical_projection.with_row_last_updated_at_version = self.needs_row_last_updated_at;
         physical_projection.with_row_created_at_version = self.needs_row_created_at;
+        physical_projection.with_row_deleted_at_version = self.needs_row_deleted_at;
 
         Ok(ProjectionPlan {
             physical_projection,
@@ -194,6 +199,9 @@ impl ProjectionPlan {
         ));
         fields.push(Arc::new(
             (*lance_core::ROW_CREATED_AT_VERSION_FIELD).clone(),
+        ));
+        fields.push(Arc::new(
+            (*lance_core::ROW_DELETED_AT_VERSION_FIELD).clone(),
         ));
         ArrowSchema::new(fields)
     }

--- a/rust/lance-table/benches/manifest_intern.rs
+++ b/rust/lance-table/benches/manifest_intern.rs
@@ -72,6 +72,7 @@ fn make_uniform_pb_fragments(n: u64, num_fields: usize) -> Vec<pb::DataFragment>
                     version_bytes.clone(),
                 ),
             ),
+            deleted_at_version_sequence: None,
         })
         .collect()
 }
@@ -148,6 +149,7 @@ fn make_diverse_pb_fragments(
                         version_payloads[version_idx].clone(),
                     ),
                 ),
+                deleted_at_version_sequence: None,
             }
         })
         .collect()

--- a/rust/lance-table/benches/row_id_index.rs
+++ b/rust/lance-table/benches/row_id_index.rs
@@ -290,10 +290,12 @@ fn bench_apply_row_id(c: &mut Criterion) {
         with_row_addr: false,
         with_row_last_updated_at_version: false,
         with_row_created_at_version: false,
+        with_row_deleted_at_version: false,
         deletion_vector: None,
         row_id_sequence: None,
         last_updated_at_sequence: None,
         created_at_sequence: None,
+        deleted_at_sequence: None,
         make_deletions_null: false,
         total_num_rows: num_rows() as u32,
     };

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -16,7 +16,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::format::pb;
 
 use crate::rowids::version::{
-    RowDatasetVersionMeta, created_at_version_meta_to_pb, last_updated_at_version_meta_to_pb,
+    RowDatasetVersionMeta, created_at_version_meta_to_pb, deleted_at_version_meta_to_pb,
+    last_updated_at_version_meta_to_pb,
 };
 use lance_core::datatypes::Schema;
 use lance_core::error::Result;
@@ -380,6 +381,10 @@ impl DataFileFieldInterner {
             physical_rows,
             last_updated_at_version_meta,
             created_at_version_meta,
+            deleted_at_version_meta: p
+                .deleted_at_version_sequence
+                .map(RowDatasetVersionMeta::try_from)
+                .transpose()?,
         })
     }
 }
@@ -503,6 +508,9 @@ pub struct Fragment {
     /// Created at version metadata
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at_version_meta: Option<RowDatasetVersionMeta>,
+    /// Deleted at version metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_at_version_meta: Option<RowDatasetVersionMeta>,
 }
 
 impl Fragment {
@@ -515,6 +523,7 @@ impl Fragment {
             physical_rows: None,
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         }
     }
 
@@ -554,6 +563,7 @@ impl Fragment {
             row_id_meta: None,
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         }
     }
 
@@ -680,6 +690,10 @@ impl TryFrom<pb::DataFragment> for Fragment {
                 .created_at_version_sequence
                 .map(RowDatasetVersionMeta::try_from)
                 .transpose()?,
+            deleted_at_version_meta: p
+                .deleted_at_version_sequence
+                .map(RowDatasetVersionMeta::try_from)
+                .transpose()?,
         })
     }
 }
@@ -713,6 +727,7 @@ impl From<&Fragment> for pb::DataFragment {
         let last_updated_at_version_sequence =
             last_updated_at_version_meta_to_pb(&f.last_updated_at_version_meta);
         let created_at_version_sequence = created_at_version_meta_to_pb(&f.created_at_version_meta);
+        let deleted_at_version_sequence = deleted_at_version_meta_to_pb(&f.deleted_at_version_meta);
         Self {
             id: f.id,
             files: f.files.iter().map(pb::DataFile::from).collect(),
@@ -721,6 +736,7 @@ impl From<&Fragment> for pb::DataFragment {
             physical_rows: f.physical_rows.unwrap_or_default() as u64,
             last_updated_at_version_sequence,
             created_at_version_sequence,
+            deleted_at_version_sequence,
         }
     }
 }

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -1321,6 +1321,7 @@ mod tests {
                 physical_rows: None,
                 created_at_version_meta: None,
                 last_updated_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
             Fragment {
                 id: 1,
@@ -1333,6 +1334,7 @@ mod tests {
                 physical_rows: None,
                 created_at_version_meta: None,
                 last_updated_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
         ];
 

--- a/rust/lance-table/src/rowids/version.rs
+++ b/rust/lance-table/src/rowids/version.rs
@@ -327,6 +327,26 @@ pub fn created_at_version_meta_to_pb(
     })
 }
 
+/// Helper function to convert RowDatasetVersionMeta to protobuf format for delete_at
+pub fn deleted_at_version_meta_to_pb(
+    meta: &Option<RowDatasetVersionMeta>,
+) -> Option<pb::data_fragment::DeletedAtVersionSequence> {
+    meta.as_ref().map(|m| match m {
+        RowDatasetVersionMeta::Inline(data) => {
+            pb::data_fragment::DeletedAtVersionSequence::InlineDeletedAtVersions(data.to_vec())
+        }
+        RowDatasetVersionMeta::External(file) => {
+            pb::data_fragment::DeletedAtVersionSequence::ExternalDeletedAtVersions(
+                pb::ExternalFile {
+                    path: file.path.clone(),
+                    offset: file.offset,
+                    size: file.size,
+                },
+            )
+        }
+    })
+}
+
 /// Serialize a dataset version sequence to a buffer (following RowIdSequence pattern)
 pub fn write_dataset_versions(sequence: &RowDatasetVersionSequence) -> Vec<u8> {
     // Convert to protobuf sequence
@@ -627,6 +647,25 @@ impl TryFrom<pb::data_fragment::CreatedAtVersionSequence> for RowDatasetVersionM
                 Ok(Self::Inline(Arc::from(data)))
             }
             pb::data_fragment::CreatedAtVersionSequence::ExternalCreatedAtVersions(file) => {
+                Ok(Self::External(ExternalFile {
+                    path: file.path,
+                    offset: file.offset,
+                    size: file.size,
+                }))
+            }
+        }
+    }
+}
+
+impl TryFrom<pb::data_fragment::DeletedAtVersionSequence> for RowDatasetVersionMeta {
+    type Error = Error;
+
+    fn try_from(value: pb::data_fragment::DeletedAtVersionSequence) -> Result<Self> {
+        match value {
+            pb::data_fragment::DeletedAtVersionSequence::InlineDeletedAtVersions(data) => {
+                Ok(Self::Inline(data.into()))
+            }
+            pb::data_fragment::DeletedAtVersionSequence::ExternalDeletedAtVersions(file) => {
                 Ok(Self::External(ExternalFile {
                     path: file.path,
                     offset: file.offset,

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -224,6 +224,8 @@ pub struct RowIdAndDeletesConfig {
     pub with_row_last_updated_at_version: bool,
     /// Whether to include the created at version column in the final batch
     pub with_row_created_at_version: bool,
+    /// Whether to include the deleted at version column in the final batch
+    pub with_row_deleted_at_version: bool,
     /// An optional deletion vector to apply to the batch
     pub deletion_vector: Option<Arc<DeletionVector>>,
     /// An optional row id sequence to use for the row id column.
@@ -232,6 +234,8 @@ pub struct RowIdAndDeletesConfig {
     pub last_updated_at_sequence: Option<Arc<crate::rowids::version::RowDatasetVersionSequence>>,
     /// The created_at version sequence
     pub created_at_sequence: Option<Arc<crate::rowids::version::RowDatasetVersionSequence>>,
+    /// The deleted_at version sequence
+    pub deleted_at_sequence: Option<Arc<crate::rowids::version::RowDatasetVersionSequence>>,
     /// Whether to make deleted rows null instead of filtering them out
     pub make_deletions_null: bool,
     /// The total number of rows that will be loaded
@@ -246,6 +250,7 @@ impl RowIdAndDeletesConfig {
             || self.with_row_addr
             || self.with_row_last_updated_at_version
             || self.with_row_created_at_version
+            || self.with_row_deleted_at_version
     }
 }
 
@@ -334,16 +339,17 @@ pub fn apply_row_id_and_deletes(
     };
 
     let batch = if config.with_row_addr {
-        let row_addr_arr = row_addrs.unwrap();
+        let row_addr_arr = row_addrs.as_ref().unwrap().clone();
         batch.try_with_column(ROW_ADDR_FIELD.clone(), row_addr_arr)?
     } else {
         batch
     };
 
-    // Add version columns if requested
-    let batch = if config.with_row_last_updated_at_version || config.with_row_created_at_version {
+    let batch = if config.with_row_last_updated_at_version
+        || config.with_row_created_at_version
+        || config.with_row_deleted_at_version
+    {
         let mut batch = batch;
-
         if config.with_row_last_updated_at_version {
             let version_arr = if let Some(sequence) = &config.last_updated_at_sequence {
                 Arc::new(UInt64Array::from(version_values_for_selection(
@@ -373,6 +379,40 @@ pub fn apply_row_id_and_deletes(
                 Arc::new(UInt64Array::from(vec![1u64; num_rows as usize]))
             };
             batch = batch.try_with_column(ROW_CREATED_AT_VERSION_FIELD.clone(), version_arr)?;
+        }
+
+        if config.with_row_deleted_at_version {
+            // Build deleted at versions; only valid on deleted rows.
+            // Non-deleted rows get None; rows without a sequence also get None.
+            let values_opt: Vec<Option<u64>> =
+                match (deletion_mask.as_ref(), &config.deleted_at_sequence) {
+                    (None, _) | (Some(_), None) => vec![None; num_rows as usize],
+                    (Some(mask), Some(sequence)) => {
+                        let raw_versions = version_values_for_selection(
+                            sequence,
+                            &config.params,
+                            batch_offset,
+                            num_rows,
+                        )?;
+                        raw_versions
+                            .iter()
+                            .enumerate()
+                            .map(|(i, v)| {
+                                // mask true means not deleted -> None
+                                if mask.value(i) || *v == 0 {
+                                    None
+                                } else {
+                                    Some(*v)
+                                }
+                            })
+                            .collect()
+                    }
+                };
+            let version_arr = Arc::new(UInt64Array::from(values_opt));
+            batch = batch.try_with_column(
+                (*lance_core::ROW_DELETED_AT_VERSION_FIELD).clone(),
+                version_arr,
+            )?;
         }
 
         batch
@@ -499,10 +539,12 @@ mod tests {
                     with_row_addr: false,
                     with_row_last_updated_at_version: false,
                     with_row_created_at_version: false,
+                    with_row_deleted_at_version: false,
                     deletion_vector: None,
                     row_id_sequence: None,
                     last_updated_at_sequence: None,
                     created_at_sequence: None,
+                    deleted_at_sequence: None,
                     make_deletions_null: false,
                     total_num_rows: 100,
                 };
@@ -599,10 +641,12 @@ mod tests {
                                 with_row_addr: false,
                                 with_row_last_updated_at_version: false,
                                 with_row_created_at_version: false,
+                                with_row_deleted_at_version: false,
                                 deletion_vector: deletion_vector.clone(),
                                 row_id_sequence: None,
                                 last_updated_at_sequence: None,
                                 created_at_sequence: None,
+                                deleted_at_sequence: None,
                                 make_deletions_null,
                                 total_num_rows: 100,
                             };
@@ -699,12 +743,14 @@ mod tests {
             with_row_addr: false,
             with_row_last_updated_at_version: false,
             with_row_created_at_version: true,
+            with_row_deleted_at_version: false,
             deletion_vector: Some(Arc::new(DeletionVector::Bitmap(RoaringBitmap::from_iter(
                 0..35,
             )))),
             row_id_sequence: None,
             last_updated_at_sequence: None,
             created_at_sequence: Some(seq),
+            deleted_at_sequence: None,
             make_deletions_null: false,
             total_num_rows: 100,
         };
@@ -770,10 +816,12 @@ mod tests {
             with_row_addr: false,
             with_row_last_updated_at_version: false,
             with_row_created_at_version: true,
+            with_row_deleted_at_version: false,
             deletion_vector: Some(Arc::new(DeletionVector::Bitmap(deletions))),
             row_id_sequence: None,
             last_updated_at_sequence: None,
             created_at_sequence: Some(seq),
+            deleted_at_sequence: None,
             make_deletions_null: false,
             total_num_rows: 100,
         };

--- a/rust/lance/src/datafusion/logical_plan.rs
+++ b/rust/lance/src/datafusion/logical_plan.rs
@@ -72,6 +72,7 @@ impl TableProvider for Dataset {
             false,
             false,
             false,
+            false,
             scan_range,
             projections.into(),
         );

--- a/rust/lance/src/dataset/delta.rs
+++ b/rust/lance/src/dataset/delta.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use lance_core::Error;
 use lance_core::ROW_CREATED_AT_VERSION;
+use lance_core::ROW_DELETED_AT_VERSION;
 use lance_core::ROW_ID;
 use lance_core::ROW_LAST_UPDATED_AT_VERSION;
 use lance_core::WILDCARD;
@@ -448,6 +449,33 @@ impl DatasetDelta {
             inserted_row_filter, updated_rows_filter
         ))
     }
+
+    /// Get deleted rows between the two versions.
+    ///
+    /// Returns rows deleted in the version range where `_row_deleted_at_version` > `begin_version`
+    /// and `_row_deleted_at_version` <= `end_version`.
+    ///
+    /// The result includes:
+    /// - `_rowid`: Row ID
+    /// - `_row_deleted_at_version`: Version when the row was deleted
+    pub async fn get_deleted_rows(&self) -> Result<DatasetRecordBatchStream> {
+        let mut scanner = self.base_dataset.scan();
+
+        // Include deleted rows so that rows that were removed logically can still be surfaced
+        scanner.include_deleted_rows();
+
+        // Project only required meta columns to avoid late materialization issues
+        scanner.project(&[ROW_ID, ROW_DELETED_AT_VERSION])?;
+
+        // Filter for rows deleted in the version range
+        let filter = format!(
+            "_row_deleted_at_version > {} AND _row_deleted_at_version <= {}",
+            self.begin_version, self.end_version
+        );
+        scanner.filter(&filter)?;
+
+        scanner.try_into_stream().await
+    }
 }
 
 #[cfg(test)]
@@ -631,6 +659,93 @@ mod tests {
             }
             _ => panic!("Expected VersionNotFound error."),
         }
+    }
+
+    #[tokio::test]
+    async fn test_get_deleted_rows_basic() {
+        // Create dataset with stable row IDs enabled
+        let data = lance_datagen::gen_batch()
+            .col("key", array::step::<Int32Type>())
+            .col("value", array::fill_utf8("value".to_string()))
+            .into_reader_rows(RowCount::from(100), BatchCount::from(1));
+
+        let write_params = WriteParams {
+            enable_stable_row_ids: true,
+            ..Default::default()
+        };
+        let mut ds = Dataset::write(data, "memory://", Some(write_params))
+            .await
+            .unwrap();
+
+        assert_eq!(ds.version().version, 1);
+
+        // Delete some rows in v2
+        ds.delete("key < 5").await.unwrap();
+        assert_eq!(ds.version().version, 2);
+
+        // Delete some other rows in v3
+        ds.delete("key >= 10 AND key < 15").await.unwrap();
+        assert_eq!(ds.version().version, 3);
+
+        // Delta for deletions in v2
+        let delta = ds
+            .delta()
+            .with_begin_version(1)
+            .with_end_version(2)
+            .build()
+            .unwrap();
+        let mut stream = delta.get_deleted_rows().await.unwrap();
+        use std::collections::HashMap;
+        let mut per_frag: HashMap<u32, usize> = HashMap::new();
+        let mut total_rows = 0usize;
+        while let Some(batch) = stream.try_next().await.unwrap() {
+            // All deleted rows in v2 should have _row_deleted_at_version = 2
+            let deleted_at = batch[lance_core::ROW_DELETED_AT_VERSION]
+                .as_primitive::<UInt64Type>()
+                .values();
+            let row_ids = batch[lance_core::ROW_ID]
+                .as_primitive::<UInt64Type>()
+                .values();
+            let mut batch_frag_counts: HashMap<u32, usize> = HashMap::new();
+            for (i, v) in deleted_at.iter().enumerate() {
+                assert_eq!(*v, 2);
+                let rid = row_ids[i];
+                let frag_id = (rid >> 32) as u32;
+                *batch_frag_counts.entry(frag_id).or_default() += 1;
+                *per_frag.entry(frag_id).or_default() += 1;
+            }
+            total_rows += batch.num_rows();
+        }
+        assert_eq!(total_rows, 5);
+
+        // Delta for deletions in v3
+        let delta = ds
+            .delta()
+            .with_begin_version(2)
+            .with_end_version(3)
+            .build()
+            .unwrap();
+        let mut stream = delta.get_deleted_rows().await.unwrap();
+        let mut per_frag3: HashMap<u32, usize> = HashMap::new();
+        let mut total_rows = 0usize;
+        while let Some(batch) = stream.try_next().await.unwrap() {
+            let deleted_at = batch[lance_core::ROW_DELETED_AT_VERSION]
+                .as_primitive::<UInt64Type>()
+                .values();
+            let row_ids = batch[lance_core::ROW_ID]
+                .as_primitive::<UInt64Type>()
+                .values();
+            let mut batch_frag_counts: HashMap<u32, usize> = HashMap::new();
+            for (i, v) in deleted_at.iter().enumerate() {
+                assert_eq!(*v, 3);
+                let rid = row_ids[i];
+                let frag_id = (rid >> 32) as u32;
+                *batch_frag_counts.entry(frag_id).or_default() += 1;
+                *per_frag3.entry(frag_id).or_default() += 1;
+            }
+            total_rows += batch.num_rows();
+        }
+        assert_eq!(total_rows, 5);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -44,6 +44,9 @@ use lance_io::utils::CachedFileSize;
 use lance_table::format::{DataFile, DeletionFile, Fragment};
 use lance_table::io::deletion::{deletion_file_path, write_deletion_file};
 use lance_table::rowids::RowIdSequence;
+use lance_table::rowids::version::{
+    RowDatasetVersionMeta, RowDatasetVersionRun, RowDatasetVersionSequence,
+};
 use lance_table::utils::stream::{
     ReadBatchFutStream, ReadBatchTask, ReadBatchTaskStream, RowIdAndDeletesConfig,
     wrap_with_row_id_and_delete,
@@ -608,6 +611,8 @@ pub struct FragReadConfig {
     pub with_row_last_updated_at_version: bool,
     // Add the created at version column
     pub with_row_created_at_version: bool,
+    // Add the deleted at version column
+    pub with_row_deleted_at_version: bool,
     /// The scan scheduler to use for reading data files.
     ///
     /// This should be specified if multiple readers are being used in
@@ -651,6 +656,12 @@ impl FragReadConfig {
             || self.with_row_address
             || self.with_row_last_updated_at_version
             || self.with_row_created_at_version
+            || self.with_row_deleted_at_version
+    }
+
+    pub fn with_row_deleted_at_version(mut self, value: bool) -> Self {
+        self.with_row_deleted_at_version = value;
+        self
     }
 
     pub fn with_scan_scheduler(mut self, value: Arc<ScanScheduler>) -> Self {
@@ -903,6 +914,9 @@ impl FileFragment {
         }
         if read_config.with_row_created_at_version {
             reader.with_row_created_at_version();
+        }
+        if read_config.with_row_deleted_at_version {
+            reader.with_row_deleted_at_version();
         }
 
         Ok(reader)
@@ -1836,6 +1850,56 @@ impl FileFragment {
         )
         .await?;
 
+        // Update deleted_at_version_meta only for datasets with stable row IDs
+        if self.dataset.manifest.uses_stable_row_ids() {
+            let current_version = self.dataset.version().version + 1;
+            let row_count = physical_rows;
+            let mut base_versions: Vec<u64> = vec![0u64; row_count];
+            if let Some(meta) = self.metadata.deleted_at_version_meta.as_ref()
+                && let Ok(prev_seq) = meta.load_sequence()
+            {
+                for (pos, slot) in base_versions.iter_mut().enumerate() {
+                    *slot = prev_seq.version_at(pos).unwrap_or(0);
+                }
+            }
+            // Mark deleted positions with current_version if not already set
+            let mut deleted_positions: Vec<usize> =
+                deletion_vector.into_iter().map(|p| p as usize).collect();
+            deleted_positions.sort_unstable();
+            for pos in deleted_positions.iter().copied() {
+                if pos < row_count && base_versions[pos] == 0 {
+                    base_versions[pos] = current_version;
+                }
+            }
+
+            let mut runs: Vec<RowDatasetVersionRun> = Vec::new();
+            if !base_versions.is_empty() {
+                let mut start = 0usize;
+                let mut curr_ver = base_versions[0];
+                for (idx, &ver) in base_versions.iter().enumerate().skip(1) {
+                    if ver != curr_ver {
+                        runs.push(RowDatasetVersionRun {
+                            span: lance_table::rowids::segment::U64Segment::Range(
+                                start as u64..idx as u64,
+                            ),
+                            version: curr_ver,
+                        });
+                        start = idx;
+                        curr_ver = ver;
+                    }
+                }
+                runs.push(RowDatasetVersionRun {
+                    span: lance_table::rowids::segment::U64Segment::Range(
+                        start as u64..base_versions.len() as u64,
+                    ),
+                    version: curr_ver,
+                });
+            }
+            let seq = RowDatasetVersionSequence { runs };
+            let meta = RowDatasetVersionMeta::from_sequence(&seq)?;
+            self.metadata.deleted_at_version_meta = Some(meta);
+        }
+
         Ok(Some(self))
     }
 }
@@ -1934,6 +1998,9 @@ pub struct FragmentReader {
     /// True if we should generate a created at version column in output
     with_row_created_at_version: bool,
 
+    /// True if we should generate a deleted at version column in output
+    with_row_deleted_at_version: bool,
+
     /// If true, deleted rows will be set to null, which is fast
     /// If false, deleted rows will be removed from the batch, requiring a copy
     make_deletions_null: bool,
@@ -1946,6 +2013,9 @@ pub struct FragmentReader {
 
     /// The created_at version sequence (loaded from fragment metadata)
     created_at_sequence: Option<Arc<lance_table::rowids::version::RowDatasetVersionSequence>>,
+
+    /// The deleted_at version sequence (loaded from fragment metadata)
+    deleted_at_sequence: Option<Arc<lance_table::rowids::version::RowDatasetVersionSequence>>,
 
     // total number of real rows in the fragment (num_physical_rows - num_deleted_rows)
     num_rows: usize,
@@ -1974,10 +2044,12 @@ impl Clone for FragmentReader {
             with_row_addr: self.with_row_addr,
             with_row_last_updated_at_version: self.with_row_last_updated_at_version,
             with_row_created_at_version: self.with_row_created_at_version,
+            with_row_deleted_at_version: self.with_row_deleted_at_version,
             make_deletions_null: self.make_deletions_null,
             fragment: self.fragment.clone(),
             last_updated_at_sequence: self.last_updated_at_sequence.clone(),
             created_at_sequence: self.created_at_sequence.clone(),
+            deleted_at_sequence: self.deleted_at_sequence.clone(),
             num_rows: self.num_rows,
             num_physical_rows: self.num_physical_rows,
         }
@@ -2041,10 +2113,12 @@ impl FragmentReader {
             with_row_addr: false,
             with_row_last_updated_at_version: false,
             with_row_created_at_version: false,
+            with_row_deleted_at_version: false,
             make_deletions_null: false,
             fragment,
             last_updated_at_sequence: None,
             created_at_sequence: None,
+            deleted_at_sequence: None,
             num_rows,
             num_physical_rows,
         })
@@ -2090,6 +2164,26 @@ impl FragmentReader {
             .output_schema
             .try_with_column(ROW_LAST_UPDATED_AT_VERSION_FIELD.clone())
             .expect("Table already has a column named _row_last_updated_at_version");
+
+        self
+    }
+
+    pub(crate) fn with_row_deleted_at_version(&mut self) -> &mut Self {
+        self.with_row_deleted_at_version = true;
+
+        // Load the version sequence if not already loaded
+        if self.deleted_at_sequence.is_none()
+            && let Some(meta) = &self.fragment.deleted_at_version_meta
+            && let Ok(sequence) = meta.load_sequence()
+        {
+            self.deleted_at_sequence = Some(Arc::new(sequence));
+        }
+
+        // Add the version column to the output schema
+        self.output_schema = self
+            .output_schema
+            .try_with_column(lance_core::ROW_DELETED_AT_VERSION_FIELD.clone())
+            .expect("Table already has a column named _row_deleted_at_version");
 
         self
     }
@@ -2283,8 +2377,10 @@ impl FragmentReader {
                 with_row_addr: self.with_row_addr,
                 with_row_last_updated_at_version: self.with_row_last_updated_at_version,
                 with_row_created_at_version: self.with_row_created_at_version,
+                with_row_deleted_at_version: self.with_row_deleted_at_version,
                 last_updated_at_sequence: self.last_updated_at_sequence.clone(),
                 created_at_sequence: self.created_at_sequence.clone(),
+                deleted_at_sequence: self.deleted_at_sequence.clone(),
                 make_deletions_null: self.make_deletions_null,
                 total_num_rows: first_reader.len() as u32,
             },
@@ -2376,8 +2472,10 @@ impl FragmentReader {
             with_row_addr: self.with_row_addr,
             with_row_last_updated_at_version: self.with_row_last_updated_at_version,
             with_row_created_at_version: self.with_row_created_at_version,
+            with_row_deleted_at_version: self.with_row_deleted_at_version,
             last_updated_at_sequence: self.last_updated_at_sequence.clone(),
             created_at_sequence: self.created_at_sequence.clone(),
+            deleted_at_sequence: self.deleted_at_sequence.clone(),
             params,
             total_num_rows,
         };
@@ -2442,6 +2540,7 @@ impl FragmentReader {
             + self.with_row_addr as usize
             + self.with_row_created_at_version as usize
             + self.with_row_last_updated_at_version as usize
+            + self.with_row_deleted_at_version as usize
     }
 
     /// Reads a range of rows from the fragment
@@ -2529,8 +2628,10 @@ impl FragmentReader {
             with_row_addr: self.with_row_addr,
             with_row_last_updated_at_version: self.with_row_last_updated_at_version,
             with_row_created_at_version: self.with_row_created_at_version,
+            with_row_deleted_at_version: self.with_row_deleted_at_version,
             last_updated_at_sequence: self.last_updated_at_sequence.clone(),
             created_at_sequence: self.created_at_sequence.clone(),
+            deleted_at_sequence: self.deleted_at_sequence.clone(),
             params: ReadBatchParams::Ranges(ranges),
             total_num_rows,
         };

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1664,6 +1664,7 @@ mod tests {
             physical_rows: Some(0),
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         };
         let single_bin = CandidateBin {
             fragments: vec![fragment.clone()],

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1875,6 +1875,7 @@ impl Scanner {
             .with_row_addr()
             .with_row_last_updated_at_version()
             .with_row_created_at_version()
+            .with_row_deleted_at_version()
             .to_schema();
 
         Ok(Arc::new(self.add_extra_columns(base_schema)?))
@@ -2658,6 +2659,7 @@ impl Scanner {
                 false
             } else if projection.with_row_last_updated_at_version
                 || projection.with_row_created_at_version
+                || projection.with_row_deleted_at_version
             {
                 // Version columns require ordered scanning because version metadata
                 // is indexed by position within each fragment
@@ -2693,6 +2695,9 @@ impl Scanner {
                 self.projection_plan
                     .physical_projection
                     .with_row_created_at_version,
+                self.projection_plan
+                    .physical_projection
+                    .with_row_deleted_at_version,
                 make_deletions_null,
                 Arc::new(projection.to_bare_schema()),
                 fragments,
@@ -3461,6 +3466,7 @@ impl Scanner {
             false,
             false,
             false,
+            false,
             flat_fts_scan_schema,
             Arc::new(fragments),
             None,
@@ -3757,6 +3763,7 @@ impl Scanner {
                 false,
                 false,
                 false,
+                false,
                 vector_scan_projection,
                 Arc::new(fallback_fragments),
                 // Can't pushdown limit/offset in an ANN search
@@ -3959,6 +3966,9 @@ impl Scanner {
                 self.projection_plan
                     .physical_projection
                     .with_row_created_at_version,
+                self.projection_plan
+                    .physical_projection
+                    .with_row_deleted_at_version,
                 false,
                 scan_schema,
                 missing_frags.into(),
@@ -4001,6 +4011,7 @@ impl Scanner {
         with_row_address: bool,
         with_row_last_updated_at_version: bool,
         with_row_created_at_version: bool,
+        with_row_deleted_at_version: bool,
         with_make_deletions_null: bool,
         range: Option<Range<u64>>,
         projection: Arc<Schema>,
@@ -4021,6 +4032,7 @@ impl Scanner {
             with_row_address,
             with_row_last_updated_at_version,
             with_row_created_at_version,
+            with_row_deleted_at_version,
             with_make_deletions_null,
             projection,
             fragments,
@@ -4036,6 +4048,7 @@ impl Scanner {
         with_row_address: bool,
         with_row_last_updated_at_version: bool,
         with_row_created_at_version: bool,
+        with_row_deleted_at_version: bool,
         with_make_deletions_null: bool,
         projection: Arc<Schema>,
         fragments: Arc<Vec<Fragment>>,
@@ -4052,6 +4065,7 @@ impl Scanner {
             with_row_address,
             with_row_last_updated_at_version,
             with_row_created_at_version,
+            with_row_deleted_at_version,
             with_make_deletions_null,
             ordered_output: ordered,
             file_reader_options: self.resolved_file_reader_options(),

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -1046,6 +1046,7 @@ mod test {
                         physical_rows: Some(50),
                         last_updated_at_version_meta: None,
                         created_at_version_meta: None,
+                        deleted_at_version_meta: None,
                     }))
                 } else {
                     Ok(None)

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -3859,6 +3859,7 @@ mod tests {
             deletion_file: None,
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         }];
         let mut next_row_id = 0;
 
@@ -3891,6 +3892,7 @@ mod tests {
             deletion_file: None,
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         }];
         let mut next_row_id = 100;
 
@@ -3923,6 +3925,7 @@ mod tests {
             deletion_file: None,
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         }];
         let mut next_row_id = 100;
 
@@ -3958,6 +3961,7 @@ mod tests {
             deletion_file: None,
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         }];
         let mut next_row_id = 100;
 
@@ -3986,6 +3990,7 @@ mod tests {
                 deletion_file: None,
                 last_updated_at_version_meta: None,
                 created_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
             Fragment {
                 id: 2,
@@ -3995,6 +4000,7 @@ mod tests {
                 deletion_file: None,
                 last_updated_at_version_meta: None,
                 created_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
         ];
         let mut next_row_id = 1000;
@@ -4039,6 +4045,7 @@ mod tests {
             deletion_file: None,
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         }];
         let mut next_row_id = 0;
 
@@ -4580,6 +4587,7 @@ mod tests {
             row_id_meta: None,
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         };
 
         let operation = Operation::Overwrite {
@@ -4668,6 +4676,7 @@ mod tests {
                 RowDatasetVersionMeta::from_sequence(&created_at_seq).unwrap(),
             ),
             last_updated_at_version_meta: None,
+            deleted_at_version_meta: None,
         };
 
         let new_seq = RowIdSequence::from([100u64, 102].as_slice());
@@ -4678,6 +4687,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
             physical_rows: Some(2),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -4723,6 +4733,7 @@ mod tests {
                     RowDatasetVersionMeta::from_sequence(&frag_a_created).unwrap(),
                 ),
                 last_updated_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
             Fragment {
                 id: 2,
@@ -4734,6 +4745,7 @@ mod tests {
                     RowDatasetVersionMeta::from_sequence(&frag_b_created).unwrap(),
                 ),
                 last_updated_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
         ]);
 
@@ -4746,6 +4758,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
             physical_rows: Some(2),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -4782,6 +4795,7 @@ mod tests {
                 RowDatasetVersionMeta::from_sequence(&existing_created).unwrap(),
             ),
             last_updated_at_version_meta: None,
+            deleted_at_version_meta: None,
         };
 
         // New fragment has row 10 (known) and row 999 (unknown — freshly inserted)
@@ -4793,6 +4807,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
             physical_rows: Some(2),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -4823,6 +4838,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq))),
             physical_rows: Some(2),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -4834,6 +4850,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
             physical_rows: Some(1),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -4862,6 +4879,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&existing_seq))),
             physical_rows: Some(2),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -4872,6 +4890,7 @@ mod tests {
             row_id_meta: None,
             physical_rows: Some(3),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -4904,6 +4923,7 @@ mod tests {
                 vec![0xFFu8; 8].as_slice(),
             ))),
             last_updated_at_version_meta: None,
+            deleted_at_version_meta: None,
         };
 
         let new_seq = RowIdSequence::from([10u64].as_slice());
@@ -4914,6 +4934,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
             physical_rows: Some(1),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -4958,6 +4979,7 @@ mod tests {
                 RowDatasetVersionMeta::from_sequence(&in_range_created).unwrap(),
             ),
             last_updated_at_version_meta: None,
+            deleted_at_version_meta: None,
         };
 
         // Fragment outside range – IDs [1000, 1001], created_at = 99 (must never appear)
@@ -4978,6 +5000,7 @@ mod tests {
                 RowDatasetVersionMeta::from_sequence(&out_of_range_created).unwrap(),
             ),
             last_updated_at_version_meta: None,
+            deleted_at_version_meta: None,
         };
 
         // New fragment rewrites both rows from the in-range fragment
@@ -4989,6 +5012,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
             physical_rows: Some(2),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -5027,6 +5051,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&seq))),
             physical_rows: Some(3),
             created_at_version_meta: Some(RowDatasetVersionMeta::from_sequence(&created).unwrap()),
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -5039,6 +5064,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
             physical_rows: Some(2),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -5090,6 +5116,7 @@ mod tests {
                 RowDatasetVersionMeta::from_sequence(&src_created).unwrap(),
             ),
             last_updated_at_version_meta: None,
+            deleted_at_version_meta: None,
         };
 
         // New fragment rewrites all 100 rows preserving their stable IDs.
@@ -5101,6 +5128,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
             physical_rows: Some(100),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 
@@ -5151,6 +5179,7 @@ mod tests {
                     RowDatasetVersionMeta::from_sequence(&created_a).unwrap(),
                 ),
                 last_updated_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
             Fragment {
                 id: 2,
@@ -5162,6 +5191,7 @@ mod tests {
                     RowDatasetVersionMeta::from_sequence(&created_b).unwrap(),
                 ),
                 last_updated_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
         ]);
 
@@ -5174,6 +5204,7 @@ mod tests {
             row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&new_seq))),
             physical_rows: Some(2),
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
             last_updated_at_version_meta: None,
         };
 

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -499,6 +499,7 @@ mod tests {
             physical_rows: Some(10),
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         }
     }
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -1683,6 +1683,7 @@ mod tests {
                 physical_rows: None,
                 last_updated_at_version_meta: None,
                 created_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
             Fragment {
                 id: 1,
@@ -1695,6 +1696,7 @@ mod tests {
                 physical_rows: None,
                 last_updated_at_version_meta: None,
                 created_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
         ];
 
@@ -1732,6 +1734,7 @@ mod tests {
                 physical_rows: None,
                 last_updated_at_version_meta: None,
                 created_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
             Fragment {
                 id: 1,
@@ -1744,6 +1747,7 @@ mod tests {
                 physical_rows: None,
                 last_updated_at_version_meta: None,
                 created_at_version_meta: None,
+                deleted_at_version_meta: None,
             },
         ];
         assert_eq!(manifest.fragments.as_ref(), &expected_fragments);
@@ -1834,6 +1838,7 @@ mod tests {
             physical_rows: Some(100),
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         };
         Manifest::new(
             schema,

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -135,6 +135,7 @@ impl ScopedFragmentRead {
             .with_row_address(self.projection.with_row_addr)
             .with_row_last_updated_at_version(self.projection.with_row_last_updated_at_version)
             .with_row_created_at_version(self.projection.with_row_created_at_version)
+            .with_row_deleted_at_version(self.projection.with_row_deleted_at_version)
             .with_scan_scheduler(self.scan_scheduler.clone())
             .with_reader_priority(self.priority);
         if let Some(file_reader_options) = &self.file_reader_options {
@@ -396,13 +397,7 @@ impl FilteredReadStream {
         // not general enough" false positives from rustc
         let frag_futs = fragments
             .iter()
-            .map(|frag| {
-                Result::Ok(Self::load_fragment(
-                    dataset.clone(),
-                    frag.clone(),
-                    options.with_deleted_rows,
-                ))
-            })
+            .map(|frag| Result::Ok(Self::load_fragment(dataset.clone(), frag.clone())))
             .collect::<Vec<_>>();
         let loaded_fragments = futures::stream::iter(frag_futs)
             // Cannot use unordered because we need to populate logical_offset based on user-provided order
@@ -465,17 +460,12 @@ impl FilteredReadStream {
         })
     }
 
-    async fn load_fragment(
-        dataset: Arc<Dataset>,
-        frag: Fragment,
-        include_deleted_rows: bool,
-    ) -> Result<LoadedFragment> {
+    async fn load_fragment(dataset: Arc<Dataset>, frag: Fragment) -> Result<LoadedFragment> {
         let file_fragment = FileFragment::new(dataset.clone(), frag.clone());
-        let deletion_vector = if include_deleted_rows {
-            None
-        } else {
-            file_fragment.get_deletion_vector().await?
-        };
+        // Always load the deletion vector. When include_deleted_rows is true, we still need DV
+        // to identify which physical rows were deleted so we can populate
+        // _row_deleted_at_version correctly and optionally mark _rowid as null.
+        let deletion_vector = file_fragment.get_deletion_vector().await?;
 
         let num_physical_rows = file_fragment.physical_rows().await? as u64;
         let (row_id_sequence, num_logical_rows) = if dataset.manifest.uses_stable_row_ids() {
@@ -552,8 +542,12 @@ impl FilteredReadStream {
                 break;
             }
 
-            let mut to_read: Vec<Range<u64>> =
-                Self::full_frag_range(*num_physical_rows, deletion_vector);
+            let mut to_read: Vec<Range<u64>> = if options.with_deleted_rows {
+                // When including deleted rows, do not prune by DV; read the full physical range.
+                vec![0..*num_physical_rows]
+            } else {
+                Self::full_frag_range(*num_physical_rows, deletion_vector)
+            };
 
             if let Some(range_before_filter) = &options.scan_range_before_filter {
                 let range_start = range_offset;
@@ -1017,11 +1011,6 @@ impl FilteredReadStream {
                         let global_metrics = global_metrics_clone.clone();
                         let scan_scheduler = scan_scheduler_clone.clone();
                         async move {
-                            // This isn't quite right.  It's counting I/O time in addition to
-                            // compute time.
-                            //
-                            // TODO: Modify the "read task" concept to have a way of marking when
-                            // the 'wait' portion of the task is complete.
                             let _timer =
                                 partition_metrics.baseline_metrics.elapsed_compute().timer();
                             let maybe_task = {
@@ -1088,6 +1077,8 @@ impl FilteredReadStream {
             .await?;
 
         if fragment_read_task.with_deleted_rows {
+            // Use make_deletions_null to retain physical rows for DV deletions while keeping
+            // system/meta columns intact and respecting non-nullability on data columns.
             fragment_reader.with_make_deletions_null();
         }
 
@@ -1168,7 +1159,6 @@ impl FilteredReadStream {
                                 "Error applying filter expression to batch: {e}"
                             ))
                         })?;
-                    // Drop any fields loaded purely for the purpose of applying the filter
                     Ok(batch.project_by_schema(output_schema.as_ref())?)
                 })
                 .boxed())
@@ -1536,14 +1526,9 @@ impl FilteredReadInternalPlan {
 impl FilteredReadExec {
     pub fn try_new(
         dataset: Arc<Dataset>,
-        mut options: FilteredReadOptions,
+        options: FilteredReadOptions,
         index_input: Option<Arc<dyn ExecutionPlan>>,
     ) -> Result<Self> {
-        if options.with_deleted_rows {
-            // Ensure we have the row id column if with_deleted_rows is set
-            options.projection = options.projection.with_row_id();
-        }
-
         if options.projection.is_empty() {
             return Err(Error::invalid_input_source("no columns were selected and with_row_id / with_row_address is false, there is nothing to scan"
                 .into()));
@@ -1663,14 +1648,12 @@ impl FilteredReadExec {
                     .clone()
                     .unwrap_or_else(|| dataset.fragments().clone());
 
-                let with_deleted_rows = options.with_deleted_rows;
                 let frag_futs = fragments
                     .iter()
                     .map(|frag| {
                         Result::Ok(FilteredReadStream::load_fragment(
                             dataset.clone(),
                             frag.clone(),
-                            with_deleted_rows,
                         ))
                     })
                     .collect::<Vec<_>>();

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -486,8 +486,11 @@ impl FragmentScanner {
                 let remainder_batch = if !remaining_fields.is_empty() {
                     let remaining_projection =
                         self.projection.project_by_ids(&remaining_fields, true);
+                    let mut remainder_reader = self.reader.clone();
+                    remainder_reader.with_row_address();
+                    remainder_reader.with_make_deletions_null();
                     Some(
-                        self.reader
+                        remainder_reader
                             .legacy_read_batch_projected(
                                 batch_id,
                                 selection.clone(),

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -292,7 +292,8 @@ impl LanceStream {
                             .with_row_last_updated_at_version(
                                 config.with_row_last_updated_at_version,
                             )
-                            .with_row_created_at_version(config.with_row_created_at_version);
+                            .with_row_created_at_version(config.with_row_created_at_version)
+                            .with_row_deleted_at_version(config.with_row_deleted_at_version);
                         if let Some(file_reader_options) = config.file_reader_options {
                             frag_config = frag_config.with_file_reader_options(file_reader_options);
                         }
@@ -390,7 +391,8 @@ impl LanceStream {
                             .with_row_last_updated_at_version(
                                 config.with_row_last_updated_at_version,
                             )
-                            .with_row_created_at_version(config.with_row_created_at_version),
+                            .with_row_created_at_version(config.with_row_created_at_version)
+                            .with_row_deleted_at_version(config.with_row_deleted_at_version),
                         config.with_make_deletions_null,
                         None,
                     ))
@@ -423,7 +425,8 @@ impl LanceStream {
                             .with_row_last_updated_at_version(
                                 config.with_row_last_updated_at_version,
                             )
-                            .with_row_created_at_version(config.with_row_created_at_version),
+                            .with_row_created_at_version(config.with_row_created_at_version)
+                            .with_row_deleted_at_version(config.with_row_deleted_at_version),
                         config.with_make_deletions_null,
                         None,
                     ))
@@ -490,6 +493,11 @@ impl RecordBatchStream for LanceStream {
                 .try_with_column((*lance_core::ROW_CREATED_AT_VERSION_FIELD).clone())
                 .unwrap();
         }
+        if self.config.with_row_deleted_at_version {
+            schema = schema
+                .try_with_column((*lance_core::ROW_DELETED_AT_VERSION_FIELD).clone())
+                .unwrap();
+        }
         Arc::new(schema)
     }
 }
@@ -504,6 +512,7 @@ pub struct LanceScanConfig {
     pub with_row_address: bool,
     pub with_row_last_updated_at_version: bool,
     pub with_row_created_at_version: bool,
+    pub with_row_deleted_at_version: bool,
     pub with_make_deletions_null: bool,
     pub ordered_output: bool,
     pub file_reader_options: Option<FileReaderOptions>,
@@ -522,6 +531,7 @@ impl Default for LanceScanConfig {
             with_row_address: false,
             with_row_last_updated_at_version: false,
             with_row_created_at_version: false,
+            with_row_deleted_at_version: false,
             with_make_deletions_null: false,
             ordered_output: false,
             file_reader_options: None,
@@ -607,6 +617,11 @@ impl LanceScanExec {
         if config.with_row_created_at_version {
             output_schema = output_schema
                 .try_with_column((*lance_core::ROW_CREATED_AT_VERSION_FIELD).clone())
+                .unwrap();
+        }
+        if config.with_row_deleted_at_version {
+            output_schema = output_schema
+                .try_with_column((*lance_core::ROW_DELETED_AT_VERSION_FIELD).clone())
                 .unwrap();
         }
         let output_schema = Arc::new(output_schema);

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -129,14 +129,25 @@ impl TakeStream {
                 ))
             })?;
 
-        let reader = Arc::new(
-            fragment
-                .open(
-                    &self.fields_to_take,
-                    FragReadConfig::default().with_scan_scheduler(self.scan_scheduler.clone()),
-                )
-                .await?,
-        );
+        let mut reader = fragment
+            .open(
+                &self.fields_to_take,
+                FragReadConfig::default().with_scan_scheduler(self.scan_scheduler.clone()),
+            )
+            .await?;
+
+        // If the output schema includes the deleted-at-version column, we must not
+        // filter out deleted rows when taking additional columns. Instead, preserve
+        // row count and make deleted rows null for data columns.
+        if self
+            .output_schema
+            .field_with_name(lance_core::ROW_DELETED_AT_VERSION)
+            .is_ok()
+        {
+            reader.with_make_deletions_null();
+        }
+
+        let reader = Arc::new(reader);
 
         let mut readers = self.readers_cache.lock().unwrap();
         readers.insert(fragment_id, reader.clone());

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -246,6 +246,7 @@ impl TestDatasetGenerator {
             physical_rows: Some(batch.num_rows()),
             last_updated_at_version_meta: None,
             created_at_version_meta: None,
+            deleted_at_version_meta: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `_row_deleted_at_version` system column to track when rows are deleted, following the existing pattern of `_row_created_at_version` and `_row_last_updated_at_version`
- Add `DatasetDelta::get_deleted_rows()` API to query rows deleted between two versions
- Add protobuf `deleted_at_version_sequence` field to `DataFragment` for persistence

Continuation of https://github.com/lance-format/lance/pull/5002, rebased and reviewed with bug fixes.