### PR TITLE
feat: allow LSM scanner to read fresh tier without a base table

### DIFF
--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -20,6 +20,13 @@ use super::data_source::ShardSnapshot;
 use super::planner::LsmScanPlanner;
 use crate::dataset::Dataset;
 
+/// Either a base Lance table, or an explicit base path used to resolve
+/// flushed-generation directories when no base dataset is configured.
+enum BaseSource {
+    Table(Arc<Dataset>),
+    PathOnly(String),
+}
+
 /// Scanner for LSM tree data spanning base table, flushed MemTables, and active MemTable.
 ///
 /// This scanner provides a unified interface for querying data across multiple
@@ -43,7 +50,11 @@ use crate::dataset::Dataset;
 /// ```
 pub struct LsmScanner {
     // Data sources
-    base_table: Arc<Dataset>,
+    base: BaseSource,
+    /// Schema used for projection, empty plans, and filter parsing.
+    /// Derived from the base dataset when one is present, otherwise supplied
+    /// explicitly by [`Self::without_base_table`].
+    schema: SchemaRef,
     shard_snapshots: Vec<ShardSnapshot>,
     active_memtables: HashMap<Uuid, ActiveMemTableRef>,
 
@@ -74,8 +85,47 @@ impl LsmScanner {
         shard_snapshots: Vec<ShardSnapshot>,
         pk_columns: Vec<String>,
     ) -> Self {
+        let lance_schema = base_table.schema();
+        let arrow_schema: arrow_schema::Schema = lance_schema.into();
         Self {
-            base_table,
+            base: BaseSource::Table(base_table),
+            schema: Arc::new(arrow_schema),
+            shard_snapshots,
+            active_memtables: HashMap::new(),
+            projection: None,
+            filter: None,
+            limit: None,
+            offset: None,
+            with_row_address: false,
+            with_memtable_gen: false,
+            pk_columns,
+        }
+    }
+
+    /// Create a scanner that reads only the fresh tier (active memtable and
+    /// flushed generations) without including a base Lance table.
+    ///
+    /// This is useful when the caller owns the base read path separately and
+    /// only needs the WAL's contribution: active memtable ∪ L0 flushed
+    /// generations. Deduplication semantics are unchanged — newer generations
+    /// still win on PK conflicts.
+    ///
+    /// # Arguments
+    ///
+    /// * `schema` - Schema used for projection, filter parsing, and empty plans.
+    ///   Should match the schema flushed generations were written with.
+    /// * `base_path` - Table-root URI used to resolve relative flushed paths.
+    /// * `shard_snapshots` - Snapshots of shard states from MemWAL index.
+    /// * `pk_columns` - Primary key column names for deduplication.
+    pub fn without_base_table(
+        schema: SchemaRef,
+        base_path: impl Into<String>,
+        shard_snapshots: Vec<ShardSnapshot>,
+        pk_columns: Vec<String>,
+    ) -> Self {
+        Self {
+            base: BaseSource::PathOnly(base_path.into()),
+            schema,
             shard_snapshots,
             active_memtables: HashMap::new(),
             projection: None,
@@ -112,9 +162,10 @@ impl LsmScanner {
     /// The filter is pushed down to each data source when possible.
     pub fn filter(mut self, filter_expr: &str) -> Result<Self> {
         let ctx = SessionContext::new();
-        let lance_schema = self.base_table.schema();
-        let arrow_schema: arrow_schema::Schema = lance_schema.into();
-        let df_schema = arrow_schema
+        let df_schema = self
+            .schema
+            .as_ref()
+            .clone()
             .to_dfschema()
             .map_err(|e| Error::invalid_input(format!("Failed to create DFSchema: {}", e)))?;
         let expr = ctx.parse_sql_expr(filter_expr, &df_schema).map_err(|e| {
@@ -157,11 +208,9 @@ impl LsmScanner {
 
     /// Get the output schema.
     pub fn schema(&self) -> SchemaRef {
-        // For now, return base schema. Full implementation would compute
-        // the projected schema with optional _gen/_rowaddr columns.
-        let lance_schema = self.base_table.schema();
-        let arrow_schema: arrow_schema::Schema = lance_schema.into();
-        Arc::new(arrow_schema)
+        // For now, return the configured schema. Full implementation would
+        // compute the projected schema with optional _gen/_rowaddr columns.
+        self.schema.clone()
     }
 
     /// Create the execution plan.
@@ -222,8 +271,15 @@ impl LsmScanner {
 
     /// Build the data source collector.
     fn build_collector(&self) -> LsmDataSourceCollector {
-        let mut collector =
-            LsmDataSourceCollector::new(self.base_table.clone(), self.shard_snapshots.clone());
+        let mut collector = match &self.base {
+            BaseSource::Table(dataset) => {
+                LsmDataSourceCollector::new(dataset.clone(), self.shard_snapshots.clone())
+            }
+            BaseSource::PathOnly(path) => LsmDataSourceCollector::without_base_table(
+                path.clone(),
+                self.shard_snapshots.clone(),
+            ),
+        };
 
         for (shard_id, memtable) in &self.active_memtables {
             collector = collector.with_active_memtable(*shard_id, memtable.clone());
@@ -235,8 +291,12 @@ impl LsmScanner {
 
 impl std::fmt::Debug for LsmScanner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (label, value) = match &self.base {
+            BaseSource::Table(dataset) => ("base_table", dataset.uri().to_string()),
+            BaseSource::PathOnly(path) => ("base_path", path.clone()),
+        };
         f.debug_struct("LsmScanner")
-            .field("base_table", &self.base_table.uri())
+            .field(label, &value)
             .field("num_shards", &self.shard_snapshots.len())
             .field("num_active_memtables", &self.active_memtables.len())
             .field("projection", &self.projection)

--- a/rust/lance/src/dataset/mem_wal/scanner/collector.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/collector.rs
@@ -31,13 +31,18 @@ pub struct ActiveMemTableRef {
 ///
 /// This collector gathers all data sources that need to be scanned
 /// for a query, including:
-/// - The base table (merged data)
+/// - The base table (merged data) — optional; omit for fresh-tier-only scans
 /// - Flushed MemTables from each shard
 /// - Active MemTables (optional, for strong consistency)
+///
+/// When the base table is omitted (see [`Self::without_base_table`]), `collect`
+/// returns only flushed-generation and active-memtable sources. This is used
+/// by callers that own the base read path elsewhere and only need the WAL's
+/// fresh tier (active memtable ∪ L0 flushed generations).
 pub struct LsmDataSourceCollector {
-    /// Base Lance table.
-    base_table: Arc<Dataset>,
-    /// Base path for resolving relative paths.
+    /// Base Lance table (None when scanning only the fresh tier).
+    base_table: Option<Arc<Dataset>>,
+    /// Base path for resolving relative flushed-generation paths.
     base_path: String,
     /// Shard snapshots from MemWAL index.
     shard_snapshots: Vec<ShardSnapshot>,
@@ -57,8 +62,25 @@ impl LsmDataSourceCollector {
         // This ensures memory:// and other scheme-based URIs work correctly.
         let base_path = base_table.uri().trim_end_matches('/').to_string();
         Self {
-            base_table,
+            base_table: Some(base_table),
             base_path,
+            shard_snapshots,
+            active_memtables: HashMap::new(),
+        }
+    }
+
+    /// Create a collector without a base table (fresh-tier scan only).
+    ///
+    /// The collector emits only flushed-generation and active-memtable sources.
+    /// `base_path` is the table-root URI used to resolve relative flushed paths
+    /// (typically the same URI that would have been the base dataset's URI).
+    pub fn without_base_table(
+        base_path: impl Into<String>,
+        shard_snapshots: Vec<ShardSnapshot>,
+    ) -> Self {
+        Self {
+            base_table: None,
+            base_path: base_path.into().trim_end_matches('/').to_string(),
             shard_snapshots,
             active_memtables: HashMap::new(),
         }
@@ -74,9 +96,9 @@ impl LsmDataSourceCollector {
         self
     }
 
-    /// Get the base table.
-    pub fn base_table(&self) -> &Arc<Dataset> {
-        &self.base_table
+    /// Get the base table, if any.
+    pub fn base_table(&self) -> Option<&Arc<Dataset>> {
+        self.base_table.as_ref()
     }
 
     /// Get all shard snapshots.
@@ -92,18 +114,18 @@ impl LsmDataSourceCollector {
     /// Collect all data sources.
     ///
     /// Returns sources in a consistent order:
-    /// 1. Base table (gen=0)
+    /// 1. Base table (gen=0), if configured
     /// 2. Flushed MemTables per shard, ordered by generation
     /// 3. Active MemTables per shard
     pub fn collect(&self) -> Result<Vec<LsmDataSource>> {
         let mut sources = Vec::new();
 
-        // 1. Add base table
-        sources.push(LsmDataSource::BaseTable {
-            dataset: self.base_table.clone(),
-        });
+        if let Some(base) = &self.base_table {
+            sources.push(LsmDataSource::BaseTable {
+                dataset: base.clone(),
+            });
+        }
 
-        // 2. Add flushed MemTables from each shard
         for snapshot in &self.shard_snapshots {
             for flushed in &snapshot.flushed_generations {
                 let path = self.resolve_flushed_path(&snapshot.shard_id, &flushed.path);
@@ -115,7 +137,6 @@ impl LsmDataSourceCollector {
             }
         }
 
-        // 3. Add active MemTables
         for (shard_id, memtable) in &self.active_memtables {
             sources.push(LsmDataSource::ActiveMemTable {
                 batch_store: memtable.batch_store.clone(),
@@ -134,17 +155,17 @@ impl LsmDataSourceCollector {
     /// This is used after shard pruning to avoid loading data from
     /// shards that cannot contain matching rows.
     ///
-    /// The base table is always included since it may contain data
-    /// from any shard (after merging).
+    /// The base table (when configured) is always included since it may
+    /// contain data from any shard (after merging).
     pub fn collect_for_shards(&self, shard_ids: &HashSet<Uuid>) -> Result<Vec<LsmDataSource>> {
         let mut sources = Vec::new();
 
-        // Base table is always included (contains merged data from all shards)
-        sources.push(LsmDataSource::BaseTable {
-            dataset: self.base_table.clone(),
-        });
+        if let Some(base) = &self.base_table {
+            sources.push(LsmDataSource::BaseTable {
+                dataset: base.clone(),
+            });
+        }
 
-        // Filter flushed MemTables by shard
         for snapshot in &self.shard_snapshots {
             if !shard_ids.contains(&snapshot.shard_id) {
                 continue;
@@ -160,7 +181,6 @@ impl LsmDataSourceCollector {
             }
         }
 
-        // Filter active MemTables by shard
         for (shard_id, memtable) in &self.active_memtables {
             if !shard_ids.contains(shard_id) {
                 continue;
@@ -185,7 +205,8 @@ impl LsmDataSourceCollector {
             .iter()
             .map(|s| s.flushed_generations.len())
             .sum();
-        1 + flushed_count + self.active_memtables.len()
+        let base_count = if self.base_table.is_some() { 1 } else { 0 };
+        base_count + flushed_count + self.active_memtables.len()
     }
 
     /// Resolve a flushed MemTable path to an absolute path.

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -1195,4 +1195,105 @@ mod integration_tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results.get(&3), Some(&"gen1_3".to_string()));
     }
+
+    #[tokio::test]
+    async fn test_lsm_scan_without_base_table() {
+        let (base_dataset, shard_snapshots, active_memtable, pk_columns, _temp_path) =
+            setup_multi_level_lsm().await;
+
+        // Use the same base URI the flushed generations were created under, so
+        // relative `gen_N` folders resolve to real datasets on disk.
+        let base_uri = base_dataset.uri().to_string();
+        let arrow_schema: arrow_schema::Schema = base_dataset.schema().into();
+        let schema = Arc::new(arrow_schema);
+
+        let mut scanner =
+            LsmScanner::without_base_table(schema, base_uri, shard_snapshots, pk_columns);
+        if let Some((shard_id, memtable)) = active_memtable {
+            scanner = scanner.with_active_memtable(shard_id, memtable);
+        }
+
+        // Verify the plan does not include a LanceRead for the base table.
+        let plan = scanner.create_plan().await.unwrap();
+        let plan_str = format!(
+            "{}",
+            datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+        );
+        assert!(
+            !plan_str.contains("base/data"),
+            "Plan must not include base table scan, got: {}",
+            plan_str
+        );
+        assert!(
+            plan_str.contains("gen_1") && plan_str.contains("gen_2"),
+            "Plan must scan flushed generations, got: {}",
+            plan_str
+        );
+        assert!(
+            plan_str.contains("MemTableScanExec"),
+            "Plan must scan the active memtable, got: {}",
+            plan_str
+        );
+
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        let mut results: HashMap<i32, String> = HashMap::new();
+        for batch in batches {
+            let ids = batch
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let names = batch
+                .column_by_name("name")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+
+            for i in 0..batch.num_rows() {
+                results.insert(ids.value(i), names.value(i).to_string());
+            }
+        }
+
+        // Without the base table, ids that only exist in base (1, 2) are gone.
+        // The fresh tier (gen1, gen2, active) supplies the rest with newest-wins.
+        assert_eq!(results.len(), 5, "Fresh tier should yield 5 unique rows");
+        assert_eq!(results.get(&1), None);
+        assert_eq!(results.get(&2), None);
+        assert_eq!(results.get(&3), Some(&"gen1_3".to_string()));
+        assert_eq!(results.get(&4), Some(&"gen2_4".to_string()));
+        assert_eq!(results.get(&5), Some(&"active_5".to_string()));
+        assert_eq!(results.get(&6), Some(&"active_6".to_string()));
+        assert_eq!(results.get(&7), Some(&"active_7".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_lsm_scan_without_base_table_no_flushed_no_active() {
+        // No base, no flushed, no active → empty result, valid plan.
+        let schema = create_pk_schema();
+        let scanner = LsmScanner::without_base_table(
+            schema,
+            "memory:///fresh-tier-empty",
+            vec![],
+            vec!["id".to_string()],
+        );
+
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 0);
+    }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -1276,6 +1276,63 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    async fn test_lsm_scan_without_base_table_with_filter() {
+        // Exercises filter() on a scanner built via without_base_table(): the
+        // filter must parse against the supplied schema (no base dataset to
+        // borrow one from) and push down to the fresh-tier sources.
+        let (base_dataset, shard_snapshots, active_memtable, pk_columns, _temp_path) =
+            setup_multi_level_lsm().await;
+
+        let base_uri = base_dataset.uri().to_string();
+        let arrow_schema: arrow_schema::Schema = base_dataset.schema().into();
+        let schema = Arc::new(arrow_schema);
+
+        let mut scanner =
+            LsmScanner::without_base_table(schema, base_uri, shard_snapshots, pk_columns)
+                .filter("id > 3")
+                .unwrap();
+        if let Some((shard_id, memtable)) = active_memtable {
+            scanner = scanner.with_active_memtable(shard_id, memtable);
+        }
+
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        let mut results: HashMap<i32, String> = HashMap::new();
+        for batch in batches {
+            let ids = batch
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let names = batch
+                .column_by_name("name")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+
+            for i in 0..batch.num_rows() {
+                results.insert(ids.value(i), names.value(i).to_string());
+            }
+        }
+
+        // id<=3 excluded by filter; id=1,2 also absent because base is excluded.
+        // Fresh tier with newest-wins: gen2_4, active_5, active_6, active_7.
+        assert_eq!(results.len(), 4);
+        assert_eq!(results.get(&4), Some(&"gen2_4".to_string()));
+        assert_eq!(results.get(&5), Some(&"active_5".to_string()));
+        assert_eq!(results.get(&6), Some(&"active_6".to_string()));
+        assert_eq!(results.get(&7), Some(&"active_7".to_string()));
+    }
+
+    #[tokio::test]
     async fn test_lsm_scan_without_base_table_no_flushed_no_active() {
         // No base, no flushed, no active → empty result, valid plan.
         let schema = create_pk_schema();

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -455,4 +455,58 @@ mod tests {
             "Expression should contain column name"
         );
     }
+
+    #[tokio::test]
+    async fn test_point_lookup_without_base_table() {
+        use futures::TryStreamExt;
+
+        let schema = create_pk_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_path = temp_dir.path().to_str().unwrap();
+
+        // No base dataset is created. We still need a base URI so the collector
+        // can resolve flushed-generation paths.
+        let base_uri = format!("{}/base", base_path);
+
+        // Create a flushed generation under {base_uri}/_mem_wal/{shard}/gen_1
+        let shard_id = Uuid::new_v4();
+        let gen1_uri = format!("{}/_mem_wal/{}/gen_1", base_uri, shard_id);
+        let gen1_batch = create_test_batch(&schema, &[2, 3], "gen1");
+        create_dataset(&gen1_uri, vec![gen1_batch]).await;
+
+        let shard_snapshot = ShardSnapshot::new(shard_id)
+            .with_current_generation(2)
+            .with_flushed_generation(1, "gen_1".to_string());
+
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![shard_snapshot]);
+        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+
+        // id=3 lives in the flushed generation
+        let pk_values = vec![ScalarValue::Int32(Some(3))];
+        let plan = planner.plan_lookup(&pk_values, None).await.unwrap();
+
+        let plan_str = format!("{}", displayable(plan.as_ref()).indent(true));
+        assert!(
+            !plan_str.contains("base/data"),
+            "Plan must not scan base table, got: {}",
+            plan_str
+        );
+        assert!(plan_str.contains("gen_1"));
+
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1);
+
+        // id=99 doesn't exist anywhere → empty
+        let plan = planner
+            .plan_lookup(&[ScalarValue::Int32(Some(99))], None)
+            .await
+            .unwrap();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 0);
+    }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -483,4 +483,39 @@ mod tests {
         assert!(cols.contains(&"vector".to_string()));
         assert!(cols.contains(&"id".to_string()));
     }
+
+    #[tokio::test]
+    async fn test_vector_search_without_base_table() {
+        let schema = create_vector_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
+
+        // No base dataset written. Plan construction must still succeed and
+        // exclude any base-table scan node.
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![]);
+
+        let planner = LsmVectorSearchPlanner::new(
+            collector,
+            vec!["id".to_string()],
+            schema,
+            "vector".to_string(),
+            lance_linalg::distance::DistanceType::L2,
+        );
+
+        let query = create_query_vector();
+        let plan = planner
+            .plan_search(&query, 10, 8, None)
+            .await
+            .expect("planner should produce a plan without a base table");
+
+        let plan_str = format!(
+            "{}",
+            datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+        );
+        assert!(
+            !plan_str.contains("base/data"),
+            "Plan must not scan base table, got: {}",
+            plan_str
+        );
+    }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -486,6 +486,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_vector_search_without_base_table() {
+        use futures::TryStreamExt;
+
         let schema = create_vector_schema();
         let temp_dir = tempfile::tempdir().unwrap();
         let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
@@ -517,5 +519,18 @@ mod tests {
             "Plan must not scan base table, got: {}",
             plan_str
         );
+
+        // Execute the plan so runtime issues (schema mismatches, missing
+        // sources, etc.) surface here rather than at the call site.
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan
+            .execute(0, ctx.task_ctx())
+            .expect("plan should execute without a base table");
+        let batches: Vec<RecordBatch> = stream
+            .try_collect()
+            .await
+            .expect("collecting batches should succeed");
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 0, "fresh tier with no sources should yield no rows");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `LsmScanner::without_base_table(schema, base_path, snapshots, pk_columns)` and `LsmDataSourceCollector::without_base_table(base_path, snapshots)` so callers can scan only the active memtable and flushed L0 generations.
- Internally, `base_table` becomes `Option<Arc<Dataset>>`; `collect()` / `collect_for_shards()` skip the base source when it is absent. All three planners (scan, point lookup, vector search) are unaffected since they already drive off the collector and keep their own `base_schema` field.
- Existing `LsmScanner::new(...)` and `LsmDataSourceCollector::new(...)` signatures are unchanged, so Python bindings and benches keep compiling without edits.

## Motivation

Some callers own the base read path elsewhere and only need the WAL's contribution to a query — the active memtable ∪ L0 flushed generations. Without this change, `LsmScanner` always pulls the base dataset in, which duplicates work and forces those callers to subtract the base contribution out of band. With the new constructor, the same scanner code path serves both modes; dedup semantics across generations are unchanged.

## Test plan

- [x] `cargo test -p lance --lib dataset::mem_wal::scanner` — 55/55 passing, including three new tests:
  - `test_lsm_scan_without_base_table` — verifies the plan excludes any base-table `LanceRead` and that ids only present in the base are absent from the result.
  - `test_lsm_scan_without_base_table_no_flushed_no_active` — empty fresh tier returns an empty plan cleanly.
  - `test_point_lookup_without_base_table` — point lookup hits a flushed generation; missing key returns empty.
  - `test_vector_search_without_base_table` — plan construction succeeds and excludes the base.
- [x] `cargo clippy -p lance --tests -- -D warnings` clean
- [x] `cargo fmt -p lance` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)