### PR TITLE
fix(mem_wal): keep dispatcher and waiters alive on flush handler errors

### DIFF
--- a/rust/lance/src/dataset/mem_wal/util.rs
+++ b/rust/lance/src/dataset/mem_wal/util.rs
@@ -71,14 +71,17 @@ impl<T: Clone + std::fmt::Debug> WatchableOnceCellReader<T> {
 
     /// Wait for a value to be written.
     ///
-    /// Returns immediately if a value is already present.
-    pub async fn await_value(&mut self) -> T {
-        self.rx
-            .wait_for(|v| v.is_some())
-            .await
-            .expect("watch channel closed")
-            .clone()
-            .expect("no value found")
+    /// Returns immediately if a value is already present. Returns
+    /// `None` if the underlying watch channel was closed before a
+    /// value was published — typically because the producing task
+    /// died (panicked or returned `Err`). Earlier this case used to
+    /// panic with `expect("watch channel closed")`, which turned a
+    /// dead-flusher consequence into a worker panic and made the
+    /// merge_insert call fail with a `RustPanic` instead of a
+    /// recoverable error.
+    pub async fn await_value(&mut self) -> Option<T> {
+        self.rx.wait_for(|v| v.is_some()).await.ok()?;
+        self.rx.borrow().clone()
     }
 }
 
@@ -326,7 +329,7 @@ mod tests {
         cell.write(123);
 
         let result = handle.await.unwrap();
-        assert_eq!(result, 123);
+        assert_eq!(result, Some(123));
     }
 
     #[tokio::test]
@@ -342,7 +345,21 @@ mod tests {
 
         cell.write(456);
 
-        assert_eq!(h1.await.unwrap(), 456);
-        assert_eq!(h2.await.unwrap(), 456);
+        assert_eq!(h1.await.unwrap(), Some(456));
+        assert_eq!(h2.await.unwrap(), Some(456));
+    }
+
+    #[tokio::test]
+    async fn test_watchable_once_cell_returns_none_on_close() {
+        let cell: WatchableOnceCell<i32> = WatchableOnceCell::new();
+        let mut reader = cell.reader();
+
+        // Drop the cell (and thereby the sender) without ever writing.
+        // Earlier this caused `await_value` to panic with
+        // "watch channel closed"; now it returns None so callers can
+        // surface the dead-producer condition as a recoverable error.
+        let handle = tokio::spawn(async move { reader.await_value().await });
+        drop(cell);
+        assert_eq!(handle.await.unwrap(), None);
     }
 }

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -370,6 +370,12 @@ impl<T: Send + Debug + 'static> TaskDispatcher<T> {
             })
             .collect();
 
