### PR TITLE
chore(python): update pyproject, docs, and cleanup makefile

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install maturin duckdb requests pytest pytest-benchmark datasets
-          maturin develop --locked --release --features datagen
+          pip install maturin==1.13.3 uv duckdb requests pytest pytest-benchmark datasets
+          maturin develop --uv --locked --release --features datagen
       - name: Build memtest
         run: |
           source venv/bin/activate

--- a/.github/workflows/codex-backport-pr.yml
+++ b/.github/workflows/codex-backport-pr.yml
@@ -142,7 +142,7 @@ jobs:
           10. Run ONLY the tests related to the changes in these PRs:
               - Use "git diff --name-only ${RELEASE_BRANCH}...HEAD" to see all files changed across all cherry-picked commits.
               - For Rust changes: Run tests for the affected crates only (e.g., "cargo test -p lance-core" if lance-core files changed).
-              - For Python changes (python/** files): Build with "cd python && maturin develop" then run "pytest" on the specific test files that were modified, or related test files.
+              - For Python changes (python/** files): Build with "cd python && make build" then run "uv run pytest" on the specific test files that were modified, or related test files.
               - For Java changes (java/** files): Run "cd java && mvn test" for the affected modules.
               - If test files themselves were modified, run those specific tests.
               - Do NOT run the full test suite - only run tests related to the changed files.

--- a/.github/workflows/codex-fix-ci.yml
+++ b/.github/workflows/codex-fix-ci.yml
@@ -144,7 +144,7 @@ jobs:
              - Run "cargo clippy --workspace --tests --benches -- -D warnings" to check for issues
              - Run ONLY the specific failing tests to confirm they pass now:
                - For Rust test failures: Run the specific test with "cargo test -p <crate> <test_name>"
-               - For Python test failures: Build with "cd python && maturin develop" then run "pytest <specific_test_file>::<test_name>"
+               - For Python test failures: Build with "cd python && make build" then run "uv run pytest <specific_test_file>::<test_name>"
                - For Java test failures: Run "cd java && mvn test -Dtest=<TestClass>#<testMethod>"
                - Do NOT run the full test suite - only run the tests that were failing
 

--- a/.github/workflows/file_verification.yml
+++ b/.github/workflows/file_verification.yml
@@ -51,8 +51,8 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install pyarrow maturin
-          maturin develop --release
+          pip install pyarrow maturin==1.13.3 uv
+          maturin develop --uv --release
 
       - name: Test Lance File Write Read Round Trip
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -87,8 +87,8 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install torch tqdm --index-url https://download.pytorch.org/whl/cpu
-          pip install maturin
-          maturin develop --profile ci --locked --extras tests,ray
+          pip install maturin==1.13.3 uv
+          maturin develop --uv --profile ci --locked --extras tests,ray
       - name: Run doctest
         run: |
           source venv/bin/activate

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -5,13 +5,15 @@ Also see [root AGENTS.md](../AGENTS.md) for cross-language standards.
 ## Commands
 
 * Environment: use `uv` for all local Python environment setup in this repository.
-* First step in every new worktree or fresh checkout: run `uv sync --extra tests --extra dev` from `python/` before any Python command. Add other extras such as `benchmarks`, `torch`, or `geo` only when needed.
+* First step in every new worktree or fresh checkout: run `make install` from `python/` before any Python command. This runs `uv sync` (dev and test dependencies are included by default via `[tool.uv] default-groups`) and sets up pre-commit hooks. Add `--group benchmarks`, `--extra torch`, or `--extra geo` only when needed.
 * `uv sync` builds the local `pylance` Rust extension as part of environment setup. This can take a long time. Start it early, let it finish, and do not interrupt it or switch to a different setup path just because the build is slow.
+* After the initial `make install`, use `uv run make test` to run tests.
+* Only run `uv sync` again when dependencies change (e.g., after pulling new commits that update `pyproject.toml` or `uv.lock`).
 * Command execution: always use `uv run ...` for Python-related repository commands. Do not rely on a globally activated environment.
 * Never invoke bare `python`, `pytest`, `pip`, `maturin`, `make test`, `make doctest`, `make lint`, or `make format` for repository work.
 * If a Python command fails outside `uv run`, that does not count as a dependency or test failure. Fix the environment usage first and rerun correctly.
-* Build time expectations: `uv sync` and `uv run maturin develop` build the local `pylance` Rust extension as part of the environment workflow. This can be slow, especially on the first run or after Rust dependency changes; treat that as expected and do not switch to a different environment manager or shortcut around the build just because it takes time.
-* Build: `uv run maturin develop` (required after Rust changes)
+* Build time expectations: `make install` and `make build` build the local `pylance` Rust extension as part of the environment workflow. This can be slow, especially on the first run or after Rust dependency changes; treat that as expected and do not switch to a different environment manager or shortcut around the build just because it takes time.
+* Build: `make build` (required after Rust changes)
 * Test: `uv run make test`
 * Run single test: `uv run pytest python/tests/<test_file>.py::<test_name>`
 * Doctest: `uv run make doctest`
@@ -34,4 +36,4 @@ Also see [root AGENTS.md](../AGENTS.md) for cross-language standards.
 ## Common Failure Mode
 
 - A missing module or missing command error from bare `python`, `pytest`, `pip`, `maturin`, or `make` is usually an environment usage mistake, not a repository issue.
-- Before reporting a Python dependency as unavailable, verify that `uv sync --extra tests --extra dev` has been run in the current worktree and that the failing command was executed with `uv run ...`.
+- Before reporting a Python dependency as unavailable, verify that `uv sync` has been run in the current worktree and that the failing command was executed with `uv run ...`.

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -10,14 +10,14 @@ The python integration is done via pyo3 + custom python code:
 To build the Python bindings, first install requirements:
 
 ```bash
-pip install maturin
+cd python
+make install
 ```
 
 To make a dev install:
 
 ```bash
-cd python
-maturin develop
+make build
 ```
 
 After installing, you can run `import lance` in a Python shell within the virtual environment.

--- a/python/DEVELOPMENT.md
+++ b/python/DEVELOPMENT.md
@@ -3,10 +3,10 @@
 For local development, prefer [uv](https://docs.astral.sh/uv/) to create and manage the Python environment:
 
 ```shell
-uv sync --extra tests --extra dev
+uv sync
 ```
 
-Add extras such as `benchmarks`, `torch`, or `geo` only when you need them. After the environment is initialized, either activate it or use `uv run ...` for commands.
+Add `--group benchmarks` for benchmarks, or `--extra torch` / `--extra geo` for those optional features. After the environment is initialized, either activate it or use `uv run ...` for commands.
 
 `uv sync` is not just downloading Python packages here. It also builds the local `pylance` Rust extension as part of the editable environment, so the first run, cache misses, or Rust dependency changes can make it noticeably slow. This is expected; let the build finish instead of interrupting it and switching to a different environment setup.
 
@@ -104,7 +104,7 @@ benchmarks added there should run in less than 5 seconds.
 Before running benchmarks, you should build pylance in release mode:
 
 ```shell
-uv sync --extra tests --extra dev --extra benchmarks
+uv sync --group benchmarks
 uv run maturin develop --profile release-with-debug --extras benchmarks --features datagen
 ```
 
@@ -172,12 +172,12 @@ the benchmarks again with `--benchmark-compare`.
 ```shell
 CURRENT_BRANCH=$(git branch --show-current)
 git checkout main
-uv sync --extra tests --extra dev --extra benchmarks
+uv sync --group benchmarks
 uv run maturin develop --profile release-with-debug --features datagen
 uv run pytest --benchmark-save=baseline python/benchmarks -m "not slow"
 COMPARE_ID=$(ls .benchmarks/*/ | tail -1 | cut -c1-4)
 git checkout $CURRENT_BRANCH
