### PR TITLE
chore: rename ser_time to serialization_time in ScalarIndexQuery display

### DIFF
--- a/rust/lance-datafusion/src/utils.rs
+++ b/rust/lance-datafusion/src/utils.rs
@@ -252,4 +252,4 @@ pub const DELTAS_SEARCHED_METRIC: &str = "deltas_searched";
 pub const PARTITIONS_SEARCHED_METRIC: &str = "partitions_searched";
 pub const FIND_PARTITIONS_ELAPSED_METRIC: &str = "find_partitions_elapsed";
 pub const SCALAR_INDEX_SEARCH_TIME_METRIC: &str = "search_time";
-pub const SCALAR_INDEX_SER_TIME_METRIC: &str = "ser_time";
+pub const SCALAR_INDEX_SER_TIME_METRIC: &str = "serialization_time";


### PR DESCRIPTION
Prior to this commit you would end up with nodes like this in the analyze plan output:

    ScalarIndexQuery: elapsed=12.53166489s, query=[..., search_time=8.00s, ser_time=116.86µs] EmptyExec, metrics=[]

This commit changes "ser_time" to "serialization_time". This makes the name more clear to readers unfamiliar with the codebase/rust convention of "serde".