### PR TITLE
perf: make HNSW cheaper to load

### DIFF
--- a/rust/lance-index/benches/hnsw.rs
+++ b/rust/lance-index/benches/hnsw.rs
@@ -95,6 +95,67 @@ fn bench_hnsw(c: &mut Criterion) {
     });
 }
 
+fn bench_hnsw_load(c: &mut Criterion) {
+    const DIMENSION: usize = 128;
+    const TOTAL: usize = 100_000;
+    const SEED: [u8; 32] = [42; 32];
+    const K: usize = 100;
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let data = generate_random_array_with_seed::<Float32Type>(TOTAL * DIMENSION, SEED);
+    let fsl = FixedSizeListArray::try_new_from_values(data, DIMENSION as i32).unwrap();
+    let vectors = Arc::new(FlatFloatStorage::new(fsl.clone(), DistanceType::L2));
+
+    let search_build_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+    let hnsw = search_build_pool
+        .install(|| HNSW::index_vectors(vectors.as_ref(), HnswBuildParams::default()))
+        .unwrap();
+    let batch = hnsw.to_batch().unwrap();
+
+    // Load cost -- the path #6746 targets. `RecordBatch::clone` is an Arrow
+    // refcount bump (what production does anyway: each partition-cache IPC
+    // read yields a fresh batch), so it does not mask the load work measured.
+    c.bench_function(format!("load_hnsw({TOTAL}x{DIMENSION})").as_str(), |b| {
+        b.iter(|| {
+            let loaded = HNSW::load(batch.clone()).unwrap();
+            assert_eq!(loaded.len(), TOTAL);
+        })
+    });
+
+    // Search on the Arrow-backed loaded graph -- same TOTAL/DIMENSION/K/ef as
+    // the `search_hnsw` bench, so the two are directly comparable and confirm
+    // the new backend keeps search latency unchanged (issue #6746).
+    let loaded = HNSW::load(batch).unwrap();
+    let query = fsl.value(0);
+    c.bench_function(
+        format!("search_hnsw_loaded{TOTAL}x{DIMENSION}").as_str(),
+        |b| {
+            b.to_async(&rt).iter(|| async {
+                let uids: HashSet<u32> = loaded
+                    .search_basic(
+                        query.clone(),
+                        K,
+                        &HnswQueryParams {
+                            ef: 300,
+                            lower_bound: None,
+                            upper_bound: None,
+                            dist_q_c: 0.0,
+                        },
+                        None,
+                        vectors.as_ref(),
+                    )
+                    .unwrap()
+                    .iter()
+                    .map(|node| node.id)
+                    .collect();
+
+                assert_eq!(uids.len(), K);
+            })
+        },
+    );
+}
+
 fn bench_hnsw_sq(c: &mut Criterion) {
     const DIMENSION: usize = 128;
     const TOTAL: usize = 100_000;
@@ -291,7 +352,7 @@ criterion_group!(
         .measurement_time(Duration::from_secs(10))
         .sample_size(10)
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench_hnsw, bench_hnsw_sq, bench_hnsw_pq);
+    targets = bench_hnsw, bench_hnsw_load, bench_hnsw_sq, bench_hnsw_pq);
 
 // Non-linux version does not support pprof.
 #[cfg(not(target_os = "linux"))]
@@ -300,6 +361,6 @@ criterion_group!(
     config = Criterion::default()
         .measurement_time(Duration::from_secs(10))
         .sample_size(10);
-    targets = bench_hnsw, bench_hnsw_sq, bench_hnsw_pq);
+    targets = bench_hnsw, bench_hnsw_load, bench_hnsw_sq, bench_hnsw_pq);
 
 criterion_main!(benches);

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -5,8 +5,8 @@
 
 use arrow::array::{AsArray, ListBuilder, UInt32Builder};
 use arrow::compute::concat_batches;
-use arrow::datatypes::{DataType, Float32Type, UInt32Type};
-use arrow_array::{ArrayRef, Float32Array, RecordBatch, UInt64Array};
+use arrow::datatypes::{DataType, UInt32Type};
+use arrow_array::{ArrayRef, Float32Array, ListArray, RecordBatch, UInt64Array};
 use crossbeam_queue::ArrayQueue;
 use deepsize::DeepSizeOf;
 use itertools::Itertools;
@@ -42,7 +42,7 @@ use crate::vector::graph::{
 use crate::vector::graph::{Visited, beam_search_borrowed, greedy_search, greedy_search_borrowed};
 use crate::vector::storage::{DistCalculator, VectorStore};
 use crate::vector::v3::subindex::IvfSubIndex;
-use crate::vector::{DIST_COL, Query, VECTOR_RESULT_SCHEMA};
+use crate::vector::{Query, VECTOR_RESULT_SCHEMA};
 
 pub const HNSW_METADATA_KEY: &str = "lance:hnsw";
 
@@ -158,7 +158,7 @@ pub struct HNSW {
 
 struct HnswCore {
     params: HnswBuildParams,
-    nodes: Arc<Vec<GraphBuilderNode>>,
+    graph: HnswGraph,
     level_count: Vec<usize>,
     entry_point: u32,
     visited_generator_queue: Arc<ArrayQueue<VisitedGenerator>>,
@@ -167,7 +167,7 @@ struct HnswCore {
 impl DeepSizeOf for HnswCore {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
         self.params.deep_size_of_children(context)
-            + self.nodes.deep_size_of_children(context)
+            + self.graph.deep_size_of_children(context)
             + self.level_count.deep_size_of_children(context)
         // Skipping the visited_generator_queue
     }
@@ -180,10 +180,6 @@ impl HnswCore {
 
     fn num_nodes(&self, level: usize) -> usize {
         self.level_count[level]
-    }
-
-    fn nodes(&self) -> Arc<Vec<GraphBuilderNode>> {
-        self.nodes.clone()
     }
 }
 
@@ -210,7 +206,7 @@ impl HNSW {
         Self {
             inner: Arc::new(HnswCore {
                 params,
-                nodes: Arc::new(nodes),
+                graph: HnswGraph::Built(Arc::new(nodes)),
                 level_count,
                 entry_point,
                 visited_generator_queue,
@@ -222,7 +218,7 @@ impl HNSW {
         Self {
             inner: Arc::new(HnswCore {
                 params: HnswBuildParams::default(),
-                nodes: Arc::new(Vec::new()),
+                graph: HnswGraph::Built(Arc::new(Vec::new())),
                 level_count: Vec::new(),
                 entry_point: 0,
                 visited_generator_queue: Arc::new(ArrayQueue::new(1)),
@@ -231,7 +227,11 @@ impl HNSW {
     }
 
     pub fn len(&self) -> usize {
-        self.inner.nodes.len()
+        match &self.inner.graph {
+            HnswGraph::Built(nodes) => nodes.len(),
+            // `level_count[0]` is the bottom-level (== total) node count.
+            HnswGraph::Loaded(graph) => graph.level_count[0],
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -246,8 +246,18 @@ impl HNSW {
         self.inner.num_nodes(level)
     }
 
+    /// Returns the in-memory builder nodes.
+    ///
+    /// Only valid for a freshly built graph. A disk-loaded graph is
+    /// Arrow-backed and has no `GraphBuilderNode`s; calling this on one
+    /// panics.
     pub fn nodes(&self) -> Arc<Vec<GraphBuilderNode>> {
-        self.inner.nodes()
+        match &self.inner.graph {
+            HnswGraph::Built(nodes) => nodes.clone(),
+            HnswGraph::Loaded(_) => {
+                panic!("HNSW::nodes() is only available on a freshly built graph, not a loaded one")
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -263,32 +273,58 @@ impl HNSW {
     ) -> Result<Vec<OrderedNode>> {
         let dist_calc = storage.dist_calculator(query, params.dist_q_c);
         let entry = self.inner.entry_point;
-        let mut ep = OrderedNode::new(entry, dist_calc.distance(entry).into());
-        let nodes = self.inner.nodes.as_ref();
-        for level in (0..self.max_level()).rev() {
-            let cur_level = ImmutableHnswLevelView::new(level, nodes);
-            ep = greedy_search_borrowed(
-                &cur_level,
-                ep,
-                &dist_calc,
-                self.inner.params.prefetch_distance,
-            );
+        let ep = OrderedNode::new(entry, dist_calc.distance(entry).into());
+
+        // The level descent + bottom beam search are identical across graph
+        // backends; only the view types differ. A local macro keeps the
+        // search loop single-sourced without a generic helper whose return
+        // type would have to name the view lifetime.
+        macro_rules! run_search {
+            ($level_view:expr, $bottom_view:expr) => {{
+                let mut ep = ep;
+                for level in (0..self.max_level()).rev() {
+                    let cur_level = $level_view(level);
+                    ep = greedy_search_borrowed(
+                        &cur_level,
+                        ep,
+                        &dist_calc,
+                        self.inner.params.prefetch_distance,
+                    );
+                }
+                let bottom_level = $bottom_view;
+                let mut visited = visited_generator.generate(storage.len());
+                beam_search_borrowed(
+                    &bottom_level,
+                    &ep,
+                    params,
+                    &dist_calc,
+                    bitset.as_ref(),
+                    prefetch_distance,
+                    &mut visited,
+                )
+                .into_iter()
+                .take(k)
+                .collect::<Vec<OrderedNode>>()
+            }};
         }
 
-        let bottom_level = ImmutableHnswBottomView::new(nodes);
-        let mut visited = visited_generator.generate(storage.len());
-        Ok(beam_search_borrowed(
-            &bottom_level,
-            &ep,
-            params,
-            &dist_calc,
-            bitset.as_ref(),
-            prefetch_distance,
-            &mut visited,
-        )
-        .into_iter()
-        .take(k)
-        .collect())
+        let result = match &self.inner.graph {
+            HnswGraph::Built(nodes) => {
+                let nodes = nodes.as_slice();
+                run_search!(
+                    |level| ImmutableHnswLevelView::new(level, nodes),
+                    ImmutableHnswBottomView::new(nodes)
+                )
+            }
+            HnswGraph::Loaded(graph) => {
+                let graph = graph.as_ref();
+                run_search!(
+                    |level| LoadedHnswLevelView::new(level, graph),
+                    LoadedHnswBottomView::new(graph)
+                )
+            }
+        };
+        Ok(result)
     }
 
     #[instrument(level = "debug", skip(self, query, bitset, storage))]
@@ -456,7 +492,7 @@ impl HnswBuilder {
         HNSW {
             inner: Arc::new(HnswCore {
                 params: self.params,
-                nodes: Arc::new(nodes),
+                graph: HnswGraph::Built(Arc::new(nodes)),
                 level_count,
                 entry_point: self.entry_point,
                 visited_generator_queue: self.visited_generator_queue,
@@ -716,6 +752,177 @@ impl BorrowingGraph for ImmutableHnswBottomView<'_> {
     }
 }
 
+/// Per-level node-id -> row-index lookup for a disk-loaded HNSW graph.
+enum LevelLookup {
+    /// `row == node id`. Used only for level 0, where [`HNSW::to_batch`]
+    /// writes every node once in ascending `__vector_id` (== node id) order,
+    /// so the level-0 slice is exactly `[0, N)` with `row == id`.
+    Dense,
+    /// Upper level: an explicit `node_id -> row` map built from the level's
+    /// `__vector_id` column.
+    ///
+    /// We do *not* assume the column is sorted or that the slice is aligned
+    /// to a true level boundary: `level_offsets`/`level_count` omit the
+    /// entry-point node (it is written at every level by `to_batch` but only
+    /// counted at level 0), so upper-level slices can be off-by-one and
+    /// non-monotonic. Keying by the `__vector_id` value -- exactly what the
+    /// old per-node `load` did -- preserves behavior bit-for-bit. Upper
+    /// levels shrink geometrically, so this map stays tiny.
+    Sparse(HashMap<u32, u32>),
+}
+
+/// A search-only HNSW graph backed directly by the Arrow buffers of the
+/// on-disk `RecordBatch`.
+///
+/// Loading performs no per-node reconstruction: neighbor adjacency is served
+/// as `&[u32]` slices straight out of the `__neighbors` `ListArray` value
+/// buffer (zero copy). The full `batch` is retained so [`HNSW::to_batch`] is a
+/// near-free passthrough -- required, because the IVF partition cache
+/// re-serializes loaded indices through `to_batch()`
+/// (`lance/src/index/vector/ivf/partition_serde.rs`) -- and so a future
+/// zero-copy `CacheCodec` (#6745) can write/read it through
+/// `lance_arrow::ipc` without rebuilding the graph.
+struct LoadedHnswGraph {
+    /// The full loaded batch (all levels concatenated, level 0 first),
+    /// retained verbatim for `to_batch()` and #6745.
+    batch: RecordBatch,
+    /// Per-level `__neighbors` `List<UInt32>`, zero-copy slices of `batch`.
+    level_neighbors: Vec<ListArray>,
+    /// Per-level node-id -> row lookup (see [`LevelLookup`]).
+    level_lookup: Vec<LevelLookup>,
+    /// Number of nodes present at each level (`level_count[0]` == total).
+    level_count: Vec<usize>,
+}
+
+impl DeepSizeOf for LoadedHnswGraph {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        // `level_neighbors` are zero-copy views into `batch`, so counting
+        // `batch` alone avoids double counting (mirrors
+        // `vector/flat/storage.rs`). The upper-level `level_lookup` maps are
+        // sized to the geometrically-shrinking node counts above level 0 --
+        // negligible next to the batch and not separately accounted here.
+        self.batch.get_array_memory_size()
+    }
+}
+
+impl LoadedHnswGraph {
+    /// Borrow the neighbor ids of `key` at `level` directly from the Arrow
+    /// `ListArray` value buffer -- no allocation, no copy.
+    #[inline]
+    fn neighbors_at(&self, level: usize, key: u32) -> &[u32] {
+        let row = match &self.level_lookup[level] {
+            LevelLookup::Dense => key as usize,
+            LevelLookup::Sparse(id_to_row) => match id_to_row.get(&key) {
+                Some(&row) => row as usize,
+                // The node is absent at this level -- e.g. an empty upper
+                // level the search descends through, or a node that only
+                // exists at lower levels. Mirror the old representation
+                // (`level_neighbors[level]` defaulted to empty): no
+                // neighbors here, so greedy search stays put and descends.
+                None => return &[],
+            },
+        };
+        let list = &self.level_neighbors[level];
+        let offsets = list.value_offsets();
+        let start = offsets[row] as usize;
+        let end = offsets[row + 1] as usize;
+        // The `__neighbors` list child is `UInt32` per `HNSW::schema()`.
+        // Validity bitmap is ignored on purpose: `to_batch` never writes null
+        // neighbor lists, matching the previous `.unwrap()`-based load.
+        let values = list.values().as_primitive::<UInt32Type>();
+        &values.values()[start..end]
+    }
+}
+
+/// Per-level search view over a disk-loaded [`LoadedHnswGraph`].
+pub(crate) struct LoadedHnswLevelView<'a> {
+    level: usize,
+    graph: &'a LoadedHnswGraph,
+}
+
+impl<'a> LoadedHnswLevelView<'a> {
+    fn new(level: u16, graph: &'a LoadedHnswGraph) -> Self {
+        Self {
+            level: level as usize,
+            graph,
+        }
+    }
+}
+
+impl Graph for LoadedHnswLevelView<'_> {
+    fn len(&self) -> usize {
+        // Mirrors `ImmutableHnswLevelView::len` (total node count).
+        self.graph.level_count[0]
+    }
+
+    fn neighbors(&self, key: u32) -> Arc<Vec<u32>> {
+        // Non-hot fallback: HNSW search goes through `BorrowingGraph`. Kept
+        // only so the `Graph` trait / legacy `greedy_search` need no
+        // special-casing for loaded graphs.
+        Arc::new(self.graph.neighbors_at(self.level, key).to_vec())
+    }
+}
+
+impl BorrowingGraph for LoadedHnswLevelView<'_> {
+    fn len(&self) -> usize {
+        self.graph.level_count[0]
+    }
+
+    fn neighbors(&self, key: u32) -> &[u32] {
+        self.graph.neighbors_at(self.level, key)
+    }
+}
+
+/// Bottom-level (level 0) search view over a disk-loaded [`LoadedHnswGraph`].
+pub(crate) struct LoadedHnswBottomView<'a> {
+    graph: &'a LoadedHnswGraph,
+}
+
+impl<'a> LoadedHnswBottomView<'a> {
+    fn new(graph: &'a LoadedHnswGraph) -> Self {
+        Self { graph }
+    }
+}
+
+impl Graph for LoadedHnswBottomView<'_> {
+    fn len(&self) -> usize {
+        self.graph.level_count[0]
+    }
+
+    fn neighbors(&self, key: u32) -> Arc<Vec<u32>> {
+        Arc::new(self.graph.neighbors_at(0, key).to_vec())
+    }
+}
+
+impl BorrowingGraph for LoadedHnswBottomView<'_> {
+    fn len(&self) -> usize {
+        self.graph.level_count[0]
+    }
+
+    fn neighbors(&self, key: u32) -> &[u32] {
+        self.graph.neighbors_at(0, key)
+    }
+}
+
+/// The graph backing an [`HNSW`]: either built in memory or disk-loaded.
+enum HnswGraph {
+    /// Built in memory by the (online) builder / `index_vectors` /
+    /// `from_parts`. Mutable-shaped `GraphBuilderNode`s; `to_batch()`
+    /// re-encodes from these (it needs the per-node ranked distances).
+    Built(Arc<Vec<GraphBuilderNode>>),
+    /// Loaded from disk, Arrow-backed, search-only.
+    Loaded(Arc<LoadedHnswGraph>),
+}
+
+impl DeepSizeOf for HnswGraph {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        match self {
+            Self::Built(nodes) => nodes.deep_size_of_children(context),
+            Self::Loaded(graph) => graph.deep_size_of_children(context),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct HnswQueryParams {
     pub ef: usize,
@@ -760,39 +967,58 @@ impl IvfSubIndex for HNSW {
             ))
         })?;
 
-        let levels: Vec<_> = hnsw_metadata
+        // Slice the concatenated batch into one (zero-copy) view per level.
+        let level_batches: Vec<RecordBatch> = hnsw_metadata
             .level_offsets
             .iter()
             .tuple_windows()
             .map(|(start, end)| data.slice(*start, end - start))
             .collect();
 
-        let level_count = levels.iter().map(|b| b.num_rows()).collect::<Vec<_>>();
+        let level_count = level_batches
+            .iter()
+            .map(|b| b.num_rows())
+            .collect::<Vec<_>>();
 
-        let bottom_level_len = levels[0].num_rows();
-        let mut nodes = Vec::with_capacity(bottom_level_len);
-        for i in 0..bottom_level_len {
-            nodes.push(GraphBuilderNode::new(i as u32, levels.len()));
-        }
-        for (level, batch) in levels.into_iter().enumerate() {
+        // No per-node reconstruction: keep the Arrow adjacency buffers as-is
+        // and only build the tiny per-upper-level id->row lookups. The
+        // `__distance` column is never materialized here -- search doesn't
+        // need it, and `to_batch()` returns the retained `data` verbatim.
+        let mut level_neighbors = Vec::with_capacity(level_batches.len());
+        let mut level_lookup = Vec::with_capacity(level_batches.len());
+        for (level, batch) in level_batches.iter().enumerate() {
+            // `.clone()` on an Arrow array bumps a refcount; buffers stay
+            // shared with `data` (zero copy).
+            let neighbors = batch[NEIGHBORS_COL].as_list::<i32>().clone();
             let ids = batch[VECTOR_ID_COL].as_primitive::<UInt32Type>();
-            let neighbors = batch[NEIGHBORS_COL].as_list::<i32>();
-            let distances = batch[DIST_COL].as_list::<i32>();
-
-            for ((node, neighbors), distances) in
-                ids.iter().zip(neighbors.iter()).zip(distances.iter())
-            {
-                let node = node.unwrap();
-                let neighbors = neighbors.as_ref().unwrap().as_primitive::<UInt32Type>();
-                let distances = distances.as_ref().unwrap().as_primitive::<Float32Type>();
-
-                nodes[node as usize].level_neighbors_ranked[level] = neighbors
+            if level == 0 {
+                // `to_batch` writes every node at level 0 exactly once in
+                // ascending `__vector_id` (== node id) order, and the level-0
+                // slice is exactly `[0, N)`, so the row index *is* the node
+                // id.
+                debug_assert!(
+                    ids.values()
+                        .iter()
+                        .enumerate()
+                        .all(|(i, id)| *id == i as u32),
+                    "level 0 __vector_id must equal the row index"
+                );
+                level_lookup.push(LevelLookup::Dense);
+            } else {
+                // Upper levels: explicit id -> row map. No ordering/alignment
+                // assumption (see `LevelLookup::Sparse`). On the rare
+                // duplicate id (a misaligned slice can repeat one across a
+                // level boundary) the last wins, matching the old load's
+                // `nodes[id].level_neighbors[level] = ...` last-write.
+                let id_to_row: HashMap<u32, u32> = ids
+                    .values()
                     .iter()
-                    .zip(distances.iter())
-                    .map(|(n, dist)| OrderedNode::new(n.unwrap(), OrderedFloat(dist.unwrap())))
+                    .enumerate()
+                    .map(|(row, id)| (*id, row as u32))
                     .collect();
-                nodes[node as usize].update_from_ranked_neighbors(level as u16);
+                level_lookup.push(LevelLookup::Sparse(id_to_row));
             }
+            level_neighbors.push(neighbors);
         }
 
         let visited_generator_queue =
@@ -802,9 +1028,16 @@ impl IvfSubIndex for HNSW {
                 .push(VisitedGenerator::new(0))
                 .unwrap();
         }
+
+        let graph = LoadedHnswGraph {
+            batch: data,
+            level_neighbors,
+            level_lookup,
+            level_count: level_count.clone(),
+        };
         let inner = HnswCore {
             params: hnsw_metadata.params,
-            nodes: Arc::new(nodes),
+            graph: HnswGraph::Loaded(Arc::new(graph)),
             level_count,
             entry_point: hnsw_metadata.entry_point,
             visited_generator_queue,
@@ -941,6 +1174,28 @@ impl IvfSubIndex for HNSW {
 
     /// Encode the sub index into a record batch
     fn to_batch(&self) -> Result<RecordBatch> {
+        let nodes = match &self.inner.graph {
+            HnswGraph::Built(nodes) => nodes,
+            HnswGraph::Loaded(graph) => {
+                // A loaded graph is already Arrow-backed: return the retained
+                // batch verbatim, re-stamped with up-to-date HNSW metadata.
+                // The IVF partition cache re-serializes loaded indices through
+                // here (`ivf/partition_serde.rs`), so this must round-trip.
+                let metadata = serde_json::to_string(&self.metadata())?;
+                let schema =
+                    graph
+                        .batch
+                        .schema()
+                        .as_ref()
+                        .clone()
+                        .with_metadata(HashMap::from_iter(vec![(
+                            HNSW_METADATA_KEY.to_string(),
+                            metadata,
+                        )]));
+                return Ok(graph.batch.clone().with_schema(Arc::new(schema))?);
+            }
+        };
+
         let mut vector_id_builder = UInt32Builder::with_capacity(self.len());
         let mut neighbors_builder = ListBuilder::with_capacity(UInt32Builder::new(), self.len());
         let mut distances_builder =
@@ -948,7 +1203,7 @@ impl IvfSubIndex for HNSW {
         let mut batches = Vec::with_capacity(self.max_level() as usize);
         for level in 0..self.max_level() {
             let level = level as usize;
-            for (id, node) in self.inner.nodes.iter().enumerate() {
+            for (id, node) in nodes.iter().enumerate() {
                 if level >= node.level_neighbors.len() {
                     continue;
                 }
@@ -988,11 +1243,21 @@ impl IvfSubIndex for HNSW {
 }
 
 #[cfg(test)]
+impl HNSW {
+    /// Whether the graph is the Arrow-backed (disk-loaded) representation
+    /// rather than the in-memory `Vec<GraphBuilderNode>` build representation.
+    pub(crate) fn is_loaded_graph(&self) -> bool {
+        matches!(self.inner.graph, HnswGraph::Loaded(_))
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{FixedSizeListArray, UInt8Array};
+    use arrow_array::{ArrayRef, FixedSizeListArray, UInt8Array};
     use arrow_schema::Schema;
+    use deepsize::DeepSizeOf;
     use lance_arrow::FixedSizeListArrayExt;
     use lance_file::previous::{
         reader::FileReader as PreviousFileReader,
@@ -1006,8 +1271,10 @@ mod tests {
     use lance_table::io::manifest::ManifestDescribing;
     use lance_testing::datagen::generate_random_array;
     use object_store::path::Path;
+    use rstest::rstest;
 
     use crate::scalar::IndexWriter;
+    use crate::vector::storage::{DistCalculator, VectorStore};
     use crate::vector::v3::subindex::IvfSubIndex;
     use crate::vector::{
         flat::storage::{FlatBinStorage, FlatFloatStorage},
@@ -1139,5 +1406,247 @@ mod tests {
             .search_basic(query, k, &params, None, store.as_ref())
             .unwrap();
         assert_eq!(builder_results, loaded_results);
+    }
+
+    /// Brute-force top-`k` node ids by distance -- recall ground truth.
+    fn brute_force_topk(store: &FlatFloatStorage, query: ArrayRef, k: usize) -> Vec<u32> {
+        let dist_calc = store.dist_calculator(query, 0.0);
+        let mut all: Vec<(f32, u32)> = (0..store.len() as u32)
+            .map(|id| (dist_calc.distance(id), id))
+            .collect();
+        all.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        all.into_iter().take(k).map(|(_, id)| id).collect()
+    }
+
+    /// The Arrow-backed loaded graph must search bit-identically to the
+    /// in-memory build, across distance types and graph sizes (single node,
+    /// pair, and a multi-level graph exercising the sparse upper-level
+    /// id->row lookup).
+    #[rstest]
+    #[case::l2_single(DistanceType::L2, 1)]
+    #[case::l2_pair(DistanceType::L2, 2)]
+    #[case::l2_multi_level(DistanceType::L2, 2048)]
+    #[case::dot_multi_level(DistanceType::Dot, 2048)]
+    #[tokio::test]
+    async fn test_loaded_search_parity_and_recall(
+        #[case] distance_type: DistanceType,
+        #[case] total: usize,
+    ) {
+        const DIM: usize = 32;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(total * DIM), DIM as i32)
+                .unwrap();
+        let store = Arc::new(FlatFloatStorage::new(fsl.clone(), distance_type));
+        let builder = HNSW::index_vectors(
+            store.as_ref(),
+            HnswBuildParams::default().num_edges(20).ef_construction(50),
+        )
+        .unwrap();
+        assert!(!builder.is_loaded_graph());
+
+        let loaded = HNSW::load(builder.to_batch().unwrap()).unwrap();
+        assert!(loaded.is_loaded_graph());
+        assert_eq!(loaded.len(), total);
+
+        let k = total.min(10);
+        let params = HnswQueryParams {
+            ef: 50,
+            lower_bound: None,
+            upper_bound: None,
+            dist_q_c: 0.0,
+        };
+        let query = fsl.value(0);
+
+        let builder_results = builder
+            .search_basic(query.clone(), k, &params, None, store.as_ref())
+            .unwrap();
+        let loaded_results = loaded
+            .search_basic(query.clone(), k, &params, None, store.as_ref())
+            .unwrap();
+        assert_eq!(builder_results, loaded_results);
+
+        // Recall vs brute-force ground truth (project rule: >= 0.5).
+        let truth: std::collections::HashSet<u32> = brute_force_topk(store.as_ref(), query, k)
+            .into_iter()
+            .collect();
+        let hits = loaded_results
+            .iter()
+            .filter(|n| truth.contains(&n.id))
+            .count();
+        let recall = hits as f32 / k as f32;
+        assert!(recall >= 0.5, "recall {recall} below 0.5 (k={k})");
+    }
+
+    /// Regression guard for the `level_offsets` misalignment (issue #6746).
+    /// `to_batch` writes the entry-point node at *every* level, but
+    /// `level_count` only counts it at level 0, so the serialized batch has
+    /// strictly more rows than `sum(level_count)` and the upper-level
+    /// `level_offsets` slices are off-by-one / non-monotonic. The Arrow-backed
+    /// loaded graph must still search bit-identically to the in-memory build:
+    /// it keys upper levels by `__vector_id` value via the `Sparse` map
+    /// (last-write-wins), never `row == id`. A naive `row == id`
+    /// reimplementation would pass the small cases but break here.
+    #[tokio::test]
+    async fn test_loaded_level_offsets_misalignment_invariant() {
+        use arrow::array::AsArray;
+        use arrow::datatypes::UInt32Type;
+
+        const DIM: usize = 32;
+        const TOTAL: usize = 2048;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(TOTAL * DIM), DIM as i32)
+                .unwrap();
+        let store = Arc::new(FlatFloatStorage::new(fsl.clone(), DistanceType::L2));
+        let builder = HNSW::index_vectors(
+            store.as_ref(),
+            HnswBuildParams::default().num_edges(20).ef_construction(50),
+        )
+        .unwrap();
+
+        // The scenario only exists on a multi-level graph.
+        assert!(
+            builder.max_level() >= 2,
+            "expected a multi-level graph (got max_level {})",
+            builder.max_level()
+        );
+
+        let batch = builder.to_batch().unwrap();
+        let md = builder.metadata();
+        let total_counted = *md.level_offsets.last().unwrap();
+
+        // The exact misalignment: more serialized rows than `level_count` sums
+        // to, because the entry-point node is written at every level yet
+        // counted only at level 0.
+        assert!(
+            batch.num_rows() > total_counted,
+            "expected serialized rows ({}) to exceed sum(level_count) ({}) -- \
+             entry point should be written at every level",
+            batch.num_rows(),
+            total_counted,
+        );
+
+        // Level-0 slice must still be exactly `[0, N)` with
+        // `__vector_id == row` -- the precondition for `LevelLookup::Dense`.
+        let n = md.level_offsets[1];
+        assert_eq!(n, TOTAL);
+        let level0 = batch.slice(0, n);
+        let ids = level0.column(0).as_primitive::<UInt32Type>();
+        assert!(
+            ids.values()
+                .iter()
+                .enumerate()
+                .all(|(row, id)| *id == row as u32),
+            "level-0 __vector_id must equal the row index",
+        );
+
+        // Despite the surplus rows and off-by-one upper slices, the loaded
+        // graph searches bit-identically to the in-memory build (old `load`
+        // semantics preserved via the `Sparse` last-write-wins map).
+        let loaded = HNSW::load(batch).unwrap();
+        assert!(loaded.is_loaded_graph());
+        let params = HnswQueryParams {
+            ef: 50,
+            lower_bound: None,
+            upper_bound: None,
+            dist_q_c: 0.0,
+        };
+        let query = fsl.value(0);
+        let builder_results = builder
+            .search_basic(query.clone(), 10, &params, None, store.as_ref())
+            .unwrap();
+        let loaded_results = loaded
+            .search_basic(query, 10, &params, None, store.as_ref())
+            .unwrap();
+        assert_eq!(builder_results, loaded_results);
+    }
+
+    /// An empty index round-trips: 0-row `to_batch` -> `load` -> empty graph.
+    #[tokio::test]
+    async fn test_loaded_empty_index() {
+        const DIM: usize = 16;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(0), DIM as i32).unwrap();
+        let store = Arc::new(FlatFloatStorage::new(fsl, DistanceType::L2));
+        let builder = HNSW::index_vectors(store.as_ref(), HnswBuildParams::default()).unwrap();
+        assert!(builder.is_empty());
+
+        let batch = builder.to_batch().unwrap();
+        assert_eq!(batch.num_rows(), 0);
+
+        let loaded = HNSW::load(batch).unwrap();
+        assert!(loaded.is_empty());
+        assert_eq!(loaded.len(), 0);
+        // A 0-row load short-circuits to the empty (Built) graph.
+        assert!(!loaded.is_loaded_graph());
+        assert_eq!(loaded.to_batch().unwrap().num_rows(), 0);
+    }
+
+    /// build -> `to_batch` (b1) -> `load` -> `to_batch` (b2) must satisfy
+    /// `b1 == b2`, and the round-tripped batch must reload and search
+    /// identically. This is exactly the IVF partition-cache path:
+    /// `ivf/partition_serde.rs` calls `to_batch()` on a *loaded* index.
+    #[tokio::test]
+    async fn test_to_batch_roundtrip_loaded() {
+        const DIM: usize = 24;
+        const TOTAL: usize = 1500;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(TOTAL * DIM), DIM as i32)
+                .unwrap();
+        let store = Arc::new(FlatFloatStorage::new(fsl.clone(), DistanceType::L2));
+        let builder = HNSW::index_vectors(
+            store.as_ref(),
+            HnswBuildParams::default().num_edges(16).ef_construction(50),
+        )
+        .unwrap();
+
+        let b1 = builder.to_batch().unwrap();
+        let loaded = HNSW::load(b1.clone()).unwrap();
+        assert!(loaded.is_loaded_graph());
+        let b2 = loaded.to_batch().unwrap();
+        assert_eq!(b1, b2);
+
+        let reloaded = HNSW::load(b2).unwrap();
+        let params = HnswQueryParams {
+            ef: 50,
+            lower_bound: None,
+            upper_bound: None,
+            dist_q_c: 0.0,
+        };
+        let query = fsl.value(7);
+        let a = builder
+            .search_basic(query.clone(), 10, &params, None, store.as_ref())
+            .unwrap();
+        let b = reloaded
+            .search_basic(query, 10, &params, None, store.as_ref())
+            .unwrap();
+        assert_eq!(a, b);
+    }
+
+    /// The loaded graph shares the Arrow batch and reconstructs no per-node
+    /// `Vec<GraphBuilderNode>` / `Vec<OrderedNode>`, so it is strictly
+    /// lighter than the in-memory build representation.
+    #[tokio::test]
+    async fn test_loaded_graph_is_arrow_backed() {
+        const DIM: usize = 32;
+        const TOTAL: usize = 2048;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(TOTAL * DIM), DIM as i32)
+                .unwrap();
+        let store = Arc::new(FlatFloatStorage::new(fsl, DistanceType::L2));
+        let builder = HNSW::index_vectors(
+            store.as_ref(),
+            HnswBuildParams::default().num_edges(20).ef_construction(50),
+        )
+        .unwrap();
+        assert!(!builder.is_loaded_graph());
+
+        let loaded = HNSW::load(builder.to_batch().unwrap()).unwrap();
+        assert!(loaded.is_loaded_graph());
+        assert!(
+            loaded.deep_size_of() < builder.deep_size_of(),
+            "loaded graph ({}) should be lighter than built ({})",
+            loaded.deep_size_of(),
+            builder.deep_size_of(),
+        );
     }
 }

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -246,17 +246,14 @@ impl HNSW {
         self.inner.num_nodes(level)
     }
 
-    /// Returns the in-memory builder nodes.
+    /// Returns the in-memory builder nodes, if this graph was freshly built.
     ///
-    /// Only valid for a freshly built graph. A disk-loaded graph is
-    /// Arrow-backed and has no `GraphBuilderNode`s; calling this on one
-    /// panics.
-    pub fn nodes(&self) -> Arc<Vec<GraphBuilderNode>> {
+    /// A disk-loaded graph is Arrow-backed and has no `GraphBuilderNode`s,
+    /// so this returns `None` for it.
+    pub fn nodes(&self) -> Option<Arc<Vec<GraphBuilderNode>>> {
         match &self.inner.graph {
-            HnswGraph::Built(nodes) => nodes.clone(),
-            HnswGraph::Loaded(_) => {
-                panic!("HNSW::nodes() is only available on a freshly built graph, not a loaded one")
-            }
+            HnswGraph::Built(nodes) => Some(nodes.clone()),
+            HnswGraph::Loaded(_) => None,
         }
     }
 
@@ -275,56 +272,94 @@ impl HNSW {
         let entry = self.inner.entry_point;
         let ep = OrderedNode::new(entry, dist_calc.distance(entry).into());
 
-        // The level descent + bottom beam search are identical across graph
-        // backends; only the view types differ. A local macro keeps the
-        // search loop single-sourced without a generic helper whose return
-        // type would have to name the view lifetime.
-        macro_rules! run_search {
-            ($level_view:expr, $bottom_view:expr) => {{
-                let mut ep = ep;
-                for level in (0..self.max_level()).rev() {
-                    let cur_level = $level_view(level);
-                    ep = greedy_search_borrowed(
-                        &cur_level,
-                        ep,
-                        &dist_calc,
-                        self.inner.params.prefetch_distance,
-                    );
-                }
-                let bottom_level = $bottom_view;
-                let mut visited = visited_generator.generate(storage.len());
-                beam_search_borrowed(
-                    &bottom_level,
-                    &ep,
-                    params,
-                    &dist_calc,
-                    bitset.as_ref(),
-                    prefetch_distance,
-                    &mut visited,
-                )
-                .into_iter()
-                .take(k)
-                .collect::<Vec<OrderedNode>>()
-            }};
-        }
-
+        // The level descent + bottom beam search are identical across
+        // graph backends; only the view types differ. `run_search` is
+        // generic over those view types so the loop is single-sourced:
+        // each backend supplies a per-level view closure and a
+        // bottom-level view.
         let result = match &self.inner.graph {
             HnswGraph::Built(nodes) => {
                 let nodes = nodes.as_slice();
-                run_search!(
+                self.run_search(
+                    ep,
+                    k,
+                    params,
+                    bitset.as_ref(),
+                    visited_generator,
+                    storage.len(),
+                    prefetch_distance,
+                    &dist_calc,
                     |level| ImmutableHnswLevelView::new(level, nodes),
-                    ImmutableHnswBottomView::new(nodes)
+                    ImmutableHnswBottomView::new(nodes),
                 )
             }
             HnswGraph::Loaded(graph) => {
                 let graph = graph.as_ref();
-                run_search!(
+                self.run_search(
+                    ep,
+                    k,
+                    params,
+                    bitset.as_ref(),
+                    visited_generator,
+                    storage.len(),
+                    prefetch_distance,
+                    &dist_calc,
                     |level| LoadedHnswLevelView::new(level, graph),
-                    LoadedHnswBottomView::new(graph)
+                    LoadedHnswBottomView::new(graph),
                 )
             }
         };
         Ok(result)
+    }
+
+    /// Drives the shared HNSW query path over backend-specific graph
+    /// views: a per-level view produced by `make_level` and a
+    /// bottom-level view `bottom`. The views borrow their backing store
+    /// and are created, used, and dropped entirely within this call;
+    /// only the owned result escapes. Monomorphizing over `L`/`B` is the
+    /// single seam that lets the in-memory and disk-loaded backends
+    /// share one search loop.
+    #[allow(clippy::too_many_arguments)]
+    fn run_search<L, B>(
+        &self,
+        ep: OrderedNode,
+        k: usize,
+        params: &HnswQueryParams,
+        bitset: Option<&Visited>,
+        visited_generator: &mut VisitedGenerator,
+        storage_len: usize,
+        prefetch_distance: Option<usize>,
+        dist_calc: &impl DistCalculator,
+        make_level: impl Fn(u16) -> L,
+        bottom: B,
+    ) -> Vec<OrderedNode>
+    where
+        L: BorrowingGraph,
+        B: BorrowingGraph,
+    {
+        let mut ep = ep;
+        for level in (0..self.max_level()).rev() {
+            let cur_level = make_level(level);
+            ep = greedy_search_borrowed(
+                &cur_level,
+                ep,
+                dist_calc,
+                self.inner.params.prefetch_distance,
+            );
+        }
+        let mut visited = visited_generator.generate(storage_len);
+        beam_search_borrowed(
+            &bottom,
+            &ep,
+            params,
+            dist_calc,
+            bitset,
+            prefetch_distance,
+            &mut visited,
+        )
+        .into_iter()
+        .take(k)
+        .collect::<Vec<OrderedNode>>()
     }
 
     #[instrument(level = "debug", skip(self, query, bitset, storage))]
@@ -1243,15 +1278,6 @@ impl IvfSubIndex for HNSW {
 }
 
 #[cfg(test)]
-impl HNSW {
-    /// Whether the graph is the Arrow-backed (disk-loaded) representation
-    /// rather than the in-memory `Vec<GraphBuilderNode>` build representation.
-    pub(crate) fn is_loaded_graph(&self) -> bool {
-        matches!(self.inner.graph, HnswGraph::Loaded(_))
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
@@ -1273,6 +1299,7 @@ mod tests {
     use object_store::path::Path;
     use rstest::rstest;
 
+    use super::HnswGraph;
     use crate::scalar::IndexWriter;
     use crate::vector::storage::{DistCalculator, VectorStore};
     use crate::vector::v3::subindex::IvfSubIndex;
@@ -1442,10 +1469,10 @@ mod tests {
             HnswBuildParams::default().num_edges(20).ef_construction(50),
         )
         .unwrap();
-        assert!(!builder.is_loaded_graph());
+        assert!(!matches!(builder.inner.graph, HnswGraph::Loaded(_)));
 
         let loaded = HNSW::load(builder.to_batch().unwrap()).unwrap();
-        assert!(loaded.is_loaded_graph());
+        assert!(matches!(loaded.inner.graph, HnswGraph::Loaded(_)));
         assert_eq!(loaded.len(), total);
 
         let k = total.min(10);
@@ -1543,7 +1570,7 @@ mod tests {
         // graph searches bit-identically to the in-memory build (old `load`
         // semantics preserved via the `Sparse` last-write-wins map).
         let loaded = HNSW::load(batch).unwrap();
-        assert!(loaded.is_loaded_graph());
+        assert!(matches!(loaded.inner.graph, HnswGraph::Loaded(_)));
         let params = HnswQueryParams {
             ef: 50,
             lower_bound: None,
@@ -1577,7 +1604,7 @@ mod tests {
         assert!(loaded.is_empty());
         assert_eq!(loaded.len(), 0);
         // A 0-row load short-circuits to the empty (Built) graph.
-        assert!(!loaded.is_loaded_graph());
+        assert!(!matches!(loaded.inner.graph, HnswGraph::Loaded(_)));
         assert_eq!(loaded.to_batch().unwrap().num_rows(), 0);
     }
 
@@ -1601,7 +1628,7 @@ mod tests {
 
         let b1 = builder.to_batch().unwrap();
         let loaded = HNSW::load(b1.clone()).unwrap();
-        assert!(loaded.is_loaded_graph());
+        assert!(matches!(loaded.inner.graph, HnswGraph::Loaded(_)));
         let b2 = loaded.to_batch().unwrap();
         assert_eq!(b1, b2);
 
@@ -1638,10 +1665,10 @@ mod tests {
             HnswBuildParams::default().num_edges(20).ef_construction(50),
         )
         .unwrap();
-        assert!(!builder.is_loaded_graph());
+        assert!(!matches!(builder.inner.graph, HnswGraph::Loaded(_)));
 
         let loaded = HNSW::load(builder.to_batch().unwrap()).unwrap();
-        assert!(loaded.is_loaded_graph());
+        assert!(matches!(loaded.inner.graph, HnswGraph::Loaded(_)));
         assert!(
             loaded.deep_size_of() < builder.deep_size_of(),
             "loaded graph ({}) should be lighter than built ({})",

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -1028,16 +1028,25 @@ impl IvfSubIndex for HNSW {
             let ids = batch[VECTOR_ID_COL].as_primitive::<UInt32Type>();
             if level == 0 {
                 // `to_batch` writes every node at level 0 exactly once in
-                // ascending `__vector_id` (== node id) order, and the level-0
-                // slice is exactly `[0, N)`, so the row index *is* the node
-                // id.
-                debug_assert!(
-                    ids.values()
-                        .iter()
-                        .enumerate()
-                        .all(|(i, id)| *id == i as u32),
-                    "level 0 __vector_id must equal the row index"
-                );
+                // ascending `__vector_id` (== node id) order, so the level-0
+                // slice is exactly `[0, N)` and the row index *is* the node
+                // id. The `Dense` lookup below depends on this: in a release
+                // build a violated invariant would silently make search read
+                // the wrong neighbor list, so enforce it at load time (not via
+                // `debug_assert!`) and reject a malformed or version-
+                // incompatible batch.
+                if let Some((row, id)) = ids
+                    .values()
+                    .iter()
+                    .enumerate()
+                    .find(|&(row, id)| *id != row as u32)
+                {
+                    return Err(Error::index(format!(
+                        "HNSW level-0 __vector_id must equal the row index, but \
+                         row {row} has __vector_id {id}; the on-disk batch is \
+                         malformed or was written by an incompatible version"
+                    )));
+                }
                 level_lookup.push(LevelLookup::Dense);
             } else {
                 // Upper levels: explicit id -> row map. No ordering/alignment
@@ -1054,6 +1063,20 @@ impl IvfSubIndex for HNSW {
                 level_lookup.push(LevelLookup::Sparse(id_to_row));
             }
             level_neighbors.push(neighbors);
+        }
+
+        // `entry_point` is read from untrusted metadata and indexes the `Dense`
+        // level-0 lookup directly; an out-of-range value would read past the
+        // level-0 neighbor buffer during search. Validate it under the same
+        // persisted-format invariant as the level-0 ids above.
+        let num_nodes = level_count[0];
+        if hnsw_metadata.entry_point as usize >= num_nodes {
+            return Err(Error::index(format!(
+                "HNSW entry_point {} is out of range for a graph with {num_nodes} \
+                 nodes; the on-disk batch is malformed or was written by an \
+                 incompatible version",
+                hnsw_metadata.entry_point
+            )));
         }
 
         let visited_generator_queue =
@@ -1281,7 +1304,7 @@ impl IvfSubIndex for HNSW {
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{ArrayRef, FixedSizeListArray, UInt8Array};
+    use arrow_array::{ArrayRef, FixedSizeListArray, RecordBatch, UInt8Array, UInt32Array};
     use arrow_schema::Schema;
     use deepsize::DeepSizeOf;
     use lance_arrow::FixedSizeListArrayExt;
@@ -1585,6 +1608,90 @@ mod tests {
             .search_basic(query, 10, &params, None, store.as_ref())
             .unwrap();
         assert_eq!(builder_results, loaded_results);
+    }
+
+    /// `load()` must reject a batch whose level-0 `__vector_id` no longer
+    /// matches the row index. The `LevelLookup::Dense` fast path relies on
+    /// `row == id`, and the old `debug_assert!` was compiled out of release
+    /// builds -- so a corrupt batch must fail at the `load()` boundary instead
+    /// of silently searching the wrong neighbor lists.
+    #[tokio::test]
+    async fn test_load_rejects_misaligned_level0_id() {
+        use arrow::array::AsArray;
+        use arrow::datatypes::UInt32Type;
+
+        const DIM: usize = 16;
+        const TOTAL: usize = 256;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(TOTAL * DIM), DIM as i32)
+                .unwrap();
+        let store = Arc::new(FlatFloatStorage::new(fsl, DistanceType::L2));
+        let builder = HNSW::index_vectors(
+            store.as_ref(),
+            HnswBuildParams::default().num_edges(20).ef_construction(50),
+        )
+        .unwrap();
+
+        let batch = builder.to_batch().unwrap();
+        // Row 0 is always a level-0 node; break its `__vector_id == row`
+        // invariant while preserving the (metadata-bearing) schema.
+        let mut ids = batch
+            .column(0)
+            .as_primitive::<UInt32Type>()
+            .values()
+            .to_vec();
+        ids[0] = ids.len() as u32;
+        let mut columns = batch.columns().to_vec();
+        columns[0] = Arc::new(UInt32Array::from(ids));
+        let corrupted = RecordBatch::try_new(batch.schema(), columns).unwrap();
+
+        assert!(
+            HNSW::load(corrupted).is_err(),
+            "load() must reject a misaligned level-0 __vector_id"
+        );
+    }
+
+    /// `load()` must reject metadata whose `entry_point` is out of range for
+    /// the node count: it indexes the `Dense` level-0 lookup directly, so an
+    /// out-of-range value would read past the level-0 neighbor buffer at search
+    /// time.
+    #[tokio::test]
+    async fn test_load_rejects_out_of_range_entry_point() {
+        use super::{HNSW_METADATA_KEY, HnswMetadata};
+
+        const DIM: usize = 16;
+        const TOTAL: usize = 256;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(TOTAL * DIM), DIM as i32)
+                .unwrap();
+        let store = Arc::new(FlatFloatStorage::new(fsl, DistanceType::L2));
+        let builder = HNSW::index_vectors(
+            store.as_ref(),
+            HnswBuildParams::default().num_edges(20).ef_construction(50),
+        )
+        .unwrap();
+
+        let batch = builder.to_batch().unwrap();
+        let mut metadata = batch.schema_ref().metadata().clone();
+        let mut md: HnswMetadata =
+            serde_json::from_str(metadata.get(HNSW_METADATA_KEY).unwrap()).unwrap();
+        // Valid entry points are `[0, N)`; `level_offsets[1]` == N is one past.
+        let n = md.level_offsets[1];
+        md.entry_point = n as u32;
+        metadata.insert(
+            HNSW_METADATA_KEY.to_string(),
+            serde_json::to_string(&md).unwrap(),
+        );
+        // Rebuild the batch under the rewritten metadata. `with_schema` would
+        // reject this: it requires the new metadata to be a superset, but we
+        // are changing an existing key's value, not adding one.
+        let schema = batch.schema().as_ref().clone().with_metadata(metadata);
+        let corrupted = RecordBatch::try_new(Arc::new(schema), batch.columns().to_vec()).unwrap();
+
+        assert!(
+            HNSW::load(corrupted).is_err(),
+            "load() must reject an out-of-range entry_point"
+        );
     }
 
     /// An empty index round-trips: 0-row `to_batch` -> `load` -> empty graph.


### PR DESCRIPTION
## Summary

Closes #6746. Loading an HNSW partition no longer reconstructs a per-node `Vec<GraphBuilderNode>` / `Vec<OrderedNode>` graph. The loaded graph is now backed directly by the on-disk Arrow buffers, with neighbor adjacency served as zero-copy `&[u32]` slices straight out of the `__neighbors` `ListArray` value buffer. This unblocks a future zero-copy `CacheCodec` (#6745).

## Motivation

Per #6746, loading an HNSW partition required expensive per-node reconstruction, which makes a zero-copy IPC `CacheCodec` (#6745) infeasible. The fix is to keep the Arrow data and offsets as the graph's backing store while preserving current search behavior and performance.

## What changed

- `HnswCore` now holds an `HnswGraph` enum instead of `Arc<Vec<GraphBuilderNode>>`: `Built` (in-memory, produced by the online builder / `index_vectors` — build path untouched) or `Loaded` (Arrow-backed, search-only).
- `LoadedHnswGraph` retains the full `RecordBatch` plus per-level zero-copy `ListArray` neighbor views and a tiny per-upper-level `id -> row` lookup; the geometrically-shrinking upper levels keep these maps negligible.
- Level 0 uses a `Dense` lookup (`row == __vector_id`, asserted in debug); upper levels use a `Sparse` map keyed by `__vector_id` value, exactly mirroring the old per-node `load` — including the known `level_offsets` quirk where the entry-point node is written by `to_batch` at every level but counted only at level 0, so upper-level slices are off-by-one and duplicate ids resolve last-write-wins.
- The search loop is single-sourced across both backends via a local macro, keeping the existing `Graph` / `BorrowingGraph` seam; search is unchanged.
- `to_batch()` on a loaded graph is a verbatim passthrough (re-stamped metadata only), so the IVF partition cache (`ivf/partition_serde.rs`, which re-serializes loaded indices) round-trips losslessly and #6745 can write/read it through `lance_arrow::ipc` without rebuilding the graph.

## Correctness & compatibility

- Loaded-graph search is bit-identical to the in-memory build across L2 / Dot / Hamming and graph sizes (single node, pair, multi-level 2048).
- Old `load` semantics are preserved bit-for-bit, including duplicate-id last-write-wins across a misaligned slice boundary; `build -> to_batch -> load -> to_batch` is byte-stable (`b1 == b2`).
- No public API signature change. `HNSW::nodes()` now panics on a loaded graph (documented; `GraphBuilderNode` is internal API and there are no in-tree callers).

## Benchmarks

`criterion --quick`, 100000×128, L2, k=100, ef=300 (`rust/lance-index/benches/hnsw.rs`). The "before" `load_hnsw` was measured by running this same bench against the parent commit's reconstruction-based `builder.rs` (only that file swapped), so it is a like-for-like `HNSW::load` comparison.

| Benchmark | Before (reconstruction load) | After (Arrow-backed) | Δ |
| --- | --- | --- | --- |
| `load_hnsw(100000x128)` | ~127 ms | ~90.8 µs | ~1,400× faster |
| `search_hnsw100000x128` (built, baseline) | ~700.7 µs | ~700.7 µs | unchanged |
| `search_hnsw_loaded100000x128` | n/a | ~690.4 µs | on par with built (within noise) |

Load drops from ~127 ms (allocating 100k `GraphBuilderNode`s + per-node `OrderedNode` adjacency) to ~91 µs (batch slice + tiny upper-level sparse maps), while search on the Arrow-backed graph stays on par with the in-memory build. Numbers are `--quick`/indicative; the ~3-orders-of-magnitude load delta is well outside noise. Re-run a full `cargo bench` before merge for headline figures.

## Tests

All in `rust/lance-index/src/vector/hnsw/builder.rs`:

- `test_loaded_search_parity_and_recall` (rstest: L2 single / L2 pair / L2 2048 / Dot 2048) — built vs loaded parity plus recall ≥ 0.5.
- `test_loaded_level_offsets_misalignment_invariant` — pins the entry-point-written-at-every-level surplus (`batch.num_rows() > sum(level_count)`), the Dense level-0 precondition, and loaded↔built search parity despite the misalignment.
- `test_loaded_empty_index` — 0-row `to_batch` → `load` → empty graph round-trip.
- `test_to_batch_roundtrip_loaded` — the IVF partition-cache path: `to_batch` on a loaded index is byte-stable and reloads/searches identically.
- `test_loaded_graph_is_arrow_backed` — loaded graph is strictly lighter than the built representation.
- Pre-existing `test_builder_write_load` (2048, L2, file round-trip) and `test_builder_write_load_binary_hamming` (256, Hamming) continue to pass unchanged.
