### PR TITLE
fix(encoding): use LargeList internally for Utf8/Binary to prevent offset overflow

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -837,15 +837,16 @@ impl CoreFieldDecoderStrategy {
                         array_encoding: Some(pb::array_encoding::ArrayEncoding::List(..))
                     }
                 ) {
-                    let list_type = if matches!(data_type, DataType::Utf8 | DataType::Binary) {
-                        DataType::List(Arc::new(ArrowField::new("item", DataType::UInt8, false)))
-                    } else {
-                        DataType::LargeList(Arc::new(ArrowField::new(
-                            "item",
-                            DataType::UInt8,
-                            false,
-                        )))
-                    };
+                    // Always use LargeList (i64 offsets) internally to avoid
+                    // "Offset overflow" errors when a single batch exceeds 2GB
+                    // of variable-length data.  The BinaryArrayDecoder will
+                    // downcast back to i32 offsets when the target type is
+                    // Utf8 / Binary and the data fits.
+                    let list_type = DataType::LargeList(Arc::new(ArrowField::new(
+                        "item",
+                        DataType::UInt8,
+                        false,
+                    )));
                     let list_field = Field::try_from(ArrowField::new(
                         field.name.clone(),
                         list_type,

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -171,7 +171,7 @@ impl BinaryArrayDecoder {
     }
 
     /// Convert a LargeList (i64 offsets) array to a small-offset byte array (Utf8 / Binary).
-    /// Falls back to LargeUtf8 / LargeBinary if the data exceeds the i32 offset limit.
+    /// Returns an error if the data exceeds the i32 offset limit.
     fn from_large_list_to_small<T: ByteArrayType<Offset = i32>>(
         array: &GenericListArray<i64>,
     ) -> Result<ArrayRef> {
@@ -260,6 +260,8 @@ mod tests {
     use arrow_array::builder::PrimitiveBuilder;
     use arrow_array::cast::AsArray;
     use arrow_array::types::UInt8Type;
+    use arrow_buffer::Buffer;
+    use arrow_data::ArrayData;
 
     #[test]
     fn test_from_large_list_to_small() {
@@ -292,24 +294,33 @@ mod tests {
     fn test_from_large_list_to_small_overflow() {
         // We can manually craft an array with a fake offset that exceeds i32::MAX
         // to test the 2GB limit check without allocating 2GB of memory.
-        let values = arrow_buffer::ScalarBuffer::from(vec![0u8; 1]);
-
         // Create offsets that exceed i32::MAX
-        let offsets = arrow_buffer::OffsetBuffer::new(arrow_buffer::ScalarBuffer::from(vec![
-            0_i64,
-            (i32::MAX as i64) + 10,
-        ]));
+        let offsets = Buffer::from_slice_ref([0_i64, (i32::MAX as i64) + 10]);
 
         // Field for LargeList
         let field = Arc::new(arrow_schema::Field::new("item", DataType::UInt8, true));
 
-        // Build the GenericListArray directly
-        let large_list_array = GenericListArray::<i64>::new(
-            field,
-            offsets,
-            Arc::new(arrow_array::UInt8Array::new(values, None)),
-            None,
-        );
+        // SAFETY: The deliberately oversized offset is invalid for the one-byte child array.
+        // This lets the test exercise BinaryArrayDecoder's overflow guard without allocating
+        // more than 2 GiB of child values.
+        let values_data = unsafe {
+            ArrayData::builder(DataType::UInt8)
+                .len(1)
+                .add_buffer(Buffer::from_slice_ref([0_u8]))
+                .build_unchecked()
+        };
+
+        // SAFETY: This intentionally constructs an invalid LargeList array with offsets beyond
+        // the child value length so the helper can reject the i64-to-i32 downcast before building
+        // a Binary / Utf8 array.
+        let list_data = unsafe {
+            ArrayData::builder(DataType::LargeList(field))
+                .len(1)
+                .add_buffer(offsets)
+                .add_child_data(values_data)
+                .build_unchecked()
+        };
+        let large_list_array = GenericListArray::<i64>::from(list_data);
 
         let result = BinaryArrayDecoder::from_large_list_to_small::<Utf8Type>(&large_list_array);
 

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -214,7 +214,13 @@ impl DecodeArrayTask for BinaryArrayDecoder {
         let result = match data_type {
             DataType::Binary => {
                 // Internal representation is always LargeList (i64 offsets) now
-                if arr.data_type() == &DataType::LargeList(Arc::new(arrow_schema::Field::new("item", DataType::UInt8, false))) {
+                if arr.data_type()
+                    == &DataType::LargeList(Arc::new(arrow_schema::Field::new(
+                        "item",
+                        DataType::UInt8,
+                        false,
+                    )))
+                {
                     Self::from_large_list_to_small::<BinaryType>(arr.as_list::<i64>())?
                 } else {
                     Self::from_list_array::<BinaryType>(arr.as_list::<i32>())
@@ -222,7 +228,13 @@ impl DecodeArrayTask for BinaryArrayDecoder {
             }
             DataType::LargeBinary => Self::from_list_array::<LargeBinaryType>(arr.as_list::<i64>()),
             DataType::Utf8 => {
-                if arr.data_type() == &DataType::LargeList(Arc::new(arrow_schema::Field::new("item", DataType::UInt8, false))) {
+                if arr.data_type()
+                    == &DataType::LargeList(Arc::new(arrow_schema::Field::new(
+                        "item",
+                        DataType::UInt8,
+                        false,
+                    )))
+                {
                     Self::from_large_list_to_small::<Utf8Type>(arr.as_list::<i64>())?
                 } else {
                     Self::from_list_array::<Utf8Type>(arr.as_list::<i32>())
@@ -266,8 +278,8 @@ mod tests {
         let large_list_array = builder.finish();
 
         // Convert to small StringArray
-        let result = BinaryArrayDecoder::from_large_list_to_small::<Utf8Type>(&large_list_array)
-            .unwrap();
+        let result =
+            BinaryArrayDecoder::from_large_list_to_small::<Utf8Type>(&large_list_array).unwrap();
 
         assert_eq!(result.data_type(), &DataType::Utf8);
         let string_array = result.as_string::<i32>();
@@ -283,9 +295,10 @@ mod tests {
         let values = arrow_buffer::ScalarBuffer::from(vec![0u8; 1]);
 
         // Create offsets that exceed i32::MAX
-        let offsets = arrow_buffer::OffsetBuffer::new(
-            arrow_buffer::ScalarBuffer::from(vec![0_i64, (i32::MAX as i64) + 10])
-        );
+        let offsets = arrow_buffer::OffsetBuffer::new(arrow_buffer::ScalarBuffer::from(vec![
+            0_i64,
+            (i32::MAX as i64) + 10,
+        ]));
 
         // Field for LargeList
         let field = Arc::new(arrow_schema::Field::new("item", DataType::UInt8, true));

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -232,7 +232,7 @@ impl DecodeArrayTask for BinaryArrayDecoder {
             _ => {
                 return Err(lance_core::Error::internal(
                     "Binary decoder does not support this data type",
-                ))
+                ));
             }
         };
         // data_size is only tracked in the v2.1 structural decode path; the legacy
@@ -266,7 +266,8 @@ mod tests {
         let large_list_array = builder.finish();
 
         // Convert to small StringArray
-        let result = BinaryArrayDecoder::from_large_list_to_small::<Utf8Type>(&large_list_array).unwrap();
+        let result = BinaryArrayDecoder::from_large_list_to_small::<Utf8Type>(&large_list_array)
+            .unwrap();
 
         assert_eq!(result.data_type(), &DataType::Utf8);
         let string_array = result.as_string::<i32>();

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -229,9 +229,11 @@ impl DecodeArrayTask for BinaryArrayDecoder {
                 }
             }
             DataType::LargeUtf8 => Self::from_list_array::<LargeUtf8Type>(arr.as_list::<i64>()),
-            _ => return Err(lance_core::Error::internal(
-                "Binary decoder does not support this data type",
-            )),
+            _ => {
+                return Err(lance_core::Error::internal(
+                    "Binary decoder does not support this data type",
+                ))
+            }
         };
         // data_size is only tracked in the v2.1 structural decode path; the legacy
         // v2.0 path does not need it so we return 0.

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -240,3 +240,71 @@ impl DecodeArrayTask for BinaryArrayDecoder {
         Ok((result, 0))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::builder::LargeListBuilder;
+    use arrow_array::builder::PrimitiveBuilder;
+    use arrow_array::cast::AsArray;
+    use arrow_array::types::UInt8Type;
+
+    #[test]
+    fn test_from_large_list_to_small() {
+        // Create a small LargeList array (i64 offsets) to test downcasting
+        let values_builder = PrimitiveBuilder::<UInt8Type>::new();
+        let mut builder = LargeListBuilder::new(values_builder);
+
+        // Add "hello"
+        builder.values().append_slice(b"hello");
+        builder.append(true);
+
+        // Add "world"
+        builder.values().append_slice(b"world");
+        builder.append(true);
+
+        let large_list_array = builder.finish();
+
+        // Convert to small StringArray
+        let result = BinaryArrayDecoder::from_large_list_to_small::<Utf8Type>(&large_list_array).unwrap();
+
+        assert_eq!(result.data_type(), &DataType::Utf8);
+        let string_array = result.as_string::<i32>();
+        assert_eq!(string_array.len(), 2);
+        assert_eq!(string_array.value(0), "hello");
+        assert_eq!(string_array.value(1), "world");
+    }
+
+    #[test]
+    fn test_from_large_list_to_small_overflow() {
+        // We can manually craft an array with a fake offset that exceeds i32::MAX
+        // to test the 2GB limit check without allocating 2GB of memory.
+        let values = arrow_buffer::ScalarBuffer::from(vec![0u8; 1]);
+
+        // Create offsets that exceed i32::MAX
+        let offsets = arrow_buffer::OffsetBuffer::new(
+            arrow_buffer::ScalarBuffer::from(vec![0_i64, (i32::MAX as i64) + 10])
+        );
+
+        // Field for LargeList
+        let field = Arc::new(arrow_schema::Field::new("item", DataType::UInt8, true));
+
+        // Build the GenericListArray directly
+        let large_list_array = GenericListArray::<i64>::new(
+            field,
+            offsets,
+            Arc::new(arrow_array::UInt8Array::new(values, None)),
+            None,
+        );
+
+        let result = BinaryArrayDecoder::from_large_list_to_small::<Utf8Type>(&large_list_array);
+
+        assert!(result.is_err());
+        match result {
+            Err(lance_core::Error::InvalidInput { message, .. }) => {
+                assert!(message.contains("exceeded 2 GiB"));
+            }
+            _ => panic!("Expected InvalidInput error"),
+        }
+    }
+}

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use arrow_array::{
-    Array, ArrayRef, GenericByteArray, GenericListArray,
+    Array, ArrayRef, GenericByteArray, GenericListArray, OffsetSizeTrait,
     cast::AsArray,
     types::{BinaryType, ByteArrayType, LargeBinaryType, LargeUtf8Type, UInt8Type, Utf8Type},
 };
@@ -152,7 +152,10 @@ pub struct BinaryArrayDecoder {
 }
 
 impl BinaryArrayDecoder {
-    fn from_list_array<T: ByteArrayType>(array: &GenericListArray<T::Offset>) -> ArrayRef {
+    fn from_list_array<T: ByteArrayType>(array: &GenericListArray<T::Offset>) -> ArrayRef
+    where
+        T::Offset: OffsetSizeTrait,
+    {
         let values = array
             .values()
             .as_primitive::<UInt8Type>()
@@ -166,6 +169,42 @@ impl BinaryArrayDecoder {
             array.nulls().cloned(),
         ))
     }
+
+    /// Convert a LargeList (i64 offsets) array to a small-offset byte array (Utf8 / Binary).
+    /// Falls back to LargeUtf8 / LargeBinary if the data exceeds the i32 offset limit.
+    fn from_large_list_to_small<T: ByteArrayType<Offset = i32>>(
+        array: &GenericListArray<i64>,
+    ) -> ArrayRef {
+        let values = array
+            .values()
+            .as_primitive::<UInt8Type>()
+            .values()
+            .inner()
+            .clone();
+        let large_offsets = array.offsets();
+
+        // Check if the offsets fit in i32
+        let last_offset = large_offsets[large_offsets.len() - 1];
+        if last_offset <= i32::MAX as i64 {
+            // Safe to downcast to i32 offsets
+            let small: Vec<i32> = large_offsets.iter().map(|&o| o as i32).collect();
+            let offsets = arrow_buffer::OffsetBuffer::new(arrow_buffer::ScalarBuffer::from(small));
+            Arc::new(GenericByteArray::<T>::new(
+                offsets,
+                values,
+                array.nulls().cloned(),
+            ))
+        } else {
+            // Data exceeds 2GB -- cannot fit in i32 offsets.
+            // This should not happen in practice because the batch-size feedback
+            // loop limits batch sizes, but if it does we return a clear error.
+            panic!(
+                "A single batch of variable-length data exceeded 2 GiB ({} bytes). \
+                 Use LargeUtf8 / LargeBinary in your schema, or reduce the batch size.",
+                last_offset
+            );
+        }
+    }
 }
 
 impl DecodeArrayTask for BinaryArrayDecoder {
@@ -173,9 +212,22 @@ impl DecodeArrayTask for BinaryArrayDecoder {
         let data_type = self.data_type;
         let (arr, _) = self.inner.decode()?;
         let result = match data_type {
-            DataType::Binary => Self::from_list_array::<BinaryType>(arr.as_list::<i32>()),
+            DataType::Binary => {
+                // Internal representation is always LargeList (i64 offsets) now
+                if arr.data_type() == &DataType::LargeList(Arc::new(arrow_schema::Field::new("item", DataType::UInt8, false))) {
+                    Self::from_large_list_to_small::<BinaryType>(arr.as_list::<i64>())
+                } else {
+                    Self::from_list_array::<BinaryType>(arr.as_list::<i32>())
+                }
+            }
             DataType::LargeBinary => Self::from_list_array::<LargeBinaryType>(arr.as_list::<i64>()),
-            DataType::Utf8 => Self::from_list_array::<Utf8Type>(arr.as_list::<i32>()),
+            DataType::Utf8 => {
+                if arr.data_type() == &DataType::LargeList(Arc::new(arrow_schema::Field::new("item", DataType::UInt8, false))) {
+                    Self::from_large_list_to_small::<Utf8Type>(arr.as_list::<i64>())
+                } else {
+                    Self::from_list_array::<Utf8Type>(arr.as_list::<i32>())
+                }
+            }
             DataType::LargeUtf8 => Self::from_list_array::<LargeUtf8Type>(arr.as_list::<i64>()),
             _ => panic!("Binary decoder does not support this data type"),
         };

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -300,11 +300,8 @@ mod tests {
         let result = BinaryArrayDecoder::from_large_list_to_small::<Utf8Type>(&large_list_array);
 
         assert!(result.is_err());
-        match result {
-            Err(lance_core::Error::InvalidInput { message, .. }) => {
-                assert!(message.contains("exceeded 2 GiB"));
-            }
-            _ => panic!("Expected InvalidInput error"),
-        }
+        let err = result.unwrap_err();
+        assert!(matches!(err, lance_core::Error::InvalidInput { .. }));
+        assert!(err.to_string().contains("exceeded 2 GiB"));
     }
 }

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -198,15 +198,11 @@ impl BinaryArrayDecoder {
             // Data exceeds 2GB -- cannot fit in i32 offsets.
             // This should not happen in practice because the batch-size feedback
             // loop limits batch sizes, but if it does we return a clear error.
-            Err(lance_core::Error::InvalidInput {
-                source: format!(
-                    "A single batch of variable-length data exceeded 2 GiB ({} bytes). \
-                     Use LargeUtf8 / LargeBinary in your schema, or reduce the batch size.",
-                    last_offset
-                )
-                .into(),
-                location: lance_core::location!(),
-            })
+            Err(lance_core::Error::invalid_input(format!(
+                "A single batch of variable-length data exceeded 2 GiB ({} bytes). \
+                 Use LargeUtf8 / LargeBinary in your schema, or reduce the batch size.",
+                last_offset
+            )))
         }
     }
 }
@@ -235,7 +231,7 @@ impl DecodeArrayTask for BinaryArrayDecoder {
             DataType::LargeUtf8 => Self::from_list_array::<LargeUtf8Type>(arr.as_list::<i64>()),
             _ => return Err(lance_core::Error::Internal {
                 message: "Binary decoder does not support this data type".to_string(),
-                location: lance_core::location!(),
+                location: snafu::location!(),
             }),
         };
         // data_size is only tracked in the v2.1 structural decode path; the legacy

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -229,10 +229,9 @@ impl DecodeArrayTask for BinaryArrayDecoder {
                 }
             }
             DataType::LargeUtf8 => Self::from_list_array::<LargeUtf8Type>(arr.as_list::<i64>()),
-            _ => return Err(lance_core::Error::Internal {
-                message: "Binary decoder does not support this data type".to_string(),
-                location: snafu::location!(),
-            }),
+            _ => return Err(lance_core::Error::internal(
+                "Binary decoder does not support this data type",
+            )),
         };
         // data_size is only tracked in the v2.1 structural decode path; the legacy
         // v2.0 path does not need it so we return 0.

--- a/rust/lance-encoding/src/previous/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/binary.rs
@@ -174,7 +174,7 @@ impl BinaryArrayDecoder {
     /// Falls back to LargeUtf8 / LargeBinary if the data exceeds the i32 offset limit.
     fn from_large_list_to_small<T: ByteArrayType<Offset = i32>>(
         array: &GenericListArray<i64>,
-    ) -> ArrayRef {
+    ) -> Result<ArrayRef> {
         let values = array
             .values()
             .as_primitive::<UInt8Type>()
@@ -189,20 +189,24 @@ impl BinaryArrayDecoder {
             // Safe to downcast to i32 offsets
             let small: Vec<i32> = large_offsets.iter().map(|&o| o as i32).collect();
             let offsets = arrow_buffer::OffsetBuffer::new(arrow_buffer::ScalarBuffer::from(small));
-            Arc::new(GenericByteArray::<T>::new(
+            Ok(Arc::new(GenericByteArray::<T>::new(
                 offsets,
                 values,
                 array.nulls().cloned(),
-            ))
+            )))
         } else {
             // Data exceeds 2GB -- cannot fit in i32 offsets.
             // This should not happen in practice because the batch-size feedback
             // loop limits batch sizes, but if it does we return a clear error.
-            panic!(
-                "A single batch of variable-length data exceeded 2 GiB ({} bytes). \
-                 Use LargeUtf8 / LargeBinary in your schema, or reduce the batch size.",
-                last_offset
-            );
+            Err(lance_core::Error::InvalidInput {
+                source: format!(
+                    "A single batch of variable-length data exceeded 2 GiB ({} bytes). \
+                     Use LargeUtf8 / LargeBinary in your schema, or reduce the batch size.",
+                    last_offset
+                )
+                .into(),
+                location: lance_core::location!(),
+            })
         }
     }
 }
@@ -215,7 +219,7 @@ impl DecodeArrayTask for BinaryArrayDecoder {
             DataType::Binary => {
                 // Internal representation is always LargeList (i64 offsets) now
                 if arr.data_type() == &DataType::LargeList(Arc::new(arrow_schema::Field::new("item", DataType::UInt8, false))) {
-                    Self::from_large_list_to_small::<BinaryType>(arr.as_list::<i64>())
+                    Self::from_large_list_to_small::<BinaryType>(arr.as_list::<i64>())?
                 } else {
                     Self::from_list_array::<BinaryType>(arr.as_list::<i32>())
                 }
@@ -223,13 +227,16 @@ impl DecodeArrayTask for BinaryArrayDecoder {
             DataType::LargeBinary => Self::from_list_array::<LargeBinaryType>(arr.as_list::<i64>()),
             DataType::Utf8 => {
                 if arr.data_type() == &DataType::LargeList(Arc::new(arrow_schema::Field::new("item", DataType::UInt8, false))) {
-                    Self::from_large_list_to_small::<Utf8Type>(arr.as_list::<i64>())
+                    Self::from_large_list_to_small::<Utf8Type>(arr.as_list::<i64>())?
                 } else {
                     Self::from_list_array::<Utf8Type>(arr.as_list::<i32>())
                 }
             }
             DataType::LargeUtf8 => Self::from_list_array::<LargeUtf8Type>(arr.as_list::<i64>()),
-            _ => panic!("Binary decoder does not support this data type"),
+            _ => return Err(lance_core::Error::Internal {
+                message: "Binary decoder does not support this data type".to_string(),
+                location: lance_core::location!(),
+            }),
         };
         // data_size is only tracked in the v2.1 structural decode path; the legacy
         // v2.0 path does not need it so we return 0.


### PR DESCRIPTION
## Summary
When reading large fragments containing variable-length data (like strings or binary), PyArrow's 32-bit (2 GiB) offset limit can be easily exceeded, resulting in a cryptic `Offset overflow error: 2151740513` panic.

This updates the decoder to always use `LargeList<UInt8>` (i64 offsets) internally. When targeting `Utf8` or `Binary` arrays, `BinaryArrayDecoder` will safely downcast to i32 offsets if the chunk data fits within 2 GiB. If the chunk strictly exceeds 2 GiB, it now panics with a descriptive error suggesting a batch size reduction or switching to LargeUtf8/LargeBinary.

Fixes #2775.

🤖 Generated with [MAI Agents](https://github.com/infinity-microsoft/mai-agents)