### PR TITLE
fix: resolve double percent-encoding in object store paths (#6643)

### DIFF
--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -54,8 +54,9 @@ pub trait ObjectStoreProvider: std::fmt::Debug + Sync + Send {
         // Path::from_url_path decodes it first so the Path internal representation
         // holds the raw UTF-8 string. This prevents double-encoding when the
         // object store client later percent-encodes the path for HTTP requests.
-        Path::from_url_path(url.path())
-            .map_err(|e| Error::invalid_input(format!("Invalid path in URL '{}': {}", url.path(), e)))
+        Path::from_url_path(url.path()).map_err(|e| {
+            Error::invalid_input(format!("Invalid path in URL '{}': {}", url.path(), e))
+        })
     }
 
     /// Calculate the unique prefix that should be used for this object store.

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -50,8 +50,12 @@ pub trait ObjectStoreProvider: std::fmt::Debug + Sync + Send {
     /// Meanwhile, for a file store, the path is relative to the filesystem root.
     /// So a URL of `file:///path/to/file` would return `/path/to/file`.
     fn extract_path(&self, url: &Url) -> Result<Path> {
-        Path::parse(url.path())
-            .map_err(|_| Error::invalid_input(format!("Invalid path in URL: {}", url.path())))
+        // url.path() returns a percent-encoded string (per the WHATWG URL spec).
+        // Path::from_url_path decodes it first so the Path internal representation
+        // holds the raw UTF-8 string. This prevents double-encoding when the
+        // object store client later percent-encodes the path for HTTP requests.
+        Path::from_url_path(url.path())
+            .map_err(|e| Error::invalid_input(format!("Invalid path in URL '{}': {}", url.path(), e)))
     }
 
     /// Calculate the unique prefix that should be used for this object store.

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -520,7 +520,7 @@ mod tests {
 
         let cases = [
             ("s3://bucket/path/to/file", "path/to/file"),
-            // for non ASCII string tests
+            // for non ASCII string tests: the URL encodes them, extract_path must decode back
             ("s3://bucket/测试path/to/file", "测试path/to/file"),
             ("s3://bucket/path/&to/file", "path/&to/file"),
             ("s3://bucket/path/=to/file", "path/=to/file"),
@@ -533,9 +533,43 @@ mod tests {
         for (uri, expected_path) in cases {
             let url = Url::parse(uri).unwrap();
             let path = provider.extract_path(&url).unwrap();
+            // Path::from(decoded_str) stores the decoded representation, same as
+            // Path::from_url_path(encoded_str), so this comparison is correct.
             let expected_path = Path::from(expected_path);
             assert_eq!(path, expected_path)
         }
+    }
+
+    // Regression test for https://github.com/lance-format/lance/issues/6643
+    // extract_path must NOT double-encode paths that contain non-ASCII characters.
+    // url.path() returns a percent-encoded string; we must decode it back to raw
+    // UTF-8 before storing it in a Path, so the object store HTTP client can apply
+    // a single, correct percent-encoding when building the request URL.
+    #[test]
+    fn test_s3_non_ascii_path_no_double_encoding() {
+        let provider = AwsStoreProvider;
+
+        // "s3://bucket/中文路径" → url.path() == "/%E4%B8%AD%E6%96%87%E8%B7%AF%E5%BE%84".
+        // With the buggy Path::parse, the internal representation is "%E4%B8%AD..."
+        // which would be double-encoded to "%25E4%25B8%25AD..." by the S3 HTTP client.
+        // With Path::from_url_path, the internal representation is the decoded UTF-8
+        // string, which equals Path::from("中文路径").
+        let url = Url::parse("s3://bucket/中文路径").unwrap();
+        let path = provider.extract_path(&url).unwrap();
+
+        // Must equal the canonical non-ASCII path (same internal decoded representation).
+        // If double-encoding were still present, this would fail because the internal
+        // path would contain literal '%' characters that Path::from does not.
+        let expected = Path::from("中文路径");
+        assert_eq!(path, expected);
+
+        // Verify the path is NOT the percent-encoded form by ensuring it differs from
+        // a path constructed with the raw percent-encoded string.
+        let double_encoded = Path::from("%E4%B8%AD%E6%96%87%E8%B7%AF%E5%BE%84");
+        assert_ne!(
+            path, double_encoded,
+            "extract_path should decode the URL path, not store the percent-encoded form"
+        );
     }
 
     #[test]

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -533,9 +533,10 @@ mod tests {
         for (uri, expected_path) in cases {
             let url = Url::parse(uri).unwrap();
             let path = provider.extract_path(&url).unwrap();
-            // Path::from(decoded_str) stores the decoded representation, same as
-            // Path::from_url_path(encoded_str), so this comparison is correct.
-            let expected_path = Path::from(expected_path);
+            // extract_path decodes url.path(), so the Path stores the raw (decoded)
+            // string. Path::parse keeps its input verbatim, matching that, whereas
+            // Path::from would percent-encode non-ASCII bytes and not match.
+            let expected_path = Path::parse(expected_path).unwrap();
             assert_eq!(path, expected_path)
         }
     }
@@ -550,26 +551,14 @@ mod tests {
         let provider = AwsStoreProvider;
 
         // "s3://bucket/中文路径" → url.path() == "/%E4%B8%AD%E6%96%87%E8%B7%AF%E5%BE%84".
-        // With the buggy Path::parse, the internal representation is "%E4%B8%AD..."
-        // which would be double-encoded to "%25E4%25B8%25AD..." by the S3 HTTP client.
-        // With Path::from_url_path, the internal representation is the decoded UTF-8
-        // string, which equals Path::from("中文路径").
+        // The buggy Path::parse(url.path()) stored "%E4%B8%AD..." verbatim; the S3
+        // client then percent-encodes the '%' again, yielding "%25E4%25B8%25AD...".
+        // With Path::from_url_path the Path stores the decoded UTF-8 instead.
         let url = Url::parse("s3://bucket/中文路径").unwrap();
         let path = provider.extract_path(&url).unwrap();
 
-        // Must equal the canonical non-ASCII path (same internal decoded representation).
-        // If double-encoding were still present, this would fail because the internal
-        // path would contain literal '%' characters that Path::from does not.
-        let expected = Path::from("中文路径");
-        assert_eq!(path, expected);
-
-        // Verify the path is NOT the percent-encoded form by ensuring it differs from
-        // a path constructed with the raw percent-encoded string.
-        let double_encoded = Path::from("%E4%B8%AD%E6%96%87%E8%B7%AF%E5%BE%84");
-        assert_ne!(
-            path, double_encoded,
-            "extract_path should decode the URL path, not store the percent-encoded form"
-        );
+        // The Path must hold the decoded UTF-8, not the percent-encoded form.
+        assert_eq!(path.as_ref(), "中文路径");
     }
 
     #[test]

--- a/rust/lance-io/src/object_store/providers/huggingface.rs
+++ b/rust/lance-io/src/object_store/providers/huggingface.rs
@@ -223,7 +223,7 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
 
     fn extract_path(&self, url: &Url) -> Result<Path> {
         let parsed = parse_hf_url(url)?;
-        Path::parse(&parsed.relative_path).map_err(|_| {
+        Path::from_url_path(&parsed.relative_path).map_err(|_| {
             Error::invalid_input(format!("Invalid path in Huggingface URL: {}", url.path()))
         })
     }

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -43,7 +43,7 @@ impl ObjectStoreProvider for FileStoreProvider {
             return Ok(path);
         }
 
-        Path::parse(url.path()).map_err(|e| {
+        Path::from_url_path(url.path()).map_err(|e| {
             Error::invalid_input(format!("Failed to parse path '{}': {}", url.path(), e))
         })
     }

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -42,9 +42,10 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             output.push_str(domain);
         }
         output.push_str(url.path());
-        Path::from_url_path(output).map_err(|e| {
-            lance_core::Error::invalid_input(format!("Failed to parse path '{}': {}", output, e))
-        })
+        // The in-memory store uses the Path directly as a key with no HTTP layer,
+        // so there is no re-encoding step and thus no double-encoding to avoid.
+        // Path::from also tolerates the empty segments that local temp paths embed.
+        Ok(Path::from(output))
     }
 
     fn calculate_object_store_prefix(

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -42,7 +42,9 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             output.push_str(domain);
         }
         output.push_str(url.path());
-        Ok(Path::from(output))
+        Path::from_url_path(output).map_err(|e| {
+            lance_core::Error::invalid_input(format!("Failed to parse path '{}': {}", output, e))
+        })
     }
 
     fn calculate_object_store_prefix(


### PR DESCRIPTION
### Description
This PR fixes the double percent-encoding bug identified in #6643. 

The issue was that `ObjectStoreProvider` implementations were using `Path::parse(url.path())`. Since `url.path()` returns a percent-encoded string (e.g., `中文` -> `%E4%B8%AD...`), `Path::parse` was storing these encoded characters verbatim. When the object store client later performed its own encoding for HTTP requests, it double-encoded them (e.g., `%` became `%25`), causing "File Not Found" errors for non-ASCII paths.

### Changes
- Replaced `Path::parse` with `Path::from_url_path` in `providers.rs` and specific overrides in `local.rs`, `memory.rs`, and `huggingface.rs`.
- `Path::from_url_path` correctly decodes the percent-encoding before creating the `Path` object.
- Updated `test_s3_path_parsing` and added a new regression test `test_s3_non_ascii_path_no_double_encoding` in `aws.rs`.

Fixes #6643