### PR TITLE
perf: reduce IO requests from loading bitmap index

### DIFF
--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -1229,6 +1229,43 @@ impl FileReader {
         )))
     }
 
+    /// Read a range of rows as a stream of record batches.
+    ///
+    /// Similar to [`Self::read_stream_projected`] with [`ReadBatchParams::Range`],
+    /// but allows overriding `batch_size_bytes` per call instead of using the
+    /// reader-level default from [`FileReaderOptions`].
+    pub fn read_range_as_stream(
+        &self,
+        range: Range<u64>,
+        batch_size: u32,
+        batch_readahead: u32,
+        projection: ReaderProjection,
+        batch_size_bytes: Option<u64>,
+    ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
+        let arrow_schema = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
+        let tasks_stream = Self::do_read_range(
+            self.collect_columns_from_projection(&projection)?,
+            self.scheduler.clone(),
+            self.cache.clone(),
+            self.num_rows,
+            self.decoder_plugins.clone(),
+            range,
+            batch_size,
+            projection,
+            FilterExpression::no_filter(),
+            self.options.decoder_config.clone(),
+            batch_size_bytes,
+        )?;
+        let batch_stream = tasks_stream
+            .map(|task| task.task)
+            .buffered(batch_readahead as usize)
+            .boxed();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            arrow_schema,
+            batch_stream,
+        )))
+    }
+
     fn take_rows_blocking(
         &self,
         indices: Vec<u64>,

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -1229,43 +1229,6 @@ impl FileReader {
         )))
     }
 
-    /// Read a range of rows as a stream of record batches.
-    ///
-    /// Similar to [`Self::read_stream_projected`] with [`ReadBatchParams::Range`],
-    /// but allows overriding `batch_size_bytes` per call instead of using the
-    /// reader-level default from [`FileReaderOptions`].
-    pub fn read_range_as_stream(
-        &self,
-        range: Range<u64>,
-        batch_size: u32,
-        batch_readahead: u32,
-        projection: ReaderProjection,
-        batch_size_bytes: Option<u64>,
-    ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
-        let arrow_schema = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
-        let tasks_stream = Self::do_read_range(
-            self.collect_columns_from_projection(&projection)?,
-            self.scheduler.clone(),
-            self.cache.clone(),
-            self.num_rows,
-            self.decoder_plugins.clone(),
-            range,
-            batch_size,
-            projection,
-            FilterExpression::no_filter(),
-            self.options.decoder_config.clone(),
-            batch_size_bytes,
-        )?;
-        let batch_stream = tasks_stream
-            .map(|task| task.task)
-            .buffered(batch_readahead as usize)
-            .boxed();
-        Ok(Box::pin(RecordBatchStreamAdapter::new(
-            arrow_schema,
-            batch_stream,
-        )))
-    }
-
     fn take_rows_blocking(
         &self,
         indices: Vec<u64>,

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -20,10 +20,10 @@ use std::{any::Any, ops::Bound, sync::Arc};
 use datafusion_expr::Expr;
 use datafusion_expr::expr::ScalarFunction;
 use deepsize::DeepSizeOf;
-use futures::{Stream, StreamExt};
 use inverted::query::{FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, fill_fts_query_column};
 use lance_core::utils::mask::{NullableRowAddrSet, RowAddrTreeMap, RowSetOps};
 use lance_core::{Error, Result};
+use lance_io::stream::{RecordBatchStream, RecordBatchStreamAdapter};
 use roaring::RoaringBitmap;
 use serde::Serialize;
 
@@ -219,9 +219,13 @@ pub trait IndexReader: Send + Sync {
         &self,
         range: std::ops::Range<usize>,
         projection: Option<&[&str]>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>> {
+    ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
         let batch = self.read_range(range, projection).await?;
-        Ok(futures::stream::once(async move { Ok(batch) }).boxed())
+        let schema = batch.schema();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::once(async move { Ok(batch) }),
+        )))
     }
     /// Return the number of batches in the file
     async fn num_batches(&self, batch_size: u64) -> u32;

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -14,11 +14,13 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion_common::{Column, scalar::ScalarValue};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
+use std::pin::Pin;
 use std::{any::Any, ops::Bound, sync::Arc};
 
 use datafusion_expr::Expr;
 use datafusion_expr::expr::ScalarFunction;
 use deepsize::DeepSizeOf;
