### PR TITLE
feat: show scalar index type in ScalarIndexQuery plan output

### DIFF
--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -1495,7 +1495,11 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
         index_name: String,
         _index_details: &prost_types::Any,
     ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(SargableQueryParser::new(index_name, false)))
+        Some(Box::new(SargableQueryParser::new(
+            index_name,
+            self.name().to_string(),
+            false,
+        )))
     }
 
     async fn train_index(

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -1088,7 +1088,11 @@ impl ScalarIndexPlugin for BloomFilterIndexPlugin {
         index_name: String,
         _index_details: &prost_types::Any,
     ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(BloomFilterQueryParser::new(index_name, true)))
+        Some(Box::new(BloomFilterQueryParser::new(
+            index_name,
+            self.name().to_string(),
+            true,
+        )))
     }
 
     async fn load_index(

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -2706,7 +2706,11 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
         index_name: String,
         _index_details: &prost_types::Any,
     ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(SargableQueryParser::new(index_name, false)))
+        Some(Box::new(SargableQueryParser::new(
+            index_name,
+            self.name().to_string(),
+            false,
+        )))
     }
 
     async fn train_index(

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -262,13 +262,15 @@ impl ScalarQueryParser for MultiQueryParser {
 #[derive(Debug)]
 pub struct SargableQueryParser {
     index_name: String,
+    index_type: String,
     needs_recheck: bool,
 }
 
 impl SargableQueryParser {
-    pub fn new(index_name: String, needs_recheck: bool) -> Self {
+    pub fn new(index_name: String, index_type: String, needs_recheck: bool) -> Self {
         Self {
             index_name,
+            index_type,
             needs_recheck,
         }
     }
@@ -304,6 +306,7 @@ impl ScalarQueryParser for SargableQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(query),
             self.needs_recheck,
         ))
@@ -317,6 +320,7 @@ impl ScalarQueryParser for SargableQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(query),
             self.needs_recheck,
         ))
@@ -326,6 +330,7 @@ impl ScalarQueryParser for SargableQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(SargableQuery::Equals(ScalarValue::Boolean(Some(value)))),
             self.needs_recheck,
         ))
@@ -335,6 +340,7 @@ impl ScalarQueryParser for SargableQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(SargableQuery::IsNull()),
             self.needs_recheck,
         ))
@@ -366,6 +372,7 @@ impl ScalarQueryParser for SargableQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(query),
             self.needs_recheck,
         ))
@@ -393,6 +400,7 @@ impl ScalarQueryParser for SargableQueryParser {
             return Some(IndexedExpression::index_query_with_recheck(
                 column.to_string(),
                 self.index_name.clone(),
+                self.index_type.clone(),
                 Arc::new(query),
                 self.needs_recheck,
             ));
@@ -433,6 +441,7 @@ impl ScalarQueryParser for SargableQueryParser {
         let scalar_query = Some(ScalarIndexExpr::Query(ScalarIndexSearch {
             column: column.to_string(),
             index_name: self.index_name.clone(),
+            index_type: self.index_type.clone(),
             query: Arc::new(query),
             needs_recheck: self.needs_recheck,
         }));
@@ -574,13 +583,15 @@ fn extract_like_leading_prefix(pattern: &str, escape_char: Option<char>) -> Opti
 #[derive(Debug)]
 pub struct BloomFilterQueryParser {
     index_name: String,
+    index_type: String,
     needs_recheck: bool,
 }
 
 impl BloomFilterQueryParser {
-    pub fn new(index_name: String, needs_recheck: bool) -> Self {
+    pub fn new(index_name: String, index_type: String, needs_recheck: bool) -> Self {
         Self {
             index_name,
+            index_type,
             needs_recheck,
         }
     }
@@ -602,6 +613,7 @@ impl ScalarQueryParser for BloomFilterQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(query),
             self.needs_recheck,
         ))
@@ -611,6 +623,7 @@ impl ScalarQueryParser for BloomFilterQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(BloomFilterQuery::Equals(ScalarValue::Boolean(Some(value)))),
             self.needs_recheck,
         ))
