### PR TITLE
fix: swap dataset.rs warning argument order

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -989,7 +989,15 @@ impl Dataset {
                 })? {
                     Ok(r) => r,
                     Err(error) => {
-                        log::warn!("Cannot derive index type for {:?}: {}", idx, error);
+                        log::warn!(
+                            "Cannot derive index type for index {} (uuid={}, type_url={:?}, version={}) on dataset {}: {}",
+                            idx.name,
+                            idx.uuid,
+                            idx.index_details.as_ref().map(|d| d.type_url.as_str()),
+                            idx.index_version,
+                            self_.ds.uri(),
+                            error,
+                        );
                         // mark the type as unknown for any new index type
                         "Unknown".to_owned()
                     }


### PR DESCRIPTION
Prior to this commit, we emitted a warning that would log the index structure in front of the error message that produced the warning. If the index structure was so large that it caused the log processor to truncate the log line, the original error message could be lost.

This changes the warning line to put the error ahead of the structure.