+        // A single failing message must not bring down the dispatcher:
+        // the WAL flusher and MemTable flusher both run on this loop,
+        // and dropping their channels deadlocks all subsequent puts
+        // (and panics any task waiting on the corresponding watch).
+        // Log and keep draining; the worst case for a transient flush
+        // failure is replay from the WAL on next open.
         let result = loop {
             if ticker_intervals.is_empty() {
                 tokio::select! {
@@ -383,7 +389,6 @@ impl<T: Send + Debug + 'static> TaskDispatcher<T> {
                             Some(message) => {
                                 if let Err(e) = self.handler.handle(message).await {
                                     error!("Task '{}' error handling message: {}", self.name, e);
-                                    break Err(e);
                                 }
                             }
                             None => {
@@ -407,7 +412,6 @@ impl<T: Send + Debug + 'static> TaskDispatcher<T> {
                         let message = (ticker_intervals[0].1)();
                         if let Err(e) = self.handler.handle(message).await {
                             error!("Task '{}' error handling ticker message: {}", self.name, e);
-                            break Err(e);
                         }
                     }
                     msg = self.rx.recv() => {
@@ -415,7 +419,6 @@ impl<T: Send + Debug + 'static> TaskDispatcher<T> {
                             Some(message) => {
                                 if let Err(e) = self.handler.handle(message).await {
                                     error!("Task '{}' error handling message: {}", self.name, e);
-                                    break Err(e);
                                 }
                             }
                             None => {
@@ -1537,8 +1540,13 @@ impl ShardWriter {
             )?;
             let mut reader = reader;
             match reader.await_value().await {
-                Ok(_) => {}
-                Err(msg) => return Err(Error::io(msg)),
+                Some(Ok(_)) => {}
+                Some(Err(msg)) => return Err(Error::io(msg)),
+                None => {
+                    return Err(Error::io(
+                        "WAL flush handler exited before reporting durability",
+                    ));
+                }
             }
         }
 
@@ -1982,10 +1990,15 @@ impl MemTableFlushHandler {
         // The TriggerWalFlush message was sent by freeze_memtable to ensure
         // strict ordering of WAL entries.
         if let Some(mut completion_reader) = memtable.take_wal_flush_completion() {
-            completion_reader
-                .await_value()
-                .await
-                .map_err(|e| Error::io(format!("WAL flush failed: {}", e)))?;
+            match completion_reader.await_value().await {
+                Some(Ok(_)) => {}
+                Some(Err(e)) => return Err(Error::io(format!("WAL flush failed: {}", e))),
+                None => {
+                    return Err(Error::io(
+                        "WAL flush handler exited before reporting completion",
+                    ));
+                }
+            }
         }
 
         // Step 2: Flush the memtable to Lance storage
@@ -2504,6 +2517,215 @@ mod tests {
         assert!(
             stats.generation > initial_gen,
             "Generation should increment after auto-flush"
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// Regression for #6713: a single failing `handle()` must not kill
+    /// the dispatcher. Earlier the loop would `break Err(e)` on the
+    /// first message error, dropping the rx side and stranding
+    /// subsequent senders. The flusher tasks need to survive transient
+    /// errors so the writer keeps making forward progress.
+    #[tokio::test]
+    async fn test_task_dispatcher_survives_handle_error() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct FlakyHandler {
+            call_count: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl MessageHandler<u32> for FlakyHandler {
+            async fn handle(&mut self, message: u32) -> Result<()> {
+                let n = self.call_count.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    Err(Error::io("first message intentionally fails"))
+                } else {
+                    let _ = message;
+                    Ok(())
+                }
+            }
+        }
+
+        let executor = TaskExecutor::new();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = mpsc::unbounded_channel::<u32>();
+        executor
+            .add_handler(
+                "flaky".to_string(),
+                Box::new(FlakyHandler {
+                    call_count: call_count.clone(),
+                }),
+                rx,
+            )
+            .unwrap();
+
+        // Send three messages: the first errors, the next two should
+        // still be delivered to the (still-alive) handler.
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+        tx.send(3).unwrap();
+
+        for _ in 0..50 {
+            if call_count.load(Ordering::SeqCst) >= 3 {
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+        }
+
+        assert!(
+            call_count.load(Ordering::SeqCst) >= 3,
+            "dispatcher exited after the first error; only {} message(s) were handled",
+            call_count.load(Ordering::SeqCst)
+        );
+
+        executor.shutdown_all().await.ok();
+    }
+
+    /// Same as the local-fs test but against memory:// — closer to S3
+    /// semantics (conditional PUT, list-prefix consistency).
+    #[tokio::test]
+    async fn test_shard_writer_auto_flush_repeatedly_memory_store() {
+        let base_uri = "memory:///bench_test_flush";
+        let (store, base_path) = ObjectStore::from_uri(base_uri).await.unwrap();
+        let base_uri = base_uri.to_string();
+        let schema = create_test_schema();
+
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            shard_spec_id: 0,
+            durable_write: true,
+            sync_indexed_write: false,
+            max_wal_buffer_size: 1024 * 1024,
+            max_wal_flush_interval: None,
+            max_memtable_size: 64,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        };
+
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+
+        let initial_gen = writer.memtable_stats().await.unwrap().generation;
+
+        for i in 0..1000 {
+            let batch = create_test_batch(&schema, i * 10, 10);
+            writer.put(vec![batch]).await.unwrap();
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+        let stats = writer.memtable_stats().await.unwrap();
+        assert!(
+            stats.generation >= initial_gen + 50,
+            "expected many flushes; generation went {} → {}",
+            initial_gen,
+            stats.generation
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// Regression for #6713: with durable_write=true and a memtable
+    /// size threshold that fires frequently, the memtable flush task
+    /// hit "Dataset already exists: …_gen_1" once the second flush
+    /// started.
+    #[tokio::test]
+    async fn test_shard_writer_auto_flush_repeatedly_stress() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            shard_spec_id: 0,
+            durable_write: true,
+            sync_indexed_write: false,
+            max_wal_buffer_size: 1024 * 1024,
+            max_wal_flush_interval: None,
+            // Tiny size threshold — every batch crosses it.
+            max_memtable_size: 64,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        };
+
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+
+        let initial_gen = writer.memtable_stats().await.unwrap().generation;
+
+        // Every put crosses the size threshold, so each one queues a
+        // freeze. We want to catch any bug where two flushes collide on
+        // path/generation. Drive 1000 puts so we get ≥ 100 flushes —
+        // enough rope for the bug to show up.
+        for i in 0..1000 {
+            let batch = create_test_batch(&schema, i * 10, 10);
+            writer.put(vec![batch]).await.unwrap();
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+        let stats = writer.memtable_stats().await.unwrap();
+        assert!(
+            stats.generation >= initial_gen + 50,
+            "expected many successful auto-flushes; generation went {} → {}",
+            initial_gen,
+            stats.generation
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// Regression: the memtable flush should successfully fire many
+    /// times in a row. A bug where every flush wrote the same path was
+    /// caught by lance-format/lance#6713.
+    #[tokio::test]
+    async fn test_shard_writer_auto_flush_repeatedly() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+
+        // durable_write=true matches the LSM `merge_insert` defaults and
+        // is the configuration that surfaced #6713 in the wild.
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            shard_spec_id: 0,
+            durable_write: true,
+            sync_indexed_write: false,
+            max_wal_buffer_size: 1024 * 1024,
+            max_wal_flush_interval: None,
+            // Tiny size threshold so a few batches cross it.
+            max_memtable_size: 1024,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        };
+
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+
+        let initial_gen = writer.memtable_stats().await.unwrap().generation;
+
+        // Drive enough write traffic to trigger several auto-flushes.
+        // durable_write=true means each put waits for the WAL flush, so
+        // we don't need explicit yields between puts.
+        for i in 0..200 {
+            let batch = create_test_batch(&schema, i * 10, 10);
+            writer.put(vec![batch]).await.unwrap();
+        }
+
+        // Wait for the background memtable flushes to drain.
+        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+        // Generation should have advanced by at least 3 — i.e. we want to
+        // confirm multiple flushes succeeded back to back, not just one.
+        let stats = writer.memtable_stats().await.unwrap();
+        assert!(
+            stats.generation >= initial_gen + 3,
+            "expected ≥ 3 successful auto-flushes; generation went {} → {}",
+            initial_gen,
+            stats.generation
         );
 
         writer.close().await.unwrap();


### PR DESCRIPTION
## Summary

Two defensive fixes to the MemWAL flush task tree, surfaced by lance-format/lance#6713:

1. `TaskExecutor`'s dispatcher loop no longer breaks on `handle()` Err — it logs and keeps consuming messages so subsequent flushes still make progress.
2. `WatchableOnceCellReader::await_value` returns `Option<T>` instead of `expect`-panicking when the producer drops. All callsites translate `None` into a recoverable `Error::io`, so a dead flusher manifests as a query error rather than a `RustPanic` from a worker task.

Adds a regression test (`test_task_dispatcher_survives_handle_error`).

## Note on root cause of #6713

After this PR was first opened I tracked the underlying \"Dataset already exists: …_gen_1\" error to **lancedb**, not Lance: lancedb's `database/listing.rs` was capturing `query_string = Some(\"\")` after `url::Url::query_pairs_mut()` accidentally set it on URLs that had no input query, which then appended a trailing `?` to every per-table URI. Sub-paths like `<table_uri>/_mem_wal/<shard>/<rand>_gen_<n>` re-parsed as `path=<base table>` + `query=/_mem_wal/...`, so `Dataset::write` resolved to the *base table* manifest and falsely reported \"already exists\". Fix is going up in lancedb separately.

The two fixes here remain valuable on their own — a transient flush error should not panic the writer or strand its waiters — and stand independent of the lancedb fix.