### PR TITLE
refactor(index): use arrow stats for scalar index stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4729,6 +4729,7 @@ dependencies = [
  "jieba-rs",
  "jsonb",
  "lance-arrow",
+ "lance-arrow-stats",
  "lance-core",
  "lance-datafusion",
  "lance-datagen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "58.0.0", optional = false, features = ["prettyprint"] }
 lance-arrow-scalar = { version = "=58.0.0", path = "./rust/arrow-scalar" }
+lance-arrow-stats = { version = "=58.0.0", path = "./rust/arrow-stats" }
 arrow-arith = "58.0.0"
 arrow-array = "58.0.0"
 arrow-buffer = "58.0.0"

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4064,6 +4064,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-arrow-scalar"
+version = "58.0.0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-row",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "lance-arrow-stats"
+version = "58.0.0"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "lance-arrow-scalar",
+]
+
+[[package]]
 name = "lance-bitpacking"
 version = "7.0.0-beta.10"
 dependencies = [
@@ -4272,6 +4294,7 @@ dependencies = [
  "jieba-rs",
  "jsonb",
  "lance-arrow",
+ "lance-arrow-stats",
  "lance-core",
  "lance-datafusion",
  "lance-datagen",

--- a/rust/arrow-scalar/src/lib.rs
+++ b/rust/arrow-scalar/src/lib.rs
@@ -16,6 +16,8 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+use arrow_array::cast::AsArray;
+use arrow_array::types::{Float16Type, Float32Type, Float64Type};
 use arrow_array::{ArrayRef, make_array, new_null_array};
 use arrow_cast::display::ArrayFormatter;
 use arrow_data::transform::MutableArrayData;
@@ -108,6 +110,28 @@ impl ArrowScalar {
     /// Returns `true` if this scalar is null.
     pub fn is_null(&self) -> bool {
         self.array.null_count() == 1
+    }
+
+    /// Returns `true` if this scalar is a non-null floating-point NaN.
+    ///
+    /// ```
+    /// use lance_arrow_scalar::ArrowScalar;
+    ///
+    /// assert!(ArrowScalar::from(f32::NAN).is_nan());
+    /// assert!(!ArrowScalar::from(1.0f32).is_nan());
+    /// assert!(!ArrowScalar::from(1i32).is_nan());
+    /// ```
+    pub fn is_nan(&self) -> bool {
+        if self.is_null() {
+            return false;
+        }
+
+        match self.data_type() {
+            DataType::Float16 => self.array.as_primitive::<Float16Type>().value(0).is_nan(),
+            DataType::Float32 => self.array.as_primitive::<Float32Type>().value(0).is_nan(),
+            DataType::Float64 => self.array.as_primitive::<Float64Type>().value(0).is_nan(),
+            _ => false,
+        }
     }
 }
 
@@ -280,6 +304,23 @@ mod tests {
         #[case] expected: Ordering,
     ) {
         assert_eq!(a.cmp(&b), expected);
+    }
+
+    #[rstest]
+    #[case::float16_nan(ArrowScalar::from(half::f16::NAN), true)]
+    #[case::float32_nan(ArrowScalar::from(f32::NAN), true)]
+    #[case::float64_nan(ArrowScalar::from(f64::NAN), true)]
+    #[case::float64_finite(ArrowScalar::from(1.0f64), false)]
+    #[case::int32(ArrowScalar::from(1i32), false)]
+    fn test_is_nan(#[case] scalar: ArrowScalar, #[case] expected: bool) {
+        assert_eq!(scalar.is_nan(), expected);
+    }
+
+    #[test]
+    fn test_null_is_not_nan() {
+        let array: ArrayRef = Arc::new(Float64Array::from(vec![None]));
+        let scalar = ArrowScalar::try_from_array(array).unwrap();
+        assert!(!scalar.is_nan());
     }
 
     #[test]

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -38,6 +38,7 @@ itertools.workspace = true
 jieba-rs = { workspace = true, optional = true }
 jsonb.workspace = true
 lance-arrow.workspace = true
+lance-arrow-stats.workspace = true
 lance-core.workspace = true
 lance-datafusion.workspace = true
 lance-encoding.workspace = true

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -17,8 +17,7 @@ use std::fmt::Debug;
 use std::pin::Pin;
 use std::{any::Any, ops::Bound, sync::Arc};
 
-use datafusion_expr::Expr;
-use datafusion_expr::expr::ScalarFunction;
+use datafusion_expr::{Expr, expr::ScalarFunction};
 use deepsize::DeepSizeOf;
 use inverted::query::{FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, fill_fts_query_column};
 use lance_core::utils::mask::{NullableRowAddrSet, RowAddrTreeMap, RowSetOps};

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -20,6 +20,7 @@ use arrow_array::{Array, UInt64Array};
 mod as_bytes;
 pub mod sbbf;
 use arrow_schema::{DataType, Field};
+use lance_arrow_stats::StatisticsAccumulator;
 use serde::{Deserialize, Serialize};
 
 use std::sync::LazyLock;
@@ -647,7 +648,7 @@ impl BloomFilterIndexBuilder {
 struct BloomFilterProcessor {
     params: BloomFilterIndexBuilderParams,
     sbbf: Option<Sbbf>,
-    cur_zone_has_null: bool,
+    statistics: Option<StatisticsAccumulator>,
 }
 
 impl BloomFilterProcessor {
@@ -655,7 +656,7 @@ impl BloomFilterProcessor {
         let mut processor = Self {
             params,
             sbbf: None,
-            cur_zone_has_null: false,
+            statistics: None,
         };
         processor.reset()?;
         Ok(processor)
@@ -743,6 +744,11 @@ impl ZoneProcessor for BloomFilterProcessor {
         let sbbf = self.sbbf.as_mut().ok_or_else(|| {
             Error::invalid_input("BloomFilterProcessor did not initialize bloom filter")
         })?;
+
+        let statistics = self
+            .statistics
+            .get_or_insert_with(|| StatisticsAccumulator::new(array.data_type()));
+        statistics.update(array)?;
 
         let has_null = match array.data_type() {
             // Signed integers
@@ -946,7 +952,7 @@ impl ZoneProcessor for BloomFilterProcessor {
         };
 
         // Update the current zone's null tracking
-        self.cur_zone_has_null = self.cur_zone_has_null || has_null;
+        debug_assert_eq!(has_null, array.null_count() > 0);
         Ok(())
     }
 
@@ -954,16 +960,21 @@ impl ZoneProcessor for BloomFilterProcessor {
         let bloom_filter = self.sbbf.as_ref().ok_or_else(|| {
             Error::invalid_input("BloomFilterProcessor did not initialize bloom filter")
         })?;
+        let has_null = self
+            .statistics
+            .as_ref()
+            .map(|statistics| statistics.statistics().null_count > 0)
+            .unwrap_or(false);
         Ok(BloomFilterStatistics {
             bound,
-            has_null: self.cur_zone_has_null,
+            has_null,
             bloom_filter: bloom_filter.clone(),
         })
     }
 
     fn reset(&mut self) -> Result<()> {
         self.sbbf = Some(Self::build_filter(&self.params)?);
-        self.cur_zone_has_null = false;
+        self.statistics = None;
         Ok(())
     }
 }

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -22,13 +22,14 @@ use crate::scalar::{
     BuiltinIndexType, CreatedIndex, SargableQuery, ScalarIndexParams, UpdateCriteria,
     compute_next_prefix,
 };
-use datafusion::functions_aggregate::min_max::{MaxAccumulator, MinAccumulator};
-use datafusion_expr::Accumulator;
+use lance_arrow_stats::StatisticsAccumulator;
 use lance_core::cache::{LanceCache, WeakLanceCache};
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 
-use arrow_array::{ArrayRef, RecordBatch, UInt32Array, UInt64Array, new_empty_array};
+use arrow_array::{
+    ArrayRef, RecordBatch, UInt32Array, UInt64Array, new_empty_array, new_null_array,
+};
 use arrow_schema::{DataType, Field};
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion_common::ScalarValue;
@@ -131,9 +132,45 @@ impl DeepSizeOf for ZoneMapIndex {
 }
 
 impl ZoneMapIndex {
-    /// Evaluates whether a zone could potentially contain values matching the query
-    /// For NaN, total order is used here
-    /// reference: https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp
+    fn scalar_is_nan(value: &ScalarValue) -> bool {
+        match value {
+            ScalarValue::Float16(Some(value)) => value.is_nan(),
+            ScalarValue::Float32(Some(value)) => value.is_nan(),
+            ScalarValue::Float64(Some(value)) => value.is_nan(),
+            _ => false,
+        }
+    }
+
+    /// Returns true if the zone has a non-null, non-NaN min value.
+    fn zone_has_finite_min(zone: &ZoneMapStatistics) -> bool {
+        !(zone.min.is_null() || Self::scalar_is_nan(&zone.min))
+    }
+
+    /// Returns true if both min and max are non-null / non-NaN.
+    fn zone_has_finite_extrema(zone: &ZoneMapStatistics) -> bool {
+        Self::zone_has_finite_min(zone) && !(zone.max.is_null() || Self::scalar_is_nan(&zone.max))
+    }
+
+    fn finite_value_may_be_in_zone(value: &ScalarValue, zone: &ZoneMapStatistics) -> bool {
+        if !Self::zone_has_finite_min(zone) || value < &zone.min {
+            return false;
+        }
+
+        if Self::scalar_is_nan(&zone.max) {
+            // A NaN max means this zone had both NaNs and finite values.  The
+            // finite max is not persisted, so keep the zone as a false positive
+            // instead of using total ordering to prune it.
+            return true;
+        }
+
+        !zone.max.is_null() && value <= &zone.max
+    }
+
+    /// Evaluates whether a zone could potentially contain values matching the query.
+    ///
+    /// NaN query values use the explicit `nan_count`.  When the stored max is
+    /// NaN we do not treat it as a finite upper bound; that representation means
+    /// the zone had finite values plus NaNs, and the finite max was not persisted.
     fn evaluate_zone_against_query(
         &self,
         zone: &ZoneMapStatistics,
@@ -165,20 +202,19 @@ impl ZoneMapIndex {
                     return Ok(zone.nan_count > 0);
                 }
 
-                // Check if target is within the zone's range
-                // Handle the case where zone.max is NaN (zone contains both finite values and NaN)
-                let min_check = target >= &zone.min;
-                let max_check = match &zone.max {
-                    ScalarValue::Float16(Some(f)) if f.is_nan() => true,
-                    ScalarValue::Float32(Some(f)) if f.is_nan() => true,
-                    ScalarValue::Float64(Some(f)) if f.is_nan() => true,
-                    _ => target <= &zone.max,
-                };
-                Ok(min_check && max_check)
+                if !Self::zone_has_finite_min(zone) {
+                    return Ok(false);
+                }
+
+                Ok(Self::finite_value_may_be_in_zone(target, zone))
             }
             SargableQuery::Range(start, end) => {
                 // Zone overlaps with query range if there's any intersection between
                 // the zone's [min, max] and the query's range
+                if !Self::zone_has_finite_min(zone) {
+                    return Ok(false);
+                }
+
                 let zone_min = &zone.min;
                 let zone_max = &zone.max;
 
@@ -301,24 +337,28 @@ impl ZoneMapIndex {
                                 if f.is_nan() {
                                     zone.nan_count > 0
                                 } else {
-                                    value >= &zone.min && value <= &zone.max
+                                    Self::finite_value_may_be_in_zone(value, zone)
                                 }
                             }
                             ScalarValue::Float32(Some(f)) => {
                                 if f.is_nan() {
                                     zone.nan_count > 0
                                 } else {
-                                    value >= &zone.min && value <= &zone.max
+                                    Self::finite_value_may_be_in_zone(value, zone)
                                 }
                             }
                             ScalarValue::Float64(Some(f)) => {
                                 if f.is_nan() {
                                     zone.nan_count > 0
                                 } else {
-                                    value >= &zone.min && value <= &zone.max
+                                    Self::finite_value_may_be_in_zone(value, zone)
                                 }
                             }
-                            _ => value >= &zone.min && value <= &zone.max,
+                            _ => {
+                                Self::zone_has_finite_extrema(zone)
+                                    && value >= &zone.min
+                                    && value <= &zone.max
+                            }
                         }
                     }
                 }))
@@ -754,50 +794,59 @@ impl ZoneMapIndexBuilder {
 /// trainer takes care of chunking and fragment boundaries.
 struct ZoneMapProcessor {
     data_type: DataType,
-    min: MinAccumulator,
-    max: MaxAccumulator,
-    null_count: u32,
-    nan_count: u32,
+    statistics: StatisticsAccumulator,
 }
 
 impl ZoneMapProcessor {
     fn new(data_type: DataType) -> Result<Self> {
-        let min = MinAccumulator::try_new(&data_type)?;
-        let max = MaxAccumulator::try_new(&data_type)?;
         Ok(Self {
+            statistics: StatisticsAccumulator::new(&data_type),
             data_type,
-            min,
-            max,
-            null_count: 0,
-            nan_count: 0,
         })
     }
 
-    fn count_nans(array: &ArrayRef) -> u32 {
-        match array.data_type() {
-            DataType::Float16 => {
-                let array = array
-                    .as_any()
-                    .downcast_ref::<arrow_array::Float16Array>()
-                    .unwrap();
-                array.values().iter().filter(|&&x| x.is_nan()).count() as u32
-            }
-            DataType::Float32 => {
-                let array = array
-                    .as_any()
-                    .downcast_ref::<arrow_array::Float32Array>()
-                    .unwrap();
-                array.values().iter().filter(|&&x| x.is_nan()).count() as u32
-            }
-            DataType::Float64 => {
-                let array = array
-                    .as_any()
-                    .downcast_ref::<arrow_array::Float64Array>()
-                    .unwrap();
-                array.values().iter().filter(|&&x| x.is_nan()).count() as u32
-            }
-            _ => 0,
+    fn scalar_value_from_stat(
+        value: Option<&ArrayRef>,
+        data_type: &DataType,
+    ) -> Result<ScalarValue> {
+        let array = value
+            .cloned()
+            .unwrap_or_else(|| new_null_array(data_type, 1));
+        Ok(ScalarValue::try_from_array(&array, 0)?)
+    }
+
+    fn stat_count_to_u32(name: &str, value: u64) -> Result<u32> {
+        u32::try_from(value).map_err(|_| {
+            Error::invalid_input(format!(
+                "{} value {} exceeds the supported UInt32 range",
+                name, value
+            ))
+        })
+    }
+
+    fn nan_scalar(data_type: &DataType) -> Option<ScalarValue> {
+        match data_type {
+            DataType::Float16 => Some(ScalarValue::Float16(Some(half::f16::NAN))),
+            DataType::Float32 => Some(ScalarValue::Float32(Some(f32::NAN))),
+            DataType::Float64 => Some(ScalarValue::Float64(Some(f64::NAN))),
+            _ => None,
         }
+    }
+
+    fn max_value_from_stats(
+        value: Option<&ArrayRef>,
+        data_type: &DataType,
+        nan_count: u32,
+    ) -> Result<ScalarValue> {
+        if nan_count > 0
+            && let Some(nan) = Self::nan_scalar(data_type)
+        {
+            // DataFusion's max accumulator surfaced NaN as the zone max.  Keep
+            // that stored zonemap shape while using arrow_stats so existing
+            // range/equality pruning remains conservative around NaN.
+            return Ok(nan);
+        }
+        Self::scalar_value_from_stat(value, data_type)
     }
 }
 
@@ -805,28 +854,31 @@ impl ZoneProcessor for ZoneMapProcessor {
     type ZoneStatistics = ZoneMapStatistics;
 
     fn process_chunk(&mut self, array: &ArrayRef) -> Result<()> {
-        self.null_count += array.null_count() as u32;
-        self.nan_count += Self::count_nans(array);
-        self.min.update_batch(std::slice::from_ref(array))?;
-        self.max.update_batch(std::slice::from_ref(array))?;
+        self.statistics.update(array)?;
         Ok(())
     }
 
     fn finish_zone(&mut self, bound: ZoneBound) -> Result<Self::ZoneStatistics> {
+        let statistics = self.statistics.statistics();
+        let nan_count = Self::stat_count_to_u32("nan_count", statistics.nan_count.unwrap_or(0))?;
         Ok(ZoneMapStatistics {
-            min: self.min.evaluate()?,
-            max: self.max.evaluate()?,
-            null_count: self.null_count,
-            nan_count: self.nan_count,
+            min: Self::scalar_value_from_stat(
+                statistics.min.as_ref().map(|scalar| scalar.as_array()),
+                &self.data_type,
+            )?,
+            max: Self::max_value_from_stats(
+                statistics.max.as_ref().map(|scalar| scalar.as_array()),
+                &self.data_type,
+                nan_count,
+            )?,
+            null_count: Self::stat_count_to_u32("null_count", statistics.null_count)?,
+            nan_count,
             bound,
         })
     }
 
     fn reset(&mut self) -> Result<()> {
-        self.min = MinAccumulator::try_new(&self.data_type)?;
-        self.max = MaxAccumulator::try_new(&self.data_type)?;
-        self.null_count = 0;
-        self.nan_count = 0;
+        self.statistics.reset();
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Replace zonemap DataFusion min/max accumulators with `lance_arrow_stats::StatisticsAccumulator`.
- Use `arrow_stats` to track bloom filter zone null counts.
- Keep scalar-index NaN handling local to Lance instead of importing DataFusion math UDFs.
- Add `lance-arrow-stats` to the `lance-index` dependency graph and update the Python lockfile.

## Testing
- All tests pass.