### PR TITLE
feat: add commit timeout to CommitBuilder

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -369,11 +369,13 @@ impl BlockingDataset {
         max_retries: u32,
         skip_auto_cleanup: bool,
         commit_handler: Option<Arc<dyn CommitHandler>>,
+        commit_timeout: Option<std::time::Duration>,
     ) -> Result<Self> {
         let mut builder = CommitBuilder::new(Arc::new(self.clone().inner))
             .with_store_params(store_params)
             .with_detached(detached)
-            .enable_v2_manifest_paths(enable_v2_manifest_paths);
+            .enable_v2_manifest_paths(enable_v2_manifest_paths)
+            .with_timeout(commit_timeout);
         if let Some(use_stable) = use_stable_row_ids {
             builder = builder.use_stable_row_ids(use_stable);
         }

--- a/java/lance-jni/src/error.rs
+++ b/java/lance-jni/src/error.rs
@@ -17,6 +17,7 @@ pub enum JavaExceptionClass {
     UnsupportedOperationException,
     AlreadyInException,
     LanceNamespaceException,
+    LanceTimeoutException,
 }
 
 impl JavaExceptionClass {
@@ -29,6 +30,7 @@ impl JavaExceptionClass {
             // Included for display purposes.  This is not a real exception.
             Self::AlreadyInException => "AlreadyInException",
             Self::LanceNamespaceException => "org/lance/namespace/errors/LanceNamespaceException",
+            Self::LanceTimeoutException => "org/lance/LanceTimeoutException",
         }
     }
 }
@@ -67,6 +69,10 @@ impl Error {
 
     pub fn unsupported_error(message: String) -> Self {
         Self::new(message, JavaExceptionClass::UnsupportedOperationException)
+    }
+
+    pub fn timeout_error(message: String) -> Self {
+        Self::new(message, JavaExceptionClass::LanceTimeoutException)
     }
 
     pub fn namespace_error(code: u32, message: String) -> Self {
@@ -181,6 +187,7 @@ impl From<LanceError> for Error {
             | LanceError::CommitConflict { .. }
             | LanceError::InvalidInput { .. } => Self::input_error(err.to_string()),
             LanceError::IO { .. } => Self::io_error(err.to_string()),
+            LanceError::Timeout { .. } => Self::timeout_error(err.to_string()),
             LanceError::NotSupported { .. } => Self::unsupported_error(err.to_string()),
             LanceError::NotFound { .. } => Self::io_error(err.to_string()),
             LanceError::Namespace { source, .. } => {

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -609,16 +609,16 @@ fn parse_storage_format(name: &str) -> Result<LanceFileVersion> {
     }
 }
 
-/// Translate the Java `commitTimeoutMillis` sentinel into an
+/// Translate the Java `commitTimeoutNanos` sentinel into an
 /// `Option<Duration>` for [`CommitBuilder::with_timeout`]. The Java side is
 /// the source of truth for the default (5 minutes) and for rejecting
 /// zero/negative-from-the-user inputs; here `< 0` simply means "disabled" and
-/// any other value is the timeout in milliseconds.
-fn parse_commit_timeout(millis: i64) -> Option<std::time::Duration> {
-    if millis < 0 {
+/// any other value is the timeout in nanoseconds.
+fn parse_commit_timeout(nanos: i64) -> Option<std::time::Duration> {
+    if nanos < 0 {
         None
     } else {
-        Some(std::time::Duration::from_millis(millis as u64))
+        Some(std::time::Duration::from_nanos(nanos as u64))
     }
 }
 
@@ -639,7 +639,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
     namespace_obj: JObject,
     table_id_obj: JObject,
     namespace_client_managed_versioning: jboolean,
-    commit_timeout_millis: jlong,
+    commit_timeout_nanos: jlong,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -657,7 +657,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
             namespace_obj,
             table_id_obj,
             namespace_client_managed_versioning != 0,
-            commit_timeout_millis,
+            commit_timeout_nanos,
         )
     )
 }
@@ -677,9 +677,9 @@ fn inner_commit_to_dataset<'local>(
     namespace_obj: JObject,
     table_id_obj: JObject,
     namespace_client_managed_versioning: bool,
-    commit_timeout_millis: jlong,
+    commit_timeout_nanos: jlong,
 ) -> Result<JObject<'local>> {
-    let commit_timeout = parse_commit_timeout(commit_timeout_millis);
+    let commit_timeout = parse_commit_timeout(commit_timeout_nanos);
     let write_param = if write_params_obj.is_null() {
         HashMap::new()
     } else {
@@ -1401,7 +1401,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
     max_retries: jint,
     skip_auto_cleanup: jboolean,
     namespace_client_managed_versioning: jboolean,
-    commit_timeout_millis: jlong,
+    commit_timeout_nanos: jlong,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -1420,7 +1420,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
             max_retries as u32,
             skip_auto_cleanup != 0,
             namespace_client_managed_versioning != 0,
-            commit_timeout_millis,
+            commit_timeout_nanos,
         )
     )
 }
@@ -1441,9 +1441,9 @@ fn inner_commit_to_uri<'local>(
     max_retries: u32,
     skip_auto_cleanup: bool,
     namespace_client_managed_versioning: bool,
-    commit_timeout_millis: jlong,
+    commit_timeout_nanos: jlong,
 ) -> Result<JObject<'local>> {
-    let commit_timeout = parse_commit_timeout(commit_timeout_millis);
+    let commit_timeout = parse_commit_timeout(commit_timeout_nanos);
     let uri_str: String = uri.extract(env)?;
 
     // Extract write params from parameter

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -609,6 +609,32 @@ fn parse_storage_format(name: &str) -> Result<LanceFileVersion> {
     }
 }
 
+/// Parse the Java `Optional<Long>` (passed as a possibly-null boxed `Long` of
+/// milliseconds) describing the commit timeout. A null Java value falls back to
+/// [`lance::dataset::DEFAULT_COMMIT_TIMEOUT`]; a negative value disables the
+/// timeout; zero is rejected.
+fn parse_commit_timeout(
+    env: &mut JNIEnv,
+    commit_timeout_millis_obj: &JObject,
+) -> Result<Option<std::time::Duration>> {
+    if commit_timeout_millis_obj.is_null() {
+        return Ok(Some(lance::dataset::DEFAULT_COMMIT_TIMEOUT));
+    }
+    let millis = env
+        .call_method(commit_timeout_millis_obj, "longValue", "()J", &[])?
+        .j()?;
+    if millis < 0 {
+        Ok(None)
+    } else if millis == 0 {
+        Err(Error::input_error(
+            "commit timeout must be a positive duration; pass a negative value to disable"
+                .to_string(),
+        ))
+    } else {
+        Ok(Some(std::time::Duration::from_millis(millis as u64)))
+    }
+}
+
 #[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
 pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local>(
@@ -626,6 +652,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
     namespace_obj: JObject,
     table_id_obj: JObject,
     namespace_client_managed_versioning: jboolean,
+    commit_timeout_millis_obj: JObject,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -643,6 +670,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
             namespace_obj,
             table_id_obj,
             namespace_client_managed_versioning != 0,
+            commit_timeout_millis_obj,
         )
     )
 }
@@ -662,7 +690,9 @@ fn inner_commit_to_dataset<'local>(
     namespace_obj: JObject,
     table_id_obj: JObject,
     namespace_client_managed_versioning: bool,
+    commit_timeout_millis_obj: JObject,
 ) -> Result<JObject<'local>> {
+    let commit_timeout = parse_commit_timeout(env, &commit_timeout_millis_obj)?;
     let write_param = if write_params_obj.is_null() {
         HashMap::new()
     } else {
@@ -780,6 +810,7 @@ fn inner_commit_to_dataset<'local>(
             max_retries,
             skip_auto_cleanup,
             commit_handler,
+            commit_timeout,
         )?
     };
     new_blocking_ds.into_java(env)
@@ -1383,6 +1414,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
     max_retries: jint,
     skip_auto_cleanup: jboolean,
     namespace_client_managed_versioning: jboolean,
+    commit_timeout_millis_obj: JObject,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -1401,6 +1433,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
             max_retries as u32,
             skip_auto_cleanup != 0,
             namespace_client_managed_versioning != 0,
+            commit_timeout_millis_obj,
         )
     )
 }
@@ -1421,7 +1454,9 @@ fn inner_commit_to_uri<'local>(
     max_retries: u32,
     skip_auto_cleanup: bool,
     namespace_client_managed_versioning: bool,
+    commit_timeout_millis_obj: JObject,
 ) -> Result<JObject<'local>> {
+    let commit_timeout = parse_commit_timeout(env, &commit_timeout_millis_obj)?;
     let uri_str: String = uri.extract(env)?;
 
     // Extract write params from parameter
@@ -1520,7 +1555,8 @@ fn inner_commit_to_uri<'local>(
     let mut builder = CommitBuilder::new(&*uri_str)
         .with_store_params(store_params)
         .with_detached(detached)
