### PR TITLE
fix: use physical scan stream for update

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1981,6 +1981,14 @@ impl Scanner {
         execute_plan(plan, options)
     }
 
+    pub(crate) fn execution_options(&self) -> LanceExecutionOptions {
+        LanceExecutionOptions {
+            batch_size: self.batch_size,
+            execution_stats_callback: self.scan_stats_callback.clone(),
+            ..Default::default()
+        }
+    }
+
     pub async fn try_into_batch(&self) -> Result<RecordBatch> {
         let stream = self.try_into_stream().await?;
         let schema = stream.schema();

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -260,7 +260,9 @@ impl UpdateJob {
             scanner.filter_expr(expr.clone());
         }
 
-        let stream = scanner.try_into_stream().await?.into();
+        let stream = scanner
+            .try_into_dfstream(scanner.execution_options())
+            .await?;
 
         // We keep track of seen row ids so we can delete them from the existing
         // fragments and then set the row id segments in the new fragments.
@@ -473,6 +475,7 @@ impl RetryExecutor for UpdateJob {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::time::Duration;
 
     use crate::{
@@ -487,12 +490,17 @@ mod tests {
     use crate::index::DatasetIndexExt;
     use crate::index::vector::VectorIndexParams;
     use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
-    use arrow::{array::AsArray, datatypes::UInt32Type};
+    use arrow::{
+        array::AsArray,
+        datatypes::{Int64Type, UInt32Type},
+    };
     use arrow_array::types::Float32Type;
     use arrow_array::{Int64Array, RecordBatchIterator, StringArray, UInt32Array, UInt64Array};
     use arrow_schema::{Field, Schema as ArrowSchema};
     use arrow_select::concat::concat_batches;
     use futures::{TryStreamExt, future::try_join_all};
+    use lance_arrow::ARROW_EXT_NAME_KEY;
+    use lance_arrow::json::{ARROW_JSON_EXT_NAME, is_arrow_json_field, is_json_field};
     use lance_core::ROW_ID;
     use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::{Dimension, RowCount};
@@ -706,6 +714,81 @@ mod tests {
         );
         // One fragment fully modified
         assert_eq!(fragments[2].metadata.physical_rows, Some(15));
+    }
+
+    #[tokio::test]
+    async fn test_update_json_and_regular_columns() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            ARROW_EXT_NAME_KEY.to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("meta", DataType::Utf8, true).with_metadata(metadata),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from_iter_values([1, 2, 3])),
+                Arc::new(StringArray::from(vec!["a", "b", "c"])),
+                Arc::new(StringArray::from(vec![
+                    r#"{"before":1}"#,
+                    r#"{"before":2}"#,
+                    r#"{"before":3}"#,
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let test_dir = TempStrDir::default();
+        let batches = RecordBatchIterator::new([Ok(batch)], schema);
+        let dataset = Arc::new(
+            Dataset::write(batches, &test_dir, Some(WriteParams::default()))
+                .await
+                .unwrap(),
+        );
+
+        let physical_schema: ArrowSchema = dataset.schema().into();
+        assert!(is_json_field(
+            physical_schema.field_with_name("meta").unwrap()
+        ));
+
+        let update_result = UpdateBuilder::new(dataset)
+            .update_where("id = 2")
+            .unwrap()
+            .set("name", "'updated'")
+            .unwrap()
+            .set("meta", r#"jsonb '{"after":true,"n":2}'"#)
+            .unwrap()
+            .build()
+            .unwrap()
+            .execute()
+            .await
+            .unwrap();
+
+        let updated_dataset = update_result.new_dataset;
+        let actual_batches = updated_dataset
+            .scan()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let actual_batch = concat_batches(&actual_batches[0].schema(), &actual_batches).unwrap();
+        assert!(is_arrow_json_field(
+            actual_batch.schema().field_with_name("meta").unwrap()
+        ));
+
+        let ids = actual_batch["id"].as_primitive::<Int64Type>();
+        let names = actual_batch["name"].as_string::<i32>();
+        let metas = actual_batch["meta"].as_string::<i32>();
+        let updated_row_idx = ids.iter().position(|id| id == Some(2)).unwrap();
+
+        assert_eq!(names.value(updated_row_idx), "updated");
+        assert_eq!(metas.value(updated_row_idx), r#"{"after":true,"n":2}"#);
     }
 
     #[rstest]


### PR DESCRIPTION
Update rewrites affected rows using the dataset physical schema. Avoid wrapping the scan output in DatasetRecordBatchStream, which may convert internal JSON columns from lance.json/LargeBinary to arrow.json/Utf8 for user-facing reads and cause schema mismatches during rewrite. Add coverage for updating both regular and JSON columns.

Error msg
```
Traceback (most recent call last):
  File "/Users/bytedance/Project/emr/jinglun-lance-hello-python/main.py", line 298, in <module>
    chunsheng_debug()
    ~~~~~~~~~~~~~~~^^
  File "/Users/bytedance/Project/emr/jinglun-lance-hello-python/main.py", line 291, in chunsheng_debug
    ds.update({'speaker_id': '"SPEAKER_9172"'}, where="name='沈逸'")
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bytedance/miniconda3/lib/python3.13/site-packages/lance/dataset.py", line 2577, in update
    return self._ds.update(updates, where, conflict_retries, retry_timeout)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: Encountered internal error. Please file a bug report at https://github.com/lance-format/lance/issues. Expected schema Schema { fields: [Field { name: "id", data_type: Int64, nullable: true }, Field { name: "users_id", data_type: Int64, nullable: true }, Field { name: "user_id", data_type: Utf8, nullable: true }, Field { name: "name", data_type: Utf8, nullable: true }, Field { name: "files", data_type: LargeBinary, nullable: true, metadata: {"ARROW:extension:metadata": "", "ARROW:extension:name": "lance.json"} }, Field { name: "user_tags", data_type: LargeBinary, nullable: true, metadata: {"ARROW:extension:name": "lance.json", "ARROW:extension:metadata": ""} }, Field { name: "output_text", data_type: Utf8, nullable: true }, Field { name: "ai_tags", data_type: LargeBinary, nullable: true, metadata: {"ARROW:extension:name": "lance.json", "ARROW:extension:metadata": ""} }, Field { name: "created_time", data_type: Timestamp(Microsecond, Some("Asia/Shanghai")), nullable: true }, Field { name: "updated_time", data_type: Timestamp(Microsecond, Some("Asia/Shanghai")), nullable: true }, Field { name: "del_flag", data_type: Int32, nullable: true }, Field { name: "speaker_id", data_type: Utf8, nullable: true }], metadata: {} } but got Schema { fields: [Field { name: "id", data_type: Int64, nullable: true }, Field { name: "users_id", data_type: Int64, nullable: true }, Field { name: "user_id", data_type: Utf8, nullable: true }, Field { name: "name", data_type: Utf8, nullable: true }, Field { name: "files", data_type: Utf8, nullable: true, metadata: {"ARROW:extension:metadata": "", "ARROW:extension:name": "arrow.json"} }, Field { name: "user_tags", data_type: Utf8, nullable: true, metadata: {"ARROW:extension:name": "arrow.json", "ARROW:extension:metadata": ""} }, Field { name: "output_text", data_type: Utf8, nullable: true }, Field { name: "ai_tags", data_type: Utf8, nullable: true, metadata: {"ARROW:extension:name": "arrow.json", "ARROW:extension:metadata": ""} }, Field { name: "created_time", data_type: Timestamp(Microsecond, Some("Asia/Shanghai")), nullable: true }, Field { name: "updated_time", data_type: Timestamp(Microsecond, Some("Asia/Shanghai")), nullable: true }, Field { name: "del_flag", data_type: Int32, nullable: true }, Field { name: "speaker_id", data_type: Utf8, nullable: true }], metadata: {} }, /Users/runner/work/lance/lance/rust/lance/src/dataset/write/update.rs:274:24

Process finished with exit code 1
```

Closes #6329