### PR TITLE
chore: use Uuid type throughout index infrastructure instead of String

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -61,6 +61,7 @@ use std::iter::empty;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
+use uuid::Uuid;
 
 pub const NATIVE_DATASET: &str = "nativeDatasetHandle";
 
@@ -951,7 +952,13 @@ fn inner_create_index<'local>(
     let fragment_ids = env
         .get_ints_opt(&fragments_jobj)?
         .map(|vec| vec.into_iter().map(|i| i as u32).collect());
-    let index_uuid = env.get_string_opt(&index_uuid_jobj)?;
+    let index_uuid = env
+        .get_string_opt(&index_uuid_jobj)?
+        .map(|s| {
+            Uuid::parse_str(&s)
+                .map_err(|e| Error::input_error(format!("Invalid UUID string for index_uuid: {e}")))
+        })
+        .transpose()?;
     let arrow_stream_addr_opt = env.get_long_opt(&arrow_stream_addr_jobj)?;
     let batch_reader = if let Some(arrow_stream_addr) = arrow_stream_addr_opt {
         let stream_ptr = arrow_stream_addr as *mut FFI_ArrowArrayStream;
@@ -1089,7 +1096,9 @@ fn inner_merge_index_metadata(
     index_type_code_jobj: jint,
     batch_readhead_jobj: JObject, // Optional<Integer>
 ) -> Result<()> {
-    let index_uuid = index_uuid.extract(env)?;
+    let index_uuid_str = index_uuid.extract(env)?;
+    let index_uuid = Uuid::parse_str(&index_uuid_str)
+        .map_err(|e| Error::input_error(format!("Invalid UUID string for index_uuid: {e}")))?;
     let index_type = IndexType::try_from(index_type_code_jobj)?;
     let batch_readhead = env
         .get_int_opt(&batch_readhead_jobj)?

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -108,6 +108,23 @@ def _commit_segmented_btree_index(dataset, column, index_name):
     return dataset.commit_existing_index_segments(index_name, column, segments)
 
 
+def test_create_scalar_index_rejects_invalid_uuid(tmp_path):
+    """Invalid UUID strings passed to create_scalar_index and merge_index_metadata
+    must surface as a Python ValueError at the FFI boundary."""
+    data = pa.table({"id": pa.array(range(100), type=pa.int64())})
+    dataset = lance.write_dataset(data, tmp_path / "ds")
+
+    with pytest.raises(ValueError, match="Invalid UUID"):
+        dataset.create_scalar_index(
+            column="id",
+            index_type="BTREE",
+            index_uuid="not-a-uuid",
+        )
+
+    with pytest.raises(ValueError, match="Invalid UUID"):
+        dataset.merge_index_metadata("also-not-a-uuid", index_type="BTREE")
+
+
 @pytest.fixture
 def btree_comparison_datasets(tmp_path):
     """Setup datasets for B-tree comparison tests"""

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -89,6 +89,7 @@ use lance_linalg::distance::MetricType;
 use lance_table::format::{BasePath, Fragment, IndexMetadata};
 use lance_table::io::commit::CommitHandler;
 use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
+use uuid::Uuid;
 
 use crate::error::PythonErrorExt;
 use crate::file::object_store_from_uri_or_path;
@@ -2304,10 +2305,22 @@ impl Dataset {
             None
         };
 
-        let index_uuid: Option<String> = if let Some(kwargs) = kwargs {
+        let index_uuid: Option<Uuid> = if let Some(kwargs) = kwargs {
             kwargs
                 .get_item("index_uuid")?
-                .and_then(|v| if v.is_none() { None } else { Some(v.extract()) })
+                .and_then(|v| {
+                    if v.is_none() {
+                        None
+                    } else {
+                        Some(v.extract::<String>())
+                    }
+                })
+                .transpose()?
+                .map(|s| {
+                    Uuid::parse_str(&s).map_err(|e| {
+                        PyValueError::new_err(format!("Invalid UUID string for index_uuid: {e}"))
+                    })
+                })
                 .transpose()?
         } else {
             None
@@ -2410,6 +2423,9 @@ impl Dataset {
         batch_readhead: Option<usize>,
         progress_callback: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<()> {
+        let parsed_uuid = Uuid::parse_str(index_uuid).map_err(|e| {
+            PyValueError::new_err(format!("Invalid UUID string for index_uuid: {e}"))
+        })?;
         let mut progress_handler =
             Self::make_index_progress_handler_from_callback(progress_callback)?;
         let progress: Arc<dyn IndexBuildProgress> = progress_handler
@@ -2421,7 +2437,7 @@ impl Dataset {
             async {
                 self.ds
                     .merge_index_metadata(
-                        index_uuid,
+                        &parsed_uuid,
                         IndexType::try_from(index_type)?,
                         batch_readhead,
                         progress,
@@ -3070,11 +3086,7 @@ impl Dataset {
 
             let vindex = self
                 .ds
-                .open_vector_index(
-                    column_name,
-                    &idx_meta.uuid.to_string(),
-                    &NoOpMetricsCollector,
-                )
+                .open_vector_index(column_name, &idx_meta.uuid, &NoOpMetricsCollector)
                 .await
                 .infer_error()?;
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -89,7 +89,6 @@ use lance_linalg::distance::MetricType;
 use lance_table::format::{BasePath, Fragment, IndexMetadata};
 use lance_table::io::commit::CommitHandler;
 use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
-use uuid::Uuid;
 
 use crate::error::PythonErrorExt;
 use crate::file::object_store_from_uri_or_path;

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -145,11 +145,7 @@ async fn do_get_ivf_model(dataset: &Dataset, index_name: &str) -> PyResult<IvfMo
     // Open the vector index
     let vindex = dataset
         .ds
-        .open_vector_index(
-            column_name,
-            &idx_meta.uuid.to_string(),
-            &NoOpMetricsCollector,
-        )
+        .open_vector_index(column_name, &idx_meta.uuid, &NoOpMetricsCollector)
         .await
         .infer_error()?;
 

--- a/rust/lance/benches/distributed_vector_build.rs
+++ b/rust/lance/benches/distributed_vector_build.rs
@@ -290,7 +290,7 @@ async fn build_partial_fixture(dataset: &mut Dataset, bench_case: BenchCase) -> 
         builder = builder
             .name("distributed_merge_only".to_string())
             .fragments(fragments)
-            .index_uuid(fixture_uuid.to_string());
+            .index_uuid(fixture_uuid);
         Box::pin(builder.execute_uncommitted()).await.unwrap();
     }
 
@@ -416,7 +416,7 @@ fn bench_distributed_merge_only(c: &mut Criterion) {
                     || prepare_iteration_target(&source_index_dir_fs, &target_index_dir_fs),
                     |_| {
                         rt.block_on(dataset.merge_index_metadata(
-                            &target_uuid.to_string(),
+                            &target_uuid,
                             IndexType::IvfPq,
                             None,
                             noop_progress(),

--- a/rust/lance/benches/mem_wal/vector/hnsw/mem_wal_recall_hnsw.rs
+++ b/rust/lance/benches/mem_wal/vector/hnsw/mem_wal_recall_hnsw.rs
@@ -542,8 +542,7 @@ async fn run_checkpoint(
         let uuid = idx_metas
             .first()
             .ok_or_else(|| lance_core::Error::io("flushed gen has no vector index".to_string()))?
-            .uuid
-            .to_string();
+            .uuid;
         let vidx = gen_ds
             .open_vector_index(VECTOR_COL, &uuid, &NoOpMetricsCollector)
             .await?;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -128,6 +128,7 @@ pub use schema_evolution::{
     BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
 };
 pub use take::TakeBuilder;
+use uuid::Uuid;
 pub use write::merge_insert::{
     MergeInsertBuilder, MergeInsertJob, MergeStats, UncommittedMergeInsert, WhenMatched,
     WhenNotMatched, WhenNotMatchedBySource,
@@ -3034,13 +3035,13 @@ impl Dataset {
     /// progress via the supplied callback.
     pub async fn merge_index_metadata(
         &self,
-        index_uuid: &str,
+        index_uuid: &Uuid,
         index_type: IndexType,
         _batch_readhead: Option<usize>,
         progress: Arc<dyn IndexBuildProgress>,
     ) -> Result<()> {
         let store = LanceIndexStore::from_dataset_for_new(self, index_uuid)?;
-        let index_dir = self.indices_dir().join(index_uuid);
+        let index_dir = self.indices_dir().join(index_uuid.to_string());
         match index_type {
             IndexType::Inverted => {
                 // Call merge_index_files function for inverted index

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -21,6 +21,7 @@ use lance_index::pb::VectorIndexDetails;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_table::format::IndexMetadata;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use super::optimize::{IndexRemapper, IndexRemapperOptions};
 
@@ -121,7 +122,7 @@ impl IndexRemapper for DatasetIndexRemapper {
 #[async_trait]
 pub trait LanceIndexStoreExt {
     /// Create an index store for a new index (will always be absolute with no base id)
-    fn from_dataset_for_new(dataset: &Dataset, uuid: &str) -> Result<Self>
+    fn from_dataset_for_new(dataset: &Dataset, uuid: &Uuid) -> Result<Self>
     where
         Self: Sized;
 
@@ -147,8 +148,8 @@ pub(crate) fn dataset_format_version(dataset: &Dataset) -> LanceFileVersion {
 
 #[async_trait]
 impl LanceIndexStoreExt for LanceIndexStore {
-    fn from_dataset_for_new(dataset: &Dataset, uuid: &str) -> Result<Self> {
-        let index_dir = dataset.indices_dir().join(uuid);
+    fn from_dataset_for_new(dataset: &Dataset, uuid: &Uuid) -> Result<Self> {
+        let index_dir = dataset.indices_dir().join(uuid.to_string());
         let cache = dataset.metadata_cache.file_metadata_cache(&index_dir);
         let format_version = dataset_format_version(dataset);
         Ok(Self::with_format_version(
@@ -223,7 +224,7 @@ mod tests {
         let built_index = dataset
             .create_index_builder(&["vector"], IndexType::Vector, &params)
             .name("vector_idx".to_string())
-            .index_uuid(first_segment_uuid.to_string())
+            .index_uuid(first_segment_uuid)
             .execute_uncommitted()
             .await
             .unwrap();

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -738,7 +738,7 @@ async fn load_vector_index_config(
     // bake this metric into their on-disk metadata, so a wrong default would
     // be durable corruption.
     let distance_type = dataset
-        .open_vector_index(&column, &index_meta.uuid.to_string(), &NoOpMetricsCollector)
+        .open_vector_index(&column, &index_meta.uuid, &NoOpMetricsCollector)
         .await
         .map_err(|e| {
             Error::invalid_input(format!(

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -3681,7 +3681,7 @@ impl Scanner {
                         .dataset
                         .open_vector_index(
                             q.column.as_str(),
-                            &selected_index_segments[0].uuid.to_string(),
+                            &selected_index_segments[0].uuid,
                             &NoOpMetricsCollector,
                         )
                         .await?;
@@ -3715,11 +3715,7 @@ impl Scanner {
                     // Fall back to opening the index for legacy indices without details
                     let idx = self
                         .dataset
-                        .open_vector_index(
-                            q.column.as_str(),
-                            &index.uuid.to_string(),
-                            &NoOpMetricsCollector,
-                        )
+                        .open_vector_index(q.column.as_str(), &index.uuid, &NoOpMetricsCollector)
                         .await?;
                     idx.metric_type()
                 };

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::FutureExt;
 use itertools::Itertools;
-use lance_core::cache::{CacheKey, UnsizedCacheKey};
+use lance_core::cache::CacheKey;
 use lance_core::datatypes::Field;
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_core::utils::address::RowAddress;
@@ -273,34 +273,6 @@ fn segment_has_btree_details(segment: &IndexMetadata) -> bool {
 }
 
 // Cache keys for different index types
-#[derive(Debug, Clone)]
-pub struct ScalarIndexCacheKey<'a> {
-    pub uuid: &'a Uuid,
-    pub fri_uuid: Option<&'a Uuid>,
-}
-
-impl<'a> ScalarIndexCacheKey<'a> {
-    pub fn new(uuid: &'a Uuid, fri_uuid: Option<&'a Uuid>) -> Self {
-        Self { uuid, fri_uuid }
-    }
-}
-
-impl UnsizedCacheKey for ScalarIndexCacheKey<'_> {
-    type ValueType = dyn ScalarIndex;
-
-    fn key(&self) -> std::borrow::Cow<'_, str> {
-        if let Some(fri_uuid) = self.fri_uuid {
-            format!("{}-{}", self.uuid, fri_uuid).into()
-        } else {
-            self.uuid.to_string().into()
-        }
-    }
-
-    fn type_name() -> &'static str {
-        "ScalarIndex"
-    }
-}
-
 #[derive(Debug, Clone)]
 pub(crate) struct LegacyVectorIndexCacheKey<'a> {
     uuid: &'a Uuid,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -274,13 +274,41 @@ fn segment_has_btree_details(segment: &IndexMetadata) -> bool {
 
 // Cache keys for different index types
 #[derive(Debug, Clone)]
+pub struct ScalarIndexCacheKey<'a> {
+    pub uuid: &'a Uuid,
+    pub fri_uuid: Option<&'a Uuid>,
+}
+
+impl<'a> ScalarIndexCacheKey<'a> {
+    pub fn new(uuid: &'a Uuid, fri_uuid: Option<&'a Uuid>) -> Self {
+        Self { uuid, fri_uuid }
+    }
+}
+
+impl UnsizedCacheKey for ScalarIndexCacheKey<'_> {
+    type ValueType = dyn ScalarIndex;
+
+    fn key(&self) -> std::borrow::Cow<'_, str> {
+        if let Some(fri_uuid) = self.fri_uuid {
+            format!("{}-{}", self.uuid, fri_uuid).into()
+        } else {
+            self.uuid.to_string().into()
+        }
+    }
+
+    fn type_name() -> &'static str {
+        "ScalarIndex"
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct LegacyVectorIndexCacheKey<'a> {
-    uuid: &'a str,
+    uuid: &'a Uuid,
     fri_uuid: Option<&'a Uuid>,
 }
 
 impl<'a> LegacyVectorIndexCacheKey<'a> {
-    fn new(uuid: &'a str, fri_uuid: Option<&'a Uuid>) -> Self {
+    fn new(uuid: &'a Uuid, fri_uuid: Option<&'a Uuid>) -> Self {
         Self { uuid, fri_uuid }
     }
 }
@@ -292,7 +320,7 @@ impl CacheKey for LegacyVectorIndexCacheKey<'_> {
         if let Some(fri_uuid) = self.fri_uuid {
             format!("{}-{}", self.uuid, fri_uuid).into()
         } else {
-            self.uuid.into()
+            self.uuid.to_string().into()
         }
     }
 
@@ -308,12 +336,12 @@ impl CacheKey for LegacyVectorIndexCacheKey<'_> {
 /// Legacy indices use `LegacyVectorIndexCacheKey` instead (in-memory only).
 #[derive(Debug, Clone)]
 pub(crate) struct IvfIndexStateCacheKey<'a> {
-    uuid: &'a str,
+    uuid: &'a Uuid,
     fri_uuid: Option<&'a Uuid>,
 }
 
 impl<'a> IvfIndexStateCacheKey<'a> {
-    fn new(uuid: &'a str, fri_uuid: Option<&'a Uuid>) -> Self {
+    fn new(uuid: &'a Uuid, fri_uuid: Option<&'a Uuid>) -> Self {
         Self { uuid, fri_uuid }
     }
 }
@@ -329,7 +357,7 @@ impl CacheKey for IvfIndexStateCacheKey<'_> {
         if let Some(fri_uuid) = self.fri_uuid {
             format!("{}-{}", self.uuid, fri_uuid).into()
         } else {
-            self.uuid.into()
+            self.uuid.to_string().into()
         }
     }
 
@@ -345,12 +373,12 @@ pub(crate) struct CachedLegacyVectorIndex(Arc<dyn VectorIndex>);
 
 #[derive(Debug, Clone)]
 pub struct FragReuseIndexCacheKey<'a> {
-    pub uuid: &'a str,
+    pub uuid: &'a Uuid,
     pub fri_uuid: Option<&'a Uuid>,
 }
 
 impl<'a> FragReuseIndexCacheKey<'a> {
-    pub fn new(uuid: &'a str, fri_uuid: Option<&'a Uuid>) -> Self {
+    pub fn new(uuid: &'a Uuid, fri_uuid: Option<&'a Uuid>) -> Self {
         Self { uuid, fri_uuid }
     }
 }
@@ -362,7 +390,7 @@ impl CacheKey for FragReuseIndexCacheKey<'_> {
         if let Some(fri_uuid) = self.fri_uuid {
             format!("{}-{}", self.uuid, fri_uuid).into()
         } else {
-            self.uuid.into()
+            self.uuid.to_string().into()
         }
     }
 
@@ -497,7 +525,7 @@ pub(crate) async fn remap_index(
     let new_id = Uuid::new_v4();
 
     let generic = match dataset
-        .open_generic_index(&field_path, &index_id.to_string(), &NoOpMetricsCollector)
+        .open_generic_index(&field_path, index_id, &NoOpMetricsCollector)
         .await
     {
         Ok(g) => g,
@@ -515,10 +543,10 @@ pub(crate) async fn remap_index(
 
     let created_index = match generic.index_type() {
         it if it.is_scalar() => {
-            let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_id.to_string())?;
+            let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_id)?;
 
             let scalar_index = dataset
-                .open_scalar_index(&field_path, &index_id.to_string(), &NoOpMetricsCollector)
+                .open_scalar_index(&field_path, index_id, &NoOpMetricsCollector)
                 .await?;
             if !scalar_index.can_remap() {
                 return Ok(RemapResult::Drop);
@@ -955,7 +983,7 @@ impl DatasetIndexExt for Dataset {
 
         for index_meta in indices {
             let index = self
-                .open_generic_index(name, &index_meta.uuid.to_string(), &NoOpMetricsCollector)
+                .open_generic_index(name, &index_meta.uuid, &NoOpMetricsCollector)
                 .await?;
             index.prewarm().await?;
         }
@@ -971,7 +999,7 @@ impl DatasetIndexExt for Dataset {
 
         for index_meta in indices {
             let index = self
-                .open_generic_index(name, &index_meta.uuid.to_string(), &NoOpMetricsCollector)
+                .open_generic_index(name, &index_meta.uuid, &NoOpMetricsCollector)
                 .await?;
 
             match options {
@@ -1081,8 +1109,9 @@ impl DatasetIndexExt for Dataset {
         if let Some(frag_reuse_index_meta) =
             indices.iter().find(|idx| idx.name == FRAG_REUSE_INDEX_NAME)
         {
-            let uuid = frag_reuse_index_meta.uuid.to_string();
-            let fri_key = FragReuseIndexKey { uuid: &uuid };
+            let fri_key = FragReuseIndexKey {
+                uuid: &frag_reuse_index_meta.uuid,
+            };
             let frag_reuse_index = self
                 .index_cache
                 .get_or_insert_with_key(fri_key, || async move {
@@ -1617,7 +1646,7 @@ async fn collect_regular_indices_statistics(
         }
 
         let index = ds
-            .open_generic_index(field_path, &meta.uuid.to_string(), &NoOpMetricsCollector)
+            .open_generic_index(field_path, &meta.uuid, &NoOpMetricsCollector)
             .await?;
 
         indices_stats.push(index.statistics()?);
@@ -1710,21 +1739,21 @@ pub trait DatasetIndexInternalExt: DatasetIndexExt {
     async fn open_generic_index(
         &self,
         column: &str,
-        uuid: &str,
+        uuid: &Uuid,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn Index>>;
     /// Opens the requested scalar index
     async fn open_scalar_index(
         &self,
         column: &str,
-        uuid: &str,
+        uuid: &Uuid,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn ScalarIndex>>;
     /// Opens the requested vector index
     async fn open_vector_index(
         &self,
         column: &str,
-        uuid: &str,
+        uuid: &Uuid,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn VectorIndex>>;
     /// Opens all segments for one logical vector index and returns a materialized snapshot.
@@ -1771,7 +1800,7 @@ impl DatasetIndexInternalExt for Dataset {
     async fn open_generic_index(
         &self,
         column: &str,
-        uuid: &str,
+        uuid: &Uuid,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn Index>> {
         // Checking for cache existence is cheap so we just check the vector caches.
@@ -1816,7 +1845,10 @@ impl DatasetIndexInternalExt for Dataset {
         } else {
             // Fall back to file existence check for older indices without file metadata
             let index_dir = self.indice_files_dir(&index_meta)?;
-            let index_file = index_dir.clone().join(uuid).join(INDEX_FILE_NAME);
+            let index_file = index_dir
+                .clone()
+                .join(uuid.to_string())
+                .join(INDEX_FILE_NAME);
             let object_store = self.object_store_for_index(&index_meta).await?;
             object_store.exists(&index_file).await?
         };
@@ -1834,7 +1866,7 @@ impl DatasetIndexInternalExt for Dataset {
     async fn open_scalar_index(
         &self,
         column: &str,
-        uuid: &str,
+        uuid: &Uuid,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn ScalarIndex>> {
         // Caching (including the choice of in-memory vs. serializable state) is
@@ -1850,7 +1882,7 @@ impl DatasetIndexInternalExt for Dataset {
     async fn open_vector_index(
         &self,
         column: &str,
-        uuid: &str,
+        uuid: &Uuid,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn VectorIndex>> {
         let frag_reuse_uuid = self.frag_reuse_index_uuid().await;
@@ -1879,7 +1911,10 @@ impl DatasetIndexInternalExt for Dataset {
 
         let frag_reuse_index = self.open_frag_reuse_index(metrics).await?;
         let index_dir = self.indice_files_dir(&index_meta)?;
-        let index_file = index_dir.clone().join(uuid).join(INDEX_FILE_NAME);
+        let index_file = index_dir
+            .clone()
+            .join(uuid.to_string())
+            .join(INDEX_FILE_NAME);
         let file_sizes = index_meta.file_size_map();
         let reader: Arc<dyn Reader> = vector::open_index_file(
             object_store.as_ref(),
@@ -1911,7 +1946,7 @@ impl DatasetIndexInternalExt for Dataset {
             minor_version,
         ) {
             (0, 1) | (0, 0) => {
-                info!(target: TRACE_IO_EVENTS, index_uuid=uuid, r#type=IO_TYPE_OPEN_VECTOR, version="0.1", index_type="IVF_PQ");
+                info!(target: TRACE_IO_EVENTS, index_uuid=%uuid, r#type=IO_TYPE_OPEN_VECTOR, version="0.1", index_type="IVF_PQ");
                 let proto = open_index_proto(reader.as_ref()).await?;
                 match &proto.implementation {
                     Some(Implementation::VectorIndex(vector_index)) => {
@@ -1933,7 +1968,7 @@ impl DatasetIndexInternalExt for Dataset {
             }
 
             (0, 2) => {
-                info!(target: TRACE_IO_EVENTS, index_uuid=uuid, r#type=IO_TYPE_OPEN_VECTOR, version="0.2", index_type="IVF_PQ");
+                info!(target: TRACE_IO_EVENTS, index_uuid=%uuid, r#type=IO_TYPE_OPEN_VECTOR, version="0.2", index_type="IVF_PQ");
                 let reader = PreviousFileReader::try_new_self_described_from_reader(
                     reader.clone(),
                     Some(&self.metadata_cache.file_metadata_cache(&index_file)),
@@ -1981,7 +2016,7 @@ impl DatasetIndexInternalExt for Dataset {
 
                 let (_, element_type) = get_vector_type(self.schema(), &field_path)?;
 
-                info!(target: TRACE_IO_EVENTS, index_uuid=uuid, r#type=IO_TYPE_OPEN_VECTOR, version="0.3", index_type=index_metadata.index_type);
+                info!(target: TRACE_IO_EVENTS, index_uuid=%uuid, r#type=IO_TYPE_OPEN_VECTOR, version="0.3", index_type=index_metadata.index_type);
 
                 match index_metadata.index_type.as_str() {
                     "IVF_FLAT" => match element_type {
@@ -2166,7 +2201,7 @@ impl DatasetIndexInternalExt for Dataset {
         let mut segments = Vec::with_capacity(metadatas.len());
         for metadata in metadatas {
             let index = self
-                .open_vector_index(column, &metadata.uuid.to_string(), &NoOpMetricsCollector)
+                .open_vector_index(column, &metadata.uuid, &NoOpMetricsCollector)
                 .await?;
             segments.push((metadata, index));
         }
@@ -2179,19 +2214,27 @@ impl DatasetIndexInternalExt for Dataset {
         metrics: &dyn MetricsCollector,
     ) -> Result<Option<Arc<FragReuseIndex>>> {
         if let Some(frag_reuse_index_meta) = self.load_index_by_name(FRAG_REUSE_INDEX_NAME).await? {
-            let uuid = frag_reuse_index_meta.uuid.to_string();
-            let frag_reuse_key = FragReuseIndexKey { uuid: &uuid };
-            let uuid_clone = uuid.clone();
+            let frag_reuse_uuid = frag_reuse_index_meta.uuid;
+            let frag_reuse_key = FragReuseIndexKey {
+                uuid: &frag_reuse_uuid,
+            };
 
             let index = self
                 .index_cache
                 .get_or_insert_with_key(frag_reuse_key, || async move {
-                    let index_meta = self.load_index(&uuid_clone).await?.ok_or_else(|| Error::index(format!("Index with id {} does not exist", uuid_clone)))?;
+                    let index_meta =
+                        self.load_index(&frag_reuse_uuid).await?.ok_or_else(|| {
+                            Error::index(format!(
+                                "Index with id {} does not exist",
+                                frag_reuse_uuid
+                            ))
+                        })?;
                     let index_details = load_frag_reuse_index_details(self, &index_meta).await?;
                     let index =
-                        open_frag_reuse_index(frag_reuse_index_meta.uuid, index_details.as_ref()).await?;
+                        open_frag_reuse_index(frag_reuse_index_meta.uuid, index_details.as_ref())
+                            .await?;
 
-                    info!(target: TRACE_IO_EVENTS, index_uuid=uuid_clone, r#type=IO_TYPE_OPEN_FRAG_REUSE);
+                    info!(target: TRACE_IO_EVENTS, index_uuid=%frag_reuse_uuid, r#type=IO_TYPE_OPEN_FRAG_REUSE);
                     metrics.record_index_load();
 
                     Ok(index)
@@ -2219,7 +2262,7 @@ impl DatasetIndexInternalExt for Dataset {
             return Ok(Some(index));
         }
 
-        let uuid = mem_wal_meta.uuid.to_string();
+        let uuid = mem_wal_meta.uuid;
 
         let index_meta = self
             .load_index(&uuid)
@@ -2227,7 +2270,7 @@ impl DatasetIndexInternalExt for Dataset {
             .ok_or_else(|| Error::index(format!("Index with id {} does not exist", uuid)))?;
         let index = open_mem_wal_index(index_meta)?;
 
-        info!(target: TRACE_IO_EVENTS, index_uuid=uuid, r#type=IO_TYPE_OPEN_MEM_WAL);
+        info!(target: TRACE_IO_EVENTS, index_uuid=%uuid, r#type=IO_TYPE_OPEN_MEM_WAL);
         metrics.record_index_load();
 
         self.index_cache
@@ -3965,7 +4008,7 @@ mod tests {
             .unwrap();
         let indices = dataset.load_indices().await.unwrap();
         let index = dataset
-            .open_generic_index("tag", &indices[0].uuid.to_string(), &NoOpMetricsCollector)
+            .open_generic_index("tag", &indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         assert_eq!(index.index_type(), IndexType::Bitmap);

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::FutureExt;
 use itertools::Itertools;
-use lance_core::cache::CacheKey;
+use lance_core::cache::{CacheKey, UnsizedCacheKey};
 use lance_core::datatypes::Field;
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_core::utils::address::RowAddress;

--- a/rust/lance/src/index/api.rs
+++ b/rust/lance/src/index/api.rs
@@ -177,13 +177,10 @@ pub trait DatasetIndexExt {
     ///
     /// Note that it is possible to have multiple indices with the same UUID,
     /// as they are the deltas of the same index.
-    async fn load_index(&self, uuid: &str) -> Result<Option<IndexMetadata>> {
-        self.load_indices().await.map(|indices| {
-            indices
-                .iter()
-                .find(|idx| idx.uuid.to_string() == uuid)
-                .cloned()
-        })
+    async fn load_index(&self, uuid: &Uuid) -> Result<Option<IndexMetadata>> {
+        self.load_indices()
+            .await
+            .map(|indices| indices.iter().find(|idx| idx.uuid == *uuid).cloned())
     }
 
     /// Loads a specific index with the given index name.

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -535,7 +535,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
         let mut indices = Vec::with_capacity(old_indices.len());
         for idx in old_indices {
             match dataset
-                .open_generic_index(&field_path, &idx.uuid.to_string(), &NoOpMetricsCollector)
+                .open_generic_index(&field_path, &idx.uuid, &NoOpMetricsCollector)
                 .await
             {
                 Ok(index) => indices.push(index),
@@ -883,11 +883,7 @@ mod tests {
         let mut num_rows = 0;
         for index in indices.iter() {
             let index = dataset
-                .open_vector_index(
-                    "vector",
-                    index.uuid.to_string().as_str(),
-                    &NoOpMetricsCollector,
-                )
+                .open_vector_index("vector", &index.uuid, &NoOpMetricsCollector)
                 .await
                 .unwrap();
             num_rows += index.num_rows();

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -579,11 +579,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     .copied()
                     .unwrap_or(old_indices[old_indices.len() - 1]);
                 let reference_index = dataset
-                    .open_scalar_index(
-                        &field_path,
-                        &reference_idx.uuid.to_string(),
-                        &NoOpMetricsCollector,
-                    )
+                    .open_scalar_index(&field_path, &reference_idx.uuid, &NoOpMetricsCollector)
                     .await?;
                 let update_criteria = reference_index.update_criteria();
                 if update_criteria.requires_old_data {
@@ -601,7 +597,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                     let created_index = super::scalar::build_scalar_index(
                         dataset.as_ref(),
                         column.name.as_str(),
-                        &new_uuid.to_string(),
+                        new_uuid,
                         &params,
                         true,
                         None,
@@ -640,11 +636,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                         effective_old_frags |= &effective;
                     }
                     let scalar_index = dataset
-                        .open_scalar_index(
-                            &field_path,
-                            &idx.uuid.to_string(),
-                            &NoOpMetricsCollector,
-                        )
+                        .open_scalar_index(&field_path, &idx.uuid, &NoOpMetricsCollector)
                         .await?;
                     let inverted_index = scalar_index
                         .as_any()
@@ -673,14 +665,13 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                 };
 
                 let new_uuid = Uuid::new_v4();
-                let new_store =
-                    LanceIndexStore::from_dataset_for_new(&dataset, &new_uuid.to_string())?;
+                let new_store = LanceIndexStore::from_dataset_for_new(&dataset, &new_uuid)?;
                 let created_index = if selected_indices.is_empty() {
                     let params = reference_index.derive_index_params()?;
                     super::scalar::build_scalar_index(
                         dataset.as_ref(),
                         column.name.as_str(),
-                        &new_uuid.to_string(),
+                        new_uuid,
                         &params,
                         true,
                         None,

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -123,7 +123,7 @@ async fn rebuild_scalar_segment(
     reference_index: &Arc<dyn ScalarIndex>,
     field_path: &str,
     column_name: &str,
-    uuid: &str,
+    uuid: Uuid,
     fragment_ids: Vec<u32>,
 ) -> Result<CreatedIndex> {
     let params = reference_index.derive_index_params()?;
@@ -186,11 +186,7 @@ async fn merge_scalar_indices<'a>(
         .copied()
         .unwrap_or(old_indices[old_indices.len() - 1]);
     let reference_index = dataset
-        .open_scalar_index(
-            field_path,
-            &reference_idx.uuid.to_string(),
-            &NoOpMetricsCollector,
-        )
+        .open_scalar_index(field_path, &reference_idx.uuid, &NoOpMetricsCollector)
         .await?;
 
     // Effective = bitmap ∩ live fragments; deleted = bitmap \ live fragments.
@@ -230,7 +226,7 @@ async fn merge_scalar_indices<'a>(
             &reference_index,
             field_path,
             column_name,
-            &new_uuid.to_string(),
+            new_uuid,
             frag_bitmap.iter().collect(),
         )
         .await?
@@ -239,7 +235,7 @@ async fn merge_scalar_indices<'a>(
         let new_data_stream =
             load_unindexed_training_data(dataset.as_ref(), field_path, &update_criteria, unindexed)
                 .await?;
-        let new_store = LanceIndexStore::from_dataset_for_new(&dataset, &new_uuid.to_string())?;
+        let new_store = LanceIndexStore::from_dataset_for_new(&dataset, &new_uuid)?;
         let old_data_filter =
             build_old_data_filter(dataset.as_ref(), &effective_old_frags, &deleted_old_frags)
                 .await?;

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -52,7 +52,7 @@ pub struct CreateIndexBuilder<'a> {
     replace: bool,
     train: bool,
     fragments: Option<Vec<u32>>,
-    index_uuid: Option<String>,
+    index_uuid: Option<Uuid>,
     preprocessed_data: Option<Box<dyn RecordBatchReader + Send + 'static>>,
     progress: Arc<dyn IndexBuildProgress>,
     /// Transaction properties to store with this commit.
@@ -102,7 +102,7 @@ impl<'a> CreateIndexBuilder<'a> {
         self
     }
 
-    pub fn index_uuid(mut self, uuid: String) -> Self {
+    pub fn index_uuid(mut self, uuid: Uuid) -> Self {
         self.index_uuid = Some(uuid);
         self
     }
@@ -209,11 +209,7 @@ impl<'a> CreateIndexBuilder<'a> {
             self.index_uuid.as_deref(),
         )?;
 
-        let index_id = match &self.index_uuid {
-            Some(uuid_str) => Uuid::parse_str(uuid_str)
-                .map_err(|e| Error::index(format!("Invalid UUID string provided: {}", e)))?,
-            None => Uuid::new_v4(),
-        };
+        let index_id = self.index_uuid.unwrap_or_else(Uuid::new_v4);
         let mut output_index_uuid = index_id;
         let created_index = match (self.index_type, self.params.index_name()) {
             (
@@ -287,7 +283,7 @@ impl<'a> CreateIndexBuilder<'a> {
                     build_scalar_index(
                         self.dataset,
                         column,
-                        &index_id.to_string(),
+                        index_id,
                         &params,
                         train,
                         self.fragments.clone(),
@@ -309,7 +305,7 @@ impl<'a> CreateIndexBuilder<'a> {
                 build_scalar_index(
                     self.dataset,
                     column,
-                    &index_id.to_string(),
+                    index_id,
                     params,
                     train,
                     self.fragments.clone(),
@@ -335,7 +331,7 @@ impl<'a> CreateIndexBuilder<'a> {
                 build_scalar_index(
                     self.dataset,
                     column,
-                    &index_id.to_string(),
+                    index_id,
                     &params,
                     train,
                     self.fragments.clone(),
@@ -374,7 +370,7 @@ impl<'a> CreateIndexBuilder<'a> {
                             self.dataset,
                             column,
                             &index_name,
-                            &index_id.to_string(),
+                            index_id,
                             vec_params,
                             fri,
                             fragments,
@@ -389,7 +385,7 @@ impl<'a> CreateIndexBuilder<'a> {
                             self.dataset,
                             column,
                             &index_name,
-                            &index_id.to_string(),
+                            index_id,
                             vec_params,
                             fri,
                             self.progress.clone(),
@@ -402,7 +398,7 @@ impl<'a> CreateIndexBuilder<'a> {
                         self.dataset,
                         column,
                         &index_name,
-                        &index_id.to_string(),
+                        index_id,
                         vec_params,
                     )
                     .await?
@@ -437,7 +433,7 @@ impl<'a> CreateIndexBuilder<'a> {
                     ))?;
 
                 if train {
-                    ext.create_index(self.dataset, column, &index_id.to_string(), self.params)
+                    ext.create_index(self.dataset, column, &index_id, self.params)
                         .await?;
                 } else {
                     todo!("create empty vector index when train=false");
@@ -1039,7 +1035,7 @@ mod tests {
         let params = InvertedIndexParams::default();
         let fragments = dataset.get_fragments();
         let fragment_ids: Vec<u32> = fragments.iter().map(|f| f.id() as u32).collect();
-        let shared_uuid = Uuid::new_v4().to_string();
+        let shared_uuid = Uuid::new_v4();
         let build_progress = Arc::new(RecordingProgress::default());
 
         for &fragment_id in &fragment_ids {
@@ -1047,11 +1043,11 @@ mod tests {
                 CreateIndexBuilder::new(&mut dataset, &["text"], IndexType::Inverted, &params)
                     .name("distributed_index".to_string())
                     .fragments(vec![fragment_id])
-                    .index_uuid(shared_uuid.clone())
+                    .index_uuid(shared_uuid)
                     .progress(build_progress.clone());
 
             let index_metadata = builder.execute_uncommitted().await.unwrap();
-            assert_eq!(index_metadata.uuid.to_string(), shared_uuid);
+            assert_eq!(index_metadata.uuid, shared_uuid);
             assert_eq!(index_metadata.name, "distributed_index");
 
             let fragment_bitmap = index_metadata.fragment_bitmap.as_ref().unwrap();
@@ -2053,7 +2049,7 @@ mod tests {
 
         CreateIndexBuilder::new(&mut dataset, &["vector"], IndexType::Vector, &params)
             .name("vector_idx".to_string())
-            .index_uuid(uuid.to_string())
+            .index_uuid(uuid)
             .execute_uncommitted()
             .await
             .unwrap();

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -206,7 +206,7 @@ impl<'a> CreateIndexBuilder<'a> {
             self.index_type,
             self.params,
             self.fragments.as_ref(),
-            self.index_uuid.as_deref(),
+            self.index_uuid.as_ref(),
         )?;
 
         let index_id = self.index_uuid.unwrap_or_else(Uuid::new_v4);
@@ -274,7 +274,7 @@ impl<'a> CreateIndexBuilder<'a> {
                     build_bitmap_index_segment(
                         self.dataset,
                         column,
-                        &index_id.to_string(),
+                        index_id,
                         fragments,
                         self.progress.clone(),
                     )
@@ -552,7 +552,7 @@ fn ensure_index_uuid_allowed(
     index_type: IndexType,
     params: &dyn IndexParams,
     fragments: Option<&Vec<u32>>,
-    index_uuid: Option<&str>,
+    index_uuid: Option<&Uuid>,
 ) -> Result<()> {
     let is_btree = index_type == IndexType::BTree
         || params
@@ -1156,7 +1156,7 @@ mod tests {
 
         let err = dataset
             .merge_index_metadata(
-                &Uuid::new_v4().to_string(),
+                &Uuid::new_v4(),
                 IndexType::BTree,
                 None,
                 Arc::new(NoopIndexBuildProgress),
@@ -1307,7 +1307,7 @@ mod tests {
             let err = CreateIndexBuilder::new(&mut dataset, &["value"], index_type, &params)
                 .name("value_btree_segments".to_string())
                 .fragments(vec![fragment_id])
-                .index_uuid(Uuid::new_v4().to_string())
+                .index_uuid(Uuid::new_v4())
                 .execute_uncommitted()
                 .await
                 .unwrap_err();

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -432,6 +432,7 @@ pub async fn open_scalar_index(
     index: &IndexMetadata,
     metrics: &dyn MetricsCollector,
 ) -> Result<Arc<dyn ScalarIndex>> {
+    let index_uuid = index.uuid;
     let index_store = Arc::new(LanceIndexStore::from_dataset_for_existing(dataset, index).await?);
 
     let index_details = fetch_index_details(dataset, column, index).await?;
@@ -461,7 +462,7 @@ pub async fn open_scalar_index(
         .load_index(index_store, &index_details, frag_reuse_index, &index_cache)
         .await?;
 
-    tracing::info!(target: TRACE_IO_EVENTS, index_uuid = uuid_str, r#type = IO_TYPE_OPEN_SCALAR, index_type = index.index_type().to_string());
+    tracing::info!(target: TRACE_IO_EVENTS, index_uuid = %index_uuid, r#type = IO_TYPE_OPEN_SCALAR, index_type = index.index_type().to_string());
     metrics.record_index_load();
 
     plugin.put_in_cache(&index_cache, index.clone()).await?;

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -12,6 +12,8 @@ pub use inverted::{load_segment_details, load_segments};
 
 use std::sync::{Arc, LazyLock};
 
+use uuid::Uuid;
+
 use crate::index::DatasetIndexExt;
 use crate::index::DatasetIndexInternalExt;
 use crate::session::index_caches::ProstAny;
@@ -272,7 +274,7 @@ impl IndexDetails {
 pub(super) async fn build_scalar_index(
     dataset: &Dataset,
     column: &str,
-    uuid: &str,
+    uuid: Uuid,
     params: &ScalarIndexParams,
     train: bool,
     fragment_ids: Option<Vec<u32>>,
@@ -287,7 +289,7 @@ pub(super) async fn build_scalar_index(
         ))?;
     let field: arrow_schema::Field = field.into();
 
-    let index_store = LanceIndexStore::from_dataset_for_new(dataset, uuid)?;
+    let index_store = LanceIndexStore::from_dataset_for_new(dataset, &uuid)?;
 
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
     let training_request =
@@ -430,7 +432,6 @@ pub async fn open_scalar_index(
     index: &IndexMetadata,
     metrics: &dyn MetricsCollector,
 ) -> Result<Arc<dyn ScalarIndex>> {
-    let uuid_str = index.uuid.to_string();
     let index_store = Arc::new(LanceIndexStore::from_dataset_for_existing(dataset, index).await?);
 
     let index_details = fetch_index_details(dataset, column, index).await?;
@@ -440,7 +441,7 @@ pub async fn open_scalar_index(
 
     let index_cache = dataset
         .index_cache
-        .for_index(&uuid_str, frag_reuse_index.as_ref().map(|f| &f.uuid));
+        .for_index(&index.uuid, frag_reuse_index.as_ref().map(|f| &f.uuid));
 
     if let Some(index) = plugin
         .get_from_cache(index_store.clone(), frag_reuse_index.clone(), &index_cache)
@@ -472,13 +473,14 @@ pub(crate) async fn infer_scalar_index_details(
     column: &str,
     index: &IndexMetadata,
 ) -> Result<Arc<prost_types::Any>> {
-    let uuid = index.uuid.to_string();
-    let type_key = crate::session::index_caches::ScalarIndexDetailsKey { uuid: &uuid };
+    let type_key = crate::session::index_caches::ScalarIndexDetailsKey { uuid: &index.uuid };
     if let Some(index_details) = dataset.index_cache.get_with_key(&type_key).await {
         return Ok(index_details.0.clone());
     }
 
-    let index_dir = dataset.indice_files_dir(index)?.join(uuid.clone());
+    let index_dir = dataset
+        .indice_files_dir(index)?
+        .join(index.uuid.to_string());
     let col = dataset
         .schema()
         .field(column)
@@ -611,11 +613,7 @@ pub async fn initialize_scalar_index(
     let column_name = field_names[0];
 
     let source_scalar_index = source_dataset
-        .open_scalar_index(
-            column_name,
-            &source_index.uuid.to_string(),
-            &NoOpMetricsCollector,
-        )
+        .open_scalar_index(column_name, &source_index.uuid, &NoOpMetricsCollector)
         .await?;
 
     let params = source_scalar_index.derive_index_params()?;
@@ -1158,11 +1156,7 @@ mod tests {
 
         // Verify the index type is correct
         let target_scalar_index = target_dataset
-            .open_scalar_index(
-                "id",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_scalar_index("id", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -1236,7 +1230,7 @@ mod tests {
 
         // Verify the index type is correct
         let scalar_index = dataset
-            .open_scalar_index("id", &indices[0].uuid.to_string(), &NoOpMetricsCollector)
+            .open_scalar_index("id", &indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -1281,7 +1275,7 @@ mod tests {
         );
 
         let scalar_index = dataset
-            .open_scalar_index("id", &indices[0].uuid.to_string(), &NoOpMetricsCollector)
+            .open_scalar_index("id", &indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -1464,11 +1458,7 @@ mod tests {
 
         // Verify the index type is correct
         let target_scalar_index = target_dataset
-            .open_scalar_index(
-                "text",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_scalar_index("text", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -1602,11 +1592,7 @@ mod tests {
 
         // Verify the index type is correct
         let target_scalar_index = target_dataset
-            .open_scalar_index(
-                "value",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_scalar_index("value", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -335,7 +335,7 @@ pub(super) async fn build_scalar_index(
 pub(super) async fn build_bitmap_index_segment(
     dataset: &Dataset,
     column: &str,
-    uuid: &str,
+    uuid: Uuid,
     fragment_ids: Vec<u32>,
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<CreatedIndex> {
@@ -358,7 +358,7 @@ pub(super) async fn build_bitmap_index_segment(
         load_training_data(dataset, column, criteria, None, true, Some(fragment_ids)).await?;
     progress.stage_complete("load_data").await?;
 
-    let index_store = LanceIndexStore::from_dataset_for_new(dataset, uuid)?;
+    let index_store = LanceIndexStore::from_dataset_for_new(dataset, &uuid)?;
     plugin
         .train_index(
             training_data,

--- a/rust/lance/src/index/scalar/bitmap.rs
+++ b/rust/lance/src/index/scalar/bitmap.rs
@@ -53,7 +53,7 @@ pub(in crate::index) async fn merge_segments(
     }
 
     let new_uuid = Uuid::new_v4();
-    let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_uuid.to_string())?;
+    let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_uuid)?;
     let created_index = lance_index::scalar::bitmap::merge_bitmap_indices(
         &source_indices,
         &new_store,

--- a/rust/lance/src/index/scalar/btree.rs
+++ b/rust/lance/src/index/scalar/btree.rs
@@ -148,7 +148,7 @@ pub(crate) async fn merge_segments(
     .await?;
 
     let output_uuid = Uuid::new_v4();
-    let new_store = LanceIndexStore::from_dataset_for_new(dataset, &output_uuid.to_string())?;
+    let new_store = LanceIndexStore::from_dataset_for_new(dataset, &output_uuid)?;
     // Pure segment consolidation: no dataset scan, so `new_data` is an empty
     // stream and the merge is driven entirely by the source page data.
     let empty_new_data = empty_btree_update_stream(dataset, field_id)?;

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -64,7 +64,7 @@ pub(crate) async fn finalize_segment_files_if_needed(
 
     let store = Arc::new(LanceIndexStore::from_dataset_for_new(
         dataset,
-        &segment.uuid.to_string(),
+        &segment.uuid,
     )?);
     lance_index::scalar::inverted::builder::merge_index_files(
         dataset.object_store.as_ref(),

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -118,7 +118,7 @@ pub(crate) async fn merge_segments(
     }
 
     let new_uuid = Uuid::new_v4();
-    let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_uuid.to_string())?;
+    let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_uuid)?;
     let created_index = InvertedIndex::merge_segments(
         &source_indices,
         empty_inverted_update_stream(dataset, field_id)?,

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -292,13 +292,15 @@ pub async fn open_named_scalar_index(
             index_name, column
         ))),
         1 => {
-            let uuid = indices[0].uuid.to_string();
-            dataset.open_scalar_index(column, &uuid, metrics).await
+            dataset
+                .open_scalar_index(column, &indices[0].uuid, metrics)
+                .await
         }
         _ => {
-            let segments = try_join_all(indices.iter().map(|index| {
-                let uuid = index.uuid.to_string();
-                async move { dataset.open_scalar_index(column, &uuid, metrics).await }
+            let segments = try_join_all(indices.iter().map(|index| async move {
+                dataset
+                    .open_scalar_index(column, &index.uuid, metrics)
+                    .await
             }))
             .await?;
 

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -590,7 +590,7 @@ pub(crate) async fn build_distributed_vector_index(
     dataset: &Dataset,
     column: &str,
     _name: &str,
-    uuid: &str,
+    uuid: Uuid,
     params: &VectorIndexParams,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
     fragment_ids: &[u32],
@@ -616,8 +616,7 @@ pub(crate) async fn build_distributed_vector_index(
 
     let filtered_dataset = dataset.clone();
 
-    let segment_uuid = Uuid::parse_str(uuid)
-        .map_err(|err| Error::invalid_input(format!("Invalid index UUID '{uuid}': {err}")))?;
+    let segment_uuid = uuid;
     let index_dir = dataset.indices_dir().join(segment_uuid.to_string());
 
     let fragment_filter = fragment_ids.to_vec();
@@ -943,7 +942,7 @@ pub(crate) async fn build_vector_index(
     dataset: &Dataset,
     column: &str,
     name: &str,
-    uuid: &str,
+    uuid: Uuid,
     params: &VectorIndexParams,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
     progress: Arc<dyn IndexBuildProgress>,
@@ -965,7 +964,7 @@ pub(crate) async fn build_vector_index(
                 let summary = IvfIndexBuilder::<FlatIndex, FlatQuantizer>::new(
                     dataset.clone(),
                     column.to_owned(),
-                    dataset.indices_dir().clone().join(uuid),
+                    dataset.indices_dir().clone().join(uuid.to_string()),
                     params.metric_type,
                     shuffler,
                     Some(ivf_params),
@@ -982,7 +981,7 @@ pub(crate) async fn build_vector_index(
                 let summary = IvfIndexBuilder::<FlatIndex, FlatBinQuantizer>::new(
                     dataset.clone(),
                     column.to_owned(),
-                    dataset.indices_dir().clone().join(uuid),
+                    dataset.indices_dir().clone().join(uuid.to_string()),
                     params.metric_type,
                     shuffler,
                     Some(ivf_params),
@@ -1030,7 +1029,7 @@ pub(crate) async fn build_vector_index(
                     let mut builder = IvfIndexBuilder::<FlatIndex, ProductQuantizer>::new(
                         dataset.clone(),
                         column.to_owned(),
-                        dataset.indices_dir().join(uuid),
+                        dataset.indices_dir().join(uuid.to_string()),
                         params.metric_type,
                         shuffler,
                         Some(ivf_params),
@@ -1059,7 +1058,7 @@ pub(crate) async fn build_vector_index(
             let summary = IvfIndexBuilder::<FlatIndex, ScalarQuantizer>::new(
                 dataset.clone(),
                 column.to_owned(),
-                dataset.indices_dir().clone().join(uuid),
+                dataset.indices_dir().clone().join(uuid.to_string()),
                 params.metric_type,
                 shuffler,
                 Some(ivf_params),
@@ -1083,7 +1082,7 @@ pub(crate) async fn build_vector_index(
             let mut builder = IvfIndexBuilder::<FlatIndex, RabitQuantizer>::new(
                 dataset.clone(),
                 column.to_owned(),
-                dataset.indices_dir().join(uuid),
+                dataset.indices_dir().join(uuid.to_string()),
                 params.metric_type,
                 shuffler,
                 Some(ivf_params),
@@ -1111,7 +1110,7 @@ pub(crate) async fn build_vector_index(
                     let summary = IvfIndexBuilder::<HNSW, FlatBinQuantizer>::new(
                         dataset.clone(),
                         column.to_owned(),
-                        dataset.indices_dir().clone().join(uuid),
+                        dataset.indices_dir().clone().join(uuid.to_string()),
                         params.metric_type,
                         shuffler,
                         Some(ivf_params),
@@ -1128,7 +1127,7 @@ pub(crate) async fn build_vector_index(
                     let summary = IvfIndexBuilder::<HNSW, FlatQuantizer>::new(
                         dataset.clone(),
                         column.to_owned(),
-                        dataset.indices_dir().clone().join(uuid),
+                        dataset.indices_dir().clone().join(uuid.to_string()),
                         params.metric_type,
                         shuffler,
                         Some(ivf_params),
@@ -1159,7 +1158,7 @@ pub(crate) async fn build_vector_index(
             let summary = IvfIndexBuilder::<HNSW, ProductQuantizer>::new(
                 dataset.clone(),
                 column.to_owned(),
-                dataset.indices_dir().clone().join(uuid),
+                dataset.indices_dir().clone().join(uuid.to_string()),
                 params.metric_type,
                 shuffler,
                 Some(ivf_params),
@@ -1188,7 +1187,7 @@ pub(crate) async fn build_vector_index(
             let summary = IvfIndexBuilder::<HNSW, ScalarQuantizer>::new(
                 dataset.clone(),
                 column.to_owned(),
-                dataset.indices_dir().clone().join(uuid),
+                dataset.indices_dir().clone().join(uuid.to_string()),
                 params.metric_type,
                 shuffler,
                 Some(ivf_params),
@@ -1216,7 +1215,7 @@ pub(crate) async fn build_vector_index(
 pub(crate) async fn build_vector_index_incremental(
     dataset: &Dataset,
     column: &str,
-    uuid: &str,
+    uuid: Uuid,
     params: &VectorIndexParams,
     existing_index: Arc<dyn VectorIndex>,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
@@ -1273,7 +1272,7 @@ pub(crate) async fn build_vector_index_incremental(
         Some(progress.clone()),
     );
 
-    let index_dir = dataset.indices_dir().join(uuid);
+    let index_dir = dataset.indices_dir().join(uuid.to_string());
 
     // Determine the index type and build incrementally
     let (sub_index_type, quantization_type) = existing_index.sub_index_type();
@@ -1475,7 +1474,7 @@ pub(crate) async fn build_empty_vector_index(
     _dataset: &Dataset,
     column: &str,
     name: &str,
-    _uuid: &str,
+    _uuid: Uuid,
     _params: &VectorIndexParams,
 ) -> Result<Vec<IndexFile>> {
     // For now, return a NotImplementedError to indicate this functionality
@@ -1500,14 +1499,14 @@ pub(crate) async fn remap_vector_index(
     mapping: &HashMap<u64, Option<u64>>,
 ) -> Result<Vec<IndexFile>> {
     let old_index = dataset
-        .open_vector_index(column, &old_uuid.to_string(), &NoOpMetricsCollector)
+        .open_vector_index(column, old_uuid, &NoOpMetricsCollector)
         .await?;
 
     if let Some(ivf_index) = old_index.as_any().downcast_ref::<IVFIndex>() {
         let file = remap_index_file(
             dataset.as_ref(),
-            &old_uuid.to_string(),
-            &new_uuid.to_string(),
+            old_uuid,
+            new_uuid,
             old_metadata.dataset_version,
             ivf_index,
             mapping,
@@ -1524,7 +1523,7 @@ pub(crate) async fn remap_vector_index(
         // it's v3 index
         let files = remap_index_file_v3(
             dataset.as_ref(),
-            &new_uuid.to_string(),
+            new_uuid,
             old_index,
             mapping,
             column.to_string(),
@@ -1538,7 +1537,7 @@ pub(crate) async fn remap_vector_index(
 #[instrument(level = "debug", skip(dataset, vec_idx, reader))]
 pub(crate) async fn open_vector_index(
     dataset: Arc<Dataset>,
-    uuid: &str,
+    uuid: &Uuid,
     vec_idx: &lance_index::pb::VectorIndex,
     reader: Arc<dyn Reader>,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
@@ -1569,7 +1568,7 @@ pub(crate) async fn open_vector_index(
                 }
                 let ivf = IvfModel::try_from(ivf_pb.to_owned())?;
                 last_stage = Some(Arc::new(IVFIndex::try_new(
-                    uuid,
+                    *uuid,
                     ivf,
                     reader.clone(),
                     last_stage.unwrap(),
@@ -1634,7 +1633,7 @@ pub(crate) async fn open_index_file(
 pub(crate) async fn open_vector_index_v2(
     dataset: Arc<Dataset>,
     column: &str,
-    uuid: &str,
+    uuid: &Uuid,
     reader: PreviousFileReader,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
 ) -> Result<Arc<dyn VectorIndex>> {
@@ -1658,7 +1657,10 @@ pub(crate) async fn open_vector_index_v2(
 
     let index: Arc<dyn VectorIndex> = match index_metadata.index_type.as_str() {
         "IVF_HNSW_PQ" => {
-            let aux_path = index_dir.clone().join(uuid).join(INDEX_AUXILIARY_FILE_NAME);
+            let aux_path = index_dir
+                .clone()
+                .join(uuid.to_string())
+                .join(INDEX_AUXILIARY_FILE_NAME);
             let aux_reader = open_index_file(
                 object_store.as_ref(),
                 &aux_path,
@@ -1679,7 +1681,7 @@ pub(crate) async fn open_vector_index_v2(
             let ivf = IvfModel::try_from(pb_ivf)?;
 
             Arc::new(IVFIndex::try_new(
-                uuid,
+                *uuid,
                 ivf,
                 reader.object_reader.clone(),
                 Arc::new(hnsw),
@@ -1691,7 +1693,10 @@ pub(crate) async fn open_vector_index_v2(
         }
 
         "IVF_HNSW_SQ" => {
-            let aux_path = index_dir.clone().join(uuid).join(INDEX_AUXILIARY_FILE_NAME);
+            let aux_path = index_dir
+                .clone()
+                .join(uuid.to_string())
+                .join(INDEX_AUXILIARY_FILE_NAME);
             let aux_reader = open_index_file(
                 object_store.as_ref(),
                 &aux_path,
@@ -1715,7 +1720,7 @@ pub(crate) async fn open_vector_index_v2(
             let ivf = IvfModel::try_from(pb_ivf)?;
 
             Arc::new(IVFIndex::try_new(
-                uuid,
+                *uuid,
                 ivf,
                 reader.object_reader.clone(),
                 Arc::new(hnsw),
@@ -1772,11 +1777,7 @@ pub async fn initialize_vector_index(
     let column_name = field_names[0];
 
     let source_vector_index = source_dataset
-        .open_vector_index(
-            column_name,
-            &source_index.uuid.to_string(),
-            &NoOpMetricsCollector,
-        )
+        .open_vector_index(column_name, &source_index.uuid, &NoOpMetricsCollector)
         .await?;
 
     let metric_type = source_vector_index.metric_type();
@@ -1848,7 +1849,7 @@ pub async fn initialize_vector_index(
     let summary = build_vector_index_incremental(
         target_dataset,
         column_name,
-        &new_uuid.to_string(),
+        new_uuid,
         &params,
         source_vector_index,
         frag_reuse_index,
@@ -2200,11 +2201,7 @@ mod tests {
 
         // Verify the index type and parameters match
         let target_vector_index = target_dataset
-            .open_vector_index(
-                "vector",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let stats = target_vector_index.statistics().unwrap();
@@ -2232,11 +2229,7 @@ mod tests {
 
         // Verify centroids are shared between source and target indices
         let source_vector_index = source_dataset
-            .open_vector_index(
-                "vector",
-                &source_index.uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &source_index.uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -2415,11 +2408,7 @@ mod tests {
 
         // Verify the index type and parameters match
         let target_vector_index = target_dataset
-            .open_vector_index(
-                "vector",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let stats = target_vector_index.statistics().unwrap();
@@ -2451,11 +2440,7 @@ mod tests {
 
         // Verify centroids are shared between source and target indices
         let source_vector_index = source_dataset
-            .open_vector_index(
-                "vector",
-                &source_index.uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &source_index.uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -2561,7 +2546,7 @@ mod tests {
         let invalid_id = max_id + 1000;
 
         // let params = VectorIndexParams::ivf_flat(4, MetricType::L2);
-        let uuid = Uuid::new_v4().to_string();
+        let uuid = Uuid::new_v4();
 
         let mut ivf_params = IvfBuildParams {
             num_partitions: Some(4),
@@ -2589,7 +2574,7 @@ mod tests {
             &dataset,
             "vector",
             "vector_ivf_flat_dist",
-            &uuid,
+            uuid,
             &params,
             None,
             &[invalid_id],
@@ -2615,7 +2600,7 @@ mod tests {
             .into_reader_rows(RowCount::from(128), BatchCount::from(1));
         let dataset = Dataset::write(reader, &uri, None).await.unwrap();
 
-        let uuid = Uuid::new_v4().to_string();
+        let uuid = Uuid::new_v4();
         let mut ivf_params = IvfBuildParams {
             num_partitions: Some(4),
             ..Default::default()
@@ -2642,7 +2627,7 @@ mod tests {
             &dataset,
             "vector",
             "vector_ivf_flat_dist",
-            &uuid,
+            uuid,
             &params,
             None,
             &[],
@@ -2704,7 +2689,7 @@ mod tests {
         let dataset = Dataset::write(reader, &uri, None).await.unwrap();
 
         let params = VectorIndexParams::ivf_flat(4, MetricType::L2);
-        let uuid = Uuid::new_v4().to_string();
+        let uuid = Uuid::new_v4();
         let progress = Arc::new(RecordingProgress {
             train_ivf_complete: AtomicBool::new(false),
             saw_train_ivf_progress_before_complete: AtomicBool::new(false),
@@ -2715,7 +2700,7 @@ mod tests {
             &dataset,
             "vector",
             "vector_ivf_flat_progress",
-            &uuid,
+            uuid,
             &params,
             None,
             progress.clone(),
@@ -2749,11 +2734,11 @@ mod tests {
         let dataset = Dataset::write(reader, &uri, None).await.unwrap();
 
         let params = VectorIndexParams::ivf_flat(4, MetricType::L2);
-        let uuid = Uuid::new_v4().to_string();
+        let uuid = Uuid::new_v4();
 
         // Pre-create a malformed global training file that is missing the
         // `lance:global_ivf_centroids` metadata key.
-        let out_base = dataset.indices_dir().join(&*uuid);
+        let out_base = dataset.indices_dir().join(uuid.to_string());
         let training_path = out_base.clone().join("global_training.idx");
 
         let writer = dataset
@@ -2784,7 +2769,7 @@ mod tests {
             &dataset,
             "vector",
             "vector_ivf_flat_dist",
-            &uuid,
+            uuid,
             &params,
             None,
             &[valid_id],
@@ -2873,20 +2858,12 @@ mod tests {
 
         // Open both indices to compare centroids
         let source_vector_index = source_dataset
-            .open_vector_index(
-                "vector",
-                &source_index.uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &source_index.uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
         let target_vector_index = target_dataset
-            .open_vector_index(
-                "vector",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -3000,11 +2977,7 @@ mod tests {
         // Verify that the optimized index still shares centroids with the source
         let target_indices = target_dataset.load_indices().await.unwrap();
         let target_vector_index = target_dataset
-            .open_vector_index(
-                "vector",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -3110,11 +3083,7 @@ mod tests {
 
         // Verify the index type and parameters match
         let target_vector_index = target_dataset
-            .open_vector_index(
-                "vector",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let stats = target_vector_index.statistics().unwrap();
@@ -3146,11 +3115,7 @@ mod tests {
 
         // Verify centroids are shared between source and target indices
         let source_vector_index = source_dataset
-            .open_vector_index(
-                "vector",
-                &source_index.uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &source_index.uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -3336,11 +3301,7 @@ mod tests {
 
         // Verify the index type and parameters match
         let target_vector_index = target_dataset
-            .open_vector_index(
-                "vector",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let stats = target_vector_index.statistics().unwrap();
@@ -3368,11 +3329,7 @@ mod tests {
 
         // Verify centroids are shared between source and target indices
         let source_vector_index = source_dataset
-            .open_vector_index(
-                "vector",
-                &source_index.uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &source_index.uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -3594,11 +3551,7 @@ mod tests {
 
         // Verify the index type and parameters match
         let target_vector_index = target_dataset
-            .open_vector_index(
-                "vector",
-                &target_indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &target_indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let stats = target_vector_index.statistics().unwrap();
@@ -3626,11 +3579,7 @@ mod tests {
 
         // Verify centroids are shared between source and target indices
         let source_vector_index = source_dataset
-            .open_vector_index(
-                "vector",
-                &source_index.uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &source_index.uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -2392,7 +2392,7 @@ mod tests {
 
         let indices = dataset.load_indices_by_name("idx").await.unwrap();
         let initial_index = dataset
-            .open_vector_index("vec", &indices[0].uuid.to_string(), &NoOpMetricsCollector)
+            .open_vector_index("vec", &indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let initial_ivf = initial_index.ivf_model();
@@ -2422,7 +2422,7 @@ mod tests {
         let indices = dataset.load_indices_by_name("idx").await.unwrap();
         assert_eq!(indices.len(), 1, "expected merge-all on split");
         let optimized = dataset
-            .open_vector_index("vec", &indices[0].uuid.to_string(), &NoOpMetricsCollector)
+            .open_vector_index("vec", &indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let ivf = optimized.ivf_model();

--- a/rust/lance/src/index/vector/fixture_test.rs
+++ b/rust/lance/src/index/vector/fixture_test.rs
@@ -212,7 +212,7 @@ mod test {
                 ]))),
             });
             IVFIndex::try_new(
-                &Uuid::new_v4().to_string(),
+                Uuid::new_v4(),
                 ivf,
                 reader.into(),
                 mock_sub_index,

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -151,7 +151,7 @@ impl UnsizedCacheKey for LegacyIVFPartitionKey {
 /// IVF Index.
 /// WARNING: Internal API with no stability guarantees.
 pub struct IVFIndex {
-    uuid: String,
+    uuid: Uuid,
 
     /// Ivf model
     pub ivf: IvfModel,
@@ -170,16 +170,15 @@ pub struct IVFIndex {
 
 impl DeepSizeOf for IVFIndex {
     fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
-        self.uuid.deep_size_of_children(context)
-            + self.reader.deep_size_of_children(context)
-            + self.sub_index.deep_size_of_children(context)
+        // `Uuid` is a fixed 16-byte struct with no heap children, so contributes 0.
+        self.reader.deep_size_of_children(context) + self.sub_index.deep_size_of_children(context)
     }
 }
 
 impl IVFIndex {
     /// Create a new IVF index.
     pub(crate) fn try_new(
-        uuid: &str,
+        uuid: Uuid,
         ivf: IvfModel,
         reader: Arc<dyn Reader>,
         sub_index: Arc<dyn VectorIndex>,
@@ -195,7 +194,7 @@ impl IVFIndex {
 
         let num_partitions = ivf.num_partitions();
         Ok(Self {
-            uuid: uuid.to_owned(),
+            uuid,
             ivf,
             reader,
             sub_index,
@@ -1126,7 +1125,7 @@ impl Index for IVFIndex {
 
         Ok(serde_json::to_value(IvfIndexStatistics {
             index_type: self.index_type().to_string(),
-            uuid: self.uuid.clone(),
+            uuid: self.uuid.to_string(),
             uri: to_local_path(self.reader.path()),
             metric_type: self.metric_type.to_string(),
             num_partitions: self.ivf.num_partitions(),
@@ -1614,7 +1613,7 @@ pub async fn build_ivf_pq_index(
     dataset: &Dataset,
     column: &str,
     index_name: &str,
-    uuid: &str,
+    uuid: Uuid,
     metric_type: MetricType,
     ivf_params: &IvfBuildParams,
     pq_params: &PQBuildParams,
@@ -1657,7 +1656,7 @@ pub async fn build_ivf_hnsw_pq_index(
     dataset: &Dataset,
     column: &str,
     index_name: &str,
-    uuid: &str,
+    uuid: Uuid,
     metric_type: MetricType,
     ivf_params: &IvfBuildParams,
     hnsw_params: &HnswBuildParams,
@@ -1758,13 +1757,13 @@ fn generate_remap_tasks(offsets: &[usize], lengths: &[u32]) -> Result<Vec<RemapP
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn remap_index_file_v3(
     dataset: &Dataset,
-    new_uuid: &str,
+    new_uuid: &Uuid,
     index: Arc<dyn VectorIndex>,
     mapping: &HashMap<u64, Option<u64>>,
     column: String,
 ) -> Result<Vec<IndexFile>> {
     let dataset = dataset.clone();
-    let index_dir = dataset.indices_dir().join(new_uuid);
+    let index_dir = dataset.indices_dir().join(new_uuid.to_string());
     let (_, element_type) = get_vector_type(dataset.schema(), &column)?;
     match index.sub_index_type() {
         (SubIndexType::Flat, QuantizationType::Flat) => match element_type {
@@ -1855,8 +1854,8 @@ pub(crate) async fn remap_index_file_v3(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn remap_index_file(
     dataset: &Dataset,
-    old_uuid: &str,
-    new_uuid: &str,
+    old_uuid: &Uuid,
+    new_uuid: &Uuid,
     old_version: u64,
     index: &IVFIndex,
     mapping: &HashMap<u64, Option<u64>>,
@@ -1865,8 +1864,14 @@ pub(crate) async fn remap_index_file(
     transforms: Vec<pb::Transform>,
 ) -> Result<IndexFile> {
     let object_store = dataset.object_store.as_ref();
-    let old_path = dataset.indices_dir().join(old_uuid).join(INDEX_FILE_NAME);
-    let new_path = dataset.indices_dir().join(new_uuid).join(INDEX_FILE_NAME);
+    let old_path = dataset
+        .indices_dir()
+        .join(old_uuid.to_string())
+        .join(INDEX_FILE_NAME);
+    let new_path = dataset
+        .indices_dir()
+        .join(new_uuid.to_string())
+        .join(INDEX_FILE_NAME);
 
     let file_sizes = dataset
         .load_index(old_uuid)
@@ -1934,7 +1939,7 @@ async fn write_ivf_pq_file(
     index_dir: Path,
     column: &str,
     index_name: &str,
-    uuid: &str,
+    uuid: Uuid,
     dataset_version: u64,
     mut ivf: IvfModel,
     pq: ProductQuantizer,
@@ -1945,7 +1950,10 @@ async fn write_ivf_pq_file(
     shuffle_partition_concurrency: usize,
     precomputed_shuffle_buffers: Option<(Path, Vec<String>)>,
 ) -> Result<IndexFile> {
-    let path = index_dir.clone().join(uuid).join(INDEX_FILE_NAME);
+    let path = index_dir
+        .clone()
+        .join(uuid.to_string())
+        .join(INDEX_FILE_NAME);
     let mut writer = object_store.create(&path).await?;
 
     let start = std::time::Instant::now();
@@ -2031,7 +2039,7 @@ async fn write_ivf_hnsw_file(
     dataset: &Dataset,
     column: &str,
     _index_name: &str,
-    uuid: &str,
+    uuid: Uuid,
     mut ivf: IvfModel,
     quantizer: Quantizer,
     distance_type: DistanceType,
@@ -2043,7 +2051,10 @@ async fn write_ivf_hnsw_file(
     precomputed_shuffle_buffers: Option<(Path, Vec<String>)>,
 ) -> Result<()> {
     let object_store = dataset.object_store.as_ref();
-    let path = dataset.indices_dir().join(uuid).join(INDEX_FILE_NAME);
+    let path = dataset
+        .indices_dir()
+        .join(uuid.to_string())
+        .join(INDEX_FILE_NAME);
     let writer = object_store.create(&path).await?;
 
     let schema = lance_core::datatypes::Schema::try_from(HNSW::schema().as_ref())?;
@@ -2064,7 +2075,7 @@ async fn write_ivf_hnsw_file(
 
     let aux_path = dataset
         .indices_dir()
-        .join(uuid)
+        .join(uuid.to_string())
         .join(INDEX_AUXILIARY_FILE_NAME);
     let aux_writer = object_store.create(&aux_path).await?;
     let schema = Schema::new(vec![
@@ -4687,13 +4698,12 @@ mod tests {
         let pq_params = PQBuildParams::new(NUM_SUBVECTORS as usize, NUM_BITS as usize);
 
         let uuid = Uuid::new_v4();
-        let uuid_str = uuid.to_string();
 
         build_ivf_pq_index(
             &dataset,
             WellKnownIvfPqData::COLUMN,
             INDEX_NAME,
-            &uuid_str,
+            uuid,
             MetricType::L2,
             &ivf_params,
             &pq_params,
@@ -4738,7 +4748,7 @@ mod tests {
             .unwrap();
 
         let index = dataset_mut
-            .open_vector_index(WellKnownIvfPqData::COLUMN, &uuid_str, &NoOpMetricsCollector)
+            .open_vector_index(WellKnownIvfPqData::COLUMN, &uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -4782,12 +4792,11 @@ mod tests {
         let mapping = build_mapping(row_ids_to_modify, row_ids_to_remove, max_id);
 
         let new_uuid = Uuid::new_v4();
-        let new_uuid_str = new_uuid.to_string();
 
         remap_index_file(
             &dataset_mut,
-            &uuid_str,
-            &new_uuid_str,
+            &uuid,
+            &new_uuid,
             dataset_mut.version().version,
             ivf_index,
             &mapping,
@@ -4834,11 +4843,7 @@ mod tests {
             .unwrap();
 
         let remapped = dataset_mut
-            .open_vector_index(
-                WellKnownIvfPqData::COLUMN,
-                &new_uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index(WellKnownIvfPqData::COLUMN, &new_uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let ivf_remapped = remapped.as_any().downcast_ref::<IVFIndex>().unwrap();
@@ -5894,11 +5899,7 @@ mod tests {
             .unwrap();
         let indices = dataset.load_indices().await.unwrap();
         let idx = dataset
-            .open_generic_index(
-                "vector",
-                indices[0].uuid.to_string().as_str(),
-                &NoOpMetricsCollector,
-            )
+            .open_generic_index("vector", &indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let ivf_idx = idx.as_any().downcast_ref::<v2::IvfPq>().unwrap();

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -579,11 +579,7 @@ mod tests {
         assert_eq!(ds.get_fragments().len(), 2);
 
         let idx = ds
-            .open_vector_index(
-                "vector",
-                &indices[0].uuid.to_string(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let _ivf_idx = idx

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -73,6 +73,7 @@ use roaring::RoaringBitmap;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{info, instrument};
+use uuid::Uuid;
 
 use super::{IvfIndexPartitionStatistics, IvfIndexStatistics, maybe_centroids_for_stats};
 
@@ -320,7 +321,7 @@ impl<Q: Quantization + 'static> IvfStateEntry for IvfIndexState<Q> {
 
         let header = IvfIndexStateHeader {
             index_file_path: self.index_file_path.clone(),
-            uuid: self.uuid.clone(),
+            uuid: self.uuid.to_string(),
             distance_type: self.distance_type.to_string(),
             sub_index_metadata: self.sub_index_metadata.clone(),
             sub_index_type: self.sub_index_type.to_string(),
@@ -516,7 +517,7 @@ pub struct IVFIndex<S: IvfSubIndex + 'static, Q: Quantization + 'static> {
     /// Object-store path to the index file (forward-slash separated).
     /// Used by `cacheable_state()` for cross-platform reconstruction.
     index_path: String,
-    uuid: String,
+    uuid: Uuid,
 
     /// Ivf model
     ivf: IvfModel,
@@ -538,11 +539,11 @@ pub struct IVFIndex<S: IvfSubIndex + 'static, Q: Quantization + 'static> {
 
 impl<S: IvfSubIndex, Q: Quantization> DeepSizeOf for IVFIndex<S, Q> {
     fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        // `Uuid` is a fixed 16-byte struct with no heap children, so contributes 0.
         self.uri.deep_size_of_children(context)
             + self.index_path.deep_size_of_children(context)
             + self.ivf.deep_size_of_children(context)
             + self.sub_index_metadata.deep_size_of_children(context)
-            + self.uuid.deep_size_of_children(context)
             + self.storage.deep_size_of_children(context)
             + self.scratch_pool.deep_size_of_children(context)
         // Skipping session since it is a weak ref
@@ -804,7 +805,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
     pub(crate) async fn try_new(
         object_store: Arc<ObjectStore>,
         index_dir: Path,
-        uuid: String,
+        uuid: Uuid,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
         file_metadata_cache: &LanceCache,
         index_cache: LanceCache,
@@ -814,7 +815,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
         let scheduler = ScanScheduler::new(object_store, scheduler_config);
 
-        let uri = index_dir.clone().join(uuid.as_str()).join(INDEX_FILE_NAME);
+        let uuid_str = uuid.to_string();
+        let uri = index_dir
+            .clone()
+            .join(uuid_str.as_str())
+            .join(INDEX_FILE_NAME);
         let cached_size = file_sizes
             .get(INDEX_FILE_NAME)
             .map(|&size| CachedFileSize::new(size))
@@ -863,7 +868,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
                 .open_file(
                     &index_dir
                         .clone()
-                        .join(uuid.as_str())
+                        .join(uuid_str.as_str())
                         .join(INDEX_AUXILIARY_FILE_NAME),
                     &aux_cached_size,
                 )
@@ -885,7 +890,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             .await;
         let aux_path = index_dir
             .clone()
-            .join(uuid.as_str())
+            .join(uuid_str.as_str())
             .join(INDEX_AUXILIARY_FILE_NAME);
         file_metadata_cache
             .with_key_prefix(aux_path.as_ref())
@@ -895,7 +900,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         // Cache open readers so the first reconstruction also skips file opens.
         file_metadata_cache
             .insert_with_key(
-                &CachedIndexReadersKey { uuid: uuid.clone() },
+                &CachedIndexReadersKey {
+                    uuid: uuid_str.clone(),
+                },
                 Arc::new(CachedIndexReaders {
                     index_reader: Arc::new(index_reader.clone()),
                     aux_reader: Arc::new(storage.reader().clone()),
@@ -928,7 +935,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
     pub(crate) fn from_cached_state(
         uri: String,
         index_path: String,
-        uuid: String,
+        uuid: Uuid,
         ivf: IvfModel,
         reader: FileReader,
         storage: IvfQuantizationStorage<Q>,
@@ -1052,7 +1059,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         let (sub_index_type, quantization_type) = self.sub_index_type();
         IvfStateEntryBox(Arc::new(IvfIndexState::<Q> {
             index_file_path: self.index_path.clone(),
-            uuid: self.uuid.clone(),
+            uuid: self.uuid.to_string(),
             ivf: self.ivf.clone(),
             aux_ivf: self.storage.ivf().clone(),
             distance_type: self.distance_type,
@@ -1165,7 +1172,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> Index for IVFIndex<S, 
 
         Ok(serde_json::to_value(IvfIndexStatistics {
             index_type,
-            uuid: self.uuid.clone(),
+            uuid: self.uuid.to_string(),
             uri: self.uri.clone(),
             metric_type: self.distance_type.to_string(),
             num_partitions: self.ivf.num_partitions(),
@@ -1662,10 +1669,12 @@ async fn reconstruct_typed<S: IvfSubIndex + 'static, Q: Quantization + 'static>(
         None,
     );
 
+    let parsed_uuid = Uuid::parse_str(&state.uuid)
+        .map_err(|e| Error::index(format!("Invalid UUID in IvfIndexState: {e}")))?;
     let index = IVFIndex::<S, Q>::from_cached_state(
         to_local_path(&index_path),
         index_path.to_string(),
-        state.uuid.clone(),
+        parsed_uuid,
         state.ivf.clone(),
         index_reader,
         storage,
@@ -1748,6 +1757,7 @@ mod tests {
     use rand::distr::uniform::SampleUniform;
     use rand::{Rng, SeedableRng, rngs::StdRng};
     use rstest::rstest;
+    use uuid::Uuid;
 
     const NUM_ROWS: usize = 512;
     const DIM: usize = 32;
@@ -2138,11 +2148,12 @@ mod tests {
     ) -> VectorIndexTestContext {
         let stats_json = dataset.index_statistics(index_name).await.unwrap();
         let stats: serde_json::Value = serde_json::from_str(&stats_json).unwrap();
-        let uuid = stats["indices"][0]["uuid"]
+        let uuid_str = stats["indices"][0]["uuid"]
             .as_str()
             .expect("Index uuid should be present");
+        let uuid = Uuid::parse_str(uuid_str).expect("uuid in stats should be a valid UUID");
         let index = dataset
-            .open_vector_index(column, uuid, &NoOpMetricsCollector)
+            .open_vector_index(column, &uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
 
@@ -4319,11 +4330,7 @@ mod tests {
         let indices = dataset.load_indices_by_name("vector_idx").await.unwrap();
         assert_eq!(indices.len(), 1); // v1 index should be replaced by v3 index
         let index = dataset
-            .open_vector_index(
-                "vector",
-                indices[0].uuid.to_string().as_str(),
-                &NoOpMetricsCollector,
-            )
+            .open_vector_index("vector", &indices[0].uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let v3_index = index.as_any().downcast_ref::<super::IvfPq>();

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -688,11 +688,7 @@ async fn migrate_indices(dataset: &Dataset, indices: &mut [IndexMetadata]) -> Re
             let idx_field = dataset.schema().field_by_id(index.fields[0]).ok_or_else(|| Error::internal(format!("Index with uuid {} referred to field with id {} which did not exist in dataset", index.uuid, index.fields[0])))?;
             // We need to calculate the fragments covered by the index
             let idx = dataset
-                .open_generic_index(
-                    &idx_field.name,
-                    &index.uuid.to_string(),
-                    &NoOpMetricsCollector,
-                )
+                .open_generic_index(&idx_field.name, &index.uuid, &NoOpMetricsCollector)
                 .await?;
             index.fragment_bitmap = Some(idx.calculate_included_frags().await?);
         }

--- a/rust/lance/src/io/exec/ann_proto.rs
+++ b/rust/lance/src/io/exec/ann_proto.rs
@@ -20,6 +20,7 @@ use lance_index::vector::{DEFAULT_QUERY_PARALLELISM, Query};
 use lance_linalg::distance::DistanceType;
 use lance_table::format::IndexMetadata;
 use lance_table::format::pb as table_pb;
+use uuid::Uuid;
 
 use crate::Dataset;
 use crate::pb;
@@ -146,7 +147,7 @@ pub async fn ann_ivf_partition_exec_to_proto(
     Ok(pb::AnnIvfPartitionExecProto {
         query: Some(query),
         table: Some(table),
-        index_uuids: exec.index_uuids.clone(),
+        index_uuids: exec.index_uuids.iter().map(Uuid::to_string).collect(),
     })
 }
 
@@ -168,7 +169,17 @@ pub async fn ann_ivf_partition_exec_from_proto(
         ));
     }
 
-    ANNIvfPartitionExec::try_new(dataset, proto.index_uuids, query)
+    let index_uuids: Vec<Uuid> = proto
+        .index_uuids
+        .iter()
+        .map(|s| Uuid::parse_str(s))
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|e| {
+            Error::invalid_input_source(
+                format!("Invalid UUID in AnnIvfPartitionExecProto: {e}").into(),
+            )
+        })?;
+    ANNIvfPartitionExec::try_new(dataset, index_uuids, query)
 }
 
 // =============================================================================
@@ -437,7 +448,7 @@ mod tests {
 
         let exec = ANNIvfPartitionExec::try_new(
             dataset.clone(),
-            indices.iter().map(|idx| idx.uuid.to_string()).collect(),
+            indices.iter().map(|idx| idx.uuid).collect(),
             query,
         )
         .unwrap();

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -61,15 +61,16 @@ async fn open_fts_segment(
     segment: &IndexMetadata,
     metrics: &IndexMetrics,
 ) -> Result<Arc<InvertedIndex>> {
-    let uuid = segment.uuid.to_string();
-    let index = dataset.open_generic_index(column, &uuid, metrics).await?;
+    let index = dataset
+        .open_generic_index(column, &segment.uuid, metrics)
+        .await?;
     let inverted = index
         .as_any()
         .downcast_ref::<InvertedIndex>()
         .ok_or_else(|| {
             Error::invalid_input(format!(
                 "Index for column {} and segment {} is not an inverted index",
-                column, uuid
+                column, segment.uuid
             ))
         })?;
     Ok(Arc::new(inverted.clone()))
@@ -2188,7 +2189,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let index = dataset
-            .open_generic_index("text", &index_meta.uuid.to_string(), &NoOpMetricsCollector)
+            .open_generic_index("text", &index_meta.uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let inverted_index = index.as_any().downcast_ref::<InvertedIndex>().unwrap();
@@ -2251,7 +2252,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let index = dataset
-            .open_generic_index("text", &index_meta.uuid.to_string(), &NoOpMetricsCollector)
+            .open_generic_index("text", &index_meta.uuid, &NoOpMetricsCollector)
             .await
             .unwrap();
         let inverted_index = index.as_any().downcast_ref::<InvertedIndex>().unwrap();

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -58,6 +58,7 @@ use lance_linalg::distance::DistanceType;
 use lance_linalg::kernels::normalize_arrow;
 use lance_table::format::IndexMetadata;
 use tokio::sync::Notify;
+use uuid::Uuid;
 
 use crate::dataset::Dataset;
 use crate::index::DatasetIndexInternalExt;
@@ -714,7 +715,7 @@ pub fn new_knn_exec(
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let ivf_node = ANNIvfPartitionExec::try_new(
         dataset.clone(),
-        indices.iter().map(|idx| idx.uuid.to_string()).collect_vec(),
+        indices.iter().map(|idx| idx.uuid).collect_vec(),
         query.clone(),
     )?;
 
@@ -760,7 +761,7 @@ pub struct ANNIvfPartitionExec {
     pub query: Query,
 
     /// The UUIDs of the indices to search.
-    pub index_uuids: Vec<String>,
+    pub index_uuids: Vec<Uuid>,
 
     pub properties: Arc<PlanProperties>,
 
@@ -768,7 +769,7 @@ pub struct ANNIvfPartitionExec {
 }
 
 impl ANNIvfPartitionExec {
-    pub fn try_new(dataset: Arc<Dataset>, index_uuids: Vec<String>, query: Query) -> Result<Self> {
+    pub fn try_new(dataset: Arc<Dataset>, index_uuids: Vec<Uuid>, query: Query) -> Result<Self> {
         let dataset_schema = dataset.schema();
         get_vector_type(dataset_schema, &query.column)?;
         if index_uuids.is_empty() {
@@ -910,7 +911,7 @@ impl ExecutionPlan for ANNIvfPartitionExec {
                     dist_q_c_list_builder.append_value(dist_q_c.iter());
                     let dist_q_c_col = dist_q_c_list_builder.finish();
 
-                    let uuid_col = StringArray::from(vec![uuid.as_str()]);
+                    let uuid_col = StringArray::from(vec![uuid.to_string()]);
                     let batch = RecordBatch::try_new(
                         KNN_PARTITION_SCHEMA.clone(),
                         vec![
@@ -1549,7 +1550,11 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                             Arc::new(part_id.unwrap().as_primitive::<UInt32Type>().clone());
                         let dist_q_c =
                             Arc::new(dist_q_c.unwrap().as_primitive::<Float32Type>().clone());
-                        let uuid = uuid.unwrap().to_string();
+                        let uuid = Uuid::parse_str(uuid.unwrap()).map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Invalid UUID in __index_uuid column: {e}"
+                            ))
+                        })?;
                         Ok((partitions, dist_q_c, uuid))
                     })
                     .collect_vec();

--- a/rust/lance/src/session/index_caches.rs
+++ b/rust/lance/src/session/index_caches.rs
@@ -63,14 +63,14 @@ impl Deref for DSIndexCache {
 
 impl DSIndexCache {
     /// Create an index-specific cache with the given UUID prefix.
-    pub fn for_index(&self, uuid: &str, fri_uuid: Option<&Uuid>) -> LanceCache {
+    pub fn for_index(&self, uuid: &Uuid, fri_uuid: Option<&Uuid>) -> LanceCache {
         if let Some(fri_uuid) = fri_uuid {
             // If a FRI UUID is provided, use it to create a more specific cache key.
             let cache_key = format!("{}-{}", uuid, fri_uuid);
             self.0.with_key_prefix(&cache_key)
         } else {
             // Otherwise, just use the index UUID as the key prefix.
-            self.0.with_key_prefix(uuid)
+            self.0.with_key_prefix(&uuid.to_string())
         }
     }
 }
@@ -79,7 +79,7 @@ impl DSIndexCache {
 
 #[derive(Debug)]
 pub struct FragReuseIndexKey<'a> {
-    pub uuid: &'a str,
+    pub uuid: &'a Uuid,
 }
 
 impl CacheKey for FragReuseIndexKey<'_> {
@@ -131,7 +131,7 @@ impl DeepSizeOf for ProstAny {
 /// what they are.  These we cache.
 #[derive(Debug)]
 pub struct ScalarIndexDetailsKey<'a> {
-    pub uuid: &'a str,
+    pub uuid: &'a Uuid,
 }
 
 impl CacheKey for ScalarIndexDetailsKey<'_> {

--- a/rust/lance/src/session/index_extension.rs
+++ b/rust/lance/src/session/index_extension.rs
@@ -7,6 +7,7 @@ use lance_core::Result;
 use lance_core::deepsize::DeepSizeOf;
 use lance_file::previous::reader::FileReader as PreviousFileReader;
 use lance_index::{IndexParams, IndexType, vector::VectorIndex};
+use uuid::Uuid;
 
 use crate::Dataset;
 
@@ -35,7 +36,7 @@ pub trait VectorIndexExtension: IndexExtension {
         // if we wrap into an Arc, the mutable reference is lost
         dataset: &Dataset,
         column: &str,
-        uuid: &str,
+        uuid: &Uuid,
         params: &dyn IndexParams,
     ) -> Result<()>;
 
@@ -44,7 +45,7 @@ pub trait VectorIndexExtension: IndexExtension {
         &self,
         dataset: Arc<Dataset>,
         column: &str,
-        uuid: &str,
+        uuid: &Uuid,
         reader: PreviousFileReader,
     ) -> Result<Arc<dyn VectorIndex>>;
 }
@@ -259,7 +260,7 @@ mod test {
             &self,
             dataset: &Dataset,
             _column: &str,
-            uuid: &str,
+            uuid: &Uuid,
             _params: &dyn IndexParams,
         ) -> Result<()> {
             let store = dataset.object_store.clone();
@@ -305,7 +306,7 @@ mod test {
             &self,
             _dataset: Arc<Dataset>,
             _column: &str,
-            _uuid: &str,
+            _uuid: &Uuid,
             _reader: PreviousFileReader,
         ) -> Result<Arc<dyn VectorIndex>> {
             self.load_index_called
@@ -391,7 +392,7 @@ mod test {
         let idx = ds_without_extension.load_indices().await.unwrap();
         assert_eq!(idx.len(), 1);
         // get the index uuid
-        let index_uuid = idx.first().unwrap().uuid.to_string();
+        let index_uuid = idx.first().unwrap().uuid;
 
         // trying to open the index should fail as there is no extension loader
         assert!(


### PR DESCRIPTION
Closes #6347.

Replaces `String`/`&str` UUIDs with `uuid::Uuid` across the index infrastructure. `IndexMetadata.uuid` was already `Uuid`, so most internal callsites were doing `idx.uuid.to_string()` (per-iter heap alloc) or `Uuid::parse_str` to convert it back — this PR removes those round-trips.

The change extends beyond the five items listed in the issue to clean up the adjacent functions that took `uuid: &str` for the same reason: `load_index`, `merge_index_metadata`, the `build_*` helpers, `from_dataset_for_new`, and `VectorIndexExtension`.

## FFI behaviour

Python `create_scalar_index(..., index_uuid="not-a-uuid")` and `merge_index_metadata("not-a-uuid", ...)` now raise `ValueError("Invalid UUID string for index_uuid: ...")` at the binding boundary, instead of an `lance::Error::Index` from deeper in. Java JNI behaves equivalently via `Error::input_error`. A new test in `python/python/tests/test_scalar_index.py` locks the Python behaviour in.

## Performance note

Cache key `fn key() -> Cow<'_, str>` impls now allocate a `String` (via `Uuid::to_string`) instead of returning 
 `Cow::Borrowed(&str)`. This is unavoidable when changing the field type and matches what `MemWalCacheKey::key()` already does. The savings on the lookup side — no `idx.uuid.to_string()` per index in `load_index`, no `Uuid::parse_str`
in `build_distributed_vector_index` — outweigh the per-key allocation in practice (one alloc per lookup vs. one alloc per index per scan).

## Wire-format stability (verified unchanged)

- `IvfIndexStateHeader` JSON (on-disk cache)
- `IvfIndexState` / `IvfIndexStatistics` JSON
- `pb::AnnIvfPartitionExecProto.index_uuids` (proto)
- Arrow `__index_uuid` column type (`DataType::Utf8`)
- `Uuid::Display` produces the canonical hyphenated-lowercase form, identical to the previous `String` representation, so any caller reading these fields textually sees the same bytes.