### PR TITLE
perf: reduce memory use when splitting IVF partitions

### DIFF
--- a/rust/lance-index/src/optimize.rs
+++ b/rust/lance-index/src/optimize.rs
@@ -4,9 +4,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::progress::{IndexBuildProgress, noop_progress};
+
 /// Options for optimizing all indices.
 #[non_exhaustive]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct OptimizeOptions {
     /// Number of delta indices to merge for one column. Default: 1.
     ///
@@ -43,6 +45,21 @@ pub struct OptimizeOptions {
     /// and can be read later to identify the source of the commit
     /// (e.g., job_id for tracking completed index jobs).
     pub transaction_properties: Option<Arc<HashMap<String, String>>>,
+
+    /// Progress callback for index building during optimization.
+    pub progress: Arc<dyn IndexBuildProgress>,
+}
+
+impl Default for OptimizeOptions {
+    fn default() -> Self {
+        Self {
+            num_indices_to_merge: None,
+            index_names: None,
+            retrain: false,
+            transaction_properties: None,
+            progress: noop_progress(),
+        }
+    }
 }
 
 impl OptimizeOptions {
@@ -88,6 +105,12 @@ impl OptimizeOptions {
     /// Set transaction properties to store in the commit manifest.
     pub fn transaction_properties(mut self, properties: HashMap<String, String>) -> Self {
         self.transaction_properties = Some(Arc::new(properties));
+        self
+    }
+
+    /// Set progress callback for index building during optimization.
+    pub fn progress(mut self, progress: Arc<dyn IndexBuildProgress>) -> Self {
+        self.progress = progress;
         self
     }
 }

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -88,6 +88,8 @@ use super::{
 
 // the number of partitions to evaluate for reassigning
 const REASSIGN_RANGE: usize = 64;
+// sample size for kmeans training when splitting a partition (sample_rate * k = 256 * 2)
+const SPLIT_SAMPLE_SIZE: usize = 512;
 
 // Builder for IVF index
 // The builder will train the IVF model and quantizer, shuffle the dataset, and build the sub index
@@ -841,14 +843,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     let frag_reuse_index = frag_reuse_index.clone();
                     let partition_adjustment = partition_adjustment.clone();
                     async move {
-                        // For affected partitions in a split, read from the
-                        // split shuffle reader which has re-quantized data.
-                        // For all other partitions, use the normal path.
-                        let is_affected = matches!(
-                            partition_adjustment.as_ref(),
-                            Some(PartitionAdjustment::Split { affected_partitions, .. })
-                            if affected_partitions.contains(&partition)
-                        );
+                        let (is_affected, split_reader) = match partition_adjustment.as_ref() {
+                            Some(PartitionAdjustment::Split {
+                                affected_partitions,
+                                split_shuffle_reader,
+                            }) => (
+                                affected_partitions.contains(&partition),
+                                Some(split_shuffle_reader.clone()),
+                            ),
+                            _ => (false, None),
+                        };
                         let partition = match partition_adjustment.as_ref() {
                             Some(PartitionAdjustment::Join(joined_partition))
                                 if partition >= *joined_partition =>
@@ -858,52 +862,37 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             _ => partition,
                         };
 
-                        let (mut batches, loss) = if is_affected {
-                            // Read from the split shuffle reader only — it has
-                            // all data for this partition (existing + new),
-                            // re-assigned with updated centroids.
-                            let split_reader = match partition_adjustment.as_ref() {
-                                Some(PartitionAdjustment::Split {
-                                    split_shuffle_reader,
-                                    ..
-                                }) => split_shuffle_reader.clone(),
-                                _ => unreachable!(),
-                            };
+                        // For affected partitions, the split shuffle reader has
+                        // all data (existing + new), re-assigned with updated
+                        // centroids. For other partitions, read from existing
+                        // indices + original shuffle reader as normal.
+                        let (mut batches, mut loss) = if is_affected {
                             Self::take_partition_batches(
                                 partition,
                                 &[],
-                                Some(split_reader.as_ref()),
+                                Some(split_reader.as_ref().unwrap().as_ref()),
                             )
                             .await?
                         } else {
-                            let (mut batches, loss) = Self::take_partition_batches(
+                            Self::take_partition_batches(
                                 partition,
                                 indices.as_ref(),
                                 Some(reader.as_ref()),
                             )
-                            .await?;
-
-                            // During a split, vectors from affected partitions
-                            // may have been reassigned to this (unaffected)
-                            // partition. Read any such data from the split
-                            // shuffle reader.
-                            if let Some(PartitionAdjustment::Split {
-                                split_shuffle_reader,
-                                ..
-                            }) = partition_adjustment.as_ref()
-                            {
-                                let (extra_batches, extra_loss) = Self::take_partition_batches(
-                                    partition,
-                                    &[],
-                                    Some(split_shuffle_reader.as_ref()),
-                                )
-                                .await?;
-                                batches.extend(extra_batches);
-                                (batches, loss + extra_loss)
-                            } else {
-                                (batches, loss)
-                            }
+                            .await?
                         };
+
+                        // For unaffected partitions during a split, vectors from
+                        // affected partitions may have been reassigned here.
+                        if !is_affected {
+                            if let Some(sr) = split_reader.as_ref() {
+                                let (extra, extra_loss) =
+                                    Self::take_partition_batches(partition, &[], Some(sr.as_ref()))
+                                        .await?;
+                                batches.extend(extra);
+                                loss += extra_loss;
+                            }
+                        }
 
                         spawn_cpu(move || {
                             // Apply assign_batch for join operations (splits no
@@ -1480,9 +1469,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let mut affected_partitions = HashSet::new();
         for &part_idx in &actual_splits {
             affected_partitions.insert(part_idx);
-            let c0 = ivf
-                .centroid(part_idx)
-                .ok_or(Error::invalid_input("centroid not found"))?;
+            let c0 = ivf.centroid(part_idx).ok_or(Error::invalid_input(format!(
+                "centroid not found for partition {part_idx}",
+            )))?;
             let (neighbor_ids, _) =
                 select_reassign_candidates_impl(self.distance_type, ivf, part_idx, &c0)?;
             for neighbor_id in neighbor_ids.values() {
@@ -1611,7 +1600,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         })
         .boxed();
 
-        // Transform through IVF assignment + quantization
         let transformer = Arc::new(
             lance_index::vector::ivf::new_ivf_transformer_with_quantizer(
                 new_centroids.clone(),
@@ -1652,7 +1640,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let transformed_stream =
             Box::new(RecordBatchStreamAdapter::new(schema, transformed_stream));
 
-        // Shuffle into per-partition temp files
         let split_shuffle_dir = self.temp_dir.child("split_shuffle");
         let shuffler = create_ivf_shuffler(
             split_shuffle_dir,
@@ -1720,8 +1707,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         T::Native: Dot + L2 + Normalize,
         PrimitiveArray<T>: From<Vec<T::Native>>,
     {
-        // Sample 256 * 2 = 512 vectors for kmeans training with k=2
-        let Some(vectors) = self.sample_partition_raw_vectors(part_idx, 512).await? else {
+        let Some(vectors) = self
+            .sample_partition_raw_vectors(part_idx, SPLIT_SAMPLE_SIZE)
+            .await?
+        else {
             return Ok(None);
         };
 
@@ -1923,44 +1912,22 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             )?,
         );
 
-        let num_rows = assign_ops
-            .iter()
-            .map(|ops| {
-                ops.iter()
-                    .map(|op| match op {
-                        AssignOp::Add(_) => 1,
-                        AssignOp::Remove(_) => 0,
-                    })
-                    .sum::<usize>()
-            })
-            .sum::<usize>();
+        let num_rows: usize = assign_ops.iter().map(|ops| ops.len()).sum();
 
         // build the input batch with schema | row_id | vector | part_id |
         let mut row_ids_builder = UInt64Builder::with_capacity(num_rows);
         let mut vector_builder =
             PrimitiveBuilder::<T>::with_capacity(num_rows * centroids.value_length() as usize);
         let mut part_ids_builder = UInt32Builder::with_capacity(num_rows);
-        let mut deleted_row_ids = UInt64Builder::with_capacity(num_rows);
 
-        let mut ops_count = Vec::with_capacity(assign_ops.len());
+        let mut counts = Vec::with_capacity(assign_ops.len());
         for (part_idx, ops) in assign_ops.iter().enumerate() {
-            let mut add_count = 0;
-            let mut remove_count = 0;
-            for op in ops {
-                match op {
-                    AssignOp::Add((row_id, vector)) => {
-                        row_ids_builder.append_value(*row_id);
-                        vector_builder.append_array(vector.as_primitive::<T>());
-                        part_ids_builder.append_value(part_idx as u32);
-                        add_count += 1;
-                    }
-                    AssignOp::Remove(row_id) => {
-                        deleted_row_ids.append_value(*row_id);
-                        remove_count += 1;
-                    }
-                }
+            for AssignOp::Add((row_id, vector)) in ops {
+                row_ids_builder.append_value(*row_id);
+                vector_builder.append_array(vector.as_primitive::<T>());
+                part_ids_builder.append_value(part_idx as u32);
             }
-            ops_count.push((add_count, remove_count));
+            counts.push(ops.len());
         }
 
         let row_ids = row_ids_builder.finish();
@@ -1969,7 +1936,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             centroids.value_length(),
         )?;
         let part_ids = part_ids_builder.finish();
-        let deleted_row_ids = deleted_row_ids.finish();
         let schema = arrow_schema::Schema::new(vec![
             ROW_ID_FIELD.clone(),
             vector_field,
@@ -1981,20 +1947,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         )?;
         let batch = transformer.transform(&batch)?;
 
-        // slice the batch according to the ops count
+        let empty_deleted = UInt64Array::from(Vec::<u64>::new());
         let mut results = Vec::with_capacity(assign_ops.len());
-        let mut add_offset = 0;
-        let mut remove_offset = 0;
-        for (add_count, remove_count) in ops_count.into_iter() {
-            if add_count == 0 && remove_count == 0 {
+        let mut offset = 0;
+        for count in counts {
+            if count == 0 {
                 results.push(None);
-                continue;
+            } else {
+                results.push(Some((batch.slice(offset, count), empty_deleted.clone())));
+                offset += count;
             }
-            let batch = batch.slice(add_offset, add_count);
-            let deleted_row_ids = deleted_row_ids.slice(remove_offset, remove_count);
-            results.push(Some((batch, deleted_row_ids)));
-            add_offset += add_count;
-            remove_offset += remove_count;
         }
         Ok(results)
     }
@@ -2142,8 +2104,6 @@ struct SplitResult {
 #[derive(Debug, Clone)]
 enum AssignOp {
     Add((u64, ArrayRef)),
-    #[allow(dead_code)]
-    Remove(u64),
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -2162,6 +2122,21 @@ enum PartitionAdjustment {
     },
     /// Join partition at given id
     Join(usize),
+}
+
+impl std::fmt::Debug for PartitionAdjustment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Split {
+                affected_partitions,
+                ..
+            } => f
+                .debug_struct("Split")
+                .field("affected_partitions", affected_partitions)
+                .finish(),
+            Self::Join(id) => f.debug_tuple("Join").field(id).finish(),
+        }
+    }
 }
 
 pub(crate) fn index_type_string(sub_index: SubIndexType, quantizer: QuantizationType) -> String {

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 use std::{collections::HashMap, pin::Pin};
 
 use arrow::array::{AsArray as _, PrimitiveBuilder, UInt32Builder, UInt64Builder};
@@ -634,13 +635,25 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             HashMap::new()
         };
         let progress = self.progress.clone();
-        progress.stage_start("shuffle", None, "batches").await?;
+        let total = if let (lower, Some(upper)) = data.size_hint()
+            && lower == upper
+        {
+            Some(lower as u64)
+        } else {
+            None
+        };
+        progress.stage_start("shuffle", total, "batches").await?;
+
+        let completed = Arc::new(AtomicU64::new(0));
+        let progress_clone = progress.clone();
 
         let partition_map = Arc::new(precomputed_partitions);
         let mut transformed_stream = Box::pin(
             data.map(move |batch| {
                 let partition_map = partition_map.clone();
                 let ivf_transformer = transformer.clone();
+                let completed = completed.clone();
+                let progress_clone = progress_clone.clone();
                 tokio::spawn(async move {
                     let mut batch = batch?;
                     if !partition_map.is_empty() {
@@ -672,6 +685,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             batch = batch.take(&indices)?;
                         }
                     }
+
+                    let progress_completed =
+                        completed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    progress_clone.stage_progress("shuffle", progress_completed).await?;
+
                     match batch.schema().column_with_name(code_column) {
                         Some(_) => {
                             // this batch is already transformed (in case of GPU training)

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -884,14 +884,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
                         // For unaffected partitions during a split, vectors from
                         // affected partitions may have been reassigned here.
-                        if !is_affected {
-                            if let Some(sr) = split_reader.as_ref() {
-                                let (extra, extra_loss) =
-                                    Self::take_partition_batches(partition, &[], Some(sr.as_ref()))
-                                        .await?;
-                                batches.extend(extra);
-                                loss += extra_loss;
-                            }
+                        if !is_affected && let Some(sr) = split_reader.as_ref() {
+                            let (extra, extra_loss) =
+                                Self::take_partition_batches(partition, &[], Some(sr.as_ref()))
+                                    .await?;
+                            batches.extend(extra);
+                            loss += extra_loss;
                         }
 
                         spawn_cpu(move || {
@@ -1454,7 +1452,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             // Create a dummy empty shuffle reader
             let empty_reader = Arc::new(IvfShufflerReader::new(
                 Arc::new(self.store.clone()),
-                self.temp_dir.child("split_shuffle"),
+                self.temp_dir.clone().join("split_shuffle"),
                 vec![0; ivf.num_partitions()],
                 0.0,
             ));
@@ -1629,7 +1627,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 log::info!("no vectors to reshuffle");
                 let empty_reader: Box<dyn ShuffleReader> = Box::new(IvfShufflerReader::new(
                     Arc::new(self.store.clone()),
-                    self.temp_dir.child("split_shuffle"),
+                    self.temp_dir.clone().join("split_shuffle"),
                     vec![0; new_centroids.len()],
                     0.0,
                 ));
@@ -1640,7 +1638,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let transformed_stream =
             Box::new(RecordBatchStreamAdapter::new(schema, transformed_stream));
 
-        let split_shuffle_dir = self.temp_dir.child("split_shuffle");
+        let split_shuffle_dir = self.temp_dir.clone().join("split_shuffle");
         let shuffler = create_ivf_shuffler(
             split_shuffle_dir,
             new_centroids.len(),
@@ -1720,7 +1718,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 let vectors = normalize_fsl(&vectors)?;
                 (DistanceType::L2, vectors)
             }
-            _ => (self.distance_type, vectors.clone()),
+            _ => (self.distance_type, vectors),
         };
         let params = KMeansParams::new(None, 50, 1, normalized_dist_type);
         let kmeans = lance_index::vector::kmeans::train_kmeans::<T>(

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -1419,16 +1419,39 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let mut new_centroids: Vec<ArrayRef> =
             Vec::with_capacity(ivf.num_partitions() + split_partitions.len());
         new_centroids.extend(centroids.iter().map(|vec| vec.unwrap()));
-        let split_plans = stream::iter(split_partitions.iter().copied().enumerate())
-            .map(|(split_order, part_idx)| async move {
-                let centroid2_part_idx = ivf.num_partitions() + split_order;
-                self.build_split_plan::<T>(part_idx, centroid2_part_idx, ivf)
-                    .await
-            })
+
+        // Phase 1: Train split centroids in parallel (low memory — only samples).
+        let trained_centroids = stream::iter(split_partitions.iter().copied())
+            .map(|part_idx| async move { self.train_split_centroids::<T>(part_idx).await })
             .buffered(get_num_compute_intensive_cpus())
             .try_collect::<Vec<_>>()
             .await?;
-        let mut split_plans = split_plans.into_iter().flatten().collect::<Vec<_>>();
+
+        // Phase 2: Assign vectors sequentially (high memory — loads full raw vectors).
+        let mut split_plans = Vec::new();
+        for (split_order, (part_idx, centroids_opt)) in split_partitions
+            .iter()
+            .copied()
+            .zip(trained_centroids)
+            .enumerate()
+        {
+            let Some((centroid1, centroid2)) = centroids_opt else {
+                continue;
+            };
+            let centroid2_part_idx = ivf.num_partitions() + split_order;
+            if let Some(plan) = self
+                .assign_split_vectors::<T>(
+                    part_idx,
+                    centroid2_part_idx,
+                    &centroid1,
+                    &centroid2,
+                    ivf,
+                )
+                .await?
+            {
+                split_plans.push(plan);
+            }
+        }
         split_plans.sort_by_key(|plan| plan.part_idx);
         Self::finalize_split_plans(&mut split_plans, ivf.num_partitions());
 
@@ -1483,17 +1506,65 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         })
     }
 
-    async fn build_split_plan<T: ArrowPrimitiveType>(
+    /// Sample raw vectors from a partition for kmeans training.
+    ///
+    /// Samples row IDs first, then only loads `sample_size` vectors from disk.
+    async fn sample_partition_raw_vectors(
         &self,
         part_idx: usize,
-        centroid2_part_idx: usize,
-        ivf: &IvfModel,
-    ) -> Result<Option<SplitPlan>>
+        sample_size: usize,
+    ) -> Result<Option<FixedSizeListArray>> {
+        let Some(dataset) = self.dataset.as_ref() else {
+            return Err(Error::invalid_input(
+                "dataset not set before sample partition",
+            ));
+        };
+
+        let mut row_ids = self.partition_row_ids(part_idx).await?;
+        if !row_ids.is_sorted() {
+            row_ids.sort();
+        }
+        row_ids.dedup();
+
+        if row_ids.is_empty() {
+            return Ok(None);
+        }
+
+        // Sample row IDs with stride before loading any vectors
+        if row_ids.len() > sample_size {
+            let stride = row_ids.len() / sample_size;
+            row_ids = (0..sample_size).map(|i| row_ids[i * stride]).collect();
+        }
+
+        let batches = Self::take_vectors(dataset, &self.column, &self.store, &row_ids).await?;
+        if batches.is_empty() {
+            return Ok(None);
+        }
+        let batch = arrow::compute::concat_batches(&batches[0].schema(), batches.iter())?;
+        let batch = Flatten::new(&self.column).transform(&batch)?;
+        let vectors = batch
+            .column_by_qualified_name(&self.column)
+            .ok_or(Error::invalid_input(format!(
+                "vector column {} not found in batch",
+                self.column,
+            )))?
+            .as_fixed_size_list()
+            .clone();
+        Ok(Some(vectors))
+    }
+
+    /// Train kmeans centroids for splitting a partition. This only needs a
+    /// small sample of vectors and is cheap enough to run in parallel.
+    async fn train_split_centroids<T: ArrowPrimitiveType>(
+        &self,
+        part_idx: usize,
+    ) -> Result<Option<(ArrayRef, ArrayRef)>>
     where
         T::Native: Dot + L2 + Normalize,
         PrimitiveArray<T>: From<Vec<T::Native>>,
     {
-        let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
+        // Sample 256 * 2 = 512 vectors for kmeans training with k=2
+        let Some(vectors) = self.sample_partition_raw_vectors(part_idx, 512).await? else {
             return Ok(None);
         };
 
@@ -1514,11 +1585,33 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             256,
         )?;
 
+        let centroid1 = kmeans.centroids.slice(0, dimension);
+        let centroid2 = kmeans.centroids.slice(dimension, dimension);
+        Ok(Some((centroid1, centroid2)))
+    }
+
+    /// Assign all vectors in a partition to split centroids. This loads the
+    /// full raw vectors and is memory-intensive — should run with limited
+    /// concurrency.
+    async fn assign_split_vectors<T: ArrowPrimitiveType>(
+        &self,
+        part_idx: usize,
+        centroid2_part_idx: usize,
+        centroid1: &ArrayRef,
+        centroid2: &ArrayRef,
+        ivf: &IvfModel,
+    ) -> Result<Option<SplitPlan>>
+    where
+        T::Native: Dot + L2 + Normalize,
+        PrimitiveArray<T>: From<Vec<T::Native>>,
+    {
+        let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
+            return Ok(None);
+        };
+
         let c0 = ivf
             .centroid(part_idx)
             .ok_or(Error::invalid_input("original centroid not found"))?;
-        let centroid1 = kmeans.centroids.slice(0, dimension);
-        let centroid2 = kmeans.centroids.slice(dimension, dimension);
         let (reassign_part_ids, reassign_part_centroids) =
             self.select_reassign_candidates(ivf, part_idx, &c0)?;
 
@@ -1545,8 +1638,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(Some(SplitPlan {
             part_idx,
             centroid2_part_idx,
-            centroid1,
-            centroid2,
+            centroid1: centroid1.clone(),
+            centroid2: centroid2.clone(),
             reassign_part_ids,
             original_assign_ops,
         }))
@@ -1581,48 +1674,42 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
         }
 
-        let candidate_moves = stream::iter(candidate_partitions.into_iter())
-            .map(|(part_idx, requests)| async move {
-                let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await?
-                else {
-                    return Ok::<Vec<CandidateMove>, Error>(Vec::new());
-                };
+        // Process candidate partitions sequentially to avoid loading raw vectors
+        // for many partitions simultaneously.
+        let mut candidate_moves = Vec::new();
+        for (part_idx, requests) in candidate_partitions {
+            let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
+                continue;
+            };
 
-                let candidate_centroid = ivf.centroid(part_idx).ok_or(Error::invalid_input(
-                    format!("candidate centroid not found for partition {part_idx}"),
-                ))?;
-                let baseline_dists =
-                    self.distance_type.arrow_batch_func()(candidate_centroid.as_ref(), &vectors)?;
-                let mut best_moves = vec![None; row_ids.len()];
-                for request in requests {
-                    let d1 = self.distance_type.arrow_batch_func()(
-                        request.centroid1.as_ref(),
-                        &vectors,
-                    )?;
-                    let d2 = self.distance_type.arrow_batch_func()(
-                        request.centroid2.as_ref(),
-                        &vectors,
-                    )?;
-                    Self::update_best_candidate_moves::<T>(
-                        request.centroid1_part_idx,
-                        request.centroid2_part_idx,
-                        &row_ids,
-                        &vectors,
-                        baseline_dists.values(),
-                        d1.values(),
-                        d2.values(),
-                        &mut best_moves,
-                        part_idx,
-                    );
-                }
+            let candidate_centroid = ivf.centroid(part_idx).ok_or(Error::invalid_input(
+                format!("candidate centroid not found for partition {part_idx}"),
+            ))?;
+            let baseline_dists =
+                self.distance_type.arrow_batch_func()(candidate_centroid.as_ref(), &vectors)?;
+            let mut best_moves = vec![None; row_ids.len()];
+            for request in requests {
+                let d1 =
+                    self.distance_type.arrow_batch_func()(request.centroid1.as_ref(), &vectors)?;
+                let d2 =
+                    self.distance_type.arrow_batch_func()(request.centroid2.as_ref(), &vectors)?;
+                Self::update_best_candidate_moves::<T>(
+                    request.centroid1_part_idx,
+                    request.centroid2_part_idx,
+                    &row_ids,
+                    &vectors,
+                    baseline_dists.values(),
+                    d1.values(),
+                    d2.values(),
+                    &mut best_moves,
+                    part_idx,
+                );
+            }
 
-                Ok(best_moves.into_iter().flatten().collect::<Vec<_>>())
-            })
-            .buffered(get_num_compute_intensive_cpus())
-            .try_collect::<Vec<_>>()
-            .await?;
+            candidate_moves.extend(best_moves.into_iter().flatten());
+        }
 
-        Ok(candidate_moves.into_iter().flatten().collect())
+        Ok(candidate_moves)
     }
 
     fn finalize_split_plans(split_plans: &mut [SplitPlan], base_num_partitions: usize) {

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::{collections::HashMap, pin::Pin};
@@ -21,7 +20,6 @@ use futures::{
     Stream,
     prelude::stream::{StreamExt, TryStreamExt},
 };
-use itertools::Itertools;
 use lance_arrow::{FixedSizeListArrayExt, RecordBatchExt};
 use lance_core::ROW_ID;
 use lance_core::datatypes::Schema;
@@ -44,7 +42,7 @@ use lance_index::vector::quantizer::{QuantizerMetadata, QuantizerStorage};
 use lance_index::vector::shared::{SupportedIvfIndexType, write_unified_ivf_and_index_metadata};
 use lance_index::vector::storage::STORAGE_METADATA_KEY;
 use lance_index::vector::transform::Flatten;
-use lance_index::vector::v3::shuffler::{EmptyReader, IvfShufflerReader};
+use lance_index::vector::v3::shuffler::{EmptyReader, IvfShufflerReader, create_ivf_shuffler};
 use lance_index::vector::v3::subindex::SubIndexType;
 use lance_index::vector::{LOSS_METADATA_KEY, PART_ID_COLUMN, PQ_CODE_COLUMN, VectorIndex};
 use lance_index::vector::{PART_ID_FIELD, ivf::storage::IvfModel};
@@ -780,18 +778,22 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                         split_partitions,
                         self.existing_indices.len()
                     );
-                    let split_results = self.split_partitions(&split_partitions, ivf).await?;
-                    let actual_split_partitions = split_results.split_partitions.clone();
+                    let split_result = self
+                        .split_partitions_streaming(&split_partitions, ivf)
+                        .await?;
                     let Some(ivf) = self.ivf.as_mut() else {
                         return Err(Error::invalid_input(
                             "IVF not set before building partitions",
                         ));
                     };
-                    ivf.centroids = Some(split_results.new_centroids);
+                    ivf.centroids = Some(split_result.new_centroids);
                     (
-                        split_results.assign_batches,
+                        vec![None; ivf.num_partitions()],
                         Arc::new(self.existing_indices.clone()),
-                        Some(PartitionAdjustment::Split(actual_split_partitions)),
+                        Some(PartitionAdjustment::Split {
+                            affected_partitions: split_result.affected_partitions,
+                            split_shuffle_reader: split_result.shuffle_reader,
+                        }),
                     )
                 } else {
                     match join_partition {
@@ -824,6 +826,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let distance_type = self.distance_type;
         let column = self.column.clone();
         let frag_reuse_index = self.frag_reuse_index.clone();
+        let partition_adjustment = Arc::new(partition_adjustment);
         let build_iter =
             assign_batches
                 .into_iter()
@@ -836,33 +839,75 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     let sub_index_params = sub_index_params.clone();
                     let column = column.clone();
                     let frag_reuse_index = frag_reuse_index.clone();
-                    let skip_existing_batches = match &partition_adjustment {
-                        Some(PartitionAdjustment::Split(split_partitions)) => {
-                            split_partitions.binary_search(&partition).is_ok()
-                        }
-                        _ => false,
-                    };
-                    let partition = match &partition_adjustment {
-                        Some(PartitionAdjustment::Join(joined_partition))
-                            if partition >= *joined_partition =>
-                        {
-                            partition + 1
-                        }
-                        _ => partition,
-                    };
+                    let partition_adjustment = partition_adjustment.clone();
                     async move {
-                        let (mut batches, loss) = if skip_existing_batches {
-                            (Vec::new(), 0.0)
-                        } else {
+                        // For affected partitions in a split, read from the
+                        // split shuffle reader which has re-quantized data.
+                        // For all other partitions, use the normal path.
+                        let is_affected = matches!(
+                            partition_adjustment.as_ref(),
+                            Some(PartitionAdjustment::Split { affected_partitions, .. })
+                            if affected_partitions.contains(&partition)
+                        );
+                        let partition = match partition_adjustment.as_ref() {
+                            Some(PartitionAdjustment::Join(joined_partition))
+                                if partition >= *joined_partition =>
+                            {
+                                partition + 1
+                            }
+                            _ => partition,
+                        };
+
+                        let (mut batches, loss) = if is_affected {
+                            // Read from the split shuffle reader only — it has
+                            // all data for this partition (existing + new),
+                            // re-assigned with updated centroids.
+                            let split_reader = match partition_adjustment.as_ref() {
+                                Some(PartitionAdjustment::Split {
+                                    split_shuffle_reader,
+                                    ..
+                                }) => split_shuffle_reader.clone(),
+                                _ => unreachable!(),
+                            };
                             Self::take_partition_batches(
+                                partition,
+                                &[],
+                                Some(split_reader.as_ref()),
+                            )
+                            .await?
+                        } else {
+                            let (mut batches, loss) = Self::take_partition_batches(
                                 partition,
                                 indices.as_ref(),
                                 Some(reader.as_ref()),
                             )
-                            .await?
+                            .await?;
+
+                            // During a split, vectors from affected partitions
+                            // may have been reassigned to this (unaffected)
+                            // partition. Read any such data from the split
+                            // shuffle reader.
+                            if let Some(PartitionAdjustment::Split {
+                                split_shuffle_reader,
+                                ..
+                            }) = partition_adjustment.as_ref()
+                            {
+                                let (extra_batches, extra_loss) = Self::take_partition_batches(
+                                    partition,
+                                    &[],
+                                    Some(split_shuffle_reader.as_ref()),
+                                )
+                                .await?;
+                                batches.extend(extra_batches);
+                                (batches, loss + extra_loss)
+                            } else {
+                                (batches, loss)
+                            }
                         };
 
                         spawn_cpu(move || {
+                            // Apply assign_batch for join operations (splits no
+                            // longer use assign_batches)
                             if let Some((assign_batch, deleted_row_ids)) = assign_batch {
                                 if !deleted_row_ids.is_empty() {
                                     let deleted_row_ids = HashSet::<u64>::from_iter(
@@ -881,7 +926,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                                 }
 
                                 if assign_batch.num_rows() > 0 {
-                                    // Drop PART_ID column from assign_batch to match schema of existing batches
                                     let assign_batch = assign_batch.drop_column(PART_ID_COLUMN)?;
                                     batches.push(assign_batch);
                                 }
@@ -1370,11 +1414,20 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok((split_partitions, join_partition))
     }
 
-    async fn split_partitions(
+    /// Split oversized partitions using a streaming approach.
+    ///
+    /// 1. Train new centroids by sampling vectors (low memory).
+    /// 2. Compute the set of affected partitions (split targets + their neighbors).
+    /// 3. Stream raw vectors for affected partitions through the IVF+quantizer
+    ///    transform pipeline, writing to temp files via a shuffler.
+    ///
+    /// The returned `SplitResult` contains a `ShuffleReader` with properly
+    /// quantized data for all affected partitions.
+    async fn split_partitions_streaming(
         &self,
         split_partitions: &[usize],
         ivf: &IvfModel,
-    ) -> Result<AssignResult> {
+    ) -> Result<SplitResult> {
         let Some(dataset) = self.dataset.as_ref() else {
             return Err(Error::invalid_input(
                 "dataset not set before split partition",
@@ -1382,35 +1435,87 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         };
 
         let (_, element_type) = get_vector_type(dataset.schema(), &self.column)?;
-        match element_type {
+        let (new_centroids, actual_splits) = match element_type {
             DataType::Float16 => {
-                self.split_partitions_impl::<Float16Type>(split_partitions, ivf)
-                    .await
+                self.compute_split_centroids::<Float16Type>(split_partitions, ivf)
+                    .await?
             }
             DataType::Float32 => {
-                self.split_partitions_impl::<Float32Type>(split_partitions, ivf)
-                    .await
+                self.compute_split_centroids::<Float32Type>(split_partitions, ivf)
+                    .await?
             }
             DataType::Float64 => {
-                self.split_partitions_impl::<Float64Type>(split_partitions, ivf)
-                    .await
+                self.compute_split_centroids::<Float64Type>(split_partitions, ivf)
+                    .await?
             }
             DataType::UInt8 => {
-                self.split_partitions_impl::<UInt8Type>(split_partitions, ivf)
-                    .await
+                self.compute_split_centroids::<UInt8Type>(split_partitions, ivf)
+                    .await?
             }
-            dt => Err(Error::invalid_input(format!(
-                "vectors must be float16, float32, float64 or uint8, but got {:?}",
-                dt
-            ))),
+            dt => {
+                return Err(Error::invalid_input(format!(
+                    "vectors must be float16, float32, float64 or uint8, but got {:?}",
+                    dt
+                )));
+            }
+        };
+
+        if actual_splits.is_empty() {
+            let centroids = ivf.centroids_array().unwrap();
+            // Create a dummy empty shuffle reader
+            let empty_reader = Arc::new(IvfShufflerReader::new(
+                Arc::new(self.store.clone()),
+                self.temp_dir.child("split_shuffle"),
+                vec![0; ivf.num_partitions()],
+                0.0,
+            ));
+            return Ok(SplitResult {
+                new_centroids: centroids.clone(),
+                affected_partitions: HashSet::new(),
+                shuffle_reader: empty_reader,
+            });
         }
+
+        // Compute affected partitions: split targets + their neighbors
+        let mut affected_partitions = HashSet::new();
+        for &part_idx in &actual_splits {
+            affected_partitions.insert(part_idx);
+            let c0 = ivf
+                .centroid(part_idx)
+                .ok_or(Error::invalid_input("centroid not found"))?;
+            let (neighbor_ids, _) =
+                select_reassign_candidates_impl(self.distance_type, ivf, part_idx, &c0)?;
+            for neighbor_id in neighbor_ids.values() {
+                affected_partitions.insert(*neighbor_id as usize);
+            }
+        }
+        log::info!(
+            "split {} partitions, {} total affected partitions (including neighbors)",
+            actual_splits.len(),
+            affected_partitions.len(),
+        );
+
+        // Stream raw vectors for affected partitions through the IVF+quantizer
+        // transform, writing to temp files via a second shuffler.
+        let split_shuffle_reader = self
+            .reshuffle_partitions(&affected_partitions, &new_centroids)
+            .await?;
+
+        Ok(SplitResult {
+            new_centroids,
+            affected_partitions,
+            shuffle_reader: split_shuffle_reader.into(),
+        })
     }
 
-    async fn split_partitions_impl<T: ArrowPrimitiveType>(
+    /// Train new centroids for partitions that need splitting.
+    /// Returns the full updated centroids array and the list of partition IDs
+    /// that were actually split (empty partitions are skipped).
+    async fn compute_split_centroids<T: ArrowPrimitiveType>(
         &self,
         split_partitions: &[usize],
         ivf: &IvfModel,
-    ) -> Result<AssignResult>
+    ) -> Result<(FixedSizeListArray, Vec<usize>)>
     where
         T::Native: Dot + L2 + Normalize,
         PrimitiveArray<T>: From<Vec<T::Native>>,
@@ -1420,90 +1525,142 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             Vec::with_capacity(ivf.num_partitions() + split_partitions.len());
         new_centroids.extend(centroids.iter().map(|vec| vec.unwrap()));
 
-        // Phase 1: Train split centroids in parallel (low memory — only samples).
+        // Train split centroids in parallel (low memory — only samples).
         let trained_centroids = stream::iter(split_partitions.iter().copied())
             .map(|part_idx| async move { self.train_split_centroids::<T>(part_idx).await })
             .buffered(get_num_compute_intensive_cpus())
             .try_collect::<Vec<_>>()
             .await?;
 
-        // Phase 2: Assign vectors sequentially (high memory — loads full raw vectors).
-        let mut split_plans = Vec::new();
-        for (split_order, (part_idx, centroids_opt)) in split_partitions
-            .iter()
-            .copied()
-            .zip(trained_centroids)
-            .enumerate()
-        {
+        let mut actual_splits = Vec::new();
+        for (&part_idx, centroids_opt) in split_partitions.iter().zip(trained_centroids) {
             let Some((centroid1, centroid2)) = centroids_opt else {
                 continue;
             };
-            let centroid2_part_idx = ivf.num_partitions() + split_order;
-            if let Some(plan) = self
-                .assign_split_vectors::<T>(
-                    part_idx,
-                    centroid2_part_idx,
-                    &centroid1,
-                    &centroid2,
-                    ivf,
-                )
-                .await?
-            {
-                split_plans.push(plan);
-            }
-        }
-        split_plans.sort_by_key(|plan| plan.part_idx);
-        Self::finalize_split_plans(&mut split_plans, ivf.num_partitions());
-
-        if split_plans.is_empty() {
-            return Ok(AssignResult {
-                assign_batches: vec![None; ivf.num_partitions()],
-                new_centroids: centroids.clone(),
-                split_partitions: Vec::new(),
-            });
+            // Replace the original centroid with centroid1; append centroid2
+            new_centroids[part_idx] = centroid1;
+            new_centroids.push(centroid2);
+            actual_splits.push(part_idx);
         }
 
-        for split_plan in &split_plans {
-            new_centroids[split_plan.part_idx] = split_plan.centroid1.clone();
+        if actual_splits.is_empty() {
+            return Ok((centroids.clone(), actual_splits));
         }
-        new_centroids.extend(split_plans.iter().map(|plan| plan.centroid2.clone()));
 
-        let split_partition_set =
-            HashSet::<usize>::from_iter(split_plans.iter().map(|plan| plan.part_idx));
-        let new_centroids = new_centroids
+        let concatenated = new_centroids
             .iter()
             .map(|vec| vec.as_ref())
             .collect::<Vec<_>>();
-        let new_centroids = arrow::compute::concat(&new_centroids)?;
+        let concatenated = arrow::compute::concat(&concatenated)?;
         let new_centroids =
-            FixedSizeListArray::try_new_from_values(new_centroids, centroids.value_length())?;
-        let mut assign_ops = vec![Vec::new(); new_centroids.len()];
+            FixedSizeListArray::try_new_from_values(concatenated, centroids.value_length())?;
 
-        for split_plan in &split_plans {
-            for (target_idx, op) in &split_plan.original_assign_ops {
-                assign_ops[*target_idx].push(op.clone());
+        Ok((new_centroids, actual_splits))
+    }
+
+    /// Stream raw vectors for the given partitions through the IVF+quantizer
+    /// transform, writing to temp files. Returns a ShuffleReader for the results.
+    async fn reshuffle_partitions(
+        &self,
+        affected_partitions: &HashSet<usize>,
+        new_centroids: &FixedSizeListArray,
+    ) -> Result<Box<dyn ShuffleReader>> {
+        let Some(dataset) = self.dataset.as_ref() else {
+            return Err(Error::invalid_input("dataset not set before reshuffle"));
+        };
+        let Some(quantizer) = self.quantizer.clone() else {
+            return Err(Error::invalid_input("quantizer not set before reshuffle"));
+        };
+
+        // Collect all row IDs for affected partitions, dedup, sort.
+        let mut all_row_ids = Vec::new();
+        for &part_idx in affected_partitions {
+            let mut row_ids = self.partition_row_ids(part_idx).await?;
+            all_row_ids.append(&mut row_ids);
+        }
+        all_row_ids.sort();
+        all_row_ids.dedup();
+
+        // Stream raw vectors in chunks
+        let projection = Arc::new(dataset.schema().project(&[self.column.as_str()])?);
+        let row_ids = dataset.filter_deleted_ids(&all_row_ids).await?;
+        let block_size = self.store.block_size();
+        let column = self.column.clone();
+
+        let dataset_clone = dataset.clone();
+        let projection_clone = projection.clone();
+        let raw_stream = stream::iter(
+            row_ids
+                .chunks(block_size)
+                .map(|c| c.to_vec())
+                .collect::<Vec<_>>(),
+        )
+        .then(move |chunk| {
+            let dataset = dataset_clone.clone();
+            let projection = projection_clone.clone();
+            let column = column.clone();
+            async move {
+                let batch = dataset
+                    .take_rows(&chunk, ProjectionRequest::Schema(projection))
+                    .await?;
+                let batch = batch
+                    .try_with_column(ROW_ID_FIELD.clone(), Arc::new(UInt64Array::from(chunk)))?;
+                // For multivector, flatten
+                Flatten::new(&column).transform(&batch)
             }
-        }
-
-        for candidate_move in self
-            .collect_candidate_moves::<T>(&split_plans, &split_partition_set, ivf)
-            .await?
-        {
-            assign_ops[candidate_move.source_part_idx]
-                .push(AssignOp::Remove(candidate_move.row_id));
-            assign_ops[candidate_move.dest_part_idx].push(AssignOp::Add((
-                candidate_move.row_id,
-                candidate_move.vector,
-            )));
-        }
-
-        let assign_batches = self.build_assign_batch::<T>(&new_centroids, &assign_ops)?;
-
-        Ok(AssignResult {
-            assign_batches,
-            new_centroids,
-            split_partitions: split_plans.iter().map(|plan| plan.part_idx).collect(),
         })
+        .boxed();
+
+        // Transform through IVF assignment + quantization
+        let transformer = Arc::new(
+            lance_index::vector::ivf::new_ivf_transformer_with_quantizer(
+                new_centroids.clone(),
+                self.distance_type,
+                &self.column,
+                quantizer.into(),
+                None,
+            )?,
+        );
+
+        let mut transformed_stream = Box::pin(
+            raw_stream
+                .map(move |batch| {
+                    let ivf_transformer = transformer.clone();
+                    tokio::spawn(async move { ivf_transformer.transform(&batch?) })
+                })
+                .buffered(get_num_compute_intensive_cpus())
+                .map(|x| x.unwrap())
+                .peekable(),
+        );
+
+        // Peek transformed stream to get schema (includes PART_ID + PQ codes)
+        let schema = match transformed_stream.as_mut().peek_mut().await {
+            Some(Ok(b)) => b.schema(),
+            Some(Err(e)) => return Err(std::mem::replace(e, Error::Stop)),
+            None => {
+                log::info!("no vectors to reshuffle");
+                let empty_reader: Box<dyn ShuffleReader> = Box::new(IvfShufflerReader::new(
+                    Arc::new(self.store.clone()),
+                    self.temp_dir.child("split_shuffle"),
+                    vec![0; new_centroids.len()],
+                    0.0,
+                ));
+                return Ok(empty_reader);
+            }
+        };
+
+        let transformed_stream =
+            Box::new(RecordBatchStreamAdapter::new(schema, transformed_stream));
+
+        // Shuffle into per-partition temp files
+        let split_shuffle_dir = self.temp_dir.child("split_shuffle");
+        let shuffler = create_ivf_shuffler(
+            split_shuffle_dir,
+            new_centroids.len(),
+            self.format_version,
+            None,
+        );
+        shuffler.shuffle(transformed_stream).await
     }
 
     /// Sample raw vectors from a partition for kmeans training.
@@ -1590,144 +1747,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(Some((centroid1, centroid2)))
     }
 
-    /// Assign all vectors in a partition to split centroids. This loads the
-    /// full raw vectors and is memory-intensive — should run with limited
-    /// concurrency.
-    async fn assign_split_vectors<T: ArrowPrimitiveType>(
-        &self,
-        part_idx: usize,
-        centroid2_part_idx: usize,
-        centroid1: &ArrayRef,
-        centroid2: &ArrayRef,
-        ivf: &IvfModel,
-    ) -> Result<Option<SplitPlan>>
-    where
-        T::Native: Dot + L2 + Normalize,
-        PrimitiveArray<T>: From<Vec<T::Native>>,
-    {
-        let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
-            return Ok(None);
-        };
-
-        let c0 = ivf
-            .centroid(part_idx)
-            .ok_or(Error::invalid_input("original centroid not found"))?;
-        let (reassign_part_ids, reassign_part_centroids) =
-            self.select_reassign_candidates(ivf, part_idx, &c0)?;
-
-        let d0 = self.distance_type.arrow_batch_func()(&c0, &vectors)?;
-        let d1 = self.distance_type.arrow_batch_func()(centroid1.as_ref(), &vectors)?;
-        let d2 = self.distance_type.arrow_batch_func()(centroid2.as_ref(), &vectors)?;
-        let mut original_assign_ops = Vec::with_capacity(row_ids.len());
-        Self::assign_vectors_impl::<T, _>(
-            self.distance_type,
-            part_idx,
-            part_idx,
-            centroid2_part_idx,
-            &row_ids,
-            &vectors,
-            d0.values(),
-            d1.values(),
-            d2.values(),
-            &reassign_part_ids,
-            &reassign_part_centroids,
-            true,
-            |idx, op| original_assign_ops.push((idx, op)),
-        )?;
-
-        Ok(Some(SplitPlan {
-            part_idx,
-            centroid2_part_idx,
-            centroid1: centroid1.clone(),
-            centroid2: centroid2.clone(),
-            reassign_part_ids,
-            original_assign_ops,
-        }))
-    }
-
-    async fn collect_candidate_moves<T: ArrowPrimitiveType>(
-        &self,
-        split_plans: &[SplitPlan],
-        split_partition_set: &HashSet<usize>,
-        ivf: &IvfModel,
-    ) -> Result<Vec<CandidateMove>>
-    where
-        T::Native: Dot + L2 + Normalize,
-        PrimitiveArray<T>: From<Vec<T::Native>>,
-    {
-        let mut candidate_partitions = HashMap::<usize, Vec<CandidateRequest>>::new();
-        for split_plan in split_plans {
-            for part_id in split_plan.reassign_part_ids.values().iter().copied() {
-                let part_idx = part_id as usize;
-                if split_partition_set.contains(&part_idx) {
-                    continue;
-                }
-                candidate_partitions
-                    .entry(part_idx)
-                    .or_default()
-                    .push(CandidateRequest {
-                        centroid1_part_idx: split_plan.part_idx,
-                        centroid2_part_idx: split_plan.centroid2_part_idx,
-                        centroid1: split_plan.centroid1.clone(),
-                        centroid2: split_plan.centroid2.clone(),
-                    });
-            }
-        }
-
-        // Process candidate partitions sequentially to avoid loading raw vectors
-        // for many partitions simultaneously.
-        let mut candidate_moves = Vec::new();
-        for (part_idx, requests) in candidate_partitions {
-            let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
-                continue;
-            };
-
-            let candidate_centroid = ivf.centroid(part_idx).ok_or(Error::invalid_input(
-                format!("candidate centroid not found for partition {part_idx}"),
-            ))?;
-            let baseline_dists =
-                self.distance_type.arrow_batch_func()(candidate_centroid.as_ref(), &vectors)?;
-            let mut best_moves = vec![None; row_ids.len()];
-            for request in requests {
-                let d1 =
-                    self.distance_type.arrow_batch_func()(request.centroid1.as_ref(), &vectors)?;
-                let d2 =
-                    self.distance_type.arrow_batch_func()(request.centroid2.as_ref(), &vectors)?;
-                Self::update_best_candidate_moves::<T>(
-                    request.centroid1_part_idx,
-                    request.centroid2_part_idx,
-                    &row_ids,
-                    &vectors,
-                    baseline_dists.values(),
-                    d1.values(),
-                    d2.values(),
-                    &mut best_moves,
-                    part_idx,
-                );
-            }
-
-            candidate_moves.extend(best_moves.into_iter().flatten());
-        }
-
-        Ok(candidate_moves)
-    }
-
-    fn finalize_split_plans(split_plans: &mut [SplitPlan], base_num_partitions: usize) {
-        for (split_order, split_plan) in split_plans.iter_mut().enumerate() {
-            let actual_centroid2_part_idx = base_num_partitions + split_order;
-            if split_plan.centroid2_part_idx == actual_centroid2_part_idx {
-                continue;
-            }
-            let placeholder_centroid2_part_idx = split_plan.centroid2_part_idx;
-            for (target_idx, _) in &mut split_plan.original_assign_ops {
-                if *target_idx == placeholder_centroid2_part_idx {
-                    *target_idx = actual_centroid2_part_idx;
-                }
-            }
-            split_plan.centroid2_part_idx = actual_centroid2_part_idx;
-        }
-    }
-
     // join the given partition:
     // 1. delete the original parttion
     // 2. reasign all vectors of the original partitions
@@ -1754,7 +1773,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             return Ok(AssignResult {
                 assign_batches: vec![None; ivf.num_partitions() - 1],
                 new_centroids,
-                split_partitions: Vec::new(),
             });
         };
 
@@ -1858,7 +1876,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(AssignResult {
             assign_batches,
             new_centroids,
-            split_partitions: Vec::new(),
         })
     }
 
@@ -2027,128 +2044,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     ) -> Result<(UInt32Array, FixedSizeListArray)> {
         select_reassign_candidates_impl(self.distance_type, ivf, part_idx, c0)
     }
-    #[allow(clippy::too_many_arguments)]
-    fn assign_vectors_impl<T: ArrowPrimitiveType, F: FnMut(usize, AssignOp)>(
-        distance_type: DistanceType,
-        part_idx: usize,
-        centroid1_part_idx: usize,
-        centroid2_part_idx: usize,
-        row_ids: &UInt64Array,
-        vectors: &FixedSizeListArray,
-        d0: &[f32],
-        d1: &[f32],
-        d2: &[f32],
-        reassign_part_ids: &UInt32Array,
-        reassign_part_centroids: &FixedSizeListArray,
-        deleted_original_partition: bool,
-        mut sink: F,
-    ) -> Result<()> {
-        for (i, &row_id) in row_ids.values().iter().enumerate() {
-            if d0[i] <= d1[i] && d0[i] <= d2[i] {
-                if !deleted_original_partition {
-                    // the original partition is not deleted, we just keep the vector in the original partition
-                    continue;
-                }
-                match Self::reassign_vectors_impl(
-                    distance_type,
-                    vectors.value(i).as_primitive::<T>(),
-                    Some((d1[i], d2[i])),
-                    reassign_part_ids,
-                    reassign_part_centroids,
-                )? {
-                    ReassignPartition::NewCentroid1 => {
-                        // replace the original partition with the first new one
-                        sink(
-                            centroid1_part_idx,
-                            AssignOp::Add((row_id, vectors.value(i))),
-                        );
-                    }
-                    ReassignPartition::NewCentroid2 => {
-                        // append the new second one
-                        sink(
-                            centroid2_part_idx,
-                            AssignOp::Add((row_id, vectors.value(i))),
-                        );
-                    }
-                    ReassignPartition::ReassignCandidate(idx) => {
-                        // replace the original partition with the reassigned one
-                        sink(idx as usize, AssignOp::Add((row_id, vectors.value(i))));
-                    }
-                }
-            } else {
-                if !deleted_original_partition {
-                    // the original partition is not deleted, we need to remove the vector from the original partition
-                    sink(part_idx, AssignOp::Remove(row_id));
-                }
-                if d1[i] <= d2[i] {
-                    // centroid 1 is the closest one
-                    sink(
-                        centroid1_part_idx,
-                        AssignOp::Add((row_id, vectors.value(i))),
-                    );
-                } else {
-                    // centroid 2 is the closest one
-                    sink(
-                        centroid2_part_idx,
-                        AssignOp::Add((row_id, vectors.value(i))),
-                    );
-                }
-            }
-        }
-        Ok(())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn update_best_candidate_moves<T: ArrowPrimitiveType>(
-        centroid1_part_idx: usize,
-        centroid2_part_idx: usize,
-        row_ids: &UInt64Array,
-        vectors: &FixedSizeListArray,
-        baseline_dists: &[f32],
-        centroid1_dists: &[f32],
-        centroid2_dists: &[f32],
-        best_moves: &mut [Option<CandidateMove>],
-        part_idx: usize,
-    ) where
-        T::Native: Dot + L2 + Normalize,
-        PrimitiveArray<T>: From<Vec<T::Native>>,
-    {
-        for (i, &row_id) in row_ids.values().iter().enumerate() {
-            if baseline_dists[i] <= centroid1_dists[i] && baseline_dists[i] <= centroid2_dists[i] {
-                continue;
-            }
-            let (dest_part_idx, dest_distance) = if centroid1_dists[i] <= centroid2_dists[i] {
-                (centroid1_part_idx, centroid1_dists[i])
-            } else {
-                (centroid2_part_idx, centroid2_dists[i])
-            };
-            let candidate_move = CandidateMove {
-                row_id,
-                source_part_idx: part_idx,
-                dest_part_idx,
-                dest_distance,
-                vector: vectors.value(i),
-            };
-            match best_moves[i].as_mut() {
-                Some(best_move) if Self::is_better_candidate_move(&candidate_move, best_move) => {
-                    *best_move = candidate_move;
-                }
-                None => {
-                    best_moves[i] = Some(candidate_move);
-                }
-                _ => {}
-            }
-        }
-    }
-
-    fn is_better_candidate_move(candidate: &CandidateMove, current: &CandidateMove) -> bool {
-        match candidate.dest_distance.total_cmp(&current.dest_distance) {
-            Ordering::Less => true,
-            Ordering::Equal => candidate.dest_part_idx < current.dest_part_idx,
-            Ordering::Greater => false,
-        }
-    }
-
     // assign a vector to the closest partition among:
     // 1. the 2 new centroids
     // 2. the closest REASSIGN_RANGE partitions from the original centroid
@@ -2177,7 +2072,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         reassign_candidate_centroids: &FixedSizeListArray,
     ) -> Result<ReassignPartition> {
         let dists = distance_type.arrow_batch_func()(vector, reassign_candidate_centroids)?;
-        let min_dist_idx = dists.values().iter().position_min_by(|a, b| a.total_cmp(b));
+        let min_dist_idx = dists
+            .values()
+            .iter()
+            .enumerate()
+            .min_by(|(_, a), (_, b)| a.total_cmp(b))
+            .map(|(i, _)| i);
         let min_dist = min_dist_idx
             .map(|idx| dists.value(idx))
             .unwrap_or(f32::INFINITY);
@@ -2229,19 +2129,20 @@ fn select_reassign_candidates_impl(
 }
 
 struct AssignResult {
-    // the batches of new vectors that are assigned to the partition,
-    // and the deleted row ids
     assign_batches: Vec<Option<(RecordBatch, UInt64Array)>>,
     new_centroids: FixedSizeListArray,
-    split_partitions: Vec<usize>,
+}
+
+struct SplitResult {
+    new_centroids: FixedSizeListArray,
+    affected_partitions: HashSet<usize>,
+    shuffle_reader: Arc<dyn ShuffleReader>,
 }
 
 #[derive(Debug, Clone)]
 enum AssignOp {
-    // (row_id, vector)
-    // TODO: add the distance to the centroid to avoid recomputing it for RQ
     Add((u64, ArrayRef)),
-    // row_id
+    #[allow(dead_code)]
     Remove(u64),
 }
 
@@ -2252,37 +2153,15 @@ enum ReassignPartition {
     ReassignCandidate(u32),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 enum PartitionAdjustment {
-    /// Split partitions at the given ids.
-    Split(Vec<usize>),
+    /// Split partitions. Carries the set of all affected partitions (split
+    /// targets + neighbors) and a shuffle reader with re-quantized data.
+    Split {
+        affected_partitions: HashSet<usize>,
+        split_shuffle_reader: Arc<dyn ShuffleReader>,
+    },
     /// Join partition at given id
     Join(usize),
-}
-
-struct SplitPlan {
-    part_idx: usize,
-    centroid2_part_idx: usize,
-    centroid1: ArrayRef,
-    centroid2: ArrayRef,
-    reassign_part_ids: UInt32Array,
-    original_assign_ops: Vec<(usize, AssignOp)>,
-}
-
-struct CandidateRequest {
-    centroid1_part_idx: usize,
-    centroid2_part_idx: usize,
-    centroid1: ArrayRef,
-    centroid2: ArrayRef,
-}
-
-#[derive(Clone)]
-struct CandidateMove {
-    row_id: u64,
-    source_part_idx: usize,
-    dest_part_idx: usize,
-    dest_distance: f32,
-    vector: ArrayRef,
 }
 
 pub(crate) fn index_type_string(sub_index: SubIndexType, quantizer: QuantizationType) -> String {
@@ -2376,118 +2255,6 @@ mod tests {
                 .values(),
             expected_centroid.as_primitive::<Float32Type>().values()
         );
-    }
-
-    #[test]
-    fn compute_reassign_candidate_moves_vectors_to_new_centroids() {
-        let row_ids = UInt64Array::from(vec![1_u64, 2_u64]);
-        let vectors = FixedSizeListArray::try_new_from_values(
-            Float32Array::from(vec![0.0_f32, 0.0, 10.0, 10.0]),
-            2,
-        )
-        .unwrap();
-        let reassign_part_centroids =
-            FixedSizeListArray::try_new_from_values(Float32Array::from(vec![9.0_f32, 9.0]), 2)
-                .unwrap();
-        let baseline_dists = DistanceType::L2.arrow_batch_func()(
-            reassign_part_centroids.value(0).as_ref(),
-            &vectors,
-        )
-        .unwrap();
-        let centroid1_dists =
-            DistanceType::L2.arrow_batch_func()(&Float32Array::from(vec![0.0_f32, 0.0]), &vectors)
-                .unwrap();
-        let centroid2_dists = DistanceType::L2.arrow_batch_func()(
-            &Float32Array::from(vec![20.0_f32, 20.0]),
-            &vectors,
-        )
-        .unwrap();
-
-        let mut best_moves = vec![None; row_ids.len()];
-        IvfIndexBuilder::<FlatIndex, FlatQuantizer>::update_best_candidate_moves::<Float32Type>(
-            1,
-            2,
-            &row_ids,
-            &vectors,
-            baseline_dists.values(),
-            centroid1_dists.values(),
-            centroid2_dists.values(),
-            &mut best_moves,
-            0,
-        );
-
-        assert_eq!(best_moves.iter().flatten().count(), 1);
-        let candidate_move = best_moves[0].as_ref().unwrap();
-        assert_eq!(candidate_move.row_id, 1);
-        assert_eq!(candidate_move.source_part_idx, 0);
-        assert_eq!(candidate_move.dest_part_idx, 1);
-        assert_eq!(
-            candidate_move.vector.as_primitive::<Float32Type>().values(),
-            &[0.0_f32, 0.0]
-        );
-    }
-
-    #[test]
-    fn update_best_candidate_moves_preserves_multivector_entries() {
-        let row_ids = UInt64Array::from(vec![7_u64, 7_u64]);
-        let vectors = FixedSizeListArray::try_new_from_values(
-            Float32Array::from(vec![0.0_f32, 0.0, 1.0, 1.0]),
-            2,
-        )
-        .unwrap();
-        let baseline_dists = Float32Array::from(vec![10.0_f32, 10.0]);
-        let centroid1_dists = Float32Array::from(vec![1.0_f32, 2.0]);
-        let centroid2_dists = Float32Array::from(vec![3.0_f32, 4.0]);
-
-        let mut best_moves = vec![None; row_ids.len()];
-        IvfIndexBuilder::<FlatIndex, FlatQuantizer>::update_best_candidate_moves::<Float32Type>(
-            1,
-            2,
-            &row_ids,
-            &vectors,
-            baseline_dists.values(),
-            centroid1_dists.values(),
-            centroid2_dists.values(),
-            &mut best_moves,
-            0,
-        );
-
-        let best_moves = best_moves.into_iter().flatten().collect::<Vec<_>>();
-        assert_eq!(best_moves.len(), 2);
-        assert_eq!(best_moves[0].row_id, 7);
-        assert_eq!(best_moves[1].row_id, 7);
-        assert_eq!(
-            best_moves[0].vector.as_primitive::<Float32Type>().values(),
-            &[0.0_f32, 0.0]
-        );
-        assert_eq!(
-            best_moves[1].vector.as_primitive::<Float32Type>().values(),
-            &[1.0_f32, 1.0]
-        );
-    }
-
-    #[test]
-    fn finalize_split_plans_reassigns_filtered_centroid_ids() {
-        let centroid1: ArrayRef = Arc::new(Float32Array::from(vec![0.0_f32, 0.0]));
-        let centroid2: ArrayRef = Arc::new(Float32Array::from(vec![1.0_f32, 1.0]));
-        let vector: ArrayRef = Arc::new(Float32Array::from(vec![2.0_f32, 2.0]));
-        let mut split_plans = vec![SplitPlan {
-            part_idx: 3,
-            centroid2_part_idx: 5,
-            centroid1,
-            centroid2,
-            reassign_part_ids: UInt32Array::from(vec![0_u32]),
-            original_assign_ops: vec![
-                (3, AssignOp::Add((10, vector.clone()))),
-                (5, AssignOp::Add((11, vector))),
-            ],
-        }];
-
-        IvfIndexBuilder::<FlatIndex, FlatQuantizer>::finalize_split_plans(&mut split_plans, 4);
-
-        assert_eq!(split_plans[0].centroid2_part_idx, 4);
-        assert_eq!(split_plans[0].original_assign_ops[0].0, 3);
-        assert_eq!(split_plans[0].original_assign_ops[1].0, 4);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -633,6 +633,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         } else {
             HashMap::new()
         };
+        let progress = self.progress.clone();
+        progress.stage_start("shuffle", None, "batches").await?;
+
         let partition_map = Arc::new(precomputed_partitions);
         let mut transformed_stream = Box::pin(
             data.map(move |batch| {
@@ -708,6 +711,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 .await?
                 .into(),
         );
+        progress.stage_complete("shuffle").await?;
 
         Ok(self)
     }

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -92,6 +92,31 @@ const REASSIGN_RANGE: usize = 64;
 // sample size for kmeans training when splitting a partition (sample_rate * k = 256 * 2)
 const SPLIT_SAMPLE_SIZE: usize = 512;
 
+/// Build a new centroid array that incorporates the results of partition splits.
+///
+/// For each `(part_idx, centroid1, centroid2)` in `splits`:
+/// - `original[part_idx]` is replaced by `centroid1`
+/// - `centroid2` is appended after all existing centroids
+///
+/// Unchanged centroids keep their original indices.  The k-th split's second
+/// centroid lands at index `original.len() + k`.
+fn apply_centroid_splits(
+    original: &FixedSizeListArray,
+    splits: &[(usize, ArrayRef, ArrayRef)],
+) -> Result<FixedSizeListArray> {
+    let mut new_centroids: Vec<ArrayRef> = original.iter().map(|v| v.unwrap()).collect();
+    for (part_idx, centroid1, centroid2) in splits {
+        new_centroids[*part_idx] = centroid1.clone();
+        new_centroids.push(centroid2.clone());
+    }
+    let refs: Vec<&dyn Array> = new_centroids.iter().map(|a| a.as_ref()).collect();
+    let concatenated = arrow::compute::concat(&refs)?;
+    Ok(FixedSizeListArray::try_new_from_values(
+        concatenated,
+        original.value_length(),
+    )?)
+}
+
 // Builder for IVF index
 // The builder will train the IVF model and quantizer, shuffle the dataset, and build the sub index
 // for each partition.
@@ -688,7 +713,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
                     let progress_completed =
                         completed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    progress_clone.stage_progress("shuffle", progress_completed).await?;
+                    progress_clone
+                        .stage_progress("shuffle", progress_completed)
+                        .await?;
 
                     match batch.schema().column_with_name(code_column) {
                         Some(_) => {
@@ -1526,9 +1553,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         PrimitiveArray<T>: From<Vec<T::Native>>,
     {
         let centroids = ivf.centroids_array().unwrap();
-        let mut new_centroids: Vec<ArrayRef> =
-            Vec::with_capacity(ivf.num_partitions() + split_partitions.len());
-        new_centroids.extend(centroids.iter().map(|vec| vec.unwrap()));
 
         // Train split centroids in parallel (low memory — only samples).
         let trained_centroids = stream::iter(split_partitions.iter().copied())
@@ -1537,28 +1561,20 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             .try_collect::<Vec<_>>()
             .await?;
 
-        let mut actual_splits = Vec::new();
+        let mut splits = Vec::new();
         for (&part_idx, centroids_opt) in split_partitions.iter().zip(trained_centroids) {
             let Some((centroid1, centroid2)) = centroids_opt else {
                 continue;
             };
-            // Replace the original centroid with centroid1; append centroid2
-            new_centroids[part_idx] = centroid1;
-            new_centroids.push(centroid2);
-            actual_splits.push(part_idx);
+            splits.push((part_idx, centroid1, centroid2));
         }
 
-        if actual_splits.is_empty() {
-            return Ok((centroids.clone(), actual_splits));
+        if splits.is_empty() {
+            return Ok((centroids.clone(), vec![]));
         }
 
-        let concatenated = new_centroids
-            .iter()
-            .map(|vec| vec.as_ref())
-            .collect::<Vec<_>>();
-        let concatenated = arrow::compute::concat(&concatenated)?;
-        let new_centroids =
-            FixedSizeListArray::try_new_from_values(concatenated, centroids.value_length())?;
+        let actual_splits: Vec<usize> = splits.iter().map(|(idx, _, _)| *idx).collect();
+        let new_centroids = apply_centroid_splits(centroids, &splits)?;
 
         Ok((new_centroids, actual_splits))
     }
@@ -2218,6 +2234,45 @@ mod tests {
         fn total_loss(&self) -> Option<f64> {
             None
         }
+    }
+
+    // Helper to read centroid i from a FixedSizeListArray as a Vec<f32>
+    fn centroid_values(arr: &FixedSizeListArray, i: usize) -> Vec<f32> {
+        arr.value(i).as_primitive::<Float32Type>().values().to_vec()
+    }
+
+    #[test]
+    fn apply_centroid_splits_correct_count_and_ordering() {
+        // 4 original centroids at [0,0], [1,1], [2,2], [3,3].
+        // Split partitions 1 and 3; verify that:
+        //   - result has 6 centroids (4 original + 2 splits)
+        //   - unchanged partition indices 0 and 2 keep their original values
+        //   - split partitions 1 and 3 have centroid1 at their original index
+        //   - centroid2 for each split is appended at the end (indices 4, 5)
+        let original = FixedSizeListArray::try_new_from_values(
+            Float32Array::from(vec![0.0_f32, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0]),
+            2,
+        )
+        .unwrap();
+
+        let c1_for_1: ArrayRef = Arc::new(Float32Array::from(vec![1.1_f32, 1.1]));
+        let c2_for_1: ArrayRef = Arc::new(Float32Array::from(vec![0.9_f32, 0.9]));
+        let c1_for_3: ArrayRef = Arc::new(Float32Array::from(vec![3.1_f32, 3.1]));
+        let c2_for_3: ArrayRef = Arc::new(Float32Array::from(vec![2.9_f32, 2.9]));
+
+        let splits = vec![(1_usize, c1_for_1, c2_for_1), (3_usize, c1_for_3, c2_for_3)];
+        let result = apply_centroid_splits(&original, &splits).unwrap();
+
+        assert_eq!(result.len(), 6);
+        // Unchanged partitions
+        assert_eq!(centroid_values(&result, 0), [0.0, 0.0]);
+        assert_eq!(centroid_values(&result, 2), [2.0, 2.0]);
+        // Replaced centroids (centroid1 for each split partition)
+        assert_eq!(centroid_values(&result, 1), [1.1, 1.1]);
+        assert_eq!(centroid_values(&result, 3), [3.1, 3.1]);
+        // Appended centroid2s, in split order
+        assert_eq!(centroid_values(&result, 4), [0.9, 0.9]);
+        assert_eq!(centroid_values(&result, 5), [2.9, 2.9]);
     }
 
     #[test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, pin::Pin};
 
 use arrow::array::{AsArray as _, PrimitiveBuilder, UInt32Builder, UInt64Builder};
@@ -122,7 +122,7 @@ fn apply_centroid_splits(
 // for each partition.
 // To build the index for the whole dataset, call `build` method.
 // To build the index for given IVF, quantizer, data stream,
-// call `with_ivf`, `with_quantizer`, `shuffle_data`, and `build` in order.
+// call `with_ivf`, `with_quantizer`, `shuffle_data_input`, and `build` in order.
 pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
     store: ObjectStore,
     column: String,
@@ -141,6 +141,10 @@ pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
     ivf: Option<IvfModel>,
     quantizer: Option<Q>,
     shuffle_reader: Option<Arc<dyn ShuffleReader>>,
+    // unindexed input stream attached by callers; consumed during `build`'s
+    // shuffle stage so progress is reported. Wrapped in Mutex so the builder
+    // remains `Sync` (the boxed dyn Stream is not Sync on its own).
+    shuffle_data_input: Mutex<Option<UnindexedStream>>,
 
     // fields for merging indices / remapping
     existing_indices: Vec<Arc<dyn VectorIndex>>,
@@ -165,6 +169,8 @@ pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
 
 type BuildStream<S, Q> =
     Pin<Box<dyn Stream<Item = Result<Option<(<Q as Quantization>::Storage, S, f64)>>> + Send>>;
+
+type UnindexedStream = Box<dyn Stream<Item = Result<RecordBatch>> + Send + Unpin + 'static>;
 
 impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> {
     #[allow(clippy::too_many_arguments)]
@@ -198,6 +204,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             ivf: None,
             quantizer: None,
             shuffle_reader: None,
+            shuffle_data_input: Mutex::new(None),
             existing_indices: Vec::new(),
             frag_reuse_index,
             fragment_filter: None,
@@ -264,6 +271,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             ivf: Some(ivf_index.ivf_model().clone()),
             quantizer: Some(ivf_index.quantizer().try_into()?),
             shuffle_reader: None,
+            shuffle_data_input: Mutex::new(None),
             existing_indices: vec![index],
             frag_reuse_index: None,
             fragment_filter: None,
@@ -296,7 +304,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         if self.shuffle_reader.is_none() {
             let num_rows = self.num_rows_to_shuffle().await?;
             progress.stage_start("shuffle", num_rows, "rows").await?;
-            self.shuffle_dataset().boxed().await?;
+            let input = self.shuffle_data_input.lock().unwrap().take();
+            if let Some(input) = input {
+                self.shuffle_data(Some(input)).boxed().await?;
+            } else {
+                self.shuffle_dataset().boxed().await?;
+            }
             progress.stage_complete("shuffle").await?;
         }
 
@@ -612,12 +625,23 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(())
     }
 
+    /// Attach an unindexed input stream. The shuffle is deferred until
+    /// `build()` so progress reporting wraps the actual shuffle work.
+    /// Data must have schema | ROW_ID | vector_column |.
+    pub fn shuffle_data_input(
+        &mut self,
+        data: Option<impl RecordBatchStream + Unpin + 'static>,
+    ) -> &mut Self {
+        *self.shuffle_data_input.lock().unwrap() = data.map(|d| Box::new(d) as UnindexedStream);
+        self
+    }
+
     // shuffle the unindexed data and existing indices
     // data must be with schema | ROW_ID | vector_column |
     // the shuffled data will be with schema | ROW_ID | PART_ID | code_column |
     pub async fn shuffle_data(
         &mut self,
-        data: Option<impl RecordBatchStream + Unpin + 'static>,
+        data: Option<impl Stream<Item = Result<RecordBatch>> + Unpin + Send + 'static>,
     ) -> Result<&mut Self> {
         let Some(ivf) = self.ivf.as_ref() else {
             return Err(Error::invalid_input("IVF not set before shuffle data"));
@@ -667,18 +691,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         } else {
             None
         };
-        progress.stage_start("shuffle", total, "batches").await?;
-
-        let completed = Arc::new(AtomicU64::new(0));
-        let progress_clone = progress.clone();
 
         let partition_map = Arc::new(precomputed_partitions);
         let mut transformed_stream = Box::pin(
             data.map(move |batch| {
                 let partition_map = partition_map.clone();
                 let ivf_transformer = transformer.clone();
-                let completed = completed.clone();
-                let progress_clone = progress_clone.clone();
                 tokio::spawn(async move {
                     let mut batch = batch?;
                     if !partition_map.is_empty() {
@@ -710,12 +728,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             batch = batch.take(&indices)?;
                         }
                     }
-
-                    let progress_completed =
-                        completed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    progress_clone
-                        .stage_progress("shuffle", progress_completed)
-                        .await?;
 
                     match batch.schema().column_with_name(code_column) {
                         Some(_) => {
@@ -756,7 +768,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 .await?
                 .into(),
         );
-        progress.stage_complete("shuffle").await?;
 
         Ok(self)
     }

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -627,11 +627,22 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     /// Attach an unindexed input stream. The shuffle is deferred until
     /// `build()` so progress reporting wraps the actual shuffle work.
     /// Data must have schema | ROW_ID | vector_column |.
+    ///
+    /// Passing `None` records "no unindexed data" by installing an empty
+    /// shuffle reader directly, so `build()` won't fall back to re-scanning
+    /// the dataset.
     pub fn shuffle_data_input(
         &mut self,
         data: Option<impl RecordBatchStream + Unpin + 'static>,
     ) -> &mut Self {
-        *self.shuffle_data_input.lock().unwrap() = data.map(|d| Box::new(d) as UnindexedStream);
+        match data {
+            Some(d) => {
+                *self.shuffle_data_input.lock().unwrap() = Some(Box::new(d) as UnindexedStream);
+            }
+            None => {
+                self.shuffle_reader = Some(Arc::new(EmptyReader));
+            }
+        }
         self
     }
 

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::collections::HashSet;
-use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, pin::Pin};
 
@@ -682,14 +681,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 .unwrap_or_default()
         } else {
             HashMap::new()
-        };
-        let progress = self.progress.clone();
-        let total = if let (lower, Some(upper)) = data.size_hint()
-            && lower == upper
-        {
-            Some(lower as u64)
-        } else {
-            None
         };
 
         let partition_map = Arc::new(precomputed_partitions);

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -2307,6 +2307,106 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn optimize_split_after_append_pushes_partition_over_threshold() {
+        use crate::dataset::{InsertBuilder, WriteMode, WriteParams};
+        use crate::index::vector::VectorIndexParams;
+        use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
+        use arrow_array::RecordBatchIterator;
+        use arrow_schema::Schema as ArrowSchema;
+        use lance_index::optimize::OptimizeOptions;
+        use lance_linalg::distance::MetricType;
+
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "vec",
+            DataType::FixedSizeList(item_field, 4),
+            false,
+        )]));
+
+        // Tiny per-row perturbation gives kmeans something to fit while keeping
+        // within-cluster variance negligible relative to the 1000-unit cluster
+        // separation, so kmeans (k=2) reliably places one centroid per cluster.
+        let make_batch = |num_rows: usize, center: f32| -> RecordBatch {
+            let mut values = Vec::with_capacity(num_rows * 4);
+            for i in 0..num_rows {
+                let p = center + (i as f32) * 0.0001;
+                values.extend_from_slice(&[p, p, p, p]);
+            }
+            let fsl =
+                FixedSizeListArray::try_new_from_values(Float32Array::from(values), 4).unwrap();
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap()
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+
+        // 15k near origin (just under split threshold of 4 * 4096 = 16384) plus
+        // 1.5k far away in cluster B.
+        let initial = vec![Ok(make_batch(15_000, 0.0)), Ok(make_batch(1_500, 1000.0))];
+        let reader = RecordBatchIterator::new(initial, schema.clone());
+        let mut dataset = crate::Dataset::write(reader, uri, None).await.unwrap();
+
+        let params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let indices = dataset.load_indices_by_name("idx").await.unwrap();
+        let initial_index = dataset
+            .open_vector_index("vec", &indices[0].uuid.to_string(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        let initial_ivf = initial_index.ivf_model();
+        assert_eq!(initial_ivf.num_partitions(), 2);
+        let max_initial = (0..2).map(|p| initial_ivf.partition_size(p)).max().unwrap();
+        assert!(
+            max_initial <= 16_384,
+            "initial max partition size {max_initial} should be at or under split threshold",
+        );
+
+        // Append 3k more cluster-A rows so partition 0 grows past the threshold.
+        let append = make_batch(3_000, 0.0);
+        let mut dataset = InsertBuilder::new(Arc::new(dataset))
+            .with_params(&WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            })
+            .execute(vec![append])
+            .await
+            .unwrap();
+
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+
+        let indices = dataset.load_indices_by_name("idx").await.unwrap();
+        assert_eq!(indices.len(), 1, "expected merge-all on split");
+        let optimized = dataset
+            .open_vector_index("vec", &indices[0].uuid.to_string(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        let ivf = optimized.ivf_model();
+
+        assert_eq!(
+            ivf.num_partitions(),
+            3,
+            "expected one split: 2 original + 1 new = 3 partitions",
+        );
+        let total_rows: usize = (0..ivf.num_partitions())
+            .map(|p| optimized.partition_size(p))
+            .sum();
+        assert_eq!(total_rows, 19_500, "all vectors preserved across split");
+    }
+
+    #[tokio::test]
     async fn take_partition_batches_preserves_partition_order_for_large_fixed_size_list() {
         let value_length = 1_073_741_824i32;
         let num_rows = 5usize;

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -960,6 +960,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                                 }
 
                                 if assign_batch.num_rows() > 0 {
+                                    // Drop PART_ID column from assign_batch to match schema of existing batches
                                     let assign_batch = assign_batch.drop_column(PART_ID_COLUMN)?;
                                     batches.push(assign_batch);
                                 }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -515,8 +515,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_indices(existing_indices.clone())
                 .with_progress(options.progress.clone())
-                .shuffle_data(unindexed)
-                .await?
+                .shuffle_data_input(unindexed)
                 .build()
                 .await?
             } else {
@@ -534,8 +533,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_indices(existing_indices.clone())
                 .with_progress(options.progress.clone())
-                .shuffle_data(unindexed)
-                .await?
+                .shuffle_data_input(unindexed)
                 .build()
                 .await?
             }
@@ -556,8 +554,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
             .with_progress(options.progress.clone())
-            .shuffle_data(unindexed)
-            .await?
+            .shuffle_data_input(unindexed)
             .build()
             .await?
         }
@@ -577,8 +574,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
             .with_progress(options.progress.clone())
-            .shuffle_data(unindexed)
-            .await?
+            .shuffle_data_input(unindexed)
             .build()
             .await?
         }
@@ -598,8 +594,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
             .with_progress(options.progress.clone())
-            .shuffle_data(unindexed)
-            .await?
+            .shuffle_data_input(unindexed)
             .build()
             .await?
         }
@@ -618,8 +613,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
             .with_progress(options.progress.clone())
-            .shuffle_data(unindexed)
-            .await?
+            .shuffle_data_input(unindexed)
             .build()
             .await?
         }
@@ -640,8 +634,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_indices(existing_indices.clone())
                 .with_progress(options.progress.clone())
-                .shuffle_data(unindexed)
-                .await?
+                .shuffle_data_input(unindexed)
                 .build()
                 .await?
             } else {
@@ -659,8 +652,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_indices(existing_indices.clone())
                 .with_progress(options.progress.clone())
-                .shuffle_data(unindexed)
-                .await?
+                .shuffle_data_input(unindexed)
                 .build()
                 .await?
             }
@@ -681,8 +673,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
             .with_progress(options.progress.clone())
-            .shuffle_data(unindexed)
-            .await?
+            .shuffle_data_input(unindexed)
             .build()
             .await?
         }
@@ -702,8 +693,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
             .with_progress(options.progress.clone())
-            .shuffle_data(unindexed)
-            .await?
+            .shuffle_data_input(unindexed)
             .build()
             .await?
         }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -514,6 +514,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_indices(existing_indices.clone())
+                .with_progress(options.progress.clone())
                 .shuffle_data(unindexed)
                 .await?
                 .build()
@@ -532,6 +533,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_indices(existing_indices.clone())
+                .with_progress(options.progress.clone())
                 .shuffle_data(unindexed)
                 .await?
                 .build()
@@ -553,6 +555,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
+            .with_progress(options.progress.clone())
             .shuffle_data(unindexed)
             .await?
             .build()
@@ -573,6 +576,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
+            .with_progress(options.progress.clone())
             .shuffle_data(unindexed)
             .await?
             .build()
@@ -593,6 +597,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
+            .with_progress(options.progress.clone())
             .shuffle_data(unindexed)
             .await?
             .build()
@@ -612,6 +617,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
+            .with_progress(options.progress.clone())
             .shuffle_data(unindexed)
             .await?
             .build()
@@ -633,6 +639,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_indices(existing_indices.clone())
+                .with_progress(options.progress.clone())
                 .shuffle_data(unindexed)
                 .await?
                 .build()
@@ -651,6 +658,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_ivf(ivf_model.clone())
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_indices(existing_indices.clone())
+                .with_progress(options.progress.clone())
                 .shuffle_data(unindexed)
                 .await?
                 .build()
@@ -672,6 +680,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
+            .with_progress(options.progress.clone())
             .shuffle_data(unindexed)
             .await?
             .build()
@@ -692,6 +701,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_ivf(ivf_model.clone())
             .with_quantizer(quantizer.try_into()?)
             .with_existing_indices(existing_indices.clone())
+            .with_progress(options.progress.clone())
             .shuffle_data(unindexed)
             .await?
             .build()


### PR DESCRIPTION
We improve memory use when splitting IVF partitions in two of the stages:

1. **Training new IVF centroids.** Currently, all raw vectors to partition to split are loaded into memory and used to train the centroids. This could be 400MB for a 3072 f32 vector dataset when partition size has reached 33k, triggering a split. We now just sample `512` of the vectors, which should be sufficient to train for just 2 centroids.
2. **Shuffle**. Currently, all vectors that will be moved across all partitions being split are held in memory simultaneously in `Vec<SplitPlan>`. **This is the largest source of peak memory use currently**. If many partitions are being split, this can be > 100GB. We now instead stream these raw vectors through the partition assignment and quantization pipeline, just like we do in the case of new indices.

This PR also adds progress reporting to `optimize_indices`, to make this more observable.

**Test Workload**: IVF_PQ append on 560K base rows (16 partitions, 3072-dim float32 vectors) with 160K new rows — triggers partition splitting since each partition exceeds the 32K row threshold.

**Peak RSS**: 26.2 GB before, 4.1 GB after.
**Runtime**: 93s before, 16.5s after — 5.6x faster as well

<img width="2100" height="900" alt="memory_comparison" src="https://github.com/user-attachments/assets/fa890a6d-4b3e-45af-9adb-df7cc191292e" />


Closes #6378