### PR TITLE
feat: support FTS index segment merging

### DIFF
--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -204,6 +204,33 @@ fn validate_segment_index_details(index_name: &str, segments: &[IndexMetadata]) 
     Ok(())
 }
 
+/// Detect vector segments while preserving the legacy pre-details fallback.
+///
+/// Older vector segments may not have `VectorIndexDetails` in the manifest, so
+/// we also recognize them by the legacy monolithic index file name.
+fn segment_has_vector_details(segment: &IndexMetadata) -> bool {
+    segment.index_details.as_ref().map_or_else(
+        || {
+            segment
+                .files
+                .as_ref()
+                .is_some_and(|files| files.iter().any(|file| file.path == INDEX_FILE_NAME))
+        },
+        |details| details.type_url.ends_with("VectorIndexDetails"),
+    )
+}
+
+/// Detect FTS / inverted segments from manifest details.
+///
+/// Unlike vector, inverted segment support was added after index details were
+/// part of the segment contract, so there is no legacy file-name fallback here.
+fn segment_has_inverted_details(segment: &IndexMetadata) -> bool {
+    segment
+        .index_details
+        .as_ref()
+        .is_some_and(|details| details.type_url.ends_with("InvertedIndexDetails"))
+}
+
 // Cache keys for different index types
 #[derive(Debug, Clone)]
 pub struct ScalarIndexCacheKey<'a> {
@@ -1035,28 +1062,25 @@ impl DatasetIndexExt for Dataset {
                 "merge_existing_index_segments requires segments with identical fields".to_string(),
             ));
         }
