### PR TITLE
fix(mem_wal): keep sealed memtables queryable until flush commits

### DIFF
--- a/rust/lance/src/dataset/mem_wal/scanner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner.rs
@@ -41,7 +41,9 @@ mod projection;
 mod vector_search;
 
 pub use builder::LsmScanner;
-pub use collector::{ActiveMemTableRef, LsmDataSourceCollector};
+pub use collector::{
+    ActiveMemTableRef, InMemoryMemTableRef, InMemoryMemTables, LsmDataSourceCollector,
+};
 pub use data_source::{FlushedGeneration, LsmDataSource, LsmGeneration, ShardSnapshot};
 pub use point_lookup::LsmPointLookupPlanner;
 pub use projection::DISTANCE_COLUMN;

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -4,6 +4,7 @@
 //! LSM Scanner builder.
 
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
@@ -15,7 +16,7 @@ use futures::TryStreamExt;
 use lance_core::{Error, Result};
 use uuid::Uuid;
 
-use super::collector::{ActiveMemTableRef, LsmDataSourceCollector};
+use super::collector::{InMemoryMemTableRef, InMemoryMemTables, LsmDataSourceCollector};
 use super::data_source::ShardSnapshot;
 use super::planner::LsmScanPlanner;
 use crate::dataset::Dataset;
