### PR TITLE
perf: fix O(N·K) slow row-id lookup on stable-row-id datasets

### DIFF
--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -76,6 +76,47 @@ impl RowIdIndex {
         let address = address_segment.get(pos)?;
         Some(RowAddress::from(address))
     }
+
+    /// Get addresses for many row ids in one pass over the index.
+    ///
+    /// Returns one entry per input id, in input order (`None` for missing).
+    /// Sorts a working copy of the input internally so the chunk iterator
+    /// is advanced at most once per chunk, amortizing the per-id tree walk
+    /// from O(N · log F) to O(F + N).
+    pub fn get_many(&self, row_ids: &[u64]) -> Vec<Option<RowAddress>> {
+        let n = row_ids.len();
+        let mut out = vec![None; n];
+        if n == 0 {
+            return out;
+        }
+
+        let mut sorted: Vec<(u64, usize)> = row_ids.iter().copied().zip(0..n).collect();
+        sorted.sort_unstable_by_key(|&(id, _)| id);
+
+        let mut chunks = self.0.iter().peekable();
+        for (id, orig_idx) in sorted {
+            // Advance past chunks that end before this id.
+            while let Some((range, _)) = chunks.peek() {
+                if *range.end() < id {
+                    chunks.next();
+                } else {
+                    break;
+                }
+            }
+            let Some((range, (row_id_seg, addr_seg))) = chunks.peek() else {
+                break;
+            };
+            if id < *range.start() {
+                continue; // falls in a gap between chunks
+            }
+            if let Some(pos) = row_id_seg.position(id) {
+                if let Some(addr) = addr_seg.get(pos) {
+                    out[orig_idx] = Some(RowAddress::from(addr));
+                }
+            }
+        }
+        out
+    }
 }
 
 impl DeepSizeOf for RowIdIndex {

--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -109,10 +109,10 @@ impl RowIdIndex {
             if id < *range.start() {
                 continue; // falls in a gap between chunks
             }
-            if let Some(pos) = row_id_seg.position(id) {
-                if let Some(addr) = addr_seg.get(pos) {
-                    out[orig_idx] = Some(RowAddress::from(addr));
-                }
+            if let Some(pos) = row_id_seg.position(id)
+                && let Some(addr) = addr_seg.get(pos)
+            {
+                out[orig_idx] = Some(RowAddress::from(addr));
             }
         }
         out

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -323,12 +323,17 @@ impl U64Segment {
                 }
             }
             Self::RangeWithHoles { range, holes } => {
-                if range.contains(&val) && holes.binary_search(val).is_err() {
-                    let offset = (val - range.start) as usize;
-                    let holes = holes.iter().take_while(|&hole| hole < val).count();
-                    Some(offset - holes)
-                } else {
-                    None
+                if !range.contains(&val) {
+                    return None;
+                }
+                // binary_search returns Err(idx) where idx is the count of holes
+                // strictly less than val (holes are unique and sorted).
+                match holes.binary_search(val) {
+                    Ok(_) => None,
+                    Err(num_holes_before) => {
+                        let offset = (val - range.start) as usize;
+                        Some(offset - num_holes_before)
+                    }
                 }
             }
             Self::RangeWithBitmap { range, bitmap } => {
@@ -351,17 +356,47 @@ impl U64Segment {
                 Some(val) if val < range.end => Some(val),
                 _ => None,
             },
-            Self::RangeWithHoles { range, .. } => {
-                if i >= (range.end - range.start) as usize {
+            Self::RangeWithHoles { range, holes } => {
+                let len = (range.end - range.start) as usize - holes.len();
+                if i >= len {
                     return None;
                 }
-                self.iter().nth(i)
+                // The i-th surviving value v satisfies v = range.start + i + k,
+                // where k = |{h ∈ holes : h < v}|. holes[k] - k is monotone
+                // non-decreasing in k (holes are sorted and unique), so binary
+                // search for the smallest k such that holes[k] - k > range.start + i.
+                let target = range.start + i as u64;
+                let mut lo = 0usize;
+                let mut hi = holes.len();
+                while lo < hi {
+                    let mid = (lo + hi) / 2;
+                    let h = holes.get(mid).unwrap();
+                    if h.saturating_sub(mid as u64) > target {
+                        hi = mid;
+                    } else {
+                        lo = mid + 1;
+                    }
+                }
+                Some(range.start + i as u64 + lo as u64)
             }
-            Self::RangeWithBitmap { range, .. } => {
-                if i >= (range.end - range.start) as usize {
-                    return None;
+            Self::RangeWithBitmap { range, bitmap } => {
+                // Find the i-th set bit (a "select1") via byte-wise popcount.
+                // Bytes past `bitmap.len()` are zero-padded by construction
+                // (Bitmap::new_full), so popcount counts only valid positions.
+                let mut remaining = i;
+                for (byte_idx, &byte) in bitmap.data.iter().enumerate() {
+                    let ones = byte.count_ones() as usize;
+                    if remaining < ones {
+                        let mut b = byte;
+                        for _ in 0..remaining {
+                            b &= b - 1; // clear lowest set bit
+                        }
+                        let bit = b.trailing_zeros() as usize;
+                        return Some(range.start + (byte_idx * 8 + bit) as u64);
+                    }
+                    remaining -= ones;
                 }
-                self.iter().nth(i)
+                None
             }
             Self::SortedArray(array) => array.get(i),
             Self::Array(array) => array.get(i),

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -530,9 +530,10 @@ impl TakeBuilder {
                 .as_ref()
                 .expect("row_ids must be set if row_addrs is not");
             let addrs = if let Some(row_id_index) = get_row_id_index(&self.dataset).await? {
-                row_ids
-                    .iter()
-                    .filter_map(|id| row_id_index.get(*id).map(|address| address.into()))
+                row_id_index
+                    .get_many(row_ids)
+                    .into_iter()
+                    .filter_map(|opt| opt.map(|address| address.into()))
                     .collect::<Vec<_>>()
             } else {
                 row_ids.clone()


### PR DESCRIPTION
`Dataset._take_rows` could be very slow on datasets with stable row IDs enabled and any fragment containing deletions. `RowIdIndex::get` ends in `U64Segment::get(pos)`, and for `RangeWithHoles` / `RangeWithBitmap` this was implemented as `self.iter().nth(i)` — an O(i) walk through the filtered iterator. Called once per input id in `TakeBuilder::get_row_addrs`, the total cost was O(N · K). At 1000 ids against a 4M-row dataset with 8 interior deletions, the take ran in 67s; the same workload now completes in ~7ms.

`RangeWithHoles::get` now binary-searches the hole-count function (which is monotone in `holes[k] - k`) for O(log H) lookups. `RangeWithBitmap::get` walks bytes with `count_ones` until it finds the byte holding the i-th set bit, then `trailing_zeros` within that byte — O(K/64). `RangeWithHoles::position` swaps `take_while().count()` for `binary_search`, also O(log H).

Adds `RowIdIndex::get_many` that sorts a working copy of the input and sweeps the chunk iterator once, amortizing the per-id `RangeInclusiveMap` walk from O(N · log F) to O(F + N). `TakeBuilder::get_row_addrs` now routes through it.