### PR TITLE
fix(java): honor user-specified distance type in VectorTrainer

### DIFF
--- a/java/lance-jni/src/vector_trainer.rs
+++ b/java/lance-jni/src/vector_trainer.rs
@@ -34,6 +34,11 @@ fn flatten_fixed_size_list_to_f32(arr: &FixedSizeListArray) -> Result<Vec<f32>> 
     Ok(values.values().to_vec())
 }
 
+fn parse_distance_type(env: &mut JNIEnv, distance_type_jstr: &JString) -> Result<MetricType> {
+    let distance_type_str: String = env.get_string(distance_type_jstr)?.into();
+    MetricType::try_from(distance_type_str.as_str()).map_err(|e| Error::input_error(e.to_string()))
+}
+
 fn build_ivf_params_from_java(
     env: &mut JNIEnv,
     ivf_params_obj: &JObject,
@@ -80,14 +85,21 @@ fn build_pq_params_from_java(
 pub extern "system" fn Java_org_lance_index_vector_VectorTrainer_nativeTrainIvfCentroids<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
-    dataset_obj: JObject<'local>,    // org.lance.Dataset
-    column_jstr: JString<'local>,    // java.lang.String
-    ivf_params_obj: JObject<'local>, // org.lance.index.vector.IvfBuildParams
+    dataset_obj: JObject<'local>,        // org.lance.Dataset
+    column_jstr: JString<'local>,        // java.lang.String
+    ivf_params_obj: JObject<'local>,     // org.lance.index.vector.IvfBuildParams
+    distance_type_jstr: JString<'local>, // org.lance.index.DistanceType#toString()
 ) -> jfloatArray {
     ok_or_throw_with_return!(
         env,
-        inner_train_ivf_centroids(&mut env, dataset_obj, column_jstr, ivf_params_obj)
-            .map(|arr| arr.into_raw()),
+        inner_train_ivf_centroids(
+            &mut env,
+            dataset_obj,
+            column_jstr,
+            ivf_params_obj,
+            distance_type_jstr,
+        )
+        .map(|arr| arr.into_raw()),
         JFloatArray::default().into_raw()
     )
 }
@@ -97,9 +109,11 @@ fn inner_train_ivf_centroids<'local>(
     dataset_obj: JObject<'local>,
     column_jstr: JString<'local>,
     ivf_params_obj: JObject<'local>,
+    distance_type_jstr: JString<'local>,
 ) -> Result<JFloatArray<'local>> {
     let column: String = env.get_string(&column_jstr)?.into();
     let ivf_params = build_ivf_params_from_java(env, &ivf_params_obj)?;
