### PR TITLE
docs: change a typo of WAL entry filename suffix to '.arrow'

### DIFF
--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -137,7 +137,7 @@ Each WAL entry is stored within the WAL directory of the shard located at `_mem_
 
 WAL files use bit-reversed 64-bit binary naming to distribute files evenly across the directory keyspace.
 This optimizes S3 throughput by spreading sequential writes across S3's internal partitions, minimizing throttling.
-The filename is the bit-reversed binary representation of the entry ID with suffix `.lance`.
+The filename is the bit-reversed binary representation of the entry ID with suffix `.arrow`.
 For example, entry ID 5 (binary `000...101`) becomes `1010000000000000000000000000000000000000000000000000000000000000.arrow`.
 
 ### Flushed MemTable


### PR DESCRIPTION
Updated filename suffix from '.lance' to '.arrow' for WAL entries.