### PR TITLE
fix(encoding): scope blob field-data cache key by projection mode (#6381)

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -3290,6 +3290,16 @@ struct PageInfoAndScheduler {
 pub struct StructuralPrimitiveFieldScheduler {
     page_schedulers: Vec<PageInfoAndScheduler>,
     column_index: u32,
+    // A blob column can be scheduled in two different "projection modes":
+    //   * blob descriptor (the column is projected as a struct of position/size) —
+    //     selects `BlobDescriptionPageScheduler` per page.
+    //   * blob data (the column is projected as the loaded large_binary value) —
+    //     selects `BlobPageScheduler` per page.
+    // The two modes produce incompatible `CachedPageData` shapes, so they must
+    // not share a cache entry (otherwise `BlobPageScheduler::load` will downcast
+    // the wrong type and panic).  Track the mode here so it can be folded into
+    // the field-data cache key.
+    is_blob_descriptor_projection: bool,
 }
 
 impl StructuralPrimitiveFieldScheduler {
@@ -3313,9 +3323,12 @@ impl StructuralPrimitiveFieldScheduler {
                 )
             })
             .collect::<Result<Vec<_>>>()?;
+        let is_blob_descriptor_projection =
+            target_field.is_blob() && matches!(target_field.data_type(), DataType::Struct(_));
         Ok(Self {
             page_schedulers,
             column_index: column_info.index,
+            is_blob_descriptor_projection,
         })
     }
 