-        .enable_v2_manifest_paths(enable_v2_manifest_paths);
+        .enable_v2_manifest_paths(enable_v2_manifest_paths)
+        .with_timeout(commit_timeout);
 
     if let Some(use_stable) = use_stable_row_ids {
         builder = builder.use_stable_row_ids(use_stable);

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -15,7 +15,7 @@ use arrow_schema::ffi::FFI_ArrowSchema;
 use chrono::DateTime;
 use jni::JNIEnv;
 use jni::objects::{JByteArray, JLongArray, JMap, JObject, JString, JValue, JValueGen};
-use jni::sys::{jboolean, jint};
+use jni::sys::{jboolean, jint, jlong};
 use lance::dataset::CommitBuilder;
 use lance::dataset::transaction::{
     DataReplacementGroup, Operation, RewriteGroup, RewrittenIndex, Transaction, TransactionBuilder,
@@ -609,29 +609,16 @@ fn parse_storage_format(name: &str) -> Result<LanceFileVersion> {
     }
 }
 
-/// Parse the Java `Optional<Long>` (passed as a possibly-null boxed `Long` of
-/// milliseconds) describing the commit timeout. A null Java value falls back to
-/// [`lance::dataset::DEFAULT_COMMIT_TIMEOUT`]; a negative value disables the
-/// timeout; zero is rejected.
-fn parse_commit_timeout(
-    env: &mut JNIEnv,
-    commit_timeout_millis_obj: &JObject,
-) -> Result<Option<std::time::Duration>> {
-    if commit_timeout_millis_obj.is_null() {
-        return Ok(Some(lance::dataset::DEFAULT_COMMIT_TIMEOUT));
-    }
-    let millis = env
-        .call_method(commit_timeout_millis_obj, "longValue", "()J", &[])?
-        .j()?;
+/// Translate the Java `commitTimeoutMillis` sentinel into an
+/// `Option<Duration>` for [`CommitBuilder::with_timeout`]. The Java side is
+/// the source of truth for the default (5 minutes) and for rejecting
+/// zero/negative-from-the-user inputs; here `< 0` simply means "disabled" and
+/// any other value is the timeout in milliseconds.
+fn parse_commit_timeout(millis: i64) -> Option<std::time::Duration> {
     if millis < 0 {
-        Ok(None)
-    } else if millis == 0 {
-        Err(Error::input_error(
-            "commit timeout must be a positive duration; pass a negative value to disable"
-                .to_string(),
-        ))
+        None
     } else {
-        Ok(Some(std::time::Duration::from_millis(millis as u64)))
+        Some(std::time::Duration::from_millis(millis as u64))
     }
 }
 
@@ -652,7 +639,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
     namespace_obj: JObject,
     table_id_obj: JObject,
     namespace_client_managed_versioning: jboolean,
-    commit_timeout_millis_obj: JObject,
+    commit_timeout_millis: jlong,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -670,7 +657,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToDataset<'local
             namespace_obj,
             table_id_obj,
             namespace_client_managed_versioning != 0,
-            commit_timeout_millis_obj,
+            commit_timeout_millis,
         )
     )
 }
@@ -690,9 +677,9 @@ fn inner_commit_to_dataset<'local>(
     namespace_obj: JObject,
     table_id_obj: JObject,
     namespace_client_managed_versioning: bool,
-    commit_timeout_millis_obj: JObject,
+    commit_timeout_millis: jlong,
 ) -> Result<JObject<'local>> {
-    let commit_timeout = parse_commit_timeout(env, &commit_timeout_millis_obj)?;
+    let commit_timeout = parse_commit_timeout(commit_timeout_millis);
     let write_param = if write_params_obj.is_null() {
         HashMap::new()
     } else {
@@ -1414,7 +1401,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
     max_retries: jint,
     skip_auto_cleanup: jboolean,
     namespace_client_managed_versioning: jboolean,
-    commit_timeout_millis_obj: JObject,
+    commit_timeout_millis: jlong,
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -1433,7 +1420,7 @@ pub extern "system" fn Java_org_lance_CommitBuilder_nativeCommitToUri<'local>(
             max_retries as u32,
             skip_auto_cleanup != 0,
             namespace_client_managed_versioning != 0,
-            commit_timeout_millis_obj,
+            commit_timeout_millis,
         )
     )
 }
@@ -1454,9 +1441,9 @@ fn inner_commit_to_uri<'local>(
     max_retries: u32,
     skip_auto_cleanup: bool,
     namespace_client_managed_versioning: bool,
-    commit_timeout_millis_obj: JObject,
+    commit_timeout_millis: jlong,
 ) -> Result<JObject<'local>> {
-    let commit_timeout = parse_commit_timeout(env, &commit_timeout_millis_obj)?;
+    let commit_timeout = parse_commit_timeout(commit_timeout_millis);
     let uri_str: String = uri.extract(env)?;
 
     // Extract write params from parameter

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -611,7 +611,7 @@ fn parse_storage_format(name: &str) -> Result<LanceFileVersion> {
 
 /// Translate the Java `commitTimeoutNanos` sentinel into an
 /// `Option<Duration>` for [`CommitBuilder::with_timeout`]. The Java side is
-/// the source of truth for the default (5 minutes) and for rejecting
+/// the source of truth for the default (30 minutes) and for rejecting
 /// zero/negative-from-the-user inputs; here `< 0` simply means "disabled" and
 /// any other value is the timeout in nanoseconds.
 fn parse_commit_timeout(nanos: i64) -> Option<std::time::Duration> {

--- a/java/src/main/java/org/lance/CommitBuilder.java
+++ b/java/src/main/java/org/lance/CommitBuilder.java
@@ -75,7 +75,7 @@ public class CommitBuilder {
   private int maxRetries = 0;
   private boolean skipAutoCleanup = false;
   // -1 disables the timeout; any positive value is the timeout in nanoseconds.
-  private long commitTimeoutNanos = Duration.ofMinutes(5).toNanos();
+  private long commitTimeoutNanos = Duration.ofMinutes(30).toNanos();
 
   /**
    * Create a commit builder for committing against an existing dataset.
@@ -243,7 +243,7 @@ public class CommitBuilder {
    *
    * <p>If the commit (including retries on conflict) does not complete within {@code timeout},
    * {@link #execute(Transaction)} will fail. Pass {@code null} to disable the timeout entirely. The
-   * default is 5 minutes.
+   * default is 30 minutes.
    *
    * @param timeout the commit timeout, or {@code null} to disable
    * @return this builder instance

--- a/java/src/main/java/org/lance/CommitBuilder.java
+++ b/java/src/main/java/org/lance/CommitBuilder.java
@@ -242,8 +242,8 @@ public class CommitBuilder {
    * Set a timeout for the commit operation.
    *
    * <p>If the commit (including retries on conflict) does not complete within {@code timeout},
-   * {@link #execute(Transaction)} will fail. Pass {@code null} to disable the timeout entirely.
-   * The default is 5 minutes.
+   * {@link #execute(Transaction)} will fail. Pass {@code null} to disable the timeout entirely. The
+   * default is 5 minutes.
    *
    * @param timeout the commit timeout, or {@code null} to disable
    * @return this builder instance

--- a/java/src/main/java/org/lance/CommitBuilder.java
+++ b/java/src/main/java/org/lance/CommitBuilder.java
@@ -74,8 +74,8 @@ public class CommitBuilder {
   private String storageFormat;
   private int maxRetries = 0;
   private boolean skipAutoCleanup = false;
-  // -1 disables the timeout; any positive value is the timeout in millis.
-  private long commitTimeoutMillis = Duration.ofMinutes(5).toMillis();
+  // -1 disables the timeout; any positive value is the timeout in nanoseconds.
+  private long commitTimeoutNanos = Duration.ofMinutes(5).toNanos();
 
   /**
    * Create a commit builder for committing against an existing dataset.
@@ -251,12 +251,12 @@ public class CommitBuilder {
    */
   public CommitBuilder commitTimeout(Duration timeout) {
     if (timeout == null) {
-      this.commitTimeoutMillis = -1L;
+      this.commitTimeoutNanos = -1L;
     } else {
       Preconditions.checkArgument(
           !timeout.isZero() && !timeout.isNegative(),
           "commit timeout must be a positive duration; pass null to disable");
-      this.commitTimeoutMillis = timeout.toMillis();
+      this.commitTimeoutNanos = timeout.toNanos();
     }
     return this;
   }
@@ -287,7 +287,7 @@ public class CommitBuilder {
               namespaceClient,
               tableId,
               namespaceClientManagedVersioning,
-              commitTimeoutMillis);
+              commitTimeoutNanos);
       result.setAllocator(dataset.allocator());
       return result;
     }
@@ -307,7 +307,7 @@ public class CommitBuilder {
               maxRetries,
               skipAutoCleanup,
               namespaceClientManagedVersioning,
-              commitTimeoutMillis);
+              commitTimeoutNanos);
       result.setAllocator(allocator);
       return result;
     }
@@ -327,7 +327,7 @@ public class CommitBuilder {
       Object namespace,
       Object tableId,
       boolean namespaceClientManagedVersioning,
-      long commitTimeoutMillis);
+      long commitTimeoutNanos);
 
   private static native Dataset nativeCommitToUri(
       String uri,
@@ -343,5 +343,5 @@ public class CommitBuilder {
       int maxRetries,
       boolean skipAutoCleanup,
       boolean namespaceClientManagedVersioning,
-      long commitTimeoutMillis);
+      long commitTimeoutNanos);
 }