-        if !source_segments.iter().all(|segment| {
-            segment.index_details.as_ref().map_or_else(
-                || {
-                    segment
-                        .files
-                        .as_ref()
-                        .is_some_and(|files| files.iter().any(|file| file.path == INDEX_FILE_NAME))
-                },
-                |details| details.type_url.ends_with("VectorIndexDetails"),
-            )
-        }) {
+        let all_vector = source_segments.iter().all(segment_has_vector_details);
+        let all_inverted = source_segments.iter().all(segment_has_inverted_details);
+        if !all_vector && !all_inverted {
             return Err(Error::invalid_input(
-                "merge_existing_index_segments currently only supports vector segments".to_string(),
+                "merge_existing_index_segments requires all segments to have the same supported index type"
+                    .to_string(),
             ));
         }
 
-        let mut merged_segment = crate::index::vector::ivf::merge_segments(
-            self.object_store.as_ref(),
-            &self.indices_dir(),
-            source_segments,
-        )
-        .await?;
+        let mut merged_segment = if all_vector {
+            crate::index::vector::ivf::merge_segments(
+                self.object_store.as_ref(),
+                &self.indices_dir(),
+                source_segments,
+            )
+            .await?
+        } else {
+            crate::index::scalar::inverted::merge_segments(self, source_segments).await?
+        };
         merged_segment.dataset_version = self.manifest.version;
         merged_segment.fields = vec![field_id];
         Ok(merged_segment)

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -760,7 +760,7 @@ mod tests {
     use lance_datagen::{self, gen_batch};
     use lance_index::optimize::OptimizeOptions;
     use lance_index::progress::IndexBuildProgress;
-    use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+    use lance_index::scalar::{FullTextSearchQuery, inverted::tokenizer::InvertedIndexParams};
     use lance_index::vector::hnsw::builder::HnswBuildParams;
     use lance_index::vector::ivf::IvfBuildParams;
     use lance_index::vector::kmeans::{KMeansParams, train_kmeans};
@@ -1852,6 +1852,85 @@ mod tests {
 
         let indices = dataset.load_indices_by_name("text_idx").await.unwrap();
         assert_eq!(indices.len(), input_segments.len());
+    }
+
+    #[tokio::test]
+    async fn test_merge_existing_index_segments_supports_fts_segments() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+
+        let batches = RecordBatchIterator::new(
+            vec![
+                Ok(create_text_batch(0, 10)),
+                Ok(create_text_batch(10, 20)),
+                Ok(create_text_batch(20, 30)),
+            ],
+            create_text_batch(0, 1).schema(),
+        );
+        let mut dataset = Dataset::write(
+            batches,
+            &dataset_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 5,
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let params = InvertedIndexParams::default();
+        let mut input_segments = Vec::new();
+        let mut expected_fragments = roaring::RoaringBitmap::new();
+        for fragment in dataset.get_fragments() {
+            expected_fragments.insert(fragment.id() as u32);
+            let segment =
+                CreateIndexBuilder::new(&mut dataset, &["text"], IndexType::Inverted, &params)
+                    .name("text_idx".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap();
+            input_segments.push(segment);
+        }
+
+        let merged = dataset
+            .merge_existing_index_segments(input_segments)
+            .await
+            .unwrap();
+        assert_eq!(
+            merged
+                .fragment_bitmap
+                .as_ref()
+                .expect("merged FTS segment should have fragment coverage"),
+            &expected_fragments
+        );
+        assert!(
+            merged
+                .index_details
+                .as_ref()
+                .expect("merged FTS segment should have index details")
+                .type_url
+                .ends_with("InvertedIndexDetails")
+        );
+
+        dataset
+            .commit_existing_index_segments("text_idx", "text", vec![merged])
+            .await
+            .unwrap();
+
+        let indices = dataset.load_indices_by_name("text_idx").await.unwrap();
+        assert_eq!(indices.len(), 1);
+
+        let results = dataset
+            .scan()
+            .full_text_search(FullTextSearchQuery::new("document".to_string()))
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(results.num_rows(), 20);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -5,10 +5,19 @@
 
 use std::sync::Arc;
 
+use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use lance_core::ROW_ID;
+use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::pbold::InvertedIndexDetails;
+use lance_index::scalar::inverted::InvertedIndex;
+use lance_index::scalar::registry::VALUE_COLUMN_NAME;
 use lance_index::{IndexType, scalar::lance_format::LanceIndexStore};
 use lance_table::format::IndexMetadata;
 use prost::Message;
+use roaring::RoaringBitmap;
+use uuid::Uuid;
 
 use crate::{
     Dataset, Error, Result,
@@ -19,6 +28,56 @@ use crate::{
         scalar::fetch_index_details,
     },
 };
+
+/// Build an empty update stream for the inverted merge API.
+///
+/// `InvertedIndex::merge_segments` is shaped as "merge old segments plus new
+/// rows", so even a pure segment merge needs a stream with the document column
+/// and `_rowid` fields. The stream intentionally contains no batches.
+fn empty_inverted_update_stream(
+    dataset: &Dataset,
+    field_id: i32,
+) -> Result<SendableRecordBatchStream> {
+    let field = dataset.schema().field_by_id(field_id).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "merge_existing_index_segments: field id {} does not exist",
+            field_id
+        ))
+    })?;
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new(VALUE_COLUMN_NAME, field.data_type(), true),
+        ArrowField::new(ROW_ID, arrow_schema::DataType::UInt64, false),
+    ]));
+    Ok(Box::pin(RecordBatchStreamAdapter::new(
+        schema,
+        futures::stream::empty(),
+    )))
+}
+
+async fn finalize_segment_files_if_needed(
+    dataset: &Dataset,
+    segment: &IndexMetadata,
+) -> Result<()> {
+    let index_dir = dataset.indices_dir().join(segment.uuid.to_string());
+    let metadata_path = index_dir
+        .clone()
+        .join(lance_index::scalar::inverted::METADATA_FILE);
+    if dataset.object_store.as_ref().exists(&metadata_path).await? {
+        return Ok(());
+    }
+
+    let store = Arc::new(LanceIndexStore::from_dataset_for_new(
+        dataset,
+        &segment.uuid.to_string(),
+    )?);
+    lance_index::scalar::inverted::builder::merge_index_files(
+        dataset.object_store.as_ref(),
+        &index_dir,
+        store,
+        lance_index::progress::noop_progress(),
+    )
+    .await
+}
 
 /// Plan physical segments for staged inverted-index outputs.
 ///
