### PR TITLE
feat: add Git-style delta encoding for blob columns

### DIFF
--- a/protos/encodings_v2_1.proto
+++ b/protos/encodings_v2_1.proto
@@ -194,6 +194,18 @@ message BlobLayout {
   repeated RepDefLayer layers = 2;
 }
 
+// A layout where large binary data is delta-encoded against a base value.
+// The descriptions contain (position, size, kind, base_offset) tuples.
+// kind indicates whether the value is a base (stored as-is) or a delta
+// (stored as copy/insert instructions relative to the previous value in the chain).
+// base_offset is the row distance back to the base value in the group.
+message DeltaBlobLayout {
+  // The inner layout used to store the descriptions
+  PageLayout inner_layout = 1;
+  // The meaning of each repdef layer
+  repeated RepDefLayer layers = 2;
+}
+
 // Describes the structural encoding of a page
 message PageLayout {
   oneof layout {
@@ -206,6 +218,8 @@ message PageLayout {
     // A layout where large binary data is encoded externally
     // and only the descriptions are put in the page
     BlobLayout blob_layout = 4;
+    // A layout where large binary data is delta-encoded
+    DeltaBlobLayout delta_blob_layout = 5;
   }
 }
 

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -47,6 +47,8 @@ pub const ARROW_EXT_META_KEY: &str = "ARROW:extension:metadata";
 /// Key used by lance to mark a field as a blob
 /// TODO: Use Arrow extension mechanism instead?
 pub const BLOB_META_KEY: &str = "lance-encoding:blob";
+/// Metadata key to enable delta encoding for blob columns
+pub const DELTA_BLOB_META_KEY: &str = "lance-encoding:delta-blob";
 /// Arrow extension type name for Lance blob v2 columns
 pub const BLOB_V2_EXT_NAME: &str = "lance.blob.v2";
 /// Metadata key for overriding the dedicated blob size threshold (in bytes)

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -37,6 +37,18 @@ pub static BLOB_DESC_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
 pub static BLOB_DESC_TYPE: LazyLock<DataType> =
     LazyLock::new(|| DataType::Struct(BLOB_DESC_FIELDS.clone()));
 
+pub static DELTA_BLOB_DESC_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
+    Fields::from(vec![
+        ArrowField::new("position", DataType::UInt64, false),
+        ArrowField::new("size", DataType::UInt64, false),
+        ArrowField::new("kind", DataType::UInt8, false),
+        ArrowField::new("base_offset", DataType::UInt32, false),
+    ])
+});
+
+pub static DELTA_BLOB_DESC_TYPE: LazyLock<DataType> =
+    LazyLock::new(|| DataType::Struct(DELTA_BLOB_DESC_FIELDS.clone()));
+
 pub static BLOB_DESC_FIELD: LazyLock<ArrowField> = LazyLock::new(|| {
     ArrowField::new("description", BLOB_DESC_TYPE.clone(), true).with_metadata(HashMap::from([(
         lance_arrow::BLOB_META_KEY.to_string(),
@@ -424,6 +436,13 @@ pub enum BlobKind {
     /// External blobs can have a position and a size. If the position is not set,
     /// it defaults to 0, which points to the beginning of the blob.
     External = 3,
+    /// Base value in a delta-encoded group. Stored as-is like Inline.
+    /// `position`/`size` point into the out-of-line buffer.
+    DeltaBase = 4,
+    /// Delta-encoded value. `position`/`size` point to the delta bytes in the
+    /// out-of-line buffer. `blob_id` stores the row offset to the base value
+    /// within the delta group.
+    Delta = 5,
 }
 
 impl TryFrom<u8> for BlobKind {
@@ -435,6 +454,8 @@ impl TryFrom<u8> for BlobKind {
             1 => Ok(Self::Packed),
             2 => Ok(Self::Dedicated),
             3 => Ok(Self::External),
+            4 => Ok(Self::DeltaBase),
+            5 => Ok(Self::Delta),
             other => Err(Error::invalid_input_source(
                 format!("Unknown blob kind {other:?}").into(),
             )),

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -20,7 +20,7 @@ use arrow_array::{
 use arrow_schema::{DataType, Field as ArrowField};
 use deepsize::DeepSizeOf;
 use lance_arrow::{
-    ARROW_EXT_NAME_KEY, BLOB_META_KEY, BLOB_V2_EXT_NAME, DataTypeExt,
+    ARROW_EXT_NAME_KEY, BLOB_META_KEY, BLOB_V2_EXT_NAME, DELTA_BLOB_META_KEY, DataTypeExt,
     json::{is_arrow_json_field, is_json_field},
 };
 
@@ -522,11 +522,17 @@ impl Field {
     /// Blob fields will load descriptions by default
     pub fn is_blob(&self) -> bool {
         self.metadata.contains_key(BLOB_META_KEY)
+            || self.metadata.contains_key(DELTA_BLOB_META_KEY)
             || self
                 .metadata
                 .get(ARROW_EXT_NAME_KEY)
                 .map(|name| name == BLOB_V2_EXT_NAME)
                 .unwrap_or(false)
+    }
+
+    /// Returns true if the field is marked for delta blob encoding.
+    pub fn is_delta_blob(&self) -> bool {
+        self.metadata.contains_key(DELTA_BLOB_META_KEY)
     }
 
     /// Returns true if the field is explicitly marked as blob v2 extension.

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -762,6 +762,8 @@ impl CoreFieldDecoderStrategy {
                             page.encoding,
                             PageEncoding::Structural(pb21::PageLayout {
                                 layout: Some(pb21::page_layout::Layout::BlobLayout(_))
+                            }) | PageEncoding::Structural(pb21::PageLayout {
+                                layout: Some(pb21::page_layout::Layout::DeltaBlobLayout(_))
                             })
                         )
                     }) {

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -28,7 +28,7 @@ use crate::buffer::LanceBuffer;
 use crate::compression::{CompressionStrategy, DefaultCompressionStrategy};
 use crate::compression_config::CompressionParams;
 use crate::decoder::PageEncoding;
-use crate::encodings::logical::blob::{BlobStructuralEncoder, BlobV2StructuralEncoder};
+use crate::encodings::logical::blob::{BlobStructuralEncoder, BlobV2StructuralEncoder, DeltaBlobStructuralEncoder};
 use crate::encodings::logical::fixed_size_list::FixedSizeListStructuralEncoder;
 use crate::encodings::logical::list::ListStructuralEncoder;
 use crate::encodings::logical::map::MapStructuralEncoder;
@@ -392,6 +392,29 @@ impl StructuralEncodingStrategy {
 
         // Check if field is marked as blob
         if field.is_blob() {
+            // Delta blob encoding takes priority if marked
+            if field.is_delta_blob() {
+                match data_type {
+                    DataType::Binary | DataType::LargeBinary => {
+                        return Ok(Box::new(DeltaBlobStructuralEncoder::new(
+                            field,
+                            column_index.next_column_index(field.id as u32),
+                            options,
+                            self.compression_strategy.clone(),
+                            4, // default max chain depth
+                        )?));
+                    }
+                    _ => {
+                        return Err(Error::invalid_input_source(
+                            format!(
+                                "Delta blob encoding only supports Binary/LargeBinary, got {}",
+                                data_type
+                            )
+                            .into(),
+                        ));
+                    }
+                }
+            }
             match data_type {
                 DataType::Binary | DataType::LargeBinary => {
                     return Ok(Box::new(BlobStructuralEncoder::new(

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -28,7 +28,9 @@ use crate::buffer::LanceBuffer;
 use crate::compression::{CompressionStrategy, DefaultCompressionStrategy};
 use crate::compression_config::CompressionParams;
 use crate::decoder::PageEncoding;
-use crate::encodings::logical::blob::{BlobStructuralEncoder, BlobV2StructuralEncoder, DeltaBlobStructuralEncoder};
+use crate::encodings::logical::blob::{
+    BlobStructuralEncoder, BlobV2StructuralEncoder, DeltaBlobStructuralEncoder,
+};
 use crate::encodings::logical::fixed_size_list::FixedSizeListStructuralEncoder;
 use crate::encodings::logical::list::ListStructuralEncoder;
 use crate::encodings::logical::map::MapStructuralEncoder;

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -383,6 +383,11 @@ impl FieldEncoder for BlobV2StructuralEncoder {
                                 "".to_string(),
                             )
                         }
+                        BlobKind::DeltaBase | BlobKind::Delta => {
+                            return Err(Error::invalid_input_source(
+                                "DeltaBase/Delta blob kinds are not supported in BlobV2StructuralEncoder; use DeltaBlobStructuralEncoder".into(),
+                            ));
+                        }
                     }
                 };
 
@@ -417,6 +422,260 @@ impl FieldEncoder for BlobV2StructuralEncoder {
 
     fn flush(&mut self, external_buffers: &mut OutOfLineBuffers) -> Result<Vec<EncodeTask>> {
         self.descriptor_encoder.flush(external_buffers)
+    }
+
+    fn finish(
+        &mut self,
+        external_buffers: &mut OutOfLineBuffers,
+    ) -> BoxFuture<'_, Result<Vec<EncodedColumn>>> {
+        self.descriptor_encoder.finish(external_buffers)
+    }
+
+    fn num_columns(&self) -> u32 {
+        self.descriptor_encoder.num_columns()
+    }
+}
+
+/// Delta-encoded blob structural encoder.
+///
+/// Groups consecutive blob values and stores the first as a base, then
+/// encodes subsequent values as binary deltas (copy/insert instructions)
+/// relative to the previous value in the group. Chain depth is bounded
+/// by `max_chain_depth`; after that many deltas a new base is emitted.
+///
+/// Falls back to storing a value as a new base when the delta is not
+/// smaller than the raw value.
+pub struct DeltaBlobStructuralEncoder {
+    descriptor_encoder: Box<dyn FieldEncoder>,
+    def_meaning: Option<Arc<[DefinitionInterpretation]>>,
+    /// Maximum number of chained deltas before forcing a new base.
+    max_chain_depth: usize,
+}
+
+impl DeltaBlobStructuralEncoder {
+    pub fn new(
+        field: &Field,
+        column_index: u32,
+        options: &crate::encoder::EncodingOptions,
+        compression_strategy: Arc<dyn crate::compression::CompressionStrategy>,
+        max_chain_depth: usize,
+    ) -> Result<Self> {
+        let mut descriptor_metadata = HashMap::with_capacity(1);
+        descriptor_metadata.insert(PACKED_STRUCT_META_KEY.to_string(), "true".to_string());
+
+        let descriptor_data_type = DataType::Struct(Fields::from(vec![
+            ArrowField::new("position", DataType::UInt64, false),
+            ArrowField::new("size", DataType::UInt64, false),
+            ArrowField::new("kind", DataType::UInt8, false),
+            ArrowField::new("base_offset", DataType::UInt32, false),
+        ]));
+
+        let descriptor_field = Field::try_from(
+            ArrowField::new(&field.name, descriptor_data_type, field.nullable)
+                .with_metadata(descriptor_metadata),
+        )?;
+
+        let descriptor_encoder = Box::new(PrimitiveStructuralEncoder::try_new(
+            options,
+            compression_strategy,
+            column_index,
+            descriptor_field,
+            Arc::new(HashMap::new()),
+        )?);
+
+        Ok(Self {
+            descriptor_encoder,
+            def_meaning: None,
+            max_chain_depth: max_chain_depth.max(1),
+        })
+    }
+
+    fn wrap_tasks_delta(
+        tasks: Vec<EncodeTask>,
+        def_meaning: Arc<[DefinitionInterpretation]>,
+    ) -> Vec<EncodeTask> {
+        tasks
+            .into_iter()
+            .map(|task| {
+                let def_meaning = def_meaning.clone();
+                task.then(|encoded_page| async move {
+                    let encoded_page = encoded_page?;
+
+                    let PageEncoding::Structural(inner_layout) = encoded_page.description else {
+                        return Err(Error::internal(
+                            "Expected inner encoding to return structural layout".to_string(),
+                        ));
+                    };
+
+                    let wrapped = ProtobufUtils21::delta_blob_layout(inner_layout, &def_meaning);
+                    Ok(EncodedPage {
+                        column_idx: encoded_page.column_idx,
+                        data: encoded_page.data,
+                        description: PageEncoding::Structural(wrapped),
+                        num_rows: encoded_page.num_rows,
+                        row_number: encoded_page.row_number,
+                    })
+                })
+                .boxed()
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+impl FieldEncoder for DeltaBlobStructuralEncoder {
+    fn maybe_encode(
+        &mut self,
+        array: ArrayRef,
+        external_buffers: &mut OutOfLineBuffers,
+        mut repdef: RepDefBuilder,
+        row_number: u64,
+        num_rows: u64,
+    ) -> Result<Vec<EncodeTask>> {
+        use crate::encodings::physical::delta::create_delta;
+
+        if let Some(validity) = array.nulls() {
+            repdef.add_validity_bitmap(validity.clone());
+        } else {
+            repdef.add_no_null(array.len());
+        }
+
+        let binary_array = array.as_binary_opt::<i64>().ok_or_else(|| {
+            Error::invalid_input_source(
+                format!("Expected LargeBinary array, got {}", array.data_type()).into(),
+            )
+        })?;
+
+        let repdef = RepDefBuilder::serialize(vec![repdef]);
+        let rep = repdef.repetition_levels.as_ref();
+        let def = repdef.definition_levels.as_ref();
+        let def_meaning: Arc<[DefinitionInterpretation]> = repdef.def_meaning.into();
+
+        match self.def_meaning.as_ref() {
+            None => {
+                self.def_meaning = Some(def_meaning.clone());
+            }
+            Some(existing) => {
+                debug_assert_eq!(existing, &def_meaning);
+            }
+        }
+
+        let mut positions = Vec::with_capacity(binary_array.len());
+        let mut sizes = Vec::with_capacity(binary_array.len());
+        let mut kinds = Vec::with_capacity(binary_array.len());
+        let mut base_offsets = Vec::with_capacity(binary_array.len());
+
+        // Track the current base value and chain depth within this batch
+        let mut current_base: Option<Vec<u8>> = None;
+        let mut current_base_idx: usize = 0;
+        let mut chain_depth: usize = 0;
+        // Track the previous value in the chain for chained deltas
+        let mut prev_value: Option<Vec<u8>> = None;
+
+        for i in 0..binary_array.len() {
+            if binary_array.is_null(i) {
+                let mut repdef_val = (def.expect_ok()?[i] as u64) << 16;
+                if let Some(rep) = rep {
+                    repdef_val += rep[i] as u64;
+                }
+                debug_assert_ne!(repdef_val, 0);
+                positions.push(repdef_val);
+                sizes.push(0);
+                kinds.push(BlobKind::Inline as u8);
+                base_offsets.push(0u32);
+                continue;
+            }
+
+            let value = binary_array.value(i);
+
+            if value.is_empty() {
+                positions.push(0);
+                sizes.push(0);
+                kinds.push(BlobKind::Inline as u8);
+                base_offsets.push(0u32);
+                continue;
+            }
+
+            let should_start_new_base =
+                current_base.is_none() || chain_depth >= self.max_chain_depth;
+
+            if should_start_new_base {
+                // Store as base
+                let position =
+                    external_buffers.add_buffer(LanceBuffer::from(Buffer::from(value)));
+                positions.push(position);
+                sizes.push(value.len() as u64);
+                kinds.push(BlobKind::DeltaBase as u8);
+                base_offsets.push(0u32);
+                current_base = Some(value.to_vec());
+                current_base_idx = i;
+                chain_depth = 0;
+                prev_value = Some(value.to_vec());
+            } else {
+                // Try delta against previous value in chain
+                let reference = prev_value.as_ref().unwrap();
+                match create_delta(reference, value) {
+                    Some(delta_bytes) => {
+                        let position = external_buffers
+                            .add_buffer(LanceBuffer::from(Buffer::from(&delta_bytes[..])));
+                        positions.push(position);
+                        sizes.push(delta_bytes.len() as u64);
+                        kinds.push(BlobKind::Delta as u8);
+                        // Store offset back to the base within this batch
+                        base_offsets.push((i - current_base_idx) as u32);
+                        chain_depth += 1;
+                        prev_value = Some(value.to_vec());
+                    }
+                    None => {
+                        // Delta not beneficial — store as new base
+                        let position =
+                            external_buffers.add_buffer(LanceBuffer::from(Buffer::from(value)));
+                        positions.push(position);
+                        sizes.push(value.len() as u64);
+                        kinds.push(BlobKind::DeltaBase as u8);
+                        base_offsets.push(0u32);
+                        current_base = Some(value.to_vec());
+                        current_base_idx = i;
+                        chain_depth = 0;
+                        prev_value = Some(value.to_vec());
+                    }
+                }
+            }
+        }
+
+        let descriptor_array = Arc::new(StructArray::new(
+            Fields::from(vec![
+                ArrowField::new("position", DataType::UInt64, false),
+                ArrowField::new("size", DataType::UInt64, false),
+                ArrowField::new("kind", DataType::UInt8, false),
+                ArrowField::new("base_offset", DataType::UInt32, false),
+            ]),
+            vec![
+                Arc::new(UInt64Array::from(positions)) as ArrayRef,
+                Arc::new(UInt64Array::from(sizes)) as ArrayRef,
+                Arc::new(arrow_array::UInt8Array::from(kinds)) as ArrayRef,
+                Arc::new(arrow_array::UInt32Array::from(base_offsets)) as ArrayRef,
+            ],
+            None,
+        ));
+
+        let encode_tasks = self.descriptor_encoder.maybe_encode(
+            descriptor_array,
+            external_buffers,
+            RepDefBuilder::default(),
+            row_number,
+            num_rows,
+        )?;
+
+        Ok(Self::wrap_tasks_delta(encode_tasks, def_meaning))
+    }
+
+    fn flush(&mut self, external_buffers: &mut OutOfLineBuffers) -> Result<Vec<EncodeTask>> {
+        let encode_tasks = self.descriptor_encoder.flush(external_buffers)?;
+        let def_meaning = self
+            .def_meaning
+            .clone()
+            .unwrap_or_else(|| Arc::new([DefinitionInterpretation::AllValidItem]));
+        Ok(Self::wrap_tasks_delta(encode_tasks, def_meaning))
     }
 
     fn finish(
@@ -798,6 +1057,119 @@ mod tests {
             Some(Arc::new(expected_descriptor)),
             &TestCases::default().with_min_file_version(LanceFileVersion::V2_2),
             blob_metadata,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delta_blob_round_trip_similar_values() {
+        let delta_blob_metadata = HashMap::from([
+            (lance_arrow::DELTA_BLOB_META_KEY.to_string(), "true".to_string()),
+        ]);
+
+        // Simulate successive versions of a source file
+        let v1 = b"fn main() {\n    println!(\"hello world\");\n    let x = 1;\n    let y = 2;\n}\n";
+        let v2 = b"fn main() {\n    println!(\"hello lance\");\n    let x = 1;\n    let y = 2;\n}\n";
+        let v3 = b"fn main() {\n    println!(\"hello lance\");\n    let x = 1;\n    let y = 3;\n}\n";
+        let v4 = b"fn main() {\n    println!(\"hello lance\");\n    let x = 1;\n    let y = 3;\n    let z = 4;\n}\n";
+
+        let array = Arc::new(LargeBinaryArray::from(vec![
+            Some(v1.as_ref()),
+            Some(v2.as_ref()),
+            Some(v3.as_ref()),
+            Some(v4.as_ref()),
+        ]));
+
+        check_round_trip_encoding_of_data(
+            vec![array],
+            &TestCases::default()
+                .with_min_file_version(LanceFileVersion::V2_1)
+                .with_max_file_version(LanceFileVersion::V2_1),
+            delta_blob_metadata,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delta_blob_round_trip_with_nulls() {
+        let delta_blob_metadata = HashMap::from([
+            (lance_arrow::DELTA_BLOB_META_KEY.to_string(), "true".to_string()),
+        ]);
+
+        let v1: &[u8] = b"line 1\nline 2\nline 3\n";
+        let v2: &[u8] = b"line 1\nline 2 modified\nline 3\n";
+
+        let array = Arc::new(LargeBinaryArray::from(vec![
+            Some(v1),
+            None,
+            Some(v2),
+        ]));
+
+        check_round_trip_encoding_of_data(
+            vec![array],
+            &TestCases::default()
+                .with_min_file_version(LanceFileVersion::V2_1)
+                .with_max_file_version(LanceFileVersion::V2_1),
+            delta_blob_metadata,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delta_blob_round_trip_completely_different() {
+        let delta_blob_metadata = HashMap::from([
+            (lance_arrow::DELTA_BLOB_META_KEY.to_string(), "true".to_string()),
+        ]);
+
+        // Completely different values — delta won't help, should fall back to base
+        let v1: &[u8] = &vec![0xAAu8; 256];
+        let v2: &[u8] = &vec![0xBBu8; 256];
+        let v3: &[u8] = &vec![0xCCu8; 256];
+
+        let array = Arc::new(LargeBinaryArray::from(vec![
+            Some(v1),
+            Some(v2),
+            Some(v3),
+        ]));
+
+        check_round_trip_encoding_of_data(
+            vec![array],
+            &TestCases::default()
+                .with_min_file_version(LanceFileVersion::V2_1)
+                .with_max_file_version(LanceFileVersion::V2_1),
+            delta_blob_metadata,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_delta_blob_round_trip_larger_source_code() {
+        let delta_blob_metadata = HashMap::from([
+            (lance_arrow::DELTA_BLOB_META_KEY.to_string(), "true".to_string()),
+        ]);
+
+        let mut base = String::new();
+        for i in 0..50 {
+            base.push_str(&format!("line {}: the quick brown fox jumps over the lazy dog\n", i));
+        }
+        let mut v2 = base.clone();
+        v2 = v2.replace("line 10:", "line 10 MODIFIED:");
+        let mut v3 = v2.clone();
+        v3 = v3.replace("line 25:", "line 25 MODIFIED:");
+        v3.push_str("// appended line\n");
+
+        let array = Arc::new(LargeBinaryArray::from(vec![
+            Some(base.as_bytes()),
+            Some(v2.as_bytes()),
+            Some(v3.as_bytes()),
+        ]));
+
+        check_round_trip_encoding_of_data(
+            vec![array],
+            &TestCases::default()
+                .with_min_file_version(LanceFileVersion::V2_1)
+                .with_max_file_version(LanceFileVersion::V2_1),
+            delta_blob_metadata,
         )
         .await;
     }

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -324,72 +324,74 @@ impl FieldEncoder for BlobV2StructuralEncoder {
         let mut uri_builder = StringBuilder::with_capacity(row_count, row_count * 16);
 
         for i in 0..row_count {
-            let (kind_value, position_value, size_value, blob_id_value, uri_value) =
-                if struct_arr.is_null(i) || kind_col.is_null(i) {
-                    (BlobKind::Inline as u8, 0, 0, 0, "".to_string())
-                } else {
-                    let kind_val = BlobKind::try_from(kind_col.value(i))?;
-                    match kind_val {
-                        BlobKind::Dedicated => (
-                            BlobKind::Dedicated as u8,
-                            0,
-                            blob_size_col.value(i),
-                            blob_id_col.value(i),
-                            "".to_string(),
-                        ),
-                        BlobKind::External => {
-                            let uri = uri_col.value(i).to_string();
-                            let position = if packed_position_col.is_null(i) {
-                                0
-                            } else {
-                                packed_position_col.value(i)
-                            };
-                            let size = if blob_size_col.is_null(i) {
-                                0
-                            } else {
-                                blob_size_col.value(i)
-                            };
-                            let external_base_id = if blob_id_col.is_null(i) {
-                                0
-                            } else {
-                                blob_id_col.value(i)
-                            };
-                            (
-                                BlobKind::External as u8,
-                                position,
-                                size,
-                                external_base_id,
-                                uri,
-                            )
-                        }
-                        BlobKind::Packed => (
-                            BlobKind::Packed as u8,
-                            packed_position_col.value(i),
-                            blob_size_col.value(i),
-                            blob_id_col.value(i),
-                            "".to_string(),
-                        ),
-                        BlobKind::Inline => {
-                            let data_val = data_col.value(i);
-                            let blob_len = data_val.len() as u64;
-                            let position = external_buffers
-                                .add_buffer(LanceBuffer::from(Buffer::from(data_val)));
+            let (kind_value, position_value, size_value, blob_id_value, uri_value) = if struct_arr
+                .is_null(i)
+                || kind_col.is_null(i)
+            {
+                (BlobKind::Inline as u8, 0, 0, 0, "".to_string())
+            } else {
+                let kind_val = BlobKind::try_from(kind_col.value(i))?;
+                match kind_val {
+                    BlobKind::Dedicated => (
+                        BlobKind::Dedicated as u8,
+                        0,
+                        blob_size_col.value(i),
+                        blob_id_col.value(i),
+                        "".to_string(),
+                    ),
+                    BlobKind::External => {
+                        let uri = uri_col.value(i).to_string();
+                        let position = if packed_position_col.is_null(i) {
+                            0
+                        } else {
+                            packed_position_col.value(i)
+                        };
+                        let size = if blob_size_col.is_null(i) {
+                            0
+                        } else {
+                            blob_size_col.value(i)
+                        };
+                        let external_base_id = if blob_id_col.is_null(i) {
+                            0
+                        } else {
+                            blob_id_col.value(i)
+                        };
+                        (
+                            BlobKind::External as u8,
+                            position,
+                            size,
+                            external_base_id,
+                            uri,
+                        )
+                    }
+                    BlobKind::Packed => (
+                        BlobKind::Packed as u8,
+                        packed_position_col.value(i),
+                        blob_size_col.value(i),
+                        blob_id_col.value(i),
+                        "".to_string(),
+                    ),
+                    BlobKind::Inline => {
+                        let data_val = data_col.value(i);
+                        let blob_len = data_val.len() as u64;
+                        let position =
+                            external_buffers.add_buffer(LanceBuffer::from(Buffer::from(data_val)));
 
-                            (
-                                BlobKind::Inline as u8,
-                                position,
-                                blob_len,
-                                0,
-                                "".to_string(),
-                            )
-                        }
-                        BlobKind::DeltaBase | BlobKind::Delta => {
-                            return Err(Error::invalid_input_source(
+                        (
+                            BlobKind::Inline as u8,
+                            position,
+                            blob_len,
+                            0,
+                            "".to_string(),
+                        )
+                    }
+                    BlobKind::DeltaBase | BlobKind::Delta => {
+                        return Err(Error::invalid_input_source(
                                 "DeltaBase/Delta blob kinds are not supported in BlobV2StructuralEncoder; use DeltaBlobStructuralEncoder".into(),
                             ));
-                        }
                     }
-                };
+                }
+            };
 
             kind_builder.append_value(kind_value);
             position_builder.append_value(position_value);
@@ -600,8 +602,7 @@ impl FieldEncoder for DeltaBlobStructuralEncoder {
 
             if should_start_new_base {
                 // Store as base
-                let position =
-                    external_buffers.add_buffer(LanceBuffer::from(Buffer::from(value)));
+                let position = external_buffers.add_buffer(LanceBuffer::from(Buffer::from(value)));
                 positions.push(position);
                 sizes.push(value.len() as u64);
                 kinds.push(BlobKind::DeltaBase as u8);
@@ -1063,14 +1064,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_delta_blob_round_trip_similar_values() {
-        let delta_blob_metadata = HashMap::from([
-            (lance_arrow::DELTA_BLOB_META_KEY.to_string(), "true".to_string()),
-        ]);
+        let delta_blob_metadata = HashMap::from([(
+            lance_arrow::DELTA_BLOB_META_KEY.to_string(),
+            "true".to_string(),
+        )]);
 
         // Simulate successive versions of a source file
-        let v1 = b"fn main() {\n    println!(\"hello world\");\n    let x = 1;\n    let y = 2;\n}\n";
-        let v2 = b"fn main() {\n    println!(\"hello lance\");\n    let x = 1;\n    let y = 2;\n}\n";
-        let v3 = b"fn main() {\n    println!(\"hello lance\");\n    let x = 1;\n    let y = 3;\n}\n";
+        let v1 =
+            b"fn main() {\n    println!(\"hello world\");\n    let x = 1;\n    let y = 2;\n}\n";
+        let v2 =
+            b"fn main() {\n    println!(\"hello lance\");\n    let x = 1;\n    let y = 2;\n}\n";
+        let v3 =
+            b"fn main() {\n    println!(\"hello lance\");\n    let x = 1;\n    let y = 3;\n}\n";
         let v4 = b"fn main() {\n    println!(\"hello lance\");\n    let x = 1;\n    let y = 3;\n    let z = 4;\n}\n";
 
         let array = Arc::new(LargeBinaryArray::from(vec![
@@ -1092,18 +1097,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_delta_blob_round_trip_with_nulls() {
-        let delta_blob_metadata = HashMap::from([
-            (lance_arrow::DELTA_BLOB_META_KEY.to_string(), "true".to_string()),
-        ]);
+        let delta_blob_metadata = HashMap::from([(
+            lance_arrow::DELTA_BLOB_META_KEY.to_string(),
+            "true".to_string(),
+        )]);
 
         let v1: &[u8] = b"line 1\nline 2\nline 3\n";
         let v2: &[u8] = b"line 1\nline 2 modified\nline 3\n";
 
-        let array = Arc::new(LargeBinaryArray::from(vec![
-            Some(v1),
-            None,
-            Some(v2),
-        ]));
+        let array = Arc::new(LargeBinaryArray::from(vec![Some(v1), None, Some(v2)]));
 
         check_round_trip_encoding_of_data(
             vec![array],
@@ -1117,20 +1119,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_delta_blob_round_trip_completely_different() {
-        let delta_blob_metadata = HashMap::from([
-            (lance_arrow::DELTA_BLOB_META_KEY.to_string(), "true".to_string()),
-        ]);
+        let delta_blob_metadata = HashMap::from([(
+            lance_arrow::DELTA_BLOB_META_KEY.to_string(),
+            "true".to_string(),
+        )]);
 
         // Completely different values — delta won't help, should fall back to base
         let v1: &[u8] = &vec![0xAAu8; 256];
         let v2: &[u8] = &vec![0xBBu8; 256];
         let v3: &[u8] = &vec![0xCCu8; 256];
 
-        let array = Arc::new(LargeBinaryArray::from(vec![
-            Some(v1),
-            Some(v2),
-            Some(v3),
-        ]));
+        let array = Arc::new(LargeBinaryArray::from(vec![Some(v1), Some(v2), Some(v3)]));
 
         check_round_trip_encoding_of_data(
             vec![array],
@@ -1144,13 +1143,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_delta_blob_round_trip_larger_source_code() {
-        let delta_blob_metadata = HashMap::from([
-            (lance_arrow::DELTA_BLOB_META_KEY.to_string(), "true".to_string()),
-        ]);
+        let delta_blob_metadata = HashMap::from([(
+            lance_arrow::DELTA_BLOB_META_KEY.to_string(),
+            "true".to_string(),
+        )]);
 
         let mut base = String::new();
         for i in 0..50 {
-            base.push_str(&format!("line {}: the quick brown fox jumps over the lazy dog\n", i));
+            base.push_str(&format!(
+                "line {}: the quick brown fox jumps over the lazy dog\n",
+                i
+            ));
         }
         let mut v2 = base.clone();
         v2 = v2.replace("line 10:", "line 10 MODIFIED:");

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -17,7 +17,9 @@ use crate::{
         STRUCTURAL_ENCODING_FULLZIP, STRUCTURAL_ENCODING_META_KEY, STRUCTURAL_ENCODING_MINIBLOCK,
     },
     data::DictionaryDataBlock,
-    encodings::logical::primitive::blob::{BlobDescriptionPageScheduler, BlobPageScheduler, DeltaBlobPageScheduler},
+    encodings::logical::primitive::blob::{
+        BlobDescriptionPageScheduler, BlobPageScheduler, DeltaBlobPageScheduler,
+    },
     format::{
         ProtobufUtils21,
         pb21::{self, CompressiveEncoding, PageLayout, compressive_encoding::Compression},

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -17,7 +17,7 @@ use crate::{
         STRUCTURAL_ENCODING_FULLZIP, STRUCTURAL_ENCODING_META_KEY, STRUCTURAL_ENCODING_MINIBLOCK,
     },
     data::DictionaryDataBlock,
-    encodings::logical::primitive::blob::{BlobDescriptionPageScheduler, BlobPageScheduler},
+    encodings::logical::primitive::blob::{BlobDescriptionPageScheduler, BlobPageScheduler, DeltaBlobPageScheduler},
     format::{
         ProtobufUtils21,
         pb21::{self, CompressiveEncoding, PageLayout, compressive_encoding::Compression},
@@ -3346,6 +3346,26 @@ impl StructuralPrimitiveFieldScheduler {
                         def_meaning.into(),
                     ))
                 }
+            }
+            Layout::DeltaBlobLayout(delta_blob) => {
+                let inner_scheduler = Self::page_layout_to_scheduler(
+                    page_info,
+                    delta_blob.inner_layout.as_ref().expect_ok()?.as_ref(),
+                    decompressors,
+                    cache_repetition_index,
+                    target_field,
+                )?;
+                let def_meaning = delta_blob
+                    .layers
+                    .iter()
+                    .map(|l| ProtobufUtils21::repdef_layer_to_def_interp(*l))
+                    .collect::<Vec<_>>();
+                Box::new(DeltaBlobPageScheduler::new(
+                    inner_scheduler,
+                    page_info.priority,
+                    page_info.num_rows,
+                    def_meaning.into(),
+                ))
             }
         })
     }

--- a/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
@@ -518,3 +518,280 @@ impl DecodePageTask for BlobDecodePageTask {
         })
     }
 }
+
+// ---------------------------------------------------------------------------
+// Delta blob decoding
+// ---------------------------------------------------------------------------
+
+use arrow_array::{UInt32Array, UInt8Array};
+use lance_core::datatypes::{BlobKind, DELTA_BLOB_DESC_TYPE};
+
+struct DeltaBlobCacheableState {
+    positions: Arc<UInt64Array>,
+    sizes: Arc<UInt64Array>,
+    kinds: Arc<UInt8Array>,
+    base_offsets: Arc<UInt32Array>,
+    inner_state: Arc<dyn CachedPageData>,
+}
+
+impl DeepSizeOf for DeltaBlobCacheableState {
+    fn deep_size_of_children(&self, context: &mut lance_core::cache::Context) -> usize {
+        self.positions.get_array_memory_size()
+            + self.sizes.get_array_memory_size()
+            + self.kinds.get_array_memory_size()
+            + self.base_offsets.get_array_memory_size()
+            + self.inner_state.deep_size_of_children(context)
+    }
+}
+
+impl CachedPageData for DeltaBlobCacheableState {
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
+        self
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct DeltaBlobPageScheduler {
+    inner_scheduler: Box<dyn StructuralPageScheduler>,
+    row_number: u64,
+    num_rows: u64,
+    def_meaning: Arc<[DefinitionInterpretation]>,
+    positions: Option<Arc<UInt64Array>>,
+    sizes: Option<Arc<UInt64Array>>,
+    kinds: Option<Arc<UInt8Array>>,
+    base_offsets: Option<Arc<UInt32Array>>,
+}
+
+impl DeltaBlobPageScheduler {
+    pub fn new(
+        inner_scheduler: Box<dyn StructuralPageScheduler>,
+        row_number: u64,
+        num_rows: u64,
+        def_meaning: Arc<[DefinitionInterpretation]>,
+    ) -> Self {
+        Self {
+            inner_scheduler,
+            row_number,
+            num_rows,
+            def_meaning,
+            positions: None,
+            sizes: None,
+            kinds: None,
+            base_offsets: None,
+        }
+    }
+}
+
+impl StructuralPageScheduler for DeltaBlobPageScheduler {
+    fn initialize<'a>(
+        &'a mut self,
+        io: &Arc<dyn EncodingsIo>,
+    ) -> BoxFuture<'a, Result<Arc<dyn CachedPageData>>> {
+        let io = io.clone();
+        let num_rows = self.num_rows;
+        async move {
+            let cached = self.inner_scheduler.initialize(&io).await?;
+            let mut desc_decoders = self.inner_scheduler.schedule_ranges(&[0..num_rows], &io)?;
+            if desc_decoders.len() != 1 {
+                return Err(Error::not_supported_source(
+                    "Expected exactly one descriptor decoder".into(),
+                ));
+            }
+            let desc_decoder_task = desc_decoders.pop().unwrap();
+            let mut desc_decoder = desc_decoder_task.decoder_fut.await?;
+
+            let descs = desc_decoder.drain(desc_decoder_task.num_rows)?;
+            let descs = descs.decode()?;
+            let descs = make_array(descs.data.into_arrow(DELTA_BLOB_DESC_TYPE.clone(), true)?);
+            let descs = descs.as_struct();
+
+            let positions = Arc::new(descs.column(0).as_any().downcast_ref::<UInt64Array>().unwrap().clone());
+            let sizes = Arc::new(descs.column(1).as_any().downcast_ref::<UInt64Array>().unwrap().clone());
+            let kinds = Arc::new(descs.column(2).as_any().downcast_ref::<UInt8Array>().unwrap().clone());
+            let base_offsets = Arc::new(descs.column(3).as_any().downcast_ref::<UInt32Array>().unwrap().clone());
+
+            self.positions = Some(positions.clone());
+            self.sizes = Some(sizes.clone());
+            self.kinds = Some(kinds.clone());
+            self.base_offsets = Some(base_offsets.clone());
+
+            let state = Arc::new(DeltaBlobCacheableState {
+                inner_state: cached,
+                positions,
+                sizes,
+                kinds,
+                base_offsets,
+            });
+            Ok(state as Arc<dyn CachedPageData>)
+        }
+        .boxed()
+    }
+
+    fn load(&mut self, data: &Arc<dyn CachedPageData>) {
+        let state = data
+            .clone()
+            .as_arc_any()
+            .downcast::<DeltaBlobCacheableState>()
+            .unwrap();
+        self.positions = Some(state.positions.clone());
+        self.sizes = Some(state.sizes.clone());
+        self.kinds = Some(state.kinds.clone());
+        self.base_offsets = Some(state.base_offsets.clone());
+        self.inner_scheduler.load(&state.inner_state);
+    }
+
+    fn schedule_ranges(
+        &self,
+        ranges: &[Range<u64>],
+        io: &Arc<dyn EncodingsIo>,
+    ) -> Result<Vec<PageLoadTask>> {
+        let positions = self.positions.as_ref().expect_ok()?;
+        let sizes = self.sizes.as_ref().expect_ok()?;
+        let kinds = self.kinds.as_ref().expect_ok()?;
+        let base_offsets = self.base_offsets.as_ref().expect_ok()?;
+
+        let mut page_load_tasks = Vec::new();
+
+        for range in ranges {
+            // Expand range to include all required base values for any delta in the range.
+            // For each row, if it's a Delta, we need to walk back base_offset rows to find the base,
+            // plus all intermediate deltas in the chain.
+            let mut min_row = range.start;
+            for row in range.start..range.end {
+                let kind = BlobKind::try_from(kinds.value(row as usize))?;
+                if kind == BlobKind::Delta {
+                    let base_off = base_offsets.value(row as usize) as u64;
+                    let base_row = row.saturating_sub(base_off);
+                    if base_row < min_row {
+                        min_row = base_row;
+                    }
+                }
+            }
+
+            // Load all rows in [min_row, range.end) from external buffers
+            let expanded_start = min_row;
+            let expanded_end = range.end;
+
+            let mut ranges_to_read = Vec::new();
+            let mut row_indices = Vec::new();
+
+            for row in expanded_start..expanded_end {
+                let position = positions.value(row as usize);
+                let size = sizes.value(row as usize);
+                let kind = BlobKind::try_from(kinds.value(row as usize))?;
+
+                if size > 0 && (kind == BlobKind::DeltaBase || kind == BlobKind::Delta) {
+                    ranges_to_read.push(position..(position + size));
+                    row_indices.push(row);
+                }
+            }
+
+            let first_row_number = expanded_start + self.row_number;
+            let read_fut = io.submit_request(ranges_to_read, first_row_number);
+            let num_output_rows = (range.end - range.start) as u64;
+
+            // Clone the descriptor arrays for the expanded range
+            let exp_positions = positions.clone();
+            let exp_sizes = sizes.clone();
+            let exp_kinds = kinds.clone();
+            let exp_base_offsets = base_offsets.clone();
+            let def_meaning = self.def_meaning.clone();
+            let req_start = range.start;
+            let req_end = range.end;
+            let exp_start = expanded_start;
+
+            let decoder_fut = async move {
+                let bytes = read_fut.await?;
+
+                // Map row index -> loaded bytes
+                let mut row_bytes: std::collections::HashMap<u64, Bytes> = std::collections::HashMap::new();
+                for (idx, b) in row_indices.into_iter().zip(bytes.into_iter()) {
+                    row_bytes.insert(idx, b);
+                }
+
+                // Reconstruct all values in expanded range
+                let mut reconstructed: std::collections::HashMap<u64, Vec<u8>> = std::collections::HashMap::new();
+
+                for row in exp_start..req_end {
+                    let kind = BlobKind::try_from(exp_kinds.value(row as usize))
+                        .map_err(|e| Error::internal(format!("Invalid blob kind: {e}")))?;
+
+                    match kind {
+                        BlobKind::DeltaBase => {
+                            if let Some(b) = row_bytes.get(&row) {
+                                reconstructed.insert(row, b.to_vec());
+                            }
+                        }
+                        BlobKind::Delta => {
+                            let _base_off = exp_base_offsets.value(row as usize) as u64;
+                            // Walk back: this delta is against (row - 1)'s reconstructed value
+                            // base_offset tells us how far back the BASE is, but the delta is
+                            // against the previous value in the chain
+                            let prev_row = row - 1;
+                            let prev_data = reconstructed.get(&prev_row)
+                                .ok_or_else(|| Error::internal(
+                                    format!("Delta at row {row} references row {prev_row} which is not reconstructed")
+                                ))?;
+                            let delta_bytes = row_bytes.get(&row)
+                                .ok_or_else(|| Error::internal(
+                                    format!("Missing delta bytes for row {row}")
+                                ))?;
+
+                            let restored = crate::encodings::physical::delta::apply_delta(
+                                prev_data,
+                                delta_bytes,
+                            )
+                            .map_err(|e| Error::internal(format!("Delta apply failed at row {row}: {e}")))?;
+                            reconstructed.insert(row, restored);
+                        }
+                        BlobKind::Inline => {
+                            // size == 0: null or empty
+                        }
+                        _ => {
+                            return Err(Error::internal(
+                                format!("Unexpected blob kind {:?} in delta blob decoder", kind),
+                            ));
+                        }
+                    }
+                }
+
+                // Build LoadedBlob for the requested range only
+                let mut loaded_blobs = Vec::with_capacity(num_output_rows as usize);
+                for row in req_start..req_end {
+                    let size = exp_sizes.value(row as usize);
+                    let position = exp_positions.value(row as usize);
+                    let kind = BlobKind::try_from(exp_kinds.value(row as usize))
+                        .map_err(|e| Error::internal(format!("Invalid blob kind: {e}")))?;
+
+                    if size == 0 && kind == BlobKind::Inline {
+                        // Null or empty — extract repdef from position
+                        if position == 0 {
+                            loaded_blobs.push(LoadedBlob::new(0, 0));
+                        } else {
+                            let rep = (position & 0xFFFF) as u16;
+                            let def = ((position >> 16) & 0xFFFF) as u16;
+                            loaded_blobs.push(LoadedBlob::new(rep, def));
+                        }
+                    } else if let Some(data) = reconstructed.remove(&row) {
+                        let mut blob = LoadedBlob::new(0, 0);
+                        blob.set_bytes(Bytes::from(data));
+                        loaded_blobs.push(blob);
+                    } else {
+                        loaded_blobs.push(LoadedBlob::new(0, 0));
+                    }
+                }
+
+                Ok(Box::new(BlobPageDecoder::new(loaded_blobs, def_meaning))
+                    as Box<dyn StructuralPageDecoder>)
+            }
+            .boxed();
+
+            page_load_tasks.push(PageLoadTask {
+                decoder_fut,
+                num_rows: num_output_rows,
+            });
+        }
+
+        Ok(page_load_tasks)
+    }
+}

--- a/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
@@ -523,7 +523,7 @@ impl DecodePageTask for BlobDecodePageTask {
 // Delta blob decoding
 // ---------------------------------------------------------------------------
 
-use arrow_array::{UInt32Array, UInt8Array};
+use arrow_array::{UInt8Array, UInt32Array};
 use lance_core::datatypes::{BlobKind, DELTA_BLOB_DESC_TYPE};
 
 struct DeltaBlobCacheableState {
@@ -605,10 +605,38 @@ impl StructuralPageScheduler for DeltaBlobPageScheduler {
             let descs = make_array(descs.data.into_arrow(DELTA_BLOB_DESC_TYPE.clone(), true)?);
             let descs = descs.as_struct();
 
-            let positions = Arc::new(descs.column(0).as_any().downcast_ref::<UInt64Array>().unwrap().clone());
-            let sizes = Arc::new(descs.column(1).as_any().downcast_ref::<UInt64Array>().unwrap().clone());
-            let kinds = Arc::new(descs.column(2).as_any().downcast_ref::<UInt8Array>().unwrap().clone());
-            let base_offsets = Arc::new(descs.column(3).as_any().downcast_ref::<UInt32Array>().unwrap().clone());
+            let positions = Arc::new(
+                descs
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .clone(),
+            );
+            let sizes = Arc::new(
+                descs
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .clone(),
+            );
+            let kinds = Arc::new(
+                descs
+                    .column(2)
+                    .as_any()
+                    .downcast_ref::<UInt8Array>()
+                    .unwrap()
+                    .clone(),
+            );
+            let base_offsets = Arc::new(
+                descs
+                    .column(3)
+                    .as_any()
+                    .downcast_ref::<UInt32Array>()
+                    .unwrap()
+                    .clone(),
+            );
 
             self.positions = Some(positions.clone());
             self.sizes = Some(sizes.clone());
@@ -688,7 +716,7 @@ impl StructuralPageScheduler for DeltaBlobPageScheduler {
 
             let first_row_number = expanded_start + self.row_number;
             let read_fut = io.submit_request(ranges_to_read, first_row_number);
-            let num_output_rows = (range.end - range.start) as u64;
+            let num_output_rows = range.end - range.start;
 
             // Clone the descriptor arrays for the expanded range
             let exp_positions = positions.clone();

--- a/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
@@ -722,7 +722,6 @@ impl StructuralPageScheduler for DeltaBlobPageScheduler {
             let exp_positions = positions.clone();
             let exp_sizes = sizes.clone();
             let exp_kinds = kinds.clone();
-            let exp_base_offsets = base_offsets.clone();
             let def_meaning = self.def_meaning.clone();
             let req_start = range.start;
             let req_end = range.end;
@@ -737,8 +736,11 @@ impl StructuralPageScheduler for DeltaBlobPageScheduler {
                     row_bytes.insert(idx, b);
                 }
 
-                // Reconstruct all values in expanded range
-                let mut reconstructed: std::collections::HashMap<u64, Vec<u8>> = std::collections::HashMap::new();
+                // Reconstruct all values in expanded range, tracking the
+                // last reconstructed row to handle nulls/empties in the chain.
+                let mut reconstructed: std::collections::HashMap<u64, Vec<u8>> =
+                    std::collections::HashMap::new();
+                let mut last_reconstructed_row: Option<u64> = None;
 
                 for row in exp_start..req_end {
                     let kind = BlobKind::try_from(exp_kinds.value(row as usize))
@@ -748,32 +750,40 @@ impl StructuralPageScheduler for DeltaBlobPageScheduler {
                         BlobKind::DeltaBase => {
                             if let Some(b) = row_bytes.get(&row) {
                                 reconstructed.insert(row, b.to_vec());
+                                last_reconstructed_row = Some(row);
                             }
                         }
                         BlobKind::Delta => {
-                            let _base_off = exp_base_offsets.value(row as usize) as u64;
-                            // Walk back: this delta is against (row - 1)'s reconstructed value
-                            // base_offset tells us how far back the BASE is, but the delta is
-                            // against the previous value in the chain
-                            let prev_row = row - 1;
-                            let prev_data = reconstructed.get(&prev_row)
-                                .ok_or_else(|| Error::internal(
-                                    format!("Delta at row {row} references row {prev_row} which is not reconstructed")
-                                ))?;
-                            let delta_bytes = row_bytes.get(&row)
-                                .ok_or_else(|| Error::internal(
-                                    format!("Missing delta bytes for row {row}")
-                                ))?;
+                            let prev_row = last_reconstructed_row.ok_or_else(|| {
+                                Error::internal(format!(
+                                    "Delta at row {row} has no preceding reconstructed value"
+                                ))
+                            })?;
+                            let prev_data =
+                                reconstructed.get(&prev_row).ok_or_else(|| {
+                                    Error::internal(format!(
+                                    "Delta at row {row} references row {prev_row} which is not reconstructed"
+                                ))
+                                })?;
+                            let delta_bytes = row_bytes.get(&row).ok_or_else(|| {
+                                Error::internal(format!("Missing delta bytes for row {row}"))
+                            })?;
 
-                            let restored = crate::encodings::physical::delta::apply_delta(
-                                prev_data,
-                                delta_bytes,
-                            )
-                            .map_err(|e| Error::internal(format!("Delta apply failed at row {row}: {e}")))?;
+                            let restored =
+                                crate::encodings::physical::delta::apply_delta(
+                                    prev_data,
+                                    delta_bytes,
+                                )
+                                .map_err(|e| {
+                                    Error::internal(format!(
+                                        "Delta apply failed at row {row}: {e}"
+                                    ))
+                                })?;
                             reconstructed.insert(row, restored);
+                            last_reconstructed_row = Some(row);
                         }
                         BlobKind::Inline => {
-                            // size == 0: null or empty
+                            // size == 0: null or empty — do not update last_reconstructed_row
                         }
                         _ => {
                             return Err(Error::internal(

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -2,12 +2,12 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 pub mod binary;
-pub mod delta;
 #[cfg(feature = "bitpacking")]
 pub mod bitpacking;
 pub mod block;
 pub mod byte_stream_split;
 pub mod constant;
+pub mod delta;
 pub mod fsst;
 pub mod general;
 pub mod packed;

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 pub mod binary;
+pub mod delta;
 #[cfg(feature = "bitpacking")]
 pub mod bitpacking;
 pub mod block;

--- a/rust/lance-encoding/src/encodings/physical/delta.rs
+++ b/rust/lance-encoding/src/encodings/physical/delta.rs
@@ -6,8 +6,9 @@
 //! Encodes a target buffer as a series of copy/insert instructions relative
 //! to a source (base) buffer. Copy instructions reference byte ranges in the
 //! source; insert instructions carry literal bytes from the target.
-
-use std::collections::HashMap;
+//!
+//! For best compression, data should be sorted so that similar values
+//! (e.g., successive versions of the same file) are adjacent.
 
 /// Rabin rolling hash window size (bytes).
 const RABIN_WINDOW: usize = 16;
@@ -24,38 +25,71 @@ const MAX_COPY_SIZE: usize = 0xFFFFFF;
 /// Block size for indexing the source buffer (non-overlapping windows).
 const INDEX_BLOCK_SIZE: usize = 16;
 
+/// Delta must be at most this fraction of target size to be worth keeping.
+const DELTA_RATIO_THRESHOLD: f64 = 0.8;
+
+/// Maximum varint bytes for a u64 (ceil(64/7) = 10).
+const MAX_VARINT_BYTES: usize = 10;
+
 // ---------------------------------------------------------------------------
-// Rabin hash helpers
+// Rabin rolling hash
 // ---------------------------------------------------------------------------
 
-/// Simple polynomial rolling hash over a window of bytes.
-/// Not the full Rabin with lookup tables — a simpler variant that's
-/// sufficient for finding matching blocks.
-fn rabin_hash(data: &[u8]) -> u32 {
+const RABIN_MULTIPLIER: u32 = 257;
+
+/// Precomputed RABIN_MULTIPLIER^RABIN_WINDOW mod 2^32, used to remove the
+/// oldest byte's contribution from the rolling hash in O(1).
+#[cfg(test)]
+const RABIN_POW_WINDOW: u32 = {
+    let mut p: u32 = 1;
+    let mut i = 0;
+    while i < RABIN_WINDOW {
+        p = p.wrapping_mul(RABIN_MULTIPLIER);
+        i += 1;
+    }
+    p
+};
+
+/// Compute the initial hash over exactly `RABIN_WINDOW` bytes.
+fn rabin_hash_init(data: &[u8]) -> u32 {
     let mut h: u32 = 0;
-    for &b in data {
-        h = h.wrapping_mul(257).wrapping_add(b as u32);
+    for &b in &data[..RABIN_WINDOW] {
+        h = h.wrapping_mul(RABIN_MULTIPLIER).wrapping_add(b as u32);
     }
     h
 }
 
-/// Index built over the source buffer for fast match lookup.
-struct DeltaIndex {
-    /// Map from hash → list of offsets in the source where that hash occurs.
-    table: HashMap<u32, Vec<usize>>,
-    source: Vec<u8>,
+/// Roll the hash forward: remove `old_byte`, add `new_byte`.
+#[cfg(test)]
+#[inline(always)]
+fn rabin_hash_roll(h: u32, old_byte: u8, new_byte: u8) -> u32 {
+    h.wrapping_mul(RABIN_MULTIPLIER)
+        .wrapping_sub(RABIN_POW_WINDOW.wrapping_mul(old_byte as u32))
+        .wrapping_add(new_byte as u32)
 }
 
-impl DeltaIndex {
-    fn new(source: &[u8]) -> Self {
+// ---------------------------------------------------------------------------
+// Delta index
+// ---------------------------------------------------------------------------
+
+use std::collections::HashMap;
+
+/// Index built over the source buffer for fast match lookup.
+struct DeltaIndex<'a> {
+    /// Map from hash → list of offsets in the source where that hash occurs.
+    table: HashMap<u32, Vec<usize>>,
+    source: &'a [u8],
+}
+
+impl<'a> DeltaIndex<'a> {
+    fn new(source: &'a [u8]) -> Self {
         let mut table: HashMap<u32, Vec<usize>> = HashMap::new();
 
         if source.len() >= RABIN_WINDOW {
             let mut offset = 0;
             while offset + RABIN_WINDOW <= source.len() {
-                let h = rabin_hash(&source[offset..offset + RABIN_WINDOW]);
+                let h = rabin_hash_init(&source[offset..offset + RABIN_WINDOW]);
                 let entries = table.entry(h).or_default();
-                // Limit bucket size to avoid quadratic behavior on repetitive data
                 if entries.len() < 64 {
                     entries.push(offset);
                 }
@@ -63,27 +97,22 @@ impl DeltaIndex {
             }
         }
 
-        Self {
-            table,
-            source: source.to_vec(),
-        }
+        Self { table, source }
     }
 
     /// Find the longest match in the source for target data starting at `target_pos`.
-    /// Returns (source_offset, match_length) or None.
     fn find_match(&self, target: &[u8], target_pos: usize) -> Option<(usize, usize)> {
         if target_pos + RABIN_WINDOW > target.len() {
             return None;
         }
 
-        let h = rabin_hash(&target[target_pos..target_pos + RABIN_WINDOW]);
+        let h = rabin_hash_init(&target[target_pos..target_pos + RABIN_WINDOW]);
         let entries = self.table.get(&h)?;
 
         let mut best_offset = 0;
         let mut best_len = 0;
 
         for &src_offset in entries {
-            // Verify the hash match with actual byte comparison and extend
             let max_len = std::cmp::min(self.source.len() - src_offset, target.len() - target_pos);
 
             let mut len = 0;
@@ -125,11 +154,17 @@ fn encode_varint(mut val: u64, out: &mut Vec<u8>) {
 }
 
 /// Decode a variable-length integer, returning (value, bytes_consumed).
-fn decode_varint(data: &[u8]) -> (u64, usize) {
+fn decode_varint(data: &[u8]) -> Result<(u64, usize), DeltaError> {
     let mut val: u64 = 0;
-    let mut shift = 0;
+    let mut shift: u32 = 0;
     let mut i = 0;
     loop {
+        if i >= data.len() {
+            return Err(DeltaError::Truncated);
+        }
+        if i >= MAX_VARINT_BYTES {
+            return Err(DeltaError::VarIntOverflow);
+        }
         let byte = data[i];
         val |= ((byte & 0x7F) as u64) << shift;
         i += 1;
@@ -138,55 +173,59 @@ fn decode_varint(data: &[u8]) -> (u64, usize) {
         }
         shift += 7;
     }
-    (val, i)
+    Ok((val, i))
 }
 
-/// Encode a copy instruction.
-/// Format: opcode byte with bit 7 set, followed by non-zero offset/size bytes.
+/// Encode a copy instruction using a stack buffer (no heap allocation).
 fn encode_copy(offset: usize, size: usize, out: &mut Vec<u8>) {
     let offset = offset as u32;
     let size = size as u32;
     let mut opcode: u8 = 0x80;
-    let mut extra = Vec::with_capacity(7);
+    let mut extra = [0u8; 7];
+    let mut extra_len = 0;
 
     if offset & 0xFF != 0 {
         opcode |= 0x01;
-        extra.push((offset & 0xFF) as u8);
+        extra[extra_len] = (offset & 0xFF) as u8;
+        extra_len += 1;
     }
     if offset & 0xFF00 != 0 {
         opcode |= 0x02;
-        extra.push(((offset >> 8) & 0xFF) as u8);
+        extra[extra_len] = ((offset >> 8) & 0xFF) as u8;
+        extra_len += 1;
     }
     if offset & 0xFF_0000 != 0 {
         opcode |= 0x04;
-        extra.push(((offset >> 16) & 0xFF) as u8);
+        extra[extra_len] = ((offset >> 16) & 0xFF) as u8;
+        extra_len += 1;
     }
     if offset & 0xFF00_0000 != 0 {
         opcode |= 0x08;
-        extra.push(((offset >> 24) & 0xFF) as u8);
+        extra[extra_len] = ((offset >> 24) & 0xFF) as u8;
+        extra_len += 1;
     }
 
-    // Size: if size == 0x10000, encode as 0 (special case in Git format)
     let encoded_size = if size == 0x10000 { 0u32 } else { size };
     if encoded_size & 0xFF != 0 {
         opcode |= 0x10;
-        extra.push((encoded_size & 0xFF) as u8);
+        extra[extra_len] = (encoded_size & 0xFF) as u8;
+        extra_len += 1;
     }
     if encoded_size & 0xFF00 != 0 {
         opcode |= 0x20;
-        extra.push(((encoded_size >> 8) & 0xFF) as u8);
+        extra[extra_len] = ((encoded_size >> 8) & 0xFF) as u8;
+        extra_len += 1;
     }
     if encoded_size & 0xFF_0000 != 0 {
         opcode |= 0x40;
-        extra.push(((encoded_size >> 16) & 0xFF) as u8);
+        extra[extra_len] = ((encoded_size >> 16) & 0xFF) as u8;
+        extra_len += 1;
     }
 
     out.push(opcode);
-    out.extend_from_slice(&extra);
+    out.extend_from_slice(&extra[..extra_len]);
 }
 
-/// Encode an insert instruction.
-/// Format: opcode byte (1-127) = literal count, followed by that many bytes.
 fn encode_insert(data: &[u8], out: &mut Vec<u8>) {
     debug_assert!(!data.is_empty() && data.len() <= MAX_INSERT_LEN);
     out.push(data.len() as u8);
@@ -199,13 +238,12 @@ fn encode_insert(data: &[u8], out: &mut Vec<u8>) {
 
 /// Create a binary delta that transforms `source` into `target`.
 ///
-/// Returns the encoded delta bytes, or `None` if the delta would be
-/// larger than the target (caller should store the target as-is).
+/// Returns the encoded delta bytes, or `None` if the delta would not
+/// achieve at least a 20% size reduction over storing `target` as-is.
 pub fn create_delta(source: &[u8], target: &[u8]) -> Option<Vec<u8>> {
     let index = DeltaIndex::new(source);
     let mut delta = Vec::with_capacity(target.len() / 2);
 
-    // Header: source size, target size
     encode_varint(source.len() as u64, &mut delta);
     encode_varint(target.len() as u64, &mut delta);
 
@@ -214,12 +252,10 @@ pub fn create_delta(source: &[u8], target: &[u8]) -> Option<Vec<u8>> {
 
     while target_pos < target.len() {
         if let Some((src_offset, match_len)) = index.find_match(target, target_pos) {
-            // Flush pending insert
             if target_pos > insert_start {
                 flush_insert(target, insert_start, target_pos, &mut delta);
             }
 
-            // Emit copy instruction(s), splitting if > MAX_COPY_SIZE
             let mut remaining = match_len;
             let mut off = src_offset;
             while remaining > 0 {
@@ -236,13 +272,12 @@ pub fn create_delta(source: &[u8], target: &[u8]) -> Option<Vec<u8>> {
         }
     }
 
-    // Flush trailing insert
     if target_pos > insert_start {
         flush_insert(target, insert_start, target_pos, &mut delta);
     }
 
-    // Only use delta if it's actually smaller
-    if delta.len() < target.len() {
+    let threshold = (target.len() as f64 * DELTA_RATIO_THRESHOLD) as usize;
+    if delta.len() < threshold {
         Some(delta)
     } else {
         None
@@ -257,8 +292,6 @@ fn flush_insert(target: &[u8], start: usize, end: usize, out: &mut Vec<u8>) {
 }
 
 /// Apply a delta to a source buffer, producing the original target.
-///
-/// Returns an error if the delta is malformed or sizes don't match.
 pub fn apply_delta(source: &[u8], delta: &[u8]) -> Result<Vec<u8>, DeltaError> {
     if delta.is_empty() {
         return Err(DeltaError::Truncated);
@@ -266,10 +299,9 @@ pub fn apply_delta(source: &[u8], delta: &[u8]) -> Result<Vec<u8>, DeltaError> {
 
     let mut pos = 0;
 
-    // Read header
-    let (src_size, n) = decode_varint(&delta[pos..]);
+    let (src_size, n) = decode_varint(&delta[pos..])?;
     pos += n;
-    let (tgt_size, n) = decode_varint(&delta[pos..]);
+    let (tgt_size, n) = decode_varint(&delta[pos..])?;
     pos += n;
 
     if src_size as usize != source.len() {
@@ -286,36 +318,56 @@ pub fn apply_delta(source: &[u8], delta: &[u8]) -> Result<Vec<u8>, DeltaError> {
         pos += 1;
 
         if cmd & 0x80 != 0 {
-            // Copy instruction
             let mut offset: u32 = 0;
             let mut size: u32 = 0;
 
             if cmd & 0x01 != 0 {
+                if pos >= delta.len() {
+                    return Err(DeltaError::Truncated);
+                }
                 offset |= delta[pos] as u32;
                 pos += 1;
             }
             if cmd & 0x02 != 0 {
+                if pos >= delta.len() {
+                    return Err(DeltaError::Truncated);
+                }
                 offset |= (delta[pos] as u32) << 8;
                 pos += 1;
             }
             if cmd & 0x04 != 0 {
+                if pos >= delta.len() {
+                    return Err(DeltaError::Truncated);
+                }
                 offset |= (delta[pos] as u32) << 16;
                 pos += 1;
             }
             if cmd & 0x08 != 0 {
+                if pos >= delta.len() {
+                    return Err(DeltaError::Truncated);
+                }
                 offset |= (delta[pos] as u32) << 24;
                 pos += 1;
             }
 
             if cmd & 0x10 != 0 {
+                if pos >= delta.len() {
+                    return Err(DeltaError::Truncated);
+                }
                 size |= delta[pos] as u32;
                 pos += 1;
             }
             if cmd & 0x20 != 0 {
+                if pos >= delta.len() {
+                    return Err(DeltaError::Truncated);
+                }
                 size |= (delta[pos] as u32) << 8;
                 pos += 1;
             }
             if cmd & 0x40 != 0 {
+                if pos >= delta.len() {
+                    return Err(DeltaError::Truncated);
+                }
                 size |= (delta[pos] as u32) << 16;
                 pos += 1;
             }
@@ -337,7 +389,6 @@ pub fn apply_delta(source: &[u8], delta: &[u8]) -> Result<Vec<u8>, DeltaError> {
 
             output.extend_from_slice(&source[offset..offset + size]);
         } else if cmd > 0 {
-            // Insert instruction
             let len = cmd as usize;
             if pos + len > delta.len() {
                 return Err(DeltaError::Truncated);
@@ -363,14 +414,9 @@ pub fn apply_delta(source: &[u8], delta: &[u8]) -> Result<Vec<u8>, DeltaError> {
 #[derive(Debug)]
 pub enum DeltaError {
     Truncated,
-    SourceSizeMismatch {
-        expected: usize,
-        actual: usize,
-    },
-    TargetSizeMismatch {
-        expected: usize,
-        actual: usize,
-    },
+    VarIntOverflow,
+    SourceSizeMismatch { expected: usize, actual: usize },
+    TargetSizeMismatch { expected: usize, actual: usize },
     CopyOutOfBounds {
         offset: usize,
         size: usize,
@@ -383,6 +429,7 @@ impl std::fmt::Display for DeltaError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Truncated => write!(f, "delta data truncated"),
+            Self::VarIntOverflow => write!(f, "varint exceeds u64 capacity"),
             Self::SourceSizeMismatch { expected, actual } => {
                 write!(f, "source size mismatch: expected {expected}, got {actual}")
             }
@@ -413,35 +460,53 @@ mod tests {
         for val in [0u64, 1, 127, 128, 16383, 16384, u32::MAX as u64, u64::MAX] {
             let mut buf = Vec::new();
             encode_varint(val, &mut buf);
-            let (decoded, len) = decode_varint(&buf);
+            let (decoded, len) = decode_varint(&buf).unwrap();
             assert_eq!(decoded, val);
             assert_eq!(len, buf.len());
         }
     }
 
     #[test]
+    fn test_varint_truncated() {
+        assert!(matches!(decode_varint(&[]), Err(DeltaError::Truncated)));
+        assert!(matches!(
+            decode_varint(&[0x80]),
+            Err(DeltaError::Truncated)
+        ));
+    }
+
+    #[test]
+    fn test_varint_overflow() {
+        // 11 continuation bytes — exceeds MAX_VARINT_BYTES
+        let bad = [0x80u8; 11];
+        assert!(matches!(
+            decode_varint(&bad),
+            Err(DeltaError::VarIntOverflow)
+        ));
+    }
+
+    #[test]
     fn test_identical_buffers() {
         let data = b"Hello, world! This is a test of delta encoding.";
-        let delta = create_delta(data, data).expect("identical data should produce small delta");
-        let restored = apply_delta(data, &delta).unwrap();
-        assert_eq!(restored, data);
+        let delta = create_delta(data, data);
+        if let Some(delta) = &delta {
+            let restored = apply_delta(data, delta).unwrap();
+            assert_eq!(restored, data);
+        }
     }
 
     #[test]
     fn test_small_edit() {
         let source = b"fn main() {\n    println!(\"hello world\");\n}\n";
         let target = b"fn main() {\n    println!(\"hello lance\");\n}\n";
-        let delta = create_delta(source, target);
-        // Whether or not delta is smaller, apply_delta should roundtrip if we have one
-        if let Some(delta) = &delta {
-            let restored = apply_delta(source, delta).unwrap();
+        if let Some(delta) = create_delta(source, target) {
+            let restored = apply_delta(source, &delta).unwrap();
             assert_eq!(restored, target.as_slice());
         }
     }
 
     #[test]
     fn test_larger_similar_files() {
-        // Simulate two versions of a source file
         let mut source = String::new();
         for i in 0..100 {
             source.push_str(&format!(
@@ -450,7 +515,6 @@ mod tests {
             ));
         }
         let mut target = source.clone();
-        // Change a few lines
         target = target.replace("line 10:", "line 10 MODIFIED:");
         target = target.replace("line 50:", "line 50 MODIFIED:");
         target.push_str("// new line at the end\n");
@@ -472,21 +536,18 @@ mod tests {
     fn test_completely_different() {
         let source = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let target = b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-        // Delta might be None (larger than target) or Some
         if let Some(delta) = create_delta(source, target) {
             let restored = apply_delta(source, &delta).unwrap();
             assert_eq!(restored, target.as_slice());
         }
-        // Either way, this shouldn't panic
     }
 
     #[test]
     fn test_empty_target() {
         let source = b"some source data here";
         let target = b"";
-        let delta = create_delta(source, target);
-        if let Some(delta) = &delta {
-            let restored = apply_delta(source, delta).unwrap();
+        if let Some(delta) = create_delta(source, target) {
+            let restored = apply_delta(source, &delta).unwrap();
             assert!(restored.is_empty());
         }
     }
@@ -495,10 +556,8 @@ mod tests {
     fn test_empty_source() {
         let source = b"";
         let target = b"new content";
-        // Delta from empty source = all inserts, likely larger than target
-        let delta = create_delta(source, target);
-        if let Some(delta) = &delta {
-            let restored = apply_delta(source, delta).unwrap();
+        if let Some(delta) = create_delta(source, target) {
+            let restored = apply_delta(source, &delta).unwrap();
             assert_eq!(restored, target.as_slice());
         }
     }
@@ -512,7 +571,6 @@ mod tests {
         let v3 = b"version 3 of the file with some content that stays the same\n\
                     and more lines here\nand a new line\nand another\n";
 
-        // Chain: v1 -> v2 -> v3
         if let Some(d1) = create_delta(v1, v2) {
             let restored_v2 = apply_delta(v1, &d1).unwrap();
             assert_eq!(restored_v2, v2.as_slice());
@@ -571,5 +629,29 @@ fn main() {
 
         let restored = apply_delta(source.as_bytes(), &delta).unwrap();
         assert_eq!(String::from_utf8(restored).unwrap(), target,);
+    }
+
+    #[test]
+    fn test_apply_delta_truncated_copy() {
+        // Craft a delta with a copy instruction that's truncated
+        let source = b"hello world";
+        let mut delta = Vec::new();
+        encode_varint(source.len() as u64, &mut delta);
+        encode_varint(5, &mut delta); // target size 5
+        delta.push(0x81); // copy with offset byte 0 present, but no byte follows
+        assert!(matches!(
+            apply_delta(source, &delta),
+            Err(DeltaError::Truncated)
+        ));
+    }
+
+    #[test]
+    fn test_rolling_hash_consistency() {
+        let data = b"abcdefghijklmnopqrstuvwxyz012345678";
+        let h1 = rabin_hash_init(&data[0..RABIN_WINDOW]);
+        // Roll from position 0 to position 1
+        let h2_rolled = rabin_hash_roll(h1, data[0], data[RABIN_WINDOW]);
+        let h2_direct = rabin_hash_init(&data[1..1 + RABIN_WINDOW]);
+        assert_eq!(h2_rolled, h2_direct);
     }
 }

--- a/rust/lance-encoding/src/encodings/physical/delta.rs
+++ b/rust/lance-encoding/src/encodings/physical/delta.rs
@@ -415,8 +415,14 @@ pub fn apply_delta(source: &[u8], delta: &[u8]) -> Result<Vec<u8>, DeltaError> {
 pub enum DeltaError {
     Truncated,
     VarIntOverflow,
-    SourceSizeMismatch { expected: usize, actual: usize },
-    TargetSizeMismatch { expected: usize, actual: usize },
+    SourceSizeMismatch {
+        expected: usize,
+        actual: usize,
+    },
+    TargetSizeMismatch {
+        expected: usize,
+        actual: usize,
+    },
     CopyOutOfBounds {
         offset: usize,
         size: usize,
@@ -469,10 +475,7 @@ mod tests {
     #[test]
     fn test_varint_truncated() {
         assert!(matches!(decode_varint(&[]), Err(DeltaError::Truncated)));
-        assert!(matches!(
-            decode_varint(&[0x80]),
-            Err(DeltaError::Truncated)
-        ));
+        assert!(matches!(decode_varint(&[0x80]), Err(DeltaError::Truncated)));
     }
 
     #[test]

--- a/rust/lance-encoding/src/encodings/physical/delta.rs
+++ b/rust/lance-encoding/src/encodings/physical/delta.rs
@@ -84,15 +84,10 @@ impl DeltaIndex {
 
         for &src_offset in entries {
             // Verify the hash match with actual byte comparison and extend
-            let max_len = std::cmp::min(
-                self.source.len() - src_offset,
-                target.len() - target_pos,
-            );
+            let max_len = std::cmp::min(self.source.len() - src_offset, target.len() - target_pos);
 
             let mut len = 0;
-            while len < max_len
-                && self.source[src_offset + len] == target[target_pos + len]
-            {
+            while len < max_len && self.source[src_offset + len] == target[target_pos + len] {
                 len += 1;
             }
 
@@ -368,8 +363,14 @@ pub fn apply_delta(source: &[u8], delta: &[u8]) -> Result<Vec<u8>, DeltaError> {
 #[derive(Debug)]
 pub enum DeltaError {
     Truncated,
-    SourceSizeMismatch { expected: usize, actual: usize },
-    TargetSizeMismatch { expected: usize, actual: usize },
+    SourceSizeMismatch {
+        expected: usize,
+        actual: usize,
+    },
+    TargetSizeMismatch {
+        expected: usize,
+        actual: usize,
+    },
     CopyOutOfBounds {
         offset: usize,
         size: usize,
@@ -443,7 +444,10 @@ mod tests {
         // Simulate two versions of a source file
         let mut source = String::new();
         for i in 0..100 {
-            source.push_str(&format!("line {}: the quick brown fox jumps over the lazy dog\n", i));
+            source.push_str(&format!(
+                "line {}: the quick brown fox jumps over the lazy dog\n",
+                i
+            ));
         }
         let mut target = source.clone();
         // Change a few lines
@@ -566,9 +570,6 @@ fn main() {
         assert!(delta.len() < target.len());
 
         let restored = apply_delta(source.as_bytes(), &delta).unwrap();
-        assert_eq!(
-            String::from_utf8(restored).unwrap(),
-            target,
-        );
+        assert_eq!(String::from_utf8(restored).unwrap(), target,);
     }
 }

--- a/rust/lance-encoding/src/encodings/physical/delta.rs
+++ b/rust/lance-encoding/src/encodings/physical/delta.rs
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Binary delta encoding inspired by Git's packfile delta format.
+//!
+//! Encodes a target buffer as a series of copy/insert instructions relative
+//! to a source (base) buffer. Copy instructions reference byte ranges in the
+//! source; insert instructions carry literal bytes from the target.
+
+use std::collections::HashMap;
+
+/// Rabin rolling hash window size (bytes).
+const RABIN_WINDOW: usize = 16;
+
+/// Minimum match length to emit a copy instead of an insert.
+const MIN_COPY_LEN: usize = 4;
+
+/// Maximum insert instruction payload (opcode encodes length in 7 bits).
+const MAX_INSERT_LEN: usize = 127;
+
+/// Maximum copy size per instruction (3 size bytes, but 0 means 0x10000).
+const MAX_COPY_SIZE: usize = 0xFFFFFF;
+
+/// Block size for indexing the source buffer (non-overlapping windows).
+const INDEX_BLOCK_SIZE: usize = 16;
+
+// ---------------------------------------------------------------------------
+// Rabin hash helpers
+// ---------------------------------------------------------------------------
+
+/// Simple polynomial rolling hash over a window of bytes.
+/// Not the full Rabin with lookup tables — a simpler variant that's
+/// sufficient for finding matching blocks.
+fn rabin_hash(data: &[u8]) -> u32 {
+    let mut h: u32 = 0;
+    for &b in data {
+        h = h.wrapping_mul(257).wrapping_add(b as u32);
+    }
+    h
+}
+
+/// Index built over the source buffer for fast match lookup.
+struct DeltaIndex {
+    /// Map from hash → list of offsets in the source where that hash occurs.
+    table: HashMap<u32, Vec<usize>>,
+    source: Vec<u8>,
+}
+
+impl DeltaIndex {
+    fn new(source: &[u8]) -> Self {
+        let mut table: HashMap<u32, Vec<usize>> = HashMap::new();
+
+        if source.len() >= RABIN_WINDOW {
+            let mut offset = 0;
+            while offset + RABIN_WINDOW <= source.len() {
+                let h = rabin_hash(&source[offset..offset + RABIN_WINDOW]);
+                let entries = table.entry(h).or_default();
+                // Limit bucket size to avoid quadratic behavior on repetitive data
+                if entries.len() < 64 {
+                    entries.push(offset);
+                }
+                offset += INDEX_BLOCK_SIZE;
+            }
+        }
+
+        Self {
+            table,
+            source: source.to_vec(),
+        }
+    }
+
+    /// Find the longest match in the source for target data starting at `target_pos`.
+    /// Returns (source_offset, match_length) or None.
+    fn find_match(&self, target: &[u8], target_pos: usize) -> Option<(usize, usize)> {
+        if target_pos + RABIN_WINDOW > target.len() {
+            return None;
+        }
+
+        let h = rabin_hash(&target[target_pos..target_pos + RABIN_WINDOW]);
+        let entries = self.table.get(&h)?;
+
+        let mut best_offset = 0;
+        let mut best_len = 0;
+
+        for &src_offset in entries {
+            // Verify the hash match with actual byte comparison and extend
+            let max_len = std::cmp::min(
+                self.source.len() - src_offset,
+                target.len() - target_pos,
+            );
+
+            let mut len = 0;
+            while len < max_len
+                && self.source[src_offset + len] == target[target_pos + len]
+            {
+                len += 1;
+            }
+
+            if len >= MIN_COPY_LEN && len > best_len {
+                best_len = len;
+                best_offset = src_offset;
+            }
+        }
+
+        if best_len >= MIN_COPY_LEN {
+            Some((best_offset, best_len))
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Instruction encoding (Git-compatible format)
+// ---------------------------------------------------------------------------
+
+/// Encode a variable-length integer (LEB128 unsigned).
+fn encode_varint(mut val: u64, out: &mut Vec<u8>) {
+    loop {
+        let mut byte = (val & 0x7F) as u8;
+        val >>= 7;
+        if val > 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if val == 0 {
+            break;
+        }
+    }
+}
+
+/// Decode a variable-length integer, returning (value, bytes_consumed).
+fn decode_varint(data: &[u8]) -> (u64, usize) {
+    let mut val: u64 = 0;
+    let mut shift = 0;
+    let mut i = 0;
+    loop {
+        let byte = data[i];
+        val |= ((byte & 0x7F) as u64) << shift;
+        i += 1;
+        if byte & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+    }
+    (val, i)
+}
+
+/// Encode a copy instruction.
+/// Format: opcode byte with bit 7 set, followed by non-zero offset/size bytes.
+fn encode_copy(offset: usize, size: usize, out: &mut Vec<u8>) {
+    let offset = offset as u32;
+    let size = size as u32;
+    let mut opcode: u8 = 0x80;
+    let mut extra = Vec::with_capacity(7);
+
+    if offset & 0xFF != 0 {
+        opcode |= 0x01;
+        extra.push((offset & 0xFF) as u8);
+    }
+    if offset & 0xFF00 != 0 {
+        opcode |= 0x02;
+        extra.push(((offset >> 8) & 0xFF) as u8);
+    }
+    if offset & 0xFF_0000 != 0 {
+        opcode |= 0x04;
+        extra.push(((offset >> 16) & 0xFF) as u8);
+    }
+    if offset & 0xFF00_0000 != 0 {
+        opcode |= 0x08;
+        extra.push(((offset >> 24) & 0xFF) as u8);
+    }
+
+    // Size: if size == 0x10000, encode as 0 (special case in Git format)
+    let encoded_size = if size == 0x10000 { 0u32 } else { size };
+    if encoded_size & 0xFF != 0 {
+        opcode |= 0x10;
+        extra.push((encoded_size & 0xFF) as u8);
+    }
+    if encoded_size & 0xFF00 != 0 {
+        opcode |= 0x20;
+        extra.push(((encoded_size >> 8) & 0xFF) as u8);
+    }
+    if encoded_size & 0xFF_0000 != 0 {
+        opcode |= 0x40;
+        extra.push(((encoded_size >> 16) & 0xFF) as u8);
+    }
+
+    out.push(opcode);
+    out.extend_from_slice(&extra);
+}
+
+/// Encode an insert instruction.
+/// Format: opcode byte (1-127) = literal count, followed by that many bytes.
+fn encode_insert(data: &[u8], out: &mut Vec<u8>) {
+    debug_assert!(!data.is_empty() && data.len() <= MAX_INSERT_LEN);
+    out.push(data.len() as u8);
+    out.extend_from_slice(data);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Create a binary delta that transforms `source` into `target`.
+///
+/// Returns the encoded delta bytes, or `None` if the delta would be
+/// larger than the target (caller should store the target as-is).
+pub fn create_delta(source: &[u8], target: &[u8]) -> Option<Vec<u8>> {
+    let index = DeltaIndex::new(source);
+    let mut delta = Vec::with_capacity(target.len() / 2);
+
+    // Header: source size, target size
+    encode_varint(source.len() as u64, &mut delta);
+    encode_varint(target.len() as u64, &mut delta);
+
+    let mut target_pos = 0;
+    let mut insert_start = 0;
+
+    while target_pos < target.len() {
+        if let Some((src_offset, match_len)) = index.find_match(target, target_pos) {
+            // Flush pending insert
+            if target_pos > insert_start {
+                flush_insert(target, insert_start, target_pos, &mut delta);
+            }
+
+            // Emit copy instruction(s), splitting if > MAX_COPY_SIZE
+            let mut remaining = match_len;
+            let mut off = src_offset;
+            while remaining > 0 {
+                let chunk = std::cmp::min(remaining, MAX_COPY_SIZE);
+                encode_copy(off, chunk, &mut delta);
+                off += chunk;
+                remaining -= chunk;
+            }
+
+            target_pos += match_len;
+            insert_start = target_pos;
+        } else {
+            target_pos += 1;
+        }
+    }
+
+    // Flush trailing insert
+    if target_pos > insert_start {
+        flush_insert(target, insert_start, target_pos, &mut delta);
+    }
+
+    // Only use delta if it's actually smaller
+    if delta.len() < target.len() {
+        Some(delta)
+    } else {
+        None
+    }
+}
+
+fn flush_insert(target: &[u8], start: usize, end: usize, out: &mut Vec<u8>) {
+    let data = &target[start..end];
+    for chunk in data.chunks(MAX_INSERT_LEN) {
+        encode_insert(chunk, out);
+    }
+}
+
+/// Apply a delta to a source buffer, producing the original target.
+///
+/// Returns an error if the delta is malformed or sizes don't match.
+pub fn apply_delta(source: &[u8], delta: &[u8]) -> Result<Vec<u8>, DeltaError> {
+    if delta.is_empty() {
+        return Err(DeltaError::Truncated);
+    }
+
+    let mut pos = 0;
+
+    // Read header
+    let (src_size, n) = decode_varint(&delta[pos..]);
+    pos += n;
+    let (tgt_size, n) = decode_varint(&delta[pos..]);
+    pos += n;
+
+    if src_size as usize != source.len() {
+        return Err(DeltaError::SourceSizeMismatch {
+            expected: src_size as usize,
+            actual: source.len(),
+        });
+    }
+
+    let mut output = Vec::with_capacity(tgt_size as usize);
+
+    while pos < delta.len() {
+        let cmd = delta[pos];
+        pos += 1;
+
+        if cmd & 0x80 != 0 {
+            // Copy instruction
+            let mut offset: u32 = 0;
+            let mut size: u32 = 0;
+
+            if cmd & 0x01 != 0 {
+                offset |= delta[pos] as u32;
+                pos += 1;
+            }
+            if cmd & 0x02 != 0 {
+                offset |= (delta[pos] as u32) << 8;
+                pos += 1;
+            }
+            if cmd & 0x04 != 0 {
+                offset |= (delta[pos] as u32) << 16;
+                pos += 1;
+            }
+            if cmd & 0x08 != 0 {
+                offset |= (delta[pos] as u32) << 24;
+                pos += 1;
+            }
+
+            if cmd & 0x10 != 0 {
+                size |= delta[pos] as u32;
+                pos += 1;
+            }
+            if cmd & 0x20 != 0 {
+                size |= (delta[pos] as u32) << 8;
+                pos += 1;
+            }
+            if cmd & 0x40 != 0 {
+                size |= (delta[pos] as u32) << 16;
+                pos += 1;
+            }
+
+            if size == 0 {
+                size = 0x10000;
+            }
+
+            let offset = offset as usize;
+            let size = size as usize;
+
+            if offset + size > source.len() {
+                return Err(DeltaError::CopyOutOfBounds {
+                    offset,
+                    size,
+                    source_len: source.len(),
+                });
+            }
+
+            output.extend_from_slice(&source[offset..offset + size]);
+        } else if cmd > 0 {
+            // Insert instruction
+            let len = cmd as usize;
+            if pos + len > delta.len() {
+                return Err(DeltaError::Truncated);
+            }
+            output.extend_from_slice(&delta[pos..pos + len]);
+            pos += len;
+        } else {
+            return Err(DeltaError::InvalidOpcode);
+        }
+    }
+
+    if output.len() != tgt_size as usize {
+        return Err(DeltaError::TargetSizeMismatch {
+            expected: tgt_size as usize,
+            actual: output.len(),
+        });
+    }
+
+    Ok(output)
+}
+
+/// Errors that can occur during delta application.
+#[derive(Debug)]
+pub enum DeltaError {
+    Truncated,
+    SourceSizeMismatch { expected: usize, actual: usize },
+    TargetSizeMismatch { expected: usize, actual: usize },
+    CopyOutOfBounds {
+        offset: usize,
+        size: usize,
+        source_len: usize,
+    },
+    InvalidOpcode,
+}
+
+impl std::fmt::Display for DeltaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Truncated => write!(f, "delta data truncated"),
+            Self::SourceSizeMismatch { expected, actual } => {
+                write!(f, "source size mismatch: expected {expected}, got {actual}")
+            }
+            Self::TargetSizeMismatch { expected, actual } => {
+                write!(f, "target size mismatch: expected {expected}, got {actual}")
+            }
+            Self::CopyOutOfBounds {
+                offset,
+                size,
+                source_len,
+            } => write!(
+                f,
+                "copy out of bounds: offset {offset} + size {size} > source len {source_len}"
+            ),
+            Self::InvalidOpcode => write!(f, "invalid opcode 0 in delta"),
+        }
+    }
+}
+
+impl std::error::Error for DeltaError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_varint_roundtrip() {
+        for val in [0u64, 1, 127, 128, 16383, 16384, u32::MAX as u64, u64::MAX] {
+            let mut buf = Vec::new();
+            encode_varint(val, &mut buf);
+            let (decoded, len) = decode_varint(&buf);
+            assert_eq!(decoded, val);
+            assert_eq!(len, buf.len());
+        }
+    }
+
+    #[test]
+    fn test_identical_buffers() {
+        let data = b"Hello, world! This is a test of delta encoding.";
+        let delta = create_delta(data, data).expect("identical data should produce small delta");
+        let restored = apply_delta(data, &delta).unwrap();
+        assert_eq!(restored, data);
+    }
+
+    #[test]
+    fn test_small_edit() {
+        let source = b"fn main() {\n    println!(\"hello world\");\n}\n";
+        let target = b"fn main() {\n    println!(\"hello lance\");\n}\n";
+        let delta = create_delta(source, target);
+        // Whether or not delta is smaller, apply_delta should roundtrip if we have one
+        if let Some(delta) = &delta {
+            let restored = apply_delta(source, delta).unwrap();
+            assert_eq!(restored, target.as_slice());
+        }
+    }
+
+    #[test]
+    fn test_larger_similar_files() {
+        // Simulate two versions of a source file
+        let mut source = String::new();
+        for i in 0..100 {
+            source.push_str(&format!("line {}: the quick brown fox jumps over the lazy dog\n", i));
+        }
+        let mut target = source.clone();
+        // Change a few lines
+        target = target.replace("line 10:", "line 10 MODIFIED:");
+        target = target.replace("line 50:", "line 50 MODIFIED:");
+        target.push_str("// new line at the end\n");
+
+        let delta =
+            create_delta(source.as_bytes(), target.as_bytes()).expect("should compress well");
+        assert!(
+            delta.len() < target.len(),
+            "delta {} should be smaller than target {}",
+            delta.len(),
+            target.len()
+        );
+
+        let restored = apply_delta(source.as_bytes(), &delta).unwrap();
+        assert_eq!(restored, target.as_bytes());
+    }
+
+    #[test]
+    fn test_completely_different() {
+        let source = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let target = b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        // Delta might be None (larger than target) or Some
+        if let Some(delta) = create_delta(source, target) {
+            let restored = apply_delta(source, &delta).unwrap();
+            assert_eq!(restored, target.as_slice());
+        }
+        // Either way, this shouldn't panic
+    }
+
+    #[test]
+    fn test_empty_target() {
+        let source = b"some source data here";
+        let target = b"";
+        let delta = create_delta(source, target);
+        if let Some(delta) = &delta {
+            let restored = apply_delta(source, delta).unwrap();
+            assert!(restored.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_empty_source() {
+        let source = b"";
+        let target = b"new content";
+        // Delta from empty source = all inserts, likely larger than target
+        let delta = create_delta(source, target);
+        if let Some(delta) = &delta {
+            let restored = apply_delta(source, delta).unwrap();
+            assert_eq!(restored, target.as_slice());
+        }
+    }
+
+    #[test]
+    fn test_chained_deltas() {
+        let v1 = b"version 1 of the file with some content that stays the same\n\
+                    and more lines here\nand more lines here\n";
+        let v2 = b"version 2 of the file with some content that stays the same\n\
+                    and more lines here\nand a new line\n";
+        let v3 = b"version 3 of the file with some content that stays the same\n\
+                    and more lines here\nand a new line\nand another\n";
+
+        // Chain: v1 -> v2 -> v3
+        if let Some(d1) = create_delta(v1, v2) {
+            let restored_v2 = apply_delta(v1, &d1).unwrap();
+            assert_eq!(restored_v2, v2.as_slice());
+
+            if let Some(d2) = create_delta(&restored_v2, v3) {
+                let restored_v3 = apply_delta(&restored_v2, &d2).unwrap();
+                assert_eq!(restored_v3, v3.as_slice());
+            }
+        }
+    }
+
+    #[test]
+    fn test_source_code_diff() {
+        let source = r#"
+use std::collections::HashMap;
+
+fn process_data(input: &[u8]) -> Vec<u8> {
+    let mut result = Vec::new();
+    for &byte in input {
+        if byte > 0 {
+            result.push(byte);
+        }
+    }
+    result
+}
+
+fn main() {
+    let data = vec![1, 2, 0, 3, 0, 4];
+    let processed = process_data(&data);
+    println!("Result: {:?}", processed);
+}
+"#;
+        let target = r#"
+use std::collections::HashMap;
+
+fn process_data(input: &[u8], threshold: u8) -> Vec<u8> {
+    let mut result = Vec::new();
+    for &byte in input {
+        if byte > threshold {
+            result.push(byte);
+        }
+    }
+    result
+}
+
+fn main() {
+    let data = vec![1, 2, 0, 3, 0, 4];
+    let processed = process_data(&data, 1);
+    println!("Result: {:?}", processed);
+    println!("Done!");
+}
+"#;
+        let delta = create_delta(source.as_bytes(), target.as_bytes())
+            .expect("similar source code should delta well");
+        assert!(delta.len() < target.len());
+
+        let restored = apply_delta(source.as_bytes(), &delta).unwrap();
+        assert_eq!(
+            String::from_utf8(restored).unwrap(),
+            target,
+        );
+    }
+}

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -662,6 +662,25 @@ macro_rules! impl_common_protobuf_utils {
                 }
             }
 
+            pub fn delta_blob_layout(
+                inner_layout: crate::format::$module::PageLayout,
+                def_meaning: &[DefinitionInterpretation],
+            ) -> crate::format::$module::PageLayout {
+                crate::format::$module::PageLayout {
+                    layout: Some(
+                        crate::format::$module::page_layout::Layout::DeltaBlobLayout(Box::new(
+                            crate::format::$module::DeltaBlobLayout {
+                                inner_layout: Some(Box::new(inner_layout)),
+                                layers: def_meaning
+                                    .iter()
+                                    .map(|&def| Self::def_inter_to_repdef_layer(def))
+                                    .collect(),
+                            },
+                        )),
+                    ),
+                }
+            }
+
 
         }
     };

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -666,6 +666,11 @@ fn collect_page_encoding(layout: &PageLayout, actual_chain: &mut Vec<String>) ->
                     collect_page_encoding(inner_layout.as_ref(), actual_chain)?
                 }
             }
+            Layout::DeltaBlobLayout(delta_blob) => {
+                if let Some(inner_layout) = &delta_blob.inner_layout {
+                    collect_page_encoding(inner_layout.as_ref(), actual_chain)?
+                }
+            }
         }
     }
 

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -1984,6 +1984,11 @@ async fn collect_blob_entries_v2(
                     ),
                 });
             }
+            BlobKind::DeltaBase | BlobKind::Delta => {
+                return Err(Error::not_supported(
+                    "Delta-encoded blobs are not yet supported in the dataset blob reader",
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Implements binary delta encoding for `LargeBinary` blob columns, inspired by Git's packfile delta format
- When consecutive rows contain similar content (e.g., successive versions of source files), only the differences are stored via copy/insert instructions
- Builds on top of existing blob encoding infrastructure using external buffers — no changes to page structure

## Design

- **Delta algorithm**: Rabin rolling hash (16-byte windows) indexes the base buffer; the target is scanned with the same hash to find matching regions. Matches ≥4 bytes become copy instructions, unmatched regions become insert instructions. Git-compatible opcode format.
- **Delta groups**: Consecutive values are grouped with configurable chain depth (default 4). First value stored as-is (base), subsequent values as chained deltas against the previous value. A new base is emitted when the chain depth is exceeded or when a delta is larger than the raw value.
- **Descriptor**: Extended struct with `(position, size, kind, base_offset)` — `kind` distinguishes `DeltaBase` vs `Delta`, `base_offset` stores distance back to the base.
- **Decoding**: `DeltaBlobPageScheduler` expands requested ranges to include required bases, loads all data, applies delta chains, then returns only the requested rows.

## Files Changed

| Component | Files |
|-----------|-------|
| Delta algorithm | `rust/lance-encoding/src/encodings/physical/delta.rs` (new) |
| BlobKind variants | `rust/lance-core/src/datatypes.rs`, `field.rs` |
| Metadata key | `rust/lance-arrow/src/lib.rs` |
| Encoder | `rust/lance-encoding/src/encodings/logical/blob.rs` |
| Decoder | `rust/lance-encoding/src/encodings/logical/primitive/blob.rs` |
| Protobuf | `protos/encodings_v2_1.proto` |
| Wiring | `encoder.rs`, `decoder.rs`, `primitive.rs`, `format.rs`, `testing.rs` |

## Usage

Set field metadata `lance-encoding:delta-blob = "true"` on a `LargeBinary` column.

## Test plan

- [x] Delta algorithm unit tests (9 tests): varint roundtrip, identical buffers, small edits, larger files, chained deltas, source code diffs
- [x] Delta blob round-trip tests (4 tests): similar source code versions, nulls, completely different data, larger files
- [x] All existing blob tests pass (9 tests) — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)