--- a/java/src/main/java/org/lance/CommitBuilder.java
+++ b/java/src/main/java/org/lance/CommitBuilder.java
@@ -18,6 +18,7 @@ import org.lance.namespace.LanceNamespace;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -73,6 +74,9 @@ public class CommitBuilder {
   private String storageFormat;
   private int maxRetries = 0;
   private boolean skipAutoCleanup = false;
+  // null → use Rust default (5 minutes). Sentinel boxed Long is sent across JNI:
+  // null = default, -1 = disable, positive = timeout in millis.
+  private Long commitTimeoutMillis;
 
   /**
    * Create a commit builder for committing against an existing dataset.
@@ -236,6 +240,30 @@ public class CommitBuilder {
   }
 
   /**
+   * Set a timeout for the commit operation.
+   *
+   * <p>If the commit (including retries on conflict) does not complete within {@code timeout},
+   * {@link #execute(Transaction)} will fail. Pass {@code null} to disable the timeout entirely.
+   * The default is 5 minutes.
+   *
+   * @param timeout the commit timeout, or {@code null} to disable
+   * @return this builder instance
+   * @throws IllegalArgumentException if {@code timeout} is zero or negative
+   */
+  public CommitBuilder commitTimeout(Duration timeout) {
+    if (timeout == null) {
+      // -1 millis is the sentinel for "disabled" across JNI.
+      this.commitTimeoutMillis = -1L;
+    } else {
+      Preconditions.checkArgument(
+          !timeout.isZero() && !timeout.isNegative(),
+          "commit timeout must be a positive duration; pass null to disable");
+      this.commitTimeoutMillis = timeout.toMillis();
+    }
+    return this;
+  }
+
+  /**
    * Execute the commit with the given transaction.
    *
    * <p>The caller is responsible for closing the transaction (via try-with-resources or {@link
@@ -260,7 +288,8 @@ public class CommitBuilder {
               skipAutoCleanup,
               namespaceClient,
               tableId,
-              namespaceClientManagedVersioning);
+              namespaceClientManagedVersioning,
+              commitTimeoutMillis);
       result.setAllocator(dataset.allocator());
       return result;
     }
@@ -279,7 +308,8 @@ public class CommitBuilder {
               storageFormat,
               maxRetries,
               skipAutoCleanup,
-              namespaceClientManagedVersioning);
+              namespaceClientManagedVersioning,
+              commitTimeoutMillis);
       result.setAllocator(allocator);
       return result;
     }
@@ -298,7 +328,8 @@ public class CommitBuilder {
       boolean skipAutoCleanup,
       Object namespace,
       Object tableId,
-      boolean namespaceClientManagedVersioning);
+      boolean namespaceClientManagedVersioning,
+      Long commitTimeoutMillis);
 
   private static native Dataset nativeCommitToUri(
       String uri,
@@ -313,5 +344,6 @@ public class CommitBuilder {
       String storageFormat,
       int maxRetries,
       boolean skipAutoCleanup,
-      boolean namespaceClientManagedVersioning);
+      boolean namespaceClientManagedVersioning,
+      Long commitTimeoutMillis);
 }

--- a/java/src/main/java/org/lance/CommitBuilder.java
+++ b/java/src/main/java/org/lance/CommitBuilder.java
@@ -74,9 +74,8 @@ public class CommitBuilder {
   private String storageFormat;
   private int maxRetries = 0;
   private boolean skipAutoCleanup = false;
-  // null → use Rust default (5 minutes). Sentinel boxed Long is sent across JNI:
-  // null = default, -1 = disable, positive = timeout in millis.
-  private Long commitTimeoutMillis;
+  // -1 disables the timeout; any positive value is the timeout in millis.
+  private long commitTimeoutMillis = Duration.ofMinutes(5).toMillis();
 
   /**
    * Create a commit builder for committing against an existing dataset.
@@ -252,7 +251,6 @@ public class CommitBuilder {
    */
   public CommitBuilder commitTimeout(Duration timeout) {
     if (timeout == null) {
-      // -1 millis is the sentinel for "disabled" across JNI.
       this.commitTimeoutMillis = -1L;
     } else {
       Preconditions.checkArgument(
@@ -329,7 +327,7 @@ public class CommitBuilder {
       Object namespace,
       Object tableId,
       boolean namespaceClientManagedVersioning,
-      Long commitTimeoutMillis);
+      long commitTimeoutMillis);
 
   private static native Dataset nativeCommitToUri(
       String uri,
@@ -345,5 +343,5 @@ public class CommitBuilder {
       int maxRetries,
       boolean skipAutoCleanup,
       boolean namespaceClientManagedVersioning,
-      Long commitTimeoutMillis);
+      long commitTimeoutMillis);
 }

--- a/java/src/main/java/org/lance/LanceTimeoutException.java
+++ b/java/src/main/java/org/lance/LanceTimeoutException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+/**
+ * Thrown when a Lance operation exceeds its configured timeout.
+ *
+ * <p>For example, a commit issued via {@link CommitBuilder} that does not complete within the
+ * duration set by {@link CommitBuilder#commitTimeout(java.time.Duration)} fails with this
+ * exception. It is unchecked so it does not change existing method signatures; catch it
+ * specifically to distinguish a timeout from other failures.
+ */
+public class LanceTimeoutException extends RuntimeException {
+  public LanceTimeoutException(String message) {
+    super(message);
+  }
+}

--- a/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
+++ b/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+import org.lance.operation.Append;
+import org.lance.operation.OperationTestBase;
+
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CommitBuilderTimeoutTest extends OperationTestBase {
+
+  @Test
+  void testZeroTimeoutRejected(@TempDir Path tempDir) {
+    String datasetPath = tempDir.resolve("zeroTimeout").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new CommitBuilder(dataset).commitTimeout(Duration.ZERO));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new CommitBuilder(dataset).commitTimeout(Duration.ofMillis(-1)));
+    }
+  }
+
+  @Test
+  void testNullDisablesTimeout(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("nullTimeout").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+      FragmentMetadata fragment = testDataset.createNewFragment(10);
+      try (Transaction txn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(Append.builder().fragments(Collections.singletonList(fragment)).build())
+              .build()) {
+        try (Dataset committed =
+            new CommitBuilder(dataset).commitTimeout(null).execute(txn)) {
+          assertEquals(2, committed.version());
+        }
+      }
+    }
+  }
+
+  @Test
+  void testPositiveTimeoutSucceeds(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("posTimeout").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+      FragmentMetadata fragment = testDataset.createNewFragment(10);
+      try (Transaction txn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(Append.builder().fragments(Collections.singletonList(fragment)).build())
+              .build()) {
+        try (Dataset committed =
+            new CommitBuilder(dataset).commitTimeout(Duration.ofMinutes(5)).execute(txn)) {
+          assertEquals(2, committed.version());
+        }
+      }
+    }
+  }
+}

--- a/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
+++ b/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CommitBuilderTimeoutTest extends OperationTestBase {
 
@@ -87,32 +86,8 @@ public class CommitBuilderTimeoutTest extends OperationTestBase {
     }
   }
 
-  /** A 1-nanosecond timeout fires before any local filesystem commit can finish. */
-  @Test
-  void testTimeoutFires(@TempDir Path tempDir) throws Exception {
-    String datasetPath = tempDir.resolve("fires").toString();
-    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
-      TestUtils.SimpleTestDataset testDataset =
-          new TestUtils.SimpleTestDataset(allocator, datasetPath);
-      dataset = testDataset.createEmptyDataset();
-      FragmentMetadata fragment = testDataset.createNewFragment(10);
-      try (Transaction txn =
-          new Transaction.Builder()
-              .readVersion(dataset.version())
-              .operation(Append.builder().fragments(Collections.singletonList(fragment)).build())
-              .build()) {
-        LanceTimeoutException ex =
-            assertThrows(
-                LanceTimeoutException.class,
-                () ->
-                    new CommitBuilder(dataset)
-                        .commitTimeout(Duration.ofNanos(1))
-                        .execute(txn)
-                        .close());
-        assertTrue(
-            ex.getMessage().toLowerCase().contains("timed out"),
-            "expected timeout error, got: " + ex.getMessage());
-      }
-    }
-  }
+  // Timeout *firing* behavior is covered by the Rust test
+  // `test_commit_timeout_triggers`, which uses a throttled store for a reliable
+  // trigger; reproducing it from Java without exposing throttling would be
+  // flaky on fast runners.
 }

--- a/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
+++ b/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CommitBuilderTimeoutTest extends OperationTestBase {
 
@@ -83,6 +84,35 @@ public class CommitBuilderTimeoutTest extends OperationTestBase {
             new CommitBuilder(dataset).commitTimeout(Duration.ofMinutes(5)).execute(txn)) {
           assertEquals(2, committed.version());
         }
+      }
+    }
+  }
+
+  /** A 1-nanosecond timeout fires before any local filesystem commit can finish. */
+  @Test
+  void testTimeoutFires(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("fires").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+      FragmentMetadata fragment = testDataset.createNewFragment(10);
+      try (Transaction txn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(Append.builder().fragments(Collections.singletonList(fragment)).build())
+              .build()) {
+        RuntimeException ex =
+            assertThrows(
+                RuntimeException.class,
+                () ->
+                    new CommitBuilder(dataset)
+                        .commitTimeout(Duration.ofNanos(1))
+                        .execute(txn)
+                        .close());
+        assertTrue(
+            ex.getMessage().toLowerCase().contains("timed out"),
+            "expected timeout error, got: " + ex.getMessage());
       }
     }
   }

--- a/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
+++ b/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
@@ -59,8 +59,7 @@ public class CommitBuilderTimeoutTest extends OperationTestBase {
               .readVersion(dataset.version())
               .operation(Append.builder().fragments(Collections.singletonList(fragment)).build())
               .build()) {
-        try (Dataset committed =
-            new CommitBuilder(dataset).commitTimeout(null).execute(txn)) {
+        try (Dataset committed = new CommitBuilder(dataset).commitTimeout(null).execute(txn)) {
           assertEquals(2, committed.version());
         }
       }

--- a/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
+++ b/java/src/test/java/org/lance/CommitBuilderTimeoutTest.java
@@ -102,9 +102,9 @@ public class CommitBuilderTimeoutTest extends OperationTestBase {
               .readVersion(dataset.version())
               .operation(Append.builder().fragments(Collections.singletonList(fragment)).build())
               .build()) {
-        RuntimeException ex =
+        LanceTimeoutException ex =
             assertThrows(
-                RuntimeException.class,
+                LanceTimeoutException.class,
                 () ->
                     new CommitBuilder(dataset)
                         .commitTimeout(Duration.ofNanos(1))

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -93,6 +93,8 @@ if TYPE_CHECKING:
         Iterable[float],
     ]
 LANCE_COMMIT_MESSAGE_KEY = "__lance_commit_message"
+# Mirrors Rust's `lance::dataset::DEFAULT_COMMIT_TIMEOUT`; keep the two in sync.
+_DEFAULT_COMMIT_TIMEOUT = timedelta(minutes=5)
 _BLOB_PANDAS_MODE_LAZY = "lazy"
 _BLOB_PANDAS_MODE_BYTES = "bytes"
 _BLOB_PANDAS_MODE_DESCRIPTIONS = "descriptions"
@@ -3983,7 +3985,7 @@ class LanceDataset(pa.dataset.Dataset):
         table_id: Optional[List[str]] = None,
         namespace_client_managed_versioning: bool = False,
         base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
-        commit_timeout: Optional[timedelta] = timedelta(minutes=5),
+        commit_timeout: Optional[timedelta] = _DEFAULT_COMMIT_TIMEOUT,
     ) -> LanceDataset:
         """Create a new version of dataset
 
@@ -4186,7 +4188,7 @@ class LanceDataset(pa.dataset.Dataset):
         detached: Optional[bool] = False,
         max_retries: int = 20,
         base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
-        commit_timeout: Optional[timedelta] = timedelta(minutes=5),
+        commit_timeout: Optional[timedelta] = _DEFAULT_COMMIT_TIMEOUT,
     ) -> BulkCommitResult:
         """Create a new version of dataset with multiple transactions.
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -94,7 +94,7 @@ if TYPE_CHECKING:
     ]
 LANCE_COMMIT_MESSAGE_KEY = "__lance_commit_message"
 # Mirrors Rust's `lance::dataset::DEFAULT_COMMIT_TIMEOUT`; keep the two in sync.