@@ -98,26 +157,75 @@ pub(crate) async fn build_segment(
         ));
     }
 
-    let index_dir = dataset.indices_dir().join(source_segment.uuid.to_string());
-    let metadata_path = index_dir
-        .clone()
-        .join(lance_index::scalar::inverted::METADATA_FILE);
-    if dataset.object_store.as_ref().exists(&metadata_path).await? {
-        return Ok(built_segment);
+    finalize_segment_files_if_needed(dataset, source_segment).await?;
+    Ok(built_segment)
+}
+
+/// Merge one caller-defined group of source FTS segments into a single segment.
+pub(crate) async fn merge_segments(
+    dataset: &Dataset,
+    segments: Vec<IndexMetadata>,
+) -> Result<IndexMetadata> {
+    if segments.is_empty() {
+        return Err(Error::index("No segment metadata was provided".to_string()));
     }
 
-    let store = Arc::new(LanceIndexStore::from_dataset_for_new(
-        dataset,
-        &source_segment.uuid.to_string(),
-    )?);
-    lance_index::scalar::inverted::builder::merge_index_files(
-        dataset.object_store.as_ref(),
-        &index_dir,
-        store,
+    let field_id = *segments[0].fields.first().ok_or_else(|| {
+        Error::invalid_input(format!(
+            "CreateIndex: segment {} is missing field ids",
+            segments[0].uuid
+        ))
+    })?;
+    let field_path = dataset.schema().field_path(field_id)?;
+
+    let mut source_indices = Vec::with_capacity(segments.len());
+    let mut fragment_bitmap = RoaringBitmap::new();
+    for segment in &segments {
+        finalize_segment_files_if_needed(dataset, segment).await?;
+        fragment_bitmap |= segment.fragment_bitmap.as_ref().cloned().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "CreateIndex: segment {} is missing fragment coverage",
+                segment.uuid
+            ))
+        })?;
+        let scalar_index =
+            super::open_scalar_index(dataset, &field_path, segment, &NoOpMetricsCollector).await?;
+        let inverted_index = scalar_index
+            .as_any()
+            .downcast_ref::<InvertedIndex>()
+            .ok_or_else(|| {
+                Error::index(format!(
+                    "merge_existing_index_segments: expected inverted segment {}, got {:?}",
+                    segment.uuid,
+                    scalar_index.index_type()
+                ))
+            })?;
+        source_indices.push(Arc::new(inverted_index.clone()));
+    }
+
+    let new_uuid = Uuid::new_v4();
+    let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_uuid.to_string())?;
+    let created_index = InvertedIndex::merge_segments(
+        &source_indices,
+        empty_inverted_update_stream(dataset, field_id)?,
+        &new_store,
+        None,
         lance_index::progress::noop_progress(),
     )
     .await?;
-    Ok(built_segment)
+
+    Ok(IndexMetadata {
+        uuid: new_uuid,
+        fields: vec![field_id],
+        dataset_version: dataset.manifest.version,
+        fragment_bitmap: Some(fragment_bitmap),
+        index_details: Some(Arc::new(created_index.index_details)),
+        index_version: created_index.index_version as i32,
+        created_at: Some(chrono::Utc::now()),
+        base_id: None,
+        files: created_index.files,
+        ..segments[0].clone()
+    })
 }
 
 /// Load all committed inverted-index segments that belong to the same named


### PR DESCRIPTION
`merge_existing_index_segments` already had the right public shape for merging physical index segments, but its implementation only accepted vector segment details while FTS segment merge support lived underneath in the inverted index layer. This wires FTS segments into that API path by finalizing staged FTS outputs when needed, loading the inverted segments, and producing a single commit-ready merged segment.

This lets distributed FTS build workflows use the same merge-and-commit path as vector indices instead of stopping at unmerged multi-segment commits.
