### PR TITLE
fix(rust): avoid pushdown limit/offset for stable row id

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -3088,6 +3088,39 @@ def test_update_dataset(tmp_path: Path):
     check_update_stats(update_dict, (100,))
 
 
+def test_update_dataset_scanner_after_stable_row_id_update(tmp_path: Path):
+    dataset = lance.write_dataset(
+        pa.table(
+            {
+                "name_1": pa.array(["1", "4", "7"]),
+                "name_2": pa.array(["2", "5", "8"]),
+                "name_3": pa.array(["3", "6", "9"]),
+            }
+        ),
+        tmp_path / "dataset",
+        enable_stable_row_ids=True,
+    )
+
+    update_dict = dataset.update(
+        updates=dict(name_3="'xxxx'"), where="name_1 = '7'"
+    )
+    check_update_stats(update_dict, (1,))
+
+    expected = pa.table(
+        {
+            "name_1": pa.array(["1", "4", "7"]),
+            "name_2": pa.array(["2", "5", "8"]),
+            "name_3": pa.array(["3", "6", "xxxx"]),
+        }
+    )
+    actual = dataset.to_table().sort_by("name_1")
+    assert actual == expected
+
+    scanner_table = dataset.scanner(limit=10).to_table().sort_by("name_1")
+    assert scanner_table == expected
+    assert scanner_table == actual
+
+
 def test_update_dataset_all_types(tmp_path: Path):
     table = pa.table(
         {

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -3101,9 +3101,7 @@ def test_update_dataset_scanner_after_stable_row_id_update(tmp_path: Path):
         enable_stable_row_ids=True,
     )
 
-    update_dict = dataset.update(
-        updates=dict(name_3="'xxxx'"), where="name_1 = '7'"
-    )
+    update_dict = dataset.update(updates=dict(name_3="'xxxx'"), where="name_1 = '7'")
     check_update_stats(update_dict, (1,))
 
     expected = pa.table(

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2357,6 +2357,14 @@ impl Scanner {
             // If there is ordering, we can't pushdown limit / offset
             // because we need to sort all data first before applying the limit
             Ok(None)
+        } else if self.dataset.manifest.uses_stable_row_ids() {
+            // Stable-row-id datasets can contain deleted / rewritten rows that still occupy
+            // physical positions in older fragments while the live replacement rows are appended
+            // to new fragments. `scan_range_before_filter` is a logical offset over visible rows,
+            // but filtered-read planning trims fragments before the stable-row-id/deletion-aware
+            // remapping is finished. Pushing limit / offset down here can spend the range on
+            // tombstoned positions and skip still-live rows in later fragments.
+            Ok(None)
         } else {
             match (self.limit, self.offset) {
                 (None, None) => Ok(None),

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -2062,6 +2062,10 @@ impl ExecutionPlan for FilteredReadExec {
         }
         let limit = limit?;
 
+        if self.dataset.manifest.uses_stable_row_ids() {
+            return None;
+        }
+
         let mut updated_options = self.options.clone();
 
         if self.options.full_filter.is_none() && self.options.refine_filter.is_none() {


### PR DESCRIPTION
When we enable stable row ID, if we update rows, we can not scan updated rows with a limit condition.

<img width="1160" height="418" alt="image" src="https://github.com/user-attachments/assets/86a9dfbc-bed9-440d-b784-ecc2b638d953" />

<img width="1268" height="542" alt="image" src="https://github.com/user-attachments/assets/4b338fcb-9891-4377-9fef-b2302e72dc03" />
