### PR TITLE
feat(io): make shared-memory:// provider available outside tests

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -544,11 +544,7 @@ impl ObjectStore {
     }
 
     pub fn is_cloud(&self) -> bool {
-        if self.is_local() || self.scheme == "memory" {
-            return false;
-        }
-        #[cfg(test)]
-        if self.scheme == "shared-memory" {
+        if self.is_local() || self.scheme == "memory" || self.scheme == "shared-memory" {
             return false;
         }
         true

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -30,7 +30,6 @@ pub mod local;
 pub mod memory;
 #[cfg(feature = "oss")]
 pub mod oss;
-#[cfg(test)]
 pub mod shared_memory;
 #[cfg(feature = "tencent")]
 pub mod tencent;
@@ -294,7 +293,6 @@ impl Default for ObjectStoreRegistry {
         let mut providers: HashMap<String, Arc<dyn ObjectStoreProvider>> = HashMap::new();
 
         providers.insert("memory".into(), Arc::new(memory::MemoryStoreProvider));
-        #[cfg(test)]
         providers.insert(
             "shared-memory".into(),
             Arc::new(shared_memory::SharedMemoryStoreProvider::default()),

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -744,11 +744,9 @@ pub async fn commit_handler_from_url(
 
     match url.scheme() {
         "file" | "file-object-store" => Ok(local_handler),
-        "s3" | "gs" | "az" | "abfss" | "memory" | "oss" | "cos" => {
+        "s3" | "gs" | "az" | "abfss" | "memory" | "oss" | "cos" | "shared-memory" => {
             Ok(Arc::new(ConditionalPutCommitHandler))
         }
-        #[cfg(test)]
-        "shared-memory" => Ok(Arc::new(ConditionalPutCommitHandler)),
         #[cfg(not(feature = "dynamodb"))]
         "s3+ddb" => Err(Error::invalid_input_source(
             "`s3+ddb://` scheme requires `dynamodb` feature to be enabled".into(),


### PR DESCRIPTION
## Summary

The `shared-memory://` object store provider (added in #6753) was gated behind `#[cfg(test)]`, so it only compiled for this project's own test builds. Downstream crates and integration harnesses depending on `lance-io` could never resolve the scheme — which defeats the purpose of having a shareable, cross-component in-memory store.

This removes the `#[cfg(test)]` gates from the four production sites required for the provider to function:

- **`providers.rs`** — module declaration + registration in `ObjectStoreRegistry::default()`
- **`object_store.rs`** — `is_cloud()` classification (folded into the existing local/`memory` check)
- **`commit.rs`** — commit-handler routing to `ConditionalPutCommitHandler` (folded into the existing cloud-scheme arm)

The provider stays strictly **opt-in**: callers must explicitly use the `shared-memory://` scheme, so existing `memory://` per-call isolation is unchanged. The in-module `#[cfg(test)] mod tests` remains test-only.

## Testing

- `cargo check -p lance-io -p lance-table` — clean
- `cargo clippy -p lance-io -p lance-table --tests -- -D warnings` — clean
- `cargo test -p lance-io shared_memory` — 5/5 pass
- `cargo test -p lance-table test_commit_handler_from_url_memory_schemes` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)