+use futures::{Stream, StreamExt};
 use inverted::query::{FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, fill_fts_query_column};
 use lance_core::utils::mask::{NullableRowAddrSet, RowAddrTreeMap, RowSetOps};
 use lance_core::{Error, Result};
@@ -206,6 +208,21 @@ pub trait IndexReader: Send + Sync {
         range: std::ops::Range<usize>,
         projection: Option<&[&str]>,
     ) -> Result<RecordBatch>;
+    /// Read a range of rows as a stream of record batches.
+    ///
+    /// This allows the caller to process rows incrementally without loading the
+    /// entire range into memory at once.
+    ///
+    /// The default implementation falls back to [`Self::read_range`] and wraps
+    /// the result in a single-item stream.
+    async fn read_range_stream(
+        &self,
+        range: std::ops::Range<usize>,
+        projection: Option<&[&str]>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>> {
+        let batch = self.read_range(range, projection).await?;
+        Ok(futures::stream::once(async move { Ok(batch) }).boxed())
+    }
     /// Return the number of batches in the file
     async fn num_batches(&self, batch_size: u64) -> u32;
     /// Return the number of rows in the file

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -191,35 +191,24 @@ impl BitmapIndex {
 
         let mut index_map: BTreeMap<OrderableScalarValue, usize> = BTreeMap::new();
         let mut null_map = Arc::new(RowAddrTreeMap::default());
-        let mut value_type: Option<DataType> = None;
         let mut null_location: Option<usize> = None;
-        let mut row_offset = 0;
+        let value_type = page_lookup_file.schema().fields[0].data_type();
 
-        for start_row in (0..total_rows).step_by(MAX_ROWS_PER_CHUNK) {
-            let end_row = (start_row + MAX_ROWS_PER_CHUNK).min(total_rows);
-            let chunk = page_lookup_file
-                .read_range(start_row..end_row, Some(&["keys"]))
-                .await?;
-
-            if chunk.num_rows() == 0 {
-                continue;
-            }
-
-            if value_type.is_none() {
-                value_type = Some(chunk.schema().field(0).data_type().clone());
-            }
-
-            let dict_keys = chunk.column(0);
-
-            for idx in 0..chunk.num_rows() {
+        // Stream keys in bounded batches to avoid loading the entire keys
+        // column into memory at once.
+        let mut keys_stream = page_lookup_file
+            .read_range_stream(0..total_rows, Some(&["keys"]))
+            .await?;
+        let mut row_offset: usize = 0;
+        while let Some(keys_batch) = keys_stream.try_next().await? {
+            let dict_keys = keys_batch.column(0);
+            for idx in 0..keys_batch.num_rows() {
                 let key = OrderableScalarValue(ScalarValue::try_from_array(dict_keys, idx)?);
-
                 if key.0.is_null() {
                     null_location = Some(row_offset);
                 } else {
                     index_map.insert(key, row_offset);
                 }
-
                 row_offset += 1;
             }
         }
@@ -245,12 +234,10 @@ impl BitmapIndex {
             null_map = Arc::new(bitmap);
         }
 
-        let final_value_type = value_type.expect_ok()?;
-
         Ok(Arc::new(Self::new(
             index_map,
             null_map,
-            final_value_type,
+            value_type,
             store,
             WeakLanceCache::from(index_cache),
             frag_reuse_index,

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -9,7 +9,7 @@ use arrow_schema::Schema;
 use async_trait::async_trait;
 use bytes::Bytes;
 use deepsize::DeepSizeOf;
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::TryStreamExt;
 use lance_core::{Error, Result, cache::LanceCache};
 use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
 use lance_encoding::version::LanceFileVersion;
@@ -17,9 +17,7 @@ use lance_file::previous::{
     reader::FileReader as PreviousFileReader,
     writer::{FileWriter as PreviousFileWriter, ManifestProvider as PreviousManifestProvider},
 };
-use lance_file::reader::{
-    self as current_reader, DEFAULT_READ_CHUNK_SIZE, FileReaderOptions, ReaderProjection,
-};
+use lance_file::reader::{self as current_reader, FileReaderOptions, ReaderProjection};
 use lance_file::writer as current_writer;
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::utils::CachedFileSize;
@@ -228,9 +226,12 @@ impl IndexReader for current_reader::FileReader {
         &self,
         range: std::ops::Range<usize>,
         projection: Option<&[&str]>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>> {
+    ) -> Result<Pin<Box<dyn lance_io::stream::RecordBatchStream>>> {
         if range.is_empty() {
-            return Ok(futures::stream::empty().boxed());
+            return Ok(Box::pin(lance_io::stream::RecordBatchStreamAdapter::new(
+                Arc::new(self.schema().as_ref().into()),
+                futures::stream::empty(),
+            )));
         }
         let projection = if let Some(projection) = projection {
             ReaderProjection::from_column_names(
@@ -241,14 +242,13 @@ impl IndexReader for current_reader::FileReader {
         } else {
             ReaderProjection::from_whole_schema(self.schema(), self.metadata().version())
         };
-        let stream = self.read_range_as_stream(
-            range.start as u64..range.end as u64,
-            u32::MAX,
+        self.read_stream_projected(
+            ReadBatchParams::Range(range),
+            4096,
             2,
             projection,
-            Some(DEFAULT_READ_CHUNK_SIZE),
-        )?;
-        Ok(StreamExt::boxed(stream))
+            FilterExpression::no_filter(),
+        )
     }
 
     // V2 format has removed the row group concept,

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -9,7 +9,7 @@ use arrow_schema::Schema;
 use async_trait::async_trait;
 use bytes::Bytes;
 use deepsize::DeepSizeOf;
-use futures::TryStreamExt;
+use futures::{Stream, StreamExt, TryStreamExt};
 use lance_core::{Error, Result, cache::LanceCache};
 use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
 use lance_encoding::version::LanceFileVersion;
@@ -17,7 +17,9 @@ use lance_file::previous::{
     reader::FileReader as PreviousFileReader,
     writer::{FileWriter as PreviousFileWriter, ManifestProvider as PreviousManifestProvider},
 };
-use lance_file::reader::{self as current_reader, FileReaderOptions, ReaderProjection};
+use lance_file::reader::{
+    self as current_reader, DEFAULT_READ_CHUNK_SIZE, FileReaderOptions, ReaderProjection,
+};
 use lance_file::writer as current_writer;
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::utils::CachedFileSize;
@@ -27,6 +29,7 @@ use lance_table::format::{IndexFile, list_index_files_with_sizes};
 use object_store::path::Path;
 use std::cmp::min;
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::{any::Any, sync::Arc};
 
 /// An index store that serializes scalar indices using the lance format
@@ -219,6 +222,33 @@ impl IndexReader for current_reader::FileReader {
             .await?;
         assert_eq!(batches.len(), 1);
         Ok(batches[0].clone())
+    }
+
+    async fn read_range_stream(
+        &self,
+        range: std::ops::Range<usize>,
+        projection: Option<&[&str]>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>> {
+        if range.is_empty() {
+            return Ok(futures::stream::empty().boxed());
+        }
+        let projection = if let Some(projection) = projection {
+            ReaderProjection::from_column_names(
+                self.metadata().version(),
+                self.schema(),
+                projection,
+            )?
+        } else {
+            ReaderProjection::from_whole_schema(self.schema(), self.metadata().version())
+        };
+        let stream = self.read_range_as_stream(
+            range.start as u64..range.end as u64,
+            u32::MAX,
+            2,
+            projection,
+            Some(DEFAULT_READ_CHUNK_SIZE),
+        )?;
+        Ok(StreamExt::boxed(stream))
     }
 
     // V2 format has removed the row group concept,


### PR DESCRIPTION
Current code loads 2048 values from lookup file at a time, regardless of width. This PR changes us to stream, and defers the choice of batch size to the reader.

In my simple benchmark, this reduced IO requests 55x (down to 9 from 497).

```python
import lance
import pyarrow as pa

data = pa.table({"id": range(1_000_000)})
ds = lance.write_dataset(data, "/tmp/test_bitmap", mode="overwrite")

ds.create_scalar_index("id", "bitmap")

ds = lance.dataset("/tmp/test_bitmap", block_size=64 * 1024)
ds.io_stats_incremental()
ds.to_table(filter="id == 123456").to_pandas()
print(ds.io_stats_incremental())
# Before: IOStats(read_iops=497, read_bytes=2621958, write_iops=0, write_bytes=0)
# After: IOStats(read_iops=9, read_bytes=2621958, write_iops=0, write_bytes=0)
```

Closes #6660

🤖 Generated with [Claude Code](https://claude.com/claude-code)