### PR TITLE
feat(index): merge incremental inverted index segments

### DIFF
--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -976,6 +976,52 @@ def test_fts_stats(dataset):
     assert "num_workers" not in params
 
 
+def test_fts_optimize_num_indices_to_merge(tmp_path):
+    def append_rows(rows):
+        return lance.write_dataset(pa.table(rows), tmp_path, mode="append")
+
+    def num_indices(ds):
+        return ds.stats.index_stats("text_idx")["num_indices"]
+
+    ds = lance.write_dataset(
+        pa.table(
+            {
+                "id": [0, 1],
+                "text": ["alpha base phrase", "beta base phrase"],
+            }
+        ),
+        tmp_path,
+    )
+    ds.create_scalar_index("text", index_type="INVERTED", with_position=True)
+    assert num_indices(ds) == 1
+
+    ds = append_rows({"id": [2], "text": ["gamma delta phrase"]})
+    ds.optimize.optimize_indices(num_indices_to_merge=0)
+    assert num_indices(ds) == 2
+
+    ds = append_rows({"id": [3], "text": ["epsilon zeta phrase"]})
+    ds.optimize.optimize_indices(num_indices_to_merge=1)
+    assert num_indices(ds) == 2
+    assert ds.to_table(full_text_query="epsilon")["id"].to_pylist() == [3]
+
+    ds = append_rows({"id": [4], "text": ["eta theta phrase"]})
+    ds.optimize.optimize_indices(num_indices_to_merge=0)
+    assert num_indices(ds) == 3
+
+    ds.optimize.optimize_indices(num_indices_to_merge=2)
+    assert num_indices(ds) == 2
+    assert ds.to_table(full_text_query=PhraseQuery("eta theta", "text"))["id"].to_pylist() == [4]
+
+    ds = append_rows({"id": [5], "text": ["iota kappa phrase"]})
+    ds.optimize.optimize_indices(num_indices_to_merge=0)
+    assert num_indices(ds) == 3
+
+    ds.optimize.optimize_indices(num_indices_to_merge=10)
+    assert num_indices(ds) == 1
+    assert ds.to_table(full_text_query="alpha")["id"].to_pylist() == [0]
+    assert ds.to_table(full_text_query="iota")["id"].to_pylist() == [5]
+
+
 def test_fts_score(tmp_path):
     # the number of tokens matters for scoring,
     # make a table that all docs have the same number of tokens

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -1010,7 +1010,9 @@ def test_fts_optimize_num_indices_to_merge(tmp_path):
 
     ds.optimize.optimize_indices(num_indices_to_merge=2)
     assert num_indices(ds) == 2
-    assert ds.to_table(full_text_query=PhraseQuery("eta theta", "text"))["id"].to_pylist() == [4]
+    assert ds.to_table(full_text_query=PhraseQuery("eta theta", "text"))[
+        "id"
+    ].to_pylist() == [4]
 
     ds = append_rows({"id": [5], "text": ["iota kappa phrase"]})
     ds.optimize.optimize_indices(num_indices_to_merge=0)

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -187,6 +187,11 @@ impl InvertedIndexBuilder {
         self
     }
 
