### PR TITLE
feat(index): serializable cache for the BTree scalar index

### DIFF
--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -44,9 +44,13 @@ use futures::{
     future::BoxFuture,
     stream::{self},
 };
+use lance_arrow::ipc::{
+    read_ipc_stream_single_at, read_len_prefixed_bytes_at, write_ipc_stream,
+    write_len_prefixed_bytes,
+};
 use lance_core::{
     Error, ROW_ID, Result,
-    cache::{CacheKey, LanceCache, WeakLanceCache},
+    cache::{CacheCodec, CacheCodecImpl, CacheKey, LanceCache, WeakLanceCache},
     error::LanceOptionExt,
     utils::{
         mask::NullableRowAddrSet,
@@ -998,6 +1002,133 @@ impl CacheKey for BTreePageKey {
     fn type_name() -> &'static str {
         "BTreePage"
     }
+
+    fn codec() -> Option<CacheCodec> {
+        Some(CacheCodec::from_impl::<FlatIndex>())
+    }
+}
+
+/// The serializable state of a [`BTreeIndex`].
+///
+/// A `BTreeIndex` holds non-serializable infrastructure (an `IndexStore`, a
+/// cache handle, a fragment-reuse index). `BTreeIndexState` captures just the
+/// data needed to rebuild it: the `page_lookup.lance` batch (from which
+/// [`BTreeIndex::try_from_serialized`] reconstructs the in-memory lookup with
+/// no IO) plus the page batch size and range-partition map.
+#[derive(Debug, Clone)]
+pub struct BTreeIndexState {
+    lookup_batch: RecordBatch,
+    batch_size: u64,
+    ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
+}
+
+impl DeepSizeOf for BTreeIndexState {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        // `ranges_to_files` is tiny and `RangeInclusiveMap` is not `DeepSizeOf`;
+        // the lookup batch dominates, matching how `BTreeIndex` accounts for itself.
+        self.lookup_batch.get_array_memory_size()
+    }
+}
+
+/// Header preceding the lookup batch in the [`BTreeIndexState`] wire format.
+#[derive(Serialize, Deserialize)]
+struct BTreeIndexStateHeader {
+    version: u32,
+    batch_size: u64,
+    /// Each entry is `(range_start, range_end, file_path, start_offset)`.
+    ranges_to_files: Option<Vec<(u32, u32, String, u32)>>,
+}
+
+const BTREE_INDEX_STATE_VERSION: u32 = 1;
+
+impl BTreeIndexState {
+    fn reconstruct(
+        &self,
+        store: Arc<dyn IndexStore>,
+        index_cache: &LanceCache,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Arc<dyn ScalarIndex>> {
+        let index = BTreeIndex::try_from_serialized(
+            self.lookup_batch.clone(),
+            store,
+            index_cache,
+            self.batch_size,
+            self.ranges_to_files.clone(),
+            frag_reuse_index,
+        )?;
+        Ok(Arc::new(index) as Arc<dyn ScalarIndex>)
+    }
+}
+
+impl CacheCodecImpl for BTreeIndexState {
+    fn serialize(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+        // Format: [len-prefixed header JSON][lookup batch IPC stream]
+        let ranges_to_files = self.ranges_to_files.as_ref().map(|ranges| {
+            ranges
+                .iter()
+                .map(|(range, (path, offset))| {
+                    (*range.start(), *range.end(), path.clone(), *offset)
+                })
+                .collect()
+        });
+        let header = BTreeIndexStateHeader {
+            version: BTREE_INDEX_STATE_VERSION,
+            batch_size: self.batch_size,
+            ranges_to_files,
+        };
+        let header = serde_json::to_vec(&header)
+            .map_err(|e| Error::io(format!("BTreeIndexState header: {e}")))?;
+        write_len_prefixed_bytes(writer, &header)?;
+        write_ipc_stream(&self.lookup_batch, writer)?;
+        Ok(())
+    }
+
+    fn deserialize(data: &bytes::Bytes) -> Result<Self> {
+        let mut offset = 0;
+        let header = read_len_prefixed_bytes_at(data, &mut offset)?;
+        let header: BTreeIndexStateHeader = serde_json::from_slice(&header)
+            .map_err(|e| Error::io(format!("BTreeIndexState header: {e}")))?;
+        if header.version != BTREE_INDEX_STATE_VERSION {
+            return Err(Error::io(format!(
+                "BTreeIndexState: unsupported version {} (expected {})",
+                header.version, BTREE_INDEX_STATE_VERSION
+            )));
+        }
+        let lookup_batch = read_ipc_stream_single_at(data, &mut offset)?;
+        let ranges_to_files = header.ranges_to_files.map(|ranges| {
+            Arc::new(
+                ranges
+                    .into_iter()
+                    .map(|(start, end, path, off)| (start..=end, (path, off)))
+                    .collect(),
+            )
+        });
+        Ok(Self {
+            lookup_batch,
+            batch_size: header.batch_size,
+            ranges_to_files,
+        })
+    }
+}
+
+/// Cache key for a [`BTreeIndexState`]. The cache it is used with is already
+/// namespaced per-index, so the key string is a constant.
+struct BTreeIndexStateKey;
+
+impl CacheKey for BTreeIndexStateKey {
+    type ValueType = BTreeIndexState;
+
+    fn key(&self) -> std::borrow::Cow<'_, str> {
+        "state".into()
+    }
+
+    fn type_name() -> &'static str {
+        "BTreeIndexState"
+    }
+
+    fn codec() -> Option<CacheCodec> {
+        Some(CacheCodec::from_impl::<BTreeIndexState>())
+    }
 }
 
 /// Note: this is very similar to the IVF index except we store the IVF part in a btree
@@ -1040,13 +1171,20 @@ pub struct BTreeIndex {
     /// - The system now knows to read page `42` from the file `part_2_page_file.lance`.
     ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
+
+    /// The raw lookup batch this index was built from (the contents of
+    /// `page_lookup.lance`). Retained so the index can be serialized into a
+    /// cache as a [`BTreeIndexState`] without re-reading it from storage.
+    lookup_batch: RecordBatch,
 }
 
 impl DeepSizeOf for BTreeIndex {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
         // We don't include the index cache, or anything stored in it. For example:
         // sub_index and fri.
-        self.page_lookup.deep_size_of_children(context) + self.store.deep_size_of_children(context)
+        self.page_lookup.deep_size_of_children(context)
+            + self.store.deep_size_of_children(context)
+            + self.lookup_batch.get_array_memory_size()
     }
 }
 
@@ -1060,6 +1198,7 @@ impl BTreeIndex {
         batch_size: u64,
         ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        lookup_batch: RecordBatch,
     ) -> Self {
         Self {
             page_lookup,
@@ -1069,6 +1208,7 @@ impl BTreeIndex {
             batch_size,
             ranges_to_files,
             frag_reuse_index,
+            lookup_batch,
         }
     }
 
@@ -1158,6 +1298,7 @@ impl BTreeIndex {
                 batch_size,
                 ranges_to_files,
                 frag_reuse_index,
+                data,
             ));
         }
 
@@ -1199,18 +1340,19 @@ impl BTreeIndex {
         let last_max = ScalarValue::try_from_array(&maxs, data.num_rows() - 1)?;
         map.entry(OrderableScalarValue(last_max)).or_default();
 
-        let data_type = mins.data_type();
+        let data_type = mins.data_type().clone();
 
         let page_lookup = Arc::new(BTreeLookup::new(map, null_pages, all_null_pages));
 
         Ok(Self::new(
             page_lookup,
             store,
-            data_type.clone(),
+            data_type,
             WeakLanceCache::from(index_cache),
             batch_size,
             ranges_to_files,
             frag_reuse_index,
+            data,
         ))
     }
 
@@ -2753,6 +2895,43 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
     ) -> Result<Arc<dyn ScalarIndex>> {
         Ok(BTreeIndex::load(index_store, frag_reuse_index, cache).await? as Arc<dyn ScalarIndex>)
     }
+
+    async fn get_from_cache(
+        &self,
+        index_store: Arc<dyn IndexStore>,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        cache: &LanceCache,
+        _key: std::borrow::Cow<'_, str>,
+    ) -> Result<Option<Arc<dyn ScalarIndex>>> {
+        let Some(state) = cache.get_with_key(&BTreeIndexStateKey).await else {
+            return Ok(None);
+        };
+        Ok(Some(state.reconstruct(
+            index_store,
+            cache,
+            frag_reuse_index,
+        )?))
+    }
+
+    async fn put_in_cache(
+        &self,
+        cache: &LanceCache,
+        _key: std::borrow::Cow<'_, str>,
+        index: Arc<dyn ScalarIndex>,
+    ) -> Result<()> {
+        let btree = index.as_any().downcast_ref::<BTreeIndex>().ok_or_else(|| {
+            Error::internal("BTreeIndexPlugin::put_in_cache called with a non-BTree index")
+        })?;
+        let state = BTreeIndexState {
+            lookup_batch: btree.lookup_batch.clone(),
+            batch_size: btree.batch_size,
+            ranges_to_files: btree.ranges_to_files.clone(),
+        };
+        cache
+            .insert_with_key(&BTreeIndexStateKey, Arc::new(state))
+            .await;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -2791,9 +2970,14 @@ mod tests {
     };
 
     use super::{
-        DEFAULT_BTREE_BATCH_SIZE, OrderableScalarValue, part_lookup_file_path,
-        part_page_data_file_path, train_btree_index,
+        BTreeIndexPlugin, BTreeIndexState, BTreePageKey, DEFAULT_BTREE_BATCH_SIZE,
+        OrderableScalarValue, part_lookup_file_path, part_page_data_file_path, train_btree_index,
     };
+    use crate::scalar::registry::ScalarIndexPlugin;
+    use arrow_array::RecordBatch;
+    use lance_core::cache::{CacheCodecImpl, CacheKey};
+    use rangemap::RangeInclusiveMap;
+    use std::borrow::Cow;
 
     lance_testing::define_stage_event_progress!(
         RecordingProgress,
@@ -4768,5 +4952,128 @@ mod tests {
             }
             _ => panic!("BTree search should return Exact"),
         }
+    }
+
+    fn sample_lookup_batch() -> RecordBatch {
+        record_batch!(
+            ("min", Int32, [Some(0), Some(10), Some(20)]),
+            ("max", Int32, [Some(9), Some(19), Some(29)]),
+            ("null_count", UInt32, [0, 2, 0]),
+            ("page_idx", UInt32, [0, 1, 2])
+        )
+        .unwrap()
+    }
+
+    fn assert_state_roundtrips(state: &BTreeIndexState) {
+        let mut buf = Vec::new();
+        state.serialize(&mut buf).unwrap();
+        let restored = BTreeIndexState::deserialize(&bytes::Bytes::from(buf)).unwrap();
+        assert_eq!(restored.lookup_batch, state.lookup_batch);
+        assert_eq!(restored.batch_size, state.batch_size);
+        assert_eq!(restored.ranges_to_files, state.ranges_to_files);
+    }
+
+    #[test]
+    fn test_btree_page_key_codec() {
+        // FlatIndex pages can be serialized by a persistent cache backend.
+        assert!(BTreePageKey::codec().is_some());
+    }
+
+    #[test]
+    fn test_btree_index_state_roundtrip() {
+        // Not range-partitioned.
+        assert_state_roundtrips(&BTreeIndexState {
+            lookup_batch: sample_lookup_batch(),
+            batch_size: DEFAULT_BTREE_BATCH_SIZE,
+            ranges_to_files: None,
+        });
+
+        // Range-partitioned across multiple files.
+        let ranges: RangeInclusiveMap<u32, (String, u32)> = [
+            (0..=99, ("part_0_page_file.lance".to_string(), 0)),
+            (100..=199, ("part_1_page_file.lance".to_string(), 100)),
+        ]
+        .into_iter()
+        .collect();
+        assert_state_roundtrips(&BTreeIndexState {
+            lookup_batch: sample_lookup_batch(),
+            batch_size: 8192,
+            ranges_to_files: Some(Arc::new(ranges)),
+        });
+
+        // Empty index.
+        assert_state_roundtrips(&BTreeIndexState {
+            lookup_batch: RecordBatch::new_empty(sample_lookup_batch().schema()),
+            batch_size: DEFAULT_BTREE_BATCH_SIZE,
+            ranges_to_files: None,
+        });
+    }
+
+    #[tokio::test]
+    async fn test_btree_index_state_reconstruct_and_plugin_cache() {
+        let tmpdir = TempObjDir::default();
+        let test_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let stream = gen_batch()
+            .col("value", array::step::<Int32Type>())
+            .col("_rowid", array::step::<UInt64Type>())
+            .into_df_stream(RowCount::from(1000), BatchCount::from(5));
+        train_btree_index(stream, test_store.as_ref(), 1000, None, None)
+            .await
+            .unwrap();
+
+        let index = BTreeIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+
+        // Round-trip the state through the codec and reconstruct an index from it.
+        let state = BTreeIndexState {
+            lookup_batch: index.lookup_batch.clone(),
+            batch_size: index.batch_size,
+            ranges_to_files: index.ranges_to_files.clone(),
+        };
+        let mut buf = Vec::new();
+        state.serialize(&mut buf).unwrap();
+        let restored = BTreeIndexState::deserialize(&bytes::Bytes::from(buf)).unwrap();
+        let reconstructed = restored
+            .reconstruct(test_store.clone(), &LanceCache::no_cache(), None)
+            .unwrap();
+        assert_eq!(
+            reconstructed
+                .as_any()
+                .downcast_ref::<BTreeIndex>()
+                .unwrap()
+                .page_lookup,
+            index.page_lookup
+        );
+
+        // The plugin's put/get hooks round-trip through a real cache + the codec.
+        let cache = LanceCache::with_capacity(64 * 1024 * 1024);
+        let plugin = BTreeIndexPlugin;
+        plugin
+            .put_in_cache(&cache, Cow::Borrowed("idx"), index.clone())
+            .await
+            .unwrap();
+        let from_cache = plugin
+            .get_from_cache(test_store.clone(), None, &cache, Cow::Borrowed("idx"))
+            .await
+            .unwrap()
+            .expect("index should be served from the cache");
+
+        // Searches against the cached index match the original.
+        let query = SargableQuery::Range(
+            std::ops::Bound::Included(ScalarValue::Int32(Some(100))),
+            std::ops::Bound::Excluded(ScalarValue::Int32(Some(200))),
+        );
+        let expected = index.search(&query, &NoOpMetricsCollector).await.unwrap();
+        let actual = from_cache
+            .search(&query, &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert_eq!(format!("{expected:?}"), format!("{actual:?}"));
     }
 }

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -5074,6 +5074,175 @@ mod tests {
             .search(&query, &NoOpMetricsCollector)
             .await
             .unwrap();
-        assert_eq!(format!("{expected:?}"), format!("{actual:?}"));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_btree_index_state_rejects_unknown_version() {
+        // Hand-craft a header with an unsupported version. The deserializer reads the header
+        // before the lookup batch, so the trailing bytes don't matter.
+        let header = br#"{"version":999,"batch_size":1000,"ranges_to_files":null}"#;
+        let mut buf = Vec::new();
+        lance_arrow::ipc::write_len_prefixed_bytes(&mut buf, header).unwrap();
+
+        let err = BTreeIndexState::deserialize(&bytes::Bytes::from(buf)).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("999") && msg.contains("BTreeIndexState"),
+            "expected error to mention the unsupported version 999, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_btree_index_state_reconstruct_applies_frag_reuse_index() {
+        use crate::frag_reuse::{FragReuseIndex, FragReuseIndexDetails};
+        use std::collections::HashMap;
+        use uuid::Uuid;
+
+        let tmpdir = TempObjDir::default();
+        let test_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        // value == _rowid for all rows in [0, 1000).
+        let stream = gen_batch()
+            .col("value", array::step::<Int32Type>())
+            .col("_rowid", array::step::<UInt64Type>())
+            .into_df_stream(RowCount::from(1000), BatchCount::from(1));
+        train_btree_index(stream, test_store.as_ref(), 1000, None, None)
+            .await
+            .unwrap();
+
+        let index = BTreeIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let state = BTreeIndexState {
+            lookup_batch: index.lookup_batch.clone(),
+            batch_size: index.batch_size,
+            ranges_to_files: index.ranges_to_files.clone(),
+        };
+
+        // Remap row 0 -> row 5000 (outside the original [0, 1000) range so no collision).
+        // Querying for value == 0 should now return row 5000, confirming reconstruct threaded
+        // the FragReuseIndex through to the rebuilt BTreeIndex.
+        let frag_reuse_index = Arc::new(FragReuseIndex::new(
+            Uuid::new_v4(),
+            vec![HashMap::from([(0u64, Some(5000u64))])],
+            FragReuseIndexDetails { versions: vec![] },
+        ));
+        let reconstructed = state
+            .reconstruct(
+                test_store.clone(),
+                &LanceCache::no_cache(),
+                Some(frag_reuse_index),
+            )
+            .unwrap();
+
+        let result = reconstructed
+            .search(
+                &SargableQuery::Equals(ScalarValue::Int32(Some(0))),
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        let row_ids: Vec<u64> = match &result {
+            SearchResult::Exact(set) => set
+                .true_rows()
+                .row_addrs()
+                .unwrap()
+                .map(u64::from)
+                .collect(),
+            other => panic!("expected Exact, got {other:?}"),
+        };
+        assert_eq!(
+            row_ids,
+            vec![5000],
+            "frag_reuse_index remap was not applied"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_btree_index_state_range_partitioned_plugin_cache_roundtrip() {
+        // Build a range-partitioned BTree (two range partitions merged into one index) and
+        // round-trip it through the plugin's cache hooks. This exercises the
+        // `ranges_to_files = Some` path end-to-end through serialize/deserialize/reconstruct.
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let half = DEFAULT_BTREE_BATCH_SIZE;
+        let total = (2 * half) as i32;
+
+        // Partition 0: values/rowids [0, half).
+        let part0 = gen_batch()
+            .col("value", array::step::<Int32Type>())
+            .col("_rowid", array::step::<UInt64Type>())
+            .into_df_stream(RowCount::from(half), BatchCount::from(1));
+        train_btree_index(part0, store.as_ref(), half, None, Some(0u32))
+            .await
+            .unwrap();
+
+        // Partition 1: values/rowids [half, 2*half).
+        let values: Vec<i32> = (half as i32..total).collect();
+        let row_ids: Vec<u64> = (half..total as u64).collect();
+        let part1 = gen_batch()
+            .col("value", array::cycle::<Int32Type>(values))
+            .col("_rowid", array::cycle::<UInt64Type>(row_ids))
+            .into_df_stream(RowCount::from(half), BatchCount::from(1));
+        train_btree_index(part1, store.as_ref(), half, None, Some(1u32))
+            .await
+            .unwrap();
+
+        super::merge_metadata_files(
+            store.as_ref(),
+            &[
+                part_page_data_file_path(0 << 32),
+                part_page_data_file_path(1 << 32),
+            ],
+            &[
+                part_lookup_file_path(0 << 32),
+                part_lookup_file_path(1 << 32),
+            ],
+            Some(1usize),
+            noop_progress(),
+        )
+        .await
+        .unwrap();
+
+        let index = BTreeIndex::load(store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        assert!(
+            index.ranges_to_files.is_some(),
+            "test setup should produce a range-partitioned index",
+        );
+
+        let cache = LanceCache::with_capacity(64 * 1024 * 1024);
+        let plugin = BTreeIndexPlugin;
+        plugin
+            .put_in_cache(&cache, Cow::Borrowed("idx"), index.clone())
+            .await
+            .unwrap();
+        let from_cache = plugin
+            .get_from_cache(store.clone(), None, &cache, Cow::Borrowed("idx"))
+            .await
+            .unwrap()
+            .expect("index should be served from the cache");
+
+        // Search a value from each range partition and confirm both paths agree.
+        for value in [0i32, total - 1] {
+            let query = SargableQuery::Equals(ScalarValue::Int32(Some(value)));
+            let expected = index.search(&query, &NoOpMetricsCollector).await.unwrap();
+            let actual = from_cache
+                .search(&query, &NoOpMetricsCollector)
+                .await
+                .unwrap();
+            assert_eq!(expected, actual, "value {value}");
+        }
     }
 }

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1011,7 +1011,7 @@ impl CacheKey for BTreePageKey {
 /// A `BTreeIndex` holds non-serializable infrastructure (an `IndexStore`, a
 /// cache handle, a fragment-reuse index). `BTreeIndexState` captures just the
 /// data needed to rebuild it: the `page_lookup.lance` batch (from which
-/// [`BTreeIndex::try_from_serialized`] reconstructs the in-memory lookup with
+/// `BTreeIndex::try_from_serialized` reconstructs the in-memory lookup with
 /// no IO) plus the page batch size and range-partition map.
 #[derive(Debug, Clone)]
 pub struct BTreeIndexState {

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1212,6 +1212,12 @@ pub struct BTreeIndex {
     /// The raw lookup batch this index was built from (the contents of
     /// `page_lookup.lance`). Retained so the index can be serialized into a
     /// cache as a [`BTreeIndexState`] without re-reading it from storage.
+    ///
+    /// TODO: this duplicates the min/max values already held in `page_lookup`.
+    /// A follow-up could rewrite `BTreeLookup` to query this batch directly
+    /// (binary search on the sorted `min` column + linear scan, type-dispatched
+    /// per column type), eliminating the duplication and making this batch the
+    /// single source of truth.
     lookup_batch: RecordBatch,
 }
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -2937,7 +2937,6 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
         index_store: Arc<dyn IndexStore>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
         cache: &LanceCache,
-        _key: std::borrow::Cow<'_, str>,
     ) -> Result<Option<Arc<dyn ScalarIndex>>> {
         let Some(state) = cache.get_with_key(&BTreeIndexStateKey).await else {
             return Ok(None);
@@ -2949,12 +2948,7 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
         )?))
     }
 
-    async fn put_in_cache(
-        &self,
-        cache: &LanceCache,
-        _key: std::borrow::Cow<'_, str>,
-        index: Arc<dyn ScalarIndex>,
-    ) -> Result<()> {
+    async fn put_in_cache(&self, cache: &LanceCache, index: Arc<dyn ScalarIndex>) -> Result<()> {
         let btree = index.as_any().downcast_ref::<BTreeIndex>().ok_or_else(|| {
             Error::internal("BTreeIndexPlugin::put_in_cache called with a non-BTree index")
         })?;
@@ -3013,7 +3007,6 @@ mod tests {
     use arrow_array::RecordBatch;
     use lance_core::cache::{CacheCodecImpl, CacheKey};
     use rangemap::RangeInclusiveMap;
-    use std::borrow::Cow;
 
     lance_testing::define_stage_event_progress!(
         RecordingProgress,
@@ -5090,12 +5083,9 @@ mod tests {
         // The plugin's put/get hooks round-trip through a real cache + the codec.
         let cache = LanceCache::with_capacity(64 * 1024 * 1024);
         let plugin = BTreeIndexPlugin;
-        plugin
-            .put_in_cache(&cache, Cow::Borrowed("idx"), index.clone())
-            .await
-            .unwrap();
+        plugin.put_in_cache(&cache, index.clone()).await.unwrap();
         let from_cache = plugin
-            .get_from_cache(test_store.clone(), None, &cache, Cow::Borrowed("idx"))
+            .get_from_cache(test_store.clone(), None, &cache)
             .await
             .unwrap()
             .expect("index should be served from the cache");
@@ -5258,12 +5248,9 @@ mod tests {
 
         let cache = LanceCache::with_capacity(64 * 1024 * 1024);
         let plugin = BTreeIndexPlugin;
-        plugin
-            .put_in_cache(&cache, Cow::Borrowed("idx"), index.clone())
-            .await
-            .unwrap();
+        plugin.put_in_cache(&cache, index.clone()).await.unwrap();
         let from_cache = plugin
-            .get_from_cache(store.clone(), None, &cache, Cow::Borrowed("idx"))
+            .get_from_cache(store.clone(), None, &cache)
             .await
             .unwrap()
             .expect("index should be served from the cache");

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1001,6 +1001,7 @@ impl CacheKey for BTreePageKey {
     }
 
     fn codec() -> Option<CacheCodec> {
+        // Pages are cached as `FlatIndex` values (see `ValueType` above).
         Some(CacheCodec::from_impl::<FlatIndex>())
     }
 }

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -44,10 +44,7 @@ use futures::{
     future::BoxFuture,
     stream::{self},
 };
-use lance_arrow::ipc::{
-    read_ipc_stream_single_at, read_len_prefixed_bytes_at, write_ipc_stream,
-    write_len_prefixed_bytes,
-};
+use lance_arrow::ipc::{read_ipc_stream_single_at, write_ipc_stream};
 use lance_core::{
     Error, ROW_ID, Result,
     cache::{CacheCodec, CacheCodecImpl, CacheKey, LanceCache, WeakLanceCache},
@@ -1030,17 +1027,6 @@ impl DeepSizeOf for BTreeIndexState {
     }
 }
 
-/// Header preceding the lookup batch in the [`BTreeIndexState`] wire format.
-#[derive(Serialize, Deserialize)]
-struct BTreeIndexStateHeader {
-    version: u32,
-    batch_size: u64,
-    /// Each entry is `(range_start, range_end, file_path, start_offset)`.
-    ranges_to_files: Option<Vec<(u32, u32, String, u32)>>,
-}
-
-const BTREE_INDEX_STATE_VERSION: u32 = 1;
-
 impl BTreeIndexState {
     fn reconstruct(
         &self,
@@ -1061,54 +1047,104 @@ impl BTreeIndexState {
 }
 
 impl CacheCodecImpl for BTreeIndexState {
+    /// Wire format (no stability guarantees yet — the cache is rebuilt from
+    /// source on any version mismatch):
+    /// ```text
+    /// u64 batch_size (LE)
+    /// u8  has_ranges (0 = None, 1 = Some)
+    /// if has_ranges:
+    ///   u32 entry_count (LE)
+    ///   per entry: u32 start | u32 end | u32 offset | u32 path_len | path bytes
+    /// lookup batch (Arrow IPC stream)
+    /// ```
     fn serialize(&self, writer: &mut dyn std::io::Write) -> Result<()> {
-        // Format: [len-prefixed header JSON][lookup batch IPC stream]
-        let ranges_to_files = self.ranges_to_files.as_ref().map(|ranges| {
-            ranges
-                .iter()
-                .map(|(range, (path, offset))| {
-                    (*range.start(), *range.end(), path.clone(), *offset)
-                })
-                .collect()
-        });
-        let header = BTreeIndexStateHeader {
-            version: BTREE_INDEX_STATE_VERSION,
-            batch_size: self.batch_size,
-            ranges_to_files,
-        };
-        let header = serde_json::to_vec(&header)
-            .map_err(|e| Error::io(format!("BTreeIndexState header: {e}")))?;
-        write_len_prefixed_bytes(writer, &header)?;
+        writer.write_all(&self.batch_size.to_le_bytes())?;
+        match &self.ranges_to_files {
+            None => writer.write_all(&[0u8])?,
+            Some(ranges) => {
+                writer.write_all(&[1u8])?;
+                let count = u32::try_from(ranges.len()).map_err(|_| {
+                    Error::io("BTreeIndexState: ranges_to_files exceeds u32::MAX entries")
+                })?;
+                writer.write_all(&count.to_le_bytes())?;
+                for (range, (path, page_offset)) in ranges.iter() {
+                    writer.write_all(&range.start().to_le_bytes())?;
+                    writer.write_all(&range.end().to_le_bytes())?;
+                    writer.write_all(&page_offset.to_le_bytes())?;
+                    let path_len = u32::try_from(path.len()).map_err(|_| {
+                        Error::io("BTreeIndexState: ranges_to_files path exceeds u32::MAX bytes")
+                    })?;
+                    writer.write_all(&path_len.to_le_bytes())?;
+                    writer.write_all(path.as_bytes())?;
+                }
+            }
+        }
         write_ipc_stream(&self.lookup_batch, writer)?;
         Ok(())
     }
 
     fn deserialize(data: &bytes::Bytes) -> Result<Self> {
         let mut offset = 0;
-        let header = read_len_prefixed_bytes_at(data, &mut offset)?;
-        let header: BTreeIndexStateHeader = serde_json::from_slice(&header)
-            .map_err(|e| Error::io(format!("BTreeIndexState header: {e}")))?;
-        if header.version != BTREE_INDEX_STATE_VERSION {
-            return Err(Error::io(format!(
-                "BTreeIndexState: unsupported version {} (expected {})",
-                header.version, BTREE_INDEX_STATE_VERSION
-            )));
-        }
+        let batch_size = read_u64_le(data, &mut offset)?;
+        let has_ranges = read_u8(data, &mut offset)?;
+        let ranges_to_files = match has_ranges {
+            0 => None,
+            1 => {
+                let count = read_u32_le(data, &mut offset)? as usize;
+                let mut entries = Vec::with_capacity(count);
+                for _ in 0..count {
+                    let start = read_u32_le(data, &mut offset)?;
+                    let end = read_u32_le(data, &mut offset)?;
+                    let page_offset = read_u32_le(data, &mut offset)?;
+                    let path_len = read_u32_le(data, &mut offset)? as usize;
+                    let path = read_bytes(data, &mut offset, path_len)?;
+                    let path = std::str::from_utf8(&path)
+                        .map_err(|e| Error::io(format!("BTreeIndexState path: {e}")))?
+                        .to_string();
+                    entries.push((start..=end, (path, page_offset)));
+                }
+                Some(Arc::new(entries.into_iter().collect()))
+            }
+            other => {
+                return Err(Error::io(format!(
+                    "BTreeIndexState: invalid has_ranges tag {other}"
+                )));
+            }
+        };
         let lookup_batch = read_ipc_stream_single_at(data, &mut offset)?;
-        let ranges_to_files = header.ranges_to_files.map(|ranges| {
-            Arc::new(
-                ranges
-                    .into_iter()
-                    .map(|(start, end, path, off)| (start..=end, (path, off)))
-                    .collect(),
-            )
-        });
         Ok(Self {
             lookup_batch,
-            batch_size: header.batch_size,
+            batch_size,
             ranges_to_files,
         })
     }
+}
+
+fn read_bytes(data: &bytes::Bytes, offset: &mut usize, len: usize) -> Result<bytes::Bytes> {
+    if data.len() < *offset + len {
+        return Err(Error::io(format!(
+            "BTreeIndexState: short read of {len} bytes at offset {offset} (have {})",
+            data.len()
+        )));
+    }
+    let slice = data.slice(*offset..*offset + len);
+    *offset += len;
+    Ok(slice)
+}
+
+fn read_u8(data: &bytes::Bytes, offset: &mut usize) -> Result<u8> {
+    let bytes = read_bytes(data, offset, 1)?;
+    Ok(bytes[0])
+}
+
+fn read_u32_le(data: &bytes::Bytes, offset: &mut usize) -> Result<u32> {
+    let bytes = read_bytes(data, offset, 4)?;
+    Ok(u32::from_le_bytes(bytes.as_ref().try_into().unwrap()))
+}
+
+fn read_u64_le(data: &bytes::Bytes, offset: &mut usize) -> Result<u64> {
+    let bytes = read_bytes(data, offset, 8)?;
+    Ok(u64::from_le_bytes(bytes.as_ref().try_into().unwrap()))
 }
 
 /// Cache key for a [`BTreeIndexState`]. The cache it is used with is already
@@ -5078,18 +5114,16 @@ mod tests {
     }
 
     #[test]
-    fn test_btree_index_state_rejects_unknown_version() {
-        // Hand-craft a header with an unsupported version. The deserializer reads the header
-        // before the lookup batch, so the trailing bytes don't matter.
-        let header = br#"{"version":999,"batch_size":1000,"ranges_to_files":null}"#;
+    fn test_btree_index_state_rejects_invalid_has_ranges_tag() {
+        // u64 batch_size (any) then a bad has_ranges tag.
         let mut buf = Vec::new();
-        lance_arrow::ipc::write_len_prefixed_bytes(&mut buf, header).unwrap();
-
+        buf.extend_from_slice(&1000u64.to_le_bytes());
+        buf.push(7u8);
         let err = BTreeIndexState::deserialize(&bytes::Bytes::from(buf)).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("999") && msg.contains("BTreeIndexState"),
-            "expected error to mention the unsupported version 999, got: {msg}"
+            msg.contains("has_ranges") && msg.contains("7"),
+            "expected error to mention the bad has_ranges tag, got: {msg}"
         );
     }
 

--- a/rust/lance-index/src/scalar/btree/flat.rs
+++ b/rust/lance-index/src/scalar/btree/flat.rs
@@ -14,7 +14,9 @@ use datafusion_expr::execution_props::ExecutionProps;
 use datafusion_physical_expr::create_physical_expr;
 use deepsize::DeepSizeOf;
 use lance_arrow::RecordBatchExt;
+use lance_arrow::ipc::{read_ipc_stream_single_at, read_len_prefixed_bytes_at, write_ipc_stream};
 use lance_core::Result;
+use lance_core::cache::CacheCodecImpl;
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::mask::{NullableRowAddrSet, RowAddrTreeMap, RowSetOps};
 use roaring::RoaringBitmap;
@@ -233,6 +235,45 @@ impl FlatIndex {
     }
 }
 
+impl CacheCodecImpl for FlatIndex {
+    fn serialize(&self, writer: &mut dyn std::io::Write) -> Result<()> {
+        // Format:
+        // [len-prefixed all_addrs_map][len-prefixed null_addrs_map][batch IPC stream]
+        writer.write_all(&(self.all_addrs_map.serialized_size() as u64).to_le_bytes())?;
+        self.all_addrs_map.serialize_into(&mut *writer)?;
+
+        writer.write_all(&(self.null_addrs_map.serialized_size() as u64).to_le_bytes())?;
+        self.null_addrs_map.serialize_into(&mut *writer)?;
+
+        write_ipc_stream(self.data.as_ref(), writer)?;
+
+        Ok(())
+    }
+
+    fn deserialize(data: &bytes::Bytes) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut offset = 0;
+        let all_addrs_bytes = read_len_prefixed_bytes_at(data, &mut offset)?;
+        let all_addrs_map = RowAddrTreeMap::deserialize_from(all_addrs_bytes.as_ref())?;
+
+        let null_addrs_bytes = read_len_prefixed_bytes_at(data, &mut offset)?;
+        let null_addrs_map = RowAddrTreeMap::deserialize_from(null_addrs_bytes.as_ref())?;
+
+        let batch = read_ipc_stream_single_at(data, &mut offset)?;
+
+        let df_schema = DFSchema::try_from(batch.schema())?;
+
+        Ok(Self {
+            data: Arc::new(batch),
+            all_addrs_map,
+            null_addrs_map,
+            df_schema,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -264,6 +305,34 @@ mod tests {
         let expected =
             NullableRowAddrSet::new(RowAddrTreeMap::from_iter(expected), Default::default());
         assert_eq!(actual, expected);
+    }
+
+    fn assert_roundtrips(index: &FlatIndex) {
+        let mut buf = Vec::new();
+        index.serialize(&mut buf).unwrap();
+        let restored = FlatIndex::deserialize(&bytes::Bytes::from(buf)).unwrap();
+
+        assert_eq!(restored.data, index.data);
+        assert_eq!(restored.all_addrs_map, index.all_addrs_map);
+        assert_eq!(restored.null_addrs_map, index.null_addrs_map);
+    }
+
+    #[test]
+    fn test_cache_codec_roundtrip() {
+        // No nulls
+        assert_roundtrips(&example_index());
+
+        // With nulls in the values column
+        let batch = record_batch!(
+            (BTREE_VALUES_COLUMN, Int32, [None, Some(0), Some(5)]),
+            (BTREE_IDS_COLUMN, UInt64, [0, 1, 2])
+        )
+        .unwrap();
+        assert_roundtrips(&FlatIndex::try_new(batch).unwrap());
+
+        // Empty index
+        let empty = RecordBatch::new_empty(example_index().data.schema());
+        assert_roundtrips(&FlatIndex::try_new(empty).unwrap());
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -164,6 +164,9 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
 
     /// Look up a previously-opened index in the cache.
     ///
+    /// `cache` is already per-index namespaced by the caller, so a plugin's key
+    /// only needs to disambiguate entries within a single index.
+    ///
     /// The default implementation reads an in-memory `Arc<dyn ScalarIndex>` entry.
     /// Plugins whose index has a serializable representation should override this
     /// (together with [`put_in_cache`](Self::put_in_cache)) to store that
@@ -176,25 +179,19 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
         _index_store: Arc<dyn IndexStore>,
         _frag_reuse_index: Option<Arc<FragReuseIndex>>,
         cache: &LanceCache,
-        key: Cow<'_, str>,
     ) -> Result<Option<Arc<dyn ScalarIndex>>> {
-        Ok(cache
-            .get_unsized_with_key(&ScalarIndexCacheKey { key })
-            .await)
+        Ok(cache.get_unsized_with_key(&ScalarIndexCacheKey).await)
     }
 
     /// Store a freshly-opened index in the cache.
     ///
+    /// `cache` is already per-index namespaced; see
+    /// [`get_from_cache`](Self::get_from_cache).
+    ///
     /// The default implementation stores the `Arc<dyn ScalarIndex>` in-memory.
-    /// See [`get_from_cache`](Self::get_from_cache) for when to override.
-    async fn put_in_cache(
-        &self,
-        cache: &LanceCache,
-        key: Cow<'_, str>,
-        index: Arc<dyn ScalarIndex>,
-    ) -> Result<()> {
+    async fn put_in_cache(&self, cache: &LanceCache, index: Arc<dyn ScalarIndex>) -> Result<()> {
         cache
-            .insert_unsized_with_key(&ScalarIndexCacheKey { key }, index)
+            .insert_unsized_with_key(&ScalarIndexCacheKey, index)
             .await;
         Ok(())
     }
@@ -225,18 +222,18 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
 /// In-memory cache key for a whole `Arc<dyn ScalarIndex>`.
 ///
 /// Used by the default [`ScalarIndexPlugin::get_from_cache`] /
-/// [`ScalarIndexPlugin::put_in_cache`] implementations. Trait objects cannot be
-/// serialized, so this is an [`UnsizedCacheKey`] with no codec — plugins that
-/// want a persistable cache entry override those methods with a sized key.
-pub struct ScalarIndexCacheKey<'a> {
-    pub key: Cow<'a, str>,
-}
+/// [`ScalarIndexPlugin::put_in_cache`] implementations. The cache is already
+/// per-index namespaced by the caller, so a constant key suffices. Trait objects
+/// cannot be serialized, so this is an [`UnsizedCacheKey`] with no codec —
+/// plugins that want a persistable cache entry override those methods with a
+/// sized key.
+pub struct ScalarIndexCacheKey;
 
-impl UnsizedCacheKey for ScalarIndexCacheKey<'_> {
+impl UnsizedCacheKey for ScalarIndexCacheKey {
     type ValueType = dyn ScalarIndex;
 
     fn key(&self) -> Cow<'_, str> {
-        Cow::Borrowed(self.key.as_ref())
+        Cow::Borrowed("scalar_index")
     }
 
     fn type_name() -> &'static str {

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use arrow_schema::Field;
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
-use lance_core::{Result, cache::LanceCache};
+use lance_core::{
+    Result,
+    cache::{LanceCache, UnsizedCacheKey},
+};
 
 use crate::progress::IndexBuildProgress;
 use crate::registry::IndexPluginRegistry;
@@ -158,6 +162,43 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
         cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>>;
 
+    /// Look up a previously-opened index in the cache.
+    ///
+    /// The default implementation reads an in-memory `Arc<dyn ScalarIndex>` entry.
+    /// Plugins whose index has a serializable representation should override this
+    /// (together with [`put_in_cache`](Self::put_in_cache)) to store that
+    /// representation under a sized [`CacheKey`](lance_core::cache::CacheKey) with
+    /// a codec, and reconstruct the index here. `index_store` and
+    /// `frag_reuse_index` are provided so the override can rebuild the index
+    /// without re-reading metadata.
+    async fn get_from_cache(
+        &self,
+        _index_store: Arc<dyn IndexStore>,
+        _frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        cache: &LanceCache,
+        key: Cow<'_, str>,
+    ) -> Result<Option<Arc<dyn ScalarIndex>>> {
+        Ok(cache
+            .get_unsized_with_key(&ScalarIndexCacheKey { key })
+            .await)
+    }
+
+    /// Store a freshly-opened index in the cache.
+    ///
+    /// The default implementation stores the `Arc<dyn ScalarIndex>` in-memory.
+    /// See [`get_from_cache`](Self::get_from_cache) for when to override.
+    async fn put_in_cache(
+        &self,
+        cache: &LanceCache,
+        key: Cow<'_, str>,
+        index: Arc<dyn ScalarIndex>,
+    ) -> Result<()> {
+        cache
+            .insert_unsized_with_key(&ScalarIndexCacheKey { key }, index)
+            .await;
+        Ok(())
+    }
+
     /// Optional hook allowing a plugin to provide statistics without loading the index.
     async fn load_statistics(
         &self,
@@ -178,5 +219,27 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
     fn details_as_json(&self, _details: &prost_types::Any) -> Result<serde_json::Value> {
         // Return an empty JSON object as the default implementation
         Ok(serde_json::json!({}))
+    }
+}
+
+/// In-memory cache key for a whole `Arc<dyn ScalarIndex>`.
+///
+/// Used by the default [`ScalarIndexPlugin::get_from_cache`] /
+/// [`ScalarIndexPlugin::put_in_cache`] implementations. Trait objects cannot be
+/// serialized, so this is an [`UnsizedCacheKey`] with no codec — plugins that
+/// want a persistable cache entry override those methods with a sized key.
+pub struct ScalarIndexCacheKey<'a> {
+    pub key: Cow<'a, str>,
+}
+
+impl UnsizedCacheKey for ScalarIndexCacheKey<'_> {
+    type ValueType = dyn ScalarIndex;
+
+    fn key(&self) -> Cow<'_, str> {
+        Cow::Borrowed(self.key.as_ref())
+    }
+
+    fn type_name() -> &'static str {
+        "ScalarIndex"
     }
 }

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2194,6 +2194,109 @@ async fn test_fts_prewarm_with_serializing_backend_serves_query_with_no_io() {
     );
 }
 
+/// BTree analogue of `test_fts_prewarm_with_serializing_backend_serves_query_with_no_io`:
+/// after prewarming a BTree scalar index through a serializing cache backend,
+/// an indexed-filter query serves results without any further IO. The
+/// serializing backend forces every cache hit through the `BTreeIndexState`
+/// and `FlatIndex` `CacheCodec` impls, so this also smoke-tests those
+/// round-trip paths on a multi-page index.
+#[tokio::test]
+async fn test_btree_prewarm_with_serializing_backend_serves_query_with_no_io() {
+    use lance_io::assert_io_eq;
+
+    use fts_serializing_backend::SerializingBackend;
+
+    let tmpdir = TempStrDir::default();
+    let uri = tmpdir.to_owned();
+    drop(tmpdir);
+
+    // Enough rows to span several BTree pages (default page size is 4096) so
+    // the query has to consult more than one cached `FlatIndex`.
+    let num_rows = 16_384;
+    let values = Int32Array::from_iter_values(0..num_rows);
+    let ids = UInt64Array::from_iter_values(0..num_rows as u64);
+    let batch = RecordBatch::try_new(
+        arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("value", DataType::Int32, false),
+            arrow_schema::Field::new("id", DataType::UInt64, false),
+        ])
+        .into(),
+        vec![Arc::new(values) as ArrayRef, Arc::new(ids) as ArrayRef],
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+    let mut dataset = Dataset::write(batches, &uri, None).await.unwrap();
+    dataset
+        .create_index(
+            &["value"],
+            IndexType::BTree,
+            Some("value_idx".to_owned()),
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    // Re-open on a session whose cache backend serializes every entry through
+    // its codec, with a generous capacity so nothing is evicted before we query.
+    let backend = Arc::new(SerializingBackend::new());
+    let session = Arc::new(Session::with_index_cache_backend(
+        backend.clone(),
+        128 * 1024 * 1024,
+        Arc::new(lance_io::object_store::ObjectStoreRegistry::default()),
+    ));
+    let dataset = DatasetBuilder::from_uri(&uri)
+        .with_session(session)
+        .load()
+        .await
+        .unwrap();
+
+    // Reset IO counters to isolate prewarm + query traffic from open/load.
+    dataset.object_store.as_ref().io_stats_incremental();
+
+    dataset.prewarm_index("value_idx").await.unwrap();
+
+    // Prewarm opens the index (serializing `BTreeIndexState`) and loads every
+    // page (serializing each `FlatIndex`), so the serialized store must be
+    // non-empty. The unsized fallback keys cannot have a codec by design.
+    let serialized_after_prewarm = backend.serialized_entry_count().await;
+    assert!(
+        serialized_after_prewarm > 0,
+        "prewarm should have routed the BTree state and pages through CacheCodec, \
+         but the serializing store was empty"
+    );
+
+    // After prewarm, an indexed-filter query must reconstruct the index and
+    // every page it touches from the cache, deserializing via the codec, with
+    // no disk IO. Project only `_rowid` so the scan does not read a data column.
+    dataset.object_store.as_ref().io_stats_incremental();
+
+    let result = dataset
+        .scan()
+        .project(&[ROW_ID])
+        .unwrap()
+        .filter("value >= 100 AND value < 200")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(
+        result.num_rows(),
+        100,
+        "indexed filter should still return correct results after deserialization"
+    );
+
+    let stats = dataset.object_store.as_ref().io_stats_incremental();
+    assert_io_eq!(
+        stats,
+        read_iops,
+        0,
+        "BTree filter query should not perform IO after prewarm; the serializing \
+         cache backend must serve the index state and every page from memory"
+    );
+}
+
 #[tokio::test]
 async fn test_fts_phrase_query_with_removed_stop_words() {
     let tmpdir = TempStrDir::default();

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -12,14 +12,13 @@ use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::FutureExt;
 use itertools::Itertools;
-use lance_core::cache::{CacheKey, UnsizedCacheKey};
+use lance_core::cache::CacheKey;
 use lance_core::datatypes::Field;
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::parse::parse_env_as_bool;
 use lance_core::utils::tracing::{
-    IO_TYPE_OPEN_FRAG_REUSE, IO_TYPE_OPEN_MEM_WAL, IO_TYPE_OPEN_SCALAR, IO_TYPE_OPEN_VECTOR,
-    TRACE_IO_EVENTS,
+    IO_TYPE_OPEN_FRAG_REUSE, IO_TYPE_OPEN_MEM_WAL, IO_TYPE_OPEN_VECTOR, TRACE_IO_EVENTS,
 };
 use lance_file::previous::reader::FileReader as PreviousFileReader;
 use lance_file::reader::FileReaderOptions;
@@ -205,34 +204,6 @@ fn validate_segment_index_details(index_name: &str, segments: &[IndexMetadata]) 
 }
 
 // Cache keys for different index types
-#[derive(Debug, Clone)]
-pub struct ScalarIndexCacheKey<'a> {
-    pub uuid: &'a str,
-    pub fri_uuid: Option<&'a Uuid>,
-}
-
-impl<'a> ScalarIndexCacheKey<'a> {
-    pub fn new(uuid: &'a str, fri_uuid: Option<&'a Uuid>) -> Self {
-        Self { uuid, fri_uuid }
-    }
-}
-
-impl UnsizedCacheKey for ScalarIndexCacheKey<'_> {
-    type ValueType = dyn ScalarIndex;
-
-    fn key(&self) -> std::borrow::Cow<'_, str> {
-        if let Some(fri_uuid) = self.fri_uuid {
-            format!("{}-{}", self.uuid, fri_uuid).into()
-        } else {
-            self.uuid.into()
-        }
-    }
-
-    fn type_name() -> &'static str {
-        "ScalarIndex"
-    }
-}
-
 #[derive(Debug, Clone)]
 pub(crate) struct LegacyVectorIndexCacheKey<'a> {
     uuid: &'a str,
@@ -1677,12 +1648,10 @@ impl DatasetIndexInternalExt for Dataset {
         uuid: &str,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn Index>> {
-        // Checking for cache existence is cheap so we just check both scalar and vector caches
+        // Checking for cache existence is cheap so we just check the vector caches.
+        // Scalar indices cache themselves inside `open_scalar_index` (the cache
+        // key is a plugin detail), so there is no cheap scalar check here.
         let frag_reuse_uuid = self.frag_reuse_index_uuid().await;
-        let cache_key = ScalarIndexCacheKey::new(uuid, frag_reuse_uuid.as_ref());
-        if let Some(index) = self.index_cache.get_unsized_with_key(&cache_key).await {
-            return Ok(index.as_index());
-        }
 
         // Check sized cache for IvfIndexState (v2+ indices).
         let state_key = IvfIndexStateCacheKey::new(uuid, frag_reuse_uuid.as_ref());
@@ -1742,26 +1711,14 @@ impl DatasetIndexInternalExt for Dataset {
         uuid: &str,
         metrics: &dyn MetricsCollector,
     ) -> Result<Arc<dyn ScalarIndex>> {
-        let frag_reuse_uuid = self.frag_reuse_index_uuid().await;
-        let cache_key = ScalarIndexCacheKey::new(uuid, frag_reuse_uuid.as_ref());
-        if let Some(index) = self.index_cache.get_unsized_with_key(&cache_key).await {
-            return Ok(index);
-        }
-
+        // Caching (including the choice of in-memory vs. serializable state) is
+        // a plugin implementation detail handled inside `scalar::open_scalar_index`.
         let index_meta = self
             .load_index(uuid)
             .await?
             .ok_or_else(|| Error::index(format!("Index with id {} does not exist", uuid)))?;
 
-        let index = scalar::open_scalar_index(self, column, &index_meta, metrics).await?;
-
-        info!(target: TRACE_IO_EVENTS, index_uuid=uuid, r#type=IO_TYPE_OPEN_SCALAR, index_type=index.index_type().to_string());
-        metrics.record_index_load();
-
-        self.index_cache
-            .insert_unsized_with_key(&cache_key, index.clone())
-            .await;
-        Ok(index)
+        scalar::open_scalar_index(self, column, &index_meta, metrics).await
     }
 
     async fn open_vector_index(

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -8,6 +8,7 @@ pub(crate) mod inverted;
 
 pub use inverted::{load_segment_details, load_segments};
 
+use std::borrow::Cow;
 use std::sync::{Arc, LazyLock};
 
 use crate::index::DatasetIndexExt;
@@ -23,6 +24,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::TryStreamExt;
 use itertools::Itertools;
 use lance_core::datatypes::Field;
+use lance_core::utils::tracing::{IO_TYPE_OPEN_SCALAR, TRACE_IO_EVENTS};
 use lance_core::{Error, ROW_ADDR, ROW_ID, Result};
 use lance_datafusion::exec::LanceExecutionOptions;
 use lance_index::metrics::{MetricsCollector, NoOpMetricsCollector};
@@ -398,9 +400,32 @@ pub async fn open_scalar_index(
         .index_cache
         .for_index(&uuid_str, frag_reuse_index.as_ref().map(|f| &f.uuid));
 
-    plugin
+    // The index cache is namespaced per-index, so the plugin's cache key only
+    // needs to disambiguate within a single index's entries.
+    let key = Cow::Borrowed(uuid_str.as_str());
+    if let Some(index) = plugin
+        .get_from_cache(
+            index_store.clone(),
+            frag_reuse_index.clone(),
+            &index_cache,
+            key.clone(),
+        )
+        .await?
+    {
+        return Ok(index);
+    }
+
+    let index = plugin
         .load_index(index_store, &index_details, frag_reuse_index, &index_cache)
-        .await
+        .await?;
+
+    tracing::info!(target: TRACE_IO_EVENTS, index_uuid = uuid_str, r#type = IO_TYPE_OPEN_SCALAR, index_type = index.index_type().to_string());
+    metrics.record_index_load();
+
+    plugin
+        .put_in_cache(&index_cache, key, index.clone())
+        .await?;
+    Ok(index)
 }
 
 pub(crate) async fn infer_scalar_index_details(

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -8,7 +8,6 @@ pub(crate) mod inverted;
 
 pub use inverted::{load_segment_details, load_segments};
 
-use std::borrow::Cow;
 use std::sync::{Arc, LazyLock};
 
 use crate::index::DatasetIndexExt;
@@ -400,16 +399,8 @@ pub async fn open_scalar_index(
         .index_cache
         .for_index(&uuid_str, frag_reuse_index.as_ref().map(|f| &f.uuid));
 
-    // The index cache is namespaced per-index, so the plugin's cache key only
-    // needs to disambiguate within a single index's entries.
-    let key = Cow::Borrowed(uuid_str.as_str());
     if let Some(index) = plugin
-        .get_from_cache(
-            index_store.clone(),
-            frag_reuse_index.clone(),
-            &index_cache,
-            key.clone(),
-        )
+        .get_from_cache(index_store.clone(), frag_reuse_index.clone(), &index_cache)
         .await?
     {
         return Ok(index);
@@ -422,9 +413,7 @@ pub async fn open_scalar_index(
     tracing::info!(target: TRACE_IO_EVENTS, index_uuid = uuid_str, r#type = IO_TYPE_OPEN_SCALAR, index_type = index.index_type().to_string());
     metrics.record_index_load();
 
-    plugin
-        .put_in_cache(&index_cache, key, index.clone())
-        .await?;
+    plugin.put_in_cache(&index_cache, index.clone()).await?;
     Ok(index)
 }
 


### PR DESCRIPTION
Makes BTree scalar index cache entries serializable, so a persistent cache backend can store and reload them without re-reading from storage.

Previously the whole BTree index was cached as `Arc<dyn ScalarIndex>` under an `UnsizedCacheKey`, which can never carry a codec, and each `FlatIndex` page was cached in-memory only.

Changes:
- `CacheCodecImpl for FlatIndex` (one BTree page) and `BTreePageKey::codec()`.
- Top-level scalar index caching becomes a plugin implementation detail via the existing `ScalarIndexPlugin::get_from_cache`/`put_in_cache` hooks. The default impl preserves today's in-memory unsized caching (backwards compatible); the BTree plugin overrides it with a sized, codec-backed `BTreeIndexState` (the lookup `RecordBatch` + `batch_size` + `ranges_to_files`, from which `try_from_serialized` rebuilds the index with no IO).
- Caching moves into `scalar::open_scalar_index` (get → miss → load → put); the dataset-level `ScalarIndexCacheKey` logic is removed from `Dataset::open_scalar_index`.

This keeps index-type-specific knowledge in `lance-index` rather than leaking a state trait + dispatch into `lance/src/index.rs`.

Adds an integration test asserting that after prewarming with a serializing cache backend, an indexed-filter query does 0 read IOPS.

Bitmap index will follow the same pattern in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)