### PR TITLE
fix: use multipart-aware put for transaction file writes

### DIFF
--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -60,7 +60,6 @@ use lance_core::{Error, Result};
 use lance_index::is_system_index;
 use lance_io::object_store::ObjectStoreRegistry;
 use log;
-use object_store::ObjectStoreExt;
 use object_store::path::Path;
 use prost::Message;
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -60,6 +60,8 @@ use lance_core::{Error, Result};
 use lance_index::is_system_index;
 use lance_io::object_store::ObjectStoreRegistry;
 use log;
+#[cfg(test)]
+use object_store::ObjectStoreExt;
 use object_store::path::Path;
 use prost::Message;
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -130,7 +130,7 @@ pub(crate) async fn write_transaction_file(
 
     let message = pb::Transaction::from(transaction);
     let buf = message.encode_to_vec();
-    object_store.inner.put(&path, buf.into()).await?;
+    object_store.put(&path, &buf).await?;
 
     Ok(file_name)
 }


### PR DESCRIPTION
## Summary

- `write_transaction_file` was calling `object_store.inner.put()` directly, which issues a single S3 PUT request. S3 has a 5GB hard limit on single PUT, so large transaction files (>5GB) fail with `EntityTooLarge`.
- Changed to use Lance's `ObjectStore::put()` which routes through `ObjectWriter` and handles multipart uploads automatically.

Such big transaction file is definitely not recommended, but after all this is indeed a bug in the code itself.

Resolves https://github.com/lance-format/lance-spark/issues/526