-_DEFAULT_COMMIT_TIMEOUT = timedelta(minutes=5)
+_DEFAULT_COMMIT_TIMEOUT = timedelta(minutes=30)
 _BLOB_PANDAS_MODE_LAZY = "lazy"
 _BLOB_PANDAS_MODE_BYTES = "bytes"
 _BLOB_PANDAS_MODE_DESCRIPTIONS = "descriptions"
@@ -4060,7 +4060,7 @@ class LanceDataset(pa.dataset.Dataset):
             Runtime-only object store parameters keyed by base path URI.
         commit_timeout : timedelta, optional
             Maximum time to wait for the commit operation (including retries on
-            conflict) to complete. Defaults to 5 minutes. Pass ``None`` to
+            conflict) to complete. Defaults to 30 minutes. Pass ``None`` to
             disable the timeout entirely. Must be a positive duration.
 
         Returns
@@ -4235,7 +4235,7 @@ class LanceDataset(pa.dataset.Dataset):
             Runtime-only object store parameters keyed by base path URI.
         commit_timeout : timedelta, optional
             Maximum time to wait for the commit operation (including retries on
-            conflict) to complete. Defaults to 5 minutes. Pass ``None`` to
+            conflict) to complete. Defaults to 30 minutes. Pass ``None`` to
             disable the timeout entirely. Must be a positive duration.
 
         Returns

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3983,6 +3983,7 @@ class LanceDataset(pa.dataset.Dataset):
         table_id: Optional[List[str]] = None,
         namespace_client_managed_versioning: bool = False,
         base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+        commit_timeout: Optional[timedelta] = timedelta(minutes=5),
     ) -> LanceDataset:
         """Create a new version of dataset
 
@@ -4055,6 +4056,10 @@ class LanceDataset(pa.dataset.Dataset):
             Must be provided together with namespace_client.
         base_store_params : dict of str to dict, optional
             Runtime-only object store parameters keyed by base path URI.
+        commit_timeout : timedelta, optional
+            Maximum time to wait for the commit operation (including retries on
+            conflict) to complete. Defaults to 5 minutes. Pass ``None`` to
+            disable the timeout entirely. Must be a positive duration.
 
         Returns
         -------
@@ -4134,6 +4139,7 @@ class LanceDataset(pa.dataset.Dataset):
                 namespace_client=namespace_client,
                 table_id=table_id,
                 namespace_client_managed_versioning=namespace_client_managed_versioning,
+                commit_timeout=commit_timeout,
             )
         elif isinstance(operation, LanceOperation.BaseOperation):
             new_ds = _Dataset.commit(
@@ -4150,6 +4156,7 @@ class LanceDataset(pa.dataset.Dataset):
                 namespace_client=namespace_client,
                 table_id=table_id,
                 namespace_client_managed_versioning=namespace_client_managed_versioning,
+                commit_timeout=commit_timeout,
             )
         else:
             raise TypeError(
@@ -4179,6 +4186,7 @@ class LanceDataset(pa.dataset.Dataset):
         detached: Optional[bool] = False,
         max_retries: int = 20,
         base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+        commit_timeout: Optional[timedelta] = timedelta(minutes=5),
     ) -> BulkCommitResult:
         """Create a new version of dataset with multiple transactions.
 
@@ -4223,6 +4231,10 @@ class LanceDataset(pa.dataset.Dataset):
             The maximum number of retries to perform when committing the dataset.
         base_store_params : dict of str to dict, optional
             Runtime-only object store parameters keyed by base path URI.
+        commit_timeout : timedelta, optional
+            Maximum time to wait for the commit operation (including retries on
+            conflict) to complete. Defaults to 5 minutes. Pass ``None`` to
+            disable the timeout entirely. Must be a positive duration.
 
         Returns
         -------
@@ -4259,6 +4271,7 @@ class LanceDataset(pa.dataset.Dataset):
             enable_v2_manifest_paths=enable_v2_manifest_paths,
             detached=detached,
             max_retries=max_retries,
+            commit_timeout=commit_timeout,
         )
         ds = LanceDataset.__new__(LanceDataset)
         ds._ds = new_ds

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from datetime import timedelta
 from pathlib import Path
 from typing import (
     Any,
@@ -438,6 +439,7 @@ class _Dataset:
         detached: Optional[bool] = None,
         max_retries: Optional[int] = None,
         enable_stable_row_ids: Optional[bool] = None,
+        commit_timeout: Optional[timedelta] = None,
         **kwargs,
     ) -> _Dataset: ...
     @staticmethod
@@ -449,6 +451,7 @@ class _Dataset:
         enable_v2_manifest_paths: Optional[bool] = None,
         detached: Optional[bool] = None,
         max_retries: Optional[int] = None,
+        commit_timeout: Optional[timedelta] = None,
     ) -> Tuple[_Dataset, Transaction]: ...
     def validate(self): ...
     def migrate_manifest_paths_v2(self): ...

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1656,10 +1656,16 @@ def test_commit_timeout(tmp_path: Path):
     fragment = lance.fragment.LanceFragment.create(base_dir, table)
     append = lance.LanceOperation.Append([fragment])
 
-    # Zero / negative durations are rejected.
-    with pytest.raises((ValueError, OSError)):
+    # A zero duration reaches Rust and is rejected as invalid input (PyIOError).
+    with pytest.raises(OSError, match="non-zero"):
         lance.LanceDataset.commit(
             dataset, append, read_version=1, commit_timeout=timedelta(0)
+        )
+
+    # A negative duration is rejected by PyO3's timedelta -> Duration conversion.
+    with pytest.raises(ValueError):
+        lance.LanceDataset.commit(
+            dataset, append, read_version=1, commit_timeout=timedelta(seconds=-1)
         )
 
     # None disables the timeout.

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1680,6 +1680,31 @@ def test_commit_timeout(tmp_path: Path):
     assert dataset_with_timeout.version == dataset_no_timeout.version + 1
 
 
+def test_commit_timeout_fires(tmp_path: Path):
+    """A commit_lock that blocks longer than the timeout makes the commit fail."""
+    from datetime import timedelta
+
+    table = pa.Table.from_pydict({"a": range(10)})
+    base_dir = tmp_path / "timeout_fires"
+    dataset = lance.write_dataset(table, base_dir)
+    fragment = lance.fragment.LanceFragment.create(base_dir, table)
+    append = lance.LanceOperation.Append([fragment])
+
+    @contextlib.contextmanager
+    def slow_lock(_version: int):
+        time.sleep(2)
+        yield
+
+    with pytest.raises(OSError, match="timed out"):
+        lance.LanceDataset.commit(
+            dataset,
+            append,
+            read_version=1,
+            commit_lock=slow_lock,
+            commit_timeout=timedelta(milliseconds=50),
+        )
+
+
 def test_append_with_commit(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1656,8 +1656,8 @@ def test_commit_timeout(tmp_path: Path):
     fragment = lance.fragment.LanceFragment.create(base_dir, table)
     append = lance.LanceOperation.Append([fragment])
 
-    # A zero duration reaches Rust and is rejected as invalid input (PyIOError).
-    with pytest.raises(OSError, match="non-zero"):
+    # A zero duration reaches Rust and is rejected as invalid input.
+    with pytest.raises(ValueError, match="non-zero"):
         lance.LanceDataset.commit(
             dataset, append, read_version=1, commit_timeout=timedelta(0)
         )
@@ -1701,7 +1701,7 @@ def test_commit_timeout_fires(tmp_path: Path):
         time.sleep(2)
         yield
 
-    with pytest.raises(OSError, match="timed out"):
+    with pytest.raises(TimeoutError, match="timed out"):
         lance.LanceDataset.commit(
             dataset,
             append,

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1646,6 +1646,40 @@ def test_strict_overwrite(tmp_path: Path):
         )
 
 
+def test_commit_timeout(tmp_path: Path):
+    from datetime import timedelta
+
+    table = pa.Table.from_pydict({"a": range(10)})
+    base_dir = tmp_path / "timeout"
+    dataset = lance.write_dataset(table, base_dir)
+
+    fragment = lance.fragment.LanceFragment.create(base_dir, table)
+    append = lance.LanceOperation.Append([fragment])
+
+    # Zero / negative durations are rejected.
+    with pytest.raises((ValueError, OSError)):
+        lance.LanceDataset.commit(
+            dataset, append, read_version=1, commit_timeout=timedelta(0)
+        )
+
+    # None disables the timeout.
+    dataset_no_timeout = lance.LanceDataset.commit(
+        dataset, append, read_version=1, commit_timeout=None
+    )
+    assert dataset_no_timeout.version == dataset.version + 1
+
+    # Explicit positive timeout works.
+    fragment2 = lance.fragment.LanceFragment.create(base_dir, table)
+    append2 = lance.LanceOperation.Append([fragment2])
+    dataset_with_timeout = lance.LanceDataset.commit(
+        dataset_no_timeout,
+        append2,
+        read_version=dataset_no_timeout.version,
+        commit_timeout=timedelta(minutes=1),
+    )
+    assert dataset_with_timeout.version == dataset_no_timeout.version + 1
+
+
 def test_append_with_commit(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1685,17 +1685,10 @@ def test_commit_timeout(tmp_path: Path):
     )
     assert dataset_with_timeout.version == dataset_no_timeout.version + 1
 
-    # A 1-microsecond timeout fires before the commit's first object-store
-    # write can finish, and surfaces as a TimeoutError.
-    fragment3 = lance.fragment.LanceFragment.create(base_dir, table)
-    append3 = lance.LanceOperation.Append([fragment3])
-    with pytest.raises(TimeoutError, match="timed out"):
-        lance.LanceDataset.commit(
-            dataset_with_timeout,
-            append3,
-            read_version=dataset_with_timeout.version,
-            commit_timeout=timedelta(microseconds=1),
-        )
+    # Timeout *firing* behavior is covered by the Rust test
+    # `test_commit_timeout_triggers`, which uses a throttled store for a
+    # reliable trigger; reproducing it from Python without exposing
+    # throttling would be flaky on fast runners.
 
 
 def test_append_with_commit(tmp_path: Path):

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1657,7 +1657,7 @@ def test_commit_timeout(tmp_path: Path):
     append = lance.LanceOperation.Append([fragment])
 
     # A zero duration reaches Rust and is rejected as invalid input.
-    with pytest.raises(ValueError, match="non-zero"):
+    with pytest.raises(OSError, match="non-zero"):
         lance.LanceDataset.commit(
             dataset, append, read_version=1, commit_timeout=timedelta(0)
         )
@@ -1685,29 +1685,16 @@ def test_commit_timeout(tmp_path: Path):
     )
     assert dataset_with_timeout.version == dataset_no_timeout.version + 1
 
