### PR TITLE
fix: decode constant list struct children

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/primitive/constant.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/constant.rs
@@ -124,7 +124,7 @@ impl ConstantPageScheduler {
         let max_rep = def_meaning.iter().filter(|d| d.is_list()).count() as u16;
         let max_visible_def = def_meaning
             .iter()
-            .filter(|d| !d.is_list())
+            .take_while(|d| !d.is_list())
             .map(|d| d.num_def_levels())
             .sum();
 

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -595,7 +595,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use arrow_array::{
-        Array, ArrayRef, Int32Array, ListArray, StructArray,
+        Array, ArrayRef, Float64Array, Int32Array, Int64Array, ListArray, StructArray,
         builder::{Int32Builder, ListBuilder},
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
@@ -838,6 +838,54 @@ mod tests {
                 .with_indices(vec![0])
                 .with_indices(vec![1])
                 .with_min_file_version(LanceFileVersion::V2_1),
+            HashMap::new(),
+        )
+        .await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_list_of_struct_with_constant_child_and_empty_lists() {
+        let item_fields = Fields::from(vec![
+            Field::new("maneuver", DataType::Int64, true),
+            Field::new("remaining_dist", DataType::Float64, true),
+        ]);
+        let item_array = StructArray::new(
+            item_fields.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(3), Some(3), Some(3)])),
+                Arc::new(Float64Array::from(vec![Some(1.0), Some(2.0), Some(3.0)])),
+            ],
+            None,
+        );
+
+        let list_field = Field::new("item", DataType::Struct(item_fields), true);
+        let list_array = ListArray::new(
+            Arc::new(list_field),
+            OffsetBuffer::new(ScalarBuffer::<i32>::from(vec![0, 1, 2, 3, 3, 3, 3])),
+            Arc::new(item_array),
+            None,
+        );
+
+        let data_fields = Fields::from(vec![Field::new(
+            "maneuvers",
+            list_array.data_type().clone(),
+            true,
+        )]);
+        let data_array = StructArray::new(data_fields.clone(), vec![Arc::new(list_array)], None);
+        let row_validity = NullBuffer::from(vec![true, true, true, true, true, false]);
+        let row_array = StructArray::new(
+            Fields::from(vec![Field::new(
+                "data",
+                DataType::Struct(data_fields),
+                true,
+            )]),
+            vec![Arc::new(data_array)],
+            Some(row_validity),
+        );
+
+        check_round_trip_encoding_of_data(
+            vec![Arc::new(row_array)],
+            &TestCases::default().with_min_file_version(LanceFileVersion::V2_1),
             HashMap::new(),
         )
         .await;


### PR DESCRIPTION
Fixes #6776.

When a constant-encoded child appears under `List<Struct<...>>`, empty list rows must not count as visible child values. The constant decoder was summing definition levels across the whole path, including levels after the list boundary, so a constant sibling could materialize parent-row counts while non-constant siblings materialized list-item counts.

This matches the visible-level boundary used by the miniblock and complex all-null decoders, and adds regression coverage for a constant struct child followed by empty lists under a nullable parent struct. Verified with the targeted encoding test and the dataset attached to #6776.
