### PR TITLE
feat: unify WalAppender into ShardWriter via enable_memtable mode

### DIFF
--- a/python/src/mem_wal.rs
+++ b/python/src/mem_wal.rs
@@ -201,7 +201,7 @@ impl PyRegionWriter {
                 // Snapshot stats before close so the captured state reflects
                 // what was written, not any internal bookkeeping done by close().
                 let stats_snapshot = stats_handle.snapshot();
-                let memtable_stats_before_close = writer.memtable_stats().await;
+                let memtable_stats_before_close = writer.memtable_stats().await?;
                 writer.close().await?;
                 let closed_memtable_stats = closed_memtable_stats(memtable_stats_before_close);
                 let mut closed_guard = closed_state.lock().await;
@@ -255,7 +255,7 @@ impl PyRegionWriter {
             .block_on(Some(py), async move {
                 let guard = inner.lock().await;
                 match guard.as_ref() {
-                    Some(w) => Ok(w.memtable_stats().await),
+                    Some(w) => w.memtable_stats().await,
                     None => {
                         let closed_guard = closed_state.lock().await;
                         closed_guard
@@ -267,7 +267,7 @@ impl PyRegionWriter {
                     }
                 }
             })?
-            .map_err(|e| PyIOError::new_err(e.to_string()))?;
+            .map_err(|e: lance::Error| PyIOError::new_err(e.to_string()))?;
 
         memtable_stats_to_pydict(py, &stats)
     }
@@ -296,7 +296,7 @@ impl PyRegionWriter {
                 let guard = inner.lock().await;
                 match guard.as_ref() {
                     Some(w) => {
-                        let active_ref = w.active_memtable_ref().await;
+                        let active_ref = w.active_memtable_ref().await?;
                         let writer_snapshot = w
                             .manifest()
                             .await?

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -210,5 +210,9 @@ harness = false
 name = "mem_wal_read"
 harness = false
 
+[[bench]]
+name = "mem_wal_replay"
+harness = false
+
 [lints]
 workspace = true

--- a/rust/lance/benches/mem_wal_read.rs
+++ b/rust/lance/benches/mem_wal_read.rs
@@ -307,7 +307,7 @@ async fn setup_benchmark(
     let manifest = writer.manifest().await.unwrap();
 
     // Get active memtable reference
-    let active_memtable_ref = writer.active_memtable_ref().await;
+    let active_memtable_ref = writer.active_memtable_ref().await.unwrap();
 
     // Build shard snapshot
     let mut shard_snapshot = ShardSnapshot::new(shard_id);
@@ -906,7 +906,7 @@ async fn setup_vector_benchmark(
     }
 
     let manifest = writer.manifest().await.unwrap();
-    let active_memtable_ref = writer.active_memtable_ref().await;
+    let active_memtable_ref = writer.active_memtable_ref().await.unwrap();
 
     let mut shard_snapshot = ShardSnapshot::new(shard_id);
     if let Some(ref m) = manifest {

--- a/rust/lance/benches/mem_wal_replay.rs
+++ b/rust/lance/benches/mem_wal_replay.rs
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Benchmark for MemWAL replay throughput.
+//!
+//! Two scenarios:
+//! 1. **Raw `WalTailer::read_entry`**: time the cost of pulling N WAL
+//!    entries off storage one at a time. This is the lower bound for any
+//!    higher-level replay (e.g. `ShardWriter::open` MemTable-mode replay).
+//! 2. **`ShardWriter::open` end-to-end replay** in MemTable mode: open a
+//!    shard whose previous writer left N un-flushed WAL entries on disk,
+//!    measuring how long it takes for `open` to return (replay reads +
+//!    MemTable inserts + index updates).
+//!
+//! ## Running against S3
+//!
+//! ```bash
+//! export AWS_DEFAULT_REGION=us-east-1
+//! export DATASET_PREFIX=s3://your-bucket/bench/mem_wal_replay
+//! cargo bench --bench mem_wal_replay
+//! ```
+//!
+//! ## Running against local filesystem (with temp directory)
+//!
+//! ```bash
+//! cargo bench --bench mem_wal_replay
+//! ```
+//!
+//! ## Configuration
+//!
+//! - `DATASET_PREFIX`: Base URI for datasets (optional, e.g. s3://bucket/prefix or /tmp/bench).
+//!   If not set, uses a temporary directory.
+//! - `NUM_ENTRIES`: Number of WAL entries to write before the replay run (default: 1000)
+//! - `BATCH_SIZE`: Rows per WAL entry (default: 20)
+//! - `SAMPLE_SIZE`: Number of benchmark iterations (default: 10, minimum: 10)
+
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow_array::{Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use lance::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig, ShardWriterConfig, WalTailer};
+use lance::dataset::{Dataset, WriteParams};
+use lance_io::object_store::ObjectStore;
+use uuid::Uuid;
+
+use arrow_array::RecordBatchIterator;
+
+/// Default number of WAL entries to write before replay.
+const DEFAULT_NUM_ENTRIES: usize = 1000;
+
+/// Default rows per WAL entry.
+const DEFAULT_BATCH_SIZE: usize = 20;
+
+fn get_num_entries() -> usize {
+    std::env::var("NUM_ENTRIES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_NUM_ENTRIES)
+}
+
+fn get_batch_size() -> usize {
+    std::env::var("BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_BATCH_SIZE)
+}
+
+fn get_sample_size() -> usize {
+    std::env::var("SAMPLE_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10)
+        .max(10)
+}
+
+fn get_dataset_prefix() -> String {
+    std::env::var("DATASET_PREFIX").unwrap_or_else(|_| {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+        let path = temp_dir.path().to_string_lossy().to_string();
+        std::mem::forget(temp_dir);
+        format!("file://{}", path)
+    })
+}
+
+fn get_storage_label(prefix: &str) -> &'static str {
+    if prefix.starts_with("s3://") {
+        "s3"
+    } else if prefix.starts_with("gs://") {
+        "gcs"
+    } else if prefix.starts_with("az://") {
+        "azure"
+    } else {
+        "local"
+    }
+}
+
+fn create_test_schema() -> Arc<ArrowSchema> {
+    let id_meta: std::collections::HashMap<String, String> = [(
+        "lance-schema:unenforced-primary-key".to_string(),
+        "1".to_string(),
+    )]
+    .into_iter()
+    .collect();
+    Arc::new(ArrowSchema::new(vec![
+        Field::new("id", DataType::Int64, false).with_metadata(id_meta),
+        Field::new("text", DataType::Utf8, true),
+    ]))
+}
+
+fn create_test_batch(schema: &Arc<ArrowSchema>, start_id: i64, num_rows: usize) -> RecordBatch {
+    let ids: Vec<i64> = (start_id..start_id + num_rows as i64).collect();
+    let texts: Vec<String> = (0..num_rows)
+        .map(|i| format!("row_{}", start_id as usize + i))
+        .collect();
+    RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(StringArray::from(texts)),
+        ],
+    )
+    .unwrap()
+}
+
+/// Build a base Lance dataset and initialize MemWAL on it. Returns the
+/// dataset URI.
+async fn setup_dataset(schema: &Arc<ArrowSchema>, name: &str, dataset_prefix: &str) -> String {
+    let dataset_uri = if let Some(stripped) = dataset_prefix.strip_prefix("file://") {
+        format!("file://{}/{}", stripped, name)
+    } else {
+        format!("{}/{}", dataset_prefix.trim_end_matches('/'), name)
+    };
+
+    // Best-effort delete in case a prior run left state behind.
+    if let Ok((object_store, base)) = ObjectStore::from_uri(&dataset_uri).await {
+        let _ = object_store.remove_dir_all(base).await;
+    }
+
+    // Seed an empty Lance dataset (one tiny batch). Keeps `Dataset::open`
+    // happy and lets us call `initialize_mem_wal`.
+    let initial = create_test_batch(schema, -1, 1);
+    let reader = RecordBatchIterator::new(vec![Ok(initial)].into_iter(), schema.clone());
+    let mut dataset = Dataset::write(
+        reader,
+        &dataset_uri,
+        Some(WriteParams {
+            mode: lance::dataset::WriteMode::Create,
+            ..Default::default()
+        }),
+    )
+    .await
+    .expect("Failed to seed dataset");
+
+    dataset
+        .initialize_mem_wal(MemWalConfig {
+            shard_spec: None,
+            maintained_indexes: vec![],
+        })
+        .await
+        .expect("Failed to initialize MemWAL");
+
+    dataset_uri
+}
+
+/// Pre-populate a shard with `num_entries` durable WAL entries, then
+/// drop the writer **without** calling `close` so the active MemTable
+/// is not flushed. The WAL files persist on storage and become input
+/// to the replay benchmark.
+async fn populate_shard_wal(
+    dataset_uri: &str,
+    schema: &Arc<ArrowSchema>,
+    shard_id: Uuid,
+    num_entries: usize,
+    batch_size: usize,
+) {
+    let dataset = Dataset::open(dataset_uri).await.unwrap();
+    let mut config = ShardWriterConfig::new(shard_id);
+    config.durable_write = true;
+    config.sync_indexed_write = false;
+    let writer = dataset.mem_wal_writer(shard_id, config).await.unwrap();
+
+    for i in 0..num_entries {
+        let batch = create_test_batch(schema, (i * batch_size) as i64, batch_size);
+        writer.put(vec![batch]).await.unwrap();
+    }
+
+    // Intentionally drop without close() — leaves the WAL entries on
+    // disk for replay.
+    drop(writer);
+}
+
+/// Bench: raw `WalTailer::read_entry` throughput. Measures how long it
+/// takes to walk N entries from position 0 to the tip, end-to-end.
+async fn run_tailer_replay(
+    object_store: Arc<ObjectStore>,
+    base_path: object_store::path::Path,
+    shard_id: Uuid,
+    expected_entries: usize,
+) -> usize {
+    let tailer = WalTailer::new(object_store, base_path, shard_id);
+    let mut count = 0usize;
+    let mut pos = 0u64;
+    loop {
+        match tailer.read_entry(pos).await.unwrap() {
+            None => break,
+            Some(_entry) => {
+                count += 1;
+                pos += 1;
+            }
+        }
+    }
+    assert_eq!(
+        count, expected_entries,
+        "tailer saw fewer entries than written"
+    );
+    count
+}
+
+/// Bench: full `ShardWriter::open` + replay path. Open the shard with the
+/// pre-populated WAL, time how long until `open` returns. The returned
+/// writer is closed afterwards so the next iteration is independent.
+async fn run_open_replay(dataset_uri: &str, shard_id: Uuid) -> Duration {
+    let dataset = Dataset::open(dataset_uri).await.unwrap();
+    let config = ShardWriterConfig::new(shard_id);
+    let start = Instant::now();
+    let writer = dataset.mem_wal_writer(shard_id, config).await.unwrap();
+    let elapsed = start.elapsed();
+    // Drop without close() so the next iteration sees the same WAL state.
+    drop(writer);
+    elapsed
+}
+
+fn bench_replay(c: &mut Criterion) {
+    let _ = env_logger::try_init();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    let dataset_prefix = get_dataset_prefix();
+    let storage_label = get_storage_label(&dataset_prefix);
+    let num_entries = get_num_entries();
+    let batch_size = get_batch_size();
+    let sample_size = get_sample_size();
+    let total_rows = num_entries * batch_size;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let schema = create_test_schema();
+
+    println!("=== MemWAL Replay Benchmark Setup ===");
+    println!("Storage: {}", dataset_prefix);
+    println!("Schema: id (Int64, primary key), text (Utf8)");
+    println!("Num WAL entries: {}", num_entries);
+    println!("Batch size: {} rows/entry", batch_size);
+    println!("Total rows replayed: {}", total_rows);
+    println!("Iterations: {}", sample_size);
+    println!();
+
+    // Setup: one dataset for all replay variants. Each variant uses a fresh
+    // shard so they don't interfere.
+    let dataset_uri = rt.block_on(setup_dataset(&schema, "replay_dataset", &dataset_prefix));
+
+    // Pre-populate two shards: one for the raw-tailer bench, one for the
+    // open-replay bench. Each iteration of the open-replay bench drops the
+    // writer without close(), so the WAL state is unchanged across
+    // iterations and the bench is repeatable.
+    let tailer_shard_id = Uuid::new_v4();
+    rt.block_on(populate_shard_wal(
+        &dataset_uri,
+        &schema,
+        tailer_shard_id,
+        num_entries,
+        batch_size,
+    ));
+    let open_shard_id = Uuid::new_v4();
+    rt.block_on(populate_shard_wal(
+        &dataset_uri,
+        &schema,
+        open_shard_id,
+        num_entries,
+        batch_size,
+    ));
+
+    let (object_store, base_path) = rt.block_on(ObjectStore::from_uri(&dataset_uri)).unwrap();
+
+    let mut group = c.benchmark_group("MemWAL Replay");
+    group.throughput(Throughput::Elements(num_entries as u64));
+    group.sample_size(sample_size);
+    group.warm_up_time(Duration::from_secs(1));
+
+    // 1. Raw tailer read throughput.
+    let label_tailer = format!("{} entries (tailer, {})", num_entries, storage_label);
+    println!("Running: {}", label_tailer);
+    group.bench_with_input(
+        BenchmarkId::new("WalTailer::read_entry", &label_tailer),
+        &num_entries,
+        |b, &expected| {
+            let object_store = object_store.clone();
+            let base_path = base_path.clone();
+            b.to_async(&rt).iter_custom(|iters| {
+                let object_store = object_store.clone();
+                let base_path = base_path.clone();
+                async move {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let start = Instant::now();
+                        let _count = run_tailer_replay(
+                            object_store.clone(),
+                            base_path.clone(),
+                            tailer_shard_id,
+                            expected,
+                        )
+                        .await;
+                        total += start.elapsed();
+                    }
+                    total
+                }
+            })
+        },
+    );
+
+    // 2. End-to-end ShardWriter::open replay.
+    let label_open = format!("{} entries (open, {})", num_entries, storage_label);
+    println!("Running: {}", label_open);
+    group.bench_with_input(
+        BenchmarkId::new("ShardWriter::open replay", &label_open),
+        &num_entries,
+        |b, _| {
+            let dataset_uri = dataset_uri.clone();
+            b.to_async(&rt).iter_custom(|iters| {
+                let dataset_uri = dataset_uri.clone();
+                async move {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let elapsed = run_open_replay(&dataset_uri, open_shard_id).await;
+                        total += elapsed;
+                    }
+                    total
+                }
+            })
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().significance_level(0.05);
+    targets = bench_replay
+);
+criterion_main!(benches);

--- a/rust/lance/benches/mem_wal_write.rs
+++ b/rust/lance/benches/mem_wal_write.rs
@@ -599,6 +599,7 @@ fn bench_lance_memwal_write(c: &mut Criterion) {
                                     backpressure_log_interval: default_config
                                         .backpressure_log_interval,
                                     stats_log_interval: default_config.stats_log_interval,
+                                    enable_memtable: default_config.enable_memtable,
                                 };
 
                                 // Get writer through Dataset API (index configs loaded automatically)

--- a/rust/lance/benches/mem_wal_write.rs
+++ b/rust/lance/benches/mem_wal_write.rs
@@ -39,6 +39,13 @@
 //!     - Available indexes: id_btree, text_fts, vector_ivfpq (all created on base table)
 //!     - Examples: `id_btree`, `id_btree,text_fts`, `vector_ivfpq`
 //!     - Use `none` to disable MemWAL index maintenance entirely
+//! - `ENABLE_MEMTABLE`: yes/no/both (default: yes) - whether the writer maintains an in-memory MemTable.
+//!   `yes` uses the standard MemTable + WAL pipeline (with optional indexes).
+//!   `no` uses WAL-only mode (no MemTable, no indexes, no Lance flushes; pure WAL throughput).
+//!   `both` runs each combination twice, once per mode, side-by-side.
+//!   When `no` or `both`, the WAL-only branch always runs with
+//!   `MEMWAL_MAINTAINED_INDEXES=none` and skips `INDEXED_WRITE=yes`
+//!   (sync-indexed writes require a MemTable).
 //! - `SAMPLE_SIZE`: Number of benchmark iterations (default: 10, minimum: 10)
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
@@ -115,6 +122,13 @@ fn get_durable_write_options() -> Vec<bool> {
 /// Get indexed write settings from environment.
 fn get_indexed_write_options() -> Vec<bool> {
     parse_yes_no_both("INDEXED_WRITE", "no")
+}
+
+/// Get enable_memtable settings from environment. Default `yes` keeps
+/// existing benchmark behavior; `no` runs WAL-only mode; `both` runs both
+/// modes side-by-side for comparison.
+fn get_enable_memtable_options() -> Vec<bool> {
+    parse_yes_no_both("ENABLE_MEMTABLE", "yes")
 }
 
 /// Get max WAL buffer size from environment or use default.
@@ -427,23 +441,30 @@ fn build_label(
     batch_size: usize,
     durable: bool,
     indexed: bool,
+    enable_memtable: bool,
     storage: &str,
 ) -> String {
     let durable_str = if durable { "durable" } else { "nondurable" };
     // sync_indexed_write controls sync vs async index updates
     let indexed_str = if indexed { "sync_idx" } else { "async_idx" };
+    let mode_str = if enable_memtable {
+        "memtable"
+    } else {
+        "wal_only"
+    };
     format!(
-        "{}x{} {} {} ({})",
-        num_batches, batch_size, durable_str, indexed_str, storage
+        "{}x{} {} {} {} ({})",
+        num_batches, batch_size, mode_str, durable_str, indexed_str, storage
     )
 }
 
 /// Build dataset name prefix from config options.
-fn build_name_prefix(durable: bool, indexed: bool) -> String {
+fn build_name_prefix(durable: bool, indexed: bool, enable_memtable: bool) -> String {
     let d = if durable { "d" } else { "nd" };
     // sync_indexed_write: sync (si) vs async (ai)
     let i = if indexed { "si" } else { "ai" };
-    format!("{}_{}", d, i)
+    let m = if enable_memtable { "mt" } else { "wo" };
+    format!("{}_{}_{}", m, d, i)
 }
 
 /// Benchmark Lance MemWAL write throughput.
@@ -468,6 +489,7 @@ fn bench_lance_memwal_write(c: &mut Criterion) {
 
     let durable_options = get_durable_write_options();
     let indexed_options = get_indexed_write_options();
+    let enable_memtable_options = get_enable_memtable_options();
     let max_wal_buffer_size = get_max_wal_buffer_size();
     let max_flush_interval = get_max_flush_interval();
     let max_memtable_size = get_max_memtable_size();
@@ -524,44 +546,72 @@ fn bench_lance_memwal_write(c: &mut Criterion) {
     group.warm_up_time(Duration::from_secs(1));
 
     // Generate benchmarks for all combinations
-    for &durable in &durable_options {
-        for &indexed in &indexed_options {
-            let label = build_label(num_batches, batch_size, durable, indexed, storage_label);
-            let name_prefix = build_name_prefix(durable, indexed);
+    for &enable_memtable in &enable_memtable_options {
+        for &durable in &durable_options {
+            for &indexed in &indexed_options {
+                if !enable_memtable && indexed {
+                    eprintln!(
+                        "Skipping wal_only + sync_idx (sync_indexed_write requires a MemTable)"
+                    );
+                    continue;
+                }
 
-            // Create dataset ONCE before benchmark iterations
-            // Each iteration will use a different shard on the same dataset
-            let dataset = rt.block_on(create_dataset(
-                &schema,
-                &name_prefix,
-                vector_dim,
-                &maintained_indexes,
-                &dataset_prefix,
-            ));
-            let dataset_uri = dataset.uri().to_string();
+                let label = build_label(
+                    num_batches,
+                    batch_size,
+                    durable,
+                    indexed,
+                    enable_memtable,
+                    storage_label,
+                );
+                let name_prefix = build_name_prefix(durable, indexed, enable_memtable);
 
-            // Pre-generate all batches before timing (outside iter_custom)
-            let batches: Arc<Vec<RecordBatch>> = Arc::new(
-                (0..num_batches)
-                    .map(|i| {
-                        create_test_batch(&schema, (i * batch_size) as i64, batch_size, vector_dim)
-                    })
-                    .collect(),
-            );
+                // WAL-only mode never uses indexes; force the dataset
+                // setup to skip the MemWAL index list.
+                let effective_indexes: Vec<String> = if enable_memtable {
+                    maintained_indexes.clone()
+                } else {
+                    Vec::new()
+                };
 
-            println!("Running: {}", label);
+                // Create dataset ONCE before benchmark iterations
+                // Each iteration will use a different shard on the same dataset
+                let dataset = rt.block_on(create_dataset(
+                    &schema,
+                    &name_prefix,
+                    vector_dim,
+                    &effective_indexes,
+                    &dataset_prefix,
+                ));
+                let dataset_uri = dataset.uri().to_string();
 
-            // Track if we've printed stats (only print once across all samples)
-            let stats_printed = Arc::new(AtomicBool::new(false));
+                // Pre-generate all batches before timing (outside iter_custom)
+                let batches: Arc<Vec<RecordBatch>> = Arc::new(
+                    (0..num_batches)
+                        .map(|i| {
+                            create_test_batch(
+                                &schema,
+                                (i * batch_size) as i64,
+                                batch_size,
+                                vector_dim,
+                            )
+                        })
+                        .collect(),
+                );
 
-            group.bench_with_input(
-                BenchmarkId::new("Lance MemWAL", &label),
-                &(batch_size, num_batches, durable, indexed, row_size_bytes),
-                |b, &(_batch_size, _num_batches, durable, indexed, row_size_bytes)| {
-                    let dataset_uri = dataset_uri.clone();
-                    let batches = batches.clone();
-                    let stats_printed = stats_printed.clone();
-                    b.to_async(&rt).iter_custom(|iters| {
+                println!("Running: {}", label);
+
+                // Track if we've printed stats (only print once across all samples)
+                let stats_printed = Arc::new(AtomicBool::new(false));
+
+                group.bench_with_input(
+                    BenchmarkId::new("Lance MemWAL", &label),
+                    &(batch_size, num_batches, durable, indexed, row_size_bytes),
+                    |b, &(_batch_size, _num_batches, durable, indexed, row_size_bytes)| {
+                        let dataset_uri = dataset_uri.clone();
+                        let batches = batches.clone();
+                        let stats_printed = stats_printed.clone();
+                        b.to_async(&rt).iter_custom(|iters| {
                         let dataset_uri = dataset_uri.clone();
                         let batches = batches.clone();
                         let stats_printed = stats_printed.clone();
@@ -599,7 +649,7 @@ fn bench_lance_memwal_write(c: &mut Criterion) {
                                     backpressure_log_interval: default_config
                                         .backpressure_log_interval,
                                     stats_log_interval: default_config.stats_log_interval,
-                                    enable_memtable: default_config.enable_memtable,
+                                    enable_memtable,
                                 };
 
                                 // Get writer through Dataset API (index configs loaded automatically)
@@ -648,8 +698,9 @@ fn bench_lance_memwal_write(c: &mut Criterion) {
                             total_duration
                         }
                     })
-                },
-            );
+                    },
+                );
+            }
         }
     }
 

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -8,6 +8,7 @@
 
 use std::io::Cursor;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -119,18 +120,45 @@ pub struct WalFlushResult {
     pub wal_bytes: usize,
 }
 
-/// Message to trigger a WAL flush for a specific batch store.
+/// Source for a WAL flush — either a `BatchStore` range (MemTable mode) or
+/// a drainable in-memory pending queue (WAL-only mode).
+pub enum WalFlushSource {
+    /// MemTable mode: read a `[max_flushed+1, end_batch_position)` range
+    /// from a `BatchStore`. Indexes are updated in parallel with the WAL
+    /// append.
+    BatchStore {
+        batch_store: Arc<BatchStore>,
+        indexes: Option<Arc<IndexStore>>,
+    },
+    /// WAL-only mode: drain all pending batches from the shared
+    /// `WalOnlyState`. There are no in-memory indexes to update.
+    WalOnly { state: Arc<WalOnlyState> },
+}
+
+impl WalFlushSource {
+    fn pending_count(&self) -> usize {
+        match self {
+            Self::BatchStore { batch_store, .. } => batch_store.pending_wal_flush_count(),
+            Self::WalOnly { state } => state
+                .pending
+                .lock()
+                .ok()
+                .map(|p| p.batches.len())
+                .unwrap_or(0),
+        }
+    }
+}
+
+/// Message to trigger a WAL flush.
 ///
-/// This unified message handles both:
-/// - Normal periodic flushes (specific end_batch_position)
-/// - Freeze-time flushes (end_batch_position = usize::MAX to flush all)
+/// Carries a `source` describing where to read batches from (BatchStore range
+/// or pending queue) and an optional `done` cell for completion notification.
 pub struct TriggerWalFlush {
-    /// The batch store to flush from.
-    pub batch_store: Arc<BatchStore>,
-    /// The indexes to update in parallel (for WAL-coupled index updates).
-    pub indexes: Option<Arc<IndexStore>>,
-    /// End batch position (exclusive) - flush batches after max_wal_flushed_batch_position up to this.
-    /// Use usize::MAX to flush all pending batches.
+    pub source: WalFlushSource,
+    /// End batch position (exclusive). For `BatchStore`, flush batches after
+    /// `max_flushed_batch_position` up to this. For `WalOnly`, indicates the
+    /// position the durability watermark must reach for callers waiting on
+    /// this flush. Use `usize::MAX` to flush all pending batches.
     pub end_batch_position: usize,
     /// Optional cell to write completion result.
     /// Uses Result<WalFlushResult, String> since Error doesn't implement Clone.
@@ -140,37 +168,147 @@ pub struct TriggerWalFlush {
 impl std::fmt::Debug for TriggerWalFlush {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TriggerWalFlush")
-            .field(
-                "pending_batches",
-                &self.batch_store.pending_wal_flush_count(),
-            )
+            .field("pending_batches", &self.source.pending_count())
             .field("end_batch_position", &self.end_batch_position)
             .finish()
     }
 }
 
-/// Buffer for WAL operations.
+/// Drainable pending-batch queue used by `ShardWriter` in WAL-only mode.
 ///
-/// Durability is tracked via a watch channel that broadcasts the durable watermark.
-/// The actual flush watermark is stored in `BatchStore.max_flushed_batch_position`.
+/// Lives in `wal.rs` (not `write.rs`) so the WAL flush plumbing can name it
+/// without a circular dependency.
+#[derive(Debug, Default)]
+pub struct WalOnlyState {
+    pub pending: StdMutex<PendingWalBatches>,
+}
+
+#[derive(Debug, Default)]
+pub struct PendingWalBatches {
+    /// Batches accumulated since the last successful flush. Each entry
+    /// pairs the `RecordBatch` with its memory footprint so we can keep
+    /// `estimated_bytes` accurate when the front of the queue is committed
+    /// after a successful append.
+    batches: Vec<(RecordBatch, usize)>,
+    /// Sum of memory footprints of batches currently in `batches`. Drives
+    /// the size-based flush trigger.
+    estimated_bytes: usize,
+    /// Cumulative count of batches pushed since the writer was opened.
+    /// Drives the monotonic batch positions returned in `WriteResult`.
+    next_batch_position: usize,
+}
+
+/// Snapshot of the pending queue used by the flush handler to attempt a
+/// WAL append without removing the batches first. On success the handler
+/// calls `WalOnlyState::commit_flushed(snapshot.count)` to remove the front
+/// of the queue; on failure the batches stay in the queue so a later flush
+/// can retry them, instead of being silently lost.
+#[derive(Debug)]
+pub struct WalOnlySnapshot {
+    pub batches: Vec<RecordBatch>,
+    pub count: usize,
+}
+
+impl WalOnlyState {
+    /// Push batches and return the assigned `[start, end)` position range.
+    /// Holds the lock for the entire push so position assignment is atomic.
+    pub fn push(&self, batches: Vec<RecordBatch>) -> std::ops::Range<usize> {
+        let mut pending = self
+            .pending
+            .lock()
+            .expect("WalOnlyState pending mutex poisoned");
+        let start = pending.next_batch_position;
+        let count = batches.len();
+        for batch in batches.into_iter() {
+            let bytes = batch.get_array_memory_size();
+            pending.estimated_bytes += bytes;
+            pending.batches.push((batch, bytes));
+        }
+        pending.next_batch_position += count;
+        start..pending.next_batch_position
+    }
+
+    /// Snapshot the pending queue for an attempted WAL append. Clones the
+    /// `RecordBatch` handles (cheap; `RecordBatch` is `Arc`-backed) without
+    /// removing them. The caller must call `commit_flushed(snapshot.count)`
+    /// on success; on failure, the batches remain in the queue for the next
+    /// flush attempt.
+    pub fn snapshot_pending(&self) -> WalOnlySnapshot {
+        let pending = self
+            .pending
+            .lock()
+            .expect("WalOnlyState pending mutex poisoned");
+        let batches: Vec<RecordBatch> = pending.batches.iter().map(|(b, _)| b.clone()).collect();
+        let count = batches.len();
+        WalOnlySnapshot { batches, count }
+    }
+
+    /// Remove the first `count` batches from the pending queue and decrement
+    /// `estimated_bytes` accordingly. Called by the flush handler after the
+    /// WAL append for those batches succeeded.
+    pub fn commit_flushed(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        let mut pending = self
+            .pending
+            .lock()
+            .expect("WalOnlyState pending mutex poisoned");
+        let take = count.min(pending.batches.len());
+        let bytes_removed: usize = pending.batches.drain(0..take).map(|(_, bytes)| bytes).sum();
+        pending.estimated_bytes = pending.estimated_bytes.saturating_sub(bytes_removed);
+    }
+
+    /// Pending batch count (for stats / triggers).
+    pub fn batch_count(&self) -> usize {
+        self.pending
+            .lock()
+            .ok()
+            .map(|p| p.batches.len())
+            .unwrap_or(0)
+    }
+
+    /// Pending bytes (for size-based flush trigger).
+    pub fn estimated_size(&self) -> usize {
+        self.pending
+            .lock()
+            .ok()
+            .map(|p| p.estimated_bytes)
+            .unwrap_or(0)
+    }
+
+    /// Position the next pushed batch will get. Equivalent to "total pushed
+    /// since open."
+    pub fn next_batch_position(&self) -> usize {
+        self.pending
+            .lock()
+            .ok()
+            .map(|p| p.next_batch_position)
+            .unwrap_or(0)
+    }
+}
+
+/// Background WAL flush coordinator for `ShardWriter`.
+///
+/// `WalFlusher` owns the durability watermark watch channel, the trigger
+/// channel for the background flush handler, and the wal-flush completion
+/// cell used by backpressure waiters. It does **not** own the object store,
+/// the writer epoch, or the next-position counter — those live on the
+/// shared `WalAppender`. The flusher delegates the actual WAL write to the
+/// appender, optionally running a parallel index update in MemTable mode.
 pub struct WalFlusher {
     /// Watch channel sender for durable watermark.
     /// Broadcasts the highest batch_position that is now durable.
     durable_watermark_tx: watch::Sender<usize>,
     /// Watch channel receiver for creating new watchers.
     durable_watermark_rx: watch::Receiver<usize>,
-    /// Object store for writing WAL files.
-    object_store: Option<Arc<ObjectStore>>,
-    /// Shard ID.
+    /// Underlying WAL append primitive — owns object store, epoch, and
+    /// position discovery.
+    wal_appender: Arc<WalAppender>,
+    /// Shard ID (cached for tracing; same as `wal_appender.shard_id()`).
     shard_id: Uuid,
-    /// Writer epoch (stored in WAL entries for fencing).
-    writer_epoch: u64,
-    /// Next WAL entry ID to use.
-    next_wal_entry_position: AtomicU64,
     /// Channel to send flush messages.
     flush_tx: Option<mpsc::UnboundedSender<TriggerWalFlush>>,
-    /// WAL directory path.
-    wal_dir: Path,
     /// Cell for WAL flush completion notification.
     /// Created at construction and recreated after each flush.
     /// Used by backpressure to wait for WAL flushes.
@@ -178,21 +316,13 @@ pub struct WalFlusher {
 }
 
 impl WalFlusher {
-    /// Create a new WAL flusher.
+    /// Create a new WAL flusher backed by an existing `WalAppender`.
     ///
-    /// # Arguments
-    ///
-    /// * `base_path` - Base path within the object store (from ObjectStore::from_uri)
-    /// * `shard_id` - Shard UUID
-    /// * `writer_epoch` - Current writer epoch
-    /// * `next_wal_entry_position` - Next WAL entry ID (from recovery or 1 for new shard)
-    pub fn new(
-        base_path: &Path,
-        shard_id: Uuid,
-        writer_epoch: u64,
-        next_wal_entry_position: u64,
-    ) -> Self {
-        let wal_dir = shard_wal_path(base_path, &shard_id);
+    /// The appender owns object store, epoch, and position state. The
+    /// flusher adds the durability watermark, trigger channel, and
+    /// completion cell on top.
+    pub fn new(wal_appender: Arc<WalAppender>) -> Self {
+        let shard_id = wal_appender.shard_id();
         // Initialize durable watermark at 0 (no batches durable yet)
         let (durable_watermark_tx, durable_watermark_rx) = watch::channel(0);
         // Create initial WAL flush cell for backpressure
@@ -200,24 +330,21 @@ impl WalFlusher {
         Self {
             durable_watermark_tx,
             durable_watermark_rx,
-            object_store: None,
+            wal_appender,
             shard_id,
-            writer_epoch,
-            next_wal_entry_position: AtomicU64::new(next_wal_entry_position),
             flush_tx: None,
-            wal_dir,
             wal_flush_cell: std::sync::Mutex::new(Some(wal_flush_cell)),
         }
-    }
-
-    /// Set the object store for WAL file operations.
-    pub fn set_object_store(&mut self, object_store: Arc<ObjectStore>) {
-        self.object_store = Some(object_store);
     }
 
     /// Set the flush channel for background flush handler.
     pub fn set_flush_channel(&mut self, tx: mpsc::UnboundedSender<TriggerWalFlush>) {
         self.flush_tx = Some(tx);
+    }
+
+    /// Underlying WAL appender (for tests and debug accessors).
+    pub fn wal_appender(&self) -> &Arc<WalAppender> {
+        &self.wal_appender
     }
 
     /// Track a batch for WAL durability.
@@ -262,25 +389,23 @@ impl WalFlusher {
         *guard = Some(WatchableOnceCell::new());
     }
 
-    /// Trigger an immediate flush for a specific batch store up to a specific batch ID.
+    /// Trigger an immediate WAL flush.
     ///
     /// # Arguments
     ///
-    /// * `batch_store` - The batch store to flush from
-    /// * `indexes` - Optional indexes to update in parallel with WAL I/O
-    /// * `end_batch_position` - End batch ID (exclusive). Use usize::MAX to flush all pending.
-    /// * `done` - Optional cell to write completion result
+    /// * `source` - Where the flush should pull batches from (BatchStore range or pending queue).
+    /// * `end_batch_position` - End batch position (exclusive); for `BatchStore`, the
+    ///   range to flush; for `WalOnly`, the watermark callers are waiting for.
+    /// * `done` - Optional cell to write completion result.
     pub fn trigger_flush(
         &self,
-        batch_store: Arc<BatchStore>,
-        indexes: Option<Arc<IndexStore>>,
+        source: WalFlushSource,
         end_batch_position: usize,
         done: Option<WatchableOnceCell<std::result::Result<WalFlushResult, String>>>,
     ) -> Result<()> {
         if let Some(tx) = &self.flush_tx {
             tx.send(TriggerWalFlush {
-                batch_store,
-                indexes,
+                source,
                 end_batch_position,
                 done,
             })
@@ -289,27 +414,36 @@ impl WalFlusher {
         Ok(())
     }
 
-    /// Flush batches up to a specific end_batch_position with index updates.
+    /// Flush from the given source up to `end_batch_position`, optionally
+    /// updating in-memory indexes in parallel with the WAL append.
     ///
-    /// This method flushes batches from `(max_wal_flushed_batch_position + 1)` to `end_batch_position`,
-    /// allowing each trigger to flush only the batches that existed at trigger time.
+    /// Delegates the actual WAL write to the underlying `WalAppender`
+    /// (atomic put-if-not-exists, conflict retry, fence-on-write).
     ///
-    /// # Arguments
-    ///
-    /// * `batch_store` - The BatchStore to read batches from
-    /// * `end_batch_position` - End batch ID (exclusive) - flush up to this batch
-    /// * `indexes` - Optional IndexStore to update
-    ///
-    /// # Returns
-    ///
-    /// A `WalFlushResult` with timing metrics and the WAL entry.
-    /// Returns empty result if nothing to flush (already flushed past end_batch_position).
-    #[instrument(name = "wal_flush", level = "info", skip_all, fields(shard_id = %self.shard_id, end_batch_position, has_indexes = indexes.is_some()))]
-    pub async fn flush_to_with_index_update(
+    /// Returns an empty `WalFlushResult` if there is nothing to flush.
+    #[instrument(name = "wal_flush", level = "info", skip_all, fields(shard_id = %self.shard_id, end_batch_position))]
+    pub async fn flush(
+        &self,
+        source: &WalFlushSource,
+        end_batch_position: usize,
+    ) -> Result<WalFlushResult> {
+        match source {
+            WalFlushSource::BatchStore {
+                batch_store,
+                indexes,
+            } => {
+                self.flush_from_batch_store(batch_store, indexes.clone(), end_batch_position)
+                    .await
+            }
+            WalFlushSource::WalOnly { state } => self.flush_from_wal_only(state).await,
+        }
+    }
+
+    async fn flush_from_batch_store(
         &self,
         batch_store: &BatchStore,
-        end_batch_position: usize,
         indexes: Option<Arc<IndexStore>>,
+        end_batch_position: usize,
     ) -> Result<WalFlushResult> {
         // Get current flush position from per-memtable watermark (inclusive)
         // start_batch_position is the first batch to flush
@@ -320,23 +454,8 @@ impl WalFlusher {
 
         // If we've already flushed past this end, nothing to do
         if start_batch_position >= end_batch_position {
-            return Ok(WalFlushResult {
-                entry: None,
-                wal_io_duration: std::time::Duration::ZERO,
-                index_update_duration: std::time::Duration::ZERO,
-                index_update_duration_breakdown: std::collections::HashMap::new(),
-                rows_indexed: 0,
-                wal_bytes: 0,
-            });
+            return Ok(empty_flush_result());
         }
-
-        let object_store = self
-            .object_store
-            .as_ref()
-            .ok_or_else(|| Error::io("Object store not set on WAL flusher"))?;
-
-        let wal_entry_position = self.next_wal_entry_position.fetch_add(1, Ordering::SeqCst);
-        let final_path = self.wal_entry_path(wal_entry_position);
 
         // Collect batches in range [start_batch_position, end_batch_position)
         let mut stored_batches: Vec<StoredBatch> =
@@ -349,66 +468,20 @@ impl WalFlusher {
         }
 
         if stored_batches.is_empty() {
-            return Ok(WalFlushResult {
-                entry: None,
-                wal_io_duration: std::time::Duration::ZERO,
-                index_update_duration: std::time::Duration::ZERO,
-                index_update_duration_breakdown: std::collections::HashMap::new(),
-                rows_indexed: 0,
-                wal_bytes: 0,
-            });
+            return Ok(empty_flush_result());
         }
 
         let rows_to_index: usize = stored_batches.iter().map(|b| b.num_rows).sum();
-        let num_batches = stored_batches.len();
+        let record_batches: Vec<RecordBatch> =
+            stored_batches.iter().map(|s| s.data.clone()).collect();
 
-        // Prepare WAL I/O data
-        let schema = stored_batches[0].data.schema();
-        let mut metadata = schema.metadata().clone();
-        metadata.insert(WRITER_EPOCH_KEY.to_string(), self.writer_epoch.to_string());
-        let schema_with_epoch = Arc::new(ArrowSchema::new_with_metadata(
-            schema.fields().to_vec(),
-            metadata,
-        ));
-
-        // Serialize WAL data as IPC stream (schema at start, no footer)
-        let mut buffer = Vec::new();
-        {
-            let mut writer =
-                StreamWriter::try_new(&mut buffer, &schema_with_epoch).map_err(|e| {
-                    Error::io(format!("Failed to create Arrow IPC stream writer: {}", e))
-                })?;
-
-            for stored in &stored_batches {
-                writer.write(&stored.data).map_err(|e| {
-                    Error::io(format!("Failed to write batch to Arrow IPC stream: {}", e))
-                })?;
-            }
-
-            writer
-                .finish()
-                .map_err(|e| Error::io(format!("Failed to finish Arrow IPC stream: {}", e)))?;
-        }
-
-        let wal_bytes = buffer.len();
-
-        // WAL I/O and index update in parallel
-        let wal_path = final_path.clone();
-        let wal_data = Bytes::from(buffer);
-        let store = object_store.clone();
-
-        // Returns (overall_duration, per_index_durations)
-        let (wal_result, index_result) = if let Some(idx_registry) = indexes {
-            let wal_future = async {
+        let appender = self.wal_appender.clone();
+        let (append_result, index_result) = if let Some(idx_registry) = indexes {
+            let wal_future = async move {
                 let start = Instant::now();
-                store
-                    .inner
-                    .put(&wal_path, wal_data.into())
-                    .await
-                    .map_err(|e| Error::io(format!("Failed to write WAL file: {}", e)))?;
-                Ok::<_, Error>(start.elapsed())
+                let r = appender.append(record_batches).await?;
+                Ok::<_, Error>((r, start.elapsed()))
             };
-
             let index_future = async {
                 let start = Instant::now();
                 let per_index = tokio::task::spawn_blocking(move || {
@@ -418,26 +491,20 @@ impl WalFlusher {
                 .map_err(|e| Error::internal(format!("Index update task panicked: {}", e)))??;
                 Ok::<_, Error>((start.elapsed(), per_index))
             };
-
             tokio::join!(wal_future, index_future)
         } else {
-            let wal_future = async {
+            let wal_future = async move {
                 let start = Instant::now();
-                store
-                    .inner
-                    .put(&wal_path, wal_data.into())
-                    .await
-                    .map_err(|e| Error::io(format!("Failed to write WAL file: {}", e)))?;
-                Ok::<_, Error>(start.elapsed())
+                let r = appender.append(record_batches).await?;
+                Ok::<_, Error>((r, start.elapsed()))
             };
-
             (
                 wal_future.await,
                 Ok((std::time::Duration::ZERO, std::collections::HashMap::new())),
             )
         };
 
-        let wal_io_duration = wal_result?;
+        let (append_result, wal_io_duration) = append_result?;
         let (index_update_duration, index_update_duration_breakdown) = index_result?;
 
         // Update per-memtable watermark (inclusive: last batch ID that was flushed)
@@ -448,25 +515,59 @@ impl WalFlusher {
         // Signal WAL flush completion for backpressure waiters
         self.signal_wal_flush_complete();
 
-        let entry = WalEntry {
-            position: wal_entry_position,
-            writer_epoch: self.writer_epoch,
-            num_batches,
-        };
-
         Ok(WalFlushResult {
-            entry: Some(entry),
+            entry: Some(WalEntry {
+                position: append_result.entry_position,
+                writer_epoch: self.wal_appender.writer_epoch(),
+                num_batches: append_result.num_batches,
+            }),
             wal_io_duration,
             index_update_duration,
             index_update_duration_breakdown,
             rows_indexed: rows_to_index,
-            wal_bytes,
+            wal_bytes: append_result.wal_bytes,
         })
     }
 
-    /// Get the current WAL ID (last written + 1).
+    async fn flush_from_wal_only(&self, state: &Arc<WalOnlyState>) -> Result<WalFlushResult> {
+        // Snapshot the pending queue (clone-only; cheap because RecordBatch
+        // is Arc-backed). If the append fails the batches stay in the queue
+        // for the next flush attempt. If it succeeds we truncate the front.
+        let snapshot = state.snapshot_pending();
+        if snapshot.count == 0 {
+            return Ok(empty_flush_result());
+        }
+
+        let start = Instant::now();
+        let append_result = self.wal_appender.append(snapshot.batches).await?;
+        let wal_io_duration = start.elapsed();
+
+        // Append succeeded — remove the flushed batches from the front of
+        // the queue. Note: WAL-only mode does not use the global durability
+        // watermark (`durable_watermark_tx`) — `put_wal_only` waits on the
+        // per-trigger `done` cell instead — so we don't advance it here.
+        // Same for the wal-flush-completion cell, which is only consulted
+        // by MemTable-mode backpressure waiters.
+        state.commit_flushed(snapshot.count);
+
+        Ok(WalFlushResult {
+            entry: Some(WalEntry {
+                position: append_result.entry_position,
+                writer_epoch: self.wal_appender.writer_epoch(),
+                num_batches: append_result.num_batches,
+            }),
+            wal_io_duration,
+            index_update_duration: std::time::Duration::ZERO,
+            index_update_duration_breakdown: std::collections::HashMap::new(),
+            rows_indexed: 0,
+            wal_bytes: append_result.wal_bytes,
+        })
+    }
+
+    /// Stats accessor: best-effort next-position hint, mirrored from the
+    /// underlying appender.
     pub fn next_wal_entry_position(&self) -> u64 {
-        self.next_wal_entry_position.load(Ordering::SeqCst)
+        self.wal_appender.next_entry_position_hint()
     }
 
     /// Get the shard ID.
@@ -474,15 +575,27 @@ impl WalFlusher {
         self.shard_id
     }
 
-    /// Get the writer epoch.
+    /// Get the writer epoch (delegated to the underlying appender).
     pub fn writer_epoch(&self) -> u64 {
-        self.writer_epoch
+        self.wal_appender.writer_epoch()
     }
 
     /// Get the path for a WAL entry.
     pub fn wal_entry_path(&self, wal_entry_position: u64) -> Path {
-        let filename = wal_entry_filename(wal_entry_position);
-        self.wal_dir.clone().join(filename.as_str())
+        self.wal_appender.wal_entry_path(wal_entry_position)
+    }
+}
+
+/// Sentinel "nothing to flush" result, shared by `WalFlusher` and the
+/// `WalFlushHandler` early-out path in `write.rs`.
+pub fn empty_flush_result() -> WalFlushResult {
+    WalFlushResult {
+        entry: None,
+        wal_io_duration: std::time::Duration::ZERO,
+        index_update_duration: std::time::Duration::ZERO,
+        index_update_duration_breakdown: std::collections::HashMap::new(),
+        rows_indexed: 0,
+        wal_bytes: 0,
     }
 }
 
@@ -589,6 +702,10 @@ pub struct WalAppender {
     shard_id: Uuid,
     writer_epoch: u64,
     next_entry_position: Mutex<Option<u64>>,
+    /// Mirrors `next_entry_position` for cheap sync observability (stats).
+    /// Updated after each successful append. Stays at 0 until the first
+    /// append discovers the starting position.
+    next_entry_position_hint: AtomicU64,
 }
 
 impl WalAppender {
@@ -606,14 +723,34 @@ impl WalAppender {
             2,
         ));
         let (writer_epoch, _) = manifest_store.claim_epoch(shard_spec_id).await?;
-        Ok(Self {
+        Ok(Self::with_claimed_epoch(
+            object_store,
+            base_path,
+            shard_id,
+            manifest_store,
+            writer_epoch,
+        ))
+    }
+
+    /// Create a WAL appender for a shard whose epoch was already claimed by
+    /// the caller (e.g. `ShardWriter::open` claims once then injects the
+    /// resulting epoch into both the shard writer and its appender).
+    pub(crate) fn with_claimed_epoch(
+        object_store: Arc<ObjectStore>,
+        base_path: Path,
+        shard_id: Uuid,
+        manifest_store: Arc<ShardManifestStore>,
+        writer_epoch: u64,
+    ) -> Self {
+        Self {
             object_store,
             wal_dir: shard_wal_path(&base_path, &shard_id),
             manifest_store,
             shard_id,
             writer_epoch,
             next_entry_position: Mutex::new(None),
-        })
+            next_entry_position_hint: AtomicU64::new(0),
+        }
     }
 
     /// Shard id.
@@ -624,6 +761,19 @@ impl WalAppender {
     /// Writer epoch recorded in the shard manifest.
     pub fn writer_epoch(&self) -> u64 {
         self.writer_epoch
+    }
+
+    /// Resolved path for a WAL entry at `position`.
+    pub(crate) fn wal_entry_path(&self, position: u64) -> Path {
+        self.wal_dir.clone().join(wal_entry_filename(position))
+    }
+
+    /// Cheap sync accessor for the next entry position the appender will
+    /// assign on its next `append`. Returns `0` before the first append has
+    /// happened (the appender discovers the starting position lazily). Used
+    /// for stats observability; not authoritative.
+    pub(crate) fn next_entry_position_hint(&self) -> u64 {
+        self.next_entry_position_hint.load(Ordering::SeqCst)
     }
 
     /// Append batches as one durable WAL entry.
@@ -656,9 +806,11 @@ impl WalAppender {
             .await
             {
                 Ok(()) => {
-                    *next_pos = Some(pos.checked_add(1).ok_or_else(|| {
+                    let next = pos.checked_add(1).ok_or_else(|| {
                         Error::io(format!("WAL position overflow for shard {}", self.shard_id))
-                    })?);
+                    })?;
+                    *next_pos = Some(next);
+                    self.next_entry_position_hint.store(next, Ordering::SeqCst);
                     return Ok(WalAppendResult {
                         shard_id: self.shard_id,
                         entry_position: pos,
@@ -1097,12 +1249,40 @@ mod tests {
         .unwrap()
     }
 
+    fn build_test_flusher(
+        store: Arc<ObjectStore>,
+        base_path: &Path,
+        shard_id: Uuid,
+        writer_epoch: u64,
+    ) -> WalFlusher {
+        let manifest_store = Arc::new(ShardManifestStore::new(
+            store.clone(),
+            base_path,
+            shard_id,
+            2,
+        ));
+        let appender = Arc::new(WalAppender::with_claimed_epoch(
+            store,
+            base_path.clone(),
+            shard_id,
+            manifest_store,
+            writer_epoch,
+        ));
+        WalFlusher::new(appender)
+    }
+
+    fn batch_store_source(batch_store: &Arc<BatchStore>) -> WalFlushSource {
+        WalFlushSource::BatchStore {
+            batch_store: batch_store.clone(),
+            indexes: None,
+        }
+    }
+
     #[tokio::test]
     async fn test_wal_flusher_track_batch() {
         let (store, base_path, _temp_dir) = create_local_store().await;
         let shard_id = Uuid::new_v4();
-        let mut buffer = WalFlusher::new(&base_path, shard_id, 1, 1);
-        buffer.set_object_store(store);
+        let buffer = build_test_flusher(store, &base_path, shard_id, 1);
 
         // Track a batch
         let watcher = buffer.track_batch(0);
@@ -1118,11 +1298,10 @@ mod tests {
     async fn test_track_batch_watcher_blocks_until_flush() {
         let (store, base_path, _temp_dir) = create_local_store().await;
         let region_id = Uuid::new_v4();
-        let mut flusher = WalFlusher::new(&base_path, region_id, 1, 1);
-        flusher.set_object_store(store);
+        let flusher = build_test_flusher(store, &base_path, region_id, 1);
 
         let schema = create_test_schema();
-        let batch_store = BatchStore::with_capacity(10);
+        let batch_store = Arc::new(BatchStore::with_capacity(10));
         batch_store.append(create_test_batch(&schema, 10)).unwrap();
 
         let mut watcher = flusher.track_batch(0);
@@ -1136,10 +1315,8 @@ mod tests {
         );
 
         // Flush, then the watcher should resolve
-        flusher
-            .flush_to_with_index_update(&batch_store, batch_store.len(), None)
-            .await
-            .unwrap();
+        let source = batch_store_source(&batch_store);
+        flusher.flush(&source, batch_store.len()).await.unwrap();
         watcher.wait().await.unwrap();
         assert!(watcher.is_durable());
     }
@@ -1148,15 +1325,14 @@ mod tests {
     async fn test_wal_flusher_flush_to_with_index_update() {
         let (store, base_path, _temp_dir) = create_local_store().await;
         let shard_id = Uuid::new_v4();
-        let mut buffer = WalFlusher::new(&base_path, shard_id, 1, 1);
-        buffer.set_object_store(store);
+        let buffer = build_test_flusher(store, &base_path, shard_id, 1);
 
         // Create a BatchStore with some data
         let schema = create_test_schema();
         let batch1 = create_test_batch(&schema, 10);
         let batch2 = create_test_batch(&schema, 5);
 
-        let batch_store = BatchStore::with_capacity(10);
+        let batch_store = Arc::new(BatchStore::with_capacity(10));
         batch_store.append(batch1).unwrap();
         batch_store.append(batch2).unwrap();
 
@@ -1170,12 +1346,12 @@ mod tests {
         assert!(batch_store.max_flushed_batch_position().is_none());
 
         // Flush all pending batches
-        let result = buffer
-            .flush_to_with_index_update(&batch_store, batch_store.len(), None)
-            .await
-            .unwrap();
+        let source = batch_store_source(&batch_store);
+        let result = buffer.flush(&source, batch_store.len()).await.unwrap();
         let entry = result.entry.unwrap();
-        assert_eq!(entry.position, 1);
+        // First entry from a freshly-discovered position is 0 (atomic-create
+        // path discovers the tip via list and starts at FIRST_WAL_ENTRY_POSITION).
+        assert_eq!(entry.position, FIRST_WAL_ENTRY_POSITION);
         assert_eq!(entry.writer_epoch, 1);
         assert_eq!(entry.num_batches, 2);
         // After flushing 2 batches (positions 0 and 1), max flushed position is 1 (inclusive)
@@ -1192,22 +1368,19 @@ mod tests {
     async fn test_wal_entry_read() {
         let (store, base_path, _temp_dir) = create_local_store().await;
         let shard_id = Uuid::new_v4();
-        let mut buffer = WalFlusher::new(&base_path, shard_id, 42, 1);
-        buffer.set_object_store(store.clone());
+        let buffer = build_test_flusher(store.clone(), &base_path, shard_id, 42);
 
         // Create a BatchStore with some data
         let schema = create_test_schema();
-        let batch_store = BatchStore::with_capacity(10);
+        let batch_store = Arc::new(BatchStore::with_capacity(10));
         batch_store.append(create_test_batch(&schema, 10)).unwrap();
         batch_store.append(create_test_batch(&schema, 5)).unwrap();
 
         // Track batch IDs and flush all pending batches
         let _watcher1 = buffer.track_batch(0);
         let _watcher2 = buffer.track_batch(1);
-        let result = buffer
-            .flush_to_with_index_update(&batch_store, batch_store.len(), None)
-            .await
-            .unwrap();
+        let source = batch_store_source(&batch_store);
+        let result = buffer.flush(&source, batch_store.len()).await.unwrap();
         let entry = result.entry.unwrap();
 
         // Read back the WAL entry

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -724,7 +724,10 @@ impl WalAppender {
             2,
         ));
         let (writer_epoch, manifest) = manifest_store.claim_epoch(shard_spec_id).await?;
-        let position_hint = manifest.wal_entry_position_last_seen.saturating_add(1);
+        let position_hint = manifest
+            .wal_entry_position_last_seen
+            .max(manifest.replay_after_wal_entry_position)
+            .saturating_add(1);
         Ok(Self::with_claimed_epoch(
             object_store,
             base_path,

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -703,8 +703,9 @@ pub struct WalAppender {
     writer_epoch: u64,
     next_entry_position: Mutex<Option<u64>>,
     /// Mirrors `next_entry_position` for cheap sync observability (stats).
-    /// Updated after each successful append. Stays at 0 until the first
-    /// append discovers the starting position.
+    /// Seeded at construction from `manifest.wal_entry_position_last_seen + 1`
+    /// so reopened shards report the post-recovery cursor immediately;
+    /// updated after each successful append.
     next_entry_position_hint: AtomicU64,
 }
 
@@ -722,25 +723,36 @@ impl WalAppender {
             shard_id,
             2,
         ));
-        let (writer_epoch, _) = manifest_store.claim_epoch(shard_spec_id).await?;
+        let (writer_epoch, manifest) = manifest_store.claim_epoch(shard_spec_id).await?;
+        let position_hint = manifest.wal_entry_position_last_seen.saturating_add(1);
         Ok(Self::with_claimed_epoch(
             object_store,
             base_path,
             shard_id,
             manifest_store,
             writer_epoch,
+            position_hint,
         ))
     }
 
     /// Create a WAL appender for a shard whose epoch was already claimed by
     /// the caller (e.g. `ShardWriter::open` claims once then injects the
     /// resulting epoch into both the shard writer and its appender).
+    ///
+    /// `next_entry_position_hint_seed` should be
+    /// `manifest.wal_entry_position_last_seen + 1` so the sync observability
+    /// accessor (`next_entry_position_hint` / `WalFlusher::next_wal_entry_position`)
+    /// reflects the post-recovery cursor immediately after open instead of
+    /// reading 0 until the first append has discovered the true tip. The
+    /// authoritative position counter is still discovered lazily on the
+    /// first append.
     pub(crate) fn with_claimed_epoch(
         object_store: Arc<ObjectStore>,
         base_path: Path,
         shard_id: Uuid,
         manifest_store: Arc<ShardManifestStore>,
         writer_epoch: u64,
+        next_entry_position_hint_seed: u64,
     ) -> Self {
         Self {
             object_store,
@@ -749,7 +761,7 @@ impl WalAppender {
             shard_id,
             writer_epoch,
             next_entry_position: Mutex::new(None),
-            next_entry_position_hint: AtomicU64::new(0),
+            next_entry_position_hint: AtomicU64::new(next_entry_position_hint_seed),
         }
     }
 
@@ -769,9 +781,11 @@ impl WalAppender {
     }
 
     /// Cheap sync accessor for the next entry position the appender will
-    /// assign on its next `append`. Returns `0` before the first append has
-    /// happened (the appender discovers the starting position lazily). Used
-    /// for stats observability; not authoritative.
+    /// assign on its next `append`. Seeded from the shard manifest at
+    /// construction (so reopened shards report the post-recovery cursor
+    /// immediately) and updated after each successful append. Used for
+    /// stats observability; not authoritative — the actual next position
+    /// is discovered lazily by `append`.
     pub(crate) fn next_entry_position_hint(&self) -> u64 {
         self.next_entry_position_hint.load(Ordering::SeqCst)
     }
@@ -1267,6 +1281,8 @@ mod tests {
             shard_id,
             manifest_store,
             writer_epoch,
+            // Tests start with no entries, so seed the hint at 0.
+            0,
         ));
         WalFlusher::new(appender)
     }

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -790,6 +790,17 @@ impl WalAppender {
         self.next_entry_position_hint.load(Ordering::SeqCst)
     }
 
+    /// Seed the appender's next-position counter from a known value
+    /// (e.g. one past the highest WAL entry observed during MemTable
+    /// replay on `ShardWriter::open`). Skips the first-append lazy
+    /// discovery probe.
+    pub(crate) async fn seed_next_position(&self, position: u64) {
+        let mut guard = self.next_entry_position.lock().await;
+        *guard = Some(position);
+        self.next_entry_position_hint
+            .store(position, Ordering::SeqCst);
+    }
+
     /// Append batches as one durable WAL entry.
     pub async fn append(&self, batches: Vec<RecordBatch>) -> Result<WalAppendResult> {
         validate_appender_batches(&batches)?;

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -721,9 +721,12 @@ fn now_millis() -> u64 {
 /// into the freshly-built MemTable. Updates any in-memory indexes attached to
 /// the MemTable so replayed rows are immediately searchable.
 ///
-/// Returns the highest WAL position replayed, or `None` if there were no
-/// entries to replay (fresh shard with no prior writes, or the manifest is
-/// already caught up with the WAL tip).
+/// Returns the WAL position the next `WalAppender::append` should use — i.e.
+/// one past the highest replayed position, or the original start position if
+/// the loop found nothing (we proved that position is empty by getting
+/// `None` back from the tailer). The caller can pass this directly to
+/// `WalAppender::seed_next_position` unconditionally so the first post-open
+/// append skips its own discovery probe.
 ///
 /// Aborts with an error if any replayed entry's `writer_epoch` is strictly
 /// greater than `our_epoch` — that indicates a successor writer claimed the
@@ -735,7 +738,7 @@ async fn replay_memtable_from_wal(
     our_epoch: u64,
     manifest: &ShardManifest,
     memtable: &mut MemTable,
-) -> Result<Option<u64>> {
+) -> Result<u64> {
     // Fresh shards (no flushes yet) start replay at position 0; otherwise
     // start one past the last covered position. Distinguishing "no flushes"
     // from "flushed up to position 0" requires `flushed_generations` since
@@ -746,13 +749,18 @@ async fn replay_memtable_from_wal(
         manifest.replay_after_wal_entry_position.saturating_add(1)
     };
 
+    // The MemTable is always freshly built before this function runs, so
+    // any existing BatchStore entries can only have come from this replay
+    // pass. We index everything in `[0, batch_count)` at the end.
+    debug_assert_eq!(memtable.batch_count(), 0);
+
     let tailer = WalTailer::new(object_store, base_path, shard_id);
-    let batches_before = memtable.batch_count();
-    let mut highest_replayed: Option<u64> = None;
     let mut position = start_position;
 
     loop {
         match tailer.read_entry(position).await? {
+            // The first NotFound proves the WAL tip is at `position`, which
+            // is the next write position to hand back.
             None => break,
             Some(entry) => {
                 if entry.writer_epoch > our_epoch {
@@ -764,7 +772,6 @@ async fn replay_memtable_from_wal(
                 if !entry.batches.is_empty() {
                     memtable.insert_batches_only(entry.batches).await?;
                 }
-                highest_replayed = Some(position);
                 position = position.checked_add(1).ok_or_else(|| {
                     Error::io(format!(
                         "WAL position overflow during replay for shard {}",
@@ -781,10 +788,10 @@ async fn replay_memtable_from_wal(
     // persist; this rebuilds them from the WAL.
     if let Some(indexes) = memtable.indexes_arc() {
         let batches_after = memtable.batch_count();
-        if batches_after > batches_before {
+        if batches_after > 0 {
             let store = memtable.batch_store();
-            let mut stored: Vec<StoredBatch> = Vec::with_capacity(batches_after - batches_before);
-            for pos in batches_before..batches_after {
+            let mut stored: Vec<StoredBatch> = Vec::with_capacity(batches_after);
+            for pos in 0..batches_after {
                 if let Some(s) = store.get(pos) {
                     stored.push(s.clone());
                 }
@@ -797,7 +804,7 @@ async fn replay_memtable_from_wal(
         }
     }
 
-    Ok(highest_replayed)
+    Ok(position)
 }
 
 /// Shared state for writer operations.
@@ -1143,17 +1150,24 @@ impl ShardWriter {
         );
 
         // Create WAL appender (owns object store, epoch, and position
-        // state). Seed the appender's stats hint from the manifest so
-        // `wal_stats().next_wal_entry_position` reflects the post-recovery
-        // cursor immediately on reopen instead of reading 0 until the
-        // first append has discovered the true tip.
+        // state). Seed the appender's stats hint from the higher of the
+        // manifest's two cursors: `replay_after_wal_entry_position` is
+        // updated authoritatively at every MemTable flush, while
+        // `wal_entry_position_last_seen` is a best-effort hint that may
+        // lag behind. Either can lead the other depending on which was
+        // updated last, so take the max (then +1) to get the most
+        // accurate post-recovery cursor for `wal_stats()`.
+        let position_hint_seed = manifest
+            .wal_entry_position_last_seen
+            .max(manifest.replay_after_wal_entry_position)
+            .saturating_add(1);
         let wal_appender = Arc::new(WalAppender::with_claimed_epoch(
             object_store.clone(),
             base_path.clone(),
             shard_id,
             manifest_store.clone(),
             epoch,
-            manifest.wal_entry_position_last_seen.saturating_add(1),
+            position_hint_seed,
         ));
 
         // Create WAL flusher backed by the shared appender.
@@ -1254,10 +1268,11 @@ impl ShardWriter {
         // generation. Each entry's writer_epoch is checked against ours; an
         // entry with a strictly greater epoch indicates a successor writer
         // claimed the shard between our `claim_epoch` and replay, so we
-        // abort the open with a fence error. After replay, seed the
-        // appender's next-position counter so the first put doesn't pay the
-        // lazy-discovery probe cost.
-        let last_replayed = replay_memtable_from_wal(
+        // abort the open with a fence error. The replay walked the tailer
+        // up to the WAL tip, so we hand the discovered next-write position
+        // straight to the appender — its first append skips the
+        // discover_next_position probe entirely.
+        let next_wal_position = replay_memtable_from_wal(
             object_store.clone(),
             base_path.clone(),
             shard_id,
@@ -1266,12 +1281,10 @@ impl ShardWriter {
             &mut memtable,
         )
         .await?;
-        if let Some(last) = last_replayed {
-            wal_flusher
-                .wal_appender()
-                .seed_next_position(last.saturating_add(1))
-                .await;
-        }
+        wal_flusher
+            .wal_appender()
+            .seed_next_position(next_wal_position)
+            .await;
 
         let state = Arc::new(RwLock::new(WriterState {
             memtable,

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -192,19 +192,17 @@ pub struct ShardWriterConfig {
     /// - No MemTable / BatchStore / IndexStore is allocated.
     /// - `index_configs` must be empty (validated at open time).
     /// - No MemTable freezing or Lance file flushing happens.
-    /// - No MemTable-bytes backpressure (`max_unflushed_memtable_bytes` is ignored).
-    /// - Each WAL flush drains the pending-batch queue, so the in-memory
-    ///   footprint is bounded by `max_wal_buffer_size` /
-    ///   `max_wal_flush_interval`.
+    /// - `max_unflushed_memtable_bytes` is reused as the backpressure
+    ///   budget for the WAL-only pending-batch queue: `put` blocks while
+    ///   the queue's estimated bytes meet or exceed this threshold.
     /// - The async batched WAL pipeline still runs, driven by the same
     ///   `max_wal_buffer_size`, `max_wal_flush_interval`, and
     ///   `durable_write` settings as MemTable mode.
     ///
     /// MemTable-tied tunables (`max_memtable_size`, `max_memtable_rows`,
-    /// `max_memtable_batches`, `max_unflushed_memtable_bytes`,
-    /// `ivf_index_partition_capacity_safety_factor`, `sync_indexed_write`,
-    /// `async_index_buffer_rows`, `async_index_interval`) are ignored when
-    /// `enable_memtable == false`.
+    /// `max_memtable_batches`, `ivf_index_partition_capacity_safety_factor`,
+    /// `sync_indexed_write`, `async_index_buffer_rows`,
+    /// `async_index_interval`) are ignored when `enable_memtable == false`.
     ///
     /// For raw single-entry synchronous atomic appends with no buffering and
     /// no background tasks, use `WalAppender` directly — it is a strictly
@@ -1059,13 +1057,18 @@ impl ShardWriter {
             shard_id, epoch, manifest.current_generation, config.enable_memtable
         );
 
-        // Create WAL appender (owns object store, epoch, and position state).
+        // Create WAL appender (owns object store, epoch, and position
+        // state). Seed the appender's stats hint from the manifest so
+        // `wal_stats().next_wal_entry_position` reflects the post-recovery
+        // cursor immediately on reopen instead of reading 0 until the
+        // first append has discovered the true tip.
         let wal_appender = Arc::new(WalAppender::with_claimed_epoch(
             object_store.clone(),
             base_path.clone(),
             shard_id,
             manifest_store.clone(),
             epoch,
+            manifest.wal_entry_position_last_seen.saturating_add(1),
         ));
 
         // Create WAL flusher backed by the shared appender.
@@ -2738,6 +2741,56 @@ mod tests {
         );
 
         writer_b.close().await.unwrap();
+    }
+
+    /// Regression: `wal_stats().next_wal_entry_position` must reflect the
+    /// post-recovery cursor immediately on reopen, not 0 until the first
+    /// append discovers the tip. Pre-fix the appender's hint was seeded at
+    /// 0 and only updated after the first successful append, so external
+    /// monitors saw 0 between open and first put on a shard with prior
+    /// entries.
+    #[tokio::test]
+    async fn test_wal_stats_seeded_from_manifest_on_reopen() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let shard_id = Uuid::new_v4();
+
+        // First writer creates a shard, writes one entry, closes.
+        let writer1 = ShardWriter::open(
+            store.clone(),
+            base_path.clone(),
+            base_uri.clone(),
+            wal_only_config(shard_id),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+        writer1
+            .put(vec![create_test_batch(&schema, 0, 1)])
+            .await
+            .unwrap();
+        writer1.close().await.unwrap();
+
+        // Reopen: stats must reflect the post-recovery cursor immediately,
+        // before any put has happened on this writer.
+        let writer2 = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            wal_only_config(shard_id),
+            schema,
+            vec![],
+        )
+        .await
+        .unwrap();
+        let next = writer2.wal_stats().next_wal_entry_position;
+        assert!(
+            next >= 1,
+            "expected wal_stats to reflect post-recovery cursor (>= 1) on reopen, got {next}"
+        );
+
+        writer2.close().await.unwrap();
     }
 
     /// Regression test for the size-based trigger after a drain.

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -46,7 +46,7 @@ pub use super::util::{WatchableOnceCell, WatchableOnceCellReader};
 pub use super::wal::{WalEntry, WalEntryData, WalFlushResult, WalFlusher};
 
 use super::memtable::flush::TriggerMemTableFlush;
-use super::wal::TriggerWalFlush;
+use super::wal::{TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState, empty_flush_result};
 
 use super::manifest::ShardManifestStore;
 
@@ -181,6 +181,35 @@ pub struct ShardWriterConfig {
     ///
     /// Default: 60 seconds
     pub stats_log_interval: Option<Duration>,
+
+    /// Whether to maintain an in-memory MemTable on top of the WAL.
+    ///
+    /// When `true` (default), the writer maintains an in-memory `MemTable`,
+    /// optionally with indexes, and asynchronously flushes frozen MemTables
+    /// to Lance files alongside the WAL.
+    ///
+    /// When `false`, the writer skips the MemTable layer entirely:
+    /// - No MemTable / BatchStore / IndexStore is allocated.
+    /// - `index_configs` must be empty (validated at open time).
+    /// - No MemTable freezing or Lance file flushing happens.
+    /// - No MemTable-bytes backpressure (`max_unflushed_memtable_bytes` is ignored).
+    /// - Each WAL flush drains the pending-batch queue, so the in-memory
+    ///   footprint is bounded by `max_wal_buffer_size` /
+    ///   `max_wal_flush_interval`.
+    /// - The async batched WAL pipeline still runs, driven by the same
+    ///   `max_wal_buffer_size`, `max_wal_flush_interval`, and
+    ///   `durable_write` settings as MemTable mode.
+    ///
+    /// MemTable-tied tunables (`max_memtable_size`, `max_memtable_rows`,
+    /// `max_memtable_batches`, `max_unflushed_memtable_bytes`,
+    /// `ivf_index_partition_capacity_safety_factor`, `sync_indexed_write`,
+    /// `async_index_buffer_rows`, `async_index_interval`) are ignored when
+    /// `enable_memtable == false`.
+    ///
+    /// For raw single-entry synchronous atomic appends with no buffering and
+    /// no background tasks, use `WalAppender` directly — it is a strictly
+    /// lower-level primitive.
+    pub enable_memtable: bool,
 }
 
 impl Default for ShardWriterConfig {
@@ -202,6 +231,7 @@ impl Default for ShardWriterConfig {
             async_index_buffer_rows: 10_000,
             async_index_interval: Duration::from_secs(1),
             stats_log_interval: Some(Duration::from_secs(60)), // 1 minute
+            enable_memtable: true,
         }
     }
 }
@@ -302,6 +332,13 @@ impl ShardWriterConfig {
     /// Set stats logging interval. Use None to disable periodic stats logging.
     pub fn with_stats_log_interval(mut self, interval: Option<Duration>) -> Self {
         self.stats_log_interval = interval;
+        self
+    }
+
+    /// Toggle the in-memory MemTable layer. See `enable_memtable` for the
+    /// full WAL-only-mode contract. Defaults to `true`.
+    pub fn with_enable_memtable(mut self, enable: bool) -> Self {
+        self.enable_memtable = enable;
         self
     }
 }
@@ -765,8 +802,10 @@ impl SharedWriterState {
 
             let end_batch_position = old_batch_store.len();
             self.wal_flusher.trigger_flush(
-                old_batch_store,
-                old_indexes,
+                WalFlushSource::BatchStore {
+                    batch_store: old_batch_store,
+                    indexes: old_indexes,
+                },
                 end_batch_position,
                 Some(completion_cell),
             )?;
@@ -864,8 +903,10 @@ impl SharedWriterState {
         // If time trigger fired, send a flush message
         if time_trigger.is_some() {
             let _ = self.wal_flush_tx.send(TriggerWalFlush {
-                batch_store,
-                indexes,
+                source: WalFlushSource::BatchStore {
+                    batch_store,
+                    indexes,
+                },
                 end_batch_position: batch_count,
                 done: None,
             });
@@ -888,8 +929,10 @@ impl SharedWriterState {
 
             // Trigger WAL flush with captured batch range
             let _ = self.wal_flush_tx.send(TriggerWalFlush {
-                batch_store: batch_store.clone(),
-                indexes: indexes.clone(),
+                source: WalFlushSource::BatchStore {
+                    batch_store: batch_store.clone(),
+                    indexes: indexes.clone(),
+                },
                 end_batch_position: batch_count,
                 done: None,
             });
@@ -925,17 +968,56 @@ impl SharedWriterState {
     }
 }
 
+/// Trigger-tracking state for WAL-only mode (no MemTable).
+///
+/// MemTable mode keeps these counters inside `WriterState`. WAL-only mode
+/// has no `WriterState`, so the same counters live here, with one
+/// adjustment: instead of a monotonic threshold-crossing count (which
+/// can't decrement when the pending queue drains), we record the
+/// `pending_bytes` value at the time of the last size-trigger. A trigger
+/// fires whenever `pending_bytes` has grown by at least one
+/// `max_wal_buffer_size` since `last_trigger_pending_bytes`. When the
+/// pending queue is drained, `pending_bytes` drops below the recorded
+/// baseline, and the next push detects this via `pending_bytes < baseline`
+/// and resets the baseline.
+#[derive(Debug, Default)]
+struct WalOnlyTriggerState {
+    /// `pending_bytes` value recorded the last time a size-based trigger
+    /// fired. Resets to 0 when `pending_bytes` drops below it (drain
+    /// happened since the last trigger).
+    last_trigger_pending_bytes: usize,
+    /// Last time a WAL flush was triggered (for time-based trigger).
+    last_wal_flush_trigger_time: u64,
+}
+
+/// Per-mode state for `ShardWriter`.
+enum WriterMode {
+    /// Default mode: MemTable + indexes + Lance file flushing on top of
+    /// the WAL.
+    MemTable {
+        state: Arc<RwLock<WriterState>>,
+        writer_state: Arc<SharedWriterState>,
+        backpressure: BackpressureController,
+    },
+    /// WAL-only mode: drainable pending-batch queue + WAL pipeline. No
+    /// MemTable, no indexes, no Lance file flushing.
+    WalOnly {
+        state: Arc<WalOnlyState>,
+        wal_flush_tx: mpsc::UnboundedSender<TriggerWalFlush>,
+        trigger: StdRwLock<WalOnlyTriggerState>,
+        backpressure: BackpressureController,
+    },
+}
+
 /// Main writer for a MemWAL shard.
 pub struct ShardWriter {
     config: ShardWriterConfig,
     epoch: u64,
-    state: Arc<RwLock<WriterState>>,
     wal_flusher: Arc<WalFlusher>,
     task_executor: Arc<TaskExecutor>,
     manifest_store: Arc<ShardManifestStore>,
     stats: SharedWriteStats,
-    writer_state: Arc<SharedWriterState>,
-    backpressure: BackpressureController,
+    mode: WriterMode,
 }
 
 impl ShardWriter {
@@ -952,6 +1034,13 @@ impl ShardWriter {
         schema: Arc<ArrowSchema>,
         index_configs: Vec<MemIndexConfig>,
     ) -> Result<Self> {
+        if !config.enable_memtable && !index_configs.is_empty() {
+            return Err(Error::invalid_input(
+                "indexes require enable_memtable = true; \
+                 WAL-only mode does not maintain in-memory indexes",
+            ));
+        }
+
         let base_uri = base_uri.into();
         let shard_id = config.shard_id;
         let manifest_store = Arc::new(ShardManifestStore::new(
@@ -961,14 +1050,92 @@ impl ShardWriter {
             config.manifest_scan_batch_size,
         ));
 
-        // Claim the shard (epoch-based fencing)
+        // Claim the shard (epoch-based fencing) — done once, then shared
+        // with the WalAppender via `with_claimed_epoch`.
         let (epoch, manifest) = manifest_store.claim_epoch(config.shard_spec_id).await?;
 
         info!(
-            "Opened ShardWriter for shard {} (epoch {}, generation {})",
-            shard_id, epoch, manifest.current_generation
+            "Opened ShardWriter for shard {} (epoch {}, generation {}, enable_memtable {})",
+            shard_id, epoch, manifest.current_generation, config.enable_memtable
         );
 
+        // Create WAL appender (owns object store, epoch, and position state).
+        let wal_appender = Arc::new(WalAppender::with_claimed_epoch(
+            object_store.clone(),
+            base_path.clone(),
+            shard_id,
+            manifest_store.clone(),
+            epoch,
+        ));
+
+        // Create WAL flusher backed by the shared appender.
+        let mut wal_flusher = WalFlusher::new(wal_appender);
+
+        let (wal_flush_tx, wal_flush_rx) = mpsc::unbounded_channel();
+        wal_flusher.set_flush_channel(wal_flush_tx.clone());
+        let wal_flusher = Arc::new(wal_flusher);
+
+        let stats = new_shared_stats();
+        let task_executor = Arc::new(TaskExecutor::new());
+
+        let mode = if config.enable_memtable {
+            Self::open_memtable_mode(
+                &config,
+                &schema,
+                &manifest,
+                &index_configs,
+                wal_flusher.clone(),
+                wal_flush_tx,
+                wal_flush_rx,
+                object_store.clone(),
+                base_path,
+                base_uri,
+                shard_id,
+                epoch,
+                manifest_store.clone(),
+                stats.clone(),
+                &task_executor,
+            )?
+        } else {
+            Self::open_wal_only_mode(
+                &config,
+                wal_flusher.clone(),
+                wal_flush_tx,
+                wal_flush_rx,
+                stats.clone(),
+                &task_executor,
+            )?
+        };
+
+        Ok(Self {
+            config,
+            epoch,
+            wal_flusher,
+            task_executor,
+            manifest_store,
+            stats,
+            mode,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn open_memtable_mode(
+        config: &ShardWriterConfig,
+        schema: &Arc<ArrowSchema>,
+        manifest: &ShardManifest,
+        index_configs: &[MemIndexConfig],
+        wal_flusher: Arc<WalFlusher>,
+        wal_flush_tx: mpsc::UnboundedSender<TriggerWalFlush>,
+        wal_flush_rx: mpsc::UnboundedReceiver<TriggerWalFlush>,
+        object_store: Arc<ObjectStore>,
+        base_path: Path,
+        base_uri: String,
+        shard_id: Uuid,
+        epoch: u64,
+        manifest_store: Arc<ShardManifestStore>,
+        stats: SharedWriteStats,
+        task_executor: &Arc<TaskExecutor>,
+    ) -> Result<WriterMode> {
         // Create MemTable with primary key field IDs from schema
         let lance_schema = Schema::try_from(schema.as_ref())?;
         let pk_field_ids: Vec<i32> = lance_schema
@@ -984,12 +1151,10 @@ impl ShardWriter {
             config.max_memtable_batches,
         )?;
 
-        // Create indexes if configured and set them on the MemTable
-        // Indexes are always created when index_configs is non-empty
-        // (they will be updated either sync or async based on config)
+        // Create indexes if configured and set them on the MemTable.
         if !index_configs.is_empty() {
             let indexes = Arc::new(IndexStore::from_configs(
-                &index_configs,
+                index_configs,
                 config.max_memtable_rows,
                 config.ivf_index_partition_capacity_safety_factor,
             )?);
@@ -1006,61 +1171,39 @@ impl ShardWriter {
             last_wal_flush_trigger_time: 0,
         }));
 
-        // Create WAL flusher
-        let mut wal_flusher = WalFlusher::new(
-            &base_path,
-            shard_id,
-            epoch,
-            manifest.wal_entry_position_last_seen + 1,
-        );
-        wal_flusher.set_object_store(object_store.clone());
-
-        // Create channels for background tasks
-        let (wal_flush_tx, wal_flush_rx) = mpsc::unbounded_channel();
         let (memtable_flush_tx, memtable_flush_rx) = mpsc::unbounded_channel();
 
-        wal_flusher.set_flush_channel(wal_flush_tx.clone());
-        let wal_flusher = Arc::new(wal_flusher);
-
-        // Create flusher
         let flusher = Arc::new(MemTableFlusher::new(
-            object_store.clone(),
+            object_store,
             base_path,
             base_uri,
             shard_id,
-            manifest_store.clone(),
+            manifest_store,
         ));
-
-        // Create stats collector
-        let stats = new_shared_stats();
 
         let backpressure = BackpressureController::new(config.clone());
 
-        // Create task executor
-        let task_executor = Arc::new(TaskExecutor::new());
-
-        // Start background WAL flush handler
-        // The WAL flush handler does parallel WAL I/O + index updates
-        let wal_handler = WalFlushHandler::new(wal_flusher.clone(), state.clone(), stats.clone());
+        // Background WAL flush handler — parallel WAL I/O + index updates.
+        let wal_handler =
+            WalFlushHandler::new(wal_flusher.clone(), Some(state.clone()), stats.clone());
         task_executor.add_handler(
             "wal_flusher".to_string(),
             Box::new(wal_handler),
             wal_flush_rx,
         )?;
 
-        // Start background MemTable flush handler
-        let memtable_handler =
-            MemTableFlushHandler::new(state.clone(), flusher, epoch, stats.clone());
+        // Background MemTable flush handler — frozen memtable to Lance file.
+        let memtable_handler = MemTableFlushHandler::new(state.clone(), flusher, epoch, stats);
         task_executor.add_handler(
             "memtable_flusher".to_string(),
             Box::new(memtable_handler),
             memtable_flush_rx,
         )?;
 
-        // Create shared writer state for put() operations
+        // Shared state used by `put()` to dispatch trigger checks.
         let writer_state = Arc::new(SharedWriterState::new(
             state.clone(),
-            wal_flusher.clone(),
+            wal_flusher,
             wal_flush_tx,
             memtable_flush_tx,
             config.clone(),
@@ -1069,18 +1212,44 @@ impl ShardWriter {
             config.max_memtable_batches,
             config.max_memtable_rows,
             config.ivf_index_partition_capacity_safety_factor,
-            index_configs,
+            index_configs.to_vec(),
         ));
 
-        Ok(Self {
-            config,
-            epoch,
+        Ok(WriterMode::MemTable {
             state,
-            wal_flusher,
-            task_executor,
-            manifest_store,
-            stats,
             writer_state,
+            backpressure,
+        })
+    }
+
+    fn open_wal_only_mode(
+        config: &ShardWriterConfig,
+        wal_flusher: Arc<WalFlusher>,
+        wal_flush_tx: mpsc::UnboundedSender<TriggerWalFlush>,
+        wal_flush_rx: mpsc::UnboundedReceiver<TriggerWalFlush>,
+        stats: SharedWriteStats,
+        task_executor: &Arc<TaskExecutor>,
+    ) -> Result<WriterMode> {
+        // Background WAL flush handler — no MemTable state to consult, so
+        // pass `None` for the frozen-vs-active detection.
+        let wal_handler = WalFlushHandler::new(wal_flusher, None, stats);
+        task_executor.add_handler(
+            "wal_flusher".to_string(),
+            Box::new(wal_handler),
+            wal_flush_rx,
+        )?;
+
+        // Reuse `BackpressureController` (which is keyed off
+        // `max_unflushed_memtable_bytes`) as the WAL-only backpressure
+        // budget. WAL-only callers feed it `WalOnlyState::estimated_size()`.
+        // Keeps the config knob meaningful in WAL-only mode and prevents
+        // the pending queue from growing unbounded under non-durable writes.
+        let backpressure = BackpressureController::new(config.clone());
+
+        Ok(WriterMode::WalOnly {
+            state: Arc::new(WalOnlyState::default()),
+            wal_flush_tx,
+            trigger: StdRwLock::new(WalOnlyTriggerState::default()),
             backpressure,
         })
     }
@@ -1109,17 +1278,42 @@ impl ShardWriter {
         if batches.is_empty() {
             return Err(Error::invalid_input("Cannot write empty batch list"));
         }
-
-        // Validate no empty batches
         for (i, batch) in batches.iter().enumerate() {
             if batch.num_rows() == 0 {
                 return Err(Error::invalid_input(format!("Batch {} is empty", i)));
             }
         }
 
+        match &self.mode {
+            WriterMode::MemTable {
+                state,
+                writer_state,
+                backpressure,
+            } => {
+                self.put_memtable(batches, state, writer_state, backpressure)
+                    .await
+            }
+            WriterMode::WalOnly {
+                state,
+                wal_flush_tx,
+                trigger,
+                backpressure,
+            } => {
+                self.put_wal_only(batches, state, wal_flush_tx, trigger, backpressure)
+                    .await
+            }
+        }
+    }
+
+    async fn put_memtable(
+        &self,
+        batches: Vec<RecordBatch>,
+        state_lock: &Arc<RwLock<WriterState>>,
+        writer_state: &Arc<SharedWriterState>,
+        backpressure: &BackpressureController,
+    ) -> Result<WriteResult> {
         // Apply backpressure if needed (before acquiring main lock)
-        let writer_state = &self.writer_state;
-        self.backpressure
+        backpressure
             .maybe_apply_backpressure(|| {
                 (
                     writer_state.unflushed_memtable_bytes(),
@@ -1132,7 +1326,7 @@ impl ShardWriter {
 
         // Acquire write lock for entire operation (atomic approach)
         let (batch_positions, mut durable_watcher, batch_store, indexes) = {
-            let mut state = self.state.write().await;
+            let mut state = state_lock.write().await;
 
             // 1. Insert all batches into memtable atomically
             let results = state.memtable.insert_batches_only(batches).await?;
@@ -1143,15 +1337,13 @@ impl ShardWriter {
             let batch_positions = start_pos..end_pos;
 
             // 2. Track last batch for WAL durability
-            let durable_watcher = self
-                .writer_state
-                .track_batch_for_wal(end_pos.saturating_sub(1));
+            let durable_watcher = writer_state.track_batch_for_wal(end_pos.saturating_sub(1));
 
             // 3. Check if WAL flush should be triggered
-            self.writer_state.maybe_trigger_wal_flush(&mut state);
+            writer_state.maybe_trigger_wal_flush(&mut state);
 
             // 4. Check if memtable flush is needed
-            if let Err(e) = self.writer_state.maybe_trigger_memtable_flush(&mut state) {
+            if let Err(e) = writer_state.maybe_trigger_memtable_flush(&mut state) {
                 warn!("Failed to trigger memtable flush: {}", e);
             }
 
@@ -1166,13 +1358,148 @@ impl ShardWriter {
 
         // Wait for durability if configured (outside the lock)
         if self.config.durable_write {
-            // Must trigger a flush to ensure durability (flush up to and including all batches)
-            self.wal_flusher
-                .trigger_flush(batch_store, indexes, batch_positions.end, None)?;
+            self.wal_flusher.trigger_flush(
+                WalFlushSource::BatchStore {
+                    batch_store,
+                    indexes,
+                },
+                batch_positions.end,
+                None,
+            )?;
             durable_watcher.wait().await?;
         }
 
         Ok(WriteResult { batch_positions })
+    }
+
+    async fn put_wal_only(
+        &self,
+        batches: Vec<RecordBatch>,
+        state: &Arc<WalOnlyState>,
+        wal_flush_tx: &mpsc::UnboundedSender<TriggerWalFlush>,
+        trigger: &StdRwLock<WalOnlyTriggerState>,
+        backpressure: &BackpressureController,
+    ) -> Result<WriteResult> {
+        // Apply backpressure against the pending queue before pushing. The
+        // budget reuses `max_unflushed_memtable_bytes` since WAL-only mode
+        // shares the same "in-memory bytes waiting for durable storage"
+        // shape as MemTable mode. WAL-only mode has no per-frozen-MemTable
+        // watcher, so the backpressure loop falls back to its short sleep.
+        backpressure
+            .maybe_apply_backpressure(|| (state.estimated_size(), None))
+            .await?;
+
+        let start = std::time::Instant::now();
+
+        // Push batches into the pending queue and capture the assigned
+        // [start, end) range. `next_batch_position` is monotonic across the
+        // writer's lifetime; positions are not BatchStore indices but they
+        // are used the same way for durability tracking.
+        let batch_positions = state.push(batches);
+
+        // Time- and size-based triggers, mirroring MemTable mode but reading
+        // pending bytes from `WalOnlyState` instead of an active MemTable.
+        // Only fires for non-durable writes; durable writes go through the
+        // explicit done-cell path below so flush errors (e.g., fence) reach
+        // the caller.
+        if !self.config.durable_write {
+            let target_position = batch_positions.end;
+            let pending_bytes = state.estimated_size();
+            self.maybe_trigger_wal_flush_wal_only(
+                state,
+                wal_flush_tx,
+                trigger,
+                target_position,
+                pending_bytes,
+            );
+        }
+
+        self.stats.record_put(start.elapsed());
+
+        // For durable writes, trigger an immediate flush and wait for the
+        // done cell. Using the done cell instead of the durability watermark
+        // watcher ensures flush errors (e.g., the WalAppender returning a
+        // fence error) propagate back to `put` instead of hanging.
+        if self.config.durable_write {
+            let done = WatchableOnceCell::new();
+            let reader = done.reader();
+            self.wal_flusher.trigger_flush(
+                WalFlushSource::WalOnly {
+                    state: state.clone(),
+                },
+                batch_positions.end,
+                Some(done),
+            )?;
+            let mut reader = reader;
+            match reader.await_value().await {
+                Ok(_) => {}
+                Err(msg) => return Err(Error::io(msg)),
+            }
+        }
+
+        Ok(WriteResult { batch_positions })
+    }
+
+    /// WAL-only-mode size+time trigger. Mirrors `SharedWriterState::maybe_trigger_wal_flush`
+    /// but reads its inputs from `WalOnlyState` (pending queue) instead of
+    /// the active MemTable.
+    fn maybe_trigger_wal_flush_wal_only(
+        &self,
+        state: &Arc<WalOnlyState>,
+        wal_flush_tx: &mpsc::UnboundedSender<TriggerWalFlush>,
+        trigger: &StdRwLock<WalOnlyTriggerState>,
+        end_batch_position: usize,
+        pending_bytes: usize,
+    ) {
+        let threshold = self.config.max_wal_buffer_size;
+        let has_pending = state.batch_count() > 0;
+
+        let mut t = trigger.write().unwrap();
+
+        // Time-based trigger.
+        if let Some(interval) = self.config.max_wal_flush_interval {
+            let interval_millis = interval.as_millis() as u64;
+            let now = now_millis();
+            if t.last_wal_flush_trigger_time == 0 {
+                t.last_wal_flush_trigger_time = now;
+            } else {
+                let elapsed = now.saturating_sub(t.last_wal_flush_trigger_time);
+                if elapsed >= interval_millis && has_pending {
+                    t.last_wal_flush_trigger_time = now;
+                    let _ = wal_flush_tx.send(TriggerWalFlush {
+                        source: WalFlushSource::WalOnly {
+                            state: state.clone(),
+                        },
+                        end_batch_position,
+                        done: None,
+                    });
+                    return;
+                }
+            }
+        }
+
+        if threshold == 0 {
+            return;
+        }
+
+        // Size-based trigger: fire one trigger per `max_wal_buffer_size`
+        // crossed since the last time we triggered. If the pending queue
+        // shrank below the recorded baseline (a drain happened), reset the
+        // baseline first so the next crossing fires correctly.
+        if pending_bytes < t.last_trigger_pending_bytes {
+            t.last_trigger_pending_bytes = 0;
+        }
+        while pending_bytes >= t.last_trigger_pending_bytes + threshold {
+            t.last_trigger_pending_bytes += threshold;
+            t.last_wal_flush_trigger_time = now_millis();
+            let _ = wal_flush_tx.send(TriggerWalFlush {
+                source: WalFlushSource::WalOnly {
+                    state: state.clone(),
+                },
+                end_batch_position,
+                done: None,
+            });
+        }
     }
 
     /// Get a snapshot of current write statistics.
@@ -1200,15 +1527,17 @@ impl ShardWriter {
         self.config.shard_id
     }
 
-    /// Get current MemTable statistics.
-    pub async fn memtable_stats(&self) -> MemTableStats {
-        let state = self.state.read().await;
-        MemTableStats {
+    /// Get current MemTable statistics. Returns an error in WAL-only mode
+    /// (no MemTable exists).
+    pub async fn memtable_stats(&self) -> Result<MemTableStats> {
+        let state_lock = self.memtable_state_lock()?;
+        let state = state_lock.read().await;
+        Ok(MemTableStats {
             row_count: state.memtable.row_count(),
             batch_count: state.memtable.batch_count(),
             estimated_size: state.memtable.estimated_size(),
             generation: state.memtable.generation(),
-        }
+        })
     }
 
     /// Create a scanner for querying the current MemTable data.
@@ -1219,12 +1548,11 @@ impl ShardWriter {
     /// The scanner captures the current `max_indexed_batch_position` from the
     /// `IndexStore` at construction time to ensure consistent visibility.
     ///
-    /// # Returns
-    ///
-    /// A `MemTableScanner` that can be used to execute queries.
-    pub async fn scan(&self) -> MemTableScanner {
-        let state = self.state.read().await;
-        state.memtable.scan()
+    /// Returns an error in WAL-only mode.
+    pub async fn scan(&self) -> Result<MemTableScanner> {
+        let state_lock = self.memtable_state_lock()?;
+        let state = state_lock.read().await;
+        Ok(state.memtable.scan())
     }
 
     /// Get an ActiveMemTableRef for use with LsmScanner.
@@ -1233,13 +1561,13 @@ impl ShardWriter {
     /// for unified LSM scanning across base table, flushed MemTables, and
     /// active MemTable.
     ///
-    /// # Returns
-    ///
-    /// An `ActiveMemTableRef` containing the batch store, index store, schema,
-    /// and generation of the current MemTable.
-    pub async fn active_memtable_ref(&self) -> crate::dataset::mem_wal::scanner::ActiveMemTableRef {
-        let state = self.state.read().await;
-        crate::dataset::mem_wal::scanner::ActiveMemTableRef {
+    /// Returns an error in WAL-only mode.
+    pub async fn active_memtable_ref(
+        &self,
+    ) -> Result<crate::dataset::mem_wal::scanner::ActiveMemTableRef> {
+        let state_lock = self.memtable_state_lock()?;
+        let state = state_lock.read().await;
+        Ok(crate::dataset::mem_wal::scanner::ActiveMemTableRef {
             batch_store: state.memtable.batch_store(),
             index_store: state
                 .memtable
@@ -1247,6 +1575,17 @@ impl ShardWriter {
                 .unwrap_or_else(|| Arc::new(IndexStore::new())),
             schema: state.memtable.schema().clone(),
             generation: state.memtable.generation(),
+        })
+    }
+
+    /// Returns the MemTable-mode state lock or a clear invalid_input error
+    /// when running in WAL-only mode.
+    fn memtable_state_lock(&self) -> Result<&Arc<RwLock<WriterState>>> {
+        match &self.mode {
+            WriterMode::MemTable { state, .. } => Ok(state),
+            WriterMode::WalOnly { .. } => Err(Error::invalid_input(
+                "MemTable accessor not available when enable_memtable = false (WAL-only mode)",
+            )),
         }
     }
 
@@ -1264,34 +1603,65 @@ impl ShardWriter {
     pub async fn close(self) -> Result<()> {
         info!("Closing ShardWriter for shard {}", self.config.shard_id);
 
-        // Send final WAL flush message and wait for completion
-        let state = self.state.read().await;
-        let batch_store = state.memtable.batch_store();
-        let indexes = state.memtable.indexes_arc();
-        let batch_count = state.memtable.batch_count();
-        drop(state);
+        match &self.mode {
+            WriterMode::MemTable {
+                state,
+                writer_state,
+                ..
+            } => {
+                // Send final WAL flush message and wait for completion
+                let st = state.read().await;
+                let batch_store = st.memtable.batch_store();
+                let indexes = st.memtable.indexes_arc();
+                let batch_count = st.memtable.batch_count();
+                drop(st);
 
-        // Only send flush if there are batches to flush
-        if batch_count > 0 {
-            // Create a completion cell to wait for flush
-            let done = WatchableOnceCell::new();
-            let reader = done.reader();
-
-            // Send flush message with end_batch_position = batch_count to flush all pending
-            if self
-                .writer_state
-                .wal_flush_tx
-                .send(TriggerWalFlush {
-                    batch_store,
-                    indexes,
-                    end_batch_position: batch_count,
-                    done: Some(done),
-                })
-                .is_ok()
-            {
-                // Wait for flush to complete
-                let mut reader = reader;
-                let _ = reader.await_value().await;
+                if batch_count > 0 {
+                    let done = WatchableOnceCell::new();
+                    let reader = done.reader();
+                    if writer_state
+                        .wal_flush_tx
+                        .send(TriggerWalFlush {
+                            source: WalFlushSource::BatchStore {
+                                batch_store,
+                                indexes,
+                            },
+                            end_batch_position: batch_count,
+                            done: Some(done),
+                        })
+                        .is_ok()
+                    {
+                        let mut reader = reader;
+                        let _ = reader.await_value().await;
+                    }
+                }
+            }
+            WriterMode::WalOnly {
+                state,
+                wal_flush_tx,
+                trigger: _,
+                backpressure: _,
+            } => {
+                // Drain any pending batches via a final flush; wait for completion.
+                let pending = state.batch_count();
+                let end_position = state.next_batch_position();
+                if pending > 0 {
+                    let done = WatchableOnceCell::new();
+                    let reader = done.reader();
+                    if wal_flush_tx
+                        .send(TriggerWalFlush {
+                            source: WalFlushSource::WalOnly {
+                                state: state.clone(),
+                            },
+                            end_batch_position: end_position,
+                            done: Some(done),
+                        })
+                        .is_ok()
+                    {
+                        let mut reader = reader;
+                        let _ = reader.await_value().await;
+                    }
+                }
             }
         }
 
@@ -1325,19 +1695,22 @@ pub struct WalStats {
 /// Indexes are passed through the TriggerWalFlush message.
 struct WalFlushHandler {
     wal_flusher: Arc<WalFlusher>,
-    state: Arc<RwLock<WriterState>>,
+    /// MemTable-mode writer state, used to detect "frozen vs active" flushes
+    /// via Arc::ptr_eq on the active batch_store. `None` when running in
+    /// WAL-only mode (no MemTable, no frozen-vs-active distinction).
+    memtable_state: Option<Arc<RwLock<WriterState>>>,
     stats: SharedWriteStats,
 }
 
 impl WalFlushHandler {
     fn new(
         wal_flusher: Arc<WalFlusher>,
-        state: Arc<RwLock<WriterState>>,
+        memtable_state: Option<Arc<RwLock<WriterState>>>,
         stats: SharedWriteStats,
     ) -> Self {
         Self {
             wal_flusher,
-            state,
+            memtable_state,
             stats,
         }
     }
@@ -1347,15 +1720,12 @@ impl WalFlushHandler {
 impl MessageHandler<TriggerWalFlush> for WalFlushHandler {
     async fn handle(&mut self, message: TriggerWalFlush) -> Result<()> {
         let TriggerWalFlush {
-            batch_store,
-            indexes,
+            source,
             end_batch_position,
             done,
         } = message;
 
-        let result = self
-            .do_flush(batch_store, indexes, end_batch_position)
-            .await;
+        let result = self.do_flush(source, end_batch_position).await;
 
         // Notify completion if requested
         if let Some(cell) = done {
@@ -1367,16 +1737,12 @@ impl MessageHandler<TriggerWalFlush> for WalFlushHandler {
 }
 
 impl WalFlushHandler {
-    /// Unified flush method for both active and frozen memtables.
+    /// Unified flush method for both active and frozen memtables and for
+    /// WAL-only mode.
     ///
-    /// Detects frozen vs active flush by comparing the passed batch_store with the
-    /// current active memtable's batch_store. If different, it's a frozen memtable flush.
-    ///
-    /// # Arguments
-    ///
-    /// * `batch_store` - The batch store to flush from
-    /// * `indexes` - Optional indexes to update in parallel with WAL I/O
-    /// * `end_batch_position` - End batch ID (exclusive). Flush batches in (max_flushed, end_batch_position).
+    /// For BatchStore sources, detects frozen vs active flush by comparing
+    /// the passed batch_store with the current active memtable's
+    /// batch_store. If different, it's a frozen memtable flush.
     #[instrument(
         name = "wal_do_flush",
         level = "debug",
@@ -1385,40 +1751,45 @@ impl WalFlushHandler {
     )]
     async fn do_flush(
         &self,
-        batch_store: Arc<BatchStore>,
-        indexes: Option<Arc<IndexStore>>,
+        source: WalFlushSource,
         end_batch_position: usize,
     ) -> Result<WalFlushResult> {
         let start = Instant::now();
-        // Use batch_store's watermark - this is the authoritative source
-        let max_flushed = batch_store.max_flushed_batch_position();
-        // Convert to count-like value for comparison: number of batches already flushed
-        let flushed_up_to = max_flushed.map(|p| p + 1).unwrap_or(0);
 
-        // Detect if this is a frozen memtable flush by comparing batch_store pointers.
-        // If the batch_store is different from the current active memtable's, it's frozen.
-        let is_frozen_flush = {
-            let state = self.state.read().await;
-            !Arc::ptr_eq(&batch_store, &state.memtable.batch_store())
-        };
+        // Whether this flush actually updates any in-memory indexes — only
+        // a BatchStore source carrying a non-empty `IndexStore` does. Used
+        // to gate the `record_index_update` stat so WAL-only flushes don't
+        // pollute the index-update counters.
+        let has_indexes = matches!(
+            &source,
+            WalFlushSource::BatchStore {
+                indexes: Some(_),
+                ..
+            }
+        );
 
-        // Check if there's anything to flush (only skip for active memtable)
-        if !is_frozen_flush && flushed_up_to >= end_batch_position {
-            return Ok(WalFlushResult {
-                entry: None,
-                wal_io_duration: std::time::Duration::ZERO,
-                index_update_duration: std::time::Duration::ZERO,
-                index_update_duration_breakdown: std::collections::HashMap::new(),
-                rows_indexed: 0,
-                wal_bytes: 0,
-            });
+        // Early-out for BatchStore sources where the watermark already
+        // covers the requested end position. Detection of "frozen flush"
+        // requires the active memtable's batch_store; WAL-only handlers
+        // don't have one (`memtable_state` is `None`) and never receive a
+        // BatchStore source, so the early-out simplifies to the watermark
+        // comparison.
+        if let WalFlushSource::BatchStore { batch_store, .. } = &source {
+            let max_flushed = batch_store.max_flushed_batch_position();
+            let flushed_up_to = max_flushed.map(|p| p + 1).unwrap_or(0);
+            let is_frozen_flush = if let Some(state_lock) = &self.memtable_state {
+                let state = state_lock.read().await;
+                !Arc::ptr_eq(batch_store, &state.memtable.batch_store())
+            } else {
+                false
+            };
+            if !is_frozen_flush && flushed_up_to >= end_batch_position {
+                return Ok(empty_flush_result());
+            }
         }
 
-        // Flush batches up to end_batch_position
-        let flush_result = self
-            .wal_flusher
-            .flush_to_with_index_update(&batch_store, end_batch_position, indexes)
-            .await?;
+        // Delegate the actual flush to the WalFlusher.
+        let flush_result = self.wal_flusher.flush(&source, end_batch_position).await?;
 
         let batches_flushed = flush_result
             .entry
@@ -1426,18 +1797,16 @@ impl WalFlushHandler {
             .map(|e| e.num_batches)
             .unwrap_or(0);
 
-        // Note: WAL watermark is already updated by flush_to_with_index_update()
-        // via batch_store.set_max_flushed_batch_position(). No need for separate mapping.
-
-        // Record WAL flush stats
         if batches_flushed > 0 {
             self.stats
                 .record_wal_flush(start.elapsed(), flush_result.wal_bytes);
             self.stats.record_wal_io(flush_result.wal_io_duration);
-            self.stats.record_index_update(
-                flush_result.index_update_duration,
-                flush_result.rows_indexed,
-            );
+            if has_indexes {
+                self.stats.record_index_update(
+                    flush_result.index_update_duration,
+                    flush_result.rows_indexed,
+                );
+            }
         }
 
         Ok(flush_result)
@@ -1904,7 +2273,7 @@ mod tests {
         assert_eq!(result.batch_positions, 0..1);
 
         // Check stats
-        let stats = writer.memtable_stats().await;
+        let stats = writer.memtable_stats().await.unwrap();
         assert_eq!(stats.row_count, 10);
         assert_eq!(stats.batch_count, 1);
 
@@ -1940,7 +2309,7 @@ mod tests {
         let result = writer.put(batches).await.unwrap();
         assert_eq!(result.batch_positions, 0..5);
 
-        let stats = writer.memtable_stats().await;
+        let stats = writer.memtable_stats().await.unwrap();
         assert_eq!(stats.row_count, 50);
         assert_eq!(stats.batch_count, 5);
 
@@ -1985,7 +2354,7 @@ mod tests {
         let batch = create_test_batch(&schema, 0, 10);
         writer.put(vec![batch]).await.unwrap();
 
-        let stats = writer.memtable_stats().await;
+        let stats = writer.memtable_stats().await.unwrap();
         assert_eq!(stats.row_count, 10);
 
         writer.close().await.unwrap();
@@ -2014,7 +2383,7 @@ mod tests {
             .await
             .unwrap();
 
-        let initial_gen = writer.memtable_stats().await.generation;
+        let initial_gen = writer.memtable_stats().await.unwrap().generation;
 
         // Write batches until auto-flush triggers
         for i in 0..20 {
@@ -2026,7 +2395,7 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
         // Check that generation increased (indicating flush happened)
-        let stats = writer.memtable_stats().await;
+        let stats = writer.memtable_stats().await.unwrap();
         assert!(
             stats.generation > initial_gen,
             "Generation should increment after auto-flush"
@@ -2128,6 +2497,429 @@ mod tests {
         let snapshot = stats.snapshot();
         assert_eq!(snapshot.put_count, 0);
         assert_eq!(snapshot.wal_flush_count, 0);
+    }
+
+    // ----- WAL-only mode (`enable_memtable = false`) -----
+
+    fn wal_only_config(shard_id: Uuid) -> ShardWriterConfig {
+        ShardWriterConfig {
+            shard_id,
+            shard_spec_id: 0,
+            durable_write: true,
+            enable_memtable: false,
+            max_wal_buffer_size: 1024 * 1024,
+            max_wal_flush_interval: None,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wal_only_durable_round_trip() {
+        use crate::dataset::mem_wal::wal::WalTailer;
+
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+
+        let shard_id = Uuid::new_v4();
+        let writer = ShardWriter::open(
+            store.clone(),
+            base_path.clone(),
+            base_uri,
+            wal_only_config(shard_id),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        // Two durable puts → two WAL entries (durable_write triggers an
+        // explicit flush per put).
+        let r1 = writer
+            .put(vec![create_test_batch(&schema, 0, 4)])
+            .await
+            .unwrap();
+        let r2 = writer
+            .put(vec![create_test_batch(&schema, 100, 2)])
+            .await
+            .unwrap();
+        assert_eq!(r1.batch_positions, 0..1);
+        assert_eq!(r2.batch_positions, 1..2);
+
+        writer.close().await.unwrap();
+
+        // Read back via WalTailer.
+        let tailer = WalTailer::new(store, base_path, shard_id);
+        assert_eq!(tailer.first_position().await.unwrap(), 0);
+        assert_eq!(tailer.next_position().await.unwrap(), 2);
+
+        let e0 = tailer.read_entry(0).await.unwrap().unwrap();
+        let e1 = tailer.read_entry(1).await.unwrap().unwrap();
+        assert_eq!(e0.batches.len(), 1);
+        assert_eq!(e0.batches[0].num_rows(), 4);
+        assert_eq!(e1.batches.len(), 1);
+        assert_eq!(e1.batches[0].num_rows(), 2);
+        // Both entries from the same writer should have the same epoch.
+        assert_eq!(e0.writer_epoch, e1.writer_epoch);
+        assert!(e0.writer_epoch >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_wal_only_rejects_index_configs() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let index_configs = vec![MemIndexConfig::BTree(BTreeIndexConfig {
+            name: "id_idx".to_string(),
+            field_id: 0,
+            column: "id".to_string(),
+        })];
+
+        let err = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            wal_only_config(Uuid::new_v4()),
+            schema,
+            index_configs,
+        )
+        .await
+        .err()
+        .expect("expected invalid_input");
+        assert!(
+            err.to_string().contains("indexes require enable_memtable"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wal_only_rejects_empty_batches() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            wal_only_config(Uuid::new_v4()),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        // Empty list.
+        let err = writer.put(vec![]).await.err().unwrap();
+        assert!(err.to_string().contains("empty batch list"));
+
+        // Single empty batch.
+        let zero = arrow_array::RecordBatch::new_empty(schema);
+        let err = writer.put(vec![zero]).await.err().unwrap();
+        assert!(err.to_string().contains("Batch 0 is empty"));
+
+        writer.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_wal_only_memtable_accessors_error() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            wal_only_config(Uuid::new_v4()),
+            schema,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let err = writer.memtable_stats().await.err().unwrap();
+        assert!(err.to_string().contains("WAL-only mode"));
+        let err = writer.scan().await.err().unwrap();
+        assert!(err.to_string().contains("WAL-only mode"));
+        let err = writer.active_memtable_ref().await.err().unwrap();
+        assert!(err.to_string().contains("WAL-only mode"));
+
+        writer.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_wal_only_async_batches_multiple_puts() {
+        use crate::dataset::mem_wal::wal::WalTailer;
+
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+
+        let mut config = wal_only_config(Uuid::new_v4());
+        let shard_id = config.shard_id;
+        // Non-durable: puts should accumulate in the pending queue until
+        // close() drains them with a single WAL entry.
+        config.durable_write = false;
+        config.max_wal_flush_interval = None;
+        config.max_wal_buffer_size = 100 * 1024 * 1024; // never crossed
+
+        let writer = ShardWriter::open(
+            store.clone(),
+            base_path.clone(),
+            base_uri,
+            config,
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        for i in 0..3 {
+            writer
+                .put(vec![create_test_batch(&schema, i * 10, 10)])
+                .await
+                .unwrap();
+        }
+
+        writer.close().await.unwrap();
+
+        // All three puts should be in a single WAL entry at position 0.
+        let tailer = WalTailer::new(store, base_path, shard_id);
+        assert_eq!(tailer.next_position().await.unwrap(), 1);
+        let entry = tailer.read_entry(0).await.unwrap().unwrap();
+        assert_eq!(entry.batches.len(), 3);
+        for (i, batch) in entry.batches.iter().enumerate() {
+            assert_eq!(batch.num_rows(), 10, "batch {i}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_wal_only_fencing() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let shard_id = Uuid::new_v4();
+
+        let writer_a = ShardWriter::open(
+            store.clone(),
+            base_path.clone(),
+            base_uri.clone(),
+            wal_only_config(shard_id),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+        writer_a
+            .put(vec![create_test_batch(&schema, 0, 1)])
+            .await
+            .unwrap();
+
+        // Writer B claims a higher epoch and writes — fences A.
+        let writer_b = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            wal_only_config(shard_id),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+        assert!(writer_b.epoch() > writer_a.epoch());
+        writer_b
+            .put(vec![create_test_batch(&schema, 1, 1)])
+            .await
+            .unwrap();
+
+        // A's next durable put must fail with a fence error (the underlying
+        // WalAppender::append surfaces it via atomic_put).
+        let err = writer_a
+            .put(vec![create_test_batch(&schema, 2, 1)])
+            .await
+            .expect_err("expected fence error");
+        assert!(
+            err.to_string().contains("Writer fenced"),
+            "unexpected error: {err}"
+        );
+
+        writer_b.close().await.unwrap();
+    }
+
+    /// Regression test for the size-based trigger after a drain.
+    ///
+    /// Earlier the WAL-only size trigger used a monotonic counter
+    /// (`wal_flush_trigger_count`) which never reset across drains. After
+    /// the first crossing the counter was >= 1 and `pending_bytes / threshold`
+    /// could never grow past 1 (because pending_bytes resets on drain), so
+    /// the size trigger silently stopped firing. This test pushes batches
+    /// to cross the size threshold multiple times across drains and asserts
+    /// every crossing produces a WAL entry.
+    #[tokio::test]
+    async fn test_wal_only_size_trigger_fires_repeatedly() {
+        use crate::dataset::mem_wal::wal::WalTailer;
+
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+
+        let mut config = wal_only_config(Uuid::new_v4());
+        let shard_id = config.shard_id;
+        // Non-durable so puts don't auto-flush. Time trigger off so only
+        // the size trigger drives flushes.
+        config.durable_write = false;
+        config.max_wal_flush_interval = None;
+        // Pick a tiny threshold so a single batch crosses it.
+        config.max_wal_buffer_size = 1;
+
+        let writer = ShardWriter::open(
+            store.clone(),
+            base_path.clone(),
+            base_uri,
+            config,
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        // Three puts, each large enough to cross the (1-byte) threshold.
+        // Without the fix, only the first would trigger; the rest would
+        // sit in the queue until close().
+        for i in 0..3 {
+            writer
+                .put(vec![create_test_batch(&schema, i * 10, 10)])
+                .await
+                .unwrap();
+            // Yield so the background flush handler gets a chance to drain
+            // the trigger queue before the next push, otherwise multiple
+            // pending triggers could coalesce into a single drain.
+            tokio::task::yield_now().await;
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        writer.close().await.unwrap();
+
+        // Each put should have produced its own WAL entry — three crossings,
+        // three entries. Without the regression fix, all three batches end
+        // up in a single entry written by `close()`.
+        let tailer = WalTailer::new(store, base_path, shard_id);
+        let next = tailer.next_position().await.unwrap();
+        assert!(
+            next >= 3,
+            "expected at least 3 WAL entries (one per crossing), got next_position = {next}"
+        );
+    }
+
+    /// Regression test for concurrent durable WAL-only puts on a fenced
+    /// writer. Earlier `flush_from_wal_only` did a destructive `drain()`
+    /// before calling `wal_appender.append`. If the append failed (e.g.
+    /// fence), the drained batches were dropped — the next concurrent put
+    /// would then see an empty pending queue and spuriously return Ok,
+    /// hiding the data loss. With the snapshot/commit fix, the failed flush
+    /// leaves the batches in the queue, and the concurrent put gets a clean
+    /// fence error too (when its own flush attempts the same WAL position).
+    #[tokio::test]
+    async fn test_wal_only_fenced_concurrent_puts_do_not_silently_succeed() {
+        use std::sync::Arc;
+
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let shard_id = Uuid::new_v4();
+
+        // Writer A claims epoch 1, writes one entry (takes WAL position 0,
+        // caches its next-position as 1 internally).
+        let writer_a = Arc::new(
+            ShardWriter::open(
+                store.clone(),
+                base_path.clone(),
+                base_uri.clone(),
+                wal_only_config(shard_id),
+                schema.clone(),
+                vec![],
+            )
+            .await
+            .unwrap(),
+        );
+        writer_a
+            .put(vec![create_test_batch(&schema, 0, 1)])
+            .await
+            .unwrap();
+
+        // Writer B claims epoch 2 and writes its own entry (takes WAL
+        // position 1). A is now fenced: A's next put will attempt WAL
+        // position 1 (its cached next), collide with B's entry, and
+        // surface a "Writer fenced" error from `check_fenced`.
+        let writer_b = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            wal_only_config(shard_id),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+        writer_b
+            .put(vec![create_test_batch(&schema, 1, 1)])
+            .await
+            .unwrap();
+
+        // Two concurrent durable puts on the (now-fenced) writer A. With
+        // the destructive-drain bug, the first flush would consume both
+        // pending batches into a failing append; the second flush would
+        // see an empty queue and return spurious success, silently losing
+        // the second put's data. With the snapshot/commit fix, the failed
+        // append leaves both batches in the queue and the second flush
+        // also fails with the fence error.
+        let a1 = writer_a.clone();
+        let a2 = writer_a.clone();
+        let schema1 = schema.clone();
+        let schema2 = schema.clone();
+        let h1 = tokio::spawn(async move { a1.put(vec![create_test_batch(&schema1, 2, 1)]).await });
+        let h2 = tokio::spawn(async move { a2.put(vec![create_test_batch(&schema2, 3, 1)]).await });
+
+        let r1 = h1.await.unwrap();
+        let r2 = h2.await.unwrap();
+
+        assert!(
+            r1.is_err() && r2.is_err(),
+            "expected both concurrent puts on a fenced writer to fail, got r1={r1:?} r2={r2:?}",
+        );
+
+        writer_b.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_wal_only_stats_no_memtable_flush() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            wal_only_config(Uuid::new_v4()),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+        writer
+            .put(vec![create_test_batch(&schema, 0, 1)])
+            .await
+            .unwrap();
+
+        let stats_handle = writer.stats_handle();
+        writer.close().await.unwrap();
+
+        let snapshot = stats_handle.snapshot();
+        assert!(snapshot.put_count >= 1, "expected at least one put");
+        assert!(
+            snapshot.wal_flush_count >= 1,
+            "expected at least one WAL flush"
+        );
+        assert_eq!(
+            snapshot.memtable_flush_count, 0,
+            "WAL-only mode must never trigger a memtable flush"
+        );
+        assert_eq!(
+            snapshot.index_update_count, 0,
+            "WAL-only mode must never trigger an index update"
+        );
     }
 }
 
@@ -2575,7 +3367,7 @@ mod shard_writer_tests {
             .await
             .expect("Failed to write to new shard");
 
-        let scanner = new_writer.scan().await;
+        let scanner = new_writer.scan().await.unwrap();
         let result = scanner.try_into_batch().await.expect("Failed to scan");
         assert_eq!(result.num_rows(), 10, "New shard should have 10 rows");
 

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -46,7 +46,9 @@ pub use super::util::{WatchableOnceCell, WatchableOnceCellReader};
 pub use super::wal::{WalEntry, WalEntryData, WalFlushResult, WalFlusher};
 
 use super::memtable::flush::TriggerMemTableFlush;
-use super::wal::{TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState, empty_flush_result};
+use super::wal::{
+    TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState, WalTailer, empty_flush_result,
+};
 
 use super::manifest::ShardManifestStore;
 
@@ -715,6 +717,89 @@ fn now_millis() -> u64 {
     start_time().elapsed().as_millis() as u64
 }
 
+/// Replay WAL entries written after the last successfully-flushed generation
+/// into the freshly-built MemTable. Updates any in-memory indexes attached to
+/// the MemTable so replayed rows are immediately searchable.
+///
+/// Returns the highest WAL position replayed, or `None` if there were no
+/// entries to replay (fresh shard with no prior writes, or the manifest is
+/// already caught up with the WAL tip).
+///
+/// Aborts with an error if any replayed entry's `writer_epoch` is strictly
+/// greater than `our_epoch` — that indicates a successor writer claimed the
+/// shard between our `claim_epoch` and this replay, fencing us.
+async fn replay_memtable_from_wal(
+    object_store: Arc<ObjectStore>,
+    base_path: Path,
+    shard_id: Uuid,
+    our_epoch: u64,
+    manifest: &ShardManifest,
+    memtable: &mut MemTable,
+) -> Result<Option<u64>> {
+    // Fresh shards (no flushes yet) start replay at position 0; otherwise
+    // start one past the last covered position. Distinguishing "no flushes"
+    // from "flushed up to position 0" requires `flushed_generations` since
+    // `replay_after_wal_entry_position` defaults to 0 in both cases.
+    let start_position = if manifest.flushed_generations.is_empty() {
+        0
+    } else {
+        manifest.replay_after_wal_entry_position.saturating_add(1)
+    };
+
+    let tailer = WalTailer::new(object_store, base_path, shard_id);
+    let batches_before = memtable.batch_count();
+    let mut highest_replayed: Option<u64> = None;
+    let mut position = start_position;
+
+    loop {
+        match tailer.read_entry(position).await? {
+            None => break,
+            Some(entry) => {
+                if entry.writer_epoch > our_epoch {
+                    return Err(Error::io(format!(
+                        "WAL replay aborted: entry at position {} has writer_epoch {} > our claimed epoch {} for shard {} (writer was fenced during open)",
+                        position, entry.writer_epoch, our_epoch, shard_id
+                    )));
+                }
+                if !entry.batches.is_empty() {
+                    memtable.insert_batches_only(entry.batches).await?;
+                }
+                highest_replayed = Some(position);
+                position = position.checked_add(1).ok_or_else(|| {
+                    Error::io(format!(
+                        "WAL position overflow during replay for shard {}",
+                        shard_id
+                    ))
+                })?;
+            }
+        }
+    }
+
+    // Update in-memory indexes with the replayed batches so readers see them
+    // through the index path (matching what would have happened on the
+    // pre-crash writer's WAL flush). Indexes from the previous writer don't
+    // persist; this rebuilds them from the WAL.
+    if let Some(indexes) = memtable.indexes_arc() {
+        let batches_after = memtable.batch_count();
+        if batches_after > batches_before {
+            let store = memtable.batch_store();
+            let mut stored: Vec<StoredBatch> = Vec::with_capacity(batches_after - batches_before);
+            for pos in batches_before..batches_after {
+                if let Some(s) = store.get(pos) {
+                    stored.push(s.clone());
+                }
+            }
+            tokio::task::spawn_blocking(move || indexes.insert_batches_parallel(&stored))
+                .await
+                .map_err(|e| {
+                    Error::internal(format!("WAL replay index update task panicked: {}", e))
+                })??;
+        }
+    }
+
+    Ok(highest_replayed)
+}
+
 /// Shared state for writer operations.
 struct SharedWriterState {
     state: Arc<RwLock<WriterState>>,
@@ -1098,7 +1183,8 @@ impl ShardWriter {
                 manifest_store.clone(),
                 stats.clone(),
                 &task_executor,
-            )?
+            )
+            .await?
         } else {
             Self::open_wal_only_mode(
                 &config,
@@ -1122,7 +1208,7 @@ impl ShardWriter {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn open_memtable_mode(
+    async fn open_memtable_mode(
         config: &ShardWriterConfig,
         schema: &Arc<ArrowSchema>,
         manifest: &ShardManifest,
@@ -1162,6 +1248,29 @@ impl ShardWriter {
                 config.ivf_index_partition_capacity_safety_factor,
             )?);
             memtable.set_indexes_arc(indexes);
+        }
+
+        // Replay any WAL entries written after the last successfully-flushed
+        // generation. Each entry's writer_epoch is checked against ours; an
+        // entry with a strictly greater epoch indicates a successor writer
+        // claimed the shard between our `claim_epoch` and replay, so we
+        // abort the open with a fence error. After replay, seed the
+        // appender's next-position counter so the first put doesn't pay the
+        // lazy-discovery probe cost.
+        let last_replayed = replay_memtable_from_wal(
+            object_store.clone(),
+            base_path.clone(),
+            shard_id,
+            epoch,
+            manifest,
+            &mut memtable,
+        )
+        .await?;
+        if let Some(last) = last_replayed {
+            wal_flusher
+                .wal_appender()
+                .seed_next_position(last.saturating_add(1))
+                .await;
         }
 
         let state = Arc::new(RwLock::new(WriterState {
@@ -2741,6 +2850,202 @@ mod tests {
         );
 
         writer_b.close().await.unwrap();
+    }
+
+    // ----- MemTable replay on open -----
+
+    fn memtable_config_with_pk(shard_id: Uuid) -> ShardWriterConfig {
+        ShardWriterConfig {
+            shard_id,
+            shard_spec_id: 0,
+            durable_write: true,
+            sync_indexed_write: false,
+            max_wal_buffer_size: 1024 * 1024,
+            max_wal_flush_interval: None,
+            max_memtable_size: 64 * 1024 * 1024,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        }
+    }
+
+    fn schema_with_pk() -> Arc<ArrowSchema> {
+        use arrow_schema::Field;
+        // Mark `id` as the unenforced primary key.
+        let pk_meta: std::collections::HashMap<String, String> = [(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "1".to_string(),
+        )]
+        .into_iter()
+        .collect();
+        let id_field = Field::new("id", DataType::Int32, false).with_metadata(pk_meta);
+        Arc::new(ArrowSchema::new(vec![
+            id_field,
+            Field::new("name", DataType::Utf8, true),
+        ]))
+    }
+
+    /// Replay-on-open recovers durable WAL entries that were never flushed
+    /// to a Lance generation. Setup: writer A durably writes batches, drops
+    /// without close (so MemTable freeze never runs); writer B reopens and
+    /// must see A's rows in its MemTable scan.
+    #[tokio::test]
+    async fn test_memtable_replay_recovers_unflushed_writes() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = schema_with_pk();
+        let shard_id = Uuid::new_v4();
+
+        // Writer A: write two durable batches, then drop without close.
+        // The WAL files persist; the in-memory MemTable does not.
+        {
+            let writer_a = ShardWriter::open(
+                store.clone(),
+                base_path.clone(),
+                base_uri.clone(),
+                memtable_config_with_pk(shard_id),
+                schema.clone(),
+                vec![],
+            )
+            .await
+            .unwrap();
+            writer_a
+                .put(vec![create_test_batch(&schema, 0, 5)])
+                .await
+                .unwrap();
+            writer_a
+                .put(vec![create_test_batch(&schema, 100, 3)])
+                .await
+                .unwrap();
+            // intentionally drop without close()
+        }
+
+        // Writer B reopens. Replay must rehydrate A's two batches into the
+        // active MemTable.
+        let writer_b = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            memtable_config_with_pk(shard_id),
+            schema,
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let stats = writer_b.memtable_stats().await.unwrap();
+        assert_eq!(
+            stats.row_count, 8,
+            "expected replay to insert 5 + 3 = 8 rows, got {}",
+            stats.row_count
+        );
+        assert_eq!(
+            stats.batch_count, 2,
+            "expected replay to insert 2 batches, got {}",
+            stats.batch_count
+        );
+
+        writer_b.close().await.unwrap();
+    }
+
+    /// Replay is a no-op on a fresh shard: the MemTable starts empty.
+    #[tokio::test]
+    async fn test_memtable_replay_no_op_on_fresh_shard() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = schema_with_pk();
+        let shard_id = Uuid::new_v4();
+
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            memtable_config_with_pk(shard_id),
+            schema,
+            vec![],
+        )
+        .await
+        .unwrap();
+        let stats = writer.memtable_stats().await.unwrap();
+        assert_eq!(stats.row_count, 0);
+        assert_eq!(stats.batch_count, 0);
+        writer.close().await.unwrap();
+    }
+
+    /// Replay aborts the open with a clear fence error if it encounters a
+    /// WAL entry written with an epoch strictly greater than ours. Simulate
+    /// the race where another writer wrote an entry with a higher epoch
+    /// between our `claim_epoch` and our replay by injecting a high-epoch
+    /// entry directly via `WalAppender::with_claimed_epoch` (which
+    /// bypasses `claim_epoch` and so does not bump the manifest).
+    #[tokio::test]
+    async fn test_memtable_replay_fenced_aborts_open() {
+        use crate::dataset::mem_wal::ShardManifestStore;
+
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = schema_with_pk();
+        let shard_id = Uuid::new_v4();
+
+        // Writer A: write one durable batch (claims epoch 1, writes entry at position 0).
+        {
+            let writer_a = ShardWriter::open(
+                store.clone(),
+                base_path.clone(),
+                base_uri.clone(),
+                memtable_config_with_pk(shard_id),
+                schema.clone(),
+                vec![],
+            )
+            .await
+            .unwrap();
+            writer_a
+                .put(vec![create_test_batch(&schema, 0, 1)])
+                .await
+                .unwrap();
+            // drop without close
+        }
+
+        // Inject a WAL entry written with epoch 100 — far above whatever
+        // claim_epoch will hand the next opener. The manifest is not
+        // updated since we use `with_claimed_epoch` directly.
+        let manifest_store = Arc::new(ShardManifestStore::new(
+            store.clone(),
+            &base_path,
+            shard_id,
+            2,
+        ));
+        let high_epoch_appender = WalAppender::with_claimed_epoch(
+            store.clone(),
+            base_path.clone(),
+            shard_id,
+            manifest_store,
+            100,
+            // hint seed irrelevant; the real position counter is discovered
+            // lazily on the first append.
+            0,
+        );
+        high_epoch_appender
+            .append(vec![create_test_batch(&schema, 999, 1)])
+            .await
+            .unwrap();
+
+        // Writer B opens. claim_epoch returns 2 (manifest's writer_epoch
+        // was 1 before this open). Replay reads the injected entry, sees
+        // epoch 100 > 2, and aborts with a fence error.
+        let result = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            memtable_config_with_pk(shard_id),
+            schema,
+            vec![],
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected open to fail with fence error during replay");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("WAL replay aborted") && msg.contains("fenced"),
+            "unexpected error: {msg}"
+        );
     }
 
     /// Regression: `wal_stats().next_wal_entry_position` must reflect the


### PR DESCRIPTION
## Summary

- Add `ShardWriterConfig::enable_memtable` (default `true`); when `false`, `ShardWriter` runs in a new WAL-only mode that keeps the async batched WAL pipeline but skips MemTable allocation, in-memory indexes, MemTable freezing, and MemTable-bytes backpressure (a separate WAL-only backpressure budget reuses `max_unflushed_memtable_bytes`).
- `WalAppender` becomes the WAL write primitive used by both modes inside `WalFlusher`, replacing the prior duplicate plain-`put` path. MemTable mode now also gets atomic put-if-not-exists, conflict retry, and fence-on-write.
- `WalAppender` stays public as the lowest-level synchronous-atomic appender. New `pub(crate) WalAppender::with_claimed_epoch` lets `ShardWriter::open` claim the epoch once and inject it.
- WAL-only mode uses a drainable `WalOnlyState` queue with snapshot/commit semantics so a failed append leaves batches in the queue for retry instead of dropping them silently.
- `memtable_stats()`, `scan()`, `active_memtable_ref()` now return `Result<...>` and produce a clear `invalid_input` error in WAL-only mode.

Behavior change to call out: first WAL entry on a fresh shard is now position 0 instead of 1, matching the 0-based positions documented in the [MemTable & WAL spec](https://github.com/lance-format/lance/blob/main/docs/src/format/table/mem_wal.md). The previous flusher seeded its counter from `wal_entry_position_last_seen + 1` and so always skipped position 0.

Context: this realizes the layering discussed in https://github.com/lance-format/lance/pull/6669#discussion_r3177397523 — keep `WalAppender` as the low-level primitive and let users always use `ShardWriter`, with a config switch to turn the MemTable on or off.

cc @jackye1995