### PR TITLE
test: target Lance 2.2 in bench_decode_packed_struct

### DIFF
--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -274,7 +274,7 @@ fn bench_decode_packed_struct(c: &mut Criterion) {
             RecordBatch::try_new(Arc::new(new_schema.clone()), data.columns().to_vec()).unwrap();
 
         let lance_schema = Arc::new(lance_core::datatypes::Schema::try_from(&new_schema).unwrap());
-        let encoding_strategy = default_encoding_strategy(LanceFileVersion::default());
+        let encoding_strategy = default_encoding_strategy(LanceFileVersion::V2_2);
         let encoded = rt
             .block_on(encode_batch(
                 &data,
@@ -291,7 +291,7 @@ fn bench_decode_packed_struct(c: &mut Criterion) {
                     &FilterExpression::no_filter(),
                     Arc::<DecoderPlugins>::default(),
                     false,
-                    LanceFileVersion::default(),
+                    LanceFileVersion::V2_2,
                     Some(Arc::new(LanceCache::no_cache())),
                 ))
                 .unwrap();


### PR DESCRIPTION
## Summary
- The `bench_decode_packed_struct` benchmark in `rust/lance-encoding/benches/decoder.rs` was passing `LanceFileVersion::default()` to both `default_encoding_strategy` and `decode_batch`. Since variable packed struct encoding became 2.2-only, the bench now panics inside `encode_batch` with `Variable packed struct encoding requires Lance file version 2.2 or later`.
- Pin both call sites to `LanceFileVersion::V2_2` so the benchmark exercises the encoding it's supposed to measure.

## Test plan
- [x] `cargo check --benches -p lance-encoding`
- [ ] CI runs the encoding bench job to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)