+    pub fn with_token_set_format(mut self, token_set_format: TokenSetFormat) -> Self {
+        self.token_set_format = token_set_format;
+        self
+    }
+
     pub fn with_progress(mut self, progress: Arc<dyn IndexBuildProgress>) -> Self {
         self.progress = progress;
         self
@@ -262,6 +267,8 @@ impl InvertedIndexBuilder {
         old_segments: &[Arc<InvertedIndex>],
         old_data_filter: Option<&crate::scalar::OldIndexDataFilter>,
     ) -> Result<()> {
+        let num_workers = resolve_num_workers(&self.params);
+        let memory_limit_bytes = resolve_worker_memory_limit_bytes(&self.params, num_workers);
         let mut merged: Option<InnerBuilder> = None;
         for index in old_segments {
             if old_data_filter.is_none() {
@@ -277,18 +284,53 @@ impl InvertedIndexBuilder {
                     continue;
                 }
                 match &mut merged {
-                    Some(merged) => merged.merge_from(partition_builder)?,
+                    Some(merged) => {
+                        let would_exceed_memory = merged
+                            .memory_size()
+                            .saturating_add(partition_builder.memory_size())
+                            >= memory_limit_bytes;
+                        let would_exceed_doc_ids = merged
+                            .docs
+                            .len()
+                            .saturating_add(partition_builder.docs.len())
+                            > u32::MAX as usize;
+                        if would_exceed_memory || would_exceed_doc_ids {
+                            let builder = std::mem::replace(merged, partition_builder);
+                            self.write_new_partition(dest_store, builder).await?;
+                        } else {
+                            merged.merge_from(partition_builder)?;
+                        }
+                    }
                     None => merged = Some(partition_builder),
                 }
             }
         }
 
-        if let Some(mut builder) = merged {
-            let partition_id = builder.id();
-            builder.write(dest_store).await?;
-            self.new_partitions.push(partition_id);
+        if let Some(builder) = merged {
+            self.write_new_partition(dest_store, builder).await?;
         }
         Ok(())
+    }
+
+    async fn write_new_partition(
+        &mut self,
+        dest_store: &dyn IndexStore,
+        mut builder: InnerBuilder,
+    ) -> Result<()> {
+        let partition_id = self.next_partition_id() | self.fragment_mask.unwrap_or(0);
+        builder.set_id(partition_id);
+        builder.write(dest_store).await?;
+        self.new_partitions.push(partition_id);
+        Ok(())
+    }
+
+    fn next_partition_id(&self) -> u64 {
+        self.partitions
+            .iter()
+            .chain(self.new_partitions.iter())
+            .map(|id| id + 1)
+            .max()
+            .unwrap_or(0)
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -309,13 +351,7 @@ impl InvertedIndexBuilder {
             token_set_format: self.token_set_format,
             worker_memory_limit_bytes,
         };
-        let next_id = self
-            .partitions
-            .iter()
-            .chain(self.new_partitions.iter())
-            .map(|id| id + 1)
-            .max()
-            .unwrap_or(0);
+        let next_id = self.next_partition_id();
         let id_alloc = Arc::new(AtomicU64::new(next_id));
         let tokenized_count = Arc::new(AtomicU64::new(0));
         let (sender, receiver) = async_channel::bounded(num_workers);
@@ -682,6 +718,10 @@ impl InnerBuilder {
         self.id
     }
 
+    fn set_id(&mut self, id: u64) {
+        self.id = id;
+    }
+
     pub fn is_empty(&self) -> bool {
         self.docs.is_empty()
     }
@@ -825,6 +865,18 @@ impl InnerBuilder {
         }
 
         Ok(())
+    }
+
+    fn memory_size(&self) -> u64 {
+        let posting_lists_overhead =
+            self.posting_lists.capacity() * std::mem::size_of::<PostingListBuilder>();
+        let posting_lists_size: u64 = self
+            .posting_lists
+            .iter()
+            .map(|posting| posting.size())
+            .sum();
+        (self.tokens.memory_size() + self.docs.memory_size() + posting_lists_overhead) as u64
+            + posting_lists_size
     }
 
     pub async fn write(&mut self, store: &dyn IndexStore) -> Result<()> {

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -23,6 +23,7 @@ use lance_arrow::json::JSON_EXT_NAME;
 use lance_arrow::{ARROW_EXT_NAME_KEY, iter_str_array};
 use lance_core::cache::LanceCache;
 use lance_core::error::LanceOptionExt;
+use lance_core::utils::mask::RowSetOps;
 use lance_core::utils::tokio::{IO_CORE_RESERVATION, get_num_compute_intensive_cpus, spawn_cpu};
 use lance_core::{Error, ROW_ID, ROW_ID_FIELD, Result};
 use lance_io::object_store::ObjectStore;
@@ -224,6 +225,72 @@ impl InvertedIndexBuilder {
         Ok(())
     }
 
+    pub async fn update_from_segments(
+        &mut self,
+        new_data: SendableRecordBatchStream,
+        dest_store: &dyn IndexStore,
+        old_segments: &[Arc<InvertedIndex>],
+        old_data_filter: Option<crate::scalar::OldIndexDataFilter>,
+    ) -> Result<()> {
+        let schema = new_data.schema();
+        let doc_col = schema.field(0).name();
+
+        if self.params.lance_tokenizer.is_none() {
+            let field = schema.column_with_name(doc_col).expect_ok()?.1;
+            let doc_type = DocType::try_from(field)?;
+            self.params.lance_tokenizer = Some(doc_type.as_ref().to_string());
+        }
+
+        self.merge_existing_segments(dest_store, old_segments, old_data_filter.as_ref())
+            .await?;
+
+        let new_data = document_input(new_data, doc_col)?;
+
+        self.progress
+            .stage_start("tokenize_docs", None, "rows")
+            .await?;
+        self.update_index(new_data, dest_store).await?;
+        self.progress.stage_complete("tokenize_docs").await?;
+
+        self.write(dest_store).await?;
+        Ok(())
+    }
+
+    async fn merge_existing_segments(
+        &mut self,
+        dest_store: &dyn IndexStore,
+        old_segments: &[Arc<InvertedIndex>],
+        old_data_filter: Option<&crate::scalar::OldIndexDataFilter>,
+    ) -> Result<()> {
+        let mut merged: Option<InnerBuilder> = None;
+        for index in old_segments {
+            if old_data_filter.is_none() {
+                self.deleted_fragments
+                    .extend(index.deleted_fragments().iter());
+            }
+            for partition in &index.partitions {
+                let mut partition_builder = partition.as_ref().clone().into_builder().await?;
+                if let Some(filter) = old_data_filter {
+                    partition_builder.filter_old_data(filter).await?;
+                }
+                if partition_builder.is_empty() {
+                    continue;
+                }
+                match &mut merged {
+                    Some(merged) => merged.merge_from(partition_builder)?,
+                    None => merged = Some(partition_builder),
+                }
+            }
+        }
+
+        if let Some(mut builder) = merged {
+            let partition_id = builder.id();
+            builder.write(dest_store).await?;
+            self.new_partitions.push(partition_id);
+        }
+        Ok(())
+    }
+
     #[instrument(level = "debug", skip_all)]
     async fn update_index(
         &mut self,
@@ -242,7 +309,13 @@ impl InvertedIndexBuilder {
             token_set_format: self.token_set_format,
             worker_memory_limit_bytes,
         };
-        let next_id = self.partitions.iter().map(|id| id + 1).max().unwrap_or(0);
+        let next_id = self
+            .partitions
+            .iter()
+            .chain(self.new_partitions.iter())
+            .map(|id| id + 1)
+            .max()
+            .unwrap_or(0);
         let id_alloc = Arc::new(AtomicU64::new(next_id));
         let tokenized_count = Arc::new(AtomicU64::new(0));
         let (sender, receiver) = async_channel::bounded(num_workers);
@@ -609,6 +682,10 @@ impl InnerBuilder {
         self.id
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.docs.is_empty()
+    }
+
     /// Set the token set for this builder.
     pub fn set_tokens(&mut self, tokens: TokenSet) {
         self.tokens = tokens;
@@ -648,6 +725,22 @@ impl InnerBuilder {
         self.tokens.remap(&removed_token_ids);
 
         Ok(())
+    }
+
+    async fn filter_old_data(&mut self, filter: &OldIndexDataFilter) -> Result<()> {
+        let mut mapping = HashMap::new();
+        for (row_id, _) in self.docs.iter() {
+            let keep = match filter {
+                OldIndexDataFilter::Fragments { to_keep, .. } => {
+                    to_keep.contains((*row_id >> 32) as u32)
+                }
+                OldIndexDataFilter::RowIds(valid_row_ids) => valid_row_ids.contains(*row_id),
+            };
+            if !keep {
+                mapping.insert(*row_id, None);
+            }
+        }
+        self.remap(&mapping).await
     }
 
     pub fn merge_from(&mut self, other: Self) -> Result<()> {

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -459,7 +459,7 @@ impl InvertedIndex {
     }
 
     pub async fn merge_segments(
-        segments: &[Arc<InvertedIndex>],
+        segments: &[Arc<Self>],
         new_data: SendableRecordBatchStream,
         dest_store: &dyn IndexStore,
         old_data_filter: Option<OldIndexDataFilter>,

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -5672,8 +5672,13 @@ mod tests {
 
         let merged = InvertedIndex::load(dest_store, None, &LanceCache::no_cache()).await?;
         assert_eq!(merged.partitions.len(), 2);
-        assert_eq!(merged.partitions[0].id(), 0);
-        assert_eq!(merged.partitions[1].id(), 1);
+        let mut partition_ids = merged
+            .partitions
+            .iter()
+            .map(|partition| partition.id())
+            .collect::<Vec<_>>();
+        partition_ids.sort_unstable();
+        assert_eq!(partition_ids, vec![0, 1]);
 
         Ok(())
     }

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -68,11 +68,12 @@ use super::{
 };
 use crate::frag_reuse::FragReuseIndex;
 use crate::pbold;
+use crate::progress::IndexBuildProgress;
 use crate::scalar::inverted::scorer::MemBM25Scorer;
 use crate::scalar::inverted::tokenizer::document_tokenizer::LanceTokenizer;
 use crate::scalar::{
     AnyQuery, BuiltinIndexType, CreatedIndex, IndexReader, IndexStore, MetricsCollector,
-    ScalarIndex, ScalarIndexParams, SearchResult, TokenQuery, UpdateCriteria,
+    OldIndexDataFilter, ScalarIndex, ScalarIndexParams, SearchResult, TokenQuery, UpdateCriteria,
 };
 use crate::{FtsPrewarmOptions, Index};
 use crate::{prefilter::PreFilter, scalar::inverted::iter::take_fst_keys};
@@ -455,6 +456,62 @@ impl InvertedIndex {
     /// fragments and prune them at search time (merge-on-read).
     pub fn deleted_fragments(&self) -> &RoaringBitmap {
         &self.deleted_fragments
+    }
+
+    pub async fn merge_segments(
+        segments: &[Arc<InvertedIndex>],
+        new_data: SendableRecordBatchStream,
+        dest_store: &dyn IndexStore,
+        old_data_filter: Option<OldIndexDataFilter>,
+        progress: Arc<dyn IndexBuildProgress>,
+    ) -> Result<CreatedIndex> {
+        let Some(first) = segments.first() else {
+            return Err(Error::invalid_input(
+                "cannot merge inverted index without at least one source segment".to_string(),
+            ));
+        };
+
+        for segment in segments.iter().skip(1) {
+            if segment.params != first.params {
+                return Err(Error::index(
+                    "cannot merge inverted index segments with different parameters".to_string(),
+                ));
+            }
+            if segment.token_set_format != first.token_set_format {
+                return Err(Error::index(
+                    "cannot merge inverted index segments with different token set formats"
+                        .to_string(),
+                ));
+            }
+            if segment.format_version() != first.format_version() {
+                return Err(Error::index(
+                    "cannot merge inverted index segments with different format versions"
+                        .to_string(),
+                ));
+            }
+            if segment.posting_tail_codec() != first.posting_tail_codec() {
+                return Err(Error::index(
+                    "cannot merge inverted index segments with different posting tail codecs"
+                        .to_string(),
+                ));
+            }
+        }
+
+        let mut builder = InvertedIndexBuilder::new(first.params.clone()).with_progress(progress);
+        builder = builder
+            .with_format_version(first.format_version())
+            .with_posting_tail_codec(first.posting_tail_codec());
+        builder
+            .update_from_segments(new_data, dest_store, segments, old_data_filter)
+            .await?;
+
+        let details = pbold::InvertedIndexDetails::try_from(&first.params)?;
+
+        Ok(CreatedIndex {
+            index_details: prost_types::Any::from_msg(&details).unwrap(),
+            index_version: first.index_version(),
+            files: Some(dest_store.list_files_with_sizes().await?),
+        })
     }
 
     pub fn bm25_base_scorer(&self, query_tokens: &Tokens) -> MemBM25Scorer {
@@ -1146,7 +1203,7 @@ impl InvertedPartition {
             self.token_set_format,
             self.inverted_list.posting_tail_codec(),
         );
-        builder.tokens = self.tokens;
+        builder.tokens = self.tokens.into_mutable();
         builder.docs = self.docs;
 
         builder
@@ -1448,6 +1505,33 @@ impl TokenSet {
         self.next_id += 1;
         self.total_length += token.len();
         next_id
+    }
+
+    pub(crate) fn into_mutable(self) -> Self {
+        let Self {
+            tokens,
+            next_id,
+            total_length,
+        } = self;
+        match tokens {
+            TokenMap::HashMap(_) => Self {
+                tokens,
+                next_id,
+                total_length,
+            },
+            TokenMap::Fst(map) => {
+                let mut mutable = HashMap::new();
+                let mut stream = map.stream();
+                while let Some((token, token_id)) = stream.next() {
+                    mutable.insert(String::from_utf8_lossy(token).into_owned(), token_id as u32);
+                }
+                Self {
+                    tokens: TokenMap::HashMap(mutable),
+                    next_id,
+                    total_length,
+                }
+            }
+        }
     }
 
     pub fn get(&self, token: &str) -> Option<u32> {
@@ -3846,11 +3930,13 @@ impl DocSet {
         let len = self.len();
         let row_ids = std::mem::replace(&mut self.row_ids, Vec::with_capacity(len));
         let num_tokens = std::mem::replace(&mut self.num_tokens, Vec::with_capacity(len));
+        self.total_tokens = 0;
         for (doc_id, (row_id, num_token)) in std::iter::zip(row_ids, num_tokens).enumerate() {
             match mapping.get(&row_id) {
                 Some(Some(new_row_id)) => {
                     self.row_ids.push(*new_row_id);
                     self.num_tokens.push(num_token);
+                    self.total_tokens += num_token as u64;
                 }
                 Some(None) => {
                     removed.push(doc_id as u32);
@@ -3858,6 +3944,7 @@ impl DocSet {
                 None => {
                     self.row_ids.push(row_id);
                     self.num_tokens.push(num_token);
+                    self.total_tokens += num_token as u64;
                 }
             }
         }

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -499,6 +499,7 @@ impl InvertedIndex {
 
         let mut builder = InvertedIndexBuilder::new(first.params.clone()).with_progress(progress);
         builder = builder
+            .with_token_set_format(first.token_set_format)
             .with_format_version(first.format_version())
             .with_posting_tail_codec(first.posting_tail_codec());
         builder
@@ -4337,7 +4338,9 @@ mod tests {
     use crate::metrics::NoOpMetricsCollector;
     use crate::prefilter::NoFilter;
     use crate::scalar::ScalarIndex;
-    use crate::scalar::inverted::builder::{InnerBuilder, PositionRecorder, inverted_list_schema};
+    use crate::scalar::inverted::builder::{
+        InnerBuilder, InvertedIndexBuilder, PositionRecorder, inverted_list_schema,
+    };
     use crate::scalar::inverted::encoding::{
         compress_positions, compress_posting_list_with_tail_codec,
         decompress_posting_list_with_tail_codec, encode_position_stream_block_into,
@@ -4352,6 +4355,57 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+
+    async fn write_single_partition_index(
+        store: Arc<LanceIndexStore>,
+        params: InvertedIndexParams,
+        token_set_format: TokenSetFormat,
+        token: &str,
+        row_id: u64,
+    ) -> Result<Arc<InvertedIndex>> {
+        let mut partition = InnerBuilder::new_with_format_version(
+            0,
+            false,
+            token_set_format,
+            InvertedListFormatVersion::V1,
+        );
+        partition.tokens.add(token.to_owned());
+        let mut posting_list =
+            PostingListBuilder::new_with_posting_tail_codec(false, PostingTailCodec::Fixed32);
+        posting_list.add(0, PositionRecorder::Count(1));
+        partition.posting_lists.push(posting_list);
+        partition.docs.append(row_id, 1);
+        partition.write(store.as_ref()).await?;
+
+        let metadata = HashMap::from([
+            (
+                "partitions".to_owned(),
+                serde_json::to_string(&vec![0_u64]).unwrap(),
+            ),
+            ("params".to_owned(), serde_json::to_string(&params).unwrap()),
+            (
+                TOKEN_SET_FORMAT_KEY.to_owned(),
+                token_set_format.to_string(),
+            ),
+        ]);
+        let mut writer = store
+            .new_index_file(METADATA_FILE, Arc::new(arrow_schema::Schema::empty()))
+            .await?;
+        writer.finish_with_metadata(metadata).await?;
+
+        InvertedIndex::load(store, None, &LanceCache::no_cache()).await
+    }
+
+    fn empty_doc_stream() -> SendableRecordBatchStream {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("doc", DataType::Utf8, true),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+        Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::iter(Vec::<datafusion::error::Result<RecordBatch>>::new()),
+        ))
+    }
 
     #[tokio::test]
     async fn test_posting_builder_remap() {
@@ -5513,6 +5567,113 @@ mod tests {
                 posting_tail_codec
             );
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_merge_segments_preserves_arrow_token_set_format() -> Result<()> {
+        let src_dir = TempObjDir::default();
+        let dest_dir = TempObjDir::default();
+        let src_store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            src_dir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let dest_store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            dest_dir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let index = write_single_partition_index(
+            src_store,
+            InvertedIndexParams::default(),
+            TokenSetFormat::Arrow,
+            "hello",
+            100,
+        )
+        .await?;
+        let created = InvertedIndex::merge_segments(
+            &[index],
+            empty_doc_stream(),
+            dest_store.as_ref(),
+            None,
+            crate::progress::noop_progress(),
+        )
+        .await?;
+
+        assert_eq!(created.index_version, 0);
+        let merged = InvertedIndex::load(dest_store, None, &LanceCache::no_cache()).await?;
+        assert_eq!(merged.token_set_format, TokenSetFormat::Arrow);
+
+        let tokens = Arc::new(Tokens::new(vec!["hello".to_string()], DocType::Text));
+        let params = Arc::new(FtsSearchParams::new().with_limit(Some(10)));
+        let prefilter = Arc::new(NoFilter);
+        let metrics = Arc::new(NoOpMetricsCollector);
+        let (row_ids, _) = merged
+            .bm25_search(tokens, params, Operator::Or, prefilter, metrics, None)
+            .await?;
+        assert_eq!(row_ids, vec![100]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_merge_segments_uses_memory_limit_for_old_partitions() -> Result<()> {
+        let src_dir_1 = TempObjDir::default();
+        let src_dir_2 = TempObjDir::default();
+        let dest_dir = TempObjDir::default();
+        let src_store_1 = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            src_dir_1.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let src_store_2 = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            src_dir_2.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let dest_store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            dest_dir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let params = InvertedIndexParams::default().memory_limit_mb(0);
+        let first = write_single_partition_index(
+            src_store_1,
+            params.clone(),
+            TokenSetFormat::default(),
+            "alpha",
+            100,
+        )
+        .await?;
+        let second = write_single_partition_index(
+            src_store_2,
+            params,
+            TokenSetFormat::default(),
+            "beta",
+            200,
+        )
+        .await?;
+
+        let mut builder =
+            InvertedIndexBuilder::new(InvertedIndexParams::default().memory_limit_mb(0))
+                .with_token_set_format(TokenSetFormat::default());
+        builder
+            .update_from_segments(
+                empty_doc_stream(),
+                dest_store.as_ref(),
+                &[first, second],
+                None,
+            )
+            .await?;
+
+        let merged = InvertedIndex::load(dest_store, None, &LanceCache::no_cache()).await?;
+        assert_eq!(merged.partitions.len(), 2);
+        assert_eq!(merged.partitions[0].id(), 0);
+        assert_eq!(merged.partitions[1].id(), 1);
 
         Ok(())
     }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -2876,7 +2876,7 @@ mod tests {
             // Optimize indices after write and delete
             use lance_index::optimize::OptimizeOptions;
             self.dataset
-                .optimize_indices(&OptimizeOptions::append())
+                .optimize_indices(&OptimizeOptions::merge(1))
                 .await?;
             Ok(())
         }
@@ -3083,7 +3083,7 @@ mod tests {
         assert_eq!(setup.branch1.counts.num_data_files, 2);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 2);
-        assert_eq!(setup.branch1.counts.num_index_files, 23);
+        assert_eq!(setup.branch1.counts.num_index_files, 14);
         setup.assert_all_unchanged().await;
 
         setup.branch1.compact().await.unwrap();
@@ -3098,7 +3098,7 @@ mod tests {
         assert_eq!(setup.branch1.counts.num_data_files, 2);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 1);
-        assert_eq!(setup.branch1.counts.num_index_files, 23);
+        assert_eq!(setup.branch1.counts.num_index_files, 14);
         setup.assert_all_unchanged().await;
 
         // Now we clean the referenced files of branch1 by branch2 and branch3
@@ -3112,14 +3112,14 @@ mod tests {
         assert_eq!(setup.branch2.counts.num_data_files, 1);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 0);
-        assert_eq!(setup.branch2.counts.num_index_files, 13);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
         // Only the latest manifest is retained.
         // (1, 1, 1, 0, 4) is the counts for the latest version of compaction
         assert_eq!(setup.branch3.counts.num_manifest_files, 1);
         assert_eq!(setup.branch3.counts.num_data_files, 1);
         assert_eq!(setup.branch3.counts.num_tx_files, 1);
         assert_eq!(setup.branch3.counts.num_delete_files, 0);
-        assert_eq!(setup.branch3.counts.num_index_files, 16);
+        assert_eq!(setup.branch3.counts.num_index_files, 7);
         setup.branch1.run_cleanup().await.unwrap();
 
         // Only the latest manifest is retained.
@@ -3128,7 +3128,7 @@ mod tests {
         assert_eq!(setup.branch1.counts.num_data_files, 1);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 0);
-        assert_eq!(setup.branch1.counts.num_index_files, 13);
+        assert_eq!(setup.branch1.counts.num_index_files, 7);
         setup.assert_all_unchanged().await;
     }
 
@@ -3145,7 +3145,7 @@ mod tests {
         assert_eq!(setup.branch3.counts.num_data_files, 2);
         assert_eq!(setup.branch3.counts.num_tx_files, 1);
         assert_eq!(setup.branch3.counts.num_delete_files, 2);
-        assert_eq!(setup.branch3.counts.num_index_files, 19);
+        assert_eq!(setup.branch3.counts.num_index_files, 7);
         setup
             .assert_unchanged(&["branch1", "branch2", "branch4", "main"])
             .await;
@@ -3161,7 +3161,7 @@ mod tests {
         assert_eq!(setup.branch2.counts.num_data_files, 2);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 1);
-        assert_eq!(setup.branch2.counts.num_index_files, 13);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
 
         setup.branch3.compact().await.unwrap();
         setup.branch3.run_cleanup().await.unwrap();
@@ -3171,7 +3171,7 @@ mod tests {
         assert_eq!(setup.branch3.counts.num_data_files, 1);
         assert_eq!(setup.branch3.counts.num_tx_files, 1);
         assert_eq!(setup.branch3.counts.num_delete_files, 0);
-        assert_eq!(setup.branch3.counts.num_index_files, 19);
+        assert_eq!(setup.branch3.counts.num_index_files, 7);
         setup
             .assert_unchanged(&["branch1", "branch2", "branch4", "main"])
             .await;
@@ -3184,7 +3184,7 @@ mod tests {
         assert_eq!(setup.branch2.counts.num_data_files, 1);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 0);
-        assert_eq!(setup.branch2.counts.num_index_files, 13);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
     }
 
     #[tokio::test]
@@ -3201,7 +3201,7 @@ mod tests {
         assert_eq!(setup.branch4.counts.num_data_files, 2);
         assert_eq!(setup.branch4.counts.num_tx_files, 1);
         assert_eq!(setup.branch4.counts.num_delete_files, 2);
-        assert_eq!(setup.branch4.counts.num_index_files, 16);
+        assert_eq!(setup.branch4.counts.num_index_files, 7);
         setup.assert_all_unchanged().await;
 
         setup.main.compact().await.unwrap();
@@ -3221,7 +3221,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 2);
-        assert_eq!(setup.main.counts.num_index_files, 17);
+        assert_eq!(setup.main.counts.num_index_files, 14);
 
         setup.branch4.compact().await.unwrap();
         setup.branch4.run_cleanup().await.unwrap();
@@ -3231,7 +3231,7 @@ mod tests {
         assert_eq!(setup.branch4.counts.num_data_files, 1);
         assert_eq!(setup.branch4.counts.num_tx_files, 1);
         assert_eq!(setup.branch4.counts.num_delete_files, 0);
-        assert_eq!(setup.branch4.counts.num_index_files, 16);
+        assert_eq!(setup.branch4.counts.num_index_files, 7);
         setup.assert_all_unchanged().await;
 
         setup.main.run_cleanup().await.unwrap();
@@ -3245,7 +3245,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 3);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 1);
-        assert_eq!(setup.main.counts.num_index_files, 17);
+        assert_eq!(setup.main.counts.num_index_files, 14);
     }
 
     #[tokio::test]
@@ -3270,7 +3270,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 3);
-        assert_eq!(setup.main.counts.num_index_files, 30);
+        assert_eq!(setup.main.counts.num_index_files, 21);
         setup.assert_all_unchanged().await;
 
         setup.main.compact().await.unwrap();
@@ -3281,7 +3281,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 2);
-        assert_eq!(setup.main.counts.num_index_files, 30);
+        assert_eq!(setup.main.counts.num_index_files, 21);
         setup.assert_all_unchanged().await;
 
         setup.branch1.write_data().await.unwrap();
@@ -3302,14 +3302,14 @@ mod tests {
         assert_eq!(setup.branch2.counts.num_data_files, 2);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 1);
-        assert_eq!(setup.branch2.counts.num_index_files, 29);
+        assert_eq!(setup.branch2.counts.num_index_files, 14);
         setup.branch1.run_cleanup().await.unwrap();
         // Cleanup 4 index files referenced from branch2
         assert_eq!(setup.branch1.counts.num_manifest_files, 2);
         assert_eq!(setup.branch1.counts.num_data_files, 2);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 1);
-        assert_eq!(setup.branch1.counts.num_index_files, 13);
+        assert_eq!(setup.branch1.counts.num_index_files, 7);
 
         setup.main.run_cleanup().await.unwrap();
         // Branch3 holds references from main:
@@ -3325,7 +3325,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 2);
-        assert_eq!(setup.main.counts.num_index_files, 23);
+        assert_eq!(setup.main.counts.num_index_files, 14);
 
         setup.branch3.write_data().await.unwrap();
         setup.branch3.compact().await.unwrap();
@@ -3335,7 +3335,7 @@ mod tests {
         assert_eq!(setup.branch3.counts.num_data_files, 1);
         assert_eq!(setup.branch3.counts.num_tx_files, 1);
         assert_eq!(setup.branch3.counts.num_delete_files, 0);
-        assert_eq!(setup.branch3.counts.num_index_files, 19);
+        assert_eq!(setup.branch3.counts.num_index_files, 7);
 
         setup.main.run_cleanup().await.unwrap();
         // Cleanup doesn't take effects if we don't clean branch2 and branch1 first
@@ -3343,7 +3343,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 2);
-        assert_eq!(setup.main.counts.num_index_files, 23);
+        assert_eq!(setup.main.counts.num_index_files, 14);
 
         // Cleanup doesn't take effect if we don't clean branch2 first
         setup.branch1.run_cleanup().await.unwrap();
@@ -3351,7 +3351,7 @@ mod tests {
         assert_eq!(setup.branch1.counts.num_data_files, 2);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 1);
-        assert_eq!(setup.branch1.counts.num_index_files, 13);
+        assert_eq!(setup.branch1.counts.num_index_files, 7);
 
         setup.branch2.run_cleanup().await.unwrap();
         // Only the latest manifest is retained.
@@ -3360,7 +3360,7 @@ mod tests {
         assert_eq!(setup.branch2.counts.num_data_files, 1);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 0);
-        assert_eq!(setup.branch2.counts.num_index_files, 16);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
 
         setup.branch1.run_cleanup().await.unwrap();
         // Only the latest manifest is retained.
@@ -3369,7 +3369,7 @@ mod tests {
         assert_eq!(setup.branch1.counts.num_data_files, 1);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 0);
-        assert_eq!(setup.branch1.counts.num_index_files, 13);
+        assert_eq!(setup.branch1.counts.num_index_files, 7);
 
         setup.main.run_cleanup().await.unwrap();
         // Branch4 holds references from main:
@@ -3381,7 +3381,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 2);
-        assert_eq!(setup.main.counts.num_index_files, 23);
+        assert_eq!(setup.main.counts.num_index_files, 14);
 
         setup.branch4.write_data().await.unwrap();
         setup.branch4.compact().await.unwrap();
@@ -3392,7 +3392,7 @@ mod tests {
         assert_eq!(setup.branch4.counts.num_data_files, 1);
         assert_eq!(setup.branch4.counts.num_tx_files, 1);
         assert_eq!(setup.branch4.counts.num_delete_files, 0);
-        assert_eq!(setup.branch4.counts.num_index_files, 16);
+        assert_eq!(setup.branch4.counts.num_index_files, 7);
 
         setup.main.run_cleanup().await.unwrap();
         // Only the latest manifest is retained.
@@ -3401,7 +3401,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 1);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 0);
-        assert_eq!(setup.main.counts.num_index_files, 13);
+        assert_eq!(setup.main.counts.num_index_files, 7);
     }
 
     #[tokio::test]
@@ -3425,7 +3425,7 @@ mod tests {
         assert_eq!(setup.branch2.counts.num_data_files, 1);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 1);
-        assert_eq!(setup.branch2.counts.num_index_files, 13);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
         // After auto-clean: branch3
         // 2 appends produced 2 data files
         // 2 deletes produced 2 deletion files
@@ -3433,7 +3433,7 @@ mod tests {
         assert_eq!(setup.branch3.counts.num_data_files, 2);
         assert_eq!(setup.branch3.counts.num_tx_files, 1);
         assert_eq!(setup.branch3.counts.num_delete_files, 2);
-        assert_eq!(setup.branch3.counts.num_index_files, 19);
+        assert_eq!(setup.branch3.counts.num_index_files, 7);
         setup
             .assert_unchanged(&["branch1", "branch4", "main"])
             .await;
@@ -3455,14 +3455,14 @@ mod tests {
         assert_eq!(setup.branch2.counts.num_data_files, 1);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 0);
-        assert_eq!(setup.branch2.counts.num_index_files, 16);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
         // Only the latest manifest is retained.
         // (1, 1, 1, 0, 4) is the counts of one version
         assert_eq!(setup.branch3.counts.num_manifest_files, 1);
         assert_eq!(setup.branch3.counts.num_data_files, 1);
         assert_eq!(setup.branch3.counts.num_tx_files, 1);
         assert_eq!(setup.branch3.counts.num_delete_files, 0);
-        assert_eq!(setup.branch3.counts.num_index_files, 19);
+        assert_eq!(setup.branch3.counts.num_index_files, 7);
         setup
             .assert_unchanged(&["branch1", "branch4", "main"])
             .await;
@@ -3492,7 +3492,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 3);
-        assert_eq!(setup.main.counts.num_index_files, 13);
+        assert_eq!(setup.main.counts.num_index_files, 7);
 
         setup.main.compact().await.unwrap();
         setup
@@ -3512,7 +3512,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 2);
-        assert_eq!(setup.main.counts.num_index_files, 13);
+        assert_eq!(setup.main.counts.num_index_files, 7);
 
         setup.branch4.compact().await.unwrap();
         setup
@@ -3529,13 +3529,13 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 3);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 1);
-        assert_eq!(setup.main.counts.num_index_files, 13);
+        assert_eq!(setup.main.counts.num_index_files, 7);
         // (1, 1, 1, 0, 4) is the counts of one version
         assert_eq!(setup.branch4.counts.num_manifest_files, 1);
         assert_eq!(setup.branch4.counts.num_data_files, 1);
         assert_eq!(setup.branch4.counts.num_tx_files, 1);
         assert_eq!(setup.branch4.counts.num_delete_files, 0);
-        assert_eq!(setup.branch4.counts.num_index_files, 13);
+        assert_eq!(setup.branch4.counts.num_index_files, 7);
 
         setup.branch1.write_data().await.unwrap();
         setup.branch1.compact().await.unwrap();
@@ -3553,7 +3553,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 3);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 1);
-        assert_eq!(setup.main.counts.num_index_files, 13);
+        assert_eq!(setup.main.counts.num_index_files, 7);
         // Branch3 and branch2 still hold references from branch1:
         // - 1 manifest file
         // - 1 data files
@@ -3562,7 +3562,7 @@ mod tests {
         assert_eq!(setup.branch1.counts.num_data_files, 2);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 1);
-        assert_eq!(setup.branch1.counts.num_index_files, 13);
+        assert_eq!(setup.branch1.counts.num_index_files, 7);
 
         setup.branch2.write_data().await.unwrap();
         setup.branch2.compact().await.unwrap();
@@ -3580,7 +3580,7 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 3);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 1);
-        assert_eq!(setup.main.counts.num_index_files, 13);
+        assert_eq!(setup.main.counts.num_index_files, 7);
         // Branch3 still holds references from branch1:
         // - 1 manifest file
         // - 1 data files
@@ -3589,7 +3589,7 @@ mod tests {
         assert_eq!(setup.branch1.counts.num_data_files, 2);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 1);
-        assert_eq!(setup.branch1.counts.num_index_files, 13);
+        assert_eq!(setup.branch1.counts.num_index_files, 7);
         // Branch3 still holds references from branch2:
         // - 1 manifest file
         // - 1 data files
@@ -3598,7 +3598,7 @@ mod tests {
         assert_eq!(setup.branch2.counts.num_data_files, 2);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 1);
-        assert_eq!(setup.branch2.counts.num_index_files, 16);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
 
         setup.branch3.write_data().await.unwrap();
         setup.branch3.compact().await.unwrap();
@@ -3616,22 +3616,22 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 1);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 0);
-        assert_eq!(setup.main.counts.num_index_files, 13);
+        assert_eq!(setup.main.counts.num_index_files, 7);
         assert_eq!(setup.branch1.counts.num_manifest_files, 1);
         assert_eq!(setup.branch1.counts.num_data_files, 1);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 0);