+    let metric_type = parse_distance_type(env, &distance_type_jstr)?;
 
     let flattened: Vec<f32> = {
         let dataset_guard =
@@ -107,9 +121,6 @@ fn inner_train_ivf_centroids<'local>(
         let dataset = &dataset_guard.inner;
 
         let dim = get_vector_dim(dataset.schema(), &column)?;
-
-        // For now we default to L2 metric; tests and Java bindings currently use L2.
-        let metric_type = MetricType::L2;
 
         let ivf_model = RT.block_on(lance::index::vector::ivf::build_ivf_model(
             dataset,
@@ -137,14 +148,21 @@ fn inner_train_ivf_centroids<'local>(
 pub extern "system" fn Java_org_lance_index_vector_VectorTrainer_nativeTrainPqCodebook<'local>(
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
-    dataset_obj: JObject<'local>,   // org.lance.Dataset
-    column_jstr: JString<'local>,   // java.lang.String
-    pq_params_obj: JObject<'local>, // org.lance.index.vector.PQBuildParams
+    dataset_obj: JObject<'local>,        // org.lance.Dataset
+    column_jstr: JString<'local>,        // java.lang.String
+    pq_params_obj: JObject<'local>,      // org.lance.index.vector.PQBuildParams
+    distance_type_jstr: JString<'local>, // org.lance.index.DistanceType#toString()
 ) -> jfloatArray {
     ok_or_throw_with_return!(
         env,
-        inner_train_pq_codebook(&mut env, dataset_obj, column_jstr, pq_params_obj)
-            .map(|arr| arr.into_raw()),
+        inner_train_pq_codebook(
+            &mut env,
+            dataset_obj,
+            column_jstr,
+            pq_params_obj,
+            distance_type_jstr,
+        )
+        .map(|arr| arr.into_raw()),
         JFloatArray::default().into_raw()
     )
 }
@@ -154,9 +172,11 @@ fn inner_train_pq_codebook<'local>(
     dataset_obj: JObject<'local>,
     column_jstr: JString<'local>,
     pq_params_obj: JObject<'local>,
+    distance_type_jstr: JString<'local>,
 ) -> Result<JFloatArray<'local>> {
     let column: String = env.get_string(&column_jstr)?.into();
     let pq_params = build_pq_params_from_java(env, &pq_params_obj)?;
+    let metric_type = parse_distance_type(env, &distance_type_jstr)?;
 
     let flattened: Vec<f32> = {
         let dataset_guard =
@@ -164,7 +184,6 @@ fn inner_train_pq_codebook<'local>(
         let dataset = &dataset_guard.inner;
 
         let dim = get_vector_dim(dataset.schema(), &column)?;
-        let metric_type = MetricType::L2;
 
         let pq = RT.block_on(lance::index::vector::pq::build_pq_model(
             dataset,

--- a/java/src/main/java/org/lance/index/vector/VectorTrainer.java
+++ b/java/src/main/java/org/lance/index/vector/VectorTrainer.java
@@ -15,6 +15,7 @@ package org.lance.index.vector;
 
 import org.lance.Dataset;
 import org.lance.JniLoader;
+import org.lance.index.DistanceType;
 
 import org.apache.arrow.util.Preconditions;
 
@@ -34,40 +35,75 @@ public final class VectorTrainer {
   private VectorTrainer() {}
 
   /**
+   * Train IVF centroids for the given dataset column with {@link DistanceType#L2}.
+   *
+   * <p>Equivalent to {@link #trainIvfCentroids(Dataset, String, IvfBuildParams, DistanceType)} with
+   * {@code distanceType = DistanceType.L2}.
+   */
+  public static float[] trainIvfCentroids(Dataset dataset, String column, IvfBuildParams params) {
+    return trainIvfCentroids(dataset, column, params, DistanceType.L2);
+  }
+
+  /**
    * Train IVF centroids for the given dataset column.
+   *
+   * <p>The {@code distanceType} controls the geometry used to cluster centroids and must match the
+   * distance type later passed to per-fragment index builds. If they disagree the centroids are
+   * clustered on a different geometry than the encoded data and recall will silently degrade.
    *
    * @param dataset the dataset to sample training data from
    * @param column the vector column name
    * @param params IVF build parameters (numPartitions, sampleRate, etc.)
+   * @param distanceType distance metric used during clustering
    * @return a flattened array of centroids laid out as [numPartitions][dimension]
    */
-  public static float[] trainIvfCentroids(Dataset dataset, String column, IvfBuildParams params) {
+  public static float[] trainIvfCentroids(
+      Dataset dataset, String column, IvfBuildParams params, DistanceType distanceType) {
     Preconditions.checkArgument(dataset != null, "dataset cannot be null");
     Preconditions.checkArgument(
         column != null && !column.isEmpty(), "column cannot be null or empty");
     Preconditions.checkArgument(params != null, "params cannot be null");
-    return nativeTrainIvfCentroids(dataset, column, params);
+    Preconditions.checkArgument(distanceType != null, "distanceType cannot be null");
+    return nativeTrainIvfCentroids(dataset, column, params, distanceType.toString());
+  }
+
+  /**
+   * Train a PQ codebook for the given dataset column with {@link DistanceType#L2}.
+   *
+   * <p>Equivalent to {@link #trainPqCodebook(Dataset, String, PQBuildParams, DistanceType)} with
+   * {@code distanceType = DistanceType.L2}.
+   */
+  public static float[] trainPqCodebook(Dataset dataset, String column, PQBuildParams params) {
+    return trainPqCodebook(dataset, column, params, DistanceType.L2);
   }
 
   /**
    * Train a PQ codebook for the given dataset column.
    *
+   * <p>The {@code distanceType} controls the geometry used to fit the codebook (notably, Cosine
+   * normalizes training data before k-means) and must match the distance type later passed to
+   * per-fragment index builds. If they disagree the codebook is shaped for one geometry while
+   * encoding happens against another and recall will silently degrade.
+   *
    * @param dataset the dataset to sample training data from
    * @param column the vector column name
    * @param params PQ build parameters (numSubVectors, numBits, sampleRate, etc.)
+   * @param distanceType distance metric used during codebook training
    * @return a flattened array of codebook entries laid out as [num_centroids][dimension]
    */
-  public static float[] trainPqCodebook(Dataset dataset, String column, PQBuildParams params) {
+  public static float[] trainPqCodebook(
+      Dataset dataset, String column, PQBuildParams params, DistanceType distanceType) {
     Preconditions.checkArgument(dataset != null, "dataset cannot be null");
     Preconditions.checkArgument(
         column != null && !column.isEmpty(), "column cannot be null or empty");
     Preconditions.checkArgument(params != null, "params cannot be null");
-    return nativeTrainPqCodebook(dataset, column, params);
+    Preconditions.checkArgument(distanceType != null, "distanceType cannot be null");
+    return nativeTrainPqCodebook(dataset, column, params, distanceType.toString());
   }
 
   private static native float[] nativeTrainIvfCentroids(
-      Dataset dataset, String column, IvfBuildParams params);
+      Dataset dataset, String column, IvfBuildParams params, String distanceType);
 
   private static native float[] nativeTrainPqCodebook(
-      Dataset dataset, String column, PQBuildParams params);
+      Dataset dataset, String column, PQBuildParams params, String distanceType);
 }

--- a/java/src/test/java/org/lance/index/VectorIndexTest.java
+++ b/java/src/test/java/org/lance/index/VectorIndexTest.java
@@ -322,4 +322,87 @@ public class VectorIndexTest {
       }
     }
   }
+
+  /**
+   * Regression test for the metric_type passthrough in the JNI VectorTrainer.
+   *
+   * <p>Before this fix, {@code trainIvfCentroids} hardcoded {@code MetricType::L2} on the Rust
+   * side, so users requesting a non-L2 metric got centroids clustered on L2 geometry while
+   * per-fragment encoders later quantized using the requested metric — silently degraded recall.
+   *
+   * <p>This test trains the same dataset twice with L2 and Cosine and asserts the centroid arrays
+   * differ. With the bug present, the two arrays were identical because both paths fell through to
+   * L2.
+   */
+  @Test
+  public void testTrainIvfCentroidsHonorsDistanceType(@TempDir Path tempDir) throws Exception {
+    try (TestVectorDataset testVectorDataset =
+        new TestVectorDataset(tempDir.resolve("ivf_centroids_metric"))) {
+      try (Dataset dataset = testVectorDataset.create()) {
+        IvfBuildParams params =
+            new IvfBuildParams.Builder().setNumPartitions(2).setMaxIters(10).build();
+
+        float[] l2Centroids =
+            VectorTrainer.trainIvfCentroids(
+                dataset, TestVectorDataset.vectorColumnName, params, DistanceType.L2);
+        float[] cosineCentroids =
+            VectorTrainer.trainIvfCentroids(
+                dataset, TestVectorDataset.vectorColumnName, params, DistanceType.Cosine);
+
+        assertEquals(l2Centroids.length, cosineCentroids.length);
+        assertFalse(
+            arraysApproximatelyEqual(l2Centroids, cosineCentroids),
+            "L2 and Cosine centroids should differ — Cosine normalizes input before clustering."
+                + " If they are equal, the metric is not being threaded into the trainer.");
+      }
+    }
+  }
+
+  /**
+   * Regression test for the metric_type passthrough in PQ codebook training.
+   *
+   * <p>Cosine training normalizes the input vectors before k-means; L2 does not. So the resulting
+   * codebooks must differ when the metric is honored.
+   */
+  @Test
+  public void testTrainPqCodebookHonorsDistanceType(@TempDir Path tempDir) throws Exception {
+    try (TestVectorDataset testVectorDataset =
+        new TestVectorDataset(tempDir.resolve("pq_codebook_metric"))) {
+      try (Dataset dataset = testVectorDataset.create()) {
+        PQBuildParams params =
+            new PQBuildParams.Builder()
+                .setNumSubVectors(2)
+                .setNumBits(4)
+                .setMaxIters(5)
+                .setSampleRate(64)
+                .build();
+
+        float[] l2Codebook =
+            VectorTrainer.trainPqCodebook(
+                dataset, TestVectorDataset.vectorColumnName, params, DistanceType.L2);
+        float[] cosineCodebook =
+            VectorTrainer.trainPqCodebook(
+                dataset, TestVectorDataset.vectorColumnName, params, DistanceType.Cosine);
+
+        assertEquals(l2Codebook.length, cosineCodebook.length);
+        assertFalse(
+            arraysApproximatelyEqual(l2Codebook, cosineCodebook),
+            "L2 and Cosine PQ codebooks should differ — Cosine normalizes the training data."
+                + " If they are equal, the metric is not being threaded into the trainer.");
+      }
+    }
+  }
+
+  private static boolean arraysApproximatelyEqual(float[] a, float[] b) {
+    if (a.length != b.length) {
+      return false;
+    }
+    final float epsilon = 1e-6f;
+    for (int i = 0; i < a.length; i++) {
+      if (Math.abs(a[i] - b[i]) > epsilon) {
+        return false;
+      }
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
The JNI vector trainer hardcoded `MetricType::L2` in both `inner_train_ivf_centroids` and `inner_train_pq_codebook`, ignoring the metric the caller intends to use when later building per-fragment index segments. For non-L2 metrics (cosine, dot, hamming) this silently trained centroids and PQ codebooks on L2 geometry while encoding happened against the user's actual metric, producing degraded recall with no error or warning.

Add `DistanceType distanceType` as a parameter to
`VectorTrainer.trainIvfCentroids` and `trainPqCodebook` (mirroring the shape of the underlying Rust `build_ivf_model` / `build_pq_model`, which take `metric_type` separately from `IvfBuildParams` / `PQBuildParams`). The metric belongs at the function call site, not on the algorithm-config struct — the param structs stay isomorphic to their Rust counterparts and there is a single source of truth for the metric per training call.

Backward-compat overloads default `distanceType` to `DistanceType.L2` to preserve the existing call sites. The native methods take the distance type as a separate `String` argument and parse it via `MetricType::try_from`.

Add regression tests `testTrainIvfCentroidsHonorsDistanceType` and `testTrainPqCodebookHonorsDistanceType` that train the same dataset twice with L2 and Cosine and assert the resulting arrays differ. With the bug present, the two arrays were identical because both paths fell through to L2.
