### PR TITLE
refactor: rename ShardSpec to ShardingSpec

### DIFF
--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -32,7 +32,7 @@ If two shards contain rows with the same primary key, the following scenario can
 5. The row from Shard A (older) now overwrites the row from Shard B (newer)
 
 This violates the expected "last write wins" semantics.
-By ensuring each primary key is assigned to exactly one shard via the shard spec,
+By ensuring each primary key is assigned to exactly one shard via the sharding spec,
 merge order between shards becomes irrelevant for correctness.
 
 See [MemWAL Shard Architecture](#shard-architecture) for the complete shard architecture.
@@ -42,7 +42,7 @@ See [MemWAL Shard Architecture](#shard-architecture) for the complete shard arch
 A **MemWAL Index** is the centralized structure for all MemWAL metadata on top of a base table.
 A table has at most one MemWAL index. It stores:
 
-- **Configuration**: Shard specs defining how rows map to shards, and which indexes to maintain
+- **Configuration**: Sharding specs defining how rows map to shards, and which indexes to maintain
 - **Merge progress**: Last generation merged to base table for each shard
 - **Index catchup progress**: Which merged generation each base table index has been rebuilt to cover
 - **Shard snapshots**: Point-in-time snapshot of shard states for read optimization
@@ -174,7 +174,7 @@ Each shard has a manifest file. This is the source of truth for the state of a s
 The manifest contains:
 
 - **Fencing state**: `writer_epoch` as the latest writer fencing token, see [Writer Fencing](#writer-fencing) for more details.
-- **Shard assignment**: `shard_spec_id` and `shard_field_values` record how this shard maps to its shard spec. `shard_field_values` is a map from shard field id to the raw Arrow scalar bytes of the computed value; the matching `ShardField.result_type` in the `ShardSpec` determines how to interpret each entry (e.g., 4 little-endian bytes for int32, raw UTF-8 bytes for utf8).
+- **Shard assignment**: `shard_spec_id` and `shard_field_values` record how this shard maps to its sharding spec. `shard_field_values` is a map from shard field id to the raw Arrow scalar bytes of the computed value; the matching `ShardingField.result_type` in the `ShardingSpec` determines how to interpret each entry (e.g., 4 little-endian bytes for int32, raw UTF-8 bytes for utf8).
 - **WAL pointers**: `replay_after_wal_entry_position` (last entry position flushed to MemTable, 0-based), `wal_entry_position_last_seen` (last entry position seen at manifest update, 0-based)
 - **Generation trackers**: `current_generation` (next generation to flush), `flushed_generations` list of generation number and directory path pairs (e.g., generation 1 at `a1b2c3d4_gen_1`)
 
@@ -236,7 +236,7 @@ The index stores its data in two parts:
 
 The `index_details` field in `IndexMetadata` contains a `MemWalIndexDetails` protobuf message with the following key fields:
 
-- **Configuration fields** (`shard_specs`, `maintained_indexes`) are the source of truth for MemWAL configuration.
+- **Configuration fields** (`sharding_specs`, `maintained_indexes`) are the source of truth for MemWAL configuration.
   Writers read these fields to determine how to partition data and which indexes to maintain.
 - **Merge progress** (`merged_generations`) tracks the last generation merged to the base table for each shard.
   This field is updated atomically with merge-insert data commits, enabling conflict resolution when multiple mergers operate concurrently.
@@ -270,27 +270,27 @@ writer fencing is required.
 The MemWAL index can store shard snapshots for read optimization, but those snapshots may lag the latest shard set.
 Implementations that need to discover the current shard set should list `_mem_wal/` shard directories and read each shard's latest [shard manifest](#shard-manifest).
 
-Each shard manifest records the shard UUID, shard spec ID, and computed shard field values needed to map the shard back to a shard spec assignment.
+Each shard manifest records the shard UUID, sharding spec ID, and computed shard field values needed to map the shard back to a sharding spec assignment.
 
-### Shard Spec
+### Sharding Spec
 
-A **Shard Spec** defines how all rows in a table are logically divided into different shards,
+A **Sharding Spec** defines how all rows in a table are logically divided into different shards,
 enabling automatic shard assignment and query-time shard pruning.
 
-Each shard spec has:
+Each sharding spec has:
 
 - **Spec ID**: A positive integer that uniquely identifies this spec within the MemWAL index. IDs are never reused.
-- **Shard fields**: An array of field definitions that determine how to compute shard values.
+- **Sharding fields**: An array of field definitions that determine how to compute shard values.
 
-Each shard is bound to a specific shard spec ID, recorded in its [manifest](#shard-manifest).
+Each shard is bound to a specific sharding spec ID, recorded in its [manifest](#shard-manifest).
 Shards without a spec ID (`spec_id = 0`) are manually-created shards not governed by any spec.
 
-A shard spec's field array consists of **shard field** definitions.
-Each shard field has the following properties:
+A sharding spec's field array consists of **sharding field** definitions.
+Each sharding field has the following properties:
 
 | Property      | Description                                                               |
 | ------------- | ------------------------------------------------------------------------- |
-| `field_id`    | Unique string identifier for this shard field                            |
+| `field_id`    | Unique string identifier for this sharding field                         |
 | `source_ids`  | Array of field IDs referencing source columns in the schema               |
 | `transform`   | A well-known shard expression, specify this or `expression`              |
 | `expression`  | A DataFusion SQL expression for custom logic, specify this or `transform` |
@@ -359,17 +359,17 @@ remains in the authoritative shard manifest files.
 | Column                   | Type          | Description                                                                                                |
 | ------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------- |
 | `shard_id`               | `utf8`        | Shard UUID string                                                                                          |
-| `shard_spec_id`          | `uint32`      | Shard spec ID (0 if manual)                                                                                |
-| `shard_field_{field_id}` | varies        | One column per shard field defined in the shard spec, typed to match the field's `ShardField.result_type`. |
+| `shard_spec_id`          | `uint32`      | Sharding spec ID (0 if manual)                                                                             |
+| `shard_field_{field_id}` | varies        | One column per sharding field defined in the sharding spec, typed to match the field's `ShardingField.result_type`. |
 
-For example, with a shard spec containing a field `user_bucket` of type `int32`:
+For example, with a sharding spec containing a field `user_bucket` of type `int32`:
 
 | Column                     | Type    | Description                  |
 | -------------------------- | ------- | ---------------------------- |
 | ...                        | ...     | (base columns above)         |
 | `shard_field_user_bucket`  | `int32` | Bucket value for this shard |
 
-This schema records the fields needed to map each shard back to its shard spec
+This schema records the fields needed to map each shard back to its sharding spec
 assignment. Readers that need fencing epochs, WAL positions, or flushed
 generation state must read the latest shard manifests directly.
 
@@ -532,17 +532,17 @@ The planner also collects bloom filters from each generation for staleness detec
 
 #### Shard Pruning
 
-Before executing queries, if shard spec is available,
-the planner evaluates filter predicates against shard specs to determine which shards may contain matching data.
+Before executing queries, if sharding spec is available,
+the planner evaluates filter predicates against sharding specs to determine which shards may contain matching data.
 This pruning step reduces the number of shards to scan.
 
 For each filter predicate:
 
-1. Extract predicates on columns used in shard specs
+1. Extract predicates on columns used in sharding specs
 2. Evaluate which shard values can satisfy the predicate
 3. Prune shards whose values cannot match
 
-For example, with a shard spec using `bucket(user_id, 10)` and a filter `user_id = 123`:
+For example, with a sharding spec using `bucket(user_id, 10)` and a filter `user_id = 123`:
 
 1. Compute `bucket(123, 10) = 3`
 2. Only scan shards with bucket value 3

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -540,7 +540,7 @@ message ShardManifest {
   // Computed shard field values as raw Arrow scalar bytes, keyed by shard
   // field id. The byte encoding follows Arrow's little-endian convention:
   // int32 is 4 LE bytes, utf8 is raw UTF-8 bytes, etc. The receiver looks
-  // up the result_type from the ShardSpec to interpret each value.
+  // up the result_type from the ShardingSpec to interpret each value.
   repeated ShardFieldEntry shard_field_entries = 14;
 
   // Writer fencing token - monotonically increasing.
@@ -571,11 +571,11 @@ message ShardManifest {
 
 // A shard field value stored as raw Arrow scalar bytes.
 message ShardFieldEntry {
-  // Shard field id (matches ShardField.field_id in the ShardSpec).
+  // Shard field id (matches ShardingField.field_id in the ShardingSpec).
   string field_id = 1;
 
   // Raw Arrow scalar value bytes in little-endian encoding.
-  // The data type is determined by the result_type of the matching ShardField.
+  // The data type is determined by the result_type of the matching ShardingField.
   bytes value = 2;
 }
 
@@ -611,7 +611,7 @@ message IndexCatchupProgress {
 
 // Index details for MemWAL Index, stored in IndexMetadata.index_details.
 // This is the centralized structure for all MemWAL metadata:
-// - Configuration (shard specs, indexes to maintain)
+// - Configuration (sharding specs, indexes to maintain)
 // - Merge progress (merged generations per shard)
 // - Shard state snapshots
 //
@@ -626,7 +626,7 @@ message IndexCatchupProgress {
 // authoritative in the shard manifest files.
 //   shard_id: utf8
 //   shard_spec_id: uint32
-//   shard_field_{field_id}: typed per the matching ShardField.result_type
+//   shard_field_{field_id}: typed per the matching ShardingField.result_type
 message MemWalIndexDetails {
   // Snapshot timestamp (Unix timestamp in milliseconds).
   int64 snapshot_ts_millis = 1;
@@ -641,9 +641,9 @@ message MemWalIndexDetails {
   // Format: Lance file bytes with the shard snapshot schema.
   optional bytes inline_snapshots = 3;
 
-  // Shard specs defining how to derive shard identifiers.
+  // Sharding specs defining how to derive shard identifiers.
   // This configuration determines how rows are partitioned into shards.
-  repeated ShardSpec shard_specs = 7;
+  repeated ShardingSpec sharding_specs = 7;
 
   // Indexes from the base table to maintain in MemTables.
   // These are index names referencing indexes defined on the base table.
@@ -675,18 +675,18 @@ message MemWalIndexDetails {
   repeated IndexCatchupProgress index_catchup = 10;
 }
 
-// Shard spec definition.
-message ShardSpec {
+// Sharding spec definition.
+message ShardingSpec {
   // Unique identifier for this spec within the index.
   // IDs are never reused.
   uint32 spec_id = 1;
 
-  // Shard field definitions that determine how to compute shard identifiers.
-  repeated ShardField fields = 2;
+  // Sharding field definitions that determine how to compute shard identifiers.
+  repeated ShardingField fields = 2;
 }
 
-// Shard field definition.
-message ShardField {
+// Sharding field definition.
+message ShardingField {
   // Unique string identifier for this shard field.
   string field_id = 1;
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3160,7 +3160,7 @@ impl Dataset {
         region_spec: Option<Bound<'_, PyAny>>,
     ) -> PyResult<()> {
         use lance::dataset::mem_wal::DatasetMemWalExt;
-        use lance_index::mem_wal::{ShardField as RegionField, ShardSpec as RegionSpec};
+        use lance_index::mem_wal::{ShardingField as RegionField, ShardingSpec as RegionSpec};
         use std::collections::HashMap;
 
         let region_spec_rust = if let Some(spec) = region_spec {
@@ -3187,7 +3187,7 @@ impl Dataset {
         };
 
         let config = lance::dataset::mem_wal::MemWalConfig {
-            shard_spec: region_spec_rust,
+            sharding_spec: region_spec_rust,
             maintained_indexes: maintained_indexes.unwrap_or_default(),
         };
         let mut ds = Arc::clone(&self.ds);

--- a/rust/lance-index/src/mem_wal.rs
+++ b/rust/lance-index/src/mem_wal.rs
@@ -156,7 +156,7 @@ pub struct ShardManifest {
     /// Computed shard field values as raw Arrow scalar bytes, keyed by field id.
     /// The byte encoding follows Arrow's little-endian convention: int32 is 4 LE
     /// bytes, utf8 is raw UTF-8 bytes, etc. The result_type in the corresponding
-    /// ShardField from the ShardSpec determines how to interpret each value.
+    /// ShardingField from the ShardingSpec determines how to interpret each value.
     pub shard_field_values: HashMap<String, Vec<u8>>,
     pub writer_epoch: u64,
     /// The most recent WAL entry position flushed to a MemTable.
@@ -235,9 +235,9 @@ impl TryFrom<pb::ShardManifest> for ShardManifest {
     }
 }
 
-/// Shard field definition.
+/// Sharding field definition.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
-pub struct ShardField {
+pub struct ShardingField {
     pub field_id: String,
     pub source_ids: Vec<i32>,
     pub transform: Option<String>,
@@ -246,8 +246,8 @@ pub struct ShardField {
     pub parameters: HashMap<String, String>,
 }
 
-impl From<&ShardField> for pb::ShardField {
-    fn from(rf: &ShardField) -> Self {
+impl From<&ShardingField> for pb::ShardingField {
+    fn from(rf: &ShardingField) -> Self {
         Self {
             field_id: rf.field_id.clone(),
             source_ids: rf.source_ids.clone(),
@@ -259,8 +259,8 @@ impl From<&ShardField> for pb::ShardField {
     }
 }
 
-impl From<pb::ShardField> for ShardField {
-    fn from(rf: pb::ShardField) -> Self {
+impl From<pb::ShardingField> for ShardingField {
+    fn from(rf: pb::ShardingField) -> Self {
         Self {
             field_id: rf.field_id,
             source_ids: rf.source_ids,
@@ -272,15 +272,15 @@ impl From<pb::ShardField> for ShardField {
     }
 }
 
-/// Shard spec definition.
+/// Sharding spec definition.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
-pub struct ShardSpec {
+pub struct ShardingSpec {
     pub spec_id: u32,
-    pub fields: Vec<ShardField>,
+    pub fields: Vec<ShardingField>,
 }
 
-impl From<&ShardSpec> for pb::ShardSpec {
-    fn from(rs: &ShardSpec) -> Self {
+impl From<&ShardingSpec> for pb::ShardingSpec {
+    fn from(rs: &ShardingSpec) -> Self {
         Self {
             spec_id: rs.spec_id,
             fields: rs.fields.iter().map(|f| f.into()).collect(),
@@ -288,11 +288,11 @@ impl From<&ShardSpec> for pb::ShardSpec {
     }
 }
 
-impl From<pb::ShardSpec> for ShardSpec {
-    fn from(rs: pb::ShardSpec) -> Self {
+impl From<pb::ShardingSpec> for ShardingSpec {
+    fn from(rs: pb::ShardingSpec) -> Self {
         Self {
             spec_id: rs.spec_id,
-            fields: rs.fields.into_iter().map(ShardField::from).collect(),
+            fields: rs.fields.into_iter().map(ShardingField::from).collect(),
         }
     }
 }
@@ -303,7 +303,7 @@ pub struct MemWalIndexDetails {
     pub snapshot_ts_millis: i64,
     pub num_shards: u32,
     pub inline_snapshots: Option<Vec<u8>>,
-    pub shard_specs: Vec<ShardSpec>,
+    pub sharding_specs: Vec<ShardingSpec>,
     pub maintained_indexes: Vec<String>,
     pub merged_generations: Vec<MergedGeneration>,
     pub index_catchup: Vec<IndexCatchupProgress>,
@@ -315,7 +315,7 @@ impl From<&MemWalIndexDetails> for pb::MemWalIndexDetails {
             snapshot_ts_millis: details.snapshot_ts_millis,
             num_shards: details.num_shards,
             inline_snapshots: details.inline_snapshots.clone(),
-            shard_specs: details.shard_specs.iter().map(|rs| rs.into()).collect(),
+            sharding_specs: details.sharding_specs.iter().map(|rs| rs.into()).collect(),
             maintained_indexes: details.maintained_indexes.clone(),
             merged_generations: details
                 .merged_generations
@@ -335,10 +335,10 @@ impl TryFrom<pb::MemWalIndexDetails> for MemWalIndexDetails {
             snapshot_ts_millis: details.snapshot_ts_millis,
             num_shards: details.num_shards,
             inline_snapshots: details.inline_snapshots,
-            shard_specs: details
-                .shard_specs
+            sharding_specs: details
+                .sharding_specs
                 .into_iter()
-                .map(ShardSpec::from)
+                .map(ShardingSpec::from)
                 .collect(),
             maintained_indexes: details.maintained_indexes,
             merged_generations: details
@@ -424,7 +424,7 @@ impl Index for MemWalIndex {
         let stats = MemWalStatistics {
             num_shards: self.details.num_shards,
             num_merged_generations: self.details.merged_generations.len(),
-            num_shard_specs: self.details.shard_specs.len(),
+            num_shard_specs: self.details.sharding_specs.len(),
             num_maintained_indexes: self.details.maintained_indexes.len(),
             num_index_catchup_entries: self.details.index_catchup.len(),
         };

--- a/rust/lance/benches/mem_wal_index_micro.rs
+++ b/rust/lance/benches/mem_wal_index_micro.rs
@@ -188,7 +188,7 @@ async fn main() -> lance_core::Result<()> {
     let mut dataset = build_base_dataset(&uri, dim).await?;
     dataset
         .initialize_mem_wal(MemWalConfig {
-            shard_spec: None,
+            sharding_spec: None,
             maintained_indexes: vec![VECTOR_INDEX_NAME.to_string()],
         })
         .await?;

--- a/rust/lance/benches/mem_wal_read.rs
+++ b/rust/lance/benches/mem_wal_read.rs
@@ -232,7 +232,7 @@ async fn setup_benchmark(
     // Initialize MemWAL
     lsm_dataset
         .initialize_mem_wal(MemWalConfig {
-            shard_spec: None,
+            sharding_spec: None,
             maintained_indexes: vec![],
         })
         .await
@@ -841,7 +841,7 @@ async fn setup_vector_benchmark(
     // Initialize MemWAL
     lsm_dataset
         .initialize_mem_wal(MemWalConfig {
-            shard_spec: None,
+            sharding_spec: None,
             maintained_indexes: vec![],
         })
         .await

--- a/rust/lance/benches/mem_wal_recall_hnsw.rs
+++ b/rust/lance/benches/mem_wal_recall_hnsw.rs
@@ -313,7 +313,7 @@ async fn build_base_dataset(uri: &str, schema: Arc<ArrowSchema>) -> lance_core::
         .await?;
     dataset
         .initialize_mem_wal(MemWalConfig {
-            shard_spec: None,
+            sharding_spec: None,
             maintained_indexes: vec![VECTOR_INDEX_NAME.to_string()],
         })
         .await?;

--- a/rust/lance/benches/mem_wal_replay.rs
+++ b/rust/lance/benches/mem_wal_replay.rs
@@ -157,7 +157,7 @@ async fn setup_dataset(schema: &Arc<ArrowSchema>, name: &str, dataset_prefix: &s
 
     dataset
         .initialize_mem_wal(MemWalConfig {
-            shard_spec: None,
+            sharding_spec: None,
             maintained_indexes: vec![],
         })
         .await

--- a/rust/lance/benches/mem_wal_shard_writer_backpressure.rs
+++ b/rust/lance/benches/mem_wal_shard_writer_backpressure.rs
@@ -283,7 +283,7 @@ async fn run(args: Args) -> Result<()> {
 
     dataset
         .initialize_mem_wal(MemWalConfig {
-            shard_spec: None,
+            sharding_spec: None,
             maintained_indexes: if args.mode.indexed() {
                 vec![VECTOR_INDEX_NAME.to_string()]
             } else {

--- a/rust/lance/benches/mem_wal_vector.rs
+++ b/rust/lance/benches/mem_wal_vector.rs
@@ -248,7 +248,7 @@ async fn setup_benchmark(
     .await;
     lsm_dataset
         .initialize_mem_wal(MemWalConfig {
-            shard_spec: None,
+            sharding_spec: None,
             maintained_indexes: vec![VECTOR_INDEX_NAME.to_string()],
         })
         .await

--- a/rust/lance/benches/mem_wal_write.rs
+++ b/rust/lance/benches/mem_wal_write.rs
@@ -407,7 +407,7 @@ async fn create_dataset(
     // Initialize MemWAL with specified maintained indexes
     dataset
         .initialize_mem_wal(MemWalConfig {
-            shard_spec: None,
+            sharding_spec: None,
             maintained_indexes: maintained_indexes.to_vec(),
         })
         .await

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use crate::index::DatasetIndexExt;
 use async_trait::async_trait;
 use lance_core::{Error, Result};
-use lance_index::mem_wal::{MEM_WAL_INDEX_NAME, MemWalIndexDetails, ShardSpec};
+use lance_index::mem_wal::{MEM_WAL_INDEX_NAME, MemWalIndexDetails, ShardingSpec};
 use lance_io::object_store::ObjectStore;
 use uuid::Uuid;
 
@@ -30,10 +30,10 @@ use super::write::ShardWriter;
 pub struct MemWalConfig {
     /// Optional shard specification for partitioning writes.
     ///
-    /// If None, MemWAL is initialized without any shard spec (manual shard management).
+    /// If None, MemWAL is initialized without any sharding spec (manual shard management).
     ///
-    /// TODO: Add `add_shard_spec()` API to add shard specs after initialization.
-    pub shard_spec: Option<ShardSpec>,
+    /// TODO: Add `add_sharding_spec()` API to add sharding specs after initialization.
+    pub sharding_spec: Option<ShardingSpec>,
     /// Index names to maintain in MemTables.
     /// These must reference indexes already defined on the base table.
     pub maintained_indexes: Vec<String>,
@@ -59,7 +59,7 @@ pub trait DatasetMemWalExt {
     /// ```ignore
     /// let mut dataset = Dataset::open("s3://bucket/dataset").await?;
     /// dataset.initialize_mem_wal(MemWalConfig {
-    ///     shard_spec: None,
+    ///     sharding_spec: None,
     ///     maintained_indexes: vec!["id_btree".to_string()],
     /// }).await?;
     /// ```
@@ -285,7 +285,7 @@ async fn initialize_mem_wal_impl(
     let details = MemWalIndexDetails {
         num_shards: shard_config.num_shards,
         inline_snapshots: None,
-        shard_specs: config.shard_spec.into_iter().collect(),
+        sharding_specs: config.sharding_spec.into_iter().collect(),
         maintained_indexes: config.maintained_indexes,
         ..Default::default()
     };

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -4092,7 +4092,7 @@ mod shard_writer_tests {
         // Initialize MemWAL (no indexes for smoke test)
         dataset
             .initialize_mem_wal(MemWalConfig {
-                shard_spec: None,
+                sharding_spec: None,
                 maintained_indexes: vec![],
             })
             .await
@@ -4149,7 +4149,7 @@ mod shard_writer_tests {
 
         dataset
             .initialize_mem_wal(MemWalConfig {
-                shard_spec: None,
+                sharding_spec: None,
                 maintained_indexes: vec!["vector_idx".to_string()],
             })
             .await
@@ -4290,7 +4290,7 @@ mod shard_writer_tests {
         // Initialize MemWAL with all three indexes
         dataset
             .initialize_mem_wal(MemWalConfig {
-                shard_spec: None,
+                sharding_spec: None,
                 maintained_indexes: vec![
                     "id_btree".to_string(),
                     "text_fts".to_string(),
@@ -4372,7 +4372,7 @@ mod shard_writer_tests {
         // Initialize MemWAL with BTree index only (simpler for this test)
         dataset
             .initialize_mem_wal(MemWalConfig {
-                shard_spec: None,
+                sharding_spec: None,
                 maintained_indexes: vec!["id_btree".to_string()],
             })
             .await

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -4,7 +4,7 @@
 //! MemWAL Index operations.
 //!
 //! The MemWAL Index stores:
-//! - Configuration (shard_specs, maintained_indexes)
+//! - Configuration (sharding_specs, maintained_indexes)
 //! - Merge progress (merged_generations per shard)
 //! - Shard state snapshots (eventually consistent)
 //!


### PR DESCRIPTION
## Summary

Renames the `ShardSpec` / `ShardField` types — and the `shard_spec` /
`shard_specs` identifiers and the corresponding protobuf messages — to
`ShardingSpec` / `ShardingField` for naming consistency.

The protobuf message names change and the `shard_specs` field is renamed to
`sharding_specs`; all field numbers and tags are unchanged, so the change is
wire-compatible.