@@ -3477,13 +3490,20 @@ impl DeepSizeOf for CachedFieldData {
 #[derive(Debug, Clone)]
 pub struct FieldDataCacheKey {
     pub column_index: u32,
+    // Distinguishes blob-descriptor projection from blob-data projection for the
+    // same column.  See `StructuralPrimitiveFieldScheduler::is_blob_descriptor_projection`.
+    pub is_blob_descriptor_projection: bool,
 }
 
 impl CacheKey for FieldDataCacheKey {
     type ValueType = CachedFieldData;
 
     fn key(&self) -> std::borrow::Cow<'_, str> {
-        self.column_index.to_string().into()
+        if self.is_blob_descriptor_projection {
+            format!("{}/desc", self.column_index).into()
+        } else {
+            self.column_index.to_string().into()
+        }
     }
 
     fn type_name() -> &'static str {
@@ -3499,6 +3519,7 @@ impl StructuralFieldScheduler for StructuralPrimitiveFieldScheduler {
     ) -> BoxFuture<'a, Result<()>> {
         let cache_key = FieldDataCacheKey {
             column_index: self.column_index,
+            is_blob_descriptor_projection: self.is_blob_descriptor_projection,
         };
         let cache = context.cache().clone();
 

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1900,6 +1900,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_append_blob_columns_preserves_blob_encoding() {
+        // Regression test for https://github.com/lance-format/lance/issues/6381.
+        // When a dataset with a blob column has multiple fragments (here,
+        // produced by an append) reading the same column with two different
+        // projections — the descriptor struct (`take_blobs`) and the loaded
+        // `LargeBinary` value (`compact_files`) — used to share a cache entry
+        // keyed only by column index.  The two projections produce
+        // incompatible `CachedPageData` shapes, so the second reader's
+        // `BlobPageScheduler::load` downcast panicked.
+        let test_dir = TempStrDir::default();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("blob", DataType::LargeBinary, false)
+                .with_metadata([(BLOB_META_KEY.to_string(), "true".to_string())].into()),
+        ]));
+
+        let make_batch = |start: i32, payload: &[&[u8]]| {
+            let ids: ArrayRef = Arc::new(Int32Array::from_iter_values(
+                start..(start + payload.len() as i32),
+            ));
+            let blobs: ArrayRef = Arc::new(LargeBinaryArray::from_iter(
+                payload.iter().map(|v| Some(*v)),
+            ));
+            RecordBatch::try_new(schema.clone(), vec![ids, blobs]).unwrap()
+        };
+
+        let first_payload: Vec<&[u8]> = vec![b"foo", b"bar", b"baz"];
+        let reader =
+            RecordBatchIterator::new(vec![Ok(make_batch(0, &first_payload))], schema.clone());
+        let dataset = Dataset::write(
+            reader,
+            &test_dir,
+            Some(WriteParams {
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        drop(dataset);
+
+        let second_payload: Vec<&[u8]> = vec![b"qux", b"quux", b"corge"];
+        let reader =
+            RecordBatchIterator::new(vec![Ok(make_batch(3, &second_payload))], schema.clone());
+        let mut dataset = Dataset::write(
+            reader,
+            &test_dir,
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        dataset.validate().await.unwrap();
+        assert_eq!(dataset.get_fragments().len(), 2);
+
+        let dataset_arc = Arc::new(dataset.clone());
+        let row_indices: Vec<u64> =
+            (0..(first_payload.len() + second_payload.len()) as u64).collect();
+        let blobs = dataset_arc
+            .take_blobs_by_indices(&row_indices, "blob")
+            .await
+            .unwrap();
+        let mut expected: Vec<&[u8]> = first_payload.clone();
+        expected.extend(second_payload.iter().copied());
+        assert_eq!(blobs.len(), expected.len());
+        for (blob, want) in blobs.iter().zip(expected.iter()) {
+            let bytes = blob.read().await.unwrap();
+            assert_eq!(bytes.as_ref(), *want);
+        }
+
+        compact_files(&mut dataset, CompactionOptions::default(), None)
+            .await
+            .unwrap();
+        dataset.validate().await.unwrap();
+        assert_eq!(dataset.get_fragments().len(), 1);
+    }
+
+    #[tokio::test]
     async fn test_compact_blob_columns() {
         let test_dir = TempStrDir::default();
         let schema = Arc::new(Schema::new(vec![
@@ -1931,6 +2011,24 @@ mod tests {
         dataset.validate().await.unwrap();
         assert!(dataset.get_fragments().len() > 1);
 
+        let row_indices: Vec<u64> = (0..expected_payload.len() as u64).collect();
+
+        // Take blobs while the dataset still has multiple fragments.  This
+        // exercises the descriptor-projection scheduling path; doing it
+        // before `compact_files` previously poisoned the per-column scheduler
+        // cache and caused the subsequent (LargeBinary) scan to panic.
+        let dataset_arc = Arc::new(dataset.clone());
+        let blobs = dataset_arc
+            .take_blobs_by_indices(&row_indices, "blob")
+            .await
+            .unwrap();
+        assert_eq!(blobs.len(), expected_payload.len());
+        for (blob, expected) in blobs.iter().zip(expected_payload.iter()) {
+            let bytes = blob.read().await.unwrap();
+            assert_eq!(bytes.as_ref(), expected.as_slice());
+        }
+        drop(dataset_arc);
+
         compact_files(&mut dataset, CompactionOptions::default(), None)
             .await
             .unwrap();
@@ -1938,7 +2036,6 @@ mod tests {
         assert_eq!(dataset.get_fragments().len(), 1);
 
         let dataset = Arc::new(dataset);
-        let row_indices: Vec<u64> = (0..expected_payload.len() as u64).collect();
         let blobs = dataset
             .take_blobs_by_indices(&row_indices, "blob")
             .await


### PR DESCRIPTION
## Summary

Closes #6381.

A blob column can be scheduled in two incompatible projection modes:

- **Descriptor** — `struct<position, size>`, used by `take_blobs` / `take_blobs_by_indices`. Selects `BlobDescriptionPageScheduler`, which caches the inner scheduler's state directly.
- **Data** — `LargeBinary`, used by full scans and `compact_files`. Selects `BlobPageScheduler`, which wraps the inner state in a `BlobCacheableState { positions, sizes, inner_state }`.

The two modes produce structurally incompatible `CachedPageData`. However, the per-column field-data cache key in `StructuralPrimitiveFieldScheduler` was just `column_index`, so on a multi-fragment dataset the two modes collided on the same cache entry. Whichever scheduler ran first poisoned the cache for the other, and `BlobPageScheduler::load` would panic on the wrong-type downcast at `blob.rs:335`.

This is what #6381 surfaces as "appending corrupts blob columns": after `mode=\"append\"` the dataset has ≥2 fragments, and the typical `take_blobs` → `compact_files` flow trips the cache collision. Append is incidental — a single `Dataset::write` with `max_rows_per_file=1` followed by `take_blobs` and then `compact_files` reproduces exactly the same panic. The write path was always correct; only the read-side cache key was wrong.

## Fix

- Track `is_blob_descriptor_projection` on `StructuralPrimitiveFieldScheduler` (true iff `target_field.is_blob()` and its data type is `Struct`).
- Fold that bit into `FieldDataCacheKey` so the two projections produce distinct cache keys (`\"{col}/desc\"` vs `\"{col}\"`).

```rust
fn key(&self) -> std::borrow::Cow<'_, str> {
    if self.is_blob_descriptor_projection {
        format!(\"{}/desc\", self.column_index).into()
    } else {
        self.column_index.to_string().into()
    }
}
```

Diff is 23 lines of production code in `rust/lance-encoding/src/encodings/logical/primitive.rs`; no public API changes.

## Test plan

- [x] Added `test_append_blob_columns_preserves_blob_encoding` in `rust/lance/src/dataset/optimize.rs` — exact #6381 repro (overwrite + append + `take_blobs_by_indices` + `compact_files`).
- [x] Extended existing `test_compact_blob_columns` to call `take_blobs_by_indices` while the dataset still has multiple fragments (before compaction), covering the same cache-collision path in a single-write scenario.
- [x] Both regression tests **panic at `blob.rs:335`** on `main` (verified by stashing the fix), **pass with the fix**.
- [x] `cargo test -p lance --lib dataset::blob::` — 35/35 pass.
- [x] `cargo test -p lance --lib dataset::optimize::` — 62/62 pass.
- [x] `cargo test -p lance-encoding --lib` — 371/371 pass.
- [x] `cargo clippy -p lance-encoding -p lance --tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.