### PR TITLE
feat(io): add shared-memory:// scheme for cross-component in-memory state

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -544,7 +544,14 @@ impl ObjectStore {
     }
 
     pub fn is_cloud(&self) -> bool {
-        !self.is_local() && self.scheme != "memory" && self.scheme != "shared-memory"
+        if self.is_local() || self.scheme == "memory" {
+            return false;
+        }
+        #[cfg(test)]
+        if self.scheme == "shared-memory" {
+            return false;
+        }
+        true
     }
 
     /// Whether this object store prefers the lite scheduler.

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -544,7 +544,7 @@ impl ObjectStore {
     }
 
     pub fn is_cloud(&self) -> bool {
-        !self.is_local() && self.scheme != "memory"
+        !self.is_local() && self.scheme != "memory" && self.scheme != "shared-memory"
     }
 
     /// Whether this object store prefers the lite scheduler.

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -30,6 +30,7 @@ pub mod local;
 pub mod memory;
 #[cfg(feature = "oss")]
 pub mod oss;
+pub mod shared_memory;
 #[cfg(feature = "tencent")]
 pub mod tencent;
 
@@ -292,6 +293,10 @@ impl Default for ObjectStoreRegistry {
         let mut providers: HashMap<String, Arc<dyn ObjectStoreProvider>> = HashMap::new();
 
         providers.insert("memory".into(), Arc::new(memory::MemoryStoreProvider));
+        providers.insert(
+            "shared-memory".into(),
+            Arc::new(shared_memory::SharedMemoryStoreProvider::default()),
+        );
         providers.insert("file".into(), Arc::new(local::FileStoreProvider));
         // The "file" scheme has special optimized code paths that bypass
         // the ObjectStore API for better performance. However, this can make it

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -30,6 +30,7 @@ pub mod local;
 pub mod memory;
 #[cfg(feature = "oss")]
 pub mod oss;
+#[cfg(test)]
 pub mod shared_memory;
 #[cfg(feature = "tencent")]
 pub mod tencent;
@@ -293,6 +294,7 @@ impl Default for ObjectStoreRegistry {
         let mut providers: HashMap<String, Arc<dyn ObjectStoreProvider>> = HashMap::new();
 
         providers.insert("memory".into(), Arc::new(memory::MemoryStoreProvider));
+        #[cfg(test)]
         providers.insert(
             "shared-memory".into(),
             Arc::new(shared_memory::SharedMemoryStoreProvider::default()),

--- a/rust/lance-io/src/object_store/providers/shared_memory.rs
+++ b/rust/lance-io/src/object_store/providers/shared_memory.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock, Mutex},
+};
+
+use crate::object_store::{
+    ObjectStore, ObjectStoreParams, ObjectStoreProvider, providers::memory::MemoryStoreProvider,
+};
+use lance_core::error::Result;
+use object_store::{memory::InMemory, path::Path};
+use url::Url;
+
+/// Process-global pool of in-memory backends keyed by URL authority.
+///
+/// Different authorities map to different backends (act as "buckets"); same
+/// authority across any caller in the process resolves to the same `Arc<InMemory>`.
+/// The pool grows for the lifetime of the process — entries are never evicted.
+static SHARED_BACKENDS: LazyLock<Mutex<HashMap<String, Arc<InMemory>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn shared_backend_for(url: &Url) -> Arc<InMemory> {
+    SHARED_BACKENDS
+        .lock()
+        .expect("SHARED_BACKENDS mutex poisoned")
+        .entry(url.authority().to_string())
+        .or_insert_with(|| Arc::new(InMemory::new()))
+        .clone()
+}
+
+/// Like [`MemoryStoreProvider`], but every caller resolving a `shared-memory://<authority>/...`
+/// URL with the same `<authority>` sees the same backing bytes — across `ObjectStoreRegistry`
+/// instances, threads, and unrelated components in the same process.
+///
+/// Intended for tests and harnesses that need multiple actors to coordinate through a
+/// common in-memory object store (e.g. a writer and an independent reader, multi-pod
+/// fence simulations). Choose distinct authorities for isolation
+/// (`shared-memory://test-a` vs `shared-memory://test-b`).
+///
+/// Unlike `memory://` — which mints a fresh `InMemory` per `new_store` call — this
+/// provider is opt-in precisely so existing tests relying on per-call isolation are
+/// unaffected.
+#[derive(Default, Debug)]
+pub struct SharedMemoryStoreProvider {
+    inner: MemoryStoreProvider,
+}
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for SharedMemoryStoreProvider {
+    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
+        let mut store = self.inner.new_store(base_path.clone(), params).await?;
+        store.inner = shared_backend_for(&base_path);
+        store.scheme = String::from("shared-memory");
+        store.store_prefix = self.calculate_object_store_prefix(&base_path, None)?;
+        Ok(store)
+    }
+
+    fn extract_path(&self, url: &Url) -> Result<Path> {
+        // The authority is the bucket; the URL path is the object path within it.
+        Ok(Path::from(url.path().trim_start_matches('/')))
+    }
+
+    fn calculate_object_store_prefix(
+        &self,
+        url: &Url,
+        _storage_options: Option<&HashMap<String, String>>,
+    ) -> Result<String> {
+        Ok(format!("shared-memory${}", url.authority()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object_store::ObjectStoreRegistry;
+    use bytes::Bytes;
+    use object_store::{ObjectStoreExt as _, PutPayload};
+
+    async fn store_for(uri: &str) -> (Arc<ObjectStore>, Path) {
+        let registry = Arc::new(ObjectStoreRegistry::default());
+        let (store, path) = ObjectStore::from_uri_and_params(registry, uri, &Default::default())
+            .await
+            .unwrap();
+        (store, path)
+    }
+
+    #[tokio::test]
+    async fn same_authority_shares_bytes_across_registries() {
+        let (writer, _) = store_for("shared-memory://bucket-a/").await;
+        writer
+            .inner
+            .put(&Path::from("file"), PutPayload::from_static(b"hello"))
+            .await
+            .unwrap();
+
+        // Build a *separate* registry — no shared state at the registry layer.
+        let (reader, _) = store_for("shared-memory://bucket-a/").await;
+        let bytes = reader.inner.get(&Path::from("file")).await.unwrap();
+        assert_eq!(bytes.bytes().await.unwrap(), Bytes::from_static(b"hello"));
+    }
+
+    #[tokio::test]
+    async fn different_authorities_are_isolated() {
+        let (a, _) = store_for("shared-memory://iso-a/").await;
+        let (b, _) = store_for("shared-memory://iso-b/").await;
+        a.inner
+            .put(&Path::from("k"), PutPayload::from_static(b"in-a"))
+            .await
+            .unwrap();
+        assert!(b.inner.get(&Path::from("k")).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn extract_path_strips_authority() {
+        let provider = SharedMemoryStoreProvider::default();
+        let url = Url::parse("shared-memory://bucket/foo/bar").unwrap();
+        assert_eq!(provider.extract_path(&url).unwrap(), Path::from("foo/bar"));
+    }
+
+    #[tokio::test]
+    async fn from_uri_and_params_resolves_path_correctly() {
+        let (store, path) = store_for("shared-memory://path-test/sub/dir/obj").await;
+        assert_eq!(path, Path::from("sub/dir/obj"));
+        store
+            .inner
+            .put(&path, PutPayload::from_static(b"payload"))
+            .await
+            .unwrap();
+
+        let (peer, peer_path) = store_for("shared-memory://path-test/sub/dir/obj").await;
+        let bytes = peer.inner.get(&peer_path).await.unwrap();
+        assert_eq!(bytes.bytes().await.unwrap(), Bytes::from_static(b"payload"));
+    }
+
+    #[test]
+    fn calculate_prefix_is_per_authority() {
+        let provider = SharedMemoryStoreProvider::default();
+        let a = provider
+            .calculate_object_store_prefix(&Url::parse("shared-memory://x/p").unwrap(), None)
+            .unwrap();
+        let b = provider
+            .calculate_object_store_prefix(&Url::parse("shared-memory://y/p").unwrap(), None)
+            .unwrap();
+        assert_ne!(a, b);
+        assert_eq!(a, "shared-memory$x");
+    }
+}

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -744,9 +744,11 @@ pub async fn commit_handler_from_url(
 
     match url.scheme() {
         "file" | "file-object-store" => Ok(local_handler),
-        "s3" | "gs" | "az" | "abfss" | "memory" | "shared-memory" | "oss" | "cos" => {
+        "s3" | "gs" | "az" | "abfss" | "memory" | "oss" | "cos" => {
             Ok(Arc::new(ConditionalPutCommitHandler))
         }
+        #[cfg(test)]
+        "shared-memory" => Ok(Arc::new(ConditionalPutCommitHandler)),
         #[cfg(not(feature = "dynamodb"))]
         "s3+ddb" => Err(Error::invalid_input_source(
             "`s3+ddb://` scheme requires `dynamodb` feature to be enabled".into(),

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -744,7 +744,7 @@ pub async fn commit_handler_from_url(
 
     match url.scheme() {
         "file" | "file-object-store" => Ok(local_handler),
-        "s3" | "gs" | "az" | "abfss" | "memory" | "oss" | "cos" => {
+        "s3" | "gs" | "az" | "abfss" | "memory" | "shared-memory" | "oss" | "cos" => {
             Ok(Arc::new(ConditionalPutCommitHandler))
         }
         #[cfg(not(feature = "dynamodb"))]
@@ -1353,5 +1353,21 @@ mod tests {
         let mut expected_versions = detached_versions.clone();
         expected_versions.sort();
         assert_eq!(found_versions, expected_versions);
+    }
+
+    #[tokio::test]
+    async fn test_commit_handler_from_url_memory_schemes() {
+        // Both `memory://` and `shared-memory://` must route to
+        // ConditionalPutCommitHandler — otherwise concurrent writers fall
+        // through to UnsafeCommitHandler and silently clobber each other's
+        // manifests.
+        for url in ["memory://bucket-a/ds", "shared-memory://bucket-a/ds"] {
+            let handler = commit_handler_from_url(url, &None).await.unwrap();
+            assert_eq!(
+                format!("{:?}", handler),
+                "ConditionalPutCommitHandler",
+                "{url} should route to ConditionalPutCommitHandler",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

The existing `memory://` object store provider returns a fresh `InMemory` backend on every `new_store` call, which makes it impossible for independent components in the same process to coordinate through a shared in-memory store — each writes to its own isolated bytes even when the URL matches.

This PR adds a sibling `shared-memory://` scheme that wraps `MemoryStoreProvider` and swaps the inner backend for a process-global `Arc<InMemory>` keyed by URL authority.

- All `shared-memory://bucket-a/...` URLs resolve to the same underlying `InMemory` backend (the URL path is the object key within that backend), so a write to `shared-memory://bucket-a/x` from one component is visible to another component reading `shared-memory://bucket-a/x` — across `ObjectStoreRegistry` instances, threads, and unrelated callers in the same process.
- `shared-memory://bucket-a/...` and `shared-memory://bucket-b/...` resolve to separate backends and remain isolated.
- `memory://` is **unchanged**, so existing tests that rely on per-call isolation are unaffected.

The cache lives in a process-global `LazyLock<Mutex<HashMap<String, Arc<InMemory>>>>` rather than on the provider instance because `ObjectStore::from_uri` constructs a fresh `ObjectStoreRegistry` per call — a per-provider cache wouldn't actually share state across components.

### Why a new scheme rather than caching `memory://`

`"memory://"` (no path) is reused as a generic "give me a temp store" URL across ~70+ test sites in the codebase (e.g. `Dataset::write(data, "memory://", ...)`). With `cargo test` running in parallel, adding caching to `memory://` would cause cross-test contamination at the dataset root. Opt-in via a new scheme avoids any migration churn.

### Use case

Tests and harnesses that need multiple actors to coordinate through a common in-memory object store — e.g. a writer and an independent reader, multi-pod fence simulations, manifest-store + WAL-writer agreement on the same backing bytes.

## Test plan

- [x] `cargo test -p lance-io --lib shared_memory` — 5 new tests pass (cross-registry sharing, per-authority isolation, path extraction, prefix uniqueness, end-to-end via `from_uri_and_params`)
- [x] `cargo test -p lance-io --lib memory` — existing `memory://` tests still pass
- [x] `cargo clippy -p lance-io --tests -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)