### PR TITLE
fix!: disable auto-cleanup by default

### DIFF
--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1184,7 +1184,7 @@ mod tests {
     use crate::index::DatasetIndexExt;
     use crate::{
         dataset::transaction::{Operation, Transaction},
-        dataset::{ReadParams, WriteMode, WriteParams, builder::DatasetBuilder},
+        dataset::{AutoCleanupParams, ReadParams, WriteMode, WriteParams, builder::DatasetBuilder},
         index::vector::VectorIndexParams,
     };
     use all_asserts::{assert_gt, assert_lt};
@@ -1329,6 +1329,24 @@ mod tests {
 
         async fn create_some_data(&self) -> Result<()> {
             self.write_some_data_impl(WriteMode::Create).await
+        }
+
+        // Auto-cleanup is disabled by default; this helper creates a dataset
+        // with auto-cleanup enabled using the default interval/older_than.
+        async fn create_some_data_with_auto_cleanup(&self) -> Result<()> {
+            Dataset::write(
+                some_batch(),
+                &self.dataset_path,
+                Some(WriteParams {
+                    store_params: Some(self.os_params()),
+                    commit_handler: Some(Arc::new(RenameCommitHandler)),
+                    mode: WriteMode::Create,
+                    auto_cleanup: Some(AutoCleanupParams::default()),
+                    ..Default::default()
+                }),
+            )
+            .await?;
+            Ok(())
         }
 
         async fn overwrite_some_data(&self) -> Result<()> {
@@ -1907,7 +1925,7 @@ mod tests {
         // commit.
         let fixture = MockDatasetFixture::try_new().unwrap();
 
-        fixture.create_some_data().await.unwrap();
+        fixture.create_some_data_with_auto_cleanup().await.unwrap();
 
         let dataset_config = &fixture.open().await.unwrap().manifest.config;
         let cleanup_interval: usize = dataset_config

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -257,11 +257,19 @@ pub struct WriteParams {
     pub session: Option<Arc<Session>>,
 
     /// If Some and this is a new dataset, old dataset versions will be
-    /// automatically cleaned up according to the parameters set out in
-    /// [`AutoCleanupParams`]. This parameter has no effect on existing datasets.
-    /// To add auto-cleanup to an existing dataset, use [`Dataset::update_config`]
-    /// to set `lance.auto_cleanup.interval` and `lance.auto_cleanup.older_than`.
-    /// Both parameters must be set to invoke auto-cleanup.
+    /// automatically cleaned up after commits according to the parameters set
+    /// out in [`AutoCleanupParams`]. This parameter has no effect on existing
+    /// datasets. To add auto-cleanup to an existing dataset, use
+    /// [`Dataset::update_config`] to set `lance.auto_cleanup.interval` and
+    /// `lance.auto_cleanup.older_than`. Both parameters must be set to invoke
+    /// auto-cleanup.
+    ///
+    /// Defaults to `None` (auto-cleanup disabled). Enabling it makes every
+    /// `interval`-th commit run a full cleanup pass, which lists and reads every
+    /// manifest in the dataset even when nothing is old enough to delete; on
+    /// object stores this adds noticeable per-commit latency that grows with the
+    /// version count. Prefer calling [`Dataset::cleanup_old_versions`] explicitly
+    /// when you actually need to reclaim space.
     pub auto_cleanup: Option<AutoCleanupParams>,
 
     /// If true, skip auto cleanup during commits. This should be set to true
@@ -325,7 +333,7 @@ impl Default for WriteParams {
             enable_stable_row_ids: false,
             enable_v2_manifest_paths: true,
             session: None,
-            auto_cleanup: Some(AutoCleanupParams::default()),
+            auto_cleanup: None,
             skip_auto_cleanup: false,
             transaction_properties: None,
             initial_bases: None,
@@ -1402,6 +1410,16 @@ mod tests {
     use lance_io::object_store::StorageOptionsAccessor;
     use lance_io::traits::Reader;
     use lance_table::format::BasePath;
+
+    #[test]
+    fn test_auto_cleanup_disabled_by_default() {
+        // Auto-cleanup must be off by default: the cleanup hook is expensive on
+        // object stores and the 14-day default rarely deletes anything anyway.
+        // See https://github.com/lance-format/lance/issues/6728
+        let params = WriteParams::default();
+        assert!(params.auto_cleanup.is_none());
+        assert!(!params.skip_auto_cleanup);
+    }
 
     #[tokio::test]
     async fn test_chunking_large_batches() {


### PR DESCRIPTION
## Summary

- Default `WriteParams::auto_cleanup` to `None` so new datasets do not opt into the periodic cleanup hook.
- Aligns the Rust default with the Python binding (already defaults to `None`) and the Java binding (inherits the Rust default).
- Adds a regression test asserting the new default and updates the cleanup-tests fixture so the auto-cleanup behavioural tests explicitly enable it.

Closes #6728

## Why

With the old default, every 20th commit ran a full cleanup pass — listing `_versions/`, reading every manifest plus its index sidecar, and listing the `data/`, `_transactions/`, `_indices/` subtrees — even when nothing was older than the 14-day default. A short S3 (us-east-1) benchmark of 60 sequential overwrites on a tiny dataset:

| Group | mean | max |
| --- | --- | --- |
| ON, v % 20 == 0 (hook fires) | 2548 ms | 2671 ms |
| ON, v % 20 != 0 | 1180 ms | 1390 ms |
| OFF (`skip_auto_cleanup=true`) | 1196 ms | 1456 ms |

The 14-day window meant the periodic spike paid the inspection cost and deleted nothing in practice. Users who want auto-cleanup can still opt in by setting `WriteParams::auto_cleanup` at create time or by setting `lance.auto_cleanup.interval` / `lance.auto_cleanup.older_than` via `Dataset::update_config` on an existing dataset.