@@ -56,7 +57,9 @@ pub struct LsmScanner {
     /// explicitly by [`Self::without_base_table`].
     schema: SchemaRef,
     shard_snapshots: Vec<ShardSnapshot>,
-    active_memtables: HashMap<Uuid, ActiveMemTableRef>,
+    /// In-memory memtables by shard (active + frozen-awaiting-flush), so
+    /// the scanner path carries frozen-undrained generations too.
+    in_memory_memtables: HashMap<Uuid, InMemoryMemTables>,
 
     // Query configuration
     projection: Option<Vec<String>>,
@@ -91,7 +94,7 @@ impl LsmScanner {
             base: BaseSource::Table(base_table),
             schema: Arc::new(arrow_schema),
             shard_snapshots,
-            active_memtables: HashMap::new(),
+            in_memory_memtables: HashMap::new(),
             projection: None,
             filter: None,
             limit: None,
@@ -127,7 +130,7 @@ impl LsmScanner {
             base: BaseSource::PathOnly(base_path.into()),
             schema,
             shard_snapshots,
-            active_memtables: HashMap::new(),
+            in_memory_memtables: HashMap::new(),
             projection: None,
             filter: None,
             limit: None,
@@ -138,13 +141,32 @@ impl LsmScanner {
         }
     }
 
-    /// Add an active MemTable for strong consistency reads.
-    ///
-    /// Active MemTables contain data that may not be persisted yet.
-    /// Including them provides strong consistency at the cost of
-    /// requiring coordination with the writer.
-    pub fn with_active_memtable(mut self, shard_id: Uuid, memtable: ActiveMemTableRef) -> Self {
-        self.active_memtables.insert(shard_id, memtable);
+    /// Set a shard's active memtable. Back-compat / test entry point; the
+    /// read path uses [`Self::with_in_memory_memtables`]. Replaces the
+    /// active memtable, preserving any frozen memtables already registered.
+    pub fn with_active_memtable(mut self, shard_id: Uuid, memtable: InMemoryMemTableRef) -> Self {
+        match self.in_memory_memtables.entry(shard_id) {
+            Entry::Occupied(mut e) => e.get_mut().active = memtable,
+            Entry::Vacant(e) => {
+                e.insert(InMemoryMemTables {
+                    active: memtable,
+                    frozen: Vec::new(),
+                });
+            }
+        }
+        self
+    }
+
+    /// Register a shard's in-memory memtables (active + frozen-awaiting-
+    /// flush) captured atomically by `ShardWriter::in_memory_memtable_refs`.
+    /// The read path's entry point — closes the concurrent-read-vs-flush
+    /// hole by carrying frozen-undrained generations into the scan.
+    pub fn with_in_memory_memtables(
+        mut self,
+        shard_id: Uuid,
+        memtables: InMemoryMemTables,
+    ) -> Self {
+        self.in_memory_memtables.insert(shard_id, memtables);
         self
     }
 
@@ -281,8 +303,8 @@ impl LsmScanner {
             ),
         };
 
-        for (shard_id, memtable) in &self.active_memtables {
-            collector = collector.with_active_memtable(*shard_id, memtable.clone());
+        for (shard_id, mems) in &self.in_memory_memtables {
+            collector = collector.with_in_memory_memtables(*shard_id, mems.clone());
         }
 
         collector
@@ -298,7 +320,14 @@ impl std::fmt::Debug for LsmScanner {
         f.debug_struct("LsmScanner")
             .field(label, &value)
             .field("num_shards", &self.shard_snapshots.len())
-            .field("num_active_memtables", &self.active_memtables.len())
+            .field(
+                "num_in_memory_memtables",
+                &self
+                    .in_memory_memtables
+                    .values()
+                    .map(|m| 1 + m.frozen.len())
+                    .sum::<usize>(),
+            )
             .field("projection", &self.projection)
             .field("limit", &self.limit)
             .field("offset", &self.offset)
@@ -343,14 +372,14 @@ mod tests {
     }
 
     #[test]
-    fn test_active_memtable_ref() {
+    fn test_in_memory_memtable_ref() {
         use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 
         let batch_store = Arc::new(BatchStore::with_capacity(100));
         let index_store = Arc::new(IndexStore::new());
         let schema = Arc::new(arrow_schema::Schema::empty());
 
-        let memtable_ref = ActiveMemTableRef {
+        let memtable_ref = InMemoryMemTableRef {
             batch_store,
             index_store,
             schema,

--- a/rust/lance/src/dataset/mem_wal/scanner/collector.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/collector.rs
@@ -3,6 +3,7 @@
 
 //! Data source collector for LSM scanner.
 
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -14,17 +15,34 @@ use super::data_source::{LsmDataSource, LsmGeneration, ShardSnapshot};
 use crate::dataset::Dataset;
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 
-/// Reference to an active (in-memory) MemTable.
+/// A point-in-time handle to one in-memory memtable, active or frozen —
+/// structurally identical (a frozen memtable is just the immutable case).
 #[derive(Clone)]
-pub struct ActiveMemTableRef {
+pub struct InMemoryMemTableRef {
     /// Batch store containing the data.
     pub batch_store: Arc<BatchStore>,
     /// Index store for the MemTable.
     pub index_store: Arc<IndexStore>,
     /// Schema of the data.
     pub schema: SchemaRef,
-    /// Current generation number.
+    /// Generation number.
     pub generation: u64,
+}
+
+/// Back-compat alias; prefer [`InMemoryMemTableRef`].
+pub type ActiveMemTableRef = InMemoryMemTableRef;
+
+/// A shard's in-memory memtables: the one live `active` memtable plus any
+/// `frozen` memtables awaiting flush (not yet recorded in the manifest).
+/// Mirrors the writer's `WriterState { memtable, frozen_memtables }` so the
+/// reader and writer name the same thing the same way.
+#[derive(Clone)]
+pub struct InMemoryMemTables {
+    /// The single live memtable accepting writes.
+    pub active: InMemoryMemTableRef,
+    /// Frozen memtables awaiting flush; order is irrelevant — dedup orders
+    /// by `generation`.
+    pub frozen: Vec<InMemoryMemTableRef>,
 }
 
 /// Collects data sources from base table and MemWAL shards.
@@ -33,7 +51,7 @@ pub struct ActiveMemTableRef {
 /// for a query, including:
 /// - The base table (merged data) — optional; omit for fresh-tier-only scans
 /// - Flushed MemTables from each shard
-/// - Active MemTables (optional, for strong consistency)
+/// - In-memory memtables per shard (active + frozen-awaiting-flush)
 ///
 /// When the base table is omitted (see [`Self::without_base_table`]), `collect`
 /// returns only flushed-generation and active-memtable sources. This is used
@@ -46,8 +64,8 @@ pub struct LsmDataSourceCollector {
     base_path: String,
     /// Shard snapshots from MemWAL index.
     shard_snapshots: Vec<ShardSnapshot>,
-    /// Active MemTables by shard (for strong consistency).
-    active_memtables: HashMap<Uuid, ActiveMemTableRef>,
+    /// In-memory memtables by shard (active + frozen-awaiting-flush).
+    in_memory_memtables: HashMap<Uuid, InMemoryMemTables>,
 }
 
 impl LsmDataSourceCollector {
@@ -65,7 +83,7 @@ impl LsmDataSourceCollector {
             base_table: Some(base_table),
             base_path,
             shard_snapshots,
-            active_memtables: HashMap::new(),
+            in_memory_memtables: HashMap::new(),
         }
     }
 
@@ -82,17 +100,35 @@ impl LsmDataSourceCollector {
             base_table: None,
             base_path: base_path.into().trim_end_matches('/').to_string(),
             shard_snapshots,
-            active_memtables: HashMap::new(),
+            in_memory_memtables: HashMap::new(),
         }
     }
 
-    /// Add an active MemTable for strong consistency reads.
-    ///
-    /// Active MemTables contain data that may not be persisted yet.
-    /// Including them provides strong consistency at the cost of
-    /// requiring coordination with the writer.
-    pub fn with_active_memtable(mut self, shard_id: Uuid, memtable: ActiveMemTableRef) -> Self {
-        self.active_memtables.insert(shard_id, memtable);
+    /// Set a shard's active memtable. Back-compat / test entry point; the
+    /// read path uses [`Self::with_in_memory_memtables`]. Replaces the
+    /// active memtable, preserving any frozen memtables already registered.
+    pub fn with_active_memtable(mut self, shard_id: Uuid, memtable: InMemoryMemTableRef) -> Self {
+        match self.in_memory_memtables.entry(shard_id) {
+            Entry::Occupied(mut e) => e.get_mut().active = memtable,
+            Entry::Vacant(e) => {
+                e.insert(InMemoryMemTables {
+                    active: memtable,
+                    frozen: Vec::new(),
+                });
+            }
+        }
+        self
+    }
+
+    /// Register a shard's in-memory memtables (active + frozen-awaiting-
+    /// flush) captured atomically by `ShardWriter::in_memory_memtable_refs`.
+    /// The WAL read path's entry point.
+    pub fn with_in_memory_memtables(
+        mut self,
+        shard_id: Uuid,
+        memtables: InMemoryMemTables,
+    ) -> Self {
+        self.in_memory_memtables.insert(shard_id, memtables);
         self
     }
 
@@ -106,9 +142,21 @@ impl LsmDataSourceCollector {
         &self.shard_snapshots
     }
 
-    /// Get active MemTables.
-    pub fn active_memtables(&self) -> &HashMap<Uuid, ActiveMemTableRef> {
-        &self.active_memtables
+    /// In-memory memtables (active + frozen-awaiting-flush) by shard.
+    pub fn in_memory_memtables(&self) -> &HashMap<Uuid, InMemoryMemTables> {
+        &self.in_memory_memtables
+    }
+
+    /// One [`LsmDataSource::ActiveMemTable`] per in-memory memtable —
+    /// active or frozen are the same shape, distinguished by `generation`.
+    fn memtable_source(shard_id: Uuid, m: &InMemoryMemTableRef) -> LsmDataSource {
+        LsmDataSource::ActiveMemTable {
+            batch_store: m.batch_store.clone(),
+            index_store: m.index_store.clone(),
+            schema: m.schema.clone(),
+            shard_id,
+            generation: LsmGeneration::memtable(m.generation),
+        }
     }
 
     /// Collect all data sources.
@@ -116,7 +164,7 @@ impl LsmDataSourceCollector {
     /// Returns sources in a consistent order:
     /// 1. Base table (gen=0), if configured
     /// 2. Flushed MemTables per shard, ordered by generation
-    /// 3. Active MemTables per shard
+    /// 3. In-memory memtables per shard (active + frozen-awaiting-flush)
     pub fn collect(&self) -> Result<Vec<LsmDataSource>> {
         let mut sources = Vec::new();
 
@@ -137,14 +185,13 @@ impl LsmDataSourceCollector {
             }
         }
 
-        for (shard_id, memtable) in &self.active_memtables {
-            sources.push(LsmDataSource::ActiveMemTable {
-                batch_store: memtable.batch_store.clone(),
-                index_store: memtable.index_store.clone(),
-                schema: memtable.schema.clone(),
-                shard_id: *shard_id,
-                generation: LsmGeneration::memtable(memtable.generation),
-            });
+        for (shard_id, mems) in &self.in_memory_memtables {
+            sources.push(Self::memtable_source(*shard_id, &mems.active));
+            sources.extend(
+                mems.frozen
+                    .iter()
+                    .map(|m| Self::memtable_source(*shard_id, m)),
+            );
         }
 
         Ok(sources)
@@ -181,18 +228,17 @@ impl LsmDataSourceCollector {
             }
         }
 
-        for (shard_id, memtable) in &self.active_memtables {
+        for (shard_id, mems) in &self.in_memory_memtables {
             if !shard_ids.contains(shard_id) {
                 continue;
             }
 
-            sources.push(LsmDataSource::ActiveMemTable {
-                batch_store: memtable.batch_store.clone(),
-                index_store: memtable.index_store.clone(),
-                schema: memtable.schema.clone(),
-                shard_id: *shard_id,
-                generation: LsmGeneration::memtable(memtable.generation),
-            });
+            sources.push(Self::memtable_source(*shard_id, &mems.active));
+            sources.extend(
+                mems.frozen
+                    .iter()
+                    .map(|m| Self::memtable_source(*shard_id, m)),
+            );
         }
 
         Ok(sources)
@@ -206,7 +252,12 @@ impl LsmDataSourceCollector {
             .map(|s| s.flushed_generations.len())
             .sum();
         let base_count = if self.base_table.is_some() { 1 } else { 0 };
-        base_count + flushed_count + self.active_memtables.len()
+        let in_memory_count: usize = self
+            .in_memory_memtables
+            .values()
+            .map(|m| 1 + m.frozen.len())
+            .sum();
+        base_count + flushed_count + in_memory_count
     }
 
     /// Resolve a flushed MemTable path to an absolute path.
@@ -265,12 +316,12 @@ mod tests {
     }
 
     #[test]
-    fn test_active_memtable_ref() {
+    fn test_in_memory_memtable_ref() {
         let batch_store = Arc::new(BatchStore::with_capacity(100));
         let index_store = Arc::new(IndexStore::new());
         let schema = Arc::new(arrow_schema::Schema::empty());
 
-        let memtable_ref = ActiveMemTableRef {
+        let memtable_ref = InMemoryMemTableRef {
             batch_store,
             index_store,
             schema,

--- a/rust/lance/src/dataset/mem_wal/scanner/collector.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/collector.rs
@@ -40,8 +40,8 @@ pub type ActiveMemTableRef = InMemoryMemTableRef;
 pub struct InMemoryMemTables {
     /// The single live memtable accepting writes.
     pub active: InMemoryMemTableRef,
-    /// Frozen memtables awaiting flush; order is irrelevant — dedup orders
-    /// by `generation`.
+    /// Frozen memtables awaiting flush; element order is irrelevant — the
+    /// collector sorts in-memory sources by `generation` before the scan.
     pub frozen: Vec<InMemoryMemTableRef>,
 }
 
@@ -147,16 +147,27 @@ impl LsmDataSourceCollector {
         &self.in_memory_memtables
     }
 
-    /// One [`LsmDataSource::ActiveMemTable`] per in-memory memtable —
-    /// active or frozen are the same shape, distinguished by `generation`.
-    fn memtable_source(shard_id: Uuid, m: &InMemoryMemTableRef) -> LsmDataSource {
-        LsmDataSource::ActiveMemTable {
-            batch_store: m.batch_store.clone(),
-            index_store: m.index_store.clone(),
-            schema: m.schema.clone(),
-            shard_id,
-            generation: LsmGeneration::memtable(m.generation),
-        }
+    /// A shard's in-memory memtables (active + frozen-awaiting-flush) as
+    /// scan sources, in **ascending generation order**. The planner relies
+    /// on this: it reverses sources to generation-DESC so the newest row
+    /// wins the dedup tiebreaker (see `LsmScanPlanner::plan_scan`). Active
+    /// is the newest generation; frozen are older sealed ones — so without
+    /// this sort a stale frozen row could outrank a re-write in the active
+    /// memtable for the same pk.
+    fn in_memory_sources(shard_id: Uuid, mems: &InMemoryMemTables) -> Vec<LsmDataSource> {
+        let mut refs: Vec<&InMemoryMemTableRef> = std::iter::once(&mems.active)
+            .chain(mems.frozen.iter())
+            .collect();
+        refs.sort_by_key(|m| m.generation);
+        refs.into_iter()
+            .map(|m| LsmDataSource::ActiveMemTable {
+                batch_store: m.batch_store.clone(),
+                index_store: m.index_store.clone(),
+                schema: m.schema.clone(),
+                shard_id,
+                generation: LsmGeneration::memtable(m.generation),
+            })
+            .collect()
     }
 
     /// Collect all data sources.
@@ -186,12 +197,7 @@ impl LsmDataSourceCollector {
         }
 
         for (shard_id, mems) in &self.in_memory_memtables {
-            sources.push(Self::memtable_source(*shard_id, &mems.active));
-            sources.extend(
-                mems.frozen
-                    .iter()
-                    .map(|m| Self::memtable_source(*shard_id, m)),
-            );
+            sources.extend(Self::in_memory_sources(*shard_id, mems));
         }
 
         Ok(sources)
@@ -233,12 +239,7 @@ impl LsmDataSourceCollector {
                 continue;
             }
 
-            sources.push(Self::memtable_source(*shard_id, &mems.active));
-            sources.extend(
-                mems.frozen
-                    .iter()
-                    .map(|m| Self::memtable_source(*shard_id, m)),
-            );
+            sources.extend(Self::in_memory_sources(*shard_id, mems));
         }
 
         Ok(sources)
@@ -329,5 +330,58 @@ mod tests {
         };
 
         assert_eq!(memtable_ref.generation, 5);
+    }
+
+    fn memtable_ref(generation: u64) -> InMemoryMemTableRef {
+        InMemoryMemTableRef {
+            batch_store: Arc::new(BatchStore::with_capacity(8)),
+            index_store: Arc::new(IndexStore::new()),
+            schema: Arc::new(arrow_schema::Schema::empty()),
+            generation,
+        }
+    }
+
+    /// Regression for the concurrent-read-vs-flush hole: frozen-awaiting-
+    /// flush memtables must reach the scan as their own sources alongside
+    /// the active one, so a reader sees no gap while a flush drains.
+    #[test]
+    fn test_collect_includes_active_and_frozen() {
+        let shard = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        // Frozen deliberately out of order to prove the collector sorts.
+        let mems = InMemoryMemTables {
+            active: memtable_ref(5),
+            frozen: vec![memtable_ref(4), memtable_ref(3)],
+        };
+
+        let collector = LsmDataSourceCollector::without_base_table("/tmp/x", vec![])
+            .with_in_memory_memtables(shard, mems);
+
+        // One source per in-memory memtable, in ascending generation order
+        // (the planner reverses to gen-DESC for the dedup tiebreaker, so a
+        // stale frozen row must not outrank a re-write in the active one).
+        // num_sources() must account for frozen too.
+        assert_eq!(collector.num_sources(), 3);
+        let sources = collector.collect().unwrap();
+        assert_eq!(sources.len(), 3);
+        assert!(sources.iter().all(|s| s.is_active_memtable()));
+        assert!(sources.iter().all(|s| s.shard_id() == Some(shard)));
+        let gens: Vec<u64> = sources.iter().map(|s| s.generation().as_u64()).collect();
+        assert_eq!(gens, vec![3, 4, 5]);
+
+        // Shard pruning keeps the active+frozen set together, all-or-nothing.
+        assert!(
+            collector
+                .collect_for_shards(&HashSet::from([other]))
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            collector
+                .collect_for_shards(&HashSet::from([shard]))
+                .unwrap()
+                .len(),
+            3
+        );
     }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -474,7 +474,7 @@ mod integration_tests {
     use uuid::Uuid;
 
     use crate::dataset::mem_wal::scanner::LsmScanner;
-    use crate::dataset::mem_wal::scanner::collector::ActiveMemTableRef;
+    use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
     use crate::dataset::mem_wal::scanner::data_source::ShardSnapshot;
     use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
     use crate::dataset::{Dataset, WriteParams};
@@ -537,7 +537,7 @@ mod integration_tests {
     async fn setup_multi_level_lsm() -> (
         Arc<Dataset>,
         Vec<ShardSnapshot>,
-        Option<(Uuid, ActiveMemTableRef)>,
+        Option<(Uuid, InMemoryMemTables)>,
         Vec<String>,
         String, // temp_dir path for cleanup
     ) {
@@ -573,11 +573,14 @@ mod integration_tests {
         let active_batch = create_test_batch(&schema, &[5, 6, 7], "active");
         let _ = batch_store.append(active_batch);
 
-        let active_memtable = ActiveMemTableRef {
-            batch_store,
-            index_store,
-            schema: schema.clone(),
-            generation: 3,
+        let active_memtable = InMemoryMemTables {
+            active: InMemoryMemTableRef {
+                batch_store,
+                index_store,
+                schema: schema.clone(),
+                generation: 3,
+            },
+            frozen: vec![],
         };
 
         let pk_columns = vec!["id".to_string()];
@@ -602,7 +605,7 @@ mod integration_tests {
         // Create scanner without requesting _memtable_gen
         let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns);
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         let plan = scanner.create_plan().await.unwrap();
@@ -639,7 +642,7 @@ mod integration_tests {
         let mut scanner =
             LsmScanner::new(base_dataset, shard_snapshots, pk_columns).with_memtable_gen();
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         let plan = scanner.create_plan().await.unwrap();
@@ -683,7 +686,7 @@ mod integration_tests {
         // Create scanner
         let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns);
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         // Execute and collect results
@@ -735,6 +738,109 @@ mod integration_tests {
         assert_eq!(results.get(&7), Some(&"active_7".to_string()));
     }
 
+    /// Regression for the concurrent-read-vs-flush hole: a sealed
+    /// (frozen-awaiting-flush) memtable is not yet recorded as a flushed
+    /// generation, but its rows must still be in the scan's read union and
+    /// dedup correctly by generation across the active/frozen seam.
+    ///
+    /// Layout: base(0) ids 1-5, flushed gen1 ids 3,4, flushed gen2 ids
+    /// 4,5,6, frozen memtable gen3 ids 6,7, active memtable gen4 ids 7,8.
+    #[tokio::test]
+    async fn test_lsm_scan_frozen_memtable_in_read_union() {
+        let schema = create_pk_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_path = temp_dir.path().to_str().unwrap();
+
+        let base_uri = format!("{}/base", base_path);
+        let base_dataset = Arc::new(
+            create_dataset(
+                &base_uri,
+                vec![create_test_batch(&schema, &[1, 2, 3, 4, 5], "base")],
+            )
+            .await,
+        );
+
+        let shard_id = Uuid::new_v4();
+        let gen1_uri = format!("{}/_mem_wal/{}/gen_1", base_uri, shard_id);
+        create_dataset(&gen1_uri, vec![create_test_batch(&schema, &[3, 4], "gen1")]).await;
+        let gen2_uri = format!("{}/_mem_wal/{}/gen_2", base_uri, shard_id);
+        create_dataset(
+            &gen2_uri,
+            vec![create_test_batch(&schema, &[4, 5, 6], "gen2")],
+        )
+        .await;
+
+        let shard_snapshot = ShardSnapshot::new(shard_id)
+            .with_current_generation(4)
+            .with_flushed_generation(1, "gen_1".to_string())
+            .with_flushed_generation(2, "gen_2".to_string());
+
+        // Frozen gen3 (sealed, NOT in the manifest) and active gen4.
+        let frozen_store = Arc::new(BatchStore::with_capacity(100));
+        let _ = frozen_store.append(create_test_batch(&schema, &[6, 7], "frozen"));
+        let frozen = InMemoryMemTableRef {
+            batch_store: frozen_store,
+            index_store: Arc::new(IndexStore::new()),
+            schema: schema.clone(),
+            generation: 3,
+        };
+
+        let active_store = Arc::new(BatchStore::with_capacity(100));
+        let _ = active_store.append(create_test_batch(&schema, &[7, 8], "active"));
+        let in_memory = InMemoryMemTables {
+            active: InMemoryMemTableRef {
+                batch_store: active_store,
+                index_store: Arc::new(IndexStore::new()),
+                schema: schema.clone(),
+                generation: 4,
+            },
+            frozen: vec![frozen],
+        };
+
+        let scanner = LsmScanner::new(base_dataset, vec![shard_snapshot], vec!["id".to_string()])
+            .with_in_memory_memtables(shard_id, in_memory);
+
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        let mut results: HashMap<i32, String> = HashMap::new();
+        for batch in batches {
+            let ids = batch
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let names = batch
+                .column_by_name("name")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            for i in 0..batch.num_rows() {
+                results.insert(ids.value(i), names.value(i).to_string());
+            }
+        }
+
+        assert_eq!(results.len(), 8, "ids 1-8 should all be present");
+        assert_eq!(results.get(&1), Some(&"base_1".to_string()));
+        assert_eq!(results.get(&3), Some(&"gen1_3".to_string()));
+        assert_eq!(results.get(&4), Some(&"gen2_4".to_string()));
+        assert_eq!(results.get(&5), Some(&"gen2_5".to_string()));
+        // id=6: in flushed gen2 AND frozen gen3 -> frozen wins. This is the
+        // bug: pre-fix the frozen memtable fell out of the read union and
+        // id=6 resolved to "gen2_6".
+        assert_eq!(results.get(&6), Some(&"frozen_6".to_string()));
+        // id=7: in frozen gen3 AND active gen4 -> active wins across the seam.
+        assert_eq!(results.get(&7), Some(&"active_7".to_string()));
+        assert_eq!(results.get(&8), Some(&"active_8".to_string()));
+    }
+
     #[tokio::test]
     async fn test_lsm_scan_with_projection() {
         let (base_dataset, shard_snapshots, active_memtable, pk_columns, _temp_path) =
@@ -744,7 +850,7 @@ mod integration_tests {
         let mut scanner =
             LsmScanner::new(base_dataset, shard_snapshots, pk_columns).project(&["id"]);
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         // Execute and collect results
@@ -774,7 +880,7 @@ mod integration_tests {
         // Create scanner with limit
         let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns).limit(3, None);
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         // Execute and collect results
@@ -896,7 +1002,7 @@ mod integration_tests {
         let mut scanner =
             LsmScanner::new(base_dataset, shard_snapshots, pk_columns).with_row_address();
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         let plan = scanner.create_plan().await.unwrap();
@@ -963,7 +1069,7 @@ mod integration_tests {
             .with_memtable_gen()
             .with_row_address();
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         let plan = scanner.create_plan().await.unwrap();
@@ -1005,7 +1111,7 @@ mod integration_tests {
     async fn setup_multi_level_lsm_with_btree_index() -> (
         Arc<Dataset>,
         Vec<ShardSnapshot>,
-        Option<(Uuid, ActiveMemTableRef)>,
+        Option<(Uuid, InMemoryMemTables)>,
         Vec<String>,
         String,
     ) {
@@ -1070,11 +1176,14 @@ mod integration_tests {
 
         let index_store = Arc::new(index_store);
 
-        let active_memtable = ActiveMemTableRef {
-            batch_store,
-            index_store,
-            schema: schema.clone(),
-            generation: 3,
+        let active_memtable = InMemoryMemTables {
+            active: InMemoryMemTableRef {
+                batch_store,
+                index_store,
+                schema: schema.clone(),
+                generation: 3,
+            },
+            frozen: vec![],
         };
 
         let pk_columns = vec!["id".to_string()];
@@ -1099,7 +1208,7 @@ mod integration_tests {
             .filter("id = 5")
             .unwrap();
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         let plan = scanner.create_plan().await.unwrap();
@@ -1191,7 +1300,7 @@ mod integration_tests {
             .filter("id = 3")
             .unwrap();
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         // Execute and verify result
@@ -1242,7 +1351,7 @@ mod integration_tests {
         let mut scanner =
             LsmScanner::without_base_table(schema, base_uri, shard_snapshots, pk_columns);
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         // Verify the plan does not include a LanceRead for the base table.
@@ -1324,7 +1433,7 @@ mod integration_tests {
                 .filter("id > 3")
                 .unwrap();
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         let batches: Vec<RecordBatch> = scanner
@@ -1404,7 +1513,7 @@ mod integration_tests {
             "_rowid",
         ]);
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         let batches: Vec<RecordBatch> = scanner
@@ -1494,7 +1603,7 @@ mod integration_tests {
         let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns)
             .project(&["id", "_rowid", "name"]);
         if let Some((shard_id, memtable)) = active_memtable {
-            scanner = scanner.with_active_memtable(shard_id, memtable);
+            scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
         let plan = scanner.create_plan().await.unwrap();

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -508,7 +508,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_vector_search_base_plus_active_returns_distance() {
-        use crate::dataset::mem_wal::scanner::collector::ActiveMemTableRef;
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
         use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
         use datafusion::prelude::SessionContext;
         use futures::TryStreamExt;
@@ -538,13 +538,16 @@ mod tests {
         let index_store = Arc::new(index_store);
 
         let shard_id = uuid::Uuid::new_v4();
-        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_active_memtable(
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_in_memory_memtables(
             shard_id,
-            ActiveMemTableRef {
-                batch_store,
-                index_store,
-                schema: schema.clone(),
-                generation: 1,
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
             },
         );
 
@@ -624,7 +627,7 @@ mod tests {
         // Regression for: active arm previously did NOT call `build_projection_for_knn`,
         // so when the caller passed `projection=Some([...])`, the active arm's output
         // dropped the PK column (and the staleness/dedup pipeline lost its hash input).
-        use crate::dataset::mem_wal::scanner::collector::ActiveMemTableRef;
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
         use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
         use datafusion::prelude::SessionContext;
         use futures::TryStreamExt;
@@ -653,13 +656,16 @@ mod tests {
         let index_store = Arc::new(index_store);
 
         let shard_id = uuid::Uuid::new_v4();
-        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_active_memtable(
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_in_memory_memtables(
             shard_id,
-            ActiveMemTableRef {
-                batch_store,
-                index_store,
-                schema: schema.clone(),
-                generation: 1,
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
             },
         );
 
@@ -700,7 +706,7 @@ mod tests {
         // Regression: `_distance` / `_rowid` in projection must not break
         // the plan. `_distance` honored at requested position (no
         // duplication); `_rowid` honored as nullable.
-        use crate::dataset::mem_wal::scanner::collector::ActiveMemTableRef;
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
         use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
         use datafusion::prelude::SessionContext;
         use futures::TryStreamExt;
@@ -729,13 +735,16 @@ mod tests {
         let index_store = Arc::new(index_store);
 
         let shard_id = uuid::Uuid::new_v4();
-        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_active_memtable(
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_in_memory_memtables(
             shard_id,
-            ActiveMemTableRef {
-                batch_store,
-                index_store,
-                schema: schema.clone(),
-                generation: 1,
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
             },
         );
 
@@ -807,7 +816,7 @@ mod tests {
         // Regression for: when bloom filters are configured, FilterStaleExec preserves
         // its `_memtable_gen` input column. Without the post-filter projection that
         // strips it, the column would leak into the user-visible output.
-        use crate::dataset::mem_wal::scanner::collector::ActiveMemTableRef;
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
         use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
         use datafusion::prelude::SessionContext;
         use futures::TryStreamExt;
@@ -837,13 +846,16 @@ mod tests {
         let index_store = Arc::new(index_store);
 
         let shard_id = uuid::Uuid::new_v4();
-        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_active_memtable(
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_in_memory_memtables(
             shard_id,
-            ActiveMemTableRef {
-                batch_store,
-                index_store,
-                schema: schema.clone(),
-                generation: 1,
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
             },
         );
 
@@ -932,7 +944,7 @@ mod tests {
         //   2. flushed-memtable arm runs without erroring
         //   3. `_rowaddr` symmetry with `_rowid` (same code path, both are
         //      surfaced when requested and NULL'd outside the base arm)
-        use crate::dataset::mem_wal::scanner::collector::ActiveMemTableRef;
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
         use crate::dataset::mem_wal::scanner::data_source::ShardSnapshot;
         use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
         use crate::index::DatasetIndexExt;
@@ -990,13 +1002,16 @@ mod tests {
             .with_flushed_generation(1, "gen_1".to_string());
 
         let collector = LsmDataSourceCollector::new(base_dataset, vec![shard_snapshot])
-            .with_active_memtable(
+            .with_in_memory_memtables(
                 shard_id,
-                ActiveMemTableRef {
-                    batch_store,
-                    index_store,
-                    schema: schema.clone(),
-                    generation: 2,
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store,
+                        schema: schema.clone(),
+                        generation: 2,
+                    },
+                    frozen: vec![],
                 },
             );
 

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -686,12 +686,32 @@ struct WriterState {
     frozen_memtable_bytes: usize,
     /// Flush watchers for frozen memtables (for backpressure).
     frozen_flush_watchers: VecDeque<(usize, DurabilityWatcher)>,
+    /// Sealed-but-undrained memtables, kept queryable so a concurrent reader
+    /// sees no hole between `freeze_memtable` and the flush task's manifest
+    /// commit. Pushed in `freeze_memtable`; removed by generation in
+    /// `flush_memtable` on commit success only (retained on failure until a
+    /// later flush or WAL replay on reopen).
+    frozen_memtables: VecDeque<Arc<MemTable>>,
     /// Flag to prevent duplicate memtable flush requests.
     flush_requested: bool,
     /// Counter for WAL flush threshold crossings.
     wal_flush_trigger_count: usize,
     /// Last time a WAL flush was triggered (for time-based flush).
     last_wal_flush_trigger_time: u64,
+}
+
+/// Capture a point-in-time scan handle to one in-memory memtable (active
+/// or frozen — same shape). Shared by `active_memtable_ref` and
+/// `in_memory_memtable_refs` so both stamp identical fields.
+fn in_memory_ref(mt: &MemTable) -> crate::dataset::mem_wal::scanner::InMemoryMemTableRef {
+    crate::dataset::mem_wal::scanner::InMemoryMemTableRef {
+        batch_store: mt.batch_store(),
+        index_store: mt
+            .indexes_arc()
+            .unwrap_or_else(|| Arc::new(IndexStore::new())),
+        schema: mt.schema().clone(),
+        generation: mt.generation(),
+    }
 }
 
 fn start_time() -> std::time::Instant {
@@ -896,6 +916,11 @@ impl SharedWriterState {
             .push_back((frozen_size, flush_watcher));
 
         let frozen_memtable = Arc::new(old_memtable);
+
+        // Keep this generation queryable until its manifest commit lands
+        // (dropped in `flush_memtable`, success only). Arc refcount, not a
+        // copy — the flush task holds it alive for the whole drain anyway.
+        state.frozen_memtables.push_back(frozen_memtable.clone());
 
         debug!(
             "Frozen memtable generation {}, pending_count = {}",
@@ -1286,6 +1311,7 @@ impl ShardWriter {
             last_flushed_wal_entry_position: initial_covered_wal_entry_position,
             frozen_memtable_bytes: 0,
             frozen_flush_watchers: VecDeque::new(),
+            frozen_memtables: VecDeque::new(),
             flush_requested: false,
             wal_flush_trigger_count: 0,
             last_wal_flush_trigger_time: 0,
@@ -1684,26 +1710,38 @@ impl ShardWriter {
         Ok(state.memtable.scan())
     }
 
-    /// Get an ActiveMemTableRef for use with LsmScanner.
-    ///
-    /// This provides read access to the current in-memory MemTable data
-    /// for unified LSM scanning across base table, flushed MemTables, and
-    /// active MemTable.
+    /// A handle to just the active memtable, for unified LSM scanning.
+    /// Prefer [`Self::in_memory_memtable_refs`] on the read path — it also
+    /// carries frozen-awaiting-flush generations.
     ///
     /// Returns an error in WAL-only mode.
     pub async fn active_memtable_ref(
         &self,
-    ) -> Result<crate::dataset::mem_wal::scanner::ActiveMemTableRef> {
+    ) -> Result<crate::dataset::mem_wal::scanner::InMemoryMemTableRef> {
         let state_lock = self.memtable_state_lock()?;
         let state = state_lock.read().await;
-        Ok(crate::dataset::mem_wal::scanner::ActiveMemTableRef {
-            batch_store: state.memtable.batch_store(),
-            index_store: state
-                .memtable
-                .indexes_arc()
-                .unwrap_or_else(|| Arc::new(IndexStore::new())),
-            schema: state.memtable.schema().clone(),
-            generation: state.memtable.generation(),
+        Ok(in_memory_ref(&state.memtable))
+    }
+
+    /// The active memtable plus every frozen-awaiting-flush memtable,
+    /// captured atomically under one `state.read()` (no torn freeze).
+    /// Mirrors `WriterState { memtable, frozen_memtables }`. The WAL read
+    /// path uses this instead of [`Self::active_memtable_ref`] so a
+    /// concurrent reader sees no hole while a flush drains.
+    ///
+    /// Returns an error in WAL-only mode.
+    pub async fn in_memory_memtable_refs(
+        &self,
+    ) -> Result<crate::dataset::mem_wal::scanner::InMemoryMemTables> {
+        let state_lock = self.memtable_state_lock()?;
+        let state = state_lock.read().await;
+        Ok(crate::dataset::mem_wal::scanner::InMemoryMemTables {
+            active: in_memory_ref(&state.memtable),
+            frozen: state
+                .frozen_memtables
+                .iter()
+                .map(|m| in_memory_ref(m))
+                .collect(),
         })
     }
 
@@ -2184,9 +2222,21 @@ impl MemTableFlushHandler {
 
         {
             let mut state = self.state.write().await;
+            // Backpressure drain: unconditional so `wait_for_flush_drain`
+            // sees the watcher's error signal, not a dropped channel.
             if let Some((_size, _watcher)) = state.frozen_flush_watchers.pop_front() {
                 state.frozen_memtable_bytes =
                     state.frozen_memtable_bytes.saturating_sub(memtable_size);
+            }
+            // Drop the queryable handle ONLY on commit success. On failure
+            // keep it: rows must stay in the read union until a later flush
+            // or WAL replay, else a transient flush error reopens the hole.
+            // Keyed by generation, so non-FIFO completion is fine.
+            if flush_result.is_ok() {
+                let flushed_generation = memtable.generation();
+                state
+                    .frozen_memtables
+                    .retain(|m| m.generation() != flushed_generation);
             }
         }
 

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -3288,6 +3288,8 @@ mod tests {
         assert!(err.to_string().contains("WAL-only mode"));
         let err = writer.active_memtable_ref().await.err().unwrap();
         assert!(err.to_string().contains("WAL-only mode"));
+        let err = writer.in_memory_memtable_refs().await.err().unwrap();
+        assert!(err.to_string().contains("WAL-only mode"));
 
         writer.close().await.unwrap();
     }
@@ -4020,6 +4022,130 @@ mod tests {
         assert_eq!(manifest.flushed_generations.len(), flushed_before + 1);
 
         writer.close().await.unwrap();
+    }
+
+    /// On a successful flush commit the sealed generation is dropped from
+    /// the queryable set (no leak), and its rows land in the manifest.
+    #[tokio::test]
+    async fn test_frozen_dropped_after_successful_flush() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            shard_spec_id: 0,
+            durable_write: false,
+            sync_indexed_write: false,
+            max_wal_buffer_size: 64 * 1024 * 1024,
+            max_wal_flush_interval: None,
+            max_memtable_size: 64 * 1024 * 1024,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        };
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+
+        let initial_gen = writer.memtable_stats().await.unwrap().generation;
+        writer
+            .put(vec![create_test_batch(&schema, 0, 10)])
+            .await
+            .unwrap();
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.unwrap();
+
+        let refs = writer.in_memory_memtable_refs().await.unwrap();
+        assert!(
+            refs.frozen.is_empty(),
+            "frozen handle must be dropped once the flush commit lands"
+        );
+        assert_eq!(refs.active.generation, initial_gen + 1);
+
+        let manifest = writer.manifest().await.unwrap().expect("manifest exists");
+        assert!(
+            manifest
+                .flushed_generations
+                .iter()
+                .any(|g| g.generation == initial_gen),
+            "flushed generation must be recorded in the manifest"
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// Regression: a transient flush failure must NOT reopen the
+    /// concurrent-read-vs-flush hole. The sealed generation stays in the
+    /// queryable set (rows intact) until a later flush or WAL replay.
+    /// Failure is induced deterministically by fencing the writer with a
+    /// successor before the seal, so the flush's `check_fenced` rejects it.
+    #[tokio::test]
+    async fn test_frozen_retained_after_failed_flush() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+        let shard_id = Uuid::new_v4();
+
+        let writer_a = ShardWriter::open(
+            store.clone(),
+            base_path.clone(),
+            base_uri.clone(),
+            memtable_config_with_pk(shard_id),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let initial_gen = writer_a.memtable_stats().await.unwrap().generation;
+        writer_a
+            .put(vec![create_test_batch(&schema, 0, 10)])
+            .await
+            .unwrap();
+
+        // Successor claims a higher epoch, fencing A.
+        let writer_b = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            memtable_config_with_pk(shard_id),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+        assert!(writer_b.epoch() > writer_a.epoch());
+
+        // `force_seal_active` would reject up-front on a fenced writer;
+        // freeze directly so the failure surfaces at flush-commit time —
+        // exactly the freeze/flush race the fix guards.
+        match &writer_a.mode {
+            WriterMode::MemTable {
+                state,
+                writer_state,
+                ..
+            } => {
+                let mut st = state.write().await;
+                writer_state.freeze_memtable(&mut st).unwrap();
+            }
+            WriterMode::WalOnly { .. } => unreachable!("opened in memtable mode"),
+        }
+
+        // The fenced flush fails; the drain surfaces that error.
+        assert!(
+            writer_a.wait_for_flush_drain().await.is_err(),
+            "fenced flush should fail the drain"
+        );
+
+        // The hole did not reopen: the sealed generation is still queryable
+        // with its rows, alongside the new (empty) active generation.
+        let refs = writer_a.in_memory_memtable_refs().await.unwrap();
+        assert_eq!(refs.frozen.len(), 1, "sealed generation must be retained");
+        assert_eq!(refs.frozen[0].generation, initial_gen);
+        assert!(
+            !refs.frozen[0].batch_store.is_empty(),
+            "retained sealed memtable must still hold its rows"
+        );
+        assert_eq!(refs.active.generation, initial_gen + 1);
+
+        writer_b.close().await.unwrap();
     }
 }
 


### PR DESCRIPTION
## Problem

A concurrent reader could miss rows in the window between `freeze_memtable` and the flush task's manifest commit. During that window the frozen generation is no longer the active memtable, but is not yet recorded as a flushed generation in the manifest — so it falls out of the read union entirely.

## Fix

- Keep frozen-awaiting-flush memtables in `WriterState.frozen_memtables` so they stay in the read union (Arc refcount, not a copy — the flush task holds them alive for the drain anyway).
- Drop them by generation **only on flush-commit success**. On failure they are retained until a later flush or WAL replay on reopen, so a transient flush error doesn't reopen the hole. Keyed by generation, so non-FIFO completion is fine.
- Add `ShardWriter::in_memory_memtable_refs` and `LsmScanner::with_in_memory_memtables` as the read-path entry point — captures active + frozen atomically under one `state.read()` (no torn freeze).
- Rename `ActiveMemTableRef` → `InMemoryMemTableRef` (frozen is just the immutable case; same shape). Back-compat alias and `with_active_memtable` test/back-compat entry point retained.
- `LsmDataSourceCollector` emits in-memory sources in ascending generation order (see below).

## Source-ordering correctness fix

Adding the scan-level test surfaced a latent bug in the first cut: `collect()` pushed `active` (newest generation) *before* `frozen` (older). The planner relies on sources being in ascending-generation order — it reverses them to generation-DESC so the newest row gets the lowest stream index and wins the dedup tiebreaker. With active emitted first, a pk that was written, sealed, then re-written into the new active memtable before the sealed one flushed would resolve to the **stale frozen value**. The collector now sorts in-memory sources by `generation`, restoring active-wins across the active/frozen seam.

## Tests

- **collector**: `collect()`/`collect_for_shards()` emit active + every frozen memtable, in ascending generation order (frozen deliberately registered out of order).
- **planner**: end-to-end scan over base + flushed + frozen + active asserting frozen rows are in the read union, frozen beats older flushed generations, and active beats frozen for the same pk.
- **write**: frozen handle dropped from the queryable set on flush-commit success; retained with rows intact on a fenced/failed flush (hole cannot reopen).
- Migrated the planner/vector_search test harnesses and the WAL-only accessor test onto the new frozen-aware entry point.

All 265 `mem_wal` tests pass; `cargo clippy -p lance --tests -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)