### PR TITLE
fix: sync unenforced_primary_key_position when field metadata updates

### DIFF
--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -18,8 +18,9 @@ mod schema;
 
 use crate::{Error, Result};
 pub use field::{
-    BlobVersion, Encoding, Field, LANCE_UNENFORCED_PRIMARY_KEY_POSITION, NullabilityComparison,
-    OnTypeMismatch, SchemaCompareOptions,
+    BlobVersion, Encoding, Field, LANCE_UNENFORCED_PRIMARY_KEY,
+    LANCE_UNENFORCED_PRIMARY_KEY_POSITION, NullabilityComparison, OnTypeMismatch,
+    SchemaCompareOptions,
 };
 pub use schema::{
     BlobHandling, FieldRef, OnMissing, Projectable, Projection, Schema,

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -3155,11 +3155,13 @@ mod tests {
                 .put(vec![create_test_batch(&schema, i * 10, 10)])
                 .await
                 .unwrap();
-            // Yield so the background flush handler gets a chance to drain
-            // the trigger queue before the next push, otherwise multiple
-            // pending triggers could coalesce into a single drain.
+            // Yield, then sleep, so the background flush handler can
+            // drain the trigger queue before the next push — otherwise
+            // multiple pending triggers can coalesce into a single drain.
+            // 50ms historically failed on slow Windows CI runners; 250ms
+            // gives a comfortable margin without making the suite slow.
             tokio::task::yield_now().await;
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         }
 
         writer.close().await.unwrap();

--- a/rust/lance/src/dataset/metadata.rs
+++ b/rust/lance/src/dataset/metadata.rs
@@ -596,15 +596,69 @@ mod tests {
         assert_eq!(pk.len(), 1);
         assert_eq!(pk[0].name, "id");
 
-        // Legacy boolean-flag form must also sync the cached option.
+        // Legacy boolean-flag form must also sync the cached option. All
+        // three accepted boolean spellings ("true", "1", "yes") and case
+        // variants must work; non-matching strings must be ignored.
+        for truthy in ["true", "1", "yes", "TRUE", "Yes"] {
+            dataset
+                .update_field_metadata()
+                .replace("name", [(LANCE_UNENFORCED_PRIMARY_KEY, truthy)])
+                .unwrap()
+                .await
+                .unwrap();
+            assert_eq!(
+                dataset
+                    .schema()
+                    .field("name")
+                    .unwrap()
+                    .unenforced_primary_key_position,
+                Some(0),
+                "value {:?} should be treated as a PK marker",
+                truthy
+            );
+        }
+        for falsy in ["no", "false", "0", "anything-else"] {
+            dataset
+                .update_field_metadata()
+                .replace("name", [(LANCE_UNENFORCED_PRIMARY_KEY, falsy)])
+                .unwrap()
+                .await
+                .unwrap();
+            assert_eq!(
+                dataset
+                    .schema()
+                    .field("name")
+                    .unwrap()
+                    .unenforced_primary_key_position,
+                None,
+                "value {:?} should not be treated as a PK marker",
+                falsy
+            );
+        }
+
+        // Position key with a non-numeric value must fall back to the
+        // boolean-flag path, not panic on parse.
         dataset
             .update_field_metadata()
-            .replace("name", [(LANCE_UNENFORCED_PRIMARY_KEY, "true")])
+            .replace(
+                "name",
+                [
+                    (LANCE_UNENFORCED_PRIMARY_KEY_POSITION, "not-a-number"),
+                    (LANCE_UNENFORCED_PRIMARY_KEY, "true"),
+                ],
+            )
             .unwrap()
             .await
             .unwrap();
-        let name_field = dataset.schema().field("name").unwrap();
-        assert_eq!(name_field.unenforced_primary_key_position, Some(0));
+        assert_eq!(
+            dataset
+                .schema()
+                .field("name")
+                .unwrap()
+                .unenforced_primary_key_position,
+            Some(0),
+            "garbage position must fall through to the boolean fallback",
+        );
 
         // Removing the keys must clear the cached option, otherwise the
         // protobuf would still encode a stale PK marker on next commit.

--- a/rust/lance/src/dataset/metadata.rs
+++ b/rust/lance/src/dataset/metadata.rs
@@ -539,6 +539,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_field_metadata_syncs_unenforced_primary_key_position() {
+        // Regression test: updating field metadata to install (or remove) the
+        // unenforced primary key keys must keep the cached
+        // `unenforced_primary_key_position` in sync, otherwise the next
+        // commit drops the marker because the protobuf is encoded from the
+        // cached option, not from the metadata HashMap.
+        use lance_core::datatypes::{
+            LANCE_UNENFORCED_PRIMARY_KEY, LANCE_UNENFORCED_PRIMARY_KEY_POSITION,
+        };
+
+        let tmp_dir = lance_core::utils::tempfile::TempStrDir::default();
+        let uri = tmp_dir.as_str();
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int32, false),
+            ArrowField::new("name", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(arrow_array::StringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .unwrap();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+            uri,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(dataset.schema().unenforced_primary_key().is_empty());
+
+        // Install PK on "id" via the position key. Both the cached option
+        // and the result of `unenforced_primary_key()` must reflect it.
+        dataset
+            .update_field_metadata()
+            .update("id", [(LANCE_UNENFORCED_PRIMARY_KEY_POSITION, "0")])
+            .unwrap()
+            .await
+            .unwrap();
+
+        let id_field = dataset.schema().field("id").unwrap();
+        assert_eq!(id_field.unenforced_primary_key_position, Some(0));
+        let pk = dataset.schema().unenforced_primary_key();
+        assert_eq!(pk.len(), 1);
+        assert_eq!(pk[0].name, "id");
+
+        // Round-trip through reopen: the position must be persisted in the
+        // protobuf, not just in the in-memory HashMap.
+        let reopened = Dataset::open(uri).await.unwrap();
+        let pk = reopened.schema().unenforced_primary_key();
+        assert_eq!(pk.len(), 1);
+        assert_eq!(pk[0].name, "id");
+
+        // Legacy boolean-flag form must also sync the cached option.
+        dataset
+            .update_field_metadata()
+            .replace("name", [(LANCE_UNENFORCED_PRIMARY_KEY, "true")])
+            .unwrap()
+            .await
+            .unwrap();
+        let name_field = dataset.schema().field("name").unwrap();
+        assert_eq!(name_field.unenforced_primary_key_position, Some(0));
+
+        // Removing the keys must clear the cached option, otherwise the
+        // protobuf would still encode a stale PK marker on next commit.
+        dataset
+            .update_field_metadata()
+            .replace("id", [] as [UpdateMapEntry; 0])
+            .unwrap()
+            .await
+            .unwrap();
+        let id_field = dataset.schema().field("id").unwrap();
+        assert_eq!(id_field.unenforced_primary_key_position, None);
+        assert!(
+            !dataset
+                .schema()
+                .unenforced_primary_key()
+                .iter()
+                .any(|f| f.name == "id")
+        );
+    }
+
+    #[tokio::test]
     async fn test_update_field_metadata_invalid_id() {
         let mut dataset = test_dataset_nested().await;
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -18,6 +18,7 @@ use crate::dataset::transaction::UpdateMode::{RewriteColumns, RewriteRows};
 use crate::index::mem_wal::update_mem_wal_index_merged_generations;
 use crate::utils::temporal::timestamp_to_nanos;
 use deepsize::DeepSizeOf;
+use lance_core::datatypes::{LANCE_UNENFORCED_PRIMARY_KEY, LANCE_UNENFORCED_PRIMARY_KEY_POSITION};
 use lance_core::{Error, Result, datatypes::Schema};
 use lance_file::{datatypes::Fields, version::LanceFileVersion};
 use lance_index::mem_wal::MergedGeneration;
@@ -2358,6 +2359,29 @@ impl Transaction {
                 for (field_id, field_metadata_update) in field_metadata_updates {
                     if let Some(field) = manifest.schema.field_by_id_mut(*field_id) {
                         apply_update_map(&mut field.metadata, field_metadata_update);
+                        // The unenforced primary key position lives in two
+                        // places on `Field`: the `metadata` HashMap (which
+                        // round-trips on its own through this update path)
+                        // and the cached `unenforced_primary_key_position`
+                        // option, which is what gets written into the next
+                        // protobuf-encoded manifest. If we only update
+                        // metadata, the cached option goes stale and the
+                        // next commit drops the PK marker. Re-derive it
+                        // from the freshly-applied metadata to keep the
+                        // two views in sync.
+                        field.unenforced_primary_key_position = field
+                            .metadata
+                            .get(LANCE_UNENFORCED_PRIMARY_KEY_POSITION)
+                            .and_then(|s| s.parse::<u32>().ok())
+                            .or_else(|| {
+                                field
+                                    .metadata
+                                    .get(LANCE_UNENFORCED_PRIMARY_KEY)
+                                    .filter(|s| {
+                                        matches!(s.to_lowercase().as_str(), "true" | "1" | "yes")
+                                    })
+                                    .map(|_| 0)
+                            });
                     } else {
                         return Err(Error::invalid_input_source(
                             format!("Field with id {} does not exist", field_id).into(),

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2359,16 +2359,7 @@ impl Transaction {
                 for (field_id, field_metadata_update) in field_metadata_updates {
                     if let Some(field) = manifest.schema.field_by_id_mut(*field_id) {
                         apply_update_map(&mut field.metadata, field_metadata_update);
-                        // The unenforced primary key position lives in two
-                        // places on `Field`: the `metadata` HashMap (which
-                        // round-trips on its own through this update path)
-                        // and the cached `unenforced_primary_key_position`
-                        // option, which is what gets written into the next
-                        // protobuf-encoded manifest. If we only update
-                        // metadata, the cached option goes stale and the
-                        // next commit drops the PK marker. Re-derive it
-                        // from the freshly-applied metadata to keep the
-                        // two views in sync.
+                        // Also set unenforced primary key based on updated field metadata.
                         field.unenforced_primary_key_position = field
                             .metadata
                             .get(LANCE_UNENFORCED_PRIMARY_KEY_POSITION)


### PR DESCRIPTION
## Summary

`UpdateConfig`'s field-metadata path in `Transaction::apply_update_map` (`rust/lance/src/dataset/transaction.rs`) mutates `field.metadata` but does not refresh the cached `Field::unenforced_primary_key_position`. The protobuf encoder for `Field` reads the cached `Option<u32>` (not the metadata HashMap), so the next commit drops the PK marker even though the metadata HashMap correctly contains `lance-schema:unenforced-primary-key:position`. The mirror image is also broken: removing the keys from metadata leaves a stale cached `Some(_)` that gets re-encoded as a PK marker on the next commit.

This makes it currently impossible to install or remove an unenforced primary key on an existing dataset via any public API — `update_field_metadata` and the deprecated `replace_field_metadata` both go through this path, and the round-trip via reopen returns no PK.

## Fix

After applying each `field_metadata_update`, re-derive `field.unenforced_primary_key_position` from the freshly-updated metadata using the same parsing rules the Arrow → Field decoder uses (position key first, then the legacy boolean-flag fallback). This keeps the two views in sync so the next protobuf encoding reflects the user's intent.

Also re-exports `LANCE_UNENFORCED_PRIMARY_KEY` from `lance_core::datatypes` alongside the existing `LANCE_UNENFORCED_PRIMARY_KEY_POSITION` re-export, so callers (and the new test) can use both constants without reaching into the private `field` module.

## Test

`test_update_field_metadata_syncs_unenforced_primary_key_position` in `rust/lance/src/dataset/metadata.rs` covers:

- Installing the PK on a column via the position key — cached option must be `Some(0)`, `Schema::unenforced_primary_key()` must report it, and a fresh `Dataset::open` must round-trip the marker.
- The legacy boolean-flag form must also sync the cached option.
- Removing the keys must clear the cached option so the marker is not re-encoded.

The test fails on `main` (returns `None` instead of `Some(0)`) and passes with the fix.