-
-def test_commit_timeout_fires(tmp_path: Path):
-    """A commit_lock that blocks longer than the timeout makes the commit fail."""
-    from datetime import timedelta
-
-    table = pa.Table.from_pydict({"a": range(10)})
-    base_dir = tmp_path / "timeout_fires"
-    dataset = lance.write_dataset(table, base_dir)
-    fragment = lance.fragment.LanceFragment.create(base_dir, table)
-    append = lance.LanceOperation.Append([fragment])
-
-    @contextlib.contextmanager
-    def slow_lock(_version: int):
-        time.sleep(2)
-        yield
-
+    # A 1-microsecond timeout fires before the commit's first object-store
+    # write can finish, and surfaces as a TimeoutError.
+    fragment3 = lance.fragment.LanceFragment.create(base_dir, table)
+    append3 = lance.LanceOperation.Append([fragment3])
     with pytest.raises(TimeoutError, match="timed out"):
         lance.LanceDataset.commit(
-            dataset,
-            append,
-            read_version=1,
-            commit_lock=slow_lock,
-            commit_timeout=timedelta(milliseconds=50),
+            dataset_with_timeout,
+            append3,
+            read_version=dataset_with_timeout.version,
+            commit_timeout=timedelta(microseconds=1),
         )
 
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2593,7 +2593,7 @@ impl Dataset {
 
     #[allow(clippy::too_many_arguments)]
     #[staticmethod]
-    #[pyo3(signature = (dest, operation, read_version = None, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, commit_message = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_managed_versioning = false))]
+    #[pyo3(signature = (dest, operation, read_version = None, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, commit_message = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_managed_versioning = false, commit_timeout = None))]
     fn commit(
         dest: PyWriteDest,
         operation: PyLance<Operation>,
@@ -2608,6 +2608,7 @@ impl Dataset {
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
         namespace_client_managed_versioning: bool,
+        commit_timeout: Option<std::time::Duration>,
     ) -> PyResult<Self> {
         let mut transaction = Transaction::new(read_version.unwrap_or_default(), operation.0, None);
 
@@ -2630,13 +2631,14 @@ impl Dataset {
             namespace_client,
             table_id,
             namespace_client_managed_versioning,
+            commit_timeout,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
     #[allow(deprecated)]
     #[staticmethod]
-    #[pyo3(signature = (dest, transaction, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_managed_versioning = false))]
+    #[pyo3(signature = (dest, transaction, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, enable_stable_row_ids = None, namespace_client = None, table_id = None, namespace_client_managed_versioning = false, commit_timeout = None))]
     fn commit_transaction(
         dest: PyWriteDest,
         transaction: PyLance<Transaction>,
@@ -2649,6 +2651,7 @@ impl Dataset {
         namespace_client: Option<&Bound<'_, PyAny>>,
         table_id: Option<Vec<String>>,
         namespace_client_managed_versioning: bool,
+        commit_timeout: Option<std::time::Duration>,
     ) -> PyResult<Self> {
         let accessor =
             crate::storage_options::create_accessor_from_storage_options(storage_options.clone())?;
@@ -2689,7 +2692,8 @@ impl Dataset {
         let mut builder = CommitBuilder::new(dest.as_dest())
             .enable_v2_manifest_paths(enable_v2_manifest_paths.unwrap_or(true))
             .with_detached(detached.unwrap_or(false))
-            .with_max_retries(max_retries.unwrap_or(20));
+            .with_max_retries(max_retries.unwrap_or(20))
+            .with_timeout(commit_timeout);
 
         if let Some(enable) = enable_stable_row_ids {
             builder = builder.use_stable_row_ids(enable);
@@ -2720,7 +2724,7 @@ impl Dataset {
     #[allow(clippy::too_many_arguments)]
     #[allow(deprecated)]
     #[staticmethod]
-    #[pyo3(signature = (dest, transactions, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None))]
+    #[pyo3(signature = (dest, transactions, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None, commit_timeout = None))]
     fn commit_batch(
         dest: PyWriteDest,
         transactions: Vec<PyLance<Transaction>>,
@@ -2729,6 +2733,7 @@ impl Dataset {
         enable_v2_manifest_paths: Option<bool>,
         detached: Option<bool>,
         max_retries: Option<u32>,
+        commit_timeout: Option<std::time::Duration>,
     ) -> PyResult<(Self, PyLance<Transaction>)> {
         let accessor =
             crate::storage_options::create_accessor_from_storage_options(storage_options.clone())?;
@@ -2753,7 +2758,8 @@ impl Dataset {
         let mut builder = CommitBuilder::new(dest.as_dest())
             .enable_v2_manifest_paths(enable_v2_manifest_paths.unwrap_or(true))
             .with_detached(detached.unwrap_or(false))
-            .with_max_retries(max_retries.unwrap_or(20));
+            .with_max_retries(max_retries.unwrap_or(20))
+            .with_timeout(commit_timeout);
 
         if let Some(store_params) = object_store_params {
             builder = builder.with_store_params(store_params);

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2712,7 +2712,7 @@ impl Dataset {
                 commit_lock.map(|cl| cl.py()),
                 builder.execute(transaction.0),
             )?
-            .map_err(|err: lance::Error| PyIOError::new_err(err.to_string()))?;
+            .infer_error()?;
 
         let uri = ds.uri().to_string();
         Ok(Self {
@@ -2776,7 +2776,7 @@ impl Dataset {
 
         let res = rt()
             .block_on(None, builder.execute_batch(transactions))?
-            .map_err(|err: lance::Error| PyIOError::new_err(err.to_string()))?;
+            .infer_error()?;
         let uri = res.dataset.uri().to_string();
         let ds = Self {
             ds: Arc::new(res.dataset),

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2712,7 +2712,7 @@ impl Dataset {
                 commit_lock.map(|cl| cl.py()),
                 builder.execute(transaction.0),
             )?
-            .infer_error()?;
+            .io_or_timeout_error()?;
 
         let uri = ds.uri().to_string();
         Ok(Self {
@@ -2776,7 +2776,7 @@ impl Dataset {
 
         let res = rt()
             .block_on(None, builder.execute_batch(transactions))?
-            .infer_error()?;
+            .io_or_timeout_error()?;
         let uri = res.dataset.uri().to_string();
         let ds = Self {
             ds: Arc::new(res.dataset),

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -15,7 +15,7 @@
 use lance_namespace::error::NamespaceError;
 use pyo3::{
     BoundObject, PyErr, PyResult, Python,
-    exceptions::{PyIOError, PyNotImplementedError, PyRuntimeError, PyValueError},
+    exceptions::{PyIOError, PyNotImplementedError, PyRuntimeError, PyTimeoutError, PyValueError},
     types::{PyAnyMethods, PyModule},
 };
 
@@ -66,6 +66,8 @@ pub trait PythonErrorExt<T> {
     fn not_implemented(self) -> PyResult<T>;
     /// Convert to PyIoError
     fn io_error(self) -> PyResult<T>;
+    /// Convert to PyTimeoutError
+    fn timeout_error(self) -> PyResult<T>;
 }
 
 impl<T> PythonErrorExt<T> for std::result::Result<T, LanceError> {
@@ -76,6 +78,7 @@ impl<T> PythonErrorExt<T> for std::result::Result<T, LanceError> {
                 LanceError::InvalidInput { .. } => self.value_error(),
                 LanceError::NotSupported { .. } => self.not_implemented(),
                 LanceError::IO { .. } => self.io_error(),
+                LanceError::Timeout { .. } => self.timeout_error(),
                 LanceError::NotFound { .. } => self.value_error(),
                 LanceError::RefNotFound { .. } => self.value_error(),
                 LanceError::VersionNotFound { .. } => self.value_error(),
@@ -111,5 +114,9 @@ impl<T> PythonErrorExt<T> for std::result::Result<T, LanceError> {
 
     fn io_error(self) -> PyResult<T> {
         self.map_err(|err| PyIOError::new_err(err.to_string()))
+    }
+
+    fn timeout_error(self) -> PyResult<T> {
+        self.map_err(|err| PyTimeoutError::new_err(err.to_string()))
     }
 }

--- a/python/src/error.rs
+++ b/python/src/error.rs
@@ -68,6 +68,11 @@ pub trait PythonErrorExt<T> {
     fn io_error(self) -> PyResult<T>;
     /// Convert to PyTimeoutError
     fn timeout_error(self) -> PyResult<T>;
+    /// Convert to PyTimeoutError for `Error::Timeout`, otherwise PyIoError.
+    ///
+    /// Used by call sites that historically mapped every `lance::Error` to
+    /// PyIoError but should surface timeouts distinctly.
+    fn io_or_timeout_error(self) -> PyResult<T>;
 }
 
 impl<T> PythonErrorExt<T> for std::result::Result<T, LanceError> {
@@ -118,5 +123,12 @@ impl<T> PythonErrorExt<T> for std::result::Result<T, LanceError> {
 
     fn timeout_error(self) -> PyResult<T> {
         self.map_err(|err| PyTimeoutError::new_err(err.to_string()))
+    }
+
+    fn io_or_timeout_error(self) -> PyResult<T> {
+        match &self {
+            Err(LanceError::Timeout { .. }) => self.timeout_error(),
+            _ => self.io_error(),
+        }
     }
 }

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -119,6 +119,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display("Operation timed out: {message}, {location}"))]
+    Timeout {
+        message: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
     #[snafu(display(
         "Encountered internal error. Please file a bug report at https://github.com/lance-format/lance/issues. {message}, {location}"
     ))]
@@ -315,6 +321,14 @@ impl Error {
     #[track_caller]
     pub fn internal(message: impl Into<String>) -> Self {
         InternalSnafu {
+            message: message.into(),
+        }
+        .build()
+    }
+
+    #[track_caller]
+    pub fn timeout(message: impl Into<String>) -> Self {
+        TimeoutSnafu {
             message: message.into(),
         }
         .build()

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -921,8 +921,54 @@ pub trait CommitLease: Send + Sync {
     async fn release(&self, success: bool) -> std::result::Result<(), CommitError>;
 }
 
+/// Guards a [CommitLease] so the lock is released even if the commit future is
+/// dropped (e.g. cancelled by a commit timeout) before reaching an explicit
+/// release.
+///
+/// [CommitLease::release] is async and cannot be awaited from `Drop`, so on the
+/// drop path we spawn a best-effort background task that releases the lock with
+/// `success = false`. Without this, a cancelled commit would leak the lock until
+/// the lease's own TTL expired, blocking other writers in the meantime.
+struct LeaseGuard<L: CommitLease + 'static> {
+    lease: Option<L>,
+}
+
+impl<L: CommitLease + 'static> LeaseGuard<L> {
+    fn new(lease: L) -> Self {
+        Self { lease: Some(lease) }
+    }
+
+    /// Explicitly release the lease, consuming the guard so `Drop` is a no-op.
+    async fn release(mut self, success: bool) -> std::result::Result<(), CommitError> {
+        let lease = self
+            .lease
+            .take()
+            .expect("LeaseGuard released more than once");
+        lease.release(success).await
+    }
+}
+
+impl<L: CommitLease + 'static> Drop for LeaseGuard<L> {
+    fn drop(&mut self) {
+        if let Some(lease) = self.lease.take() {
+            // The guard was dropped without an explicit release, meaning the
+            // commit future was cancelled while holding the lock. We can't await
+            // in `Drop`, so spawn a best-effort release. If there is no runtime,
+            // leave the lease for its TTL to reclaim.
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let _ = lease.release(false).await;
+                });
+            }
+        }
+    }
+}
+
 #[async_trait::async_trait]
-impl<T: CommitLock + Send + Sync> CommitHandler for T {
+impl<T: CommitLock + Send + Sync> CommitHandler for T
+where
+    T::Lease: 'static,
+{
     async fn commit(
         &self,
         manifest: &mut Manifest,
@@ -934,9 +980,11 @@ impl<T: CommitLock + Send + Sync> CommitHandler for T {
         transaction: Option<Transaction>,
     ) -> std::result::Result<ManifestLocation, CommitError> {
         let path = naming_scheme.manifest_path(base_path, manifest.version);
-        // NOTE: once we have the lease we cannot use ? to return errors, since
-        // we must release the lease before returning.
-        let lease = self.lock(manifest.version).await?;
+        // Hold the lease in a guard so the lock is released even if this future
+        // is cancelled before we reach an explicit release below. The explicit
+        // releases are still preferred since they report the correct success
+        // flag and surface release errors; the guard only covers cancellation.
+        let lease = LeaseGuard::new(self.lock(manifest.version).await?);
 
         // Head the location and make sure it's not already committed
         match object_store.inner.head(&path).await {
@@ -973,7 +1021,10 @@ impl<T: CommitLock + Send + Sync> CommitHandler for T {
 }
 
 #[async_trait::async_trait]
-impl<T: CommitLock + Send + Sync> CommitHandler for Arc<T> {
+impl<T: CommitLock + Send + Sync> CommitHandler for Arc<T>
+where
+    T::Lease: 'static,
+{
     async fn commit(
         &self,
         manifest: &mut Manifest,
@@ -1371,5 +1422,105 @@ mod tests {
                 "{url} should route to ConditionalPutCommitHandler",
             );
         }
+    }
+
+    /// A [CommitLock] whose lease records whether it was released, so we can
+    /// assert the lock does not leak when the commit future is cancelled.
+    #[derive(Debug)]
+    struct TrackingLock {
+        released: Arc<AtomicBool>,
+    }
+
+    struct TrackingLease {
+        released: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl CommitLock for TrackingLock {
+        type Lease = TrackingLease;
+        async fn lock(&self, _version: u64) -> std::result::Result<Self::Lease, CommitError> {
+            Ok(TrackingLease {
+                released: self.released.clone(),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CommitLease for TrackingLease {
+        async fn release(&self, _success: bool) -> std::result::Result<(), CommitError> {
+            self.released
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// A manifest writer that never completes, simulating a hung object store.
+    fn hanging_manifest_writer<'a>(
+        _object_store: &'a ObjectStore,
+        _manifest: &'a mut Manifest,
+        _indices: Option<Vec<IndexMetadata>>,
+        _path: &'a Path,
+        _transaction: Option<Transaction>,
+    ) -> BoxFuture<'a, Result<WriteResult>> {
+        Box::pin(async move {
+            future::pending::<()>().await;
+            unreachable!()
+        })
+    }
+
+    /// Cancelling a commit (as a commit timeout does) while the lock is held must
+    /// still release the lock; otherwise it leaks until the lease's TTL expires.
+    #[tokio::test]
+    async fn test_commit_lock_released_on_cancellation() {
+        use std::collections::HashMap;
+        use std::sync::atomic::Ordering;
+        use std::time::Duration;
+
+        use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+        use lance_core::datatypes::Schema;
+        use lance_file::version::LanceFileVersion;
+
+        use crate::format::DataStorageFormat;
+
+        let released = Arc::new(AtomicBool::new(false));
+        let lock = TrackingLock {
+            released: released.clone(),
+        };
+
+        let object_store = ObjectStore::memory();
+        let base_path = Path::from("test");
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new("i", DataType::Int32, false)]);
+        let mut manifest = Manifest::new(
+            Schema::try_from(&arrow_schema).unwrap(),
+            Arc::new(vec![]),
+            DataStorageFormat::new(LanceFileVersion::Stable),
+            HashMap::new(),
+        );
+
+        // The commit will hang on the manifest writer while holding the lock.
+        // Cancel it the same way a commit timeout would: drop the future.
+        let commit_fut = lock.commit(
+            &mut manifest,
+            None,
+            &base_path,
+            &object_store,
+            hanging_manifest_writer,
+            ManifestNamingScheme::V2,
+            None,
+        );
+        let timed_out = tokio::time::timeout(Duration::from_millis(50), commit_fut).await;
+        assert!(timed_out.is_err(), "commit should not have completed");
+
+        // The drop guard releases the lock on a background task; wait for it.
+        for _ in 0..100 {
+            if released.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            released.load(Ordering::SeqCst),
+            "lock must be released after the commit future is cancelled"
+        );
     }
 }

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -918,6 +918,10 @@ pub trait CommitLock: Debug {
 #[async_trait::async_trait]
 pub trait CommitLease: Send + Sync {
     /// Return the lease, indicating whether the commit was successful.
+    ///
+    /// Implementations should tolerate being called more than once: if a commit
+    /// is cancelled (e.g. by a timeout) while `release` is in flight, a
+    /// best-effort `release(false)` may be issued afterwards from the drop path.
     async fn release(&self, success: bool) -> std::result::Result<(), CommitError>;
 }
 
@@ -940,11 +944,19 @@ impl<L: CommitLease + 'static> LeaseGuard<L> {
 
     /// Explicitly release the lease, consuming the guard so `Drop` is a no-op.
     async fn release(mut self, success: bool) -> std::result::Result<(), CommitError> {
-        let lease = self
-            .lease
-            .take()
-            .expect("LeaseGuard released more than once");
-        lease.release(success).await
+        // Keep the lease inside the guard across the await so that, if this
+        // future is cancelled mid-release (e.g. the release call itself hangs
+        // and the commit timeout fires), `Drop` still issues a best-effort
+        // release. Only clear it once the release has fully completed.
+        let result = {
+            let lease = self
+                .lease
+                .as_ref()
+                .expect("LeaseGuard released more than once");
+            lease.release(success).await
+        };
+        self.lease = None;
+        result
     }
 }
 
@@ -1190,6 +1202,8 @@ impl Default for CommitConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+
     use lance_core::utils::tempfile::TempObjDir;
 
     use super::*;
@@ -1454,6 +1468,64 @@ mod tests {
         }
     }
 
+    /// A [CommitLock] whose lease hangs on its first `release` call but completes
+    /// on subsequent ones, so we can assert the drop-path best-effort release
+    /// fires when a commit is cancelled *during* the explicit release.
+    #[derive(Debug)]
+    struct HangingReleaseLock {
+        release_calls: Arc<AtomicUsize>,
+        released: Arc<AtomicBool>,
+    }
+
+    struct HangingReleaseLease {
+        release_calls: Arc<AtomicUsize>,
+        released: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl CommitLock for HangingReleaseLock {
+        type Lease = HangingReleaseLease;
+        async fn lock(&self, _version: u64) -> std::result::Result<Self::Lease, CommitError> {
+            Ok(HangingReleaseLease {
+                release_calls: self.release_calls.clone(),
+                released: self.released.clone(),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CommitLease for HangingReleaseLease {
+        async fn release(&self, _success: bool) -> std::result::Result<(), CommitError> {
+            // The first release (the explicit one) hangs, simulating a release
+            // call that stalls long enough for the commit timeout to fire. The
+            // best-effort release issued from `Drop` is the second call and
+            // succeeds.
+            if self
+                .release_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                == 0
+            {
+                future::pending::<()>().await;
+                unreachable!()
+            }
+            self.released
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// A manifest writer that succeeds immediately, so the commit reaches the
+    /// explicit lease release.
+    fn succeeding_manifest_writer<'a>(
+        _object_store: &'a ObjectStore,
+        _manifest: &'a mut Manifest,
+        _indices: Option<Vec<IndexMetadata>>,
+        _path: &'a Path,
+        _transaction: Option<Transaction>,
+    ) -> BoxFuture<'a, Result<WriteResult>> {
+        Box::pin(async move { Ok(WriteResult::default()) })
+    }
+
     /// A manifest writer that never completes, simulating a hung object store.
     fn hanging_manifest_writer<'a>(
         _object_store: &'a ObjectStore,
@@ -1521,6 +1593,71 @@ mod tests {
         assert!(
             released.load(Ordering::SeqCst),
             "lock must be released after the commit future is cancelled"
+        );
+    }
+
+    /// Cancelling a commit *during* the explicit lease release (e.g. the release
+    /// call itself hangs and the commit timeout fires) must still release the
+    /// lock via the drop-path best-effort release.
+    #[tokio::test]
+    async fn test_commit_lock_released_on_cancellation_during_release() {
+        use std::collections::HashMap;
+        use std::sync::atomic::Ordering;
+        use std::time::Duration;
+
+        use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+        use lance_core::datatypes::Schema;
+        use lance_file::version::LanceFileVersion;
+
+        use crate::format::DataStorageFormat;
+
+        let release_calls = Arc::new(AtomicUsize::new(0));
+        let released = Arc::new(AtomicBool::new(false));
+        let lock = HangingReleaseLock {
+            release_calls: release_calls.clone(),
+            released: released.clone(),
+        };
+
+        let object_store = ObjectStore::memory();
+        let base_path = Path::from("test");
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new("i", DataType::Int32, false)]);
+        let mut manifest = Manifest::new(
+            Schema::try_from(&arrow_schema).unwrap(),
+            Arc::new(vec![]),
+            DataStorageFormat::new(LanceFileVersion::Stable),
+            HashMap::new(),
+        );
+
+        // The manifest writer succeeds, so the commit reaches the explicit
+        // release, which hangs. Cancel it the same way a commit timeout would.
+        let commit_fut = lock.commit(
+            &mut manifest,
+            None,
+            &base_path,
+            &object_store,
+            succeeding_manifest_writer,
+            ManifestNamingScheme::V2,
+            None,
+        );
+        let timed_out = tokio::time::timeout(Duration::from_millis(50), commit_fut).await;
+        assert!(timed_out.is_err(), "commit should not have completed");
+
+        // The drop guard issues a best-effort release on a background task; wait
+        // for it. This is the second release call (the first one hung).
+        for _ in 0..100 {
+            if released.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            released.load(Ordering::SeqCst),
+            "lock must be released even when cancelled during the explicit release"
+        );
+        assert_eq!(
+            release_calls.load(Ordering::SeqCst),
+            2,
+            "expected the hung explicit release plus one best-effort drop release"
         );
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -136,9 +136,9 @@ use crate::dataset::index::LanceIndexStoreExt;
 pub use write::update::{UpdateBuilder, UpdateJob};
 #[allow(deprecated)]
 pub use write::{
-    AutoCleanupParams, CommitBuilder, DeleteBuilder, DeleteResult, ExternalBlobMode, InsertBuilder,
-    UncommittedDelete, WriteDestination, WriteMode, WriteParams, WriteProgressFn, WriteStats,
-    write_fragments,
+    AutoCleanupParams, CommitBuilder, DEFAULT_COMMIT_TIMEOUT, DeleteBuilder, DeleteResult,
+    ExternalBlobMode, InsertBuilder, UncommittedDelete, WriteDestination, WriteMode, WriteParams,
+    WriteProgressFn, WriteStats, write_fragments,
 };
 
 pub(crate) const INDICES_DIR: &str = "_indices";

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -53,7 +53,7 @@ mod retry;
 pub mod update;
 
 pub use super::progress::{WriteProgressFn, WriteStats};
-pub use commit::CommitBuilder;
+pub use commit::{CommitBuilder, DEFAULT_COMMIT_TIMEOUT};
 pub use delete::{DeleteBuilder, DeleteResult, UncommittedDelete};
 pub use insert::InsertBuilder;
 

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use lance_core::utils::mask::RowAddrTreeMap;
 use lance_file::version::LanceFileVersion;
@@ -47,7 +48,11 @@ pub struct CommitBuilder<'a> {
     commit_config: CommitConfig,
     affected_rows: Option<RowAddrTreeMap>,
     transaction_properties: Option<Arc<HashMap<String, String>>>,
+    timeout: Option<Duration>,
 }
+
+/// Default timeout applied to [`CommitBuilder::execute`] when none is set.
+pub const DEFAULT_COMMIT_TIMEOUT: Duration = Duration::from_secs(300);
 
 impl<'a> CommitBuilder<'a> {
     pub fn new(dest: impl Into<WriteDestination<'a>>) -> Self {
@@ -64,6 +69,7 @@ impl<'a> CommitBuilder<'a> {
             commit_config: Default::default(),
             affected_rows: None,
             transaction_properties: None,
+            timeout: Some(DEFAULT_COMMIT_TIMEOUT),
         }
     }
 
@@ -169,6 +175,23 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
+    /// Set a timeout for the commit operation.
+    ///
+    /// If the commit (including retries on conflict) does not complete within
+    /// the provided duration, [`Self::execute`] / [`Self::execute_batch`] will
+    /// return an error. Pass `None` to disable the timeout entirely.
+    ///
+    /// The default is 5 minutes (see [`DEFAULT_COMMIT_TIMEOUT`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`Error::InvalidInput`] when [`Self::execute`] is called if
+    /// `timeout` is `Some(Duration::ZERO)`.
+    pub fn with_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
     /// provide Configuration key-value pairs associated with this transaction.
     /// This is used to store metadata about the transaction, such as commit messages, engine information, etc.
     /// this properties map will be persisted as a part of the transaction object
@@ -181,6 +204,29 @@ impl<'a> CommitBuilder<'a> {
     }
 
     pub async fn execute(self, transaction: Transaction) -> Result<Dataset> {
+        let timeout = self.timeout;
+        if let Some(t) = timeout
+            && t.is_zero()
+        {
+            return Err(Error::invalid_input(
+                "CommitBuilder timeout must be non-zero; pass `None` to disable",
+            ));
+        }
+        let fut = self.execute_inner(transaction);
+        match timeout {
+            Some(t) => match tokio::time::timeout(t, fut).await {
+                Ok(res) => res,
+                Err(_) => Err(Error::io(format!(
+                    "Commit timed out after {:?}. Increase the timeout via \
+                     CommitBuilder::with_timeout or pass `None` to disable.",
+                    t
+                ))),
+            },
+            None => fut.await,
+        }
+    }
+
+    async fn execute_inner(self, transaction: Transaction) -> Result<Dataset> {
         let session = self
             .session
             .or_else(|| self.dest.dataset().map(|ds| ds.session.clone()))
@@ -716,6 +762,102 @@ mod tests {
             assert_io_lt!(io_stats, num_stages, 6);
         }
         assert_io_eq!(io_stats, write_iops, 2); // txn + manifest
+    }
+
+    #[tokio::test]
+    async fn test_commit_timeout_zero_rejected() {
+        let dataset = Arc::new(
+            InsertBuilder::new("memory://test")
+                .execute(vec![
+                    RecordBatch::try_new(
+                        Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                            "i",
+                            DataType::Int32,
+                            false,
+                        )])),
+                        vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+                    )
+                    .unwrap(),
+                ])
+                .await
+                .unwrap(),
+        );
+        let res = CommitBuilder::new(dataset.clone())
+            .with_timeout(Some(Duration::ZERO))
+            .execute(sample_transaction(1))
+            .await;
+        assert!(
+            matches!(res, Err(Error::InvalidInput { .. })),
+            "got {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_timeout_triggers() {
+        let throttled = Arc::new(ThrottledStoreWrapper {
+            config: ThrottleConfig {
+                wait_put_per_call: Duration::from_secs(5),
+                ..Default::default()
+            },
+        });
+        let write_params = WriteParams {
+            store_params: Some(ObjectStoreParams {
+                object_store_wrapper: Some(throttled),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let dataset = InsertBuilder::new("memory://timeout")
+            .with_params(&write_params)
+            .execute(vec![
+                RecordBatch::try_new(
+                    Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                        "i",
+                        DataType::Int32,
+                        false,
+                    )])),
+                    vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+                )
+                .unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        let res = CommitBuilder::new(Arc::new(dataset))
+            .with_timeout(Some(Duration::from_millis(50)))
+            .execute(sample_transaction(1))
+            .await;
+        let err = res.expect_err("commit should time out");
+        assert!(
+            matches!(&err, Error::IO { .. }) && err.to_string().contains("timed out"),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_timeout_none_disables() {
+        let dataset = Arc::new(
+            InsertBuilder::new("memory://no-timeout")
+                .execute(vec![
+                    RecordBatch::try_new(
+                        Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                            "i",
+                            DataType::Int32,
+                            false,
+                        )])),
+                        vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+                    )
+                    .unwrap(),
+                ])
+                .await
+                .unwrap(),
+        );
+        let new_ds = CommitBuilder::new(dataset.clone())
+            .with_timeout(None)
+            .execute(sample_transaction(1))
+            .await
+            .unwrap();
+        assert_eq!(new_ds.manifest.version, 2);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -214,7 +214,10 @@ impl<'a> CommitBuilder<'a> {
                 "CommitBuilder timeout must be non-zero; pass `None` to disable",
             ));
         }
-        let fut = self.execute_inner(transaction);
+        // Box the inner future so wrapping it in `tokio::time::Timeout` does
+        // not deepen the future type — downstream `async fn`s that await
+        // `execute` otherwise hit the compiler's layout-query depth limit.
+        let fut = Box::pin(self.execute_inner(transaction));
         match timeout {
             Some(t) => match tokio::time::timeout(t, fut).await {
                 Ok(res) => res,

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -187,8 +187,8 @@ impl<'a> CommitBuilder<'a> {
     ///
     /// - [`Error::InvalidInput`] if `timeout` is `Some(Duration::ZERO)` (raised
     ///   when [`Self::execute`] is called, not here).
-    /// - [`Error::IO`] with a "Commit timed out" message if the operation does
-    ///   not complete within the timeout.
+    /// - [`Error::Timeout`] if the operation does not complete within the
+    ///   timeout.
     pub fn with_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.timeout = timeout;
         self
@@ -218,9 +218,7 @@ impl<'a> CommitBuilder<'a> {
         match timeout {
             Some(t) => match tokio::time::timeout(t, fut).await {
                 Ok(res) => res,
-                // Mapped to `Error::IO` so it flows through the IO/retry
-                // handling that callers already apply to commit failures.
-                Err(_) => Err(Error::io(format!(
+                Err(_) => Err(Error::timeout(format!(
                     "Commit timed out after {:?}. Increase the timeout via \
                      CommitBuilder::with_timeout or pass `None` to disable.",
                     t
@@ -839,10 +837,7 @@ mod tests {
             .execute(sample_transaction(1))
             .await;
         let err = res.expect_err("commit should time out");
-        assert!(
-            matches!(&err, Error::IO { .. }) && err.to_string().contains("timed out"),
-            "got {err:?}"
-        );
+        assert!(matches!(&err, Error::Timeout { .. }), "got {err:?}");
     }
 
     #[tokio::test]
@@ -883,10 +878,7 @@ mod tests {
         let Err(err) = res else {
             panic!("commit should time out");
         };
-        assert!(
-            matches!(&err, Error::IO { .. }) && err.to_string().contains("timed out"),
-            "got {err:?}"
-        );
+        assert!(matches!(&err, Error::Timeout { .. }), "got {err:?}");
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -764,6 +764,13 @@ mod tests {
         assert_io_eq!(io_stats, write_iops, 2); // txn + manifest
     }
 
+    #[test]
+    fn test_commit_timeout_default_is_five_minutes() {
+        let builder = CommitBuilder::new("memory://default-timeout");
+        assert_eq!(builder.timeout, Some(DEFAULT_COMMIT_TIMEOUT));
+        assert_eq!(DEFAULT_COMMIT_TIMEOUT, Duration::from_secs(300));
+    }
+
     #[tokio::test]
     async fn test_commit_timeout_zero_rejected() {
         let dataset = Arc::new(
@@ -828,6 +835,50 @@ mod tests {
             .execute(sample_transaction(1))
             .await;
         let err = res.expect_err("commit should time out");
+        assert!(
+            matches!(&err, Error::IO { .. }) && err.to_string().contains("timed out"),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_timeout_applies_to_execute_batch() {
+        let throttled = Arc::new(ThrottledStoreWrapper {
+            config: ThrottleConfig {
+                wait_put_per_call: Duration::from_secs(5),
+                ..Default::default()
+            },
+        });
+        let write_params = WriteParams {
+            store_params: Some(ObjectStoreParams {
+                object_store_wrapper: Some(throttled),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let dataset = InsertBuilder::new("memory://batch-timeout")
+            .with_params(&write_params)
+            .execute(vec![
+                RecordBatch::try_new(
+                    Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                        "i",
+                        DataType::Int32,
+                        false,
+                    )])),
+                    vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+                )
+                .unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        let res = CommitBuilder::new(Arc::new(dataset))
+            .with_timeout(Some(Duration::from_millis(50)))
+            .execute_batch(vec![sample_transaction(1)])
+            .await;
+        let Err(err) = res else {
+            panic!("commit should time out");
+        };
         assert!(
             matches!(&err, Error::IO { .. }) && err.to_string().contains("timed out"),
             "got {err:?}"

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -52,7 +52,7 @@ pub struct CommitBuilder<'a> {
 }
 
 /// Default timeout applied to [`CommitBuilder::execute`] when none is set.
-pub const DEFAULT_COMMIT_TIMEOUT: Duration = Duration::from_secs(300);
+pub const DEFAULT_COMMIT_TIMEOUT: Duration = Duration::from_secs(1800);
 
 impl<'a> CommitBuilder<'a> {
     pub fn new(dest: impl Into<WriteDestination<'a>>) -> Self {
@@ -181,7 +181,7 @@ impl<'a> CommitBuilder<'a> {
     /// call, including all conflict retries — it is not applied per attempt.
     /// Pass `None` to disable the timeout entirely.
     ///
-    /// The default is 5 minutes (see [`DEFAULT_COMMIT_TIMEOUT`]).
+    /// The default is 30 minutes (see [`DEFAULT_COMMIT_TIMEOUT`]).
     ///
     /// # Errors
     ///
@@ -770,10 +770,10 @@ mod tests {
     }
 
     #[test]
-    fn test_commit_timeout_default_is_five_minutes() {
+    fn test_commit_timeout_default_is_thirty_minutes() {
         let builder = CommitBuilder::new("memory://default-timeout");
         assert_eq!(builder.timeout, Some(DEFAULT_COMMIT_TIMEOUT));
-        assert_eq!(DEFAULT_COMMIT_TIMEOUT, Duration::from_secs(300));
+        assert_eq!(DEFAULT_COMMIT_TIMEOUT, Duration::from_secs(1800));
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -177,16 +177,18 @@ impl<'a> CommitBuilder<'a> {
 
     /// Set a timeout for the commit operation.
     ///
-    /// If the commit (including retries on conflict) does not complete within
-    /// the provided duration, [`Self::execute`] / [`Self::execute_batch`] will
-    /// return an error. Pass `None` to disable the timeout entirely.
+    /// The timeout bounds the *entire* [`Self::execute`] / [`Self::execute_batch`]
+    /// call, including all conflict retries — it is not applied per attempt.
+    /// Pass `None` to disable the timeout entirely.
     ///
     /// The default is 5 minutes (see [`DEFAULT_COMMIT_TIMEOUT`]).
     ///
     /// # Errors
     ///
-    /// Returns an [`Error::InvalidInput`] when [`Self::execute`] is called if
-    /// `timeout` is `Some(Duration::ZERO)`.
+    /// - [`Error::InvalidInput`] if `timeout` is `Some(Duration::ZERO)` (raised
+    ///   when [`Self::execute`] is called, not here).
+    /// - [`Error::IO`] with a "Commit timed out" message if the operation does
+    ///   not complete within the timeout.
     pub fn with_timeout(mut self, timeout: Option<Duration>) -> Self {
         self.timeout = timeout;
         self
@@ -216,6 +218,8 @@ impl<'a> CommitBuilder<'a> {
         match timeout {
             Some(t) => match tokio::time::timeout(t, fut).await {
                 Ok(res) => res,
+                // Mapped to `Error::IO` so it flows through the IO/retry
+                // handling that callers already apply to commit failures.
                 Err(_) => Err(Error::io(format!(
                     "Commit timed out after {:?}. Increase the timeout via \
                      CommitBuilder::with_timeout or pass `None` to disable.",

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -881,25 +881,41 @@ mod tests {
         assert!(matches!(&err, Error::Timeout { .. }), "got {err:?}");
     }
 
+    /// `with_timeout(None)` must let a commit run unbounded. Uses a throttled
+    /// store so the commit takes real wall-clock time — long enough that the
+    /// 50ms timeout in `test_commit_timeout_triggers` would have fired.
     #[tokio::test]
     async fn test_commit_timeout_none_disables() {
-        let dataset = Arc::new(
-            InsertBuilder::new("memory://no-timeout")
-                .execute(vec![
-                    RecordBatch::try_new(
-                        Arc::new(ArrowSchema::new(vec![ArrowField::new(
-                            "i",
-                            DataType::Int32,
-                            false,
-                        )])),
-                        vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
-                    )
-                    .unwrap(),
-                ])
-                .await
+        let throttled = Arc::new(ThrottledStoreWrapper {
+            config: ThrottleConfig {
+                wait_put_per_call: Duration::from_millis(200),
+                ..Default::default()
+            },
+        });
+        let write_params = WriteParams {
+            store_params: Some(ObjectStoreParams {
+                object_store_wrapper: Some(throttled),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let dataset = InsertBuilder::new("memory://no-timeout")
+            .with_params(&write_params)
+            .execute(vec![
+                RecordBatch::try_new(
+                    Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                        "i",
+                        DataType::Int32,
+                        false,
+                    )])),
+                    vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+                )
                 .unwrap(),
-        );
-        let new_ds = CommitBuilder::new(dataset.clone())
+            ])
+            .await
+            .unwrap();
+
+        let new_ds = CommitBuilder::new(Arc::new(dataset))
             .with_timeout(None)
             .execute(sample_transaction(1))
             .await

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -381,7 +381,11 @@ impl Default for NoContextTestFixture {
 
 impl NoContextTestFixture {
     pub fn new() -> Self {
+        // `enable_time` is required because `Dataset::write` runs the commit
+        // through `tokio::time::timeout` (CommitBuilder's default timeout),
+        // which panics without a timer driver.
         let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
             .build()
             .unwrap();
 


### PR DESCRIPTION
Previously, `CommitBuilder::execute` / `execute_batch` could block
indefinitely if the underlying object store hung (we observed a 3-hour
wait in production). This adds a configurable timeout that defaults to
30 minutes:

- Rust: `CommitBuilder::with_timeout(Option<Duration>)`. `None` disables
  the timeout; `Some(Duration::ZERO)` is rejected with `InvalidInput`.
- Python: `LanceDataset.commit(..., commit_timeout=timedelta(minutes=5))`,
  pass `None` to disable.
- Java: `new CommitBuilder(ds).commitTimeout(Duration.ofMinutes(5))`,
  pass `null` to disable.

Fixes #6747