### PR TITLE
ci(python): ignore deprecated hf_xet.download_files warning

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -123,6 +123,8 @@ filterwarnings = [
     'ignore:.*the load_module\(\) method is deprecated.*:DeprecationWarning',
     # Pytorch uses deprecated jit.script_method internally (torch/utils/mkldnn.py)
     'ignore:.*torch\.jit\.script_method.*is deprecated.*:DeprecationWarning',
+    # huggingface_hub still calls the deprecated hf_xet.download_files() during Xet downloads
+    'ignore:.*hf_xet\.download_files\(\) is deprecated.*:DeprecationWarning',
     # TensorFlow/Keras import can emit NumPy deprecation FutureWarnings in some environments.
     # Keep FutureWarnings as errors generally, but ignore this known-noisy import-time warning.
     'ignore:.*np\.object.*:FutureWarning',


### PR DESCRIPTION
## Summary

- `test_write_hf_dataset` is failing on macOS and Windows CI because `huggingface_hub`'s Xet download path calls the now-deprecated `hf_xet.download_files()`, and `python/pyproject.toml` configures pytest with `error::DeprecationWarning`.
- The deprecation lives in `huggingface_hub` itself (`file_download.py:558`), not in Lance — `huggingface_hub` has not yet migrated to the new `XetSession().new_file_download_group().start_download_file()` API.
- Add a narrow `filterwarnings` ignore for that exact message, matching the existing pattern used for other third-party deprecation noise (boto3, pytorch, distutils, etc.).

Failing CI message:

```
DeprecationWarning: hf_xet.download_files() is deprecated.
Use XetSession().new_file_download_group().start_download_file() instead.
huggingface_hub/file_download.py:558: DeprecationWarning
```

The ignore is scoped to the exact message, so any other `DeprecationWarning` still escalates to a test failure as before. When `huggingface_hub` migrates to the XetSession API, this entry can be removed.

## Test plan

- [ ] CI: `test_write_hf_dataset` passes on macOS and Windows runners
- [ ] Other `DeprecationWarning`-as-error coverage is unchanged (filter only matches the `hf_xet.download_files()` message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)