### PR TITLE
refactor(mem_wal): redesign FTS mem index for single-writer multi-reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,6 +4404,7 @@ version = "7.0.0-beta.7"
 dependencies = [
  "all_asserts",
  "approx",
+ "arc-swap",
  "arrow",
  "arrow-arith",
  "arrow-array",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4034,6 +4034,7 @@ checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 name = "lance"
 version = "7.0.0-beta.7"
 dependencies = [
+ "arc-swap",
  "arrow",
  "arrow-arith",
  "arrow-array",

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -63,6 +63,7 @@ rand.workspace = true
 futures.workspace = true
 uuid.workspace = true
 arrow.workspace = true
+arc-swap.workspace = true
 # TODO: use datafusion sub-modules to reduce build size?
 datafusion.workspace = true
 datafusion-functions.workspace = true

--- a/rust/lance/src/dataset/mem_wal/index/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/index/fts.rs
@@ -1,36 +1,45 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! In-memory Full-Text Search (FTS) index.
+//! In-memory Full-Text Search (FTS) index with single-writer / multi-reader
+//! semantics.
 //!
-//! Provides inverted index for text search using crossbeam-skiplist.
-//! Uses the same tokenization as Lance's InvertedIndex for consistency.
+//! # Concurrency model
 //!
-//! ## Current Features
-//! - BM25 scoring algorithm for relevance ranking
-//! - Automatic result ordering by score (descending)
-//! - Single-column term queries
-//! - Phrase queries with slop support
+//! - **One writer** (`insert` / `insert_with_batch_position`) at a time per
+//!   index. Callers are responsible for that invariant; this is consistent
+//!   with `IndexStore`'s usage from `ShardWriter`.
+//! - **Many readers** (`search*`, `expand_fuzzy`, `to_index_builder_reversed`)
+//!   in parallel with the writer. Reads are lock-free aside from a brief
+//!   tokenizer-pool checkout.
+//! - **Per-batch monotonic visibility**: a reader either sees every row of
+//!   batch `b` or none of them. A reader never sees a batch numbered above
+//!   the published `visible_count`. BM25 statistics observed by a reader
+//!   (`doc_count`, `total_tokens`, per-term `df`) are mutually consistent
+//!   with the postings the reader walks.
 //!
-//! ## Pending Features (TODO)
-//! - Multi-column search: Search across multiple columns simultaneously
-//! - Boolean queries: MUST/SHOULD/MUST_NOT for complex query logic
-//! - Fuzzy matching: Typo tolerance with configurable edit distance
-//! - Boost queries: Positive/negative boosting for relevance tuning
-//! - WAND factor: Performance/recall tradeoff control
-//! - Per-term/column boost: Fine-grained relevance weighting
+//! Visibility is published atomically by replacing a single `Snapshot` value
+//! via `ArcSwap`. The writer first installs all term chunks into the
+//! per-term `ArcSwap<TermSlice>` slots, then atomically swaps in a new
+//! `Snapshot` whose `visible_count` covers the new batch. Readers load the
+//! `Snapshot` first and filter every term chunk by `batch_position <
+//! snapshot.visible_count`.
 //!
-//! **Note**: FTS index flush to persistent storage is NOT YET IMPLEMENTED.
-//! The in-memory index works for real-time queries on MemTable data,
-//! but is skipped during MemTable flush.
+//! # On-disk format
+//!
+//! At flush time we hand off to `lance_index::scalar::inverted::builder::InnerBuilder`
+//! via `to_index_builder_reversed`. The on-disk format is unchanged from
+//! Lance's existing inverted index.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use arrow_array::RecordBatch;
+use arc_swap::ArcSwap;
+use arrow_array::{Array, LargeStringArray, RecordBatch, StringArray, StringViewArray};
+use arrow_schema::DataType;
 use crossbeam_skiplist::SkipMap;
-use datafusion::common::ScalarValue;
 use lance_core::{Error, Result};
 use lance_index::scalar::InvertedIndexParams;
 use lance_index::scalar::inverted::tokenizer::document_tokenizer::LanceTokenizer;
@@ -38,18 +47,11 @@ use lance_tokenizer::TokenStream;
 
 use super::RowPosition;
 
-/// Composite key for FTS index.
-///
-/// By combining (token, row_position), each entry is unique.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct FtsKey {
-    /// The indexed token (lowercase).
-    pub token: String,
-    /// Row position (makes the key unique for tokens appearing in multiple docs).
-    pub row_position: RowPosition,
-}
+// ============================================================================
+// Public types preserved from previous API
+// ============================================================================
 
-/// In-memory FTS (Full-Text Search) index entry (returned from search).
+/// In-memory FTS index entry returned from search.
 #[derive(Debug, Clone)]
 pub struct FtsEntry {
     /// Row position in MemTable.
@@ -59,9 +61,6 @@ pub struct FtsEntry {
 }
 
 /// Full-text search query expression for composable queries.
-///
-/// Supports simple term matches, phrase queries, fuzzy matching, and Boolean
-/// combinations with MUST/SHOULD/MUST_NOT logic.
 #[derive(Debug, Clone)]
 pub enum FtsQueryExpr {
     /// Simple term match query.
@@ -85,9 +84,9 @@ pub enum FtsQueryExpr {
         /// The search query string.
         query: String,
         /// Maximum edit distance (Levenshtein distance).
-        /// None means auto-fuzziness based on token length.
+        /// `None` means auto-fuzziness based on token length.
         fuzziness: Option<u32>,
-        /// Maximum number of terms to expand to (default 50).
+        /// Maximum number of terms to expand to.
         max_expansions: usize,
         /// Boost factor applied to the score (default 1.0).
         boost: f32,
@@ -101,18 +100,14 @@ pub enum FtsQueryExpr {
         /// No MUST_NOT clause may match (excludes documents).
         must_not: Vec<Self>,
     },
-    /// Boosting query with positive and optional negative components.
-    ///
-    /// Documents matching the positive query are returned.
-    /// If a negative query is provided, documents matching both positive
-    /// and negative have their scores reduced by `negative_boost`.
+    /// Boosting query with a positive and an optional negative component.
     Boost {
-        /// The primary query (documents must match this).
+        /// Documents must match this query.
         positive: Box<Self>,
-        /// Optional query to demote matching documents.
+        /// Optional query whose matches are demoted.
         negative: Option<Box<Self>>,
-        /// Boost factor for documents matching negative query (typically < 1.0).
-        /// Score becomes: original_score * negative_boost for docs matching negative.
+        /// Multiplier applied to documents matching `negative` (typically
+        /// `< 1.0` to demote).
         negative_boost: f32,
     },
 }
@@ -124,23 +119,10 @@ pub const DEFAULT_MAX_EXPANSIONS: usize = 50;
 pub const DEFAULT_WAND_FACTOR: f32 = 1.0;
 
 /// Search options for controlling performance/recall tradeoffs.
-///
-/// The WAND (Weak AND) factor allows trading recall for performance:
-/// - `wand_factor = 1.0`: Full recall (default), all matching documents returned
-/// - `wand_factor < 1.0`: Faster but may miss some results. Documents with
-///   scores below `top_k_score * wand_factor` are pruned.
-///
-/// # Example
-/// ```ignore
-/// let options = SearchOptions::default()
-///     .with_limit(10)
-///     .with_wand_factor(0.5);
-/// let results = index.search_with_options(&query, options);
-/// ```
 #[derive(Debug, Clone)]
 pub struct SearchOptions {
     /// WAND factor for early termination (0.0 to 1.0).
-    /// 1.0 = full recall, <1.0 = faster but may miss low-scoring results.
+    /// 1.0 = full recall (default).
     pub wand_factor: f32,
     /// Maximum number of results to return. None means unlimited.
     pub limit: Option<usize>,
@@ -156,16 +138,11 @@ impl Default for SearchOptions {
 }
 
 impl SearchOptions {
-    /// Create new SearchOptions with default values.
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Set the WAND factor for early termination.
-    ///
-    /// - 1.0 = full recall (default)
-    /// - 0.5 = prune documents scoring below 50% of the current k-th best score
-    /// - 0.0 = only return the absolute best match
     pub fn with_wand_factor(mut self, wand_factor: f32) -> Self {
         self.wand_factor = wand_factor.clamp(0.0, 1.0);
         self
@@ -179,7 +156,6 @@ impl SearchOptions {
 }
 
 impl FtsQueryExpr {
-    /// Create a simple match query.
     pub fn match_query(query: impl Into<String>) -> Self {
         Self::Match {
             query: query.into(),
@@ -187,7 +163,6 @@ impl FtsQueryExpr {
         }
     }
 
-    /// Create a phrase query with exact matching (slop=0).
     pub fn phrase(query: impl Into<String>) -> Self {
         Self::Phrase {
             query: query.into(),
@@ -196,7 +171,6 @@ impl FtsQueryExpr {
         }
     }
 
-    /// Create a phrase query with specified slop.
     pub fn phrase_with_slop(query: impl Into<String>, slop: u32) -> Self {
         Self::Phrase {
             query: query.into(),
@@ -205,22 +179,15 @@ impl FtsQueryExpr {
         }
     }
 
-    /// Create a fuzzy match query with auto-fuzziness.
-    ///
-    /// Auto-fuzziness is calculated based on token length:
-    /// - 0-2 chars: 0 (exact match)
-    /// - 3-5 chars: 1
-    /// - 6+ chars: 2
     pub fn fuzzy(query: impl Into<String>) -> Self {
         Self::Fuzzy {
             query: query.into(),
-            fuzziness: None, // auto
+            fuzziness: None,
             max_expansions: DEFAULT_MAX_EXPANSIONS,
             boost: 1.0,
         }
     }
 
-    /// Create a fuzzy match query with specified edit distance.
     pub fn fuzzy_with_distance(query: impl Into<String>, fuzziness: u32) -> Self {
         Self::Fuzzy {
             query: query.into(),
@@ -230,7 +197,6 @@ impl FtsQueryExpr {
         }
     }
 
-    /// Create a fuzzy match query with specified edit distance and max expansions.
     pub fn fuzzy_with_options(
         query: impl Into<String>,
         fuzziness: Option<u32>,
@@ -244,14 +210,10 @@ impl FtsQueryExpr {
         }
     }
 
-    /// Create a Boolean query.
     pub fn boolean() -> BooleanQueryBuilder {
         BooleanQueryBuilder::new()
     }
 
-    /// Create a boosting query with only a positive component.
-    ///
-    /// This is equivalent to just running the positive query.
     pub fn boosting(positive: Self) -> Self {
         Self::Boost {
             positive: Box::new(positive),
@@ -260,17 +222,6 @@ impl FtsQueryExpr {
         }
     }
 
-    /// Create a boosting query with positive and negative components.
-    ///
-    /// Documents matching the positive query are returned.
-    /// Documents matching both positive and negative have their scores
-    /// multiplied by `negative_boost` (typically < 1.0 to demote).
-    ///
-    /// # Arguments
-    ///
-    /// * `positive` - The primary query (documents must match this)
-    /// * `negative` - Query to demote matching documents
-    /// * `negative_boost` - Multiplier for documents matching negative (e.g., 0.5)
     pub fn boosting_with_negative(positive: Self, negative: Self, negative_boost: f32) -> Self {
         Self::Boost {
             positive: Box::new(positive),
@@ -279,7 +230,6 @@ impl FtsQueryExpr {
         }
     }
 
-    /// Apply a boost factor to this query.
     pub fn with_boost(self, boost: f32) -> Self {
         match self {
             Self::Match { query, .. } => Self::Match { query, boost },
@@ -295,42 +245,15 @@ impl FtsQueryExpr {
                 max_expansions,
                 boost,
             },
-            Self::Boolean {
-                must,
-                should,
-                must_not,
-            } => {
-                // For Boolean queries, boost is not directly applied
-                // (would need to apply to sub-queries)
-                Self::Boolean {
-                    must,
-                    should,
-                    must_not,
-                }
-            }
-            Self::Boost {
-                positive,
-                negative,
-                negative_boost,
-            } => {
-                // For Boost queries, we wrap the positive in a boosted match
-                // This is a bit unusual - typically you'd boost individual sub-queries
-                Self::Boost {
-                    positive,
-                    negative,
-                    negative_boost,
-                }
-            }
+            // Boolean and Boost don't carry a top-level boost field today.
+            // Preserved as-is to keep behavior identical to the previous impl.
+            other @ (Self::Boolean { .. } | Self::Boost { .. }) => other,
         }
     }
 }
 
-/// Calculate auto-fuzziness based on token length.
-///
-/// This follows the same algorithm as Lance's existing InvertedIndex:
-/// - 0-2 chars: 0 (exact match only)
-/// - 3-5 chars: 1 edit allowed
-/// - 6+ chars: 2 edits allowed
+/// Auto-fuzziness based on token length:
+/// 0–2 chars → 0, 3–5 chars → 1, 6+ chars → 2.
 pub fn auto_fuzziness(token: &str) -> u32 {
     match token.chars().count() {
         0..=2 => 0,
@@ -339,17 +262,13 @@ pub fn auto_fuzziness(token: &str) -> u32 {
     }
 }
 
-/// Calculate Levenshtein distance between two strings.
-///
-/// Returns the minimum number of single-character edits (insertions,
-/// deletions, or substitutions) required to transform one string into another.
+/// Levenshtein distance using two-row dynamic programming.
 pub fn levenshtein_distance(a: &str, b: &str) -> u32 {
     let a_chars: Vec<char> = a.chars().collect();
     let b_chars: Vec<char> = b.chars().collect();
     let m = a_chars.len();
     let n = b_chars.len();
 
-    // Handle edge cases
     if m == 0 {
         return n as u32;
     }
@@ -357,21 +276,17 @@ pub fn levenshtein_distance(a: &str, b: &str) -> u32 {
         return m as u32;
     }
 
-    // Use two rows instead of full matrix for space efficiency
     let mut prev_row: Vec<u32> = (0..=n as u32).collect();
     let mut curr_row: Vec<u32> = vec![0; n + 1];
 
     for (i, a_char) in a_chars.iter().enumerate() {
         curr_row[0] = (i + 1) as u32;
-
         for (j, b_char) in b_chars.iter().enumerate() {
             let cost = if a_char == b_char { 0 } else { 1 };
-
-            curr_row[j + 1] = (prev_row[j + 1] + 1) // deletion
-                .min(curr_row[j] + 1) // insertion
-                .min(prev_row[j] + cost); // substitution
+            curr_row[j + 1] = (prev_row[j + 1] + 1)
+                .min(curr_row[j] + 1)
+                .min(prev_row[j] + cost);
         }
-
         std::mem::swap(&mut prev_row, &mut curr_row);
     }
 
@@ -387,30 +302,25 @@ pub struct BooleanQueryBuilder {
 }
 
 impl BooleanQueryBuilder {
-    /// Create a new Boolean query builder.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Add a MUST clause (document must match).
     pub fn must(mut self, query: FtsQueryExpr) -> Self {
         self.must.push(query);
         self
     }
 
-    /// Add a SHOULD clause (document should match, adds to score).
     pub fn should(mut self, query: FtsQueryExpr) -> Self {
         self.should.push(query);
         self
     }
 
-    /// Add a MUST_NOT clause (document must not match).
     pub fn must_not(mut self, query: FtsQueryExpr) -> Self {
         self.must_not.push(query);
         self
     }
 
-    /// Build the Boolean query.
     pub fn build(self) -> FtsQueryExpr {
         FtsQueryExpr::Boolean {
             must: self.must,
@@ -420,51 +330,292 @@ impl BooleanQueryBuilder {
     }
 }
 
-/// Posting value stored in the inverted index.
-/// Contains term frequency and positions for phrase query support.
-#[derive(Clone, Debug)]
-pub struct PostingValue {
-    /// Term frequency in the document.
-    pub frequency: u32,
-    /// Token positions within the document (0-indexed).
-    /// Used for phrase matching.
-    pub positions: Vec<u32>,
+// ============================================================================
+// Internal types
+// ============================================================================
+
+/// Compressed sparse row (CSR) layout for per-document positions.
+///
+/// `offsets[i]..offsets[i+1]` is the slice of `data` belonging to the i-th
+/// document in this `TermChunk`. `offsets.len() == row_positions.len() + 1`.
+#[derive(Debug)]
+struct Positions {
+    offsets: Vec<u32>,
+    data: Vec<u32>,
 }
 
-/// In-memory FTS index for full-text search.
+impl Positions {
+    fn empty() -> Self {
+        Self {
+            offsets: vec![0],
+            data: Vec::new(),
+        }
+    }
+
+    fn push_doc(&mut self, positions: &[u32]) {
+        self.data.extend_from_slice(positions);
+        self.offsets.push(self.data.len() as u32);
+    }
+
+    fn doc_positions(&self, doc_idx: usize) -> &[u32] {
+        let start = self.offsets[doc_idx] as usize;
+        let end = self.offsets[doc_idx + 1] as usize;
+        &self.data[start..end]
+    }
+
+    fn memory_size(&self) -> usize {
+        self.offsets.capacity() * std::mem::size_of::<u32>()
+            + self.data.capacity() * std::mem::size_of::<u32>()
+    }
+}
+
+/// Postings produced by a single batch insert for a single term.
+///
+/// SoA layout for cache locality and trivial handoff to
+/// `PostingListBuilder`. `row_positions` is sorted ascending.
+#[derive(Debug)]
+struct TermChunk {
+    batch_position: usize,
+    row_positions: Vec<u64>,
+    frequencies: Vec<u32>,
+    /// Present iff `params.has_positions()` was true at construction time.
+    /// Independent of that, in-memory phrase queries always work when
+    /// positions were tracked at insert time.
+    positions: Option<Positions>,
+}
+
+impl TermChunk {
+    fn doc_count(&self) -> usize {
+        self.row_positions.len()
+    }
+
+    fn memory_size(&self) -> usize {
+        let base = std::mem::size_of::<Self>()
+            + self.row_positions.capacity() * std::mem::size_of::<u64>()
+            + self.frequencies.capacity() * std::mem::size_of::<u32>();
+        base + self.positions.as_ref().map_or(0, Positions::memory_size)
+    }
+}
+
+/// Append-only list of `TermChunk`s for a single term, replaced atomically
+/// via `ArcSwap`.
+#[derive(Debug, Default)]
+struct TermSlice {
+    chunks: Vec<Arc<TermChunk>>,
+}
+
+impl TermSlice {
+    fn empty() -> Arc<Self> {
+        Arc::new(Self { chunks: Vec::new() })
+    }
+
+    /// Returns a fresh `Arc<TermSlice>` containing all current chunks plus the
+    /// new one. The previous slice is left unchanged so any reader holding
+    /// it continues to see a consistent state.
+    fn with_chunk_appended(&self, chunk: Arc<TermChunk>) -> Arc<Self> {
+        let mut chunks = Vec::with_capacity(self.chunks.len() + 1);
+        chunks.extend(self.chunks.iter().cloned());
+        chunks.push(chunk);
+        Arc::new(Self { chunks })
+    }
+
+    fn memory_size(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + self.chunks.capacity() * std::mem::size_of::<Arc<TermChunk>>()
+            + self.chunks.iter().map(|c| c.memory_size()).sum::<usize>()
+    }
+}
+
+/// Per-batch row metadata.
+#[derive(Debug)]
+struct BatchMeta {
+    batch_position: usize,
+    row_offset: u64,
+    /// `doc_lengths[i]` is the token count of the row at `row_offset + i`.
+    doc_lengths: Vec<u32>,
+    rows: u32,
+}
+
+impl BatchMeta {
+    fn dl(&self, row_position: u64) -> Option<u32> {
+        if row_position < self.row_offset {
+            return None;
+        }
+        let idx = (row_position - self.row_offset) as usize;
+        self.doc_lengths.get(idx).copied()
+    }
+
+    fn memory_size(&self) -> usize {
+        std::mem::size_of::<Self>() + self.doc_lengths.capacity() * std::mem::size_of::<u32>()
+    }
+}
+
+/// Atomic snapshot of the visible state. Replaced via `ArcSwap` after each
+/// batch is fully linked.
+#[derive(Debug)]
+struct Snapshot {
+    /// Number of batches visible to readers. `0` means empty index.
+    visible_count: usize,
+    /// Visible-batch metadata. `batches.len() >= visible_count`; the writer
+    /// may have already appended a still-invisible batch to this list, but
+    /// readers walk only `batches[0..visible_count]`. In the publication
+    /// order described in the module docs, readers never observe
+    /// `visible_count` exceeding the actual length.
+    batches: Arc<[Arc<BatchMeta>]>,
+    /// `Σ batches[i].rows` for `i < visible_count`.
+    cumulative_doc_count: u64,
+    /// `Σ batches[i].doc_lengths.iter().sum()` for `i < visible_count`.
+    cumulative_total_tokens: u64,
+}
+
+impl Snapshot {
+    fn empty() -> Arc<Self> {
+        Arc::new(Self {
+            visible_count: 0,
+            batches: Arc::from(Vec::<Arc<BatchMeta>>::new().into_boxed_slice()),
+            cumulative_doc_count: 0,
+            cumulative_total_tokens: 0,
+        })
+    }
+
+    fn batch_for(&self, batch_position: usize) -> Option<&Arc<BatchMeta>> {
+        // Visible batches are densely numbered starting at 0 in the order
+        // they were inserted. Use direct index when possible.
+        self.batches
+            .get(batch_position)
+            .filter(|m| m.batch_position == batch_position)
+            .or_else(|| {
+                self.batches[..self.visible_count]
+                    .iter()
+                    .find(|m| m.batch_position == batch_position)
+            })
+    }
+}
+
+/// Bounded pool of reader tokenizers with a writer-dedicated slot.
+///
+/// `LanceTokenizer::token_stream_for_*` takes `&mut self`, so each concurrent
+/// caller needs its own tokenizer instance. Builds are cheap for English but
+/// can load dictionaries for CJK tokenizers, so we amortize via the pool.
+struct TokenizerPool {
+    template: Box<dyn LanceTokenizer>,
+    free: Mutex<Vec<Box<dyn LanceTokenizer>>>,
+    cap: usize,
+}
+
+impl std::fmt::Debug for TokenizerPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenizerPool")
+            .field("cap", &self.cap)
+            .finish()
+    }
+}
+
+impl TokenizerPool {
+    fn new(params: &InvertedIndexParams, cap: usize) -> Result<Self> {
+        let template = params.build()?;
+        Ok(Self {
+            template,
+            free: Mutex::new(Vec::new()),
+            cap: cap.max(1),
+        })
+    }
+
+    /// Acquire a tokenizer. Pops from the free list, otherwise clones the
+    /// template.
+    fn acquire(&self) -> Box<dyn LanceTokenizer> {
+        if let Some(t) = self.free.lock().ok().and_then(|mut g| g.pop()) {
+            return t;
+        }
+        self.template.box_clone()
+    }
+
+    /// Return a tokenizer to the pool, dropping it if the pool is at cap.
+    fn release(&self, tokenizer: Box<dyn LanceTokenizer>) {
+        if let Ok(mut g) = self.free.lock()
+            && g.len() < self.cap
+        {
+            g.push(tokenizer);
+        }
+    }
+}
+
+/// RAII guard that returns the tokenizer to the pool on drop.
+struct PooledTokenizer<'a> {
+    pool: &'a TokenizerPool,
+    inner: Option<Box<dyn LanceTokenizer>>,
+}
+
+impl<'a> PooledTokenizer<'a> {
+    fn new(pool: &'a TokenizerPool) -> Self {
+        Self {
+            pool,
+            inner: Some(pool.acquire()),
+        }
+    }
+
+    fn get_mut(&mut self) -> &mut dyn LanceTokenizer {
+        self.inner.as_mut().expect("tokenizer in scope").as_mut()
+    }
+}
+
+impl<'a> Drop for PooledTokenizer<'a> {
+    fn drop(&mut self) {
+        if let Some(t) = self.inner.take() {
+            self.pool.release(t);
+        }
+    }
+}
+
+// ============================================================================
+// FtsMemIndex
+// ============================================================================
+
+/// In-memory full-text search index. See module docs for the concurrency
+/// model and visibility contract.
 pub struct FtsMemIndex {
-    /// Field ID this index is built on.
     field_id: i32,
-    /// Column name (for Arrow batch lookups).
     column_name: String,
-    /// Inverted index: (token, row_position) -> (frequency, positions).
-    postings: SkipMap<FtsKey, PostingValue>,
-    /// Total document count.
-    doc_count: AtomicUsize,
-    /// Tokenizer for text processing (same as Lance's InvertedIndex).
-    tokenizer: Mutex<Box<dyn LanceTokenizer>>,
-    /// The parameters used to create the tokenizer (for flush).
     params: InvertedIndexParams,
-    /// Document lengths: row_position -> token count (for BM25).
-    doc_lengths: SkipMap<u64, u32>,
-    /// Total token count across all documents (for computing avgdl).
-    total_tokens: AtomicUsize,
-    /// Document frequency: term -> number of documents containing the term.
-    doc_freq: SkipMap<String, AtomicUsize>,
+
+    tokenizer_pool: Arc<TokenizerPool>,
+    /// Writer-only tokenizer slot. Held under a Mutex purely so `insert`
+    /// can take `&self`. Single-writer assumption means this is uncontested.
+    writer_tokenizer: Mutex<Box<dyn LanceTokenizer>>,
+
+    /// Per-term posting slices. `Arc<str>` interns the term so a single
+    /// allocation backs every chunk that mentions it.
+    terms: SkipMap<Arc<str>, ArcSwap<TermSlice>>,
+
+    /// Atomically-swapped visibility snapshot.
+    snapshot: ArcSwap<Snapshot>,
+
+    /// Strictly-monotonic batch position counter, used by `insert` (the
+    /// no-explicit-position variant) to assign sequential ids. Reads of
+    /// this counter are not part of the visibility contract — callers
+    /// passing explicit positions to `insert_with_batch_position` must keep
+    /// these monotonic themselves.
+    next_batch_position: AtomicUsize,
 }
 
 impl std::fmt::Debug for FtsMemIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let snap = self.snapshot.load();
         f.debug_struct("FtsMemIndex")
             .field("field_id", &self.field_id)
             .field("column_name", &self.column_name)
-            .field("doc_count", &self.doc_count)
+            .field("visible_doc_count", &snap.cumulative_doc_count)
+            .field("visible_batch_count", &snap.visible_count)
             .field("params", &self.params)
             .finish()
     }
 }
 
 impl FtsMemIndex {
+    /// Default reader-tokenizer pool capacity. Small but enough to absorb
+    /// short bursts of concurrent search calls without thrashing.
+    const DEFAULT_TOKENIZER_POOL_CAP: usize = 8;
+
     /// Create a new FTS index for the given field with default parameters.
     pub fn new(field_id: i32, column_name: String) -> Self {
         Self::with_params(field_id, column_name, InvertedIndexParams::default())
@@ -472,547 +623,439 @@ impl FtsMemIndex {
 
     /// Create a new FTS index with custom tokenizer parameters.
     pub fn with_params(field_id: i32, column_name: String, params: InvertedIndexParams) -> Self {
-        let tokenizer = params.build().expect("Failed to build tokenizer");
+        let pool = TokenizerPool::new(&params, Self::DEFAULT_TOKENIZER_POOL_CAP)
+            .expect("Failed to build tokenizer");
+        let writer_tokenizer = pool.template.box_clone();
         Self {
             field_id,
             column_name,
-            postings: SkipMap::new(),
-            doc_count: AtomicUsize::new(0),
-            tokenizer: Mutex::new(tokenizer),
             params,
-            doc_lengths: SkipMap::new(),
-            total_tokens: AtomicUsize::new(0),
-            doc_freq: SkipMap::new(),
+            tokenizer_pool: Arc::new(pool),
+            writer_tokenizer: Mutex::new(writer_tokenizer),
+            terms: SkipMap::new(),
+            snapshot: ArcSwap::from(Snapshot::empty()),
+            next_batch_position: AtomicUsize::new(0),
         }
     }
 
-    /// Get the field ID this index is built on.
     pub fn field_id(&self) -> i32 {
         self.field_id
     }
 
-    /// Get the inverted index parameters.
+    pub fn column_name(&self) -> &str {
+        &self.column_name
+    }
+
     pub fn params(&self) -> &InvertedIndexParams {
         &self.params
     }
 
-    /// Insert documents from a batch into the index.
+    /// Number of visible documents.
+    pub fn doc_count(&self) -> usize {
+        self.snapshot.load().cumulative_doc_count as usize
+    }
+
+    /// Whether there are any visible documents.
+    pub fn is_empty(&self) -> bool {
+        self.snapshot.load().visible_count == 0
+    }
+
+    /// Total number of (term, doc) postings currently stored.
+    ///
+    /// Counts every chunk regardless of visibility — the writer's invariant
+    /// is that chunks become visible together with the snapshot bump, so
+    /// in steady state this equals the number of visible postings.
+    pub fn entry_count(&self) -> usize {
+        self.terms
+            .iter()
+            .map(|e| {
+                let slice = e.value().load();
+                slice.chunks.iter().map(|c| c.doc_count()).sum::<usize>()
+            })
+            .sum()
+    }
+
+    /// Estimated bytes of heap memory held by this index.
+    pub fn memory_usage(&self) -> usize {
+        let mut total = std::mem::size_of::<Self>();
+        for entry in self.terms.iter() {
+            // ~32 bytes for SkipMap node overhead plus the interned term itself.
+            let term: &Arc<str> = entry.key();
+            total += std::mem::size_of::<Arc<str>>() + term.len() + 32;
+            let slice = entry.value().load();
+            total += slice.memory_size();
+        }
+        let snap = self.snapshot.load();
+        total += snap.batches.iter().map(|b| b.memory_size()).sum::<usize>();
+        total
+    }
+
+    // ------------------------------------------------------------------
+    // Insert
+    // ------------------------------------------------------------------
+
+    /// Insert a batch using a sequentially-derived batch position.
     pub fn insert(&self, batch: &RecordBatch, row_offset: u64) -> Result<()> {
-        let col_idx = batch
+        let batch_position = self.next_batch_position.fetch_add(1, Ordering::Relaxed);
+        self.insert_with_batch_position(batch, row_offset, batch_position)
+    }
+
+    /// Insert a batch with an explicit batch position. The position is part
+    /// of the visibility contract — see module docs.
+    pub fn insert_with_batch_position(
+        &self,
+        batch: &RecordBatch,
+        row_offset: u64,
+        batch_position: usize,
+    ) -> Result<()> {
+        // Keep next_batch_position ahead of any explicit caller-supplied
+        // position so a later `insert` (no-position) doesn't collide.
+        let _ = self
+            .next_batch_position
+            .fetch_max(batch_position.saturating_add(1), Ordering::Relaxed);
+
+        let Some(col_idx) = batch
             .schema()
             .column_with_name(&self.column_name)
-            .map(|(idx, _)| idx);
+            .map(|(idx, _)| idx)
+        else {
+            // Column missing: nothing to index, but advance the snapshot so
+            // the caller's position counter stays in sync.
+            return self.publish_empty_batch(batch.num_rows() as u32, row_offset, batch_position);
+        };
 
-        if col_idx.is_none() {
-            return Ok(());
-        }
+        let column = batch.column(col_idx);
+        let texts = extract_texts(column.as_ref())?;
+        debug_assert_eq!(texts.len(), batch.num_rows());
 
-        let column = batch.column(col_idx.unwrap());
+        let mut tok_guard = self
+            .writer_tokenizer
+            .lock()
+            .expect("writer tokenizer poisoned — single-writer invariant violated");
+        let tokenizer: &mut dyn LanceTokenizer = tok_guard.as_mut();
 
-        for row_idx in 0..batch.num_rows() {
-            let value = ScalarValue::try_from_array(column.as_ref(), row_idx)?;
-            let row_position = row_offset + row_idx as u64;
+        // Per-term builders (frequency + per-doc positions, indexed by
+        // local doc index in this batch).
+        let mut term_builders: HashMap<Arc<str>, BatchTermBuilder> = HashMap::new();
+        let mut doc_lengths: Vec<u32> = Vec::with_capacity(batch.num_rows());
+        let mut total_tokens: u64 = 0;
 
-            if let ScalarValue::Utf8(Some(text)) | ScalarValue::LargeUtf8(Some(text)) = value {
-                // Use the tokenizer (same as InvertedIndex)
-                // Track both frequency and positions for each term
-                let mut term_data: HashMap<String, (u32, Vec<u32>)> = HashMap::new();
-                {
-                    let mut tokenizer = self.tokenizer.lock().unwrap();
-                    let mut token_stream = tokenizer.token_stream_for_doc(&text);
-                    let mut position: u32 = 0;
-                    while let Some(token) = token_stream.next() {
-                        let entry = term_data.entry(token.text.clone()).or_default();
-                        entry.0 += 1; // frequency
-                        entry.1.push(position); // position
-                        position += 1;
-                    }
-                }
+        for (local_doc_idx, text_opt) in texts.iter().enumerate() {
+            // Track each doc's position even for null/missing rows so the
+            // dense `doc_lengths` array stays aligned with `row_offset + i`.
+            let mut doc_token_count: u32 = 0;
+            // term -> (frequency, positions). Keyed by `String` so we only
+            // pay the `Arc<str>` allocation once per unique term per doc,
+            // when transferring to `term_builders` below.
+            let mut per_doc: HashMap<String, (u32, Vec<u32>)> = HashMap::new();
 
-                // Calculate document length (total token count in this doc)
-                let doc_length: u32 = term_data.values().map(|(freq, _)| freq).sum();
-                self.doc_lengths.insert(row_position, doc_length);
-                self.total_tokens
-                    .fetch_add(doc_length as usize, Ordering::Relaxed);
-
-                for (token, (freq, positions)) in term_data {
-                    // Update document frequency for this term
-                    if let Some(entry) = self.doc_freq.get(&token) {
-                        entry.value().fetch_add(1, Ordering::Relaxed);
-                    } else {
-                        self.doc_freq.insert(token.clone(), AtomicUsize::new(1));
-                    }
-
-                    let key = FtsKey {
-                        token,
-                        row_position,
-                    };
-                    self.postings.insert(
-                        key,
-                        PostingValue {
-                            frequency: freq,
-                            positions,
-                        },
-                    );
+            if let Some(text) = text_opt {
+                let mut stream = tokenizer.token_stream_for_doc(text);
+                let mut position: u32 = 0;
+                while let Some(tok) = stream.next() {
+                    let entry = per_doc
+                        .entry(tok.text.clone())
+                        .or_insert_with(|| (0, Vec::new()));
+                    entry.0 += 1;
+                    entry.1.push(position);
+                    position += 1;
+                    doc_token_count += 1;
                 }
             }
 
-            self.doc_count.fetch_add(1, Ordering::Relaxed);
+            doc_lengths.push(doc_token_count);
+            total_tokens += doc_token_count as u64;
+
+            let row_position = row_offset + local_doc_idx as u64;
+            for (term, (freq, positions)) in per_doc {
+                // Reuse an interned `Arc<str>` if we've already seen the
+                // term in this batch. The first occurrence pays the
+                // allocation; subsequent occurrences clone the Arc.
+                let term_arc: Arc<str> =
+                    if let Some((existing, _)) = term_builders.get_key_value(term.as_str()) {
+                        Arc::clone(existing)
+                    } else {
+                        Arc::<str>::from(term.as_str())
+                    };
+                let builder = term_builders
+                    .entry(term_arc)
+                    .or_insert_with(BatchTermBuilder::new);
+                builder.push_doc(row_position, freq, positions);
+            }
         }
 
+        // Drop the tokenizer guard before any work that could be slow so we
+        // don't hold it across allocations.
+        drop(tok_guard);
+
+        // Install per-term chunks first so any chunk a reader can possibly
+        // see (via a later snapshot store) is fully linked.
+        for (term, builder) in term_builders {
+            let chunk = builder.build(batch_position);
+            let entry = self
+                .terms
+                .get_or_insert_with(term, TermSlice::empty_arc_swap);
+            let cur = entry.value().load();
+            entry.value().store(cur.with_chunk_appended(chunk));
+        }
+
+        let new_meta = Arc::new(BatchMeta {
+            batch_position,
+            row_offset,
+            doc_lengths,
+            rows: batch.num_rows() as u32,
+        });
+
+        self.publish_batch(new_meta, total_tokens);
         Ok(())
     }
 
-    /// Search for documents containing a term.
-    ///
-    /// The term is tokenized using the same tokenizer as the index.
-    /// Returns all matching documents with their BM25 scores.
-    pub fn search(&self, term: &str) -> Vec<FtsEntry> {
-        // Tokenize the search term using token_stream_for_search
-        let tokens: Vec<String> = {
-            let mut tokenizer = self.tokenizer.lock().unwrap();
-            let mut token_stream = tokenizer.token_stream_for_search(term);
-            let mut tokens = Vec::new();
-            while let Some(token) = token_stream.next() {
-                tokens.push(token.text.clone());
-            }
-            tokens
-        };
-
-        // BM25 parameters
-        const K1: f32 = 1.2;
-        const B: f32 = 0.75;
-
-        let n = self.doc_count.load(Ordering::Relaxed) as f32;
-        let total_tokens = self.total_tokens.load(Ordering::Relaxed) as f32;
-        let avgdl = if n > 0.0 { total_tokens / n } else { 1.0 };
-
-        // Collect term frequencies per document for all query tokens
-        // Map: row_position -> Vec<(term_freq, doc_freq_for_term)>
-        let mut doc_term_info: HashMap<RowPosition, Vec<(u32, usize)>> = HashMap::new();
-
-        for token in &tokens {
-            // Get document frequency for this term
-            let df = self
-                .doc_freq
-                .get(token)
-                .map(|e| e.value().load(Ordering::Relaxed))
-                .unwrap_or(0);
-
-            if df == 0 {
-                continue;
-            }
-
-            let start = FtsKey {
-                token: token.clone(),
-                row_position: 0,
-            };
-            let end = FtsKey {
-                token: token.clone(),
-                row_position: u64::MAX,
-            };
-
-            for entry in self.postings.range(start..=end) {
-                doc_term_info
-                    .entry(entry.key().row_position)
-                    .or_default()
-                    .push((entry.value().frequency, df));
-            }
-        }
-
-        // Compute BM25 score for each document
-        doc_term_info
-            .into_iter()
-            .map(|(row_position, term_infos)| {
-                let dl = self
-                    .doc_lengths
-                    .get(&row_position)
-                    .map(|e| *e.value() as f32)
-                    .unwrap_or(1.0);
-
-                let mut score: f32 = 0.0;
-                for (tf, df) in term_infos {
-                    // IDF = log((N - n + 0.5) / (n + 0.5) + 1)
-                    let df_f = df as f32;
-                    let idf = ((n - df_f + 0.5) / (df_f + 0.5) + 1.0).ln();
-
-                    // BM25 term score = IDF * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (dl / avgdl)))
-                    let tf_f = tf as f32;
-                    let numerator = tf_f * (K1 + 1.0);
-                    let denominator = tf_f + K1 * (1.0 - B + B * (dl / avgdl));
-                    score += idf * (numerator / denominator);
-                }
-
-                FtsEntry {
-                    row_position,
-                    score,
-                }
-            })
-            .collect()
+    /// Publish a snapshot for an "empty" batch (e.g. column missing) so the
+    /// visibility counters keep up with the writer's batch_position stream.
+    fn publish_empty_batch(&self, rows: u32, row_offset: u64, batch_position: usize) -> Result<()> {
+        let meta = Arc::new(BatchMeta {
+            batch_position,
+            row_offset,
+            doc_lengths: vec![0; rows as usize],
+            rows,
+        });
+        self.publish_batch(meta, 0);
+        Ok(())
     }
 
-    /// Search for documents containing an exact phrase.
+    fn publish_batch(&self, new_meta: Arc<BatchMeta>, batch_total_tokens: u64) {
+        let cur = self.snapshot.load();
+        let new_rows = new_meta.rows as u64;
+        let mut batches: Vec<Arc<BatchMeta>> = Vec::with_capacity(cur.batches.len() + 1);
+        batches.extend(cur.batches.iter().cloned());
+        batches.push(new_meta);
+        let new_snap = Snapshot {
+            visible_count: cur.visible_count + 1,
+            batches: Arc::from(batches.into_boxed_slice()),
+            cumulative_doc_count: cur.cumulative_doc_count + new_rows,
+            cumulative_total_tokens: cur.cumulative_total_tokens + batch_total_tokens,
+        };
+        self.snapshot.store(Arc::new(new_snap));
+    }
+
+    // ------------------------------------------------------------------
+    // Read path
+    // ------------------------------------------------------------------
+
+    /// Search for documents containing a term.
     ///
-    /// The phrase is tokenized and documents must contain all tokens
-    /// in the correct order (within the specified slop distance).
-    ///
-    /// # Arguments
-    /// * `phrase` - The phrase to search for
-    /// * `slop` - Maximum allowed distance between consecutive tokens.
-    ///   0 means exact phrase match (tokens must be adjacent).
-    ///   1 allows one intervening token, etc.
-    ///
-    /// Returns matching documents with BM25 scores.
+    /// The term is tokenized using the configured tokenizer. Returns all
+    /// matching documents with BM25 scores. Result order is unspecified;
+    /// use `search_with_options` for sorted/limited output.
+    pub fn search(&self, term: &str) -> Vec<FtsEntry> {
+        let snap = self.snapshot.load_full();
+        if snap.visible_count == 0 {
+            return Vec::new();
+        }
+
+        let tokens = self.tokenize_for_search(term);
+
+        score_terms(&snap, &self.terms, &tokens)
+    }
+
+    /// Search for documents containing an exact phrase, optionally allowing
+    /// `slop` intervening tokens between consecutive query tokens.
     pub fn search_phrase(&self, phrase: &str, slop: u32) -> Vec<FtsEntry> {
-        // Tokenize the phrase
-        let tokens: Vec<String> = {
-            let mut tokenizer = self.tokenizer.lock().unwrap();
-            let mut token_stream = tokenizer.token_stream_for_search(phrase);
-            let mut tokens = Vec::new();
-            while let Some(token) = token_stream.next() {
-                tokens.push(token.text.clone());
+        let snap = self.snapshot.load_full();
+        if snap.visible_count == 0 {
+            return Vec::new();
+        }
+
+        let tokens = self.tokenize_for_search(phrase);
+        if tokens.is_empty() {
+            return Vec::new();
+        }
+        if tokens.len() == 1 {
+            // Same shortcut as the previous implementation: a single-token
+            // phrase reduces to a regular term search.
+            return score_terms(&snap, &self.terms, &tokens);
+        }
+
+        // Gather visible chunks per token.
+        let mut per_token_chunks: Vec<Vec<Arc<TermChunk>>> = Vec::with_capacity(tokens.len());
+        for tok in &tokens {
+            match self.terms.get(tok.as_str()) {
+                Some(entry) => {
+                    let slice = entry.value().load_full();
+                    let visible: Vec<Arc<TermChunk>> = slice
+                        .chunks
+                        .iter()
+                        .filter(|c| c.batch_position < snap.visible_count)
+                        .cloned()
+                        .collect();
+                    if visible.is_empty() {
+                        return Vec::new();
+                    }
+                    per_token_chunks.push(visible);
+                }
+                None => return Vec::new(),
             }
-            tokens
+        }
+
+        // Per-term `df` for IDF.
+        let dfs: Vec<u32> = per_token_chunks
+            .iter()
+            .map(|chunks| chunks.iter().map(|c| c.doc_count() as u32).sum::<u32>())
+            .collect();
+
+        let n = snap.cumulative_doc_count as f32;
+        let avgdl = if n > 0.0 {
+            snap.cumulative_total_tokens as f32 / n
+        } else {
+            1.0
         };
 
-        if tokens.is_empty() {
-            return vec![];
-        }
+        // Find candidate documents: rows that appear in every token's
+        // posting set. Start with the smallest token's docs to bound work.
+        let smallest_idx = (0..per_token_chunks.len())
+            .min_by_key(|&i| {
+                per_token_chunks[i]
+                    .iter()
+                    .map(|c| c.doc_count())
+                    .sum::<usize>()
+            })
+            .unwrap();
+        let candidate_chunks = &per_token_chunks[smallest_idx];
 
-        // Single token phrase is just a regular search
-        if tokens.len() == 1 {
-            return self.search(phrase);
-        }
-
-        // BM25 parameters
-        const K1: f32 = 1.2;
-        const B: f32 = 0.75;
-
-        let n = self.doc_count.load(Ordering::Relaxed) as f32;
-        let total_tokens = self.total_tokens.load(Ordering::Relaxed) as f32;
-        let avgdl = if n > 0.0 { total_tokens / n } else { 1.0 };
-
-        // Collect posting lists for each token
-        // Map: token_index -> Map<row_position, PostingValue>
-        let mut token_postings: Vec<HashMap<RowPosition, PostingValue>> = Vec::new();
-
-        for token in &tokens {
-            let start = FtsKey {
-                token: token.clone(),
-                row_position: 0,
-            };
-            let end = FtsKey {
-                token: token.clone(),
-                row_position: u64::MAX,
-            };
-
-            let mut postings_for_token: HashMap<RowPosition, PostingValue> = HashMap::new();
-            for entry in self.postings.range(start..=end) {
-                postings_for_token.insert(entry.key().row_position, entry.value().clone());
-            }
-            token_postings.push(postings_for_token);
-        }
-
-        // Find documents that contain ALL tokens
-        let first_token_docs: Vec<RowPosition> = token_postings[0].keys().copied().collect();
-
-        let mut matching_docs: Vec<FtsEntry> = Vec::new();
-
-        for row_position in first_token_docs {
-            // Check if this document contains all tokens
-            let all_tokens_present = token_postings
-                .iter()
-                .all(|tp| tp.contains_key(&row_position));
-            if !all_tokens_present {
-                continue;
-            }
-
-            // Check if the phrase matches (positions are in order within slop)
-            if self.check_phrase_positions(&token_postings, row_position, slop) {
-                // Calculate BM25 score
-                let dl = self
-                    .doc_lengths
-                    .get(&row_position)
-                    .map(|e| *e.value() as f32)
-                    .unwrap_or(1.0);
-
-                let mut score: f32 = 0.0;
-                for (token_idx, token) in tokens.iter().enumerate() {
-                    let df = self
-                        .doc_freq
-                        .get(token)
-                        .map(|e| e.value().load(Ordering::Relaxed))
-                        .unwrap_or(1) as f32;
-                    let tf = token_postings[token_idx]
-                        .get(&row_position)
-                        .map(|p| p.frequency as f32)
-                        .unwrap_or(1.0);
-
-                    // IDF = log((N - n + 0.5) / (n + 0.5) + 1)
-                    let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
-
-                    // BM25 term score
-                    let numerator = tf * (K1 + 1.0);
-                    let denominator = tf + K1 * (1.0 - B + B * (dl / avgdl));
-                    score += idf * (numerator / denominator);
+        let mut results = Vec::new();
+        for chunk in candidate_chunks {
+            for (doc_idx, &row_position) in chunk.row_positions.iter().enumerate() {
+                let pos = chunk
+                    .positions
+                    .as_ref()
+                    .map(|p| p.doc_positions(doc_idx).to_vec());
+                let Some(pos) = pos else { continue };
+                let mut all_positions: Vec<Vec<u32>> = vec![Vec::new(); tokens.len()];
+                all_positions[smallest_idx] = pos;
+                let mut all_present = true;
+                let mut frequencies = vec![0u32; tokens.len()];
+                frequencies[smallest_idx] = chunk.frequencies[doc_idx];
+                for (ti, chunks) in per_token_chunks.iter().enumerate() {
+                    if ti == smallest_idx {
+                        continue;
+                    }
+                    match find_doc_in_chunks(chunks, row_position) {
+                        Some((c, doc_idx_other)) => {
+                            frequencies[ti] = c.frequencies[doc_idx_other];
+                            all_positions[ti] = c
+                                .positions
+                                .as_ref()
+                                .map(|p| p.doc_positions(doc_idx_other).to_vec())
+                                .unwrap_or_default();
+                        }
+                        None => {
+                            all_present = false;
+                            break;
+                        }
+                    }
+                }
+                if !all_present {
+                    continue;
+                }
+                if !phrase_matches(&all_positions, slop) {
+                    continue;
                 }
 
-                matching_docs.push(FtsEntry {
+                let dl = lookup_dl(&snap, row_position).unwrap_or(1) as f32;
+                let mut score = 0.0f32;
+                for (ti, _tok) in tokens.iter().enumerate() {
+                    let tf = frequencies[ti] as f32;
+                    let df = dfs[ti] as f32;
+                    score += bm25_term_score(tf, df.max(1.0), n, dl, avgdl);
+                }
+                results.push(FtsEntry {
                     row_position,
                     score,
                 });
             }
         }
 
-        matching_docs
-    }
-
-    /// Check if phrase positions match within the given slop.
-    ///
-    /// Uses relative position algorithm: for each token, compute
-    /// `relative_pos = doc_position - query_position`. If all tokens
-    /// have the same relative position (within slop), the phrase matches.
-    fn check_phrase_positions(
-        &self,
-        token_postings: &[HashMap<RowPosition, PostingValue>],
-        row_position: RowPosition,
-        slop: u32,
-    ) -> bool {
-        // Get positions for each token in this document
-        let mut all_positions: Vec<&Vec<u32>> = Vec::new();
-        for tp in token_postings {
-            if let Some(posting) = tp.get(&row_position) {
-                all_positions.push(&posting.positions);
-            } else {
-                return false;
-            }
-        }
-
-        // For each position of the first token, check if we can form a phrase
-        for &first_pos in all_positions[0] {
-            if Self::check_phrase_from_position(&all_positions, first_pos, slop) {
-                return true;
-            }
-        }
-
-        false
-    }
-
-    /// Check if a phrase can be formed starting from a given position of the first token.
-    fn check_phrase_from_position(all_positions: &[&Vec<u32>], first_pos: u32, slop: u32) -> bool {
-        let mut expected_pos = first_pos;
-
-        for positions in all_positions.iter().skip(1) {
-            // Find a position for this token that's within slop of expected
-            // For slop=0, next token must be at expected_pos+1 (adjacent)
-            // For slop=1, next token can be at expected_pos+1 or expected_pos+2
-            let min_pos = expected_pos.saturating_add(1);
-            let max_pos = expected_pos.saturating_add(1 + slop);
-
-            // Find the actual position used (smallest valid one)
-            if let Some(&actual_pos) = positions
-                .iter()
-                .filter(|&&pos| pos >= min_pos && pos <= max_pos)
-                .min()
-            {
-                expected_pos = actual_pos;
-            } else {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    /// Get the number of entries in the index.
-    /// Note: This counts (token, row_position) pairs, not unique tokens.
-    pub fn entry_count(&self) -> usize {
-        self.postings.len()
-    }
-
-    /// Get the document count.
-    pub fn doc_count(&self) -> usize {
-        self.doc_count.load(Ordering::Relaxed)
-    }
-
-    /// Check if the index is empty.
-    pub fn is_empty(&self) -> bool {
-        self.doc_count.load(Ordering::Relaxed) == 0
-    }
-
-    /// Get the column name.
-    pub fn column_name(&self) -> &str {
-        &self.column_name
+        results
     }
 
     /// Expand a term to fuzzy matches within the specified edit distance.
-    ///
-    /// Returns a list of (matching_term, edit_distance) tuples, sorted by
-    /// edit distance (closest matches first), limited to max_expansions.
+    /// Returns `(matched_term, distance)` pairs sorted by distance, capped
+    /// at `max_expansions`.
     pub fn expand_fuzzy(
         &self,
         term: &str,
         max_distance: u32,
         max_expansions: usize,
     ) -> Vec<(String, u32)> {
+        let snap = self.snapshot.load();
         let mut matches: Vec<(String, u32)> = Vec::new();
 
-        // If max_distance is 0, only exact matches
         if max_distance == 0 {
-            if self.doc_freq.get(term).is_some() {
+            if let Some(entry) = self.terms.get(term)
+                && has_visible_chunk(&entry.value().load(), snap.visible_count)
+            {
                 matches.push((term.to_string(), 0));
             }
             return matches;
         }
 
-        // Iterate through all tokens in doc_freq
-        for entry in self.doc_freq.iter() {
-            let indexed_term = entry.key();
-            let distance = levenshtein_distance(term, indexed_term);
-
-            if distance <= max_distance {
-                matches.push((indexed_term.clone(), distance));
+        for entry in self.terms.iter() {
+            let key: &Arc<str> = entry.key();
+            if !has_visible_chunk(&entry.value().load(), snap.visible_count) {
+                continue;
+            }
+            let dist = levenshtein_distance(term, key);
+            if dist <= max_distance {
+                matches.push((key.to_string(), dist));
             }
         }
-
-        // Sort by distance (prefer closer matches)
         matches.sort_by_key(|(_, d)| *d);
-
-        // Limit to max_expansions
         matches.truncate(max_expansions);
-
         matches
     }
 
-    /// Search for documents using fuzzy matching.
-    ///
-    /// Each query token is expanded to fuzzy matches within the edit distance,
-    /// then searched. Results from all expansions are combined.
+    /// Search for documents using fuzzy matching on each query token.
     pub fn search_fuzzy(
         &self,
         query: &str,
         fuzziness: Option<u32>,
         max_expansions: usize,
     ) -> Vec<FtsEntry> {
-        // Tokenize the query
-        let tokens: Vec<String> = {
-            let mut tokenizer = self.tokenizer.lock().unwrap();
-            let mut token_stream = tokenizer.token_stream_for_search(query);
-            let mut tokens = Vec::new();
-            while let Some(token) = token_stream.next() {
-                tokens.push(token.text.clone());
-            }
-            tokens
-        };
+        let snap = self.snapshot.load_full();
+        if snap.visible_count == 0 {
+            return Vec::new();
+        }
 
+        let tokens = self.tokenize_for_search(query);
         if tokens.is_empty() {
-            return vec![];
+            return Vec::new();
         }
 
-        // BM25 parameters
-        const K1: f32 = 1.2;
-        const B: f32 = 0.75;
-
-        let n = self.doc_count.load(Ordering::Relaxed) as f32;
-        let total_tokens = self.total_tokens.load(Ordering::Relaxed) as f32;
-        let avgdl = if n > 0.0 { total_tokens / n } else { 1.0 };
-
-        // Collect term frequencies per document for all expanded tokens
-        // Map: row_position -> Vec<(term_freq, doc_freq_for_term)>
-        let mut doc_term_info: HashMap<RowPosition, Vec<(u32, usize)>> = HashMap::new();
-
-        for token in &tokens {
-            // Determine fuzziness for this token
-            let max_distance = fuzziness.unwrap_or_else(|| auto_fuzziness(token));
-
-            // Expand to fuzzy matches
-            let expanded = self.expand_fuzzy(token, max_distance, max_expansions);
-
-            for (matched_term, _distance) in expanded {
-                // Get document frequency for this term
-                let df = self
-                    .doc_freq
-                    .get(&matched_term)
-                    .map(|e| e.value().load(Ordering::Relaxed))
-                    .unwrap_or(0);
-
-                if df == 0 {
-                    continue;
-                }
-
-                let start = FtsKey {
-                    token: matched_term.clone(),
-                    row_position: 0,
-                };
-                let end = FtsKey {
-                    token: matched_term,
-                    row_position: u64::MAX,
-                };
-
-                for entry in self.postings.range(start..=end) {
-                    doc_term_info
-                        .entry(entry.key().row_position)
-                        .or_default()
-                        .push((entry.value().frequency, df));
-                }
+        let mut expanded: Vec<String> = Vec::new();
+        for tok in &tokens {
+            let max_dist = fuzziness.unwrap_or_else(|| auto_fuzziness(tok));
+            for (matched, _) in self.expand_fuzzy(tok, max_dist, max_expansions) {
+                expanded.push(matched);
             }
         }
+        if expanded.is_empty() {
+            return Vec::new();
+        }
 
-        // Compute BM25 score for each document
-        doc_term_info
-            .into_iter()
-            .map(|(row_position, term_infos)| {
-                let dl = self
-                    .doc_lengths
-                    .get(&row_position)
-                    .map(|e| *e.value() as f32)
-                    .unwrap_or(1.0);
-
-                let mut score: f32 = 0.0;
-                for (tf, df) in term_infos {
-                    // IDF = log((N - n + 0.5) / (n + 0.5) + 1)
-                    let df_f = df as f32;
-                    let idf = ((n - df_f + 0.5) / (df_f + 0.5) + 1.0).ln();
-
-                    // BM25 term score
-                    let tf_f = tf as f32;
-                    let numerator = tf_f * (K1 + 1.0);
-                    let denominator = tf_f + K1 * (1.0 - B + B * (dl / avgdl));
-                    score += idf * (numerator / denominator);
-                }
-
-                FtsEntry {
-                    row_position,
-                    score,
-                }
-            })
-            .collect()
+        score_terms(&snap, &self.terms, &expanded)
     }
 
     /// Execute a query expression and return matching documents with scores.
-    ///
-    /// This is the main entry point for executing complex queries including
-    /// match, phrase, fuzzy, and Boolean queries.
-    ///
-    /// For performance optimization with limits, use `search_with_options()` instead.
     pub fn search_query(&self, query: &FtsQueryExpr) -> Vec<FtsEntry> {
         match query {
             FtsQueryExpr::Match { query, boost } => {
                 let mut results = self.search(query);
-                if *boost != 1.0 {
-                    for entry in &mut results {
-                        entry.score *= boost;
-                    }
-                }
+                apply_boost(&mut results, *boost);
                 results
             }
             FtsQueryExpr::Phrase { query, slop, boost } => {
                 let mut results = self.search_phrase(query, *slop);
-                if *boost != 1.0 {
-                    for entry in &mut results {
-                        entry.score *= boost;
-                    }
-                }
+                apply_boost(&mut results, *boost);
                 results
             }
             FtsQueryExpr::Fuzzy {
@@ -1022,11 +1065,7 @@ impl FtsMemIndex {
                 boost,
             } => {
                 let mut results = self.search_fuzzy(query, *fuzziness, *max_expansions);
-                if *boost != 1.0 {
-                    for entry in &mut results {
-                        entry.score *= boost;
-                    }
-                }
+                apply_boost(&mut results, *boost);
                 results
             }
             FtsQueryExpr::Boolean {
@@ -1042,131 +1081,73 @@ impl FtsMemIndex {
         }
     }
 
-    /// Execute a query with options for performance/recall tradeoffs.
-    ///
-    /// This method extends `search_query()` with:
-    /// - **WAND factor**: Early termination based on score threshold.
-    ///   With `wand_factor < 1.0`, documents scoring below
-    ///   `threshold = top_k_score * wand_factor` are pruned after scoring.
-    /// - **Limit**: Maximum number of results to return (top-k by score).
-    ///
-    /// Results are always sorted by score in descending order.
-    ///
-    /// # Arguments
-    /// * `query` - The query expression to execute
-    /// * `options` - Search options including wand_factor and limit
-    ///
-    /// # Example
-    /// ```ignore
-    /// let options = SearchOptions::default()
-    ///     .with_limit(10)
-    ///     .with_wand_factor(0.8);
-    /// let results = index.search_with_options(&query, options);
-    /// ```
+    /// Execute a query with options (sort + WAND prune + limit).
     pub fn search_with_options(
         &self,
         query: &FtsQueryExpr,
         options: SearchOptions,
     ) -> Vec<FtsEntry> {
-        // Execute the query to get all results
         let mut results = self.search_query(query);
-
-        // Sort by score descending
         results.sort_by(|a, b| {
             b.score
                 .partial_cmp(&a.score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
-
-        // Apply WAND factor pruning if wand_factor < 1.0 and we have a limit
         if options.wand_factor < 1.0 {
             if let Some(limit) = options.limit {
                 if results.len() > limit {
-                    // Get the k-th best score (at position limit-1)
                     let top_k_score = results[limit - 1].score;
                     let threshold = top_k_score * options.wand_factor;
-
-                    // Keep results scoring above the threshold, plus all results up to limit
-                    // This ensures we don't accidentally prune results that would be in top-k
                     results.retain(|e| e.score >= threshold);
                 }
-            } else {
-                // No limit but wand_factor < 1.0: prune relative to max score
-                if let Some(max_entry) = results.first() {
-                    let threshold = max_entry.score * options.wand_factor;
-                    results.retain(|e| e.score >= threshold);
-                }
+            } else if let Some(max_entry) = results.first() {
+                let threshold = max_entry.score * options.wand_factor;
+                results.retain(|e| e.score >= threshold);
             }
         }
-
-        // Apply limit
         if let Some(limit) = options.limit {
             results.truncate(limit);
         }
-
         results
     }
 
-    /// Execute a boosting query.
-    ///
-    /// Returns documents matching the positive query. Documents that also
-    /// match the negative query have their scores multiplied by `negative_boost`.
     fn search_boost(
         &self,
         positive: &FtsQueryExpr,
         negative: Option<&FtsQueryExpr>,
         negative_boost: f32,
     ) -> Vec<FtsEntry> {
-        // Execute positive query to get base results
         let mut results = self.search_query(positive);
-
-        // If no negative query, just return positive results
-        let Some(neg_query) = negative else {
+        let Some(neg) = negative else {
             return results;
         };
-
-        // Execute negative query
-        let negative_results = self.search_query(neg_query);
-
-        // Build a set of row positions that match the negative query
-        let negative_positions: std::collections::HashSet<RowPosition> =
-            negative_results.iter().map(|e| e.row_position).collect();
-
-        // Apply negative boost to documents matching both queries
+        let negative_results = self.search_query(neg);
+        let negative_set: HashSet<RowPosition> = negative_results
+            .into_iter()
+            .map(|e| e.row_position)
+            .collect();
         for entry in &mut results {
-            if negative_positions.contains(&entry.row_position) {
+            if negative_set.contains(&entry.row_position) {
                 entry.score *= negative_boost;
             }
         }
-
         results
     }
 
-    /// Execute a Boolean query with MUST/SHOULD/MUST_NOT logic.
-    ///
-    /// - MUST: All clauses must match (intersection). Scores are summed.
-    /// - SHOULD: At least one clause should match (union). Scores are added.
-    /// - MUST_NOT: No clause may match (exclusion).
-    ///
-    /// If only SHOULD clauses are present, at least one must match.
-    /// If MUST clauses are present, SHOULD clauses just add to the score.
     fn search_boolean(
         &self,
         must: &[FtsQueryExpr],
         should: &[FtsQueryExpr],
         must_not: &[FtsQueryExpr],
     ) -> Vec<FtsEntry> {
-        // Collect MUST_NOT results for exclusion
-        let excluded: std::collections::HashSet<RowPosition> = must_not
+        let excluded: HashSet<RowPosition> = must_not
             .iter()
             .flat_map(|q| self.search_query(q))
             .map(|e| e.row_position)
             .collect();
 
-        // Start with MUST clauses (intersection)
         let mut result_map: HashMap<RowPosition, f32> = if must.is_empty() {
-            // No MUST clauses: start with all SHOULD results
-            let mut map = HashMap::new();
+            let mut map: HashMap<RowPosition, f32> = HashMap::new();
             for q in should {
                 for entry in self.search_query(q) {
                     *map.entry(entry.row_position).or_default() += entry.score;
@@ -1174,29 +1155,22 @@ impl FtsMemIndex {
             }
             map
         } else {
-            // Execute first MUST clause
             let first_results = self.search_query(&must[0]);
             let mut map: HashMap<RowPosition, f32> = first_results
                 .into_iter()
                 .map(|e| (e.row_position, e.score))
                 .collect();
-
-            // Intersect with remaining MUST clauses
             for q in must.iter().skip(1) {
                 let results = self.search_query(q);
                 let result_set: HashMap<RowPosition, f32> = results
                     .into_iter()
                     .map(|e| (e.row_position, e.score))
                     .collect();
-
-                // Keep only documents in both sets, sum scores
                 map = map
                     .into_iter()
                     .filter_map(|(pos, score)| result_set.get(&pos).map(|s| (pos, score + s)))
                     .collect();
             }
-
-            // Add SHOULD clause scores (don't require match since MUST already filters)
             for q in should {
                 for entry in self.search_query(q) {
                     if let Some(score) = map.get_mut(&entry.row_position) {
@@ -1204,16 +1178,13 @@ impl FtsMemIndex {
                     }
                 }
             }
-
             map
         };
 
-        // Filter out MUST_NOT results
         for pos in &excluded {
             result_map.remove(pos);
         }
 
-        // Convert to FtsEntry list
         result_map
             .into_iter()
             .map(|(row_position, score)| FtsEntry {
@@ -1223,18 +1194,27 @@ impl FtsMemIndex {
             .collect()
     }
 
-    /// Export the in-memory FTS index to an `InnerBuilder` for direct flush.
+    fn tokenize_for_search(&self, text: &str) -> Vec<String> {
+        let mut tok = PooledTokenizer::new(&self.tokenizer_pool);
+        let mut stream = tok.get_mut().token_stream_for_search(text);
+        let mut out = Vec::new();
+        while let Some(t) = stream.next() {
+            out.push(t.text.clone());
+        }
+        out
+    }
+
+    // ------------------------------------------------------------------
+    // Flush to Lance inverted index format
+    // ------------------------------------------------------------------
+
+    /// Export the in-memory FTS index to an `InnerBuilder` ready to be
+    /// written to disk.
     ///
-    /// This creates an `InnerBuilder` containing all the index data with
-    /// reversed row positions for efficient LSM scan. The builder can then
-    /// be written directly to disk without re-tokenizing the documents.
-    ///
-    /// # Arguments
-    /// * `partition_id` - Partition ID for the index files
-    /// * `total_rows` - Total number of rows in the MemTable (for position reversal)
-    ///
-    /// # Returns
-    /// An `InnerBuilder` ready to be written to disk
+    /// `total_rows` is the total number of rows in the MemTable being
+    /// flushed; row positions are reversed (`reversed = total_rows - pos -
+    /// 1`) to match the LSM-friendly newest-first flush order used by the
+    /// rest of MemWAL.
     pub fn to_index_builder_reversed(
         &self,
         partition_id: u64,
@@ -1243,120 +1223,344 @@ impl FtsMemIndex {
         use lance_index::scalar::inverted::builder::{InnerBuilder, PositionRecorder};
         use lance_index::scalar::inverted::{DocSet, PostingListBuilder, TokenSet};
 
-        if self.is_empty() {
+        let snap = self.snapshot.load_full();
+        let with_position = self.params.has_positions();
+
+        if snap.visible_count == 0 {
             return Ok(InnerBuilder::new(
                 partition_id,
-                self.params.has_positions(),
+                with_position,
                 Default::default(),
             ));
         }
 
         let total_rows_u64 = total_rows as u64;
-        let with_position = self.params.has_positions();
 
-        // Step 1: Build DocSet with reversed row positions
-        // Collect (original_pos, num_tokens) -> (reversed_pos, num_tokens)
-        let mut doc_entries: Vec<(u64, u32)> = self
-            .doc_lengths
-            .iter()
-            .map(|e| {
-                let original_pos = *e.key();
-                let reversed_pos = total_rows_u64 - original_pos - 1;
-                (reversed_pos, *e.value())
-            })
-            .collect();
+        // Step 1: collect (reversed_pos, num_tokens) for every visible row.
+        // We walk visible BatchMetas in order so the reverse-sort below has
+        // a small, dense input.
+        let mut entries: Vec<(u64, u32)> = Vec::new();
+        for batch in snap.batches.iter().take(snap.visible_count) {
+            for i in 0..batch.rows as usize {
+                let original_pos = batch.row_offset + i as u64;
+                if original_pos >= total_rows_u64 {
+                    return Err(Error::io(format!(
+                        "FTS flush: row position {} >= total_rows {}",
+                        original_pos, total_rows
+                    )));
+                }
+                let reversed = total_rows_u64 - original_pos - 1;
+                entries.push((reversed, batch.doc_lengths[i]));
+            }
+        }
+        entries.sort_by_key(|(rev, _)| *rev);
 
-        // Sort by reversed position so doc_id assignment matches flushed data order
-        doc_entries.sort_by_key(|(pos, _)| *pos);
-
-        // Build DocSet and create mapping from reversed_pos -> doc_id
+        // Step 2: assign doc_ids in ascending reversed-pos order.
         let mut docs = DocSet::default();
-        let mut reversed_pos_to_doc_id: HashMap<u64, u32> =
-            HashMap::with_capacity(doc_entries.len());
-        for (idx, (reversed_pos, num_tokens)) in doc_entries.into_iter().enumerate() {
-            docs.append(reversed_pos, num_tokens);
-            reversed_pos_to_doc_id.insert(reversed_pos, idx as u32);
+        let mut original_to_doc_id: HashMap<u64, u32> = HashMap::with_capacity(entries.len());
+        for (rev, num_tokens) in &entries {
+            let doc_id = docs.append(*rev, *num_tokens);
+            // Recover the original position from the reversed position so
+            // we can map per-term postings without a second pass.
+            let original = total_rows_u64 - rev - 1;
+            original_to_doc_id.insert(original, doc_id);
         }
 
-        // Step 2: Build TokenSet and group postings by token
+        // Step 3: walk terms in alphabetic (skip-list) order and emit
+        // posting lists into the builder.
         let mut tokens = TokenSet::default();
-        let mut token_postings: HashMap<String, Vec<(u32, PostingValue)>> = HashMap::new();
+        let mut posting_lists: Vec<PostingListBuilder> = Vec::new();
+        for entry in self.terms.iter() {
+            let term: &Arc<str> = entry.key();
+            let slice = entry.value().load();
 
-        for entry in self.postings.iter() {
-            let token = entry.key().token.clone();
-            let original_pos = entry.key().row_position;
-            let reversed_pos = total_rows_u64 - original_pos - 1;
-            let doc_id = *reversed_pos_to_doc_id.get(&reversed_pos).ok_or_else(|| {
-                Error::io(format!(
-                    "FTS index internal error: doc_id not found for reversed position {} (original: {}, total_rows: {})",
-                    reversed_pos, original_pos, total_rows
-                ))
-            })?;
+            // Collect per-doc postings filtered by visibility.
+            let mut docs_for_term: Vec<(u32, u32, Option<Vec<u32>>)> = Vec::new();
+            for chunk in &slice.chunks {
+                if chunk.batch_position >= snap.visible_count {
+                    continue;
+                }
+                for (i, row_position) in chunk.row_positions.iter().enumerate() {
+                    let Some(&doc_id) = original_to_doc_id.get(row_position) else {
+                        // Should not happen: a chunk's batch_position is
+                        // visible only if its meta is visible, and the meta
+                        // contributed every row above.
+                        continue;
+                    };
+                    let pos = if with_position {
+                        chunk
+                            .positions
+                            .as_ref()
+                            .map(|p| p.doc_positions(i).to_vec())
+                    } else {
+                        None
+                    };
+                    docs_for_term.push((doc_id, chunk.frequencies[i], pos));
+                }
+            }
+            if docs_for_term.is_empty() {
+                continue;
+            }
+            docs_for_term.sort_by_key(|(doc_id, _, _)| *doc_id);
 
-            token_postings
-                .entry(token)
-                .or_default()
-                .push((doc_id, entry.value().clone()));
-        }
+            let token_id = tokens.add(term.to_string()) as usize;
+            // PostingListBuilder vector is indexed by token_id. New token
+            // ids are assigned monotonically by `add`, so we just push.
+            debug_assert_eq!(token_id, posting_lists.len());
+            posting_lists.push(PostingListBuilder::new(with_position));
 
-        // Assign token IDs in sorted order for FST format
-        let mut sorted_tokens: Vec<_> = token_postings.keys().cloned().collect();
-        sorted_tokens.sort();
-        for token in &sorted_tokens {
-            tokens.add(token.clone());
-        }
-
-        // Step 3: Build posting lists
-        let mut posting_lists: Vec<PostingListBuilder> = (0..tokens.len())
-            .map(|_| PostingListBuilder::new(with_position))
-            .collect();
-
-        for (token, mut postings) in token_postings {
-            let token_id = tokens.get(&token).ok_or_else(|| {
-                Error::io(format!(
-                    "FTS index internal error: token '{}' not found in TokenSet",
-                    token
-                ))
-            })? as usize;
-
-            // Sort postings by doc_id for proper ordering
-            postings.sort_by_key(|(doc_id, _)| *doc_id);
-
-            for (doc_id, value) in postings {
-                let position_recorder = if with_position {
-                    PositionRecorder::Position(value.positions.into())
+            let plb = &mut posting_lists[token_id];
+            for (doc_id, freq, pos) in docs_for_term {
+                let recorder = if with_position {
+                    PositionRecorder::Position(pos.unwrap_or_default().into())
                 } else {
-                    PositionRecorder::Count(value.frequency)
+                    PositionRecorder::Count(freq)
                 };
-                posting_lists[token_id].add(doc_id, position_recorder);
+                plb.add(doc_id, recorder);
             }
         }
 
-        // Step 4: Create InnerBuilder with all the data
         let mut builder = InnerBuilder::new(partition_id, with_position, Default::default());
         builder.set_tokens(tokens);
         builder.set_docs(docs);
         builder.set_posting_lists(posting_lists);
-
         Ok(builder)
     }
 }
 
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+impl TermSlice {
+    fn empty_arc_swap() -> ArcSwap<Self> {
+        ArcSwap::from(Self::empty())
+    }
+}
+
+/// Helper used during insert to accumulate a single batch's contribution to
+/// one term.
+struct BatchTermBuilder {
+    row_positions: Vec<u64>,
+    frequencies: Vec<u32>,
+    positions: Vec<Vec<u32>>,
+}
+
+impl BatchTermBuilder {
+    fn new() -> Self {
+        Self {
+            row_positions: Vec::new(),
+            frequencies: Vec::new(),
+            positions: Vec::new(),
+        }
+    }
+
+    fn push_doc(&mut self, row_position: u64, frequency: u32, positions: Vec<u32>) {
+        self.row_positions.push(row_position);
+        self.frequencies.push(frequency);
+        self.positions.push(positions);
+    }
+
+    /// Always materializes the per-doc positions: in-memory phrase queries
+    /// rely on them regardless of `params.has_positions()`. The flush path
+    /// consults `params.has_positions()` and emits a `Count` recorder
+    /// instead of `Position` when positions should not be persisted.
+    fn build(self, batch_position: usize) -> Arc<TermChunk> {
+        let mut p = Positions::empty();
+        for doc in &self.positions {
+            p.push_doc(doc);
+        }
+        Arc::new(TermChunk {
+            batch_position,
+            row_positions: self.row_positions,
+            frequencies: self.frequencies,
+            positions: Some(p),
+        })
+    }
+}
+
+/// Borrowed text for a row, or `None` for null/missing.
+type TextOpt<'a> = Option<&'a str>;
+
+fn extract_texts(column: &dyn Array) -> Result<Vec<TextOpt<'_>>> {
+    match column.data_type() {
+        DataType::Utf8 => {
+            let array = column
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("Utf8 array");
+            Ok((0..array.len())
+                .map(|i| (!array.is_null(i)).then(|| array.value(i)))
+                .collect())
+        }
+        DataType::LargeUtf8 => {
+            let array = column
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .expect("LargeUtf8 array");
+            Ok((0..array.len())
+                .map(|i| (!array.is_null(i)).then(|| array.value(i)))
+                .collect())
+        }
+        DataType::Utf8View => {
+            let array = column
+                .as_any()
+                .downcast_ref::<StringViewArray>()
+                .expect("Utf8View array");
+            Ok((0..array.len())
+                .map(|i| (!array.is_null(i)).then(|| array.value(i)))
+                .collect())
+        }
+        other => Err(Error::invalid_input(format!(
+            "FTS index only supports Utf8, LargeUtf8, and Utf8View columns; got {other:?}"
+        ))),
+    }
+}
+
+fn has_visible_chunk(slice: &TermSlice, visible_count: usize) -> bool {
+    slice
+        .chunks
+        .iter()
+        .any(|c| c.batch_position < visible_count)
+}
+
+fn lookup_dl(snap: &Snapshot, row_position: u64) -> Option<u32> {
+    snap.batches[..snap.visible_count]
+        .iter()
+        .find_map(|b| b.dl(row_position))
+}
+
+fn find_doc_in_chunks(
+    chunks: &[Arc<TermChunk>],
+    row_position: u64,
+) -> Option<(&Arc<TermChunk>, usize)> {
+    for chunk in chunks {
+        if let Ok(idx) = chunk.row_positions.binary_search(&row_position) {
+            return Some((chunk, idx));
+        }
+    }
+    None
+}
+
+const BM25_K1: f32 = 1.2;
+const BM25_B: f32 = 0.75;
+
+fn bm25_term_score(tf: f32, df: f32, n: f32, dl: f32, avgdl: f32) -> f32 {
+    let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+    let numerator = tf * (BM25_K1 + 1.0);
+    let denominator = tf + BM25_K1 * (1.0 - BM25_B + BM25_B * (dl / avgdl));
+    idf * (numerator / denominator)
+}
+
+/// Score a list of query tokens against the visible state. Each token
+/// contributes its BM25 term score to every document containing it.
+fn score_terms(
+    snap: &Snapshot,
+    terms: &SkipMap<Arc<str>, ArcSwap<TermSlice>>,
+    tokens: &[String],
+) -> Vec<FtsEntry> {
+    let n = snap.cumulative_doc_count as f32;
+    let avgdl = if n > 0.0 {
+        snap.cumulative_total_tokens as f32 / n
+    } else {
+        1.0
+    };
+
+    let mut doc_scores: HashMap<RowPosition, f32> = HashMap::new();
+
+    for token in tokens {
+        let Some(entry) = terms.get(token.as_str()) else {
+            continue;
+        };
+        let slice = entry.value().load_full();
+        // df = total visible postings for this term.
+        let df: u32 = slice
+            .chunks
+            .iter()
+            .filter(|c| c.batch_position < snap.visible_count)
+            .map(|c| c.doc_count() as u32)
+            .sum();
+        if df == 0 {
+            continue;
+        }
+        let df_f = df as f32;
+        for chunk in &slice.chunks {
+            if chunk.batch_position >= snap.visible_count {
+                continue;
+            }
+            let Some(meta) = snap.batch_for(chunk.batch_position) else {
+                continue;
+            };
+            for (i, &row_position) in chunk.row_positions.iter().enumerate() {
+                let dl = meta.dl(row_position).unwrap_or(1) as f32;
+                let tf = chunk.frequencies[i] as f32;
+                let score = bm25_term_score(tf, df_f, n, dl, avgdl);
+                *doc_scores.entry(row_position).or_default() += score;
+            }
+        }
+    }
+
+    doc_scores
+        .into_iter()
+        .map(|(row_position, score)| FtsEntry {
+            row_position,
+            score,
+        })
+        .collect()
+}
+
+fn phrase_matches(positions: &[Vec<u32>], slop: u32) -> bool {
+    if positions.is_empty() {
+        return false;
+    }
+    for &first_pos in &positions[0] {
+        if phrase_from_position(positions, first_pos, slop) {
+            return true;
+        }
+    }
+    false
+}
+
+fn phrase_from_position(positions: &[Vec<u32>], first_pos: u32, slop: u32) -> bool {
+    let mut expected = first_pos;
+    for token_positions in positions.iter().skip(1) {
+        let min = expected.saturating_add(1);
+        let max = expected.saturating_add(1 + slop);
+        match token_positions
+            .iter()
+            .filter(|&&p| p >= min && p <= max)
+            .min()
+        {
+            Some(&p) => expected = p,
+            None => return false,
+        }
+    }
+    true
+}
+
+fn apply_boost(results: &mut [FtsEntry], boost: f32) {
+    if boost == 1.0 {
+        return;
+    }
+    for r in results.iter_mut() {
+        r.score *= boost;
+    }
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
 /// Configuration for a Full-Text Search index.
 #[derive(Debug, Clone)]
 pub struct FtsIndexConfig {
-    /// Index name.
     pub name: String,
-    /// Field ID the index is built on.
     pub field_id: i32,
-    /// Column name (for Arrow batch lookups).
     pub column: String,
-    /// Tokenizer parameters (same as InvertedIndex).
     pub params: InvertedIndexParams,
 }
 
 impl FtsIndexConfig {
-    /// Create a new FtsIndexConfig with default tokenizer parameters.
     pub fn new(name: String, field_id: i32, column: String) -> Self {
         Self {
             name,
@@ -1366,7 +1570,6 @@ impl FtsIndexConfig {
         }
     }
 
-    /// Create a new FtsIndexConfig with custom tokenizer parameters.
     pub fn with_params(
         name: String,
         field_id: i32,
@@ -1381,6 +1584,10 @@ impl FtsIndexConfig {
         }
     }
 }
+
+// ============================================================================
+// Tests
+// ============================================================================
 
 #[cfg(test)]
 mod tests {
@@ -1421,40 +1628,31 @@ mod tests {
 
         assert_eq!(index.doc_count(), 3);
 
-        // "hello" appears in docs 0 and 2
         let entries = index.search("hello");
-        assert!(!entries.is_empty());
         assert_eq!(entries.len(), 2);
 
-        // "world" appears in docs 0 and 1
         let entries = index.search("world");
-        assert!(!entries.is_empty());
         assert_eq!(entries.len(), 2);
 
-        // "goodbye" appears only in doc 1 (row position 1)
         let entries = index.search("goodbye");
-        assert!(!entries.is_empty());
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].row_position, 1);
 
-        // Non-existent term returns empty Vec
         let entries = index.search("nonexistent");
         assert!(entries.is_empty());
     }
 
     fn create_phrase_test_batch(schema: &ArrowSchema) -> RecordBatch {
-        // Note: The tokenizer filters stop words (the, and, very, etc.) and lowercases.
-        // Positions are assigned to non-filtered tokens only.
         RecordBatch::try_new(
             Arc::new(schema.clone()),
             vec![
                 Arc::new(Int32Array::from(vec![0, 1, 2, 3, 4])),
                 Arc::new(StringArray::from(vec![
-                    "alpha beta gamma",               // 0: alpha=0, beta=1, gamma=2
-                    "beta alpha gamma",               // 1: beta=0, alpha=1, gamma=2
-                    "alpha delta beta gamma",         // 2: alpha=0, delta=1, beta=2, gamma=3
-                    "alpha gamma",                    // 3: alpha=0, gamma=1
-                    "alpha delta epsilon beta gamma", // 4: alpha=0, delta=1, epsilon=2, beta=3, gamma=4
+                    "alpha beta gamma",
+                    "beta alpha gamma",
+                    "alpha delta beta gamma",
+                    "alpha gamma",
+                    "alpha delta epsilon beta gamma",
                 ])),
             ],
         )
@@ -1469,19 +1667,10 @@ mod tests {
         let batch = create_phrase_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Exact phrase "alpha beta" with slop=0 should match only doc 0
-        // Doc 0: "alpha beta gamma" - alpha=0, beta=1 (adjacent)
-        // Doc 2: "alpha delta beta gamma" - alpha=0, beta=2 (NOT adjacent, slop needed)
         let entries = index.search_phrase("alpha beta", 0);
-        assert_eq!(
-            entries.len(),
-            1,
-            "Expected 1 match for 'alpha beta', got {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].row_position, 0);
 
-        // "hello world" exact phrase
         let batch2 = create_test_batch(&schema);
         let index2 = FtsMemIndex::new(1, "description".to_string());
         index2.insert(&batch2, 0).unwrap();
@@ -1490,7 +1679,6 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].row_position, 0);
 
-        // "goodbye world" exact phrase
         let entries = index2.search_phrase("goodbye world", 0);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].row_position, 1);
@@ -1504,69 +1692,24 @@ mod tests {
         let batch = create_phrase_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Positions after tokenization (no stop words filtered):
-        // Doc 0: "alpha beta gamma" - alpha=0, beta=1, gamma=2
-        // Doc 2: "alpha delta beta gamma" - alpha=0, delta=1, beta=2, gamma=3
-        // Doc 4: "alpha delta epsilon beta gamma" - alpha=0, delta=1, epsilon=2, beta=3, gamma=4
-
-        // "alpha beta" with slop=0 should match only doc 0
-        // Doc 0: alpha=0, beta=1 (adjacent)
         let entries = index.search_phrase("alpha beta", 0);
-        assert_eq!(
-            entries.len(),
-            1,
-            "slop=0 matches: {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].row_position, 0);
 
-        // "alpha beta" with slop=1 should match docs 0 and 2
-        // Doc 0: alpha=0, beta=1 (diff=1, within slop=1)
-        // Doc 2: alpha=0, beta=2 (diff=2, slop=1 allows pos 1-2)
-        // Doc 4: alpha=0, beta=3 (diff=3, slop=1 does NOT allow pos 3)
         let entries = index.search_phrase("alpha beta", 1);
-        assert_eq!(
-            entries.len(),
-            2,
-            "slop=1 matches: {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 2);
         let positions: Vec<_> = entries.iter().map(|e| e.row_position).collect();
         assert!(positions.contains(&0));
         assert!(positions.contains(&2));
 
-        // "alpha beta" with slop=2 should match docs 0, 2, and 4
         let entries = index.search_phrase("alpha beta", 2);
-        assert_eq!(
-            entries.len(),
-            3,
-            "slop=2 matches: {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 3);
 
-        // "alpha gamma" with slop=0 should match docs 1 and 3 (adjacent)
-        // Doc 1: "beta alpha gamma" - alpha=1, gamma=2 (adjacent)
-        // Doc 3: "alpha gamma" - alpha=0, gamma=1 (adjacent)
         let entries = index.search_phrase("alpha gamma", 0);
-        assert_eq!(
-            entries.len(),
-            2,
-            "alpha gamma slop=0: {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 2);
 
-        // "alpha gamma" with slop=1 should match docs 0, 1, 2, and 3
-        // Doc 0: alpha=0, gamma=2 (diff=2, slop=1 allows pos 1-2)
-        // Doc 1: alpha=1, gamma=2 (adjacent)
-        // Doc 2: alpha=0, gamma=3 (diff=3, slop=1 allows pos 1-2, gamma at 3 NOT in range)
-        // Doc 3: alpha=0, gamma=1 (adjacent)
         let entries = index.search_phrase("alpha gamma", 1);
-        assert_eq!(
-            entries.len(),
-            3,
-            "alpha gamma slop=1: {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 3);
     }
 
     #[test]
@@ -1577,21 +1720,16 @@ mod tests {
         let batch = create_phrase_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // "beta alpha" with slop=0 should not match in most docs (wrong order)
-        // Doc 1 has "beta alpha gamma" - beta=0, alpha=1, so "beta alpha" matches there!
         let entries = index.search_phrase("beta alpha", 0);
-        assert_eq!(entries.len(), 1); // matches doc 1
+        assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].row_position, 1);
 
-        // Non-existent phrase
         let entries = index.search_phrase("nonexistent phrase", 0);
         assert!(entries.is_empty());
 
-        // Partial phrase not in any doc
         let entries = index.search_phrase("alpha hello", 0);
         assert!(entries.is_empty());
 
-        // "gamma alpha" should not match (wrong order in all docs)
         let entries = index.search_phrase("gamma alpha", 0);
         assert!(entries.is_empty());
     }
@@ -1604,10 +1742,8 @@ mod tests {
         let batch = create_phrase_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Single token phrase should behave like regular search
         let phrase_entries = index.search_phrase("alpha", 0);
         let search_entries = index.search("alpha");
-
         assert_eq!(phrase_entries.len(), search_entries.len());
     }
 
@@ -1619,20 +1755,11 @@ mod tests {
         let batch = create_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Empty phrase
         let entries = index.search_phrase("", 0);
         assert!(entries.is_empty());
     }
 
-    // ====== Boolean Query Tests ======
-
     fn create_boolean_test_batch(schema: &ArrowSchema) -> RecordBatch {
-        // Test documents for Boolean queries:
-        // Doc 0: "rust programming language"
-        // Doc 1: "python programming language"
-        // Doc 2: "rust web server"
-        // Doc 3: "python web framework"
-        // Doc 4: "javascript programming"
         RecordBatch::try_new(
             Arc::new(schema.clone()),
             vec![
@@ -1657,20 +1784,13 @@ mod tests {
         let batch = create_boolean_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // MUST: rust AND programming
-        // Should match doc 0 only ("rust programming language")
         let query = FtsQueryExpr::boolean()
             .must(FtsQueryExpr::match_query("rust"))
             .must(FtsQueryExpr::match_query("programming"))
             .build();
 
         let entries = index.search_query(&query);
-        assert_eq!(
-            entries.len(),
-            1,
-            "Expected 1 match for MUST(rust, programming), got {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].row_position, 0);
     }
 
@@ -1682,21 +1802,13 @@ mod tests {
         let batch = create_boolean_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // SHOULD: rust OR python
-        // Should match docs 0, 1, 2, 3 (all containing rust or python)
         let query = FtsQueryExpr::boolean()
             .should(FtsQueryExpr::match_query("rust"))
             .should(FtsQueryExpr::match_query("python"))
             .build();
 
         let entries = index.search_query(&query);
-        assert_eq!(
-            entries.len(),
-            4,
-            "Expected 4 matches for SHOULD(rust, python), got {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
-
+        assert_eq!(entries.len(), 4);
         let positions: Vec<_> = entries.iter().map(|e| e.row_position).collect();
         assert!(positions.contains(&0));
         assert!(positions.contains(&1));
@@ -1712,18 +1824,12 @@ mod tests {
         let batch = create_boolean_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // MUST_NOT alone with no MUST or SHOULD returns empty
-        // (nothing to include, only exclusions)
         let query = FtsQueryExpr::boolean()
             .must_not(FtsQueryExpr::match_query("rust"))
             .build();
 
         let entries = index.search_query(&query);
-        assert!(
-            entries.is_empty(),
-            "MUST_NOT only should return empty, got {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert!(entries.is_empty());
     }
 
     #[test]
@@ -1734,33 +1840,17 @@ mod tests {
         let batch = create_boolean_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // MUST: programming, SHOULD: rust
-        // Should match docs 0, 1, 4 (all with programming)
-        // Doc 0 should have higher score (also matches rust)
         let query = FtsQueryExpr::boolean()
             .must(FtsQueryExpr::match_query("programming"))
             .should(FtsQueryExpr::match_query("rust"))
             .build();
 
         let entries = index.search_query(&query);
-        assert_eq!(
-            entries.len(),
-            3,
-            "Expected 3 matches for MUST(programming) SHOULD(rust), got {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 3);
 
-        // Find doc 0 and doc 1 scores
         let doc0 = entries.iter().find(|e| e.row_position == 0).unwrap();
         let doc1 = entries.iter().find(|e| e.row_position == 1).unwrap();
-
-        // Doc 0 has both programming and rust, should score higher than doc 1 (only programming)
-        assert!(
-            doc0.score > doc1.score,
-            "Doc 0 (rust+programming) should score higher than doc 1 (programming only). Doc0: {}, Doc1: {}",
-            doc0.score,
-            doc1.score
-        );
+        assert!(doc0.score > doc1.score);
     }
 
     #[test]
@@ -1771,25 +1861,18 @@ mod tests {
         let batch = create_boolean_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // MUST: programming, MUST_NOT: python
-        // Should match docs 0 and 4 (programming but not python)
         let query = FtsQueryExpr::boolean()
             .must(FtsQueryExpr::match_query("programming"))
             .must_not(FtsQueryExpr::match_query("python"))
             .build();
 
         let entries = index.search_query(&query);
-        assert_eq!(
-            entries.len(),
-            2,
-            "Expected 2 matches for MUST(programming) MUST_NOT(python), got {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 2);
 
         let positions: Vec<_> = entries.iter().map(|e| e.row_position).collect();
-        assert!(positions.contains(&0)); // rust programming language
-        assert!(positions.contains(&4)); // javascript programming
-        assert!(!positions.contains(&1)); // python programming language - excluded
+        assert!(positions.contains(&0));
+        assert!(positions.contains(&4));
+        assert!(!positions.contains(&1));
     }
 
     #[test]
@@ -1800,10 +1883,6 @@ mod tests {
         let batch = create_boolean_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // MUST: web, SHOULD: rust, MUST_NOT: framework
-        // Docs with "web": 2 (rust web server), 3 (python web framework)
-        // After MUST_NOT framework: only doc 2
-        // Doc 2 also matches SHOULD(rust), so should have higher score
         let query = FtsQueryExpr::boolean()
             .must(FtsQueryExpr::match_query("web"))
             .should(FtsQueryExpr::match_query("rust"))
@@ -1811,12 +1890,7 @@ mod tests {
             .build();
 
         let entries = index.search_query(&query);
-        assert_eq!(
-            entries.len(),
-            1,
-            "Expected 1 match for MUST(web) SHOULD(rust) MUST_NOT(framework), got {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].row_position, 2);
     }
 
@@ -1828,20 +1902,12 @@ mod tests {
         let batch = create_boolean_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // MUST: phrase("programming language")
-        // Should match docs 0 and 1
         let query = FtsQueryExpr::boolean()
             .must(FtsQueryExpr::phrase("programming language"))
             .build();
 
         let entries = index.search_query(&query);
-        assert_eq!(
-            entries.len(),
-            2,
-            "Expected 2 matches for MUST(phrase 'programming language'), got {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
-
+        assert_eq!(entries.len(), 2);
         let positions: Vec<_> = entries.iter().map(|e| e.row_position).collect();
         assert!(positions.contains(&0));
         assert!(positions.contains(&1));
@@ -1855,7 +1921,6 @@ mod tests {
         let batch = create_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Test FtsQueryExpr::Match
         let query = FtsQueryExpr::match_query("hello");
         let entries = index.search_query(&query);
         assert_eq!(entries.len(), 2);
@@ -1869,7 +1934,6 @@ mod tests {
         let batch = create_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Test FtsQueryExpr::Phrase
         let query = FtsQueryExpr::phrase("hello world");
         let entries = index.search_query(&query);
         assert_eq!(entries.len(), 1);
@@ -1884,7 +1948,6 @@ mod tests {
         let batch = create_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Test boost
         let query_no_boost = FtsQueryExpr::match_query("hello");
         let query_with_boost = FtsQueryExpr::match_query("hello").with_boost(2.0);
 
@@ -1892,77 +1955,44 @@ mod tests {
         let entries_with_boost = index.search_query(&query_with_boost);
 
         assert_eq!(entries_no_boost.len(), entries_with_boost.len());
-
-        // Boosted scores should be 2x
-        for (e1, e2) in entries_no_boost.iter().zip(entries_with_boost.iter()) {
+        for e1 in &entries_no_boost {
+            let e2 = entries_with_boost
+                .iter()
+                .find(|e| e.row_position == e1.row_position)
+                .unwrap();
             let expected = e1.score * 2.0;
-            assert!(
-                (e2.score - expected).abs() < 0.001,
-                "Boosted score {} should be 2x original {}",
-                e2.score,
-                e1.score
-            );
+            assert!((e2.score - expected).abs() < 0.001);
         }
     }
 
-    // ====== Fuzzy Matching Tests ======
-
     #[test]
     fn test_levenshtein_distance() {
-        // Identical strings
         assert_eq!(levenshtein_distance("hello", "hello"), 0);
-
-        // Single character difference
-        assert_eq!(levenshtein_distance("hello", "hallo"), 1); // substitution
-        assert_eq!(levenshtein_distance("hello", "hell"), 1); // deletion
-        assert_eq!(levenshtein_distance("hello", "helloo"), 1); // insertion
-
-        // Two character differences
+        assert_eq!(levenshtein_distance("hello", "hallo"), 1);
+        assert_eq!(levenshtein_distance("hello", "hell"), 1);
+        assert_eq!(levenshtein_distance("hello", "helloo"), 1);
         assert_eq!(levenshtein_distance("hello", "hxllo"), 1);
         assert_eq!(levenshtein_distance("hello", "hxxlo"), 2);
-
-        // Completely different strings
         assert_eq!(levenshtein_distance("abc", "xyz"), 3);
-
-        // Empty strings
         assert_eq!(levenshtein_distance("", ""), 0);
         assert_eq!(levenshtein_distance("hello", ""), 5);
         assert_eq!(levenshtein_distance("", "hello"), 5);
-
-        // Case sensitivity
         assert_eq!(levenshtein_distance("Hello", "hello"), 1);
     }
 
     #[test]
     fn test_auto_fuzziness() {
-        // 0-2 chars: 0 fuzziness
         assert_eq!(auto_fuzziness(""), 0);
         assert_eq!(auto_fuzziness("a"), 0);
         assert_eq!(auto_fuzziness("ab"), 0);
-
-        // 3-5 chars: 1 fuzziness
         assert_eq!(auto_fuzziness("abc"), 1);
         assert_eq!(auto_fuzziness("abcd"), 1);
         assert_eq!(auto_fuzziness("abcde"), 1);
-
-        // 6+ chars: 2 fuzziness
         assert_eq!(auto_fuzziness("abcdef"), 2);
         assert_eq!(auto_fuzziness("programming"), 2);
     }
 
     fn create_fuzzy_test_batch(schema: &ArrowSchema) -> RecordBatch {
-        // Test documents for fuzzy matching.
-        // Note: The tokenizer stems words, so we use unstemmed single tokens
-        // for predictable fuzzy matching tests.
-        // Levenshtein distance examples:
-        // - "alpha" to "alpho" = 1 (substitution: a -> o)
-        // - "alpha" to "alphax" = 1 (insertion)
-        // - "alpha" to "alph" = 1 (deletion)
-        // Doc 0: "alpha beta gamma"
-        // Doc 1: "alpho beta delta" (typo: 'alpho' instead of 'alpha', distance=1)
-        // Doc 2: "alpha delta epsilon"
-        // Doc 3: "omega zeta"
-        // Doc 4: "alphax gamma" (typo: extra 'x', distance=1)
         RecordBatch::try_new(
             Arc::new(schema.clone()),
             vec![
@@ -1987,18 +2017,11 @@ mod tests {
         let batch = create_fuzzy_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Exact match with fuzziness=0: "alpha" exists in index
         let matches = index.expand_fuzzy("alpha", 0, 50);
-        assert_eq!(
-            matches.len(),
-            1,
-            "Expected 1 match for 'alpha', got {:?}",
-            matches
-        );
+        assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "alpha");
         assert_eq!(matches[0].1, 0);
 
-        // Non-existent term with fuzziness=0
         let matches = index.expand_fuzzy("nonexistent", 0, 50);
         assert!(matches.is_empty());
     }
@@ -2011,22 +2034,9 @@ mod tests {
         let batch = create_fuzzy_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // "alpho" (typo, substitution distance=1 from "alpha") should match "alpha"
         let matches = index.expand_fuzzy("alpho", 1, 50);
-        assert!(
-            matches
-                .iter()
-                .any(|(term, dist)| term == "alpha" && *dist == 1),
-            "Expected 'alpha' with distance 1, got {:?}",
-            matches
-        );
-
-        // Also matches itself since it's in the index
-        assert!(
-            matches.iter().any(|(term, _)| term == "alpho"),
-            "Expected 'alpho' in matches, got {:?}",
-            matches
-        );
+        assert!(matches.iter().any(|(t, d)| t == "alpha" && *d == 1));
+        assert!(matches.iter().any(|(t, _)| t == "alpho"));
     }
 
     #[test]
@@ -2037,13 +2047,8 @@ mod tests {
         let batch = create_fuzzy_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // With very high distance, should be limited by max_expansions
         let matches = index.expand_fuzzy("a", 10, 3);
-        assert!(
-            matches.len() <= 3,
-            "Expected at most 3 matches, got {}",
-            matches.len()
-        );
+        assert!(matches.len() <= 3);
     }
 
     #[test]
@@ -2054,17 +2059,8 @@ mod tests {
         let batch = create_fuzzy_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Search with typo "alpho" should match documents with "alpha" or "alpho"
         let entries = index.search_fuzzy("alpho", Some(1), 50);
-        assert!(!entries.is_empty(), "Expected matches for fuzzy 'alpho'");
-
-        // Should match docs with alpha (0, 2) and alpho (1)
-        let positions: Vec<_> = entries.iter().map(|e| e.row_position).collect();
-        assert!(
-            positions.contains(&0) || positions.contains(&1) || positions.contains(&2),
-            "Expected to match docs with alpha/alpho, got {:?}",
-            positions
-        );
+        assert!(!entries.is_empty());
     }
 
     #[test]
@@ -2075,9 +2071,8 @@ mod tests {
         let batch = create_fuzzy_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // "alpho" (5 chars) should get auto-fuzziness of 1
         let entries = index.search_fuzzy("alpho", None, 50);
-        assert!(!entries.is_empty(), "Expected matches with auto-fuzziness");
+        assert!(!entries.is_empty());
     }
 
     #[test]
@@ -2088,13 +2083,8 @@ mod tests {
         let batch = create_fuzzy_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Search for something completely different with low fuzziness
         let entries = index.search_fuzzy("xyz", Some(0), 50);
-        assert!(entries.is_empty(), "Expected no matches for 'xyz'");
-
-        // Even with fuzziness=1, "xyz" shouldn't match anything meaningful
-        // (this may or may not be empty depending on what 3-letter words are in the index)
-        let _ = index.search_fuzzy("xyz", Some(1), 50);
+        assert!(entries.is_empty());
     }
 
     #[test]
@@ -2105,13 +2095,9 @@ mod tests {
         let batch = create_fuzzy_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Test FtsQueryExpr::Fuzzy via search_query
         let query = FtsQueryExpr::fuzzy("alpho");
         let entries = index.search_query(&query);
-        assert!(
-            !entries.is_empty(),
-            "Expected matches for fuzzy query 'alpho'"
-        );
+        assert!(!entries.is_empty());
     }
 
     #[test]
@@ -2122,13 +2108,9 @@ mod tests {
         let batch = create_fuzzy_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Exact distance: "alpho" has distance 1 from "alpha"
         let query = FtsQueryExpr::fuzzy_with_distance("alpho", 1);
         let entries = index.search_query(&query);
-        assert!(
-            !entries.is_empty(),
-            "Expected matches for fuzzy query with distance 1"
-        );
+        assert!(!entries.is_empty());
     }
 
     #[test]
@@ -2144,22 +2126,15 @@ mod tests {
 
         let entries_no_boost = index.search_query(&query_no_boost);
         let entries_with_boost = index.search_query(&query_with_boost);
-
         assert_eq!(entries_no_boost.len(), entries_with_boost.len());
 
-        // Boosted scores should be 2x
         for e1 in &entries_no_boost {
             let e2 = entries_with_boost
                 .iter()
                 .find(|e| e.row_position == e1.row_position)
                 .unwrap();
             let expected = e1.score * 2.0;
-            assert!(
-                (e2.score - expected).abs() < 0.001,
-                "Boosted score {} should be 2x original {}",
-                e2.score,
-                e1.score
-            );
+            assert!((e2.score - expected).abs() < 0.001);
         }
     }
 
@@ -2171,48 +2146,19 @@ mod tests {
         let batch = create_fuzzy_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // MUST: fuzzy("alpho", distance=1), MUST_NOT: "delta"
-        // "alpho" matches "alpha" (distance=1) and itself
-        // Doc 0: "alpha beta gamma" - matches fuzzy alpho, no delta -> included
-        // Doc 1: "alpho beta delta" - matches fuzzy alpho, has delta -> excluded
-        // Doc 2: "alpha delta epsilon" - matches fuzzy alpho, has delta -> excluded
-        // Doc 4: "alphax gamma" - matches fuzzy alpho via alphax (dist=1 to alpho), no delta -> included
         let query = FtsQueryExpr::boolean()
             .must(FtsQueryExpr::fuzzy_with_distance("alpho", 1))
             .must_not(FtsQueryExpr::match_query("delta"))
             .build();
 
         let entries = index.search_query(&query);
-
-        // Should not contain docs 1 and 2 (have "delta")
         let positions: Vec<_> = entries.iter().map(|e| e.row_position).collect();
-        assert!(
-            !positions.contains(&1),
-            "Doc 1 should be excluded due to MUST_NOT, got {:?}",
-            positions
-        );
-        assert!(
-            !positions.contains(&2),
-            "Doc 2 should be excluded due to MUST_NOT, got {:?}",
-            positions
-        );
-        // Doc 0 should be included
-        assert!(
-            positions.contains(&0),
-            "Doc 0 should be included, got {:?}",
-            positions
-        );
+        assert!(!positions.contains(&1));
+        assert!(!positions.contains(&2));
+        assert!(positions.contains(&0));
     }
 
-    // ====== Boost Query Tests ======
-
     fn create_boost_test_batch(schema: &ArrowSchema) -> RecordBatch {
-        // Test documents for boost queries:
-        // Doc 0: "rust programming language" - matches rust, programming, language
-        // Doc 1: "python programming language" - matches python, programming, language
-        // Doc 2: "rust web server" - matches rust, web, server
-        // Doc 3: "python web framework" - matches python, web, framework
-        // Doc 4: "javascript programming" - matches javascript, programming
         RecordBatch::try_new(
             Arc::new(schema.clone()),
             vec![
@@ -2237,17 +2183,9 @@ mod tests {
         let batch = create_boost_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Boosting query with only positive component (same as regular query)
         let query = FtsQueryExpr::boosting(FtsQueryExpr::match_query("programming"));
         let entries = index.search_query(&query);
-
-        // Should match docs 0, 1, 4 (all with "programming")
-        assert_eq!(
-            entries.len(),
-            3,
-            "Expected 3 matches for 'programming', got {:?}",
-            entries.iter().map(|e| e.row_position).collect::<Vec<_>>()
-        );
+        assert_eq!(entries.len(), 3);
     }
 
     #[test]
@@ -2258,46 +2196,19 @@ mod tests {
         let batch = create_boost_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Boosting query: find "programming", demote docs with "python"
         let query = FtsQueryExpr::boosting_with_negative(
             FtsQueryExpr::match_query("programming"),
             FtsQueryExpr::match_query("python"),
-            0.5, // Demote python docs by half
+            0.5,
         );
         let entries = index.search_query(&query);
-
-        // Should still match docs 0, 1, 4 (all with "programming")
         assert_eq!(entries.len(), 3);
 
-        // Find scores for each doc
-        let doc0 = entries.iter().find(|e| e.row_position == 0); // rust programming
-        let doc1 = entries.iter().find(|e| e.row_position == 1); // python programming
-        let doc4 = entries.iter().find(|e| e.row_position == 4); // javascript programming
-
-        assert!(doc0.is_some() && doc1.is_some() && doc4.is_some());
-
-        // Doc 1 (python) should have lower score than doc 0 (rust) due to negative boost
-        // Doc 0 and doc 4 should have similar scores (neither match "python")
-        let score0 = doc0.unwrap().score;
-        let score1 = doc1.unwrap().score;
-        let score4 = doc4.unwrap().score;
-
-        // Doc 1 was demoted by 0.5, so it should have roughly half the score
-        assert!(
-            score1 < score0,
-            "Doc 1 (python) should have lower score than doc 0 (rust). Doc0: {}, Doc1: {}",
-            score0,
-            score1
-        );
-
-        // Doc 0 and doc 4 should have similar scores (both not demoted)
-        // They may differ slightly due to BM25 scoring differences, but doc 1 should be lower
-        assert!(
-            score1 < score4,
-            "Doc 1 (python) should have lower score than doc 4 (javascript). Doc1: {}, Doc4: {}",
-            score1,
-            score4
-        );
+        let doc0 = entries.iter().find(|e| e.row_position == 0).unwrap();
+        let doc1 = entries.iter().find(|e| e.row_position == 1).unwrap();
+        let doc4 = entries.iter().find(|e| e.row_position == 4).unwrap();
+        assert!(doc1.score < doc0.score);
+        assert!(doc1.score < doc4.score);
     }
 
     #[test]
@@ -2308,59 +2219,32 @@ mod tests {
         let batch = create_boost_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Compare different negative boost factors
         let query_no_demote = FtsQueryExpr::boosting_with_negative(
             FtsQueryExpr::match_query("programming"),
             FtsQueryExpr::match_query("python"),
-            1.0, // No demotion
+            1.0,
         );
-
         let query_half_demote = FtsQueryExpr::boosting_with_negative(
             FtsQueryExpr::match_query("programming"),
             FtsQueryExpr::match_query("python"),
-            0.5, // Half score for python
+            0.5,
         );
-
         let query_zero_demote = FtsQueryExpr::boosting_with_negative(
             FtsQueryExpr::match_query("programming"),
             FtsQueryExpr::match_query("python"),
-            0.0, // Zero score for python
+            0.0,
         );
 
-        let results_no_demote = index.search_query(&query_no_demote);
-        let results_half_demote = index.search_query(&query_half_demote);
-        let results_zero_demote = index.search_query(&query_zero_demote);
+        let r_no = index.search_query(&query_no_demote);
+        let r_half = index.search_query(&query_half_demote);
+        let r_zero = index.search_query(&query_zero_demote);
 
-        // Get doc 1 (python programming) scores
-        let score_no_demote = results_no_demote
-            .iter()
-            .find(|e| e.row_position == 1)
-            .unwrap()
-            .score;
-        let score_half_demote = results_half_demote
-            .iter()
-            .find(|e| e.row_position == 1)
-            .unwrap()
-            .score;
-        let score_zero_demote = results_zero_demote
-            .iter()
-            .find(|e| e.row_position == 1)
-            .unwrap()
-            .score;
+        let s_no = r_no.iter().find(|e| e.row_position == 1).unwrap().score;
+        let s_half = r_half.iter().find(|e| e.row_position == 1).unwrap().score;
+        let s_zero = r_zero.iter().find(|e| e.row_position == 1).unwrap().score;
 
-        // Verify demotion factors are applied correctly
-        assert!(
-            (score_half_demote - score_no_demote * 0.5).abs() < 0.001,
-            "Half demotion should give half score. Expected {}, got {}",
-            score_no_demote * 0.5,
-            score_half_demote
-        );
-
-        assert!(
-            score_zero_demote.abs() < 0.001,
-            "Zero demotion should give zero score, got {}",
-            score_zero_demote
-        );
+        assert!((s_half - s_no * 0.5).abs() < 0.001);
+        assert!(s_zero.abs() < 0.001);
     }
 
     #[test]
@@ -2371,91 +2255,23 @@ mod tests {
         let batch = create_boost_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Boosting query where negative doesn't match any positive results
         let query = FtsQueryExpr::boosting_with_negative(
-            FtsQueryExpr::match_query("rust"),   // Matches docs 0, 2
-            FtsQueryExpr::match_query("python"), // Matches docs 1, 3 (no overlap!)
+            FtsQueryExpr::match_query("rust"),
+            FtsQueryExpr::match_query("python"),
             0.1,
         );
-
         let entries = index.search_query(&query);
-
-        // Should match docs 0, 2 (rust docs)
         assert_eq!(entries.len(), 2);
 
-        // Scores should not be demoted (no overlap with python)
-        let query_baseline = FtsQueryExpr::match_query("rust");
-        let baseline_entries = index.search_query(&query_baseline);
-
+        let baseline = index.search_query(&FtsQueryExpr::match_query("rust"));
         for entry in &entries {
-            let baseline = baseline_entries
+            let b = baseline
                 .iter()
                 .find(|e| e.row_position == entry.row_position)
                 .unwrap();
-            assert!(
-                (entry.score - baseline.score).abs() < 0.001,
-                "Scores should match when no negative overlap. Got {} vs {}",
-                entry.score,
-                baseline.score
-            );
+            assert!((entry.score - b.score).abs() < 0.001);
         }
     }
-
-    #[test]
-    fn test_boost_query_nested() {
-        let schema = create_test_schema();
-        let index = FtsMemIndex::new(1, "description".to_string());
-
-        let batch = create_boost_test_batch(&schema);
-        index.insert(&batch, 0).unwrap();
-
-        // Nested boost: positive is a Boolean query
-        let positive_query = FtsQueryExpr::boolean()
-            .should(FtsQueryExpr::match_query("programming"))
-            .should(FtsQueryExpr::match_query("web"))
-            .build();
-
-        let query = FtsQueryExpr::boosting_with_negative(
-            positive_query,
-            FtsQueryExpr::match_query("python"),
-            0.5,
-        );
-
-        let entries = index.search_query(&query);
-
-        // Should match docs 0, 1, 2, 3, 4 (programming or web)
-        assert!(entries.len() >= 4, "Should match multiple docs");
-
-        // Python docs (1, 3) should be demoted
-        let python_docs: Vec<_> = entries
-            .iter()
-            .filter(|e| e.row_position == 1 || e.row_position == 3)
-            .collect();
-
-        let non_python_docs: Vec<_> = entries
-            .iter()
-            .filter(|e| e.row_position != 1 && e.row_position != 3)
-            .collect();
-
-        // At least some python docs should have lower scores
-        if !python_docs.is_empty() && !non_python_docs.is_empty() {
-            let max_python_score = python_docs.iter().map(|e| e.score).fold(0.0f32, f32::max);
-            let max_non_python_score = non_python_docs
-                .iter()
-                .map(|e| e.score)
-                .fold(0.0f32, f32::max);
-
-            // This is a soft check - depends on BM25 scoring details
-            // Just verify the demotion is happening
-            assert!(
-                python_docs.iter().any(|e| e.score < max_non_python_score)
-                    || max_python_score <= max_non_python_score,
-                "Python docs should generally have lower scores"
-            );
-        }
-    }
-
-    // ====== WAND Factor / Search Options Tests ======
 
     #[test]
     fn test_search_options_default() {
@@ -2467,28 +2283,19 @@ mod tests {
     #[test]
     fn test_search_options_builder() {
         let options = SearchOptions::new().with_wand_factor(0.5).with_limit(10);
-
         assert_eq!(options.wand_factor, 0.5);
         assert_eq!(options.limit, Some(10));
     }
 
     #[test]
     fn test_search_options_wand_factor_clamped() {
-        // wand_factor should be clamped to [0.0, 1.0]
         let options = SearchOptions::new().with_wand_factor(2.0);
         assert_eq!(options.wand_factor, 1.0);
-
         let options = SearchOptions::new().with_wand_factor(-0.5);
         assert_eq!(options.wand_factor, 0.0);
     }
 
     fn create_wand_test_batch(schema: &ArrowSchema) -> RecordBatch {
-        // Test documents with varying relevance:
-        // Doc 0: "alpha alpha alpha beta" - high relevance for "alpha" (3 occurrences)
-        // Doc 1: "alpha beta gamma" - medium relevance for "alpha" (1 occurrence)
-        // Doc 2: "beta gamma delta" - no relevance for "alpha"
-        // Doc 3: "alpha alpha" - medium-high relevance for "alpha" (2 occurrences, shorter doc)
-        // Doc 4: "alpha" - some relevance for "alpha" (1 occurrence, very short doc)
         RecordBatch::try_new(
             Arc::new(schema.clone()),
             vec![
@@ -2514,20 +2321,10 @@ mod tests {
         index.insert(&batch, 0).unwrap();
 
         let query = FtsQueryExpr::match_query("alpha");
-
-        // Full recall (wand_factor = 1.0)
-        let options = SearchOptions::default();
-        let results = index.search_with_options(&query, options);
-
-        // Should return all docs containing "alpha" (docs 0, 1, 3, 4)
-        assert_eq!(results.len(), 4, "Expected 4 matches with full recall");
-
-        // Results should be sorted by score descending
+        let results = index.search_with_options(&query, SearchOptions::default());
+        assert_eq!(results.len(), 4);
         for i in 1..results.len() {
-            assert!(
-                results[i - 1].score >= results[i].score,
-                "Results should be sorted by score descending"
-            );
+            assert!(results[i - 1].score >= results[i].score);
         }
     }
 
@@ -2540,26 +2337,14 @@ mod tests {
         index.insert(&batch, 0).unwrap();
 
         let query = FtsQueryExpr::match_query("alpha");
-
-        // Limit to top 2 results
         let options = SearchOptions::new().with_limit(2);
         let results = index.search_with_options(&query, options);
+        assert_eq!(results.len(), 2);
 
-        assert_eq!(results.len(), 2, "Expected 2 matches with limit=2");
-
-        // Should be the top 2 by score
-        let full_results = index.search_query(&query);
-        let mut full_sorted = full_results;
-        full_sorted.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
-
-        assert_eq!(
-            results[0].row_position, full_sorted[0].row_position,
-            "First result should be highest scorer"
-        );
-        assert_eq!(
-            results[1].row_position, full_sorted[1].row_position,
-            "Second result should be second highest scorer"
-        );
+        let mut full = index.search_query(&query);
+        full.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+        assert_eq!(results[0].row_position, full[0].row_position);
+        assert_eq!(results[1].row_position, full[1].row_position);
     }
 
     #[test]
@@ -2571,37 +2356,18 @@ mod tests {
         index.insert(&batch, 0).unwrap();
 
         let query = FtsQueryExpr::match_query("alpha");
+        let mut full = index.search_query(&query);
+        full.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
 
-        // Get full results first to understand the score distribution
-        let full_results = index.search_query(&query);
-        let mut full_sorted = full_results.clone();
-        full_sorted.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
-
-        // With wand_factor = 0.0, should only keep results at or above threshold (max_score * 0.0 = 0)
-        // Actually with wand_factor = 0.0, threshold = max_score * 0.0 = 0, so all positive scores pass
-        // The real test is to use a higher wand_factor like 0.5
         let options = SearchOptions::new().with_wand_factor(0.5);
         let results = index.search_with_options(&query, options);
 
-        // Results should be pruned based on threshold
         if !results.is_empty() {
-            let max_score = full_sorted[0].score;
+            let max_score = full[0].score;
             let threshold = max_score * 0.5;
-
             for result in &results {
-                assert!(
-                    result.score >= threshold - 0.001, // small epsilon for float comparison
-                    "With wand_factor=0.5, all results should score >= {} but got {}",
-                    threshold,
-                    result.score
-                );
+                assert!(result.score >= threshold - 0.001);
             }
-
-            // Should have fewer or equal results compared to full results
-            assert!(
-                results.len() <= full_results.len(),
-                "Pruned results should not exceed full results"
-            );
         }
     }
 
@@ -2614,22 +2380,9 @@ mod tests {
         index.insert(&batch, 0).unwrap();
 
         let query = FtsQueryExpr::match_query("alpha");
-
-        // Get full results to understand score distribution
-        let full_results = index.search_query(&query);
-        assert!(
-            full_results.len() >= 3,
-            "Need at least 3 results for this test"
-        );
-
-        // With limit=2 and wand_factor=0.5, prune docs scoring below 50% of 2nd best
         let options = SearchOptions::new().with_limit(2).with_wand_factor(0.5);
         let results = index.search_with_options(&query, options);
-
-        // Should have at most 2 results (the limit)
-        assert!(results.len() <= 2, "Should not exceed limit");
-
-        // Results should be sorted by score
+        assert!(results.len() <= 2);
         if results.len() > 1 {
             assert!(results[0].score >= results[1].score);
         }
@@ -2643,15 +2396,10 @@ mod tests {
         let batch = create_wand_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Query for something that doesn't exist
         let query = FtsQueryExpr::match_query("nonexistent");
         let options = SearchOptions::new().with_limit(10).with_wand_factor(0.5);
         let results = index.search_with_options(&query, options);
-
-        assert!(
-            results.is_empty(),
-            "Should return empty for non-matching query"
-        );
+        assert!(results.is_empty());
     }
 
     #[test]
@@ -2662,7 +2410,6 @@ mod tests {
         let batch = create_wand_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        // Boolean query: alpha SHOULD beta
         let query = FtsQueryExpr::boolean()
             .should(FtsQueryExpr::match_query("alpha"))
             .should(FtsQueryExpr::match_query("beta"))
@@ -2670,11 +2417,185 @@ mod tests {
 
         let options = SearchOptions::new().with_limit(3);
         let results = index.search_with_options(&query, options);
-
-        assert!(results.len() <= 3, "Should not exceed limit");
-        // Results should be sorted by score descending
+        assert!(results.len() <= 3);
         for i in 1..results.len() {
             assert!(results[i - 1].score >= results[i].score);
         }
+    }
+
+    // ====== New tests for SWMR semantics, Utf8View, memory accounting ======
+
+    #[test]
+    fn test_utf8view_insert_and_search() {
+        // Mirror of test_fts_index_insert_and_search but with a Utf8View column.
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("description", DataType::Utf8View, true),
+        ]));
+        let index = FtsMemIndex::new(1, "description".to_string());
+
+        let view =
+            arrow_array::StringViewArray::from(vec!["hello world", "goodbye world", "hello again"]);
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(vec![0, 1, 2])), Arc::new(view)],
+        )
+        .unwrap();
+        index.insert(&batch, 0).unwrap();
+
+        assert_eq!(index.doc_count(), 3);
+        assert_eq!(index.search("hello").len(), 2);
+        assert_eq!(index.search("world").len(), 2);
+        assert_eq!(index.search("goodbye").len(), 1);
+    }
+
+    #[test]
+    fn test_memory_usage_grows_with_inserts() {
+        let schema = create_test_schema();
+        let index = FtsMemIndex::new(1, "description".to_string());
+
+        let empty = index.memory_usage();
+        index.insert(&create_test_batch(&schema), 0).unwrap();
+        let after_one = index.memory_usage();
+        index
+            .insert(&create_phrase_test_batch(&schema), 100)
+            .unwrap();
+        let after_two = index.memory_usage();
+
+        assert!(after_one > empty, "memory should grow after first insert");
+        assert!(
+            after_two > after_one,
+            "memory should grow after second insert"
+        );
+    }
+
+    #[test]
+    fn test_partial_doc_never_visible_phrase() {
+        // A phrase query inside a single document must either match fully
+        // (both phrase tokens present) or not match at all — readers must
+        // never observe a half-inserted doc that contains only one of the
+        // phrase tokens. Since `search_phrase` only returns rows where
+        // every token's position constraint holds, any returned entry
+        // implicitly proves both tokens were visible together.
+        use std::sync::Arc;
+        let schema = create_test_schema();
+        let index = Arc::new(FtsMemIndex::new(1, "description".to_string()));
+
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let mut readers = Vec::new();
+        for _ in 0..4 {
+            let idx = index.clone();
+            let stop = stop.clone();
+            readers.push(std::thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    let entries = idx.search_phrase("hello world", 0);
+                    for e in &entries {
+                        // "hello world" appears as the doc at offset 0 of
+                        // every inserted batch, whose row_offset is a
+                        // multiple of 100 — so any matched row_position
+                        // must be a multiple of 100 (the row_offset itself,
+                        // not offset+1 or offset+2).
+                        assert_eq!(
+                            e.row_position % 100,
+                            0,
+                            "phrase 'hello world' should only match the row_offset row of each batch, but got row_position {}",
+                            e.row_position
+                        );
+                        assert!(e.score.is_finite() && e.score >= 0.0);
+                    }
+                }
+            }));
+        }
+
+        for i in 0..50 {
+            let batch = create_test_batch(&schema);
+            index.insert(&batch, (i * 100) as u64).unwrap();
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        stop.store(true, Ordering::Relaxed);
+
+        for r in readers {
+            r.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_swmr_visibility_torture() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let schema = create_test_schema();
+        let index = Arc::new(FtsMemIndex::new(1, "description".to_string()));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        // 8 reader threads issuing match queries.
+        let mut readers = Vec::new();
+        for _ in 0..8 {
+            let idx = index.clone();
+            let stop = stop.clone();
+            readers.push(std::thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    let r = idx.search("hello");
+                    // BM25 scores must be finite and non-negative.
+                    for e in &r {
+                        assert!(e.score.is_finite());
+                        assert!(e.score >= 0.0);
+                    }
+                }
+            }));
+        }
+
+        // One writer thread.
+        let writer = {
+            let idx = index.clone();
+            std::thread::spawn(move || {
+                for i in 0..200 {
+                    let batch = create_test_batch(&schema);
+                    idx.insert(&batch, (i * 100) as u64).unwrap();
+                }
+            })
+        };
+
+        writer.join().unwrap();
+        stop.store(true, Ordering::Relaxed);
+        for r in readers {
+            r.join().unwrap();
+        }
+
+        // After all inserts, doc_count must be 200 batches × 3 rows.
+        assert_eq!(index.doc_count(), 600);
+    }
+
+    #[test]
+    fn test_to_index_builder_reversed_smoke() {
+        // Ensure flush works on a minimal input.
+        let schema = create_test_schema();
+        let index = FtsMemIndex::new(1, "description".to_string());
+        let batch = create_test_batch(&schema);
+        index.insert(&batch, 0).unwrap();
+
+        let builder = index.to_index_builder_reversed(42, 3).unwrap();
+        // The builder can be consumed by callers; we just check it built.
+        assert!(builder.id() > 0 || builder.id() == 42);
+    }
+
+    #[test]
+    fn test_unsupported_column_type_errors() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("description", DataType::Int32, true),
+        ]));
+        let index = FtsMemIndex::new(1, "description".to_string());
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![0, 1])),
+                Arc::new(Int32Array::from(vec![1, 2])),
+            ],
+        )
+        .unwrap();
+
+        let err = index.insert(&batch, 0).unwrap_err();
+        assert!(err.to_string().contains("only supports"), "{err}");
     }
 }

--- a/rust/lance/src/dataset/mem_wal/index/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/index/fts.rs
@@ -378,9 +378,11 @@ struct TermChunk {
     batch_position: usize,
     row_positions: Vec<u64>,
     frequencies: Vec<u32>,
-    /// Present iff `params.has_positions()` was true at construction time.
-    /// Independent of that, in-memory phrase queries always work when
-    /// positions were tracked at insert time.
+    /// Per-doc token positions. Always `Some` in the current
+    /// implementation (the writer tracks positions unconditionally so
+    /// in-memory phrase queries work even when `params.has_positions()`
+    /// is false). Kept as `Option` for forward compatibility with a
+    /// future "no-positions" mode that drops the allocation.
     positions: Option<Positions>,
 }
 
@@ -456,11 +458,11 @@ impl BatchMeta {
 struct Snapshot {
     /// Number of batches visible to readers. `0` means empty index.
     visible_count: usize,
-    /// Visible-batch metadata. `batches.len() >= visible_count`; the writer
-    /// may have already appended a still-invisible batch to this list, but
-    /// readers walk only `batches[0..visible_count]`. In the publication
-    /// order described in the module docs, readers never observe
-    /// `visible_count` exceeding the actual length.
+    /// Visible-batch metadata, written to in publish order. Always
+    /// `batches.len() == visible_count` for any snapshot the writer has
+    /// stored (each `publish_batch` appends a single entry and bumps
+    /// `visible_count` by one). The slice is kept exactly the visible
+    /// length so readers can iterate it directly without re-bounding.
     batches: Arc<[Arc<BatchMeta>]>,
     /// `Σ batches[i].rows` for `i < visible_count`.
     cumulative_doc_count: u64,
@@ -479,8 +481,12 @@ impl Snapshot {
     }
 
     fn batch_for(&self, batch_position: usize) -> Option<&Arc<BatchMeta>> {
-        // Visible batches are densely numbered starting at 0 in the order
-        // they were inserted. Use direct index when possible.
+        // The fast path assumes batch_position equals the index in
+        // `batches` (true when callers use the no-arg `insert()` and let
+        // the index assign sequential positions). When callers pass
+        // explicit positions to `insert_with_batch_position`, those
+        // positions can be sparse / out of order, so we fall back to a
+        // linear search through visible batches.
         self.batches
             .get(batch_position)
             .filter(|m| m.batch_position == batch_position)
@@ -660,17 +666,22 @@ impl FtsMemIndex {
         self.snapshot.load().visible_count == 0
     }
 
-    /// Total number of (term, doc) postings currently stored.
+    /// Total number of visible (term, doc) postings.
     ///
-    /// Counts every chunk regardless of visibility — the writer's invariant
-    /// is that chunks become visible together with the snapshot bump, so
-    /// in steady state this equals the number of visible postings.
+    /// Sums posting counts only over chunks whose batch is visible per the
+    /// current snapshot, so this matches what readers can actually walk.
     pub fn entry_count(&self) -> usize {
+        let visible = self.snapshot.load().visible_count;
         self.terms
             .iter()
             .map(|e| {
                 let slice = e.value().load();
-                slice.chunks.iter().map(|c| c.doc_count()).sum::<usize>()
+                slice
+                    .chunks
+                    .iter()
+                    .filter(|c| c.batch_position < visible)
+                    .map(|c| c.doc_count())
+                    .sum::<usize>()
             })
             .sum()
     }
@@ -849,19 +860,30 @@ impl FtsMemIndex {
     /// use `search_with_options` for sorted/limited output.
     pub fn search(&self, term: &str) -> Vec<FtsEntry> {
         let snap = self.snapshot.load_full();
+        self.search_with_snapshot(term, &snap)
+    }
+
+    fn search_with_snapshot(&self, term: &str, snap: &Arc<Snapshot>) -> Vec<FtsEntry> {
         if snap.visible_count == 0 {
             return Vec::new();
         }
-
         let tokens = self.tokenize_for_search(term);
-
-        score_terms(&snap, &self.terms, &tokens)
+        score_terms(snap, &self.terms, &tokens)
     }
 
     /// Search for documents containing an exact phrase, optionally allowing
     /// `slop` intervening tokens between consecutive query tokens.
     pub fn search_phrase(&self, phrase: &str, slop: u32) -> Vec<FtsEntry> {
         let snap = self.snapshot.load_full();
+        self.search_phrase_with_snapshot(phrase, slop, &snap)
+    }
+
+    fn search_phrase_with_snapshot(
+        &self,
+        phrase: &str,
+        slop: u32,
+        snap: &Arc<Snapshot>,
+    ) -> Vec<FtsEntry> {
         if snap.visible_count == 0 {
             return Vec::new();
         }
@@ -873,7 +895,7 @@ impl FtsMemIndex {
         if tokens.len() == 1 {
             // Same shortcut as the previous implementation: a single-token
             // phrase reduces to a regular term search.
-            return score_terms(&snap, &self.terms, &tokens);
+            return score_terms(snap, &self.terms, &tokens);
         }
 
         // Gather visible chunks per token.
@@ -961,7 +983,7 @@ impl FtsMemIndex {
                     continue;
                 }
 
-                let dl = lookup_dl(&snap, row_position).unwrap_or(1) as f32;
+                let dl = lookup_dl(snap, row_position).unwrap_or(1) as f32;
                 let mut score = 0.0f32;
                 for (ti, _tok) in tokens.iter().enumerate() {
                     let tf = frequencies[ti] as f32;
@@ -987,7 +1009,17 @@ impl FtsMemIndex {
         max_distance: u32,
         max_expansions: usize,
     ) -> Vec<(String, u32)> {
-        let snap = self.snapshot.load();
+        let snap = self.snapshot.load_full();
+        self.expand_fuzzy_with_snapshot(term, max_distance, max_expansions, &snap)
+    }
+
+    fn expand_fuzzy_with_snapshot(
+        &self,
+        term: &str,
+        max_distance: u32,
+        max_expansions: usize,
+        snap: &Arc<Snapshot>,
+    ) -> Vec<(String, u32)> {
         let mut matches: Vec<(String, u32)> = Vec::new();
 
         if max_distance == 0 {
@@ -1022,6 +1054,16 @@ impl FtsMemIndex {
         max_expansions: usize,
     ) -> Vec<FtsEntry> {
         let snap = self.snapshot.load_full();
+        self.search_fuzzy_with_snapshot(query, fuzziness, max_expansions, &snap)
+    }
+
+    fn search_fuzzy_with_snapshot(
+        &self,
+        query: &str,
+        fuzziness: Option<u32>,
+        max_expansions: usize,
+        snap: &Arc<Snapshot>,
+    ) -> Vec<FtsEntry> {
         if snap.visible_count == 0 {
             return Vec::new();
         }
@@ -1034,7 +1076,8 @@ impl FtsMemIndex {
         let mut expanded: Vec<String> = Vec::new();
         for tok in &tokens {
             let max_dist = fuzziness.unwrap_or_else(|| auto_fuzziness(tok));
-            for (matched, _) in self.expand_fuzzy(tok, max_dist, max_expansions) {
+            for (matched, _) in self.expand_fuzzy_with_snapshot(tok, max_dist, max_expansions, snap)
+            {
                 expanded.push(matched);
             }
         }
@@ -1042,19 +1085,33 @@ impl FtsMemIndex {
             return Vec::new();
         }
 
-        score_terms(&snap, &self.terms, &expanded)
+        score_terms(snap, &self.terms, &expanded)
     }
 
     /// Execute a query expression and return matching documents with scores.
+    ///
+    /// Snapshots the index state once at entry so the entire compound
+    /// query — including every leaf invoked recursively from `Boolean` /
+    /// `Boost` — sees the same `Snapshot`. This preserves the per-batch
+    /// monotonic visibility contract for compound queries.
     pub fn search_query(&self, query: &FtsQueryExpr) -> Vec<FtsEntry> {
+        let snap = self.snapshot.load_full();
+        self.search_query_with_snapshot(query, &snap)
+    }
+
+    fn search_query_with_snapshot(
+        &self,
+        query: &FtsQueryExpr,
+        snap: &Arc<Snapshot>,
+    ) -> Vec<FtsEntry> {
         match query {
             FtsQueryExpr::Match { query, boost } => {
-                let mut results = self.search(query);
+                let mut results = self.search_with_snapshot(query, snap);
                 apply_boost(&mut results, *boost);
                 results
             }
             FtsQueryExpr::Phrase { query, slop, boost } => {
-                let mut results = self.search_phrase(query, *slop);
+                let mut results = self.search_phrase_with_snapshot(query, *slop, snap);
                 apply_boost(&mut results, *boost);
                 results
             }
@@ -1064,7 +1121,8 @@ impl FtsMemIndex {
                 max_expansions,
                 boost,
             } => {
-                let mut results = self.search_fuzzy(query, *fuzziness, *max_expansions);
+                let mut results =
+                    self.search_fuzzy_with_snapshot(query, *fuzziness, *max_expansions, snap);
                 apply_boost(&mut results, *boost);
                 results
             }
@@ -1072,12 +1130,12 @@ impl FtsMemIndex {
                 must,
                 should,
                 must_not,
-            } => self.search_boolean(must, should, must_not),
+            } => self.search_boolean(must, should, must_not, snap),
             FtsQueryExpr::Boost {
                 positive,
                 negative,
                 negative_boost,
-            } => self.search_boost(positive, negative.as_deref(), *negative_boost),
+            } => self.search_boost(positive, negative.as_deref(), *negative_boost, snap),
         }
     }
 
@@ -1087,7 +1145,8 @@ impl FtsMemIndex {
         query: &FtsQueryExpr,
         options: SearchOptions,
     ) -> Vec<FtsEntry> {
-        let mut results = self.search_query(query);
+        let snap = self.snapshot.load_full();
+        let mut results = self.search_query_with_snapshot(query, &snap);
         results.sort_by(|a, b| {
             b.score
                 .partial_cmp(&a.score)
@@ -1116,12 +1175,13 @@ impl FtsMemIndex {
         positive: &FtsQueryExpr,
         negative: Option<&FtsQueryExpr>,
         negative_boost: f32,
+        snap: &Arc<Snapshot>,
     ) -> Vec<FtsEntry> {
-        let mut results = self.search_query(positive);
+        let mut results = self.search_query_with_snapshot(positive, snap);
         let Some(neg) = negative else {
             return results;
         };
-        let negative_results = self.search_query(neg);
+        let negative_results = self.search_query_with_snapshot(neg, snap);
         let negative_set: HashSet<RowPosition> = negative_results
             .into_iter()
             .map(|e| e.row_position)
@@ -1139,29 +1199,30 @@ impl FtsMemIndex {
         must: &[FtsQueryExpr],
         should: &[FtsQueryExpr],
         must_not: &[FtsQueryExpr],
+        snap: &Arc<Snapshot>,
     ) -> Vec<FtsEntry> {
         let excluded: HashSet<RowPosition> = must_not
             .iter()
-            .flat_map(|q| self.search_query(q))
+            .flat_map(|q| self.search_query_with_snapshot(q, snap))
             .map(|e| e.row_position)
             .collect();
 
         let mut result_map: HashMap<RowPosition, f32> = if must.is_empty() {
             let mut map: HashMap<RowPosition, f32> = HashMap::new();
             for q in should {
-                for entry in self.search_query(q) {
+                for entry in self.search_query_with_snapshot(q, snap) {
                     *map.entry(entry.row_position).or_default() += entry.score;
                 }
             }
             map
         } else {
-            let first_results = self.search_query(&must[0]);
+            let first_results = self.search_query_with_snapshot(&must[0], snap);
             let mut map: HashMap<RowPosition, f32> = first_results
                 .into_iter()
                 .map(|e| (e.row_position, e.score))
                 .collect();
             for q in must.iter().skip(1) {
-                let results = self.search_query(q);
+                let results = self.search_query_with_snapshot(q, snap);
                 let result_set: HashMap<RowPosition, f32> = results
                     .into_iter()
                     .map(|e| (e.row_position, e.score))
@@ -1172,7 +1233,7 @@ impl FtsMemIndex {
                     .collect();
             }
             for q in should {
-                for entry in self.search_query(q) {
+                for entry in self.search_query_with_snapshot(q, snap) {
                     if let Some(score) = map.get_mut(&entry.row_position) {
                         *score += entry.score;
                     }
@@ -1595,6 +1656,7 @@ mod tests {
     use arrow_array::{Int32Array, StringArray};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
 
     fn create_test_schema() -> Arc<ArrowSchema> {
         Arc::new(ArrowSchema::new(vec![
@@ -2477,7 +2539,6 @@ mod tests {
         // phrase tokens. Since `search_phrase` only returns rows where
         // every token's position constraint holds, any returned entry
         // implicitly proves both tokens were visible together.
-        use std::sync::Arc;
         let schema = create_test_schema();
         let index = Arc::new(FtsMemIndex::new(1, "description".to_string()));
 
@@ -2521,8 +2582,6 @@ mod tests {
 
     #[test]
     fn test_swmr_visibility_torture() {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicBool, Ordering};
         let schema = create_test_schema();
         let index = Arc::new(FtsMemIndex::new(1, "description".to_string()));
         let stop = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
## Summary

Replaces the `SkipMap<(token, row_position)>` postings layout in
`rust/lance/src/dataset/mem_wal/index/fts.rs` with per-term
`ArcSwap<TermSlice>` slices and an `ArcSwap<Snapshot>`-published
per-batch visibility watermark. Readers grab the snapshot, walk per-term
chunks filtered by `chunk.batch_position < snapshot.visible_count`, and
score with snapshot-coupled BM25 stats.

The writer publishes the snapshot only after every term chunk for a
batch is linked, so readers never observe a partial document or BM25
stats out of sync with the postings — per-batch monotonic visibility.

Also in this PR:

- Tokenize-time tokenizer ownership moves out of a single shared `Mutex`
  into a small reader pool plus a writer-dedicated slot, so search
  calls no longer serialize against the writer.
- `Utf8View` is added to the supported text types alongside `Utf8` /
  `LargeUtf8`; non-string columns now produce a clear error instead of
  being silently skipped.
- `FtsMemIndex::memory_usage()` for size-based flush triggers.
- The flush path keeps using `lance_index::scalar::inverted` types
  (`TokenSet` / `DocSet` / `PostingListBuilder`); the on-disk format is
  unchanged. The stale "flush is not yet implemented" header doc is
  corrected.

Public API (`FtsMemIndex` constructors, `FtsQueryExpr`, `SearchOptions`,
`BooleanQueryBuilder`, `FtsIndexConfig`, `to_index_builder_reversed`)
is preserved. No callers of the removed internal `FtsKey` /
`PostingValue` types existed outside the file.

cc @jackye1995 for review.