### PR TITLE
docs: remove FROM community clause from DuckDB lance install command

### DIFF
--- a/docs/src/integrations/duckdb.md
+++ b/docs/src/integrations/duckdb.md
@@ -28,7 +28,7 @@ We're now ready to begin querying Lance using DuckDB! First, install the extensi
 === "SQL"
 
     ```sql
-    INSTALL lance FROM community;
+    INSTALL lance;
     LOAD lance;
     ```
 
@@ -39,7 +39,7 @@ We're now ready to begin querying Lance using DuckDB! First, install the extensi
 
     duckdb.sql(
         """
-        INSTALL lance FROM community;
+        INSTALL lance;
         LOAD lance;
         """
     )


### PR DESCRIPTION
docs: remove FROM community clause from DuckDB lance install command

The lance extension is now available as a core DuckDB extension and no
longer needs to be installed from the community repository.

Before: INSTALL lance FROM community;
After:  INSTALL lance;