@@ -620,6 +633,7 @@ impl ScalarQueryParser for BloomFilterQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(BloomFilterQuery::IsNull()),
             self.needs_recheck,
         ))
@@ -642,6 +656,7 @@ impl ScalarQueryParser for BloomFilterQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(query),
             self.needs_recheck,
         ))
@@ -663,11 +678,15 @@ impl ScalarQueryParser for BloomFilterQueryParser {
 #[derive(Debug)]
 pub struct LabelListQueryParser {
     index_name: String,
+    index_type: String,
 }
 
 impl LabelListQueryParser {
-    pub fn new(index_name: String) -> Self {
-        Self { index_name }
+    pub fn new(index_name: String, index_type: String) -> Self {
+        Self {
+            index_name,
+            index_type,
+        }
     }
 }
 
@@ -728,6 +747,7 @@ impl ScalarQueryParser for LabelListQueryParser {
             return Some(IndexedExpression::index_query(
                 column.to_string(),
                 self.index_name.clone(),
+                self.index_type.clone(),
                 Arc::new(query),
             ));
         }
@@ -747,6 +767,7 @@ impl ScalarQueryParser for LabelListQueryParser {
                 Some(IndexedExpression::index_query(
                     column.to_string(),
                     self.index_name.clone(),
+                    self.index_type.clone(),
                     Arc::new(query),
                 ))
             } else if func.name() == "array_has_any" {
@@ -754,6 +775,7 @@ impl ScalarQueryParser for LabelListQueryParser {
                 Some(IndexedExpression::index_query(
                     column.to_string(),
                     self.index_name.clone(),
+                    self.index_type.clone(),
                     Arc::new(query),
                 ))
             } else {
@@ -769,13 +791,15 @@ impl ScalarQueryParser for LabelListQueryParser {
 #[derive(Debug, Clone)]
 pub struct TextQueryParser {
     index_name: String,
+    index_type: String,
     needs_recheck: bool,
 }
 
 impl TextQueryParser {
-    pub fn new(index_name: String, needs_recheck: bool) -> Self {
+    pub fn new(index_name: String, index_type: String, needs_recheck: bool) -> Self {
         Self {
             index_name,
+            index_type,
             needs_recheck,
         }
     }
@@ -830,6 +854,7 @@ impl ScalarQueryParser for TextQueryParser {
                     Some(IndexedExpression::index_query_with_recheck(
                         column.to_string(),
                         self.index_name.clone(),
+                        self.index_type.clone(),
                         Arc::new(query),
                         self.needs_recheck,
                     ))
@@ -849,11 +874,15 @@ impl ScalarQueryParser for TextQueryParser {
 #[derive(Debug, Clone)]
 pub struct FtsQueryParser {
     index_name: String,
+    index_type: String,
 }
 
 impl FtsQueryParser {
-    pub fn new(name: String) -> Self {
-        Self { index_name: name }
+    pub fn new(name: String, index_type: String) -> Self {
+        Self {
+            index_name: name,
+            index_type,
+        }
     }
 }
 
@@ -906,6 +935,7 @@ impl ScalarQueryParser for FtsQueryParser {
             return Some(IndexedExpression::index_query(
                 column.to_string(),
                 self.index_name.clone(),
+                self.index_type.clone(),
                 Arc::new(query),
             ));
         }
@@ -918,12 +948,16 @@ impl ScalarQueryParser for FtsQueryParser {
 #[derive(Debug, Clone)]
 pub struct GeoQueryParser {
     index_name: String,
+    index_type: String,
 }
 
 #[cfg(feature = "geo")]
 impl GeoQueryParser {
-    pub fn new(index_name: String) -> Self {
-        Self { index_name }
+    pub fn new(index_name: String, index_type: String) -> Self {
+        Self {
+            index_name,
+            index_type,
+        }
     }
 }
 
@@ -950,6 +984,7 @@ impl ScalarQueryParser for GeoQueryParser {
         Some(IndexedExpression::index_query_with_recheck(
             column.to_string(),
             self.index_name.clone(),
+            self.index_type.clone(),
             Arc::new(GeoQuery::IsNull),
             true,
         ))
@@ -996,6 +1031,7 @@ impl ScalarQueryParser for GeoQueryParser {
                     Some(IndexedExpression::index_query_with_recheck(
                         column.to_string(),
                         self.index_name.clone(),
+                        self.index_type.clone(),
                         Arc::new(query),
                         true,
                     ))
@@ -1012,6 +1048,7 @@ impl ScalarQueryParser for GeoQueryParser {
                     Some(IndexedExpression::index_query_with_recheck(
                         column.to_string(),
                         self.index_name.clone(),
+                        self.index_type.clone(),
                         Arc::new(query),
                         true,
                     ))
@@ -1033,11 +1070,17 @@ impl IndexedExpression {
     }
 
     /// Create an expression that is only an index query
-    fn index_query(column: String, index_name: String, query: Arc<dyn AnyQuery>) -> Self {
+    fn index_query(
+        column: String,
+        index_name: String,
+        index_type: String,
+        query: Arc<dyn AnyQuery>,
+    ) -> Self {
         Self {
             scalar_query: Some(ScalarIndexExpr::Query(ScalarIndexSearch {
                 column,
                 index_name,
+                index_type,
                 query,
                 needs_recheck: false, // Default to false, will be set by parser
             })),
@@ -1049,6 +1092,7 @@ impl IndexedExpression {
     fn index_query_with_recheck(
         column: String,
         index_name: String,
+        index_type: String,
         query: Arc<dyn AnyQuery>,
         needs_recheck: bool,
     ) -> Self {
@@ -1056,6 +1100,7 @@ impl IndexedExpression {
             scalar_query: Some(ScalarIndexExpr::Query(ScalarIndexSearch {
                 column,
                 index_name,
+                index_type,
                 query,
                 needs_recheck,
             })),
@@ -1193,6 +1238,8 @@ pub struct ScalarIndexSearch {
     pub column: String,
     /// The name of the index to search
     pub index_name: String,
+    /// The type of the index being searched (e.g. "BTree", "Bitmap"), used for display purposes
+    pub index_type: String,
     /// The query to search for
     pub query: Arc<dyn AnyQuery>,
     /// If true, the query results are inexact and will need a recheck
@@ -1239,9 +1286,10 @@ impl std::fmt::Display for ScalarIndexExpr {
             Self::Or(lhs, rhs) => write!(f, "OR({},{})", lhs, rhs),
             Self::Query(search) => write!(
                 f,
-                "[{}]@{}",
+                "[{}]@{}({})",
                 search.query.format(&search.column),
-                search.index_name
+                search.index_name,
+                search.index_type
             ),
         }
     }
@@ -2166,6 +2214,7 @@ mod tests {
             Some(IndexedExpression::index_query(
                 col.to_string(),
                 format!("{}_idx", col),
+                "BTree".to_string(),
                 Arc::new(query),
             )),
             false,
@@ -2184,6 +2233,7 @@ mod tests {
             Some(IndexedExpression::index_query(
                 col.to_string(),
                 format!("{}_idx", col),
+                "BTree".to_string(),
                 Arc::new(query),
             )),
             true,
@@ -2203,6 +2253,7 @@ mod tests {
                 IndexedExpression::index_query(
                     col.to_string(),
                     format!("{}_idx", col),
+                    "BTree".to_string(),
                     Arc::new(query),
                 )
                 .maybe_not()
@@ -2219,28 +2270,44 @@ mod tests {
                 "color",
                 ColInfo::new(
                     DataType::Utf8,
-                    Box::new(SargableQueryParser::new("color_idx".to_string(), false)),
+                    Box::new(SargableQueryParser::new(
+                        "color_idx".to_string(),
+                        "BTree".to_string(),
+                        false,
+                    )),
                 ),
             ),
             (
                 "aisle",
                 ColInfo::new(
                     DataType::UInt32,
-                    Box::new(SargableQueryParser::new("aisle_idx".to_string(), false)),
+                    Box::new(SargableQueryParser::new(
+                        "aisle_idx".to_string(),
+                        "BTree".to_string(),
+                        false,
+                    )),
                 ),
             ),
             (
                 "on_sale",
                 ColInfo::new(
                     DataType::Boolean,
-                    Box::new(SargableQueryParser::new("on_sale_idx".to_string(), false)),
+                    Box::new(SargableQueryParser::new(
+                        "on_sale_idx".to_string(),
+                        "BTree".to_string(),
+                        false,
+                    )),
                 ),
             ),
             (
                 "price",
                 ColInfo::new(
                     DataType::Float32,
-                    Box::new(SargableQueryParser::new("price_idx".to_string(), false)),
+                    Box::new(SargableQueryParser::new(
+                        "price_idx".to_string(),
+                        "BTree".to_string(),
+                        false,
+                    )),
                 ),
             ),
             (
@@ -2249,7 +2316,11 @@ mod tests {
                     DataType::LargeBinary,
                     Box::new(JsonQueryParser::new(
                         "$.name".to_string(),
-                        Box::new(SargableQueryParser::new("json_idx".to_string(), false)),
+                        Box::new(SargableQueryParser::new(
+                            "json_idx".to_string(),
+                            "BTree".to_string(),
+                            false,
+                        )),
                     )),
                 ),
             ),
@@ -2492,12 +2563,14 @@ mod tests {
         let left = Box::new(ScalarIndexExpr::Query(ScalarIndexSearch {
             column: "aisle".to_string(),
             index_name: "aisle_idx".to_string(),
+            index_type: "BTree".to_string(),
             query: Arc::new(SargableQuery::Equals(ScalarValue::UInt32(Some(10)))),
             needs_recheck: false,
         }));
         let right = Box::new(ScalarIndexExpr::Query(ScalarIndexSearch {
             column: "color".to_string(),
             index_name: "color_idx".to_string(),
+            index_type: "BTree".to_string(),
             query: Arc::new(SargableQuery::Equals(ScalarValue::Utf8(Some(
                 "blue".to_string(),
             )))),
@@ -2777,7 +2850,11 @@ mod tests {
             "color",
             ColInfo::new(
                 DataType::Utf8,
-                Box::new(SargableQueryParser::new("color_idx".to_string(), false)),
+                Box::new(SargableQueryParser::new(
+                    "color_idx".to_string(),
+                    "BTree".to_string(),
+                    false,
+                )),
             ),
         )]);
 
@@ -2873,7 +2950,11 @@ mod tests {
             "object_id",
             ColInfo::new(
                 DataType::Utf8,
-                Box::new(SargableQueryParser::new("object_id_idx".to_string(), false)),
+                Box::new(SargableQueryParser::new(
+                    "object_id_idx".to_string(),
+                    "BTree".to_string(),
+                    false,
+                )),
             ),
         )]);
 
@@ -2933,7 +3014,11 @@ mod tests {
             "color",
             ColInfo::new(
                 DataType::Utf8,
-                Box::new(SargableQueryParser::new("color_idx".to_string(), false)),
+                Box::new(SargableQueryParser::new(
+                    "color_idx".to_string(),
+                    "BTree".to_string(),
+                    false,
+                )),
             ),
         )]);
 

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -235,7 +235,10 @@ impl ScalarIndexPlugin for InvertedIndexPlugin {
         };
 
         if Self::can_accelerate_queries(&index_details) {
-            Some(Box::new(FtsQueryParser::new(index_name)))
+            Some(Box::new(FtsQueryParser::new(
+                index_name,
+                self.name().to_string(),
+            )))
         } else {
             None
         }

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -236,11 +236,13 @@ impl JsonQueryParser {
                 ScalarIndexExpr::Query(ScalarIndexSearch {
                     column,
                     index_name,
+                    index_type,
                     query,
                     needs_recheck,
                 }) => ScalarIndexExpr::Query(ScalarIndexSearch {
                     column,
                     index_name,
+                    index_type,
                     query: Arc::new(JsonQuery::new(query, self.path.clone())),
                     needs_recheck,
                 }),

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -531,7 +531,10 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
         index_name: String,
         _index_details: &prost_types::Any,
     ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(LabelListQueryParser::new(index_name)))
+        Some(Box::new(LabelListQueryParser::new(
+            index_name,
+            self.name().to_string(),
+        )))
     }
 
     /// Train a new index

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -1277,7 +1277,11 @@ impl ScalarIndexPlugin for NGramIndexPlugin {
         index_name: String,
         _index_details: &prost_types::Any,
     ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(TextQueryParser::new(index_name, true)))
+        Some(Box::new(TextQueryParser::new(
+            index_name,
+            self.name().to_string(),
+            true,
+        )))
     }
 
     async fn train_index(

--- a/rust/lance-index/src/scalar/rtree.rs
+++ b/rust/lance-index/src/scalar/rtree.rs
@@ -986,7 +986,10 @@ impl ScalarIndexPlugin for RTreeIndexPlugin {
         index_name: String,
         _index_details: &prost_types::Any,
     ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(GeoQueryParser::new(index_name)))
+        Some(Box::new(GeoQueryParser::new(
+            index_name,
+            self.name().to_string(),
+        )))
     }
 
     async fn load_index(

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -910,7 +910,11 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
         index_name: String,
         _index_details: &prost_types::Any,
     ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(SargableQueryParser::new(index_name, true)))
+        Some(Box::new(SargableQueryParser::new(
+            index_name,
+            self.name().to_string(),
+            true,
+        )))
     }
 
     async fn train_index(

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -1062,7 +1062,7 @@ mod tests {
         crate::utils::test::assert_plan_node_equals(
             plan,
             "LanceRead: ...full_filter=id = Int32(5)...
-  ScalarIndexQuery: query=[id = 5]@id_btree",
+  ScalarIndexQuery: query=[id = 5]@id_btree(BTree)",
         )
         .await
         .unwrap();

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -3549,7 +3549,7 @@ mod tests {
         scanner.project::<String>(&[]).unwrap().with_row_id();
         let plan = scanner.explain_plan(false).await.unwrap();
         assert!(
-            plan.contains("ScalarIndexQuery: query=[category = 1]@category_idx"),
+            plan.contains("ScalarIndexQuery: query=[category = 1]@category_idx(Bitmap)"),
             "Expected index query in plan: {}",
             plan
         );
@@ -3643,7 +3643,7 @@ mod tests {
         scanner.project::<String>(&[]).unwrap().with_row_id();
         let plan = scanner.explain_plan(false).await.unwrap();
         assert!(
-            plan.contains("ScalarIndexQuery: query=[id >= 2000 && id < 3000]@id_idx"),
+            plan.contains("ScalarIndexQuery: query=[id >= 2000 && id < 3000]@id_idx(BTree)"),
             "Expected scalar index query in plan: {}",
             plan
         );
@@ -4005,7 +4005,9 @@ mod tests {
         scanner.project::<String>(&[]).unwrap().with_row_id();
         let plan = scanner.explain_plan(false).await.unwrap();
         assert!(
-            plan.contains("ScalarIndexQuery: query=[array_has_any(labels, List([1]))]@labels_idx"),
+            plan.contains(
+                "ScalarIndexQuery: query=[array_has_any(labels, List([1]))]@labels_idx(LabelList)",
+            ),
             "Expected scalar index query in plan: {}",
             plan
         );

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -7725,7 +7725,7 @@ mod test {
             "LanceRead: uri=..., projection=[ngram, exact, no_index], num_fragments=1, \
              range_before=None, range_after=None, row_id=false, row_addr=false, \
              full_filter=contains(ngram, Utf8(\"test string\")), refine_filter=--
-               ScalarIndexQuery: query=[contains(ngram, Utf8(\"test string\"))]@ngram_idx",
+               ScalarIndexQuery: query=[contains(ngram, Utf8(\"test string\"))]@ngram_idx(NGram)",
         )
         .await
         .unwrap();
@@ -7738,7 +7738,7 @@ mod test {
             range_before=None, range_after=None, row_id=false, row_addr=false, \
             full_filter=contains(ngram, Utf8(\"test string\")) AND exact < UInt32(50), \
             refine_filter=--
-              ScalarIndexQuery: query=AND([contains(ngram, Utf8(\"test string\"))]@ngram_idx,[exact < 50]@exact_idx)",
+              ScalarIndexQuery: query=AND([contains(ngram, Utf8(\"test string\"))]@ngram_idx(NGram),[exact < 50]@exact_idx(BTree))",
         )
         .await
         .unwrap();
@@ -7753,7 +7753,7 @@ mod test {
   LanceRead: uri=..., projection=[ngram, exact, no_index], num_fragments=1, range_before=None, \
   range_after=None, row_id=true, row_addr=false, full_filter=contains(ngram, Utf8(\"test string\")) AND exact < UInt32(50) AND no_index > UInt32(100), \
   refine_filter=no_index > UInt32(100)
-    ScalarIndexQuery: query=AND([contains(ngram, Utf8(\"test string\"))]@ngram_idx,[exact < 50]@exact_idx)",
+    ScalarIndexQuery: query=AND([contains(ngram, Utf8(\"test string\"))]@ngram_idx(NGram),[exact < 50]@exact_idx(BTree))",
         )
         .await
         .unwrap();
@@ -7805,7 +7805,7 @@ mod test {
             "LanceRead: uri=..., projection=[name, id], num_fragments=1, \
              range_before=None, range_after=None, row_id=false, row_addr=false, \
              full_filter=name LIKE Utf8(\"app%\"), refine_filter=--
-               ScalarIndexQuery: query=[name LIKE 'app%']@name_idx",
+               ScalarIndexQuery: query=[name LIKE 'app%']@name_idx(BTree)",
         )
         .await
         .unwrap();
@@ -7839,7 +7839,7 @@ mod test {
             "LanceRead: uri=..., projection=[name, id], num_fragments=1, \
              range_before=None, range_after=None, row_id=false, row_addr=false, \
              full_filter=name LIKE Utf8(\"ban%\"), refine_filter=--
-               ScalarIndexQuery: query=[name LIKE 'ban%']@name_idx",
+               ScalarIndexQuery: query=[name LIKE 'ban%']@name_idx(BTree)",
         )
         .await
         .unwrap();
@@ -7873,7 +7873,7 @@ mod test {
   LanceRead: uri=..., projection=[name, id], num_fragments=1, \
 range_before=None, range_after=None, row_id=true, row_addr=false, \
 full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
-    ScalarIndexQuery: query=[name LIKE 'test%']@name_idx",
+    ScalarIndexQuery: query=[name LIKE 'test%']@name_idx(BTree)",
         )
         .await
         .unwrap();
@@ -9187,7 +9187,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
       SortExec: TopK(fetch=5), expr=...
         ANNSubIndex: name=..., k=5, deltas=1, metric=L2
           ANNIvfPartition: uuid=..., minimum_nprobes=1, maximum_nprobes=None, deltas=1
-          ScalarIndexQuery: query=[i > 10]@i_idx";
+          ScalarIndexQuery: query=[i > 10]@i_idx(BTree)";
         assert_plan_equals(
             &dataset.dataset,
             |scan| {
@@ -9255,7 +9255,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
                     SortExec: TopK(fetch=8), expr=...
                       ANNSubIndex: name=..., k=8, deltas=1, metric=L2
                         ANNIvfPartition: uuid=..., minimum_nprobes=1, maximum_nprobes=None, deltas=1
-                        ScalarIndexQuery: query=[i > 10]@i_idx";
+                        ScalarIndexQuery: query=[i > 10]@i_idx(BTree)";
         assert_plan_equals(
             &dataset.dataset,
             |scan| {
@@ -9291,7 +9291,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
                     SortExec: TopK(fetch=11), expr=...
                       ANNSubIndex: name=..., k=11, deltas=1, metric=L2
                         ANNIvfPartition: uuid=..., minimum_nprobes=1, maximum_nprobes=None, deltas=1
-                        ScalarIndexQuery: query=[i > 10]@i_idx";
+                        ScalarIndexQuery: query=[i > 10]@i_idx(BTree)";
         dataset.make_scalar_index().await?;
         assert_plan_equals(
             &dataset.dataset,
@@ -9312,11 +9312,11 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             "ProjectionExec: expr=[s@1 as s]
   Take: columns=\"_rowid, (s)\"
     CoalesceBatchesExec: target_batch_size=8192
-      MaterializeIndex: query=[i > 10]@i_idx"
+      MaterializeIndex: query=[i > 10]@i_idx(BTree)"
         } else {
             "LanceRead: uri=..., projection=[s], num_fragments=4, range_before=None, \
             range_after=None, row_id=false, row_addr=false, full_filter=i > Int32(10), refine_filter=--
-              ScalarIndexQuery: query=[i > 10]@i_idx"
+              ScalarIndexQuery: query=[i > 10]@i_idx(BTree)"
         };
         assert_plan_equals(
             &dataset.dataset,
@@ -9349,11 +9349,11 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let expected = if data_storage_version == LanceFileVersion::Legacy {
             "ProjectionExec: expr=[_rowaddr@0 as _rowaddr]
   AddRowAddrExec
-    MaterializeIndex: query=[i > 10]@i_idx"
+    MaterializeIndex: query=[i > 10]@i_idx(BTree)"
         } else {
             "LanceRead: uri=..., projection=[], num_fragments=4, range_before=None, \
             range_after=None, row_id=false, row_addr=true, full_filter=i > Int32(10), refine_filter=--
-              ScalarIndexQuery: query=[i > 10]@i_idx"
+              ScalarIndexQuery: query=[i > 10]@i_idx(BTree)"
         };
         assert_plan_equals(
             &dataset.dataset,
@@ -9375,14 +9375,14 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
     UnionExec
       Take: columns=\"_rowid, (s)\"
         CoalesceBatchesExec: target_batch_size=8192
-          MaterializeIndex: query=[i > 10]@i_idx
+          MaterializeIndex: query=[i > 10]@i_idx(BTree)
       ProjectionExec: expr=[_rowid@2 as _rowid, s@1 as s]
         FilterExec: i@0 > 10
           LanceScan: uri=..., projection=[i, s], row_id=true, row_addr=false, ordered=false, range=None"
         } else {
             "LanceRead: uri=..., projection=[s], num_fragments=5, range_before=None, \
             range_after=None, row_id=false, row_addr=false, full_filter=i > Int32(10), refine_filter=--
-              ScalarIndexQuery: query=[i > 10]@i_idx"
+              ScalarIndexQuery: query=[i > 10]@i_idx(BTree)"
         };
         assert_plan_equals(
             &dataset.dataset,
@@ -9397,14 +9397,14 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
   RepartitionExec: partitioning=RoundRobinBatch(1), input_partitions=2
     UnionExec
       AddRowAddrExec
-        MaterializeIndex: query=[i > 10]@i_idx
+        MaterializeIndex: query=[i > 10]@i_idx(BTree)
       ProjectionExec: expr=[_rowaddr@2 as _rowaddr, _rowid@1 as _rowid]
         FilterExec: i@0 > 10
           LanceScan: uri=..., projection=[i], row_id=true, row_addr=true, ordered=false, range=None"
         } else {
             "LanceRead: uri=..., projection=[], num_fragments=5, range_before=None, \
             range_after=None, row_id=false, row_addr=true, full_filter=i > Int32(10), refine_filter=--
-              ScalarIndexQuery: query=[i > 10]@i_idx"
+              ScalarIndexQuery: query=[i > 10]@i_idx(BTree)"
         };
         assert_plan_equals(
             &dataset.dataset,
@@ -9427,7 +9427,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
     UnionExec
       Take: columns=\"_rowid, (s)\"
         CoalesceBatchesExec: target_batch_size=8192
-          MaterializeIndex: query=[i > 10]@i_idx
+          MaterializeIndex: query=[i > 10]@i_idx(BTree)
       ProjectionExec: expr=[_rowid@2 as _rowid, s@1 as s]
         FilterExec: i@0 > 10
           LanceScan: uri=..., row_id=true, row_addr=false, ordered=false, range=None"
@@ -9435,7 +9435,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             "ProjectionExec: expr=[regexp_match(s@0, .*) as matches]
   LanceRead: uri=..., projection=[s], num_fragments=5, range_before=None, \
   range_after=None, row_id=false, row_addr=false, full_filter=i > Int32(10), refine_filter=--
-    ScalarIndexQuery: query=[i > 10]@i_idx"
+    ScalarIndexQuery: query=[i > 10]@i_idx(BTree)"
         };
         assert_plan_equals(
             &dataset.dataset,
@@ -9515,7 +9515,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
       MatchQuery: column=s, query=hello
         RepartitionExec: partitioning=RoundRobinBatch(1), input_partitions=2
           UnionExec
-            MaterializeIndex: query=[i > 10]@i_idx
+            MaterializeIndex: query=[i > 10]@i_idx(BTree)
             ProjectionExec: expr=[_rowid@1 as _rowid]
               FilterExec: i@0 > 10
                 LanceScan: uri=..., projection=[i], row_id=true, row_addr=false, ordered=false, range=None"#
@@ -9525,7 +9525,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
     CoalesceBatchesExec: target_batch_size=8192
       MatchQuery: column=s, query=hello
         LanceRead: uri=..., projection=[], num_fragments=5, range_before=None, range_after=None, row_id=true, row_addr=false, full_filter=i > Int32(10), refine_filter=--
-          ScalarIndexQuery: query=[i > 10]@i_idx"#
+          ScalarIndexQuery: query=[i > 10]@i_idx(BTree)"#
         };
         assert_plan_equals(
             &dataset.dataset,
@@ -9592,7 +9592,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             MatchQuery: column=s, query=hello
               RepartitionExec: partitioning=RoundRobinBatch(1), input_partitions=2
                 UnionExec
-                  MaterializeIndex: query=[i > 10]@i_idx
+                  MaterializeIndex: query=[i > 10]@i_idx(BTree)
                   ProjectionExec: expr=[_rowid@1 as _rowid]
                     FilterExec: i@0 > 10
                       LanceScan: uri=..., projection=[i], row_id=true, row_addr=false, ordered=false, range=None
@@ -9608,7 +9608,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
           UnionExec
             MatchQuery: column=s, query=hello
               LanceRead: uri=..., projection=[], num_fragments=5, range_before=None, range_after=None, row_id=true, row_addr=false, full_filter=i > Int32(10), refine_filter=--
-                ScalarIndexQuery: query=[i > 10]@i_idx
+                ScalarIndexQuery: query=[i > 10]@i_idx(BTree)
             FlatMatchQuery: column=s, query=hello
               FilterExec: i@1 > 10
                 LanceScan: uri=..., projection=[s, i], row_id=true, row_addr=false, ordered=false, range=None"#

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -303,6 +303,8 @@ impl MapIndexExec {
         let query = ScalarIndexExpr::Query(ScalarIndexSearch {
             column: column_name,
             index_name,
+            // Internal IndexedLookup-style query — type is unknown at this layer
+            index_type: String::new(),
             query: Arc::new(SargableQuery::IsIn(index_vals)),
             needs_recheck: false,
         });
@@ -803,6 +805,7 @@ mod tests {
         let query = ScalarIndexExpr::Query(ScalarIndexSearch {
             column: "ordered".to_string(),
             index_name: "ordered_idx".to_string(),
+            index_type: "BTree".to_string(),
             query: Arc::new(SargableQuery::Range(
                 Bound::Unbounded,
                 Bound::Excluded(ScalarValue::UInt64(Some(47))),
@@ -841,6 +844,7 @@ mod tests {
         let query = ScalarIndexExpr::Query(ScalarIndexSearch {
             column: "ordered".to_string(),
             index_name: "ordered_idx".to_string(),
+            index_type: "BTree".to_string(),
             query: Arc::new(SargableQuery::Range(
                 Bound::Unbounded,
                 Bound::Excluded(ScalarValue::UInt64(Some(47))),


### PR DESCRIPTION
The ScalarIndexQuery (and MaterializeIndex) plan nodes now display the underlying scalar index type (BTree, Bitmap, NGram, LabelList, etc.) alongside the index name, e.g. `[category = 1]@category_idx(Bitmap)`. This makes it easier to tell which kind of index is being used when inspecting analyze/explain output without cross-referencing the manifest.