### PR TITLE
ci: bump lance-namespace to 0.7.5 and fix bench_regress recursion limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,9 +5014,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a95e7ab5bff65ecd8bacc6ec9806a1750461f0c100c1cce4d54b701837ae84"
+checksum = "2b377b75583de909f95643b1d33774eb72153cc5cdc0945f377beb319892b7d7"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ lance-linalg = { version = "=7.0.0-beta.2", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=7.0.0-beta.2", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=7.0.0-beta.2", path = "./rust/lance-namespace-impls" }
 lance-namespace-datafusion = { version = "=7.0.0-beta.2", path = "./rust/lance-namespace-datafusion" }
-lance-namespace-reqwest-client = "0.7.4"
+lance-namespace-reqwest-client = "0.7.5"
 lance-tokenizer = { version = "=7.0.0-beta.2", path = "./rust/lance-tokenizer" }
 lance-table = { version = "=7.0.0-beta.2", path = "./rust/lance-table" }
 lance-test-macros = { version = "=7.0.0-beta.2", path = "./rust/lance-test-macros" }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4086,9 +4086,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a95e7ab5bff65ecd8bacc6ec9806a1750461f0c100c1cce4d54b701837ae84"
+checksum = "2b377b75583de909f95643b1d33774eb72153cc5cdc0945f377beb319892b7d7"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -109,12 +109,12 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.4</version>
+            <version>0.7.5</version>
         </dependency>
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.4</version>
+            <version>0.7.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4478,9 +4478,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a95e7ab5bff65ecd8bacc6ec9806a1750461f0c100c1cce4d54b701837ae84"
+checksum = "2b377b75583de909f95643b1d33774eb72153cc5cdc0945f377beb319892b7d7"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -5956,7 +5956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -5975,7 +5975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pylance"
 dynamic = ["version"]
-dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.7.4,<0.8"]
+dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.7.5,<0.8"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lance.org" }]
 license = { file = "LICENSE" }

--- a/rust/lance-io/src/lib.rs
+++ b/rust/lance-io/src/lib.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
+#![recursion_limit = "512"]
 use std::{
     ops::{Range, RangeFrom, RangeFull, RangeTo},
     sync::Arc,

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -119,6 +119,11 @@ impl RestAdapter {
             )
             .route("/v1/table/:id/drop_columns", post(alter_table_drop_columns))
             .route(
+                "/v1/table/:id/backfill_column",
+                post(alter_table_backfill_columns),
+            )
+            .route("/v1/table/:id/refresh", post(refresh_materialized_view))
+            .route(
                 "/v1/table/:id/schema_metadata/update",
                 post(update_table_schema_metadata),
             )
@@ -1050,12 +1055,13 @@ async fn drop_table_index(
 
 async fn alter_table_add_columns(
     State(backend): State<Arc<dyn LanceNamespace>>,
-    _headers: HeaderMap,
+    headers: HeaderMap,
     Path(id): Path<String>,
     Query(params): Query<DelimiterQuery>,
     Json(mut request): Json<AlterTableAddColumnsRequest>,
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
+    request.identity = extract_identity(&headers);
 
     match backend.alter_table_add_columns(request).await {
         Ok(response) => (StatusCode::OK, Json(response)).into_response(),
@@ -1065,15 +1071,48 @@ async fn alter_table_add_columns(
 
 async fn alter_table_alter_columns(
     State(backend): State<Arc<dyn LanceNamespace>>,
-    _headers: HeaderMap,
+    headers: HeaderMap,
     Path(id): Path<String>,
     Query(params): Query<DelimiterQuery>,
     Json(mut request): Json<AlterTableAlterColumnsRequest>,
 ) -> Response {
     request.id = Some(parse_id(&id, params.delimiter.as_deref()));
+    request.identity = extract_identity(&headers);
 
     match backend.alter_table_alter_columns(request).await {
         Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(e) => error_to_response(e),
+    }
+}
+
+async fn alter_table_backfill_columns(
+    State(backend): State<Arc<dyn LanceNamespace>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Query(params): Query<DelimiterQuery>,
+    Json(mut request): Json<AlterTableBackfillColumnsRequest>,
+) -> Response {
+    request.id = Some(parse_id(&id, params.delimiter.as_deref()));
+    request.identity = extract_identity(&headers);
+
+    match backend.alter_table_backfill_columns(request).await {
+        Ok(response) => (StatusCode::ACCEPTED, Json(response)).into_response(),
+        Err(e) => error_to_response(e),
+    }
+}
+
+async fn refresh_materialized_view(
+    State(backend): State<Arc<dyn LanceNamespace>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Query(params): Query<DelimiterQuery>,
+    Json(mut request): Json<RefreshMaterializedViewRequest>,
+) -> Response {
+    request.id = Some(parse_id(&id, params.delimiter.as_deref()));
+    request.identity = extract_identity(&headers);
+
+    match backend.refresh_materialized_view(request).await {
+        Ok(response) => (StatusCode::ACCEPTED, Json(response)).into_response(),
         Err(e) => error_to_response(e),
     }
 }


### PR DESCRIPTION
@jackye1995 this is the fix for the broken main CI — I was already fixing it so might as well just publish.

## Summary

- Bump `lance-namespace-reqwest-client` (Rust), `lance-namespace` (Python), and `lance-namespace-core` / `lance-namespace-apache-client` (Java) to `0.7.5`
- REST adapter (`lance-namespace-impls`):
    - Extract `identity` from headers in `alter_table_add_columns` and `alter_table_alter_columns` (per `lance-namespace#337`)
    - Add new routes/handlers `POST /v1/table/:id/backfill_column` and `POST /v1/table/:id/refresh`, both returning `202 Accepted`
- `lance-io`: add `#![recursion_limit = "512"]` to fix the `bench_regress` build failure (`queries overflow the depth limit` triggered by OpenDAL's deeply layered accessor types after the recent OpenDAL 0.56 bump)