### PR TITLE
fix(encoding): widen boolean bitmaps for full-zip to avoid JVM-aborting panic

### DIFF
--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -169,13 +169,69 @@ pub struct FixedWidthDataBlock {
 }
 
 impl FixedWidthDataBlock {
+    /// Expands a 1-bit-per-value bitmap into a byte-per-value buffer.
+    ///
+    /// Each input bit becomes a byte whose value is 0 or 1. Used by encoders
+    /// (notably full-zip) that require byte-aligned data when the source is an
+    /// Arrow boolean bitmap. Round-trip pair: [`Self::pack_bytes_to_bitmap`].
+    pub fn expand_bitmap_to_bytes(self) -> Self {
+        assert_eq!(
+            self.bits_per_value, 1,
+            "expand_bitmap_to_bytes called on non-bitmap block"
+        );
+        let num_values = self.num_values as usize;
+        let bitmap = self.data.as_ref();
+        let mut expanded = Vec::with_capacity(num_values);
+        for i in 0..num_values {
+            expanded.push((bitmap[i / 8] >> (i % 8)) & 1);
+        }
+        Self {
+            data: LanceBuffer::from(expanded),
+            bits_per_value: 8,
+            num_values: self.num_values,
+            block_info: BlockInfo::new(),
+        }
+    }
+
+    /// Re-packs a byte-per-value buffer (each byte 0 or 1) back into a bitmap.
+    ///
+    /// Inverse of [`Self::expand_bitmap_to_bytes`].
+    pub fn pack_bytes_to_bitmap(self) -> Self {
+        assert_eq!(
+            self.bits_per_value, 8,
+            "pack_bytes_to_bitmap called on non-byte block"
+        );
+        let num_values = self.num_values as usize;
+        let bytes = self.data.as_ref();
+        let mut bitmap = vec![0u8; num_values.div_ceil(8)];
+        for (i, &b) in bytes.iter().enumerate() {
+            if b != 0 {
+                bitmap[i / 8] |= 1 << (i % 8);
+            }
+        }
+        Self {
+            data: LanceBuffer::from(bitmap),
+            bits_per_value: 1,
+            num_values: self.num_values,
+            block_info: BlockInfo::new(),
+        }
+    }
+
     fn do_into_arrow(
         self,
         data_type: DataType,
         num_values: u64,
         validate: bool,
     ) -> Result<ArrayData> {
-        let data_buffer = self.data.into_buffer();
+        // Full-zip encoding stores booleans as one byte per value (it cannot
+        // interleave sub-byte values with rep/def control words). Re-pack to a
+        // bitmap before handing the buffer to Arrow.
+        let block = if matches!(data_type, DataType::Boolean) && self.bits_per_value == 8 {
+            self.pack_bytes_to_bitmap()
+        } else {
+            self
+        };
+        let data_buffer = block.data.into_buffer();
         let builder = ArrayDataBuilder::new(data_type)
             .add_buffer(data_buffer)
             .len(num_values as usize)

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -302,6 +302,28 @@ mod tests {
         check_basic_random(field).await;
     }
 
+    // Regression test for lance-format/lance-spark#529.
+    //
+    // Booleans arrive as a 1-bit-per-value Arrow bitmap. When a boolean column
+    // is nested deeply enough that its rep/def levels are too sparse for
+    // miniblock encoding, the encoder falls back to full-zip — which used to
+    // panic on sub-byte values and abort the JVM via JNI.
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn test_list_of_booleans(
+        #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
+        structural_encoding: &str,
+    ) {
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert(
+            STRUCTURAL_ENCODING_META_KEY.to_string(),
+            structural_encoding.into(),
+        );
+        let field =
+            Field::new("", make_list_type(DataType::Boolean), true).with_metadata(field_metadata);
+        check_basic_random(field).await;
+    }
+
     #[test_log::test(tokio::test)]
     async fn test_nested_strings() {
         let field = Field::new("", make_list_type(DataType::Utf8), true);

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -4671,7 +4671,7 @@ impl PrimitiveStructuralEncoder {
         fixed: FixedWidthDataBlock,
         mut repdef: ControlWordIterator,
         num_values: u64,
-    ) -> SerializedFullZip {
+    ) -> Result<SerializedFullZip> {
         let len = fixed.data.len() + repdef.bytes_per_word() * num_values as usize;
         let mut zipped_data = Vec::with_capacity(len);
 
@@ -4684,13 +4684,18 @@ impl PrimitiveStructuralEncoder {
         let mut rep_index_builder =
             BytepackedIntegerEncoder::with_capacity(num_values as usize + 1, max_rep_index_val);
 
-        // I suppose we can just pad to the nearest byte but I'm not sure we need to worry about this anytime soon
-        // because it is unlikely compression of large values is going to yield a result that is not byte aligned
-        assert_eq!(
-            fixed.bits_per_value % 8,
-            0,
-            "Non-byte aligned full-zip compression not yet supported"
-        );
+        // Sub-byte widths should be widened upstream (see `encode_full_zip` for
+        // the boolean path). Return an error instead of panicking — this code
+        // is reached over the JNI boundary where a Rust panic aborts the JVM.
+        if !fixed.bits_per_value.is_multiple_of(8) {
+            return Err(Error::not_supported_source(
+                format!(
+                    "Non-byte aligned full-zip compression not yet supported ({} bits per value)",
+                    fixed.bits_per_value
+                )
+                .into(),
+            ));
+        }
 
         let bytes_per_value = fixed.bits_per_value as usize / 8;
         let mut offset = 0;
@@ -4738,10 +4743,10 @@ impl PrimitiveStructuralEncoder {
         } else {
             Some(LanceBuffer::from(rep_index))
         };
-        SerializedFullZip {
+        Ok(SerializedFullZip {
             values: zipped_data,
             repetition_index: rep_index,
-        }
+        })
     }
 
     // For variable-size data we encode < control word | length | data > for each value
@@ -4751,13 +4756,17 @@ impl PrimitiveStructuralEncoder {
         variable: VariableWidthBlock,
         mut repdef: ControlWordIterator,
         num_items: u64,
-    ) -> SerializedFullZip {
+    ) -> Result<SerializedFullZip> {
         let bytes_per_offset = variable.bits_per_offset as usize / 8;
-        assert_eq!(
-            variable.bits_per_offset % 8,
-            0,
-            "Only byte-aligned offsets supported"
-        );
+        if !variable.bits_per_offset.is_multiple_of(8) {
+            return Err(Error::not_supported_source(
+                format!(
+                    "Only byte-aligned offsets supported in full-zip ({} bits per offset)",
+                    variable.bits_per_offset
+                )
+                .into(),
+            ));
+        }
         let len = variable.data.len()
             + repdef.bytes_per_word() * num_items as usize
             + bytes_per_offset * variable.num_values as usize;
@@ -4815,7 +4824,11 @@ impl PrimitiveStructuralEncoder {
                     rep_offset = buf.len();
                 }
             }
-            _ => panic!("Unsupported offset size"),
+            n => {
+                return Err(Error::not_supported_source(
+                    format!("Unsupported offset size in full-zip: {} bytes", n).into(),
+                ));
+            }
         }
 
         // We might have saved a few bytes by not copying lengths when the length was zero.  However,
@@ -4831,10 +4844,10 @@ impl PrimitiveStructuralEncoder {
         let rep_index = rep_index_builder.into_data();
         debug_assert!(!rep_index.is_empty());
         let rep_index = Some(LanceBuffer::from(rep_index));
-        SerializedFullZip {
+        Ok(SerializedFullZip {
             values: zipped_data,
             repetition_index: rep_index,
-        }
+        })
     }
 
     /// Serializes data into a single buffer according to the full-zip format which zips
@@ -4843,7 +4856,7 @@ impl PrimitiveStructuralEncoder {
         compressed_data: PerValueDataBlock,
         repdef: ControlWordIterator,
         num_items: u64,
-    ) -> SerializedFullZip {
+    ) -> Result<SerializedFullZip> {
         match compressed_data {
             PerValueDataBlock::Fixed(fixed) => {
                 Self::serialize_full_zip_fixed(fixed, repdef, num_items)
@@ -4898,6 +4911,17 @@ impl PrimitiveStructuralEncoder {
         let bits_rep = repdef_iter.bits_rep();
         let bits_def = repdef_iter.bits_def();
 
+        // Full-zip interleaves each value with its rep/def control word and so
+        // requires byte-aligned values. Booleans arrive as a 1-bit-per-value
+        // Arrow bitmap; expand them to one byte per value here. The matching
+        // re-pack happens in FixedWidthDataBlock::do_into_arrow on read.
+        let data = match data {
+            DataBlock::FixedWidth(fixed) if fixed.bits_per_value == 1 => {
+                DataBlock::FixedWidth(fixed.expand_bitmap_to_bytes())
+            }
+            other => other,
+        };
+
         let compressor = compression_strategy.create_per_value(field, &data)?;
         let (compressed_data, value_encoding) = compressor.compress(data)?;
 
@@ -4922,7 +4946,7 @@ impl PrimitiveStructuralEncoder {
             ),
         };
 
-        let zipped = Self::serialize_full_zip(compressed_data, repdef_iter, num_items);
+        let zipped = Self::serialize_full_zip(compressed_data, repdef_iter, num_items)?;
 
         let data = if let Some(repindex) = zipped.repetition_index {
             vec![zipped.values, repindex]


### PR DESCRIPTION
## Summary

- Full-zip cannot interleave sub-byte values with rep/def control words, but a 1-bit-per-value boolean bitmap reaches the encoder whenever a boolean column's rep/def levels are too sparse for miniblock (e.g. deeply nested booleans). The byte-alignment assertion in `serialize_full_zip_fixed` then fires as a `panic_nounwind` across the JNI boundary, aborting the JVM. Reported in [lance-format/lance-spark#529](https://github.com/lance-format/lance-spark/issues/529).
- Fix: expand 1-bit bitmaps to one byte per value in `encode_full_zip` before per-value compression, and re-pack to a bitmap in `FixedWidthDataBlock::do_into_arrow` when the target Arrow type is `Boolean`. Miniblock booleans are untouched.
- Defense in depth: convert the remaining `assert_eq!` / `panic!` sites in `serialize_full_zip_{fixed,variable}` to propagated errors so future encoder bugs degrade to a `NotSupported` `Result` instead of aborting the host process via JNI.

## How this happens

Encoder dispatch (`encode_field_structural`) routes to full-zip when `repdef_too_sparse_for_miniblock` returns true. For a flat boolean column this never fires, but with enough nesting the rep/def levels exceed miniblock's ~16 KiB chunk budget, and the encoder falls back to full-zip with an unmodified `FixedWidthDataBlock { bits_per_value: 1 }`.

The assertion and its comment have been there since the introduction of full-zip in #3114 — sub-byte values were known not to be supported, with a note that compression of wide values was unlikely to produce non-byte-aligned output. Booleans reach this path *uncompressed* (the per-value `ValueEncoder` is a pass-through), which is the case the comment didn't anticipate.

## Test plan

- [x] New regression test `test_list_of_booleans` over both `STRUCTURAL_ENCODING_MINIBLOCK` and `STRUCTURAL_ENCODING_FULLZIP` (uses `check_basic_random` so it exercises real round-trips with nulls, slicing, multiple batch sizes).
- [x] All 373 existing `lance-encoding` lib tests pass.
- [x] All 68 `lance-file` tests pass.
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` clean.
- [x] Verified the new test catches the bug by temporarily removing the encoder-side widening — `test_list_of_booleans::STRUCTURAL_ENCODING_FULLZIP` fails with the expected `NotSupported` error (clean, no more `non-unwinding panic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related to https://github.com/lance-format/lance-spark/issues/529