### PR TITLE
fix: simplify column-map expressions before physical planning

### DIFF
--- a/rust/lance-datafusion/src/projection.rs
+++ b/rust/lance-datafusion/src/projection.rs
@@ -75,6 +75,10 @@ impl ProjectionBuilder {
         self.check_duplicate_column(output_name)?;
 
         let expr = self.planner.parse_expr(raw_expr)?;
+        // Run simplification + coercion so that expressions like `coalesce(...)`
+        // (which DataFusion's physical evaluator expects to have been rewritten
+        // into a `CASE` expression by the simplifier) work correctly.
+        let expr = self.planner.optimize_expr(expr)?;
 
         // If the expression is a bare column reference to a system column, mark that we need it
         if let Expr::Column(Column {
@@ -455,7 +459,44 @@ impl ProjectionPlan {
 mod tests {
     use super::*;
 
+    use arrow_array::Int64Array;
     use lance_arrow::json::{is_json_field, json_field};
+
+    #[tokio::test]
+    async fn test_coalesce_in_column_map() {
+        // Regression test: `coalesce` in a column-map expression used to fail with
+        // "coalesce should have been simplified to case" because the parsed expression
+        // was passed straight to `create_physical_expr` without running the simplifier.
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("col_a", DataType::Int64, true),
+            ArrowField::new("col_b", DataType::Int64, true),
+        ]));
+        let base_schema = Schema::try_from(arrow_schema.as_ref()).unwrap();
+        let base = Arc::new(base_schema);
+
+        let plan =
+            ProjectionPlan::from_expressions(base, &[("foo", "coalesce(col_a, col_b)")]).unwrap();
+
+        let batch = RecordBatch::try_new(
+            arrow_schema,
+            vec![
+                Arc::new(Int64Array::from(vec![Some(1), None, Some(3), None])),
+                Arc::new(Int64Array::from(vec![Some(10), Some(20), None, None])),
+            ],
+        )
+        .unwrap();
+
+        let projected = plan.project_batch(batch).await.unwrap();
+        let foo = projected
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(
+            foo.iter().collect::<Vec<_>>(),
+            vec![Some(1), Some(20), Some(3), None],
+        );
+    }
 
     #[test]
     fn test_output_schema_preserves_json_extension_metadata() {


### PR DESCRIPTION
## Summary

- `dataset.to_table(columns={"foo": "coalesce(col_a, col_b)"})` (and any other column-map expression containing `coalesce`) fails at scan time with `Internal error: coalesce should have been simplified to case`.
- Root cause: `ProjectionBuilder::add_column` in `rust/lance-datafusion/src/projection.rs` passes the parsed logical `Expr` straight into `create_physical_expr`, skipping the simplify+coerce step that `Planner::parse_expr`'s own doc comment requires. DataFusion's `coalesce` physical evaluator is a panicking stub that expects the optimizer to have rewritten `coalesce(...)` into a `CASE WHEN ... THEN ... ELSE ... END` first; without that rewrite, the panic surfaces as an `Internal error` from the scanner.
- Fix: run `optimize_expr` (the existing simplify+coerce helper already used by filter pushdown) on the parsed expression before storing it in the projection plan.

## Reproducer

```python
import tempfile
import lance
import pyarrow as pa

table = pa.table({
    "col_a": pa.array([1, None, 3, None], type=pa.int64()),
    "col_b": pa.array([10, 20, None, None], type=pa.int64()),
})
with tempfile.TemporaryDirectory() as tmp:
    ds = lance.write_dataset(table, tmp)
    print(ds.to_table(columns={"foo": "coalesce(col_a, col_b)"}, limit=2))
```

Before this PR:

```
pyarrow.lib.ArrowInvalid: External error: LanceError(IO): Internal error:
coalesce should have been simplified to case.
```

After this PR: returns `foo: [[1, 20]]` as expected.

## Test plan

- [x] Added regression test `test_coalesce_in_column_map` in `rust/lance-datafusion/src/projection.rs` that round-trips `coalesce(col_a, col_b)` through `ProjectionPlan::from_expressions` + `project_batch` and asserts the output.
- [x] `cargo test -p lance-datafusion --lib projection` — both projection tests pass.
- [x] `cargo test -p lance --lib dataset::scanner` — 131 tests pass, no regressions.
- [x] `cargo fmt --all` clean; `cargo clippy -p lance-datafusion --tests -- -D warnings` clean.
- [x] Verified end-to-end via the original Python reproducer: 2-arg coalesce, 3-arg coalesce with literal default, and the original `limit=2` form from the bug report all return the expected values.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)