-        assert_eq!(setup.branch1.counts.num_index_files, 13);
+        assert_eq!(setup.branch1.counts.num_index_files, 7);
         assert_eq!(setup.branch2.counts.num_manifest_files, 1);
         assert_eq!(setup.branch2.counts.num_data_files, 1);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 0);
-        assert_eq!(setup.branch2.counts.num_index_files, 16);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
         assert_eq!(setup.branch3.counts.num_manifest_files, 1);
         assert_eq!(setup.branch3.counts.num_data_files, 1);
         assert_eq!(setup.branch3.counts.num_tx_files, 1);
         assert_eq!(setup.branch3.counts.num_delete_files, 0);
-        assert_eq!(setup.branch3.counts.num_index_files, 19);
+        assert_eq!(setup.branch3.counts.num_index_files, 7);
         setup.assert_unchanged(&["branch4"]).await;
     }
 
@@ -3675,24 +3675,24 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 2);
         assert_eq!(setup.main.counts.num_delete_files, 2);
-        assert_eq!(setup.main.counts.num_index_files, 20);
+        assert_eq!(setup.main.counts.num_index_files, 14);
         // Branch3 tag holds branch1 with 1 tx file, 1 data files, 1 deletion files and 4 index files
         assert_eq!(setup.branch2.counts.num_manifest_files, 2);
         assert_eq!(setup.branch2.counts.num_data_files, 2);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 1);
-        assert_eq!(setup.branch2.counts.num_index_files, 13);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
         // Branch3 tag holds branch2 with 1 tx file, 1 data files, 1 deletion files and 4 index files
         assert_eq!(setup.branch2.counts.num_manifest_files, 2);
         assert_eq!(setup.branch2.counts.num_data_files, 2);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 1);
-        assert_eq!(setup.branch2.counts.num_index_files, 13);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
         assert_eq!(setup.branch4.counts.num_manifest_files, 1);
         assert_eq!(setup.branch4.counts.num_data_files, 1);
         assert_eq!(setup.branch4.counts.num_tx_files, 1);
         assert_eq!(setup.branch4.counts.num_delete_files, 0);
-        assert_eq!(setup.branch4.counts.num_index_files, 13);
+        assert_eq!(setup.branch4.counts.num_index_files, 7);
 
         setup
             .branch3
@@ -3715,27 +3715,27 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 4);
         assert_eq!(setup.main.counts.num_tx_files, 2);
         assert_eq!(setup.main.counts.num_delete_files, 2);
-        assert_eq!(setup.main.counts.num_index_files, 20);
+        assert_eq!(setup.main.counts.num_index_files, 14);
         assert_eq!(setup.branch1.counts.num_manifest_files, 1);
         assert_eq!(setup.branch1.counts.num_data_files, 1);
         assert_eq!(setup.branch1.counts.num_tx_files, 1);
         assert_eq!(setup.branch1.counts.num_delete_files, 0);
-        assert_eq!(setup.branch1.counts.num_index_files, 10);
+        assert_eq!(setup.branch1.counts.num_index_files, 7);
         assert_eq!(setup.branch2.counts.num_manifest_files, 1);
         assert_eq!(setup.branch2.counts.num_data_files, 1);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 0);
-        assert_eq!(setup.branch2.counts.num_index_files, 13);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
         assert_eq!(setup.branch3.counts.num_manifest_files, 1);
         assert_eq!(setup.branch3.counts.num_data_files, 1);
         assert_eq!(setup.branch3.counts.num_tx_files, 1);
         assert_eq!(setup.branch3.counts.num_delete_files, 0);
-        assert_eq!(setup.branch3.counts.num_index_files, 16);
+        assert_eq!(setup.branch3.counts.num_index_files, 7);
         assert_eq!(setup.branch4.counts.num_manifest_files, 1);
         assert_eq!(setup.branch4.counts.num_data_files, 1);
         assert_eq!(setup.branch4.counts.num_tx_files, 1);
         assert_eq!(setup.branch4.counts.num_delete_files, 0);
-        assert_eq!(setup.branch4.counts.num_index_files, 13);
+        assert_eq!(setup.branch4.counts.num_index_files, 7);
 
         setup.main.dataset.tags().delete("main-tag").await.unwrap();
         setup
@@ -3751,22 +3751,22 @@ mod tests {
         assert_eq!(setup.main.counts.num_data_files, 1);
         assert_eq!(setup.main.counts.num_tx_files, 1);
         assert_eq!(setup.main.counts.num_delete_files, 0);
-        assert_eq!(setup.main.counts.num_index_files, 10);
+        assert_eq!(setup.main.counts.num_index_files, 7);
         assert_eq!(setup.branch2.counts.num_manifest_files, 1);
         assert_eq!(setup.branch2.counts.num_data_files, 1);
         assert_eq!(setup.branch2.counts.num_tx_files, 1);
         assert_eq!(setup.branch2.counts.num_delete_files, 0);
-        assert_eq!(setup.branch2.counts.num_index_files, 13);
+        assert_eq!(setup.branch2.counts.num_index_files, 7);
         assert_eq!(setup.branch3.counts.num_manifest_files, 1);
         assert_eq!(setup.branch3.counts.num_data_files, 1);
         assert_eq!(setup.branch3.counts.num_tx_files, 1);
         assert_eq!(setup.branch3.counts.num_delete_files, 0);
-        assert_eq!(setup.branch3.counts.num_index_files, 16);
+        assert_eq!(setup.branch3.counts.num_index_files, 7);
         assert_eq!(setup.branch4.counts.num_manifest_files, 1);
         assert_eq!(setup.branch4.counts.num_data_files, 1);
         assert_eq!(setup.branch4.counts.num_tx_files, 1);
         assert_eq!(setup.branch4.counts.num_delete_files, 0);
-        assert_eq!(setup.branch4.counts.num_index_files, 13);
+        assert_eq!(setup.branch4.counts.num_index_files, 7);
     }
 
     #[test]

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -3606,6 +3606,133 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_optimize_fts_respects_num_indices_to_merge() {
+        use lance_index::scalar::inverted::query::PhraseQuery;
+
+        async fn append_texts(dataset: &mut Dataset, schema: Arc<Schema>, rows: &[(i32, &str)]) {
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from_iter_values(rows.iter().map(|(id, _)| *id))),
+                    Arc::new(StringArray::from_iter_values(
+                        rows.iter().map(|(_, text)| *text),
+                    )),
+                ],
+            )
+            .unwrap();
+            let batch_iter = RecordBatchIterator::new(vec![Ok(batch)], schema);
+            dataset.append(batch_iter, None).await.unwrap();
+        }
+
+        async fn num_fts_segments(dataset: &Dataset) -> usize {
+            let stats = dataset.index_statistics("text_idx").await.unwrap();
+            let stats: serde_json::Value = serde_json::from_str(&stats).unwrap();
+            stats["num_indices"].as_u64().unwrap() as usize
+        }
+
+        async fn assert_fts_ids(
+            dataset: &Dataset,
+            query: FullTextSearchQuery,
+            expected_ids: &[i32],
+        ) {
+            let result = dataset
+                .scan()
+                .project(&["id"])
+                .unwrap()
+                .full_text_search(query)
+                .unwrap()
+                .limit(Some(20), None)
+                .unwrap()
+                .try_into_batch()
+                .await
+                .unwrap();
+            let mut ids = result["id"].as_primitive::<Int32Type>().values().to_vec();
+            ids.sort_unstable();
+            assert_eq!(ids, expected_ids);
+        }
+
+        let dir = TempStrDir::default();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("text", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values([0, 1])),
+                Arc::new(StringArray::from_iter_values([
+                    "alpha base phrase",
+                    "beta base phrase",
+                ])),
+            ],
+        )
+        .unwrap();
+        let batch_iterator = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+
+        let mut dataset = Dataset::write(batch_iterator, &dir, None).await.unwrap();
+        let params = InvertedIndexParams::default().with_position(true);
+        dataset
+            .create_index(&["text"], IndexType::Inverted, None, &params, true)
+            .await
+            .unwrap();
+        assert_eq!(num_fts_segments(&dataset).await, 1);
+
+        append_texts(&mut dataset, schema.clone(), &[(2, "gamma delta phrase")]).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+        assert_eq!(num_fts_segments(&dataset).await, 2);
+
+        append_texts(&mut dataset, schema.clone(), &[(3, "epsilon zeta phrase")]).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::merge(1))
+            .await
+            .unwrap();
+        assert_eq!(num_fts_segments(&dataset).await, 2);
+        assert_fts_ids(
+            &dataset,
+            FullTextSearchQuery::new("epsilon".to_owned()),
+            &[3],
+        )
+        .await;
+
+        append_texts(&mut dataset, schema.clone(), &[(4, "eta theta phrase")]).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+        assert_eq!(num_fts_segments(&dataset).await, 3);
+
+        dataset
+            .optimize_indices(&OptimizeOptions::merge(2))
+            .await
+            .unwrap();
+        assert_eq!(num_fts_segments(&dataset).await, 2);
+        assert_fts_ids(
+            &dataset,
+            FullTextSearchQuery::new_query(PhraseQuery::new("eta theta".to_owned()).into()),
+            &[4],
+        )
+        .await;
+
+        append_texts(&mut dataset, schema, &[(5, "iota kappa phrase")]).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+        assert_eq!(num_fts_segments(&dataset).await, 3);
+
+        dataset
+            .optimize_indices(&OptimizeOptions::merge(10))
+            .await
+            .unwrap();
+        assert_eq!(num_fts_segments(&dataset).await, 1);
+        assert_fts_ids(&dataset, FullTextSearchQuery::new("alpha".to_owned()), &[0]).await;
+        assert_fts_ids(&dataset, FullTextSearchQuery::new("iota".to_owned()), &[5]).await;
+    }
+
+    #[tokio::test]
     async fn test_create_index_too_small_for_pq() {
         let test_dir = TempStrDir::default();
         let dimensions = 1536;

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -9,11 +9,13 @@ use lance_core::{
     utils::mask::{RowAddrTreeMap, RowSetOps},
 };
 use lance_index::{
-    INDEX_FILE_NAME,
+    INDEX_FILE_NAME, IndexType,
     metrics::NoOpMetricsCollector,
     optimize::OptimizeOptions,
     progress::NoopIndexBuildProgress,
-    scalar::{CreatedIndex, OldIndexDataFilter, lance_format::LanceIndexStore},
+    scalar::{
+        CreatedIndex, OldIndexDataFilter, inverted::InvertedIndex, lance_format::LanceIndexStore,
+    },
 };
 use lance_table::format::{Fragment, IndexMetadata, list_index_files_with_sizes};
 use roaring::RoaringBitmap;
@@ -311,7 +313,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
             ))
         }
     } else {
-        let mut frag_bitmap = base_unindexed_bitmap;
+        let mut frag_bitmap = base_unindexed_bitmap.clone();
         let mut indices = Vec::with_capacity(old_indices.len());
         for idx in old_indices {
             match dataset
@@ -343,6 +345,149 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
 
         let index_type = indices[0].index_type();
         match index_type {
+            IndexType::Inverted => {
+                let num_to_merge = options
+                    .num_indices_to_merge
+                    .unwrap_or(1)
+                    .min(old_indices.len());
+                if unindexed.is_empty() && num_to_merge <= 1 {
+                    return Ok(None);
+                }
+
+                let selected_start = old_indices.len().saturating_sub(num_to_merge);
+                let selected_old_indices = &old_indices[selected_start..];
+                let reference_idx = selected_old_indices
+                    .first()
+                    .copied()
+                    .unwrap_or(old_indices[old_indices.len() - 1]);
+                let reference_index = dataset
+                    .open_scalar_index(
+                        &field_path,
+                        &reference_idx.uuid.to_string(),
+                        &NoOpMetricsCollector,
+                    )
+                    .await?;
+                let update_criteria = reference_index.update_criteria();
+                if update_criteria.requires_old_data {
+                    let params = reference_index.derive_index_params()?;
+                    let new_data_stream = load_training_data(
+                        dataset.as_ref(),
+                        &field_path,
+                        &update_criteria.data_criteria,
+                        None,
+                        true,
+                        None,
+                    )
+                    .await?;
+                    let new_uuid = Uuid::new_v4();
+                    let created_index = super::scalar::build_scalar_index(
+                        dataset.as_ref(),
+                        column.name.as_str(),
+                        &new_uuid.to_string(),
+                        &params,
+                        true,
+                        None,
+                        Some(new_data_stream),
+                        Arc::new(NoopIndexBuildProgress),
+                    )
+                    .await?;
+                    return Ok(Some(IndexMergeResults {
+                        new_uuid,
+                        removed_indices: old_indices.to_vec(),
+                        new_fragment_bitmap: dataset.fragment_bitmap.as_ref().clone(),
+                        new_index_version: created_index.index_version as i32,
+                        new_index_details: created_index.index_details,
+                        files: created_index.files,
+                    }));
+                }
+
+                let fragments = Some(unindexed.to_vec());
+                let new_data_stream = load_training_data(
+                    dataset.as_ref(),
+                    &field_path,
+                    &update_criteria.data_criteria,
+                    fragments,
+                    true,
+                    None,
+                )
+                .await?;
+
+                let mut frag_bitmap = base_unindexed_bitmap;
+                let mut effective_old_frags = RoaringBitmap::new();
+                let mut selected_indices = Vec::with_capacity(selected_old_indices.len());
+                for idx in selected_old_indices {
+                    if let Some(effective) = idx.effective_fragment_bitmap(&dataset.fragment_bitmap)
+                    {
+                        frag_bitmap |= &effective;
+                        effective_old_frags |= &effective;
+                    }
+                    let scalar_index = dataset
+                        .open_scalar_index(
+                            &field_path,
+                            &idx.uuid.to_string(),
+                            &NoOpMetricsCollector,
+                        )
+                        .await?;
+                    let inverted_index = scalar_index
+                        .as_any()
+                        .downcast_ref::<InvertedIndex>()
+                        .ok_or_else(|| {
+                            Error::index(format!(
+                                "Append index: expected inverted index segment {}, got {:?}",
+                                idx.uuid,
+                                scalar_index.index_type()
+                            ))
+                        })?;
+                    selected_indices.push(Arc::new(inverted_index.clone()));
+                }
+
+                let old_data_filter = if selected_indices.is_empty() {
+                    None
+                } else if dataset.manifest.uses_stable_row_ids() {
+                    let valid_old_row_ids =
+                        build_stable_row_id_filter(dataset.as_ref(), &effective_old_frags).await?;
+                    Some(OldIndexDataFilter::RowIds(valid_old_row_ids))
+                } else {
+                    Some(OldIndexDataFilter::Fragments {
+                        to_keep: effective_old_frags,
+                        to_remove: RoaringBitmap::new(),
+                    })
+                };
+
+                let new_uuid = Uuid::new_v4();
+                let new_store =
+                    LanceIndexStore::from_dataset_for_new(&dataset, &new_uuid.to_string())?;
+                let created_index = if selected_indices.is_empty() {
+                    let params = reference_index.derive_index_params()?;
+                    super::scalar::build_scalar_index(
+                        dataset.as_ref(),
+                        column.name.as_str(),
+                        &new_uuid.to_string(),
+                        &params,
+                        true,
+                        None,
+                        Some(new_data_stream),
+                        Arc::new(NoopIndexBuildProgress),
+                    )
+                    .await?
+                } else {
+                    InvertedIndex::merge_segments(
+                        &selected_indices,
+                        new_data_stream,
+                        &new_store,
+                        old_data_filter,
+                        options.progress.clone(),
+                    )
+                    .await?
+                };
+
+                Ok((
+                    new_uuid,
+                    selected_old_indices.to_vec(),
+                    frag_bitmap,
+                    created_index,
+                ))
+            }
             it if it.is_scalar() => {
                 // Use effective bitmap (intersected with existing dataset fragments)
                 // to avoid carrying stale data from pruned indices.


### PR DESCRIPTION
Fixes #6292

## Feature

### What is the new feature?
Inverted / FTS index optimization now honors `num_indices_to_merge` for incremental index segments. `num_indices_to_merge=0` keeps append-only delta behavior, while `num_indices_to_merge=N` folds newly indexed fragments together with the latest N existing inverted segments into one replacement segment.

### Why do we need this feature?
Repeated incremental `optimize_indices()` calls could accumulate many FTS index segments even though the API already exposed `num_indices_to_merge`. That made the public optimize contract inconsistent for inverted indexes and could leave unnecessary segments for query-time search.

### How does it work?
The scalar optimize path now has an inverted-index-specific branch. It selects the requested existing FTS segments, loads them copy-on-write, filters stale / deleted old rows, merges them with newly tokenized data, writes one new inverted index root, and removes exactly the selected old metadata segments. The implementation preserves tokenizer parameters, positions settings, token-set format, FTS format version, posting-tail codec, `deleted_fragments`, and stable-row-id filtering semantics.

## Validation

- `cargo fmt --all`
- `cargo clippy -p lance-index --all-targets -- -D warnings`
- `cargo clippy -p lance --all-targets -- -D warnings`
- `cargo test -p lance test_optimize_fts_respects_num_indices_to_merge`
- `cargo test -p lance test_optimize_fts`
- `cargo test -p lance test_fts_index_incremental_reindex_after_in_place_update`
- `cargo test -p lance cleanup_lineage`
- `cargo test -p lance auto_clean_referenced_branches`
- `uv run pytest python/tests/test_scalar_index.py::test_fts_optimize_num_indices_to_merge`