-uv sync --extra tests --extra dev --extra benchmarks
+uv sync --group benchmarks
 uv run maturin develop --profile release-with-debug --features datagen
 uv run pytest --benchmark-compare=$COMPARE_ID python/benchmarks -m "not slow"
 ```

--- a/python/DEVELOPMENT.md
+++ b/python/DEVELOPMENT.md
@@ -17,7 +17,7 @@ This project is built with [maturin](https://github.com/PyO3/maturin).
 It can be built in development mode with:
 
 ```shell
-uv run maturin develop
+uv run maturin develop --uv
 ```
 
 This builds the Rust native module in place. You will need to re-run this
@@ -105,7 +105,7 @@ Before running benchmarks, you should build pylance in release mode:
 
 ```shell
 uv sync --group benchmarks
-uv run maturin develop --profile release-with-debug --extras benchmarks --features datagen
+uv run maturin develop --uv --profile release-with-debug --extras benchmarks --features datagen
 ```
 
 (You can also use `--release` or `--profile release`, but `--profile release-with-debug`
@@ -173,12 +173,12 @@ the benchmarks again with `--benchmark-compare`.
 CURRENT_BRANCH=$(git branch --show-current)
 git checkout main
 uv sync --group benchmarks
-uv run maturin develop --profile release-with-debug --features datagen
+uv run maturin develop --uv --profile release-with-debug --features datagen
 uv run pytest --benchmark-save=baseline python/benchmarks -m "not slow"
 COMPARE_ID=$(ls .benchmarks/*/ | tail -1 | cut -c1-4)
 git checkout $CURRENT_BRANCH
 uv sync --group benchmarks
-uv run maturin develop --profile release-with-debug --features datagen
+uv run maturin develop --uv --profile release-with-debug --features datagen
 uv run pytest --benchmark-compare=$COMPARE_ID python/benchmarks -m "not slow"
 ```
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -30,7 +30,7 @@ install: ## Sync dependencies and set up local development tools
 	uv tool run pre-commit install
 
 build: ## Build the local Rust extension with maturin
-	$(UV_RUN) maturin develop
+	$(UV_RUN) maturin develop --uv
 
 test: ## Run Python tests except recurring tests
 	pytest $(PYTEST_ARGS) python/tests

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,53 +1,74 @@
-ifeq ($(CI), true)
-    PYTEST_ARGS = -vvv -s --durations=30 -m "not recurring"
-else
-    PYTEST_ARGS = -vvv -s -m "not recurring"
+.DEFAULT_GOAL := help
+.PHONY: help install build test integtest doctest compattest format format-python lint lint-python lint-rust clean
+PYTHON ?=
+PYTEST_ARGS ?= -vvv -s -m "not recurring"
+KEEP_COMPOSE ?= 0
+COMPOSE_FILE ?= ../docker-compose.yml
+UV_SYNC = uv sync
+UV_RUN = uv run --frozen
+
+# Set PYTHON=3.12 to use a specific Python version with uv.
+ifneq ($(strip $(PYTHON)),)
+  UV_PYTHON_ARG = --python $(PYTHON)
+  UV_SYNC += $(UV_PYTHON_ARG)
+  UV_RUN += $(UV_PYTHON_ARG)
 endif
 
-test:
+ifeq ($(CI), true)
+  PYTEST_ARGS += --durations=30
+endif
+
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+install: ## Sync dependencies and set up local development tools
+	@if ! command -v uv > /dev/null 2>&1; then \
+		echo "uv not found. Install it from https://docs.astral.sh/uv/getting-started/installation/"; \
+		exit 1; \
+	fi
+	$(UV_SYNC)
+	uv tool run pre-commit install
+
+build: ## Build the local Rust extension with maturin
+	$(UV_RUN) maturin develop
+
+test: ## Run Python tests except recurring tests
 	pytest $(PYTEST_ARGS) python/tests
-.PHONY: test
 
-integtest:
-	pytest --run-integration $(PYTEST_ARGS) python/tests/test_s3_ddb.py python/tests/test_namespace_integration.py
-.PHONY: integtest
+integtest: ## Start LocalStack and run integration tests
+	@if [ "$(KEEP_COMPOSE)" = "1" ]; then \
+		docker compose -f $(COMPOSE_FILE) up -d --wait && \
+		pytest --run-integration $(PYTEST_ARGS) python/tests/test_s3_ddb.py python/tests/test_namespace_integration.py; \
+	else \
+		trap 'docker compose -f $(COMPOSE_FILE) down -v --remove-orphans --timeout 0 >/dev/null 2>&1 || true' EXIT; \
+		docker compose -f $(COMPOSE_FILE) up -d --wait && \
+		pytest --run-integration $(PYTEST_ARGS) python/tests/test_s3_ddb.py python/tests/test_namespace_integration.py; \
+	fi
 
-doctest:
+doctest: ## Run Python doctests
 	pytest --doctest-modules $(PYTEST_ARGS) python/lance
-.PHONY: doctest
 
-compattest:
-	pytest --run-compat $(PYTEST_ARGS)  python/tests/compat
-.PHONY: compattest
+compattest: ## Run upgrade/downgrade compatibility tests
+	pytest --run-compat $(PYTEST_ARGS) python/tests/compat
 
-format: format-python
+format: format-python ## Auto-format Python and Rust
 	cargo fmt
-.PHONY: format
 
-build:
-	maturin develop
-.PHONY: build
-
-format-python:
+format-python: ## Auto-format Python (ruff)
 	ruff format python
 	ruff check --fix python
-.PHONY: format-python
 
-lint: lint-python lint-rust
-.PHONY: lint
+lint: lint-python lint-rust ## Check Python and Rust formatting/lints
 
-lint-python:
+lint-python: ## Check Python formatting, linting, and types
 	ruff format --check --diff python
 	ruff check python
 	pyright
-.PHONY: lint-python
 
-lint-rust:
+lint-rust: ## Check Rust formatting and clippy lints
 	cargo fmt -- --check
 	cargo clippy -- -D warnings
-.PHONY: lint-rust
 
-clean:
+clean: ## Remove build artifacts
 	cargo clean
 	rm -rf target
-.PHONY: clean

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -87,6 +87,7 @@ tests = [
     "datafusion==53.0.0; python_version >= '3.10'",
 ]
 dev = [
+    "maturin==1.13.3",
     "pyright==1.1.406",
     "ruff==0.11.2",
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -71,6 +71,32 @@ geo = [
     "geoarrow-rust-io",
 ]
 
+[dependency-groups]
+tests = [
+    "boto3==1.40.43",
+    "datasets==4.1.1; python_version >= '3.10'",
+    "duckdb==1.4.0",
+    "ml_dtypes==0.5.3",
+    "pillow==11.3.0",
+    "pandas==2.3.3",
+    "polars[pyarrow,pandas]==1.34.0",
+    "psutil==7.1.0",
+    "pytest==8.4.2",
+    "tensorflow==2.20.0; sys_platform == 'linux' and python_version >= '3.10'",
+    "tqdm==4.67.1",
+    "datafusion==53.0.0; python_version >= '3.10'",
+]
+dev = [
+    "pyright==1.1.406",
+    "ruff==0.11.2",
+]
+benchmarks = [
+    "pytest-benchmark==5.1.0",
+]
+
+[tool.uv]
+default-groups = ["dev", "tests"]
+
 [tool.ruff]
 lint.select = ["F", "E", "W", "I", "G", "TCH", "PERF", "B019"]
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1242,6 +1242,30 @@ wheels = [
 ]
 
 [[package]]
+name = "maturin"
+version = "1.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/1c/612d23d33ec21b9ae7ece7b3f0dd5f9dfd57b4009e9d2938165869ebd6ae/maturin-1.13.3.tar.gz", hash = "sha256:771e1e9e71a278e56db01552e0d1acfd1464259f9575b6e72842f893cd299079", size = 357934, upload-time = "2026-05-11T07:43:39.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/66/18c2aaac0b2a5dea9f1db5984ce83b905ad205cfc7c02d0091e707c0c2e7/maturin-1.13.3-py3-none-linux_armv6l.whl", hash = "sha256:3cc13929ca82aefa4adbf0f2c35419369796213c6fb0eb24e914945f50ef5d8c", size = 10190971, upload-time = "2026-05-11T07:43:10.431Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/71/26a988d092e4fd6a9523d46d44400a46cad7cdf3fd206ce702240c748aee/maturin-1.13.3-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:53b08bd075649ce96513ad9abf241a43cb685ed6e9e7790f8dbc2d66e95d8323", size = 19716714, upload-time = "2026-05-11T07:43:36.911Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5c/f3fd0e184255d9fc7e272c62af3dfa84c617b2577ef83af9ce615f5279cc/maturin-1.13.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4cd478e6e4c56251e48ed079b8efd55b30bc5c09cf695a1bdafaeb582ee735a0", size = 10194726, upload-time = "2026-05-11T07:43:07.05Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e1/f4edb69fb647b77c4769a9bfd4d6fb62961e653d164bc277ecdffac3ab61/maturin-1.13.3-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:a2675e25f313034ae6f57388cf14818f87d8961c4a96795287f3e155f59beb11", size = 10172781, upload-time = "2026-05-11T07:43:40.796Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/a1be934690cdcc3c6609769ceaad322ab7501c2ee5bafcac1b14d609e403/maturin-1.13.3-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:4667ef609ab446c1b5e0bfe4f9fb99699ab6d8548433f8d1a684256e0b67217f", size = 10682670, upload-time = "2026-05-11T07:43:13.132Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f5/372ae19b72ce8f6e37e5864ae4dc5b252ee9fce0619ccc3aa366aa3a7f97/maturin-1.13.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:3db93337ed97e60ffc878aa8b493cd7ae44d3a5e1a37256db3a4491f57565018", size = 10060363, upload-time = "2026-05-11T07:43:21.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5b/c68340cca09368af0df80965dfabed4234205a492a93da00793c7b9aae20/maturin-1.13.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:1cc0a110b224ca90406b668a3e3c1f5a515062e59e26292f6dbaf5fd4909c6f3", size = 10017551, upload-time = "2026-05-11T07:43:33.916Z" },
+    { url = "https://files.pythonhosted.org/packages/28/1e/f90fb2b000bad9e6d850cd5afb88b2f1e2a279cfb4de02ea40078484690e/maturin-1.13.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:c00ea6428dea17bf616fe93770837634454b28c2de1a876e42ef8036c616079a", size = 13301712, upload-time = "2026-05-11T07:43:26.492Z" },
+    { url = "https://files.pythonhosted.org/packages/be/58/1670f68a8f04ccd7b90df11047bd9a046585310e84e1967cc9849cd1c5a3/maturin-1.13.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:49fd6ab08da28098ccf37afca24cdba72376ba9c1eedf9dd25ff82ed771961ff", size = 10946765, upload-time = "2026-05-11T07:43:16.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ac/00c955c2ef134817b1a7bdaa76b0309e9c5291eb17d9ff88069eecd08bc2/maturin-1.13.3-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:b6741d7bf4af97da937528fd1e523c6ab54f53d9a21870fa735d6e67fd88e273", size = 10388661, upload-time = "2026-05-11T07:43:18.727Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c6/cbf8a51dde19c19aeba0d9b075095a2effb9b31fd312b1aae3ac79f8aea2/maturin-1.13.3-py3-none-win32.whl", hash = "sha256:0ef257e692cc756c87af5bea95ddfe7d3ac49d3376a7a87f728d63f06e7b6f8b", size = 8901838, upload-time = "2026-05-11T07:43:23.76Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ff/c6a50a59dc8313097d43ac5f4d74df6a500c8cb62b0dc9e054f53e203a48/maturin-1.13.3-py3-none-win_amd64.whl", hash = "sha256:def4a435ea9d2ee93b18ba579dc8c9cf898889a66f312cd379b5e374ec3e3ad6", size = 10340801, upload-time = "2026-05-11T07:43:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/93/e32e79333f0902ba292b996f504f5f06be59587f7d02ab8d5ed1e3066445/maturin-1.13.3-py3-none-win_arm64.whl", hash = "sha256:2389fe92d017cea9d94e521fa0175314a4c52f79a1057b901fbc9f8686ef7d0b", size = 9706562, upload-time = "2026-05-11T07:43:31.743Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2625,6 +2649,7 @@ benchmarks = [
     { name = "pytest-benchmark" },
 ]
 dev = [
+    { name = "maturin" },
     { name = "pyright" },
     { name = "ruff" },
 ]
@@ -2672,6 +2697,7 @@ provides-extras = ["benchmarks", "dev", "geo", "tests", "torch"]
 [package.metadata.requires-dev]
 benchmarks = [{ name = "pytest-benchmark", specifier = "==5.1.0" }]
 dev = [
+    { name = "maturin", specifier = "==1.13.3" },
     { name = "pyright", specifier = "==1.1.406" },
     { name = "ruff", specifier = "==0.11.2" },
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1083,19 +1083,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.7.4"
+version = "0.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/5c/0d26122b2c8e6f16d4e008347bcc7b25bca9c45aa838395af37b7d2604f0/lance_namespace-0.7.4.tar.gz", hash = "sha256:f47014b4f00a18716333a0734295936904e0431098a52d3a6757028617d6795c", size = 10685, upload-time = "2026-05-05T00:11:07.437Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/da/134670003173881bed44af656badffd91e0b2e0232c083eeacc5923d7335/lance_namespace-0.7.6.tar.gz", hash = "sha256:4e12094005d105ef1b44346c9d7feda4a0f733b127dab90c1a5ffbf7cd433770", size = 10686, upload-time = "2026-05-05T18:26:38.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/90/8b0bddd186652b2b4916f1041652ff752f9fd564887fe863090b499bbe34/lance_namespace-0.7.4-py3-none-any.whl", hash = "sha256:332d495cb821bd3d89ad70368a9ca5e39e3cc7633ba0e7ce0320981f6472471c", size = 12519, upload-time = "2026-05-05T00:11:03.648Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/44463a5f41f7077b2ea641f2afded72eaceb6a6a1b4a55c11b22318fed74/lance_namespace-0.7.6-py3-none-any.whl", hash = "sha256:c94a1b8a6aab127e55a20cbf44d927ae3a9b7d435656d2130dccf84ccf7c9999", size = 12519, upload-time = "2026-05-05T18:26:36.425Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.7.4"
+version = "0.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1104,9 +1104,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/84/62b46e237e6419e60dd614a95496938e696f0c6b98f720b71791ea066070/lance_namespace_urllib3_client-0.7.4.tar.gz", hash = "sha256:061dd30b3a7a2df2cf7c07fdd900d84d12c6779db3d54e5e3d99f0d82d867102", size = 194604, upload-time = "2026-05-05T00:11:04.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/44/024aae184c08b3800482cd9b832d534249e25de145af732d4e4c8dff38a8/lance_namespace_urllib3_client-0.7.6.tar.gz", hash = "sha256:15ae7f0d8d56fa34d837f7f6ec5c80a327a905e89ccfed05f7b409d6fe704cdf", size = 195551, upload-time = "2026-05-05T18:26:37.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/76/f0770e585e440a70844a4e4328e249c1335981d470599b697c02afa18950/lance_namespace_urllib3_client-0.7.4-py3-none-any.whl", hash = "sha256:7784a00a2a78140f2ce70b2a3dac4ee071f7d87d9bb2f76ebb25b482be37a5a1", size = 323540, upload-time = "2026-05-05T00:11:06.45Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/60c983cc8180772c82370dfad2104b7e788aaacc3bf9a84e8b42bb1ae6a7/lance_namespace_urllib3_client-0.7.6-py3-none-any.whl", hash = "sha256:fb884d8afff8af3aae04a3270624694a189d7ea79225dd349e6c555a1a1d6b52", size = 324603, upload-time = "2026-05-05T18:26:39.718Z" },
 ]
 
 [[package]]
@@ -2620,6 +2620,29 @@ torch = [
     { name = "torch" },
 ]
 
+[package.dev-dependencies]
+benchmarks = [
+    { name = "pytest-benchmark" },
+]
+dev = [
+    { name = "pyright" },
+    { name = "ruff" },
+]
+tests = [
+    { name = "boto3" },
+    { name = "datafusion", marker = "python_full_version >= '3.10'" },
+    { name = "datasets", version = "4.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "duckdb" },
+    { name = "ml-dtypes" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "polars", extra = ["pandas", "pyarrow"] },
+    { name = "psutil" },
+    { name = "pytest" },
+    { name = "tensorflow", version = "2.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform == 'linux'" },
+    { name = "tqdm" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "boto3", marker = "extra == 'tests'" },
@@ -2628,7 +2651,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'tests'" },
     { name = "geoarrow-rust-core", marker = "extra == 'geo'" },
     { name = "geoarrow-rust-io", marker = "extra == 'geo'" },
-    { name = "lance-namespace", specifier = ">=0.7.4,<0.8" },
+    { name = "lance-namespace", specifier = ">=0.7.5,<0.8" },
     { name = "ml-dtypes", marker = "extra == 'tests'" },
     { name = "numpy", specifier = ">=1.22" },
     { name = "pandas", marker = "extra == 'tests'" },
@@ -2645,6 +2668,27 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'tests'" },
 ]
 provides-extras = ["benchmarks", "dev", "geo", "tests", "torch"]
+
+[package.metadata.requires-dev]
+benchmarks = [{ name = "pytest-benchmark", specifier = "==5.1.0" }]
+dev = [
+    { name = "pyright", specifier = "==1.1.406" },
+    { name = "ruff", specifier = "==0.11.2" },
+]
+tests = [
+    { name = "boto3", specifier = "==1.40.43" },
+    { name = "datafusion", marker = "python_full_version >= '3.10'", specifier = "==53.0.0" },
+    { name = "datasets", marker = "python_full_version >= '3.10'", specifier = "==4.1.1" },
+    { name = "duckdb", specifier = "==1.4.0" },
+    { name = "ml-dtypes", specifier = "==0.5.3" },
+    { name = "pandas", specifier = "==2.3.3" },
+    { name = "pillow", specifier = "==11.3.0" },
+    { name = "polars", extras = ["pyarrow", "pandas"], specifier = "==1.34.0" },
+    { name = "psutil", specifier = "==7.1.0" },
+    { name = "pytest", specifier = "==8.4.2" },
+    { name = "tensorflow", marker = "python_full_version >= '3.10' and sys_platform == 'linux'", specifier = "==2.20.0" },
+    { name = "tqdm", specifier = "==4.67.1" },
+]
 
 [[package]]
 name = "pyproj"


### PR DESCRIPTION
While working in the python bindings directory I kept hitting some issues while developing, so I cleaned up a few things that I was able to figure out.

The main problem was uv sync kept re-resolving the lockfile since our optional deps had unpinned packages, even if I was just running the tests. Fixed that by pinning the dev dependencies but ultimately can revert if im lacking context as to why they weren't pinned before. But now `uv sync` is stable out the box.

While I was in there I also, did an overhaul of the `MakeFile` so that install was just one command, leveraged a bit more uv there, and added help to document everything. Also, updated the docs that referenced the old logic to use new changes. Although there are a few more places that need this. i.e. direct `maturin` references. 

After this PR:

```
cd python && make install # once
uv run make test  # every day
make build  # after Rust changes
uv sync # after pulling commits with dep changes
```