### PR TITLE
perf!: run scheduler initialize eagerly in async read_tasks

### DIFF
--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -734,8 +734,8 @@ impl LanceFileReader {
         batch_size: u32,
         batch_readahead: u32,
     ) -> PyResult<PyArrowType<Box<dyn RecordBatchReader + Send>>> {
-        // read_stream is a synchronous method but it launches tasks and needs to be
-        // run in the context of a tokio runtime
+        // read_stream awaits the decode scheduler's `initialize` step, so it
+        // needs to be run in the context of a tokio runtime.
         let inner = self.inner.clone();
         let stream = rt().block_on(None, async move {
             inner
@@ -745,6 +745,7 @@ impl LanceFileReader {
                     batch_readahead,
                     FilterExpression::no_filter(),
                 )
+                .await
                 .infer_error()
         })??;
         Ok(PyArrowType(Box::new(LanceReaderAdapter(stream))))

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -734,8 +734,6 @@ impl LanceFileReader {
         batch_size: u32,
         batch_readahead: u32,
     ) -> PyResult<PyArrowType<Box<dyn RecordBatchReader + Send>>> {
-        // read_stream awaits the decode scheduler's `initialize` step, so it
-        // needs to be run in the context of a tokio runtime.
         let inner = self.inner.clone();
         let stream = rt().block_on(None, async move {
             inner

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -266,7 +266,7 @@ const ENV_LANCE_READ_CACHE_REPETITION_INDEX: &str = "LANCE_READ_CACHE_REPETITION
 const ENV_LANCE_INLINE_SCHEDULING_THRESHOLD: &str = "LANCE_INLINE_SCHEDULING_THRESHOLD";
 
 // If a request is for at most this many rows we skip the scheduler-task spawn
-// and run scheduling inline as part of the stream's first poll.
+// and run scheduling inline as part of the `schedule_and_decode` await.
 const DEFAULT_INLINE_SCHEDULING_THRESHOLD: u64 = 16 * 1024;
 
 fn default_cache_repetition_index() -> bool {
@@ -2238,9 +2238,9 @@ pub async fn schedule_and_decode(
     column_indices: Vec<u32>,
     target_schema: Arc<Schema>,
     config: SchedulerDecoderConfig,
-) -> BoxStream<'static, ReadBatchTask> {
+) -> Result<BoxStream<'static, ReadBatchTask>> {
     if requested_rows.num_rows() == 0 {
-        return stream::empty().boxed();
+        return Ok(stream::empty().boxed());
     }
 
     // If the user requested any ranges that are empty, ignore them.  They are pointless and
@@ -2249,7 +2249,7 @@ pub async fn schedule_and_decode(
 
     let io = config.io.clone();
 
-    match create_scheduler_decoder(
+    let stream = create_scheduler_decoder(
         column_infos,
         requested_rows,
         filter,
@@ -2257,18 +2257,11 @@ pub async fn schedule_and_decode(
         target_schema,
         config,
     )
-    .await
-    {
-        // Keep the io alive until the stream is dropped or finishes.  Otherwise the
-        // I/O drops as soon as the scheduling is finished and the I/O loop terminates.
-        Ok(stream) => stream.finally(move || drop(io)).boxed(),
-        // If the initialization failed make it look like a failed task
-        Err(e) => stream::once(std::future::ready(ReadBatchTask {
-            num_rows: 0,
-            task: std::future::ready(Err(e)).boxed(),
-        }))
-        .boxed(),
-    }
+    .await?;
+
+    // Keep the io alive until the stream is dropped or finishes.  Otherwise the
+    // I/O drops as soon as the scheduling is finished and the I/O loop terminates.
+    Ok(stream.finally(move || drop(io)).boxed())
 }
 
 pub static WAITER_RT: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -263,11 +263,26 @@ const BATCH_SIZE_BYTES_WARNING: u64 = 10 * 1024 * 1024;
 const ENV_LANCE_STRUCTURAL_BATCH_DECODE_SPAWN_MODE: &str =
     "LANCE_STRUCTURAL_BATCH_DECODE_SPAWN_MODE";
 const ENV_LANCE_READ_CACHE_REPETITION_INDEX: &str = "LANCE_READ_CACHE_REPETITION_INDEX";
+const ENV_LANCE_INLINE_SCHEDULING_THRESHOLD: &str = "LANCE_INLINE_SCHEDULING_THRESHOLD";
+
+// If a request is for at most this many rows we skip the scheduler-task spawn
+// and run scheduling inline as part of the stream's first poll.
+const DEFAULT_INLINE_SCHEDULING_THRESHOLD: u64 = 16 * 1024;
 
 fn default_cache_repetition_index() -> bool {
     static DEFAULT_CACHE_REPETITION_INDEX: OnceLock<bool> = OnceLock::new();
     *DEFAULT_CACHE_REPETITION_INDEX
         .get_or_init(|| parse_env_as_bool(ENV_LANCE_READ_CACHE_REPETITION_INDEX, true))
+}
+
+fn inline_scheduling_threshold() -> u64 {
+    static THRESHOLD: OnceLock<u64> = OnceLock::new();
+    *THRESHOLD.get_or_init(|| {
+        std::env::var(ENV_LANCE_INLINE_SCHEDULING_THRESHOLD)
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(DEFAULT_INLINE_SCHEDULING_THRESHOLD)
+    })
 }
 
 /// Top-level encoding message for a page.  Wraps both the
@@ -1956,6 +1971,24 @@ pub struct DecoderConfig {
     pub cache_repetition_index: bool,
     /// Whether to validate decoded data
     pub validate_on_decode: bool,
+    /// Override the strategy used to dispatch the scheduling work in
+    /// [`schedule_and_decode`].
+    ///
+    /// `schedule_and_decode` always awaits the scheduler's `initialize` (which
+    /// performs metadata I/O) before returning.  This flag controls what
+    /// happens with the subsequent (synchronous) work of pushing decoder
+    /// messages into the channel that feeds the decode stream.
+    ///
+    /// * `None` - default behavior: the scheduling work runs inline (as part
+    ///   of the `schedule_and_decode` await) when the request is small
+    ///   (controlled by the `LANCE_INLINE_SCHEDULING_THRESHOLD` env var) and
+    ///   is dispatched onto a spawned task otherwise.
+    /// * `Some(true)` - always run scheduling inline.  The await of
+    ///   `schedule_and_decode` does not return until every decoder message
+    ///   has been queued.
+    /// * `Some(false)` - always spawn a task for scheduling so that it can
+    ///   overlap with consumption of the decode stream.
+    pub inline_scheduling: Option<bool>,
 }
 
 impl Default for DecoderConfig {
@@ -1963,6 +1996,7 @@ impl Default for DecoderConfig {
         Self {
             cache_repetition_index: default_cache_repetition_index(),
             validate_on_decode: false,
+            inline_scheduling: None,
         }
     }
 }
@@ -2089,7 +2123,7 @@ pub fn create_decode_iterator(
     }
 }
 
-fn create_scheduler_decoder(
+async fn create_scheduler_decoder(
     column_infos: Vec<Arc<ColumnInfo>>,
     requested_rows: RequestedRows,
     filter: FilterExpression,
@@ -2120,28 +2154,37 @@ fn create_scheduler_decoder(
         config.batch_size_bytes,
     )?;
 
-    let scheduler_handle = tokio::task::spawn(async move {
-        let mut decode_scheduler = match DecodeBatchScheduler::try_new(
-            target_schema.as_ref(),
-            &column_indices,
-            &column_infos,
-            &vec![],
-            num_rows,
-            config.decoder_plugins,
-            config.io.clone(),
-            config.cache,
-            &filter,
-            &config.decoder_config,
-        )
-        .await
-        {
-            Ok(scheduler) => scheduler,
-            Err(e) => {
-                let _ = tx.send(Err(e));
-                return;
-            }
-        };
+    // The scheduler's `initialize` call performs the metadata I/O that the
+    // scheduling logic needs (chunk metadata, dictionaries, repetition
+    // index, ...).  We always await it here so the caller can choose where
+    // that I/O happens (e.g. inside a `tokio::spawn`'d fragment task).  This
+    // keeps the work explicit instead of smuggling it into the first poll
+    // of the returned stream.
+    let mut decode_scheduler = DecodeBatchScheduler::try_new(
+        target_schema.as_ref(),
+        &column_indices,
+        &column_infos,
+        &vec![],
+        num_rows,
+        config.decoder_plugins,
+        config.io.clone(),
+        config.cache,
+        &filter,
+        &config.decoder_config,
+    )
+    .await?;
 
+    // For small requests the scheduling cost is dwarfed by the overhead of
+    // spawning a task, so we run scheduling inline (still as part of this
+    // await) before returning.  The threshold is configurable via
+    // `LANCE_INLINE_SCHEDULING_THRESHOLD`, and callers can force either
+    // strategy via `DecoderConfig::inline_scheduling`.
+    let inline_scheduling = config
+        .decoder_config
+        .inline_scheduling
+        .unwrap_or_else(|| num_rows <= inline_scheduling_threshold());
+
+    if inline_scheduling {
         match requested_rows {
             RequestedRows::Ranges(ranges) => {
                 decode_scheduler.schedule_ranges(&ranges, &filter, tx, config.io)
@@ -2150,17 +2193,45 @@ fn create_scheduler_decoder(
                 decode_scheduler.schedule_take(&indices, &filter, tx, config.io)
             }
         }
-    });
-
-    Ok(check_scheduler_on_drop(decode_stream, scheduler_handle))
+        Ok(decode_stream)
+    } else {
+        // Spawn the (still synchronous) scheduling work so that decoder
+        // messages can stream into the channel while the consumer is
+        // already pulling from the decode stream.
+        let scheduling = async move {
+            match requested_rows {
+                RequestedRows::Ranges(ranges) => {
+                    decode_scheduler.schedule_ranges(&ranges, &filter, tx, config.io)
+                }
+                RequestedRows::Indices(indices) => {
+                    decode_scheduler.schedule_take(&indices, &filter, tx, config.io)
+                }
+            }
+        };
+        let scheduler_handle = tokio::task::spawn(scheduling);
+        Ok(check_scheduler_on_drop(decode_stream, scheduler_handle))
+    }
 }
 
-/// Launches a scheduler on a dedicated (spawned) task and creates a decoder to
-/// decode the scheduled data and returns the decoder as a stream of record batches.
+/// Initializes the scheduler, schedules the requested rows, and returns a
+/// stream of decode tasks for the resulting batches.
 ///
-/// This is a convenience function that creates both the scheduler and the decoder
-/// which can be a little tricky to get right.
-pub fn schedule_and_decode(
+/// This is a convenience function that creates both the scheduler and the
+/// decoder, which can be a little tricky to get right.
+///
+/// # Why is this async?
+///
+/// Constructing the scheduler runs `initialize`, which performs the metadata
+/// I/O the scheduler needs (chunk metadata, dictionaries, repetition index,
+/// ...).  We await that I/O here rather than smuggling it into the first
+/// poll of the returned stream so the caller can place the I/O on whichever
+/// task it likes (typically a per-fragment `tokio::spawn`), and so that
+/// errors surface from the await instead of from the first stream item.
+///
+/// When `DecoderConfig::inline_scheduling` resolves to `true`, the
+/// subsequent (synchronous) scheduling work also runs before this function
+/// returns, leaving a fully primed decode stream.
+pub async fn schedule_and_decode(
     column_infos: Vec<Arc<ColumnInfo>>,
     requested_rows: RequestedRows,
     filter: FilterExpression,
@@ -2178,9 +2249,6 @@ pub fn schedule_and_decode(
 
     let io = config.io.clone();
 
-    // For convenience we really want this method to be a snchronous method where all
-    // errors happen on the stream.  There is some async initialization that must happen
-    // when creating a scheduler.  We wrap that all up in the very first task.
     match create_scheduler_decoder(
         column_infos,
         requested_rows,
@@ -2188,7 +2256,9 @@ pub fn schedule_and_decode(
         column_indices,
         target_schema,
         config,
-    ) {
+    )
+    .await
+    {
         // Keep the io alive until the stream is dropped or finishes.  Otherwise the
         // I/O drops as soon as the scheduling is finished and the I/O loop terminates.
         Ok(stream) => stream.finally(move || drop(io)).boxed(),

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -2154,12 +2154,10 @@ async fn create_scheduler_decoder(
         config.batch_size_bytes,
     )?;
 
-    // The scheduler's `initialize` call performs the metadata I/O that the
-    // scheduling logic needs (chunk metadata, dictionaries, repetition
-    // index, ...).  We always await it here so the caller can choose where
-    // that I/O happens (e.g. inside a `tokio::spawn`'d fragment task).  This
-    // keeps the work explicit instead of smuggling it into the first poll
-    // of the returned stream.
+    // The scheduler's `initialize` may perform I/O to load column metadata
+    // unless that metadata is already in the cache.  This metadata loading
+    // happens as part of this call and should be parallelized if reading
+    // multiple files.
     let mut decode_scheduler = DecodeBatchScheduler::try_new(
         target_schema.as_ref(),
         &column_indices,
@@ -2221,12 +2219,8 @@ async fn create_scheduler_decoder(
 ///
 /// # Why is this async?
 ///
-/// Constructing the scheduler runs `initialize`, which performs the metadata
-/// I/O the scheduler needs (chunk metadata, dictionaries, repetition index,
-/// ...).  We await that I/O here rather than smuggling it into the first
-/// poll of the returned stream so the caller can place the I/O on whichever
-/// task it likes (typically a per-fragment `tokio::spawn`), and so that
-/// errors surface from the await instead of from the first stream item.
+/// Constructing the scheduler runs `initialize` which will perform I/O
+/// unless the data required is already in the file metadata cache.
 ///
 /// When `DecoderConfig::inline_scheduling` resolves to `true`, the
 /// subsequent (synchronous) scheduling work also runs before this function

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -89,6 +89,7 @@ fn bench_reader(c: &mut Criterion) {
                             None,
                             FilterExpression::no_filter(),
                         )
+                        .await
                         .unwrap();
                     let stats = Arc::new(Mutex::new((0, 0)));
                     let mut stream = stream
@@ -305,6 +306,7 @@ fn read_task(
                 None,
                 FilterExpression::no_filter(),
             )
+            .await
             .unwrap();
         let stats = Arc::new(Mutex::new((0, 0)));
         let mut stream = stream.then(|batch_task| {

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -912,7 +912,7 @@ impl FileReader {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn do_read_range(
+    async fn do_read_range(
         column_infos: Vec<Arc<ColumnInfo>>,
         io: Arc<dyn EncodingsIo>,
         cache: Arc<LanceCache>,
@@ -952,10 +952,11 @@ impl FileReader {
             projection.column_indices,
             projection.schema,
             config,
-        ))
+        )
+        .await)
     }
 
-    fn read_range(
+    async fn read_range(
         &self,
         range: Range<u64>,
         batch_size: u32,
@@ -976,10 +977,11 @@ impl FileReader {
             self.options.decoder_config.clone(),
             self.options.batch_size_bytes,
         )
+        .await
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn do_take_rows(
+    async fn do_take_rows(
         column_infos: Vec<Arc<ColumnInfo>>,
         io: Arc<dyn EncodingsIo>,
         cache: Arc<LanceCache>,
@@ -1018,10 +1020,11 @@ impl FileReader {
             projection.column_indices,
             projection.schema,
             config,
-        ))
+        )
+        .await)
     }
 
-    fn take_rows(
+    async fn take_rows(
         &self,
         indices: Vec<u64>,
         batch_size: u32,
@@ -1040,10 +1043,11 @@ impl FileReader {
             self.options.decoder_config.clone(),
             self.options.batch_size_bytes,
         )
+        .await
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn do_read_ranges(
+    async fn do_read_ranges(
         column_infos: Vec<Arc<ColumnInfo>>,
         io: Arc<dyn EncodingsIo>,
         cache: Arc<LanceCache>,
@@ -1084,10 +1088,11 @@ impl FileReader {
             projection.column_indices,
             projection.schema,
             config,
-        ))
+        )
+        .await)
     }
 
-    fn read_ranges(
+    async fn read_ranges(
         &self,
         ranges: Vec<Range<u64>>,
         batch_size: u32,
@@ -1106,6 +1111,7 @@ impl FileReader {
             self.options.decoder_config.clone(),
             self.options.batch_size_bytes,
         )
+        .await
     }
 
     /// Creates a stream of "read tasks" to read the data from the file
@@ -1118,7 +1124,20 @@ impl FileReader {
     /// Note that "read task" is probably a bit imprecise.  The tasks are actually "decode tasks".  The
     /// reading happens asynchronously in the background.  In other words, a single read task may map to
     /// multiple I/O operations or a single I/O operation may map to multiple read tasks.
-    pub fn read_tasks(
+    ///
+    /// # Why is this async?
+    ///
+    /// Constructing the read stream requires running the decode scheduler's
+    /// `initialize` step, which performs the metadata I/O (chunk metadata,
+    /// dictionaries, repetition index, ...) needed to plan the read.  We
+    /// drive that I/O on the awaiting task rather than smuggling it into
+    /// the stream's first poll.  This way callers control where the
+    /// scheduling I/O runs (typically inside a per-fragment
+    /// `tokio::spawn`), planning errors surface from the await instead of
+    /// from the first stream item, and small reads can also complete the
+    /// synchronous scheduling step before returning (see
+    /// [`DecoderConfig::inline_scheduling`]).
+    pub async fn read_tasks(
         &self,
         params: ReadBatchParams,
         batch_size: u32,
@@ -1150,7 +1169,7 @@ impl FileReader {
                     }
                 }
                 let indices = indices.iter().map(|idx| idx.unwrap() as u64).collect();
-                self.take_rows(indices, batch_size, projection)
+                self.take_rows(indices, batch_size, projection).await
             }
             ReadBatchParams::Range(range) => {
                 verify_bound(&params, range.end as u64, false)?;
@@ -1160,6 +1179,7 @@ impl FileReader {
                     projection,
                     filter,
                 )
+                .await
             }
             ReadBatchParams::Ranges(ranges) => {
                 let mut ranges_u64 = Vec::with_capacity(ranges.len());
@@ -1168,6 +1188,7 @@ impl FileReader {
                     ranges_u64.push(range.start..range.end);
                 }
                 self.read_ranges(ranges_u64, batch_size, projection, filter)
+                    .await
             }
             ReadBatchParams::RangeFrom(range) => {
                 verify_bound(&params, range.start as u64, true)?;
@@ -1177,13 +1198,16 @@ impl FileReader {
                     projection,
                     filter,
                 )
+                .await
             }
             ReadBatchParams::RangeTo(range) => {
                 verify_bound(&params, range.end as u64, false)?;
                 self.read_range(0..range.end as u64, batch_size, projection, filter)
+                    .await
             }
             ReadBatchParams::RangeFull => {
                 self.read_range(0..self.num_rows, batch_size, projection, filter)
+                    .await
             }
         }
     }
@@ -1209,7 +1233,15 @@ impl FileReader {
     /// * `projection` - A projection to apply to the read.  This controls which columns
     ///   are read from the file.  The projection is NOT applied on top of the base
     ///   projection.  The projection is applied directly to the file schema.
-    pub fn read_stream_projected(
+    ///
+    /// # Why is this async?
+    ///
+    /// This delegates to [`Self::read_tasks`], which awaits the decode
+    /// scheduler's `initialize` step (and, for small reads, the synchronous
+    /// scheduling that follows) before returning.  See `read_tasks` for
+    /// details on why this work is performed up front rather than on the
+    /// stream's first poll.
+    pub async fn read_stream_projected(
         &self,
         params: ReadBatchParams,
         batch_size: u32,
@@ -1218,7 +1250,9 @@ impl FileReader {
         filter: FilterExpression,
     ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
         let arrow_schema = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
-        let tasks_stream = self.read_tasks(params, batch_size, Some(projection), filter)?;
+        let tasks_stream = self
+            .read_tasks(params, batch_size, Some(projection), filter)
+            .await?;
         let batch_stream = tasks_stream
             .map(|task| task.task)
             .buffered(batch_readahead as usize)
@@ -1433,7 +1467,13 @@ impl FileReader {
     /// This is similar to [`Self::read_stream_projected`] but uses the base projection
     /// provided when the file was opened (or reads all columns if the file was
     /// opened without a base projection)
-    pub fn read_stream(
+    ///
+    /// # Why is this async?
+    ///
+    /// This delegates to [`Self::read_stream_projected`], which awaits the
+    /// decode scheduler's `initialize` step before returning the stream.
+    /// See [`Self::read_tasks`] for the rationale.
+    pub async fn read_stream(
         &self,
         params: ReadBatchParams,
         batch_size: u32,
@@ -1447,6 +1487,7 @@ impl FileReader {
             self.base_projection.clone(),
             filter,
         )
+        .await
     }
 
     pub fn schema(&self) -> &Arc<Schema> {
@@ -1746,6 +1787,7 @@ mod tests {
                     16,
                     FilterExpression::no_filter(),
                 )
+                .await
                 .unwrap();
 
             verify_expected(&data, batch_stream, read_size, None).await;
@@ -1896,6 +1938,7 @@ mod tests {
                         projection.clone(),
                         FilterExpression::no_filter(),
                     )
+                    .await
                     .unwrap();
 
                 let projection_arrow = ArrowSchema::from(projection.schema.as_ref());
@@ -1927,6 +1970,7 @@ mod tests {
                         16,
                         FilterExpression::no_filter(),
                     )
+                    .await
                     .unwrap();
 
                 let projection_arrow = ArrowSchema::from(projection.schema.as_ref());
@@ -1949,6 +1993,7 @@ mod tests {
                             empty_projection.clone(),
                             FilterExpression::no_filter(),
                         )
+                        .await
                         .is_err()
                 );
             }
@@ -2031,6 +2076,7 @@ mod tests {
                 projection.clone(),
                 FilterExpression::no_filter(),
             )
+            .await
             .unwrap();
 
         let projection_arrow = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
@@ -2073,6 +2119,7 @@ mod tests {
                 16,
                 FilterExpression::no_filter(),
             )
+            .await
             .unwrap()
             .try_collect::<Vec<_>>()
             .await
@@ -2154,6 +2201,7 @@ mod tests {
                 16,
                 FilterExpression::no_filter(),
             )
+            .await
             .unwrap();
 
         drop(file_reader);
@@ -2263,6 +2311,7 @@ mod tests {
                 16,
                 FilterExpression::no_filter(),
             )
+            .await
             .unwrap()
             .try_collect::<Vec<_>>()
             .await
@@ -2278,6 +2327,7 @@ mod tests {
                 16,
                 FilterExpression::no_filter(),
             )
+            .await
             .unwrap()
             .try_collect::<Vec<_>>()
             .await

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -945,7 +945,7 @@ impl FileReader {
 
         let requested_rows = RequestedRows::Ranges(vec![range]);
 
-        Ok(schedule_and_decode(
+        schedule_and_decode(
             column_infos,
             requested_rows,
             filter,
@@ -953,7 +953,7 @@ impl FileReader {
             projection.schema,
             config,
         )
-        .await)
+        .await
     }
 
     async fn read_range(
@@ -1013,7 +1013,7 @@ impl FileReader {
 
         let requested_rows = RequestedRows::Indices(indices);
 
-        Ok(schedule_and_decode(
+        schedule_and_decode(
             column_infos,
             requested_rows,
             filter,
@@ -1021,7 +1021,7 @@ impl FileReader {
             projection.schema,
             config,
         )
-        .await)
+        .await
     }
 
     async fn take_rows(
@@ -1081,7 +1081,7 @@ impl FileReader {
 
         let requested_rows = RequestedRows::Ranges(ranges);
 
-        Ok(schedule_and_decode(
+        schedule_and_decode(
             column_infos,
             requested_rows,
             filter,
@@ -1089,7 +1089,7 @@ impl FileReader {
             projection.schema,
             config,
         )
-        .await)
+        .await
     }
 
     async fn read_ranges(

--- a/rust/lance-file/src/testing.rs
+++ b/rust/lance-file/src/testing.rs
@@ -101,6 +101,7 @@ pub async fn read_lance_file(
 
     let batch_stream = file_reader
         .read_stream(ReadBatchParams::RangeFull, 1024, 16, filter)
+        .await
         .unwrap();
 
     batch_stream.try_collect().await.unwrap()

--- a/rust/lance-file/src/writer.rs
+++ b/rust/lance-file/src/writer.rs
@@ -1615,6 +1615,7 @@ mod tests {
                 10, // batch_readahead
                 FilterExpression::no_filter(),
             )
+            .await
             .unwrap();
 
         let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -215,7 +215,8 @@ impl IndexReader for current_reader::FileReader {
                 u32::MAX,
                 projection,
                 FilterExpression::no_filter(),
-            )?
+            )
+            .await?
             .try_collect::<Vec<_>>()
             .await?;
         assert_eq!(batches.len(), 1);
@@ -249,6 +250,7 @@ impl IndexReader for current_reader::FileReader {
             projection,
             FilterExpression::no_filter(),
         )
+        .await
     }
 
     // V2 format has removed the row group concept,

--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -341,12 +341,14 @@ pub async fn write_partition_rows(
     w: &mut FileWriter,
     range: Range<usize>,
 ) -> Result<()> {
-    let mut stream = reader.read_stream(
-        lance_io::ReadBatchParams::Range(range),
-        u32::MAX,
-        4,
-        lance_encoding::decoder::FilterExpression::no_filter(),
-    )?;
+    let mut stream = reader
+        .read_stream(
+            lance_io::ReadBatchParams::Range(range),
+            u32::MAX,
+            4,
+            lance_encoding::decoder::FilterExpression::no_filter(),
+        )
+        .await?;
     use futures::StreamExt as _;
     while let Some(rb) = stream.next().await {
         let rb = rb?;
@@ -626,12 +628,15 @@ async fn read_shard_window_partitions(
         return Ok(per_partition_batches);
     }
 
-    let mut stream = shard_job.reader.read_stream(
-        lance_io::ReadBatchParams::Range(shard_job.start_offset..shard_job.end_offset),
-        u32::MAX,
-        4,
-        lance_encoding::decoder::FilterExpression::no_filter(),
-    )?;
+    let mut stream = shard_job
+        .reader
+        .read_stream(
+            lance_io::ReadBatchParams::Range(shard_job.start_offset..shard_job.end_offset),
+            u32::MAX,
+            4,
+            lance_encoding::decoder::FilterExpression::no_filter(),
+        )
+        .await?;
 
     let mut rel_partition = 0usize;
     while rel_partition < window_len && shard_job.window_lengths[rel_partition] == 0 {
@@ -1823,6 +1828,7 @@ mod tests {
                 4,
                 lance_encoding::decoder::FilterExpression::no_filter(),
             )
+            .await
             .unwrap();
         while let Some(batch) = stream.next().await {
             total_rows += batch.unwrap().num_rows();
@@ -2368,6 +2374,7 @@ mod tests {
                 4,
                 lance_encoding::decoder::FilterExpression::no_filter(),
             )
+            .await
             .unwrap();
         while let Some(batch) = stream.next().await {
             total_rows += batch.unwrap().num_rows();
@@ -2556,6 +2563,7 @@ mod tests {
                 4,
                 lance_encoding::decoder::FilterExpression::no_filter(),
             )
+            .await
             .unwrap();
 
         let mut row_ids = Vec::new();

--- a/rust/lance-index/src/vector/ivf/shuffler.rs
+++ b/rust/lance-index/src/vector/ivf/shuffler.rs
@@ -593,6 +593,7 @@ impl IvfShuffler {
                         16,
                         FilterExpression::no_filter(),
                     )
+                    .await
                     .unwrap();
 
                 while let Some(batch) = stream.next().await {
@@ -667,7 +668,8 @@ impl IvfShuffler {
                         SHUFFLE_BATCH_SIZE as u32,
                         16,
                         FilterExpression::no_filter(),
-                    )?
+                    )
+                    .await?
                     .boxed()
             };
 
@@ -845,7 +847,8 @@ impl IvfShuffler {
                     /*batch_size=*/ 1,
                     /*batch_readahead=*/ 32,
                     FilterExpression::no_filter(),
-                )?
+                )
+                .await?
                 .and_then(|batch| {
                     let list_array = batch
                         .column(0)

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -321,7 +321,8 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
                     u32::MAX,
                     1,
                     FilterExpression::no_filter(),
-                )?
+                )
+                .await?
                 .try_collect::<Vec<_>>()
                 .await?;
             let schema = Arc::new(self.reader.schema().as_ref().into());

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -264,14 +264,17 @@ impl ShuffleReader for IvfShufflerReader {
         )
         .await?;
         let schema: Schema = reader.schema().as_ref().into();
-        Ok(Some(Box::new(RecordBatchStreamAdapter::new(
-            Arc::new(schema),
-            reader.read_stream(
+        let stream = reader
+            .read_stream(
                 lance_io::ReadBatchParams::RangeFull,
                 u32::MAX,
                 16,
                 FilterExpression::no_filter(),
-            )?,
+            )
+            .await?;
+        Ok(Some(Box::new(RecordBatchStreamAdapter::new(
+            Arc::new(schema),
+            stream,
         ))))
     }
 
@@ -629,12 +632,15 @@ impl TwoFileShuffleReader {
         }
         let positions = UInt32Array::from(positions);
         let num_positions = positions.len() as u32;
-        let offsets_stream = self.offsets_reader.read_stream(
-            ReadBatchParams::Indices(positions),
-            num_positions,
-            1,
-            FilterExpression::no_filter(),
-        )?;
+        let offsets_stream = self
+            .offsets_reader
+            .read_stream(
+                ReadBatchParams::Indices(positions),
+                num_positions,
+                1,
+                FilterExpression::no_filter(),
+            )
+            .await?;
         let schema = offsets_stream.schema().clone();
         let offsets = offsets_stream.try_collect::<Vec<_>>().await?;
         let offsets = if offsets.is_empty() {
@@ -681,14 +687,18 @@ impl ShuffleReader for TwoFileShuffleReader {
         }
 
         let schema: Schema = self.file_reader.schema().as_ref().into();
-        Ok(Some(Box::new(RecordBatchStreamAdapter::new(
-            Arc::new(schema),
-            self.file_reader.read_stream(
+        let stream = self
+            .file_reader
+            .read_stream(
                 ReadBatchParams::Ranges(ranges.into()),
                 u32::MAX,
                 16,
                 FilterExpression::no_filter(),
-            )?,
+            )
+            .await?;
+        Ok(Some(Box::new(RecordBatchStreamAdapter::new(
+            Arc::new(schema),
+            stream,
         ))))
     }
 

--- a/rust/lance/benches/take.rs
+++ b/rust/lance/benches/take.rs
@@ -213,6 +213,7 @@ fn file_reader_take(
                             16,
                             FilterExpression::no_filter(),
                         )
+                        .await
                         .unwrap();
                     stream.fold(Vec::new(), |mut acc, item| async move {
                         acc.push(item);

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -3133,6 +3133,7 @@ mod tests {
             for valid_range in [0..40, 20..40] {
                 reader
                     .take_range(valid_range, 100)
+                    .await
                     .unwrap()
                     .buffered(1)
                     .try_collect::<Vec<_>>()
@@ -3140,7 +3141,7 @@ mod tests {
                     .unwrap();
             }
             for invalid_range in [0..41, 41..42] {
-                assert!(reader.take_range(invalid_range, 100).is_err());
+                assert!(reader.take_range(invalid_range, 100).await.is_err());
             }
         }
 
@@ -3195,6 +3196,7 @@ mod tests {
             for valid_range in [0..40, 20..40] {
                 reader
                     .take_range(valid_range, 100)
+                    .await
                     .unwrap()
                     .buffered(1)
                     .try_collect::<Vec<_>>()
@@ -3202,7 +3204,7 @@ mod tests {
                     .unwrap();
             }
             for invalid_range in [0..41, 41..42] {
-                assert!(reader.take_range(invalid_range, 100).is_err());
+                assert!(reader.take_range(invalid_range, 100).await.is_err());
             }
         }
 
@@ -3288,11 +3290,8 @@ mod tests {
         } else {
             let to_batches = |range: Range<u32>| {
                 let batch_size = range.len() as u32;
-                reader
-                    .take_range(range, batch_size)
-                    .unwrap()
-                    .buffered(1)
-                    .try_collect::<Vec<_>>()
+                let fut = reader.take_range(range, batch_size);
+                async move { fut.await.unwrap().buffered(1).try_collect::<Vec<_>>().await }
             };
 
             // Since the first batch is all deleted, it will return all nulls row ids.

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -20,7 +20,7 @@ use arrow_array::{
 use arrow_schema::Schema as ArrowSchema;
 use datafusion::logical_expr::Expr;
 use datafusion::scalar::ScalarValue;
-use futures::future::try_join_all;
+use futures::future::{BoxFuture, try_join_all};
 use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt, join, stream};
 use lance_arrow::{RecordBatchExt, SchemaExt};
 use lance_core::datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions};
@@ -87,6 +87,13 @@ pub struct FileFragment {
 const DEFAULT_BATCH_READ_SIZE: u32 = 1024;
 
 /// A trait for file readers to be implemented by both the v1 and v2 readers
+///
+/// The `read_*_tasks` methods are async because for v2 files they drive
+/// the decode scheduler's `initialize` step (and, for small reads, the
+/// synchronous scheduling that follows) before returning the stream.
+/// Doing that work here keeps it on whichever task awaits this call —
+/// typically a per-fragment `tokio::spawn` — instead of smuggling it
+/// into the first poll of the returned stream.
 #[allow(clippy::len_without_is_empty)]
 pub trait GenericFileReader: std::fmt::Debug + Send + Sync {
     /// Reads the requested range of rows from the file, returning as a stream
@@ -96,20 +103,20 @@ pub trait GenericFileReader: std::fmt::Debug + Send + Sync {
         range: Range<u64>,
         batch_size: u32,
         projection: Arc<lance_core::datatypes::Schema>,
-    ) -> Result<ReadBatchTaskStream>;
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>>;
     /// Reads the requested ranges of rows from the file, only supported by v2
     fn read_ranges_tasks(
         &self,
         ranges: Arc<[Range<u64>]>,
         batch_size: u32,
         projection: Arc<lance_core::datatypes::Schema>,
-    ) -> Result<ReadBatchTaskStream>;
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>>;
     /// Reads all rows from the file, returning as a stream of tasks
     fn read_all_tasks(
         &self,
         batch_size: u32,
         projection: Arc<lance_core::datatypes::Schema>,
-    ) -> Result<ReadBatchTaskStream>;
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>>;
     /// Take specific rows from the file, returning as a stream of tasks
     fn take_all_tasks(
         &self,
@@ -117,7 +124,7 @@ pub trait GenericFileReader: std::fmt::Debug + Send + Sync {
         batch_size: u32,
         projection: Arc<lance_core::datatypes::Schema>,
         take_priority: Option<u32>,
-    ) -> Result<ReadBatchTaskStream>;
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>>;
 
     /// Return the number of rows in the file
     fn len(&self) -> u32;
@@ -199,7 +206,7 @@ impl GenericFileReader for V1Reader {
         range: Range<u64>,
         batch_size: u32,
         projection: Arc<Schema>,
-    ) -> Result<ReadBatchTaskStream> {
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
         let mut to_skip = range.start as u32;
         let mut remaining = range.end as u32 - to_skip;
         let mut ranges = Vec::new();
@@ -221,14 +228,15 @@ impl GenericFileReader for V1Reader {
                 ranges.push((next_batch_idx, (chunk_start as usize..chunk_end as usize)));
             }
         }
-        Ok(ranges_to_tasks(&self.reader, ranges, projection))
+        let stream = ranges_to_tasks(&self.reader, ranges, projection);
+        async move { Ok(stream) }.boxed()
     }
 
     fn read_all_tasks(
         &self,
         batch_size: u32,
         projection: Arc<Schema>,
-    ) -> Result<ReadBatchTaskStream> {
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
         let ranges = (0..self.reader.num_batches())
             .flat_map(move |batch_idx| {
                 let rows_in_batch = self.reader.num_rows_in_batch(batch_idx as i32);
@@ -240,7 +248,8 @@ impl GenericFileReader for V1Reader {
                     })
             })
             .collect::<Vec<_>>();
-        Ok(ranges_to_tasks(&self.reader, ranges, projection))
+        let stream = ranges_to_tasks(&self.reader, ranges, projection);
+        async move { Ok(stream) }.boxed()
     }
 
     fn read_ranges_tasks(
@@ -248,10 +257,13 @@ impl GenericFileReader for V1Reader {
         _ranges: Arc<[Range<u64>]>,
         _batch_size: u32,
         _projection: Arc<Schema>,
-    ) -> Result<ReadBatchTaskStream> {
-        Err(Error::internal(
-            "Attempt to perform FilteredRead on v1 files".to_string(),
-        ))
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
+        async move {
+            Err(Error::internal(
+                "Attempt to perform FilteredRead on v1 files".to_string(),
+            ))
+        }
+        .boxed()
     }
 
     fn take_all_tasks(
@@ -260,17 +272,22 @@ impl GenericFileReader for V1Reader {
         _batch_size: u32,
         projection: Arc<Schema>,
         _take_priority: Option<u32>,
-    ) -> Result<ReadBatchTaskStream> {
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
         let indices_vec = indices.to_vec();
         let reader = self.reader.clone();
-        // In the new path the row id is added by the fragment and not the file
-        let task_fut = async move { reader.take(&indices_vec, projection.as_ref()).await }.boxed();
-        let task = std::future::ready(ReadBatchTask {
-            task: task_fut,
-            num_rows: indices.len() as u32,
-        })
-        .boxed();
-        Ok(futures::stream::once(task).boxed())
+        let num_rows = indices.len() as u32;
+        async move {
+            // In the new path the row id is added by the fragment and not the file
+            let task_fut =
+                async move { reader.take(&indices_vec, projection.as_ref()).await }.boxed();
+            let task = std::future::ready(ReadBatchTask {
+                task: task_fut,
+                num_rows,
+            })
+            .boxed();
+            Ok(futures::stream::once(task).boxed())
+        }
+        .boxed()
     }
 
     fn projection(&self) -> &Arc<Schema> {
@@ -343,25 +360,29 @@ mod v2_adapter {
             range: Range<u64>,
             batch_size: u32,
             projection: Arc<Schema>,
-        ) -> Result<ReadBatchTaskStream> {
-            let projection = ReaderProjection::from_field_ids(
-                self.reader.metadata().version(),
-                projection.as_ref(),
-                self.field_id_to_column_idx.as_ref(),
-            )?;
-            Ok(self
-                .reader
-                .read_tasks(
-                    ReadBatchParams::Range(range.start as usize..range.end as usize),
-                    batch_size,
-                    Some(projection),
-                    FilterExpression::no_filter(),
-                )?
-                .map(|v2_task| ReadBatchTask {
-                    task: v2_task.task.map_err(Error::from).boxed(),
-                    num_rows: v2_task.num_rows,
-                })
-                .boxed())
+        ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
+            async move {
+                let projection = ReaderProjection::from_field_ids(
+                    self.reader.metadata().version(),
+                    projection.as_ref(),
+                    self.field_id_to_column_idx.as_ref(),
+                )?;
+                Ok(self
+                    .reader
+                    .read_tasks(
+                        ReadBatchParams::Range(range.start as usize..range.end as usize),
+                        batch_size,
+                        Some(projection),
+                        FilterExpression::no_filter(),
+                    )
+                    .await?
+                    .map(|v2_task| ReadBatchTask {
+                        task: v2_task.task.map_err(Error::from).boxed(),
+                        num_rows: v2_task.num_rows,
+                    })
+                    .boxed())
+            }
+            .boxed()
         }
 
         fn read_ranges_tasks(
@@ -369,50 +390,58 @@ mod v2_adapter {
             ranges: Arc<[Range<u64>]>,
             batch_size: u32,
             projection: Arc<Schema>,
-        ) -> Result<ReadBatchTaskStream> {
-            let projection = ReaderProjection::from_field_ids(
-                self.reader.metadata().version(),
-                projection.as_ref(),
-                self.field_id_to_column_idx.as_ref(),
-            )?;
-            Ok(self
-                .reader
-                .read_tasks(
-                    ReadBatchParams::Ranges(ranges),
-                    batch_size,
-                    Some(projection),
-                    FilterExpression::no_filter(),
-                )?
-                .map(|v2_task| ReadBatchTask {
-                    task: v2_task.task.map_err(Error::from).boxed(),
-                    num_rows: v2_task.num_rows,
-                })
-                .boxed())
+        ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
+            async move {
+                let projection = ReaderProjection::from_field_ids(
+                    self.reader.metadata().version(),
+                    projection.as_ref(),
+                    self.field_id_to_column_idx.as_ref(),
+                )?;
+                Ok(self
+                    .reader
+                    .read_tasks(
+                        ReadBatchParams::Ranges(ranges),
+                        batch_size,
+                        Some(projection),
+                        FilterExpression::no_filter(),
+                    )
+                    .await?
+                    .map(|v2_task| ReadBatchTask {
+                        task: v2_task.task.map_err(Error::from).boxed(),
+                        num_rows: v2_task.num_rows,
+                    })
+                    .boxed())
+            }
+            .boxed()
         }
 
         fn read_all_tasks(
             &self,
             batch_size: u32,
             projection: Arc<Schema>,
-        ) -> Result<ReadBatchTaskStream> {
-            let projection = ReaderProjection::from_field_ids(
-                self.reader.metadata().version(),
-                projection.as_ref(),
-                self.field_id_to_column_idx.as_ref(),
-            )?;
-            Ok(self
-                .reader
-                .read_tasks(
-                    ReadBatchParams::RangeFull,
-                    batch_size,
-                    Some(projection),
-                    FilterExpression::no_filter(),
-                )?
-                .map(|v2_task| ReadBatchTask {
-                    task: v2_task.task.map_err(Error::from).boxed(),
-                    num_rows: v2_task.num_rows,
-                })
-                .boxed())
+        ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
+            async move {
+                let projection = ReaderProjection::from_field_ids(
+                    self.reader.metadata().version(),
+                    projection.as_ref(),
+                    self.field_id_to_column_idx.as_ref(),
+                )?;
+                Ok(self
+                    .reader
+                    .read_tasks(
+                        ReadBatchParams::RangeFull,
+                        batch_size,
+                        Some(projection),
+                        FilterExpression::no_filter(),
+                    )
+                    .await?
+                    .map(|v2_task| ReadBatchTask {
+                        task: v2_task.task.map_err(Error::from).boxed(),
+                        num_rows: v2_task.num_rows,
+                    })
+                    .boxed())
+            }
+            .boxed()
         }
 
         fn take_all_tasks(
@@ -421,37 +450,42 @@ mod v2_adapter {
             batch_size: u32,
             projection: Arc<Schema>,
             take_priority: Option<u32>,
-        ) -> Result<ReadBatchTaskStream> {
+        ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
             let indices = UInt32Array::from(indices.to_vec());
-            let projection = ReaderProjection::from_field_ids(
-                self.reader.metadata().version(),
-                projection.as_ref(),
-                self.field_id_to_column_idx.as_ref(),
-            )?;
+            async move {
+                let projection = ReaderProjection::from_field_ids(
+                    self.reader.metadata().version(),
+                    projection.as_ref(),
+                    self.field_id_to_column_idx.as_ref(),
+                )?;
 
-            let reader = if let Some(take_priority) = take_priority {
-                let op_priority = ((take_priority as u64) << 32) | self.default_priority as u64;
-                let scheduler = self.file_scheduler.with_priority(op_priority);
-                Arc::new(
-                    self.reader
-                        .with_scheduler(Arc::new(LanceEncodingsIo::new(scheduler))),
-                )
-            } else {
-                self.reader.clone()
-            };
+                let reader = if let Some(take_priority) = take_priority {
+                    let op_priority =
+                        ((take_priority as u64) << 32) | self.default_priority as u64;
+                    let scheduler = self.file_scheduler.with_priority(op_priority);
+                    Arc::new(
+                        self.reader
+                            .with_scheduler(Arc::new(LanceEncodingsIo::new(scheduler))),
+                    )
+                } else {
+                    self.reader.clone()
+                };
 
-            Ok(reader
-                .read_tasks(
-                    ReadBatchParams::Indices(indices),
-                    batch_size,
-                    Some(projection),
-                    FilterExpression::no_filter(),
-                )?
-                .map(|v2_task| ReadBatchTask {
-                    task: v2_task.task.map_err(Error::from).boxed(),
-                    num_rows: v2_task.num_rows,
-                })
-                .boxed())
+                Ok(reader
+                    .read_tasks(
+                        ReadBatchParams::Indices(indices),
+                        batch_size,
+                        Some(projection),
+                        FilterExpression::no_filter(),
+                    )
+                    .await?
+                    .map(|v2_task| ReadBatchTask {
+                        task: v2_task.task.map_err(Error::from).boxed(),
+                        num_rows: v2_task.num_rows,
+                    })
+                    .boxed())
+            }
+            .boxed()
         }
 
         fn storage_stats(&self) -> Vec<(u32, u64)> {
@@ -531,7 +565,7 @@ impl GenericFileReader for NullReader {
         range: Range<u64>,
         batch_size: u32,
         projection: Arc<Schema>,
-    ) -> Result<ReadBatchTaskStream> {
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
         self.read_ranges_tasks(vec![range].into(), batch_size, projection)
     }
 
@@ -540,7 +574,7 @@ impl GenericFileReader for NullReader {
         ranges: Arc<[Range<u64>]>,
         batch_size: u32,
         projection: Arc<Schema>,
-    ) -> Result<ReadBatchTaskStream> {
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
         let mut remaining_rows = ranges.iter().map(|r| r.end - r.start).sum::<u64>();
         let projection: Arc<ArrowSchema> = Arc::new(projection.as_ref().into());
 
@@ -559,14 +593,14 @@ impl GenericFileReader for NullReader {
             Some(task)
         });
 
-        Ok(futures::stream::iter(task_iter).boxed())
+        async move { Ok(futures::stream::iter(task_iter).boxed()) }.boxed()
     }
 
     fn read_all_tasks(
         &self,
         batch_size: u32,
         projection: Arc<Schema>,
-    ) -> Result<ReadBatchTaskStream> {
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
         self.read_ranges_tasks(vec![0..self.num_rows as u64].into(), batch_size, projection)
     }
 
@@ -576,7 +610,7 @@ impl GenericFileReader for NullReader {
         batch_size: u32,
         projection: Arc<Schema>,
         _take_priority: Option<u32>,
-    ) -> Result<ReadBatchTaskStream> {
+    ) -> BoxFuture<'_, Result<ReadBatchTaskStream>> {
         let num_rows = indices.len() as u64;
         self.read_ranges_tasks(vec![0..num_rows].into(), batch_size, projection)
     }
@@ -1546,7 +1580,7 @@ impl FileFragment {
         let reader = reader?;
         let deletion_vector = deletion_vector?.unwrap_or_default().as_ref().clone();
 
-        Updater::try_new(self.clone(), reader, deletion_vector, schemas, batch_size)
+        Updater::try_new(self.clone(), reader, deletion_vector, schemas, batch_size).await
     }
 
     pub async fn merge_columns(
@@ -2361,12 +2395,15 @@ impl FragmentReader {
         Ok(result.project_by_schema(&output_schema)?)
     }
 
-    fn new_read_impl(
-        &self,
+    async fn new_read_impl<'a, F>(
+        &'a self,
         params: ReadBatchParams,
         batch_size: u32,
-        read_fn: impl Fn(&dyn GenericFileReader) -> Result<ReadBatchTaskStream>,
-    ) -> Result<ReadBatchFutStream> {
+        read_fn: F,
+    ) -> Result<ReadBatchFutStream>
+    where
+        F: Fn(&'a dyn GenericFileReader) -> BoxFuture<'a, Result<ReadBatchTaskStream>>,
+    {
         let total_num_rows = self.num_physical_rows as u32;
         // Note that the fragment length might be considerably smaller if there are deleted rows.
         // E.g. if a fragment has 100 rows but rows 0..10 are deleted we still need to make
@@ -2404,21 +2441,23 @@ impl FragmentReader {
             // Read each data file, these reads should produce streams of equal sized
             // tasks.  In other words, if we get 3 tasks of 20 rows and then a task
             // of 10 rows from one data file we should get the same from the other.
-            let read_streams = self
-                .readers
-                .iter()
-                .filter_map(|reader| {
-                    // Normally we filter out empty readers in the open_readers method
-                    // However, we will keep the first empty reader to use for row id
-                    // purposes on some legacy paths and so we need to filter that out
-                    // here.
-                    if reader.projection().fields.is_empty() {
-                        None
-                    } else {
-                        Some(read_fn(reader.as_ref()))
-                    }
-                })
-                .collect::<Result<Vec<_>>>()?;
+            //
+            // We launch all readers' scheduling work concurrently — for v2 files
+            // this is where the decode scheduler's `initialize` I/O happens, so
+            // running them in parallel keeps the per-file scheduling I/Os from
+            // serializing.
+            let read_futs = self.readers.iter().filter_map(|reader| {
+                // Normally we filter out empty readers in the open_readers method
+                // However, we will keep the first empty reader to use for row id
+                // purposes on some legacy paths and so we need to filter that out
+                // here.
+                if reader.projection().fields.is_empty() {
+                    None
+                } else {
+                    Some(read_fn(reader.as_ref()))
+                }
+            });
+            let read_streams = futures::future::try_join_all(read_futs).await?;
             // Merge the streams, this merges the generated batches
             lance_table::utils::stream::merge_streams(read_streams)
         };
@@ -2472,7 +2511,7 @@ impl FragmentReader {
         start..end
     }
 
-    fn do_read_range(
+    async fn do_read_range(
         &self,
         mut range: Range<u32>,
         batch_size: u32,
@@ -2492,6 +2531,7 @@ impl FragmentReader {
                 )
             },
         )
+        .await
     }
 
     fn num_system_cols(&self) -> usize {
@@ -2505,28 +2545,48 @@ impl FragmentReader {
     ///
     /// This function interprets the request as the Xth to the Nth row of the fragment (after deletions)
     /// and will always return range.len().min(self.num_rows()) rows.
-    pub fn read_range(&self, range: Range<u32>, batch_size: u32) -> Result<ReadBatchFutStream> {
-        self.do_read_range(range, batch_size, true)
+    ///
+    /// This is async because it drives the per-data-file decode scheduler
+    /// `initialize` work before returning the stream — see
+    /// [`GenericFileReader`].
+    pub async fn read_range(
+        &self,
+        range: Range<u32>,
+        batch_size: u32,
+    ) -> Result<ReadBatchFutStream> {
+        self.do_read_range(range, batch_size, true).await
     }
 
     /// Takes a range of rows from the fragment
     ///
     /// Unlike [`Self::read_range`], this function will NOT skip deleted rows.  If rows are deleted they will
     /// be filtered or set to null.  This function may return less than range.len() rows as a result.
-    pub fn take_range(&self, range: Range<u32>, batch_size: u32) -> Result<ReadBatchFutStream> {
-        self.do_read_range(range, batch_size, false)
+    ///
+    /// This is async for the same reason as [`Self::read_range`].
+    pub async fn take_range(
+        &self,
+        range: Range<u32>,
+        batch_size: u32,
+    ) -> Result<ReadBatchFutStream> {
+        self.do_read_range(range, batch_size, false).await
     }
 
-    pub fn read_all(&self, batch_size: u32) -> Result<ReadBatchFutStream> {
+    /// Reads all rows from the fragment.
+    ///
+    /// This is async for the same reason as [`Self::read_range`].
+    pub async fn read_all(&self, batch_size: u32) -> Result<ReadBatchFutStream> {
         self.new_read_impl(ReadBatchParams::RangeFull, batch_size, move |reader| {
             reader.read_all_tasks(batch_size, reader.projection().clone())
         })
+        .await
     }
 
     // This method is a clone of new_read_impl but returns tasks instead of batches
     //
     // It also only supports v2 files
-    pub fn read_ranges(
+    ///
+    /// This is async for the same reason as [`Self::read_range`].
+    pub async fn read_ranges(
         &self,
         ranges: Arc<[Range<u64>]>,
         batch_size: u32,
@@ -2561,17 +2621,13 @@ impl FragmentReader {
             // Read each data file, these reads should produce streams of equal sized
             // tasks.  In other words, if we get 3 tasks of 20 rows and then a task
             // of 10 rows from one data file we should get the same from the other.
-            let read_streams = self
-                .readers
-                .iter()
-                .map(|reader| {
-                    reader.read_ranges_tasks(
-                        ranges.clone(),
-                        batch_size,
-                        reader.projection().clone(),
-                    )
-                })
-                .collect::<Result<Vec<_>>>()?;
+            //
+            // Run all readers' scheduling concurrently so the per-file
+            // `initialize` I/Os overlap.
+            let read_futs = self.readers.iter().map(|reader| {
+                reader.read_ranges_tasks(ranges.clone(), batch_size, reader.projection().clone())
+            });
+            let read_streams = futures::future::try_join_all(read_futs).await?;
             // Merge the streams, this merges the generated batches
             lance_table::utils::stream::merge_streams(read_streams)
         };
@@ -2618,7 +2674,8 @@ impl FragmentReader {
             .take_range(
                 range.start as u32..range.end as u32,
                 DEFAULT_BATCH_READ_SIZE,
-            )?
+            )
+            .await?
             .buffered(get_num_compute_intensive_cpus())
             .try_collect::<Vec<_>>()
             .await?;
@@ -2645,6 +2702,7 @@ impl FragmentReader {
                 )
             },
         )
+        .await
     }
 
     /// Take rows from this fragment, will perform a copy if the underlying reader returns multiple
@@ -3099,6 +3157,7 @@ mod tests {
             for valid_range in [0..20, 0..10, 10..20] {
                 reader
                     .read_range(valid_range, 100)
+                    .await
                     .unwrap()
                     .buffered(1)
                     .try_collect::<Vec<_>>()
@@ -3106,7 +3165,7 @@ mod tests {
                     .unwrap();
             }
             for invalid_range in [0..21, 21..22] {
-                assert!(reader.read_range(invalid_range, 100).is_err());
+                assert!(reader.read_range(invalid_range, 100).await.is_err());
             }
         }
     }
@@ -3162,6 +3221,7 @@ mod tests {
             for valid_range in [0..20, 0..10, 10..20] {
                 reader
                     .read_range(valid_range, 100)
+                    .await
                     .unwrap()
                     .buffered(1)
                     .try_collect::<Vec<_>>()
@@ -3169,7 +3229,7 @@ mod tests {
                     .unwrap();
             }
             for invalid_range in [0..21, 21..22] {
-                assert!(reader.read_range(invalid_range, 100).is_err());
+                assert!(reader.read_range(invalid_range, 100).await.is_err());
             }
         }
     }
@@ -3295,7 +3355,7 @@ mod tests {
             // Using batch_size=20 here.  If we use batch_size=range.len() we get
             // multiple batches because we might have to read from a larger range
             // to satisfy the request
-            let mut stream = reader.read_range(range, 20).unwrap();
+            let mut stream = reader.read_range(range, 20).await.unwrap();
             let mut batches = Vec::new();
             while let Some(next) = stream.next().await {
                 batches.push(next.await.unwrap());
@@ -3872,6 +3932,7 @@ mod tests {
 
         let actual_data = reader
             .read_range(0..3, 3)
+            .await
             .unwrap()
             .next()
             .await
@@ -4047,6 +4108,7 @@ mod tests {
             .unwrap();
         let mut data = reader
             .read_all(1024)
+            .await
             .unwrap()
             .buffered(1)
             .try_collect::<Vec<_>>()

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -460,8 +460,7 @@ mod v2_adapter {
                 )?;
 
                 let reader = if let Some(take_priority) = take_priority {
-                    let op_priority =
-                        ((take_priority as u64) << 32) | self.default_priority as u64;
+                    let op_priority = ((take_priority as u64) << 32) | self.default_priority as u64;
                     let scheduler = self.file_scheduler.with_priority(op_priority);
                     Arc::new(
                         self.reader

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -59,7 +59,7 @@ impl Updater {
     ///
     /// If the schemas are not known, they can be None and will be inferred from
     /// the first batch of results.
-    pub(super) fn try_new(
+    pub(super) async fn try_new(
         fragment: FileFragment,
         reader: FragmentReader,
         deletion_vector: DeletionVector,
@@ -83,7 +83,7 @@ impl Updater {
             (None, None) => get_default_batch_size().unwrap_or(1024) as u32,
         };
 
-        let input_stream = reader.read_all(batch_size)?;
+        let input_stream = reader.read_all(batch_size).await?;
 
         Ok(Self {
             fragment,

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -893,7 +893,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
                             u32::MAX,
                             1,
                             FilterExpression::no_filter(),
-                        )?
+                        )
+                        .await?
                         .try_collect::<Vec<_>>()
                         .await?;
                     concat_batches(&schema, batches.iter())?

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -1116,7 +1116,8 @@ impl FilteredReadStream {
             .read_ranges(
                 fragment_read_task.ranges.into(),
                 fragment_read_task.batch_size,
-            )?
+            )
+            .await?
             .map(move |batch_fut: ReadBatchFut| {
                 let global_metrics = global_metrics.clone();
                 let fragment_counted = fragment_counted.clone();

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -305,9 +305,12 @@ impl LanceStream {
                         )
                         .await?;
                         let batch_stream = if let Some(range) = file_fragment.range {
-                            reader.read_range(range, config.batch_size as u32)?.boxed()
+                            reader
+                                .read_range(range, config.batch_size as u32)
+                                .await?
+                                .boxed()
                         } else {
-                            reader.read_all(config.batch_size as u32)?.boxed()
+                            reader.read_all(config.batch_size as u32).await?.boxed()
                         };
                         let batch_stream: BoxStream<Result<BoxFuture<Result<RecordBatch>>>> =
                             batch_stream
@@ -396,13 +399,12 @@ impl LanceStream {
                     ))
                 })
                 .try_buffered(fragment_readahead);
-            let tasks = readers.and_then(move |reader| {
-                std::future::ready(
-                    reader
-                        .read_all(config.batch_size as u32)
-                        .map(|task_stream| task_stream.map(Ok))
-                        .map_err(DataFusionError::from),
-                )
+            let tasks = readers.and_then(move |reader| async move {
+                reader
+                    .read_all(config.batch_size as u32)
+                    .await
+                    .map(|task_stream| task_stream.map(Ok))
+                    .map_err(DataFusionError::from)
             });
             tasks
                 // We must be waiting to finish a file before moving onto thenext. That's an issue.
@@ -429,13 +431,12 @@ impl LanceStream {
                     ))
                 })
                 .try_buffered(fragment_readahead);
-            let tasks = readers.and_then(move |reader| {
-                std::future::ready(
-                    reader
-                        .read_all(config.batch_size as u32)
-                        .map(|task_stream| task_stream.map(Ok))
-                        .map_err(DataFusionError::from),
-                )
+            let tasks = readers.and_then(move |reader| async move {
+                reader
+                    .read_all(config.batch_size as u32)
+                    .await
+                    .map(|task_stream| task_stream.map(Ok))
+                    .map_err(DataFusionError::from)
             });
             // When we flatten the streams (one stream per fragment), we allow
             // `fragment_readahead` stream to be read concurrently.


### PR DESCRIPTION
BREAKING CHANGE: the rust file reader's read methods are now async.  This is to allow the caller control over when the scheduler initialization and inline scheduling occurs so that they can parallelize this work across fragments, if appropriate.

## Summary

Fix the v6→v7 inline-scheduling regression by running the decode scheduler's `initialize` I/O eagerly on the awaiting task instead of smuggling it into the returned stream's first poll.

This is offered as an alternative to #6709 (which reverted #6637 entirely): we keep the inline-scheduling optimization for small reads, but make the work explicit and properly parallelized across fragments.

## Background

#6637 introduced an "inline scheduling" path that, for small reads, attached the scheduler future to the front of the returned stream via `flatten_stream` and only ran it on first poll. Combined with the per-fragment `try_flatten` in `FilteredReadExec` (`rust/lance/src/io/exec/filtered_read.rs:455`) and `LanceScanExec` — both of which poll one inner stream at a time — this serialized the scheduler's `initialize` I/O across fragments.

`StructuralPrimitiveFieldScheduler::initialize` (`rust/lance-encoding/src/encodings/logical/primitive.rs:3422`) does a real `io.submit_request(...).await` for chunk metadata. The cache is per-file (the `FieldDataCacheKey` is column-scoped within a file's metadata cache), so every fragment open misses. With 800 small fragments × tens of ms of S3 latency, the inline path was catastrophic.

## Repro

[gist](https://gist.github.com/wkalt/e080fc9ddff6edd8eaee5ab50a069fbe) — 400k rows / 800 fragments × 500 rows, KNN brute force, no index:

|                       | before fix    | after fix       |
|-----------------------|---------------|-----------------|
| default               | ~60–66 ms     | **~48–52 ms**   |
| `LANCE_INLINE_SCHEDULING_THRESHOLD=0` (spawn) | ~46 ms | ~50–52 ms |

Default and spawn are now matched. Cross-fragment-count ablation shows no regression at any scale (default tracks spawn ±2 ms across rpf=500/2000/8000/50000).

## Approach

The goal was to make the scheduling work explicit, not "smuggled into the poll of the first batch."

1. **`schedule_and_decode` is now `async`** (`rust/lance-encoding/src/decoder.rs`). It awaits `DecodeBatchScheduler::try_new` (which runs `initialize`) before returning. For the inline branch, it then runs the synchronous `schedule_ranges` / `schedule_take` work in line, leaving a fully primed decode stream. The non-inline branch still spawns the scheduling task so it can overlap with decoding.

2. **Cascade async through the file-reader surface.** All of `FileReader::read_tasks`, `read_range`, `read_ranges`, `read_stream`, and `read_stream_projected` are now `async`. Each got a "Why is this async?" doc paragraph explaining that the decode scheduler's metadata I/O happens on the awaiting task rather than on the consumer that polls the stream.

3. **`GenericFileReader` trait methods return `BoxFuture<'_, Result<ReadBatchTaskStream>>`.** V1Reader, the v2 adapter `Reader`, and `NullReader` updated. `FragmentReader::{read_range, read_all, read_ranges, take_range}` and `new_read_impl` are now async; `new_read_impl` uses `try_join_all` so per-data-file `initialize` I/Os run concurrently within a fragment.

4. **Callers updated** in `scan.rs` (v1 + v2 paths), `filtered_read.rs`, `dataset/updater.rs` (`Updater::try_new` made async), `lance-index` (shufflers, distributed index merger, scalar lance_format, vector storage), benches, and `python/src/file.rs`.

The fix relies on the existing `SpawnedTask::spawn` of `read_fragment` in `FilteredReadExec` and the `tokio::spawn` of the open task in `LanceScanExec`: the per-fragment task now also drives `initialize`, so all fragments' scheduling I/Os run in parallel up to `fragment_readahead`.

## Behavior change

Errors from `initialize` (e.g. corrupted metadata, transient I/O) now surface from the `read_*` await instead of from the first stream item. Existing callers that match on the result of `read_*` keep working; callers that previously assumed the construction was infallible and only the stream could error will now see the error one step earlier.

## Test plan

- [x] `cargo check --workspace --tests --benches` — clean
- [x] Repro gist — regression resolved (numbers above)
- [x] Cross-fragment-count ablation — no regression at any scale
- [x] Python tests: 526 passed across `test_dataset`, `test_scalar_index`, `test_blob`, `test_filter`, `test_file`, `test_fragment`, `test_vector_index` (minus the timing-fragile test below)
- [ ] Cloud / S3 verification — would expect a much larger improvement than local

## One known test failure to flag

`test_create_index_progress_callback_error_before_completion_propagates` fails after this change. It is a **pre-existing timing race exposed by the speedup**, not a correctness break:

- The test registers `fail_on_tag="start:train_ivf"` and expects `create_index` to raise.
- Mechanism: Rust calls `progress.stage_start("train_ivf").await`, which only does a sync channel send — the callback's error surfaces later, when Python's `block_on_pumping` (`python/src/executor.rs:200-247`) calls `pump()` between 100 ms `tokio::time::sleep`s.
- After this change the default-mode operation completes inside the first 100 ms slice often enough that pump doesn't get a chance to surface the error mid-flight. It hits the post-completion branch at `executor.rs:238-244`, which logs and ignores errors from the final pump (`"Ignoring progress callback error after operation completed successfully"`). Running with `LANCE_INLINE_SCHEDULING_THRESHOLD=0` (spawn) makes the test pass.
- Earlier perf commits on main may already have exposed variants of this on some platforms; commit 87ef5e2fc fixed a related case.

The clean fix is in `block_on_pumping` (propagate the final pump's error rather than ignoring it), but that's outside this refactor's scope and changes the contract of "operation succeeded but a callback later errored". Happy to land that as a separate PR if reviewers want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)