### PR TITLE
feat: builder-style MemWAL initialization API

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -673,6 +673,15 @@ message MemWalIndexDetails {
   //
   // If an index is not present in this list, it is assumed to be fully caught up.
   repeated IndexCatchupProgress index_catchup = 10;
+
+  // Default ShardWriter configuration values for this MemWAL index.
+  //
+  // A free-form string map persisted so that every writer — across
+  // processes and restarts — starts from the same default writer
+  // configuration. These are defaults only: an individual writer may
+  // still override any value at runtime in its own ShardWriterConfig
+  // (which is not persisted).
+  map<string, string> writer_defaults = 11;
 }
 
 // Sharding spec definition.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -681,7 +681,7 @@ message MemWalIndexDetails {
   // configuration. These are defaults only: an individual writer may
   // still override any value at runtime in its own ShardWriterConfig
   // (which is not persisted).
-  map<string, string> writer_defaults = 11;
+  map<string, string> writer_config_defaults = 11;
 }
 
 // Sharding spec definition.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4685,7 +4685,7 @@ class LanceDataset(pa.dataset.Dataset):
         -------
         dict or None
             A dict with ``num_shards``, ``maintained_indexes``,
-            ``writer_defaults``, and ``sharding_specs``, or ``None`` when
+            ``writer_config_defaults``, and ``sharding_specs``, or ``None`` when
             MemWAL has not been initialized on this dataset.
         """
         return self._ds.mem_wal_index_details()

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4597,27 +4597,55 @@ class LanceDataset(pa.dataset.Dataset):
         self,
         *,
         maintained_indexes: Optional[List[str]] = None,
-        region_spec: Optional["mem_wal.RegionSpec"] = None,
+        bucket_column: Optional[str] = None,
+        num_buckets: Optional[int] = None,
+        identity_column: Optional[str] = None,
+        unsharded: bool = False,
+        durable_write: Optional[bool] = None,
+        sync_indexed_write: Optional[bool] = None,
+        max_wal_buffer_size: Optional[int] = None,
+        max_wal_flush_interval_ms: Optional[int] = None,
+        max_memtable_size: Optional[int] = None,
+        max_memtable_rows: Optional[int] = None,
+        max_memtable_batches: Optional[int] = None,
+        max_unflushed_memtable_bytes: Optional[int] = None,
+        manifest_scan_batch_size: Optional[int] = None,
+        async_index_buffer_rows: Optional[int] = None,
+        async_index_interval_ms: Optional[int] = None,
+        backpressure_log_interval_ms: Optional[int] = None,
+        stats_log_interval_ms: Optional[int] = None,
     ) -> None:
         """Initialize MemWAL on this dataset.
 
-        Must be called once before any calls to `mem_wal_writer`.
-        The dataset schema must have at least one field annotated with
-        the ``lance-schema:unenforced-primary-key`` Arrow field metadata.
+        Must be called once before any calls to `mem_wal_writer`. The dataset
+        schema must have at least one field annotated with the
+        ``lance-schema:unenforced-primary-key`` Arrow field metadata.
+
+        At most one sharding mode may be selected: bucket sharding
+        (``bucket_column`` + ``num_buckets``), identity sharding
+        (``identity_column``), or ``unsharded``. With none selected, shards are
+        managed manually by passing region IDs to `mem_wal_writer`.
+
+        Any writer-configuration keyword arguments (``durable_write``,
+        ``max_memtable_size``, ``max_wal_flush_interval_ms``, etc. — the same
+        knobs accepted by `mem_wal_writer`) are recorded as the default
+        `~lance.mem_wal.RegionWriter` configuration in the MemWAL index, so
+        every writer starts from the same defaults.
 
         Parameters
         ----------
         maintained_indexes : list of str, optional
-            Names of existing vector indexes to keep updated as data is
-            written through the MemWAL.  Must reference indexes that
-            already exist on the dataset.
-        region_spec : RegionSpec, optional
-            Partitioning specification for automatic region routing.
-            When provided, Lance will derive a region identifier from each
-            written row according to the spec and route writes to the
-            correct `~lance.mem_wal.RegionWriter` automatically.
-            When ``None`` (default), the caller must manage region IDs
-            manually by passing them to `mem_wal_writer`.
+            Names of existing indexes to keep updated as data is written
+            through the MemWAL. Must reference indexes that already exist.
+        bucket_column : str, optional
+            With ``num_buckets``, hash-bucket writes by this column, which must
+            be the single-column unenforced primary key.
+        num_buckets : int, optional
+            Number of hash buckets (shards). Required with ``bucket_column``.
+        identity_column : str, optional
+            Shard by the raw value of this scalar column.
+        unsharded : bool, default False
+            Route every write to a single shard.
 
         Raises
         ------
@@ -4625,38 +4653,42 @@ class LanceDataset(pa.dataset.Dataset):
             - Dataset has no ``lance-schema:unenforced-primary-key`` field.
             - An entry in *maintained_indexes* does not exist on the dataset.
             - MemWAL has already been initialized on this dataset.
-
-        Examples
-        --------
-        Without region spec (manual region management):
-
-        import lance
-        import pyarrow as pa
-        import tempfile
-        schema = pa.schema([
-        ...     pa.field("id", pa.int64(), nullable=False,
-        ...              metadata={"lance-schema:unenforced-primary-key": "true"}),
-        ...     pa.field("val", pa.float32()),
-        ... ])
-        table = pa.table({"id": [1], "val": [0.1]}, schema=schema)
-        with tempfile.TemporaryDirectory() as tmpdir:
-            ds = lance.write_dataset(table, tmpdir)
-            ds.initialize_mem_wal()
-
-        With a region spec for automatic routing by ``tenant_id``:
-
-        from lance.mem_wal import RegionField, RegionSpec
-        spec = RegionSpec(
-        ...     spec_id=1,
-        ...     fields=[RegionField(field_id="tenant_id", source_ids=[0],
-        ...                        result_type="int64")],
-        ... )
-        ds.initialize_mem_wal(region_spec=spec)
+        ValueError
+            More than one sharding mode was selected, or bucket sharding was
+            given only one of ``bucket_column`` / ``num_buckets``.
         """
         self._ds.initialize_mem_wal(
             maintained_indexes=maintained_indexes,
-            region_spec=region_spec,
+            bucket_column=bucket_column,
+            num_buckets=num_buckets,
+            identity_column=identity_column,
+            unsharded=unsharded,
+            durable_write=durable_write,
+            sync_indexed_write=sync_indexed_write,
+            max_wal_buffer_size=max_wal_buffer_size,
+            max_wal_flush_interval_ms=max_wal_flush_interval_ms,
+            max_memtable_size=max_memtable_size,
+            max_memtable_rows=max_memtable_rows,
+            max_memtable_batches=max_memtable_batches,
+            max_unflushed_memtable_bytes=max_unflushed_memtable_bytes,
+            manifest_scan_batch_size=manifest_scan_batch_size,
+            async_index_buffer_rows=async_index_buffer_rows,
+            async_index_interval_ms=async_index_interval_ms,
+            backpressure_log_interval_ms=backpressure_log_interval_ms,
+            stats_log_interval_ms=stats_log_interval_ms,
         )
+
+    def mem_wal_index_details(self) -> Optional[dict]:
+        """Return the MemWAL index details, or ``None`` if not initialized.
+
+        Returns
+        -------
+        dict or None
+            A dict with ``num_shards``, ``maintained_indexes``,
+            ``writer_defaults``, and ``sharding_specs``, or ``None`` when
+            MemWAL has not been initialized on this dataset.
+        """
+        return self._ds.mem_wal_index_details()
 
     def mem_wal_writer(
         self,

--- a/python/python/tests/test_mem_wal.py
+++ b/python/python/tests/test_mem_wal.py
@@ -342,7 +342,7 @@ def test_initialize_mem_wal_manual(tmp_path):
     assert details["num_shards"] == 0
     assert details["sharding_specs"] == []
     assert details["maintained_indexes"] == []
-    assert details["writer_defaults"] == {}
+    assert details["writer_config_defaults"] == {}
 
 
 def test_initialize_mem_wal_unsharded(tmp_path):
@@ -387,7 +387,7 @@ def test_initialize_mem_wal_maintained_indexes(tmp_path):
     assert ds.mem_wal_index_details()["maintained_indexes"] == ["id_btree"]
 
 
-def test_initialize_mem_wal_writer_defaults(tmp_path):
+def test_initialize_mem_wal_writer_config_defaults(tmp_path):
     ds = _mem_wal_dataset(tmp_path)
     ds.initialize_mem_wal(
         durable_write=False,
@@ -395,7 +395,7 @@ def test_initialize_mem_wal_writer_defaults(tmp_path):
         max_wal_flush_interval_ms=250,
     )
 
-    defaults = ds.mem_wal_index_details()["writer_defaults"]
+    defaults = ds.mem_wal_index_details()["writer_config_defaults"]
     assert defaults["durable_write"] == "false"
     assert defaults["max_memtable_size"] == str(8 * 1024 * 1024)
     # Duration knobs are recorded in milliseconds with a `_ms` suffix.
@@ -405,10 +405,10 @@ def test_initialize_mem_wal_writer_defaults(tmp_path):
     assert "enable_memtable" in defaults
 
 
-def test_initialize_mem_wal_no_writer_defaults_when_unset(tmp_path):
+def test_initialize_mem_wal_no_writer_config_defaults_when_unset(tmp_path):
     ds = _mem_wal_dataset(tmp_path)
     ds.initialize_mem_wal(bucket_column="id", num_buckets=4)
-    assert ds.mem_wal_index_details()["writer_defaults"] == {}
+    assert ds.mem_wal_index_details()["writer_config_defaults"] == {}
 
 
 def test_initialize_mem_wal_rejects_conflicting_sharding(tmp_path):

--- a/python/python/tests/test_mem_wal.py
+++ b/python/python/tests/test_mem_wal.py
@@ -7,6 +7,7 @@ import uuid
 
 import lance
 import pyarrow as pa
+import pytest
 from lance.mem_wal import (
     LsmPointLookupPlanner,
     LsmScanner,
@@ -319,3 +320,109 @@ def test_region_writer_e2e_correctness(tmp_path):
     new_ids = result.column("id").to_pylist()
     assert 10000 in new_ids
     assert 10009 in new_ids
+
+
+# === initialize_mem_wal: sharding, maintained indexes, writer defaults ===
+
+
+def _mem_wal_dataset(tmp_path, name: str = "ds"):
+    """A base dataset with an unenforced primary key, ready for MemWAL init."""
+    ds_path = str(tmp_path / name)
+    return lance.write_dataset(
+        _lookup_table([1, 2, 3], "base"), ds_path, schema=_LOOKUP_SCHEMA
+    )
+
+
+def test_initialize_mem_wal_manual(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    ds.initialize_mem_wal()
+
+    details = ds.mem_wal_index_details()
+    assert details is not None
+    assert details["num_shards"] == 0
+    assert details["sharding_specs"] == []
+    assert details["maintained_indexes"] == []
+    assert details["writer_defaults"] == {}
+
+
+def test_initialize_mem_wal_unsharded(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    ds.initialize_mem_wal(unsharded=True)
+
+    details = ds.mem_wal_index_details()
+    assert details["num_shards"] == 1
+    specs = details["sharding_specs"]
+    assert len(specs) == 1
+    assert specs[0]["fields"][0]["transform"] == "unsharded"
+
+
+def test_initialize_mem_wal_bucket_sharding(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    ds.initialize_mem_wal(bucket_column="id", num_buckets=8)
+
+    details = ds.mem_wal_index_details()
+    assert details["num_shards"] == 8
+    field = details["sharding_specs"][0]["fields"][0]
+    assert field["transform"] == "bucket"
+    assert field["parameters"]["num_buckets"] == "8"
+
+
+def test_initialize_mem_wal_identity_sharding(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    ds.initialize_mem_wal(identity_column="name")
+
+    details = ds.mem_wal_index_details()
+    # identity sharding has an open-ended shard count
+    assert details["num_shards"] == 0
+    field = details["sharding_specs"][0]["fields"][0]
+    assert field["transform"] == "identity"
+    assert field["result_type"] == "utf8"
+
+
+def test_initialize_mem_wal_maintained_indexes(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    ds.create_scalar_index("id", "BTREE", name="id_btree")
+    ds.initialize_mem_wal(maintained_indexes=["id_btree"])
+
+    assert ds.mem_wal_index_details()["maintained_indexes"] == ["id_btree"]
+
+
+def test_initialize_mem_wal_writer_defaults(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    ds.initialize_mem_wal(
+        durable_write=False,
+        max_memtable_size=8 * 1024 * 1024,
+        max_wal_flush_interval_ms=250,
+    )
+
+    defaults = ds.mem_wal_index_details()["writer_defaults"]
+    assert defaults["durable_write"] == "false"
+    assert defaults["max_memtable_size"] == str(8 * 1024 * 1024)
+    # Duration knobs are recorded in milliseconds with a `_ms` suffix.
+    assert defaults["max_wal_flush_interval_ms"] == "250"
+    # Every ShardWriterConfig tunable is recorded once any default is set.
+    assert "sync_indexed_write" in defaults
+    assert "enable_memtable" in defaults
+
+
+def test_initialize_mem_wal_no_writer_defaults_when_unset(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    ds.initialize_mem_wal(bucket_column="id", num_buckets=4)
+    assert ds.mem_wal_index_details()["writer_defaults"] == {}
+
+
+def test_initialize_mem_wal_rejects_conflicting_sharding(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    with pytest.raises(ValueError, match="at most one"):
+        ds.initialize_mem_wal(unsharded=True, bucket_column="id", num_buckets=8)
+
+
+def test_initialize_mem_wal_rejects_partial_bucket(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    with pytest.raises(ValueError, match="num_buckets"):
+        ds.initialize_mem_wal(bucket_column="id")
+
+
+def test_mem_wal_index_details_none_before_init(tmp_path):
+    ds = _mem_wal_dataset(tmp_path)
+    assert ds.mem_wal_index_details() is None

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3152,49 +3152,23 @@ impl Dataset {
     /// Must be called once before any `mem_wal_writer()` calls.
     /// Requires the dataset schema to have at least one field with
     /// the `lance-schema:unenforced-primary-key` metadata.
-    #[pyo3(signature=(maintained_indexes=None, region_spec=None))]
+    #[pyo3(signature=(maintained_indexes=None))]
     fn initialize_mem_wal(
         &mut self,
         py: Python<'_>,
         maintained_indexes: Option<Vec<String>>,
-        region_spec: Option<Bound<'_, PyAny>>,
     ) -> PyResult<()> {
         use lance::dataset::mem_wal::DatasetMemWalExt;
-        use lance_index::mem_wal::{ShardingField as RegionField, ShardingSpec as RegionSpec};
-        use std::collections::HashMap;
 
-        let region_spec_rust = if let Some(spec) = region_spec {
-            let spec_id: u32 = spec.getattr("spec_id")?.extract()?;
-            let fields_py: Vec<Bound<'_, PyAny>> = spec.getattr("fields")?.extract()?;
-            let fields = fields_py
-                .iter()
-                .map(|f| -> PyResult<RegionField> {
-                    Ok(RegionField {
-                        field_id: f.getattr("field_id")?.extract()?,
-                        source_ids: f.getattr("source_ids")?.extract()?,
-                        transform: f.getattr("transform")?.extract()?,
-                        expression: f.getattr("expression")?.extract()?,
-                        result_type: f.getattr("result_type")?.extract()?,
-                        parameters: f
-                            .getattr("parameters")?
-                            .extract::<HashMap<String, String>>()?,
-                    })
-                })
-                .collect::<PyResult<Vec<_>>>()?;
-            Some(RegionSpec { spec_id, fields })
-        } else {
-            None
-        };
-
-        let config = lance::dataset::mem_wal::MemWalConfig {
-            writer_defaults: Default::default(),
-            sharding_spec: region_spec_rust,
-            maintained_indexes: maintained_indexes.unwrap_or_default(),
-        };
+        let maintained_indexes = maintained_indexes.unwrap_or_default();
         let mut ds = Arc::clone(&self.ds);
         let new_ds = rt()
             .block_on(Some(py), async move {
-                Arc::make_mut(&mut ds).initialize_mem_wal(config).await?;
+                Arc::make_mut(&mut ds)
+                    .initialize_mem_wal()
+                    .maintained_indexes(maintained_indexes)
+                    .execute()
+                    .await?;
                 Ok::<Arc<LanceDataset>, lance_core::Error>(ds)
             })?
             .map_err(|e| PyIOError::new_err(e.to_string()))?;

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3348,7 +3348,7 @@ impl Dataset {
     /// has not been initialized.
     ///
     /// The returned dict has `num_shards`, `maintained_indexes`,
-    /// `writer_defaults`, and `sharding_specs`.
+    /// `writer_config_defaults`, and `sharding_specs`.
     fn mem_wal_index_details<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDict>>> {
         use lance::dataset::mem_wal::DatasetMemWalExt;
 
@@ -3363,7 +3363,7 @@ impl Dataset {
         let dict = PyDict::new(py);
         dict.set_item("num_shards", details.num_shards)?;
         dict.set_item("maintained_indexes", details.maintained_indexes)?;
-        dict.set_item("writer_defaults", details.writer_defaults)?;
+        dict.set_item("writer_config_defaults", details.writer_config_defaults)?;
 
         let specs = PyList::empty(py);
         for spec in &details.sharding_specs {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3187,6 +3187,7 @@ impl Dataset {
         };
 
         let config = lance::dataset::mem_wal::MemWalConfig {
+            writer_defaults: Default::default(),
             sharding_spec: region_spec_rust,
             maintained_indexes: maintained_indexes.unwrap_or_default(),
         };

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -153,6 +153,85 @@ fn stats_log_interval_from_millis(ms: u64) -> Option<std::time::Duration> {
     }
 }
 
+/// Build a `ShardWriterConfig` from optional MemWAL writer keyword arguments.
+///
+/// Returns `None` when no keyword argument is supplied, so callers can tell
+/// "use the defaults" apart from an explicit configuration.
+#[allow(clippy::too_many_arguments)]
+fn writer_config_from_kwargs(
+    durable_write: Option<bool>,
+    sync_indexed_write: Option<bool>,
+    max_wal_buffer_size: Option<usize>,
+    max_wal_flush_interval_ms: Option<u64>,
+    max_memtable_size: Option<usize>,
+    max_memtable_rows: Option<usize>,
+    max_memtable_batches: Option<usize>,
+    max_unflushed_memtable_bytes: Option<usize>,
+    manifest_scan_batch_size: Option<usize>,
+    async_index_buffer_rows: Option<usize>,
+    async_index_interval_ms: Option<u64>,
+    backpressure_log_interval_ms: Option<u64>,
+    stats_log_interval_ms: Option<u64>,
+) -> Option<lance::dataset::mem_wal::ShardWriterConfig> {
+    use std::time::Duration;
+
+    let mut config = lance::dataset::mem_wal::ShardWriterConfig::default();
+    let mut any = false;
+    if let Some(v) = durable_write {
+        config = config.with_durable_write(v);
+        any = true;
+    }
+    if let Some(v) = sync_indexed_write {
+        config = config.with_sync_indexed_write(v);
+        any = true;
+    }
+    if let Some(v) = max_wal_buffer_size {
+        config = config.with_max_wal_buffer_size(v);
+        any = true;
+    }
+    if let Some(v) = max_wal_flush_interval_ms {
+        config = config.with_max_wal_flush_interval(Duration::from_millis(v));
+        any = true;
+    }
+    if let Some(v) = max_memtable_size {
+        config = config.with_max_memtable_size(v);
+        any = true;
+    }
+    if let Some(v) = max_memtable_rows {
+        config = config.with_max_memtable_rows(v);
+        any = true;
+    }
+    if let Some(v) = max_memtable_batches {
+        config = config.with_max_memtable_batches(v);
+        any = true;
+    }
+    if let Some(v) = max_unflushed_memtable_bytes {
+        config = config.with_max_unflushed_memtable_bytes(v);
+        any = true;
+    }
+    if let Some(v) = manifest_scan_batch_size {
+        config = config.with_manifest_scan_batch_size(v);
+        any = true;
+    }
+    if let Some(v) = async_index_buffer_rows {
+        config = config.with_async_index_buffer_rows(v);
+        any = true;
+    }
+    if let Some(v) = async_index_interval_ms {
+        config = config.with_async_index_interval(Duration::from_millis(v));
+        any = true;
+    }
+    if let Some(v) = backpressure_log_interval_ms {
+        config = config.with_backpressure_log_interval(Duration::from_millis(v));
+        any = true;
+    }
+    if let Some(v) = stats_log_interval_ms {
+        config = config.with_stats_log_interval(stats_log_interval_from_millis(v));
+        any = true;
+    }
+    any.then_some(config)
+}
+
 fn convert_reader(reader: &Bound<PyAny>) -> PyResult<Box<dyn RecordBatchReader + Send>> {
     let py = reader.py();
     if reader.is_instance_of::<Scanner>() {
@@ -3149,31 +3228,162 @@ impl Dataset {
 
     /// Initialize MemWAL on this dataset.
     ///
-    /// Must be called once before any `mem_wal_writer()` calls.
-    /// Requires the dataset schema to have at least one field with
-    /// the `lance-schema:unenforced-primary-key` metadata.
-    #[pyo3(signature=(maintained_indexes=None))]
+    /// Must be called once before any `mem_wal_writer()` calls. Requires the
+    /// dataset schema to have at least one field with the
+    /// `lance-schema:unenforced-primary-key` metadata.
+    ///
+    /// At most one sharding mode may be selected: bucket sharding
+    /// (`bucket_column` + `num_buckets`), identity sharding (`identity_column`),
+    /// or `unsharded`. With none selected, shards are managed manually.
+    ///
+    /// Any writer-configuration keyword arguments are recorded as the default
+    /// `ShardWriter` configuration for the MemWAL index.
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature=(
+        *,
+        maintained_indexes=None,
+        bucket_column=None,
+        num_buckets=None,
+        identity_column=None,
+        unsharded=false,
+        durable_write=None,
+        sync_indexed_write=None,
+        max_wal_buffer_size=None,
+        max_wal_flush_interval_ms=None,
+        max_memtable_size=None,
+        max_memtable_rows=None,
+        max_memtable_batches=None,
+        max_unflushed_memtable_bytes=None,
+        manifest_scan_batch_size=None,
+        async_index_buffer_rows=None,
+        async_index_interval_ms=None,
+        backpressure_log_interval_ms=None,
+        stats_log_interval_ms=None,
+    ))]
     fn initialize_mem_wal(
         &mut self,
         py: Python<'_>,
         maintained_indexes: Option<Vec<String>>,
+        bucket_column: Option<String>,
+        num_buckets: Option<u32>,
+        identity_column: Option<String>,
+        unsharded: bool,
+        durable_write: Option<bool>,
+        sync_indexed_write: Option<bool>,
+        max_wal_buffer_size: Option<usize>,
+        max_wal_flush_interval_ms: Option<u64>,
+        max_memtable_size: Option<usize>,
+        max_memtable_rows: Option<usize>,
+        max_memtable_batches: Option<usize>,
+        max_unflushed_memtable_bytes: Option<usize>,
+        manifest_scan_batch_size: Option<usize>,
+        async_index_buffer_rows: Option<usize>,
+        async_index_interval_ms: Option<u64>,
+        backpressure_log_interval_ms: Option<u64>,
+        stats_log_interval_ms: Option<u64>,
     ) -> PyResult<()> {
         use lance::dataset::mem_wal::DatasetMemWalExt;
 
+        let bucket = match (bucket_column.as_deref(), num_buckets) {
+            (Some(_), Some(_)) => true,
+            (None, None) => false,
+            _ => {
+                return Err(PyValueError::new_err(
+                    "bucket sharding requires both `bucket_column` and `num_buckets`",
+                ));
+            }
+        };
+        let modes = [bucket, identity_column.is_some(), unsharded]
+            .into_iter()
+            .filter(|&m| m)
+            .count();
+        if modes > 1 {
+            return Err(PyValueError::new_err(
+                "at most one of bucket sharding, `identity_column`, or `unsharded` may be set",
+            ));
+        }
+
+        let writer_config = writer_config_from_kwargs(
+            durable_write,
+            sync_indexed_write,
+            max_wal_buffer_size,
+            max_wal_flush_interval_ms,
+            max_memtable_size,
+            max_memtable_rows,
+            max_memtable_batches,
+            max_unflushed_memtable_bytes,
+            manifest_scan_batch_size,
+            async_index_buffer_rows,
+            async_index_interval_ms,
+            backpressure_log_interval_ms,
+            stats_log_interval_ms,
+        );
         let maintained_indexes = maintained_indexes.unwrap_or_default();
+
         let mut ds = Arc::clone(&self.ds);
         let new_ds = rt()
             .block_on(Some(py), async move {
-                Arc::make_mut(&mut ds)
-                    .initialize_mem_wal()
-                    .maintained_indexes(maintained_indexes)
-                    .execute()
-                    .await?;
+                let dataset = Arc::make_mut(&mut ds);
+                let mut builder = dataset.initialize_mem_wal();
+                if let (Some(column), Some(n)) = (bucket_column, num_buckets) {
+                    builder = builder.bucket_sharding(column, n);
+                } else if let Some(column) = identity_column {
+                    builder = builder.identity_sharding(column);
+                } else if unsharded {
+                    builder = builder.unsharded();
+                }
+                builder = builder.maintained_indexes(maintained_indexes);
+                if let Some(config) = writer_config {
+                    builder = builder.writer_config_defaults(config);
+                }
+                builder.execute().await?;
                 Ok::<Arc<LanceDataset>, lance_core::Error>(ds)
             })?
             .map_err(|e| PyIOError::new_err(e.to_string()))?;
         self.ds = new_ds;
         Ok(())
+    }
+
+    /// Return the MemWAL index details for this dataset, or `None` if MemWAL
+    /// has not been initialized.
+    ///
+    /// The returned dict has `num_shards`, `maintained_indexes`,
+    /// `writer_defaults`, and `sharding_specs`.
+    fn mem_wal_index_details<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDict>>> {
+        use lance::dataset::mem_wal::DatasetMemWalExt;
+
+        let ds = self.ds.clone();
+        let details = rt()
+            .block_on(Some(py), async move { ds.mem_wal_index_details().await })?
+            .map_err(|e| PyIOError::new_err(e.to_string()))?;
+        let Some(details) = details else {
+            return Ok(None);
+        };
+
+        let dict = PyDict::new(py);
+        dict.set_item("num_shards", details.num_shards)?;
+        dict.set_item("maintained_indexes", details.maintained_indexes)?;
+        dict.set_item("writer_defaults", details.writer_defaults)?;
+
+        let specs = PyList::empty(py);
+        for spec in &details.sharding_specs {
+            let spec_dict = PyDict::new(py);
+            spec_dict.set_item("spec_id", spec.spec_id)?;
+            let fields = PyList::empty(py);
+            for field in &spec.fields {
+                let field_dict = PyDict::new(py);
+                field_dict.set_item("field_id", &field.field_id)?;
+                field_dict.set_item("source_ids", field.source_ids.clone())?;
+                field_dict.set_item("transform", field.transform.clone())?;
+                field_dict.set_item("result_type", &field.result_type)?;
+                field_dict.set_item("parameters", field.parameters.clone())?;
+                fields.append(field_dict)?;
+            }
+            spec_dict.set_item("fields", fields)?;
+            specs.append(spec_dict)?;
+        }
+        dict.set_item("sharding_specs", specs)?;
+        Ok(Some(dict))
     }
 
     /// Get a RegionWriter for the specified region.
@@ -3215,51 +3425,27 @@ impl Dataset {
         backpressure_log_interval_ms: Option<u64>,
         stats_log_interval_ms: Option<u64>,
     ) -> PyResult<crate::mem_wal::PyRegionWriter> {
-        use lance::dataset::mem_wal::{DatasetMemWalExt, ShardWriterConfig as RegionWriterConfig};
+        use lance::dataset::mem_wal::DatasetMemWalExt;
 
         let uuid = uuid::Uuid::parse_str(&region_id)
             .map_err(|e| PyValueError::new_err(format!("Invalid region_id UUID: {}", e)))?;
 
-        let mut config = RegionWriterConfig::default();
-        if let Some(v) = durable_write {
-            config = config.with_durable_write(v);
-        }
-        if let Some(v) = sync_indexed_write {
-            config = config.with_sync_indexed_write(v);
-        }
-        if let Some(v) = max_wal_buffer_size {
-            config = config.with_max_wal_buffer_size(v);
-        }
-        if let Some(v) = max_wal_flush_interval_ms {
-            config = config.with_max_wal_flush_interval(std::time::Duration::from_millis(v));
-        }
-        if let Some(v) = max_memtable_size {
-            config = config.with_max_memtable_size(v);
-        }
-        if let Some(v) = max_memtable_rows {
-            config = config.with_max_memtable_rows(v);
-        }
-        if let Some(v) = max_memtable_batches {
-            config = config.with_max_memtable_batches(v);
-        }
-        if let Some(v) = max_unflushed_memtable_bytes {
-            config = config.with_max_unflushed_memtable_bytes(v);
-        }
-        if let Some(v) = manifest_scan_batch_size {
-            config = config.with_manifest_scan_batch_size(v);
-        }
-        if let Some(v) = async_index_buffer_rows {
-            config = config.with_async_index_buffer_rows(v);
-        }
-        if let Some(v) = async_index_interval_ms {
-            config = config.with_async_index_interval(std::time::Duration::from_millis(v));
-        }
-        if let Some(v) = backpressure_log_interval_ms {
-            config = config.with_backpressure_log_interval(std::time::Duration::from_millis(v));
-        }
-        if let Some(v) = stats_log_interval_ms {
-            config = config.with_stats_log_interval(stats_log_interval_from_millis(v));
-        }
+        let config = writer_config_from_kwargs(
+            durable_write,
+            sync_indexed_write,
+            max_wal_buffer_size,
+            max_wal_flush_interval_ms,
+            max_memtable_size,
+            max_memtable_rows,
+            max_memtable_batches,
+            max_unflushed_memtable_bytes,
+            manifest_scan_batch_size,
+            async_index_buffer_rows,
+            async_index_interval_ms,
+            backpressure_log_interval_ms,
+            stats_log_interval_ms,
+        )
+        .unwrap_or_default();
 
         let ds = self.ds.clone();
         let writer = rt()

--- a/rust/lance-index/src/mem_wal.rs
+++ b/rust/lance-index/src/mem_wal.rs
@@ -313,7 +313,7 @@ pub struct MemWalIndexDetails {
     /// from the same default writer configuration. These are defaults only;
     /// an individual writer may still override any value at runtime in its
     /// own (non-persisted) `ShardWriterConfig`.
-    pub writer_defaults: HashMap<String, String>,
+    pub writer_config_defaults: HashMap<String, String>,
 }
 
 impl From<&MemWalIndexDetails> for pb::MemWalIndexDetails {
@@ -330,7 +330,7 @@ impl From<&MemWalIndexDetails> for pb::MemWalIndexDetails {
                 .map(|mg| mg.into())
                 .collect(),
             index_catchup: details.index_catchup.iter().map(|icp| icp.into()).collect(),
-            writer_defaults: details.writer_defaults.clone(),
+            writer_config_defaults: details.writer_config_defaults.clone(),
         }
     }
 }
@@ -359,7 +359,7 @@ impl TryFrom<pb::MemWalIndexDetails> for MemWalIndexDetails {
                 .into_iter()
                 .map(IndexCatchupProgress::try_from)
                 .collect::<lance_core::Result<_>>()?,
-            writer_defaults: details.writer_defaults,
+            writer_config_defaults: details.writer_config_defaults,
         })
     }
 }

--- a/rust/lance-index/src/mem_wal.rs
+++ b/rust/lance-index/src/mem_wal.rs
@@ -307,6 +307,13 @@ pub struct MemWalIndexDetails {
     pub maintained_indexes: Vec<String>,
     pub merged_generations: Vec<MergedGeneration>,
     pub index_catchup: Vec<IndexCatchupProgress>,
+    /// Default `ShardWriter` configuration values for this MemWAL index.
+    ///
+    /// Persisted so every writer — across processes and restarts — starts
+    /// from the same default writer configuration. These are defaults only;
+    /// an individual writer may still override any value at runtime in its
+    /// own (non-persisted) `ShardWriterConfig`.
+    pub writer_defaults: HashMap<String, String>,
 }
 
 impl From<&MemWalIndexDetails> for pb::MemWalIndexDetails {
@@ -323,6 +330,7 @@ impl From<&MemWalIndexDetails> for pb::MemWalIndexDetails {
                 .map(|mg| mg.into())
                 .collect(),
             index_catchup: details.index_catchup.iter().map(|icp| icp.into()).collect(),
+            writer_defaults: details.writer_defaults.clone(),
         }
     }
 }
@@ -351,6 +359,7 @@ impl TryFrom<pb::MemWalIndexDetails> for MemWalIndexDetails {
                 .into_iter()
                 .map(IndexCatchupProgress::try_from)
                 .collect::<lance_core::Result<_>>()?,
+            writer_defaults: details.writer_defaults,
         })
     }
 }

--- a/rust/lance/benches/mem_wal_index_micro.rs
+++ b/rust/lance/benches/mem_wal_index_micro.rs
@@ -39,7 +39,7 @@ use lance::dataset::mem_wal::write::{
     HnswIndexConfig, IndexStore, MemIndexConfig, MemTable, MemTableFlusher, MemTableScanner,
     ShardWriterConfig,
 };
-use lance::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig, ShardManifestStore};
+use lance::dataset::mem_wal::{DatasetMemWalExt, ShardManifestStore};
 use lance::dataset::{Dataset, WriteParams};
 use lance::index::DatasetIndexExt;
 use lance::index::vector::VectorIndexParams;
@@ -187,11 +187,9 @@ async fn main() -> lance_core::Result<()> {
 
     let mut dataset = build_base_dataset(&uri, dim).await?;
     dataset
-        .initialize_mem_wal(MemWalConfig {
-            writer_defaults: Default::default(),
-            sharding_spec: None,
-            maintained_indexes: vec![VECTOR_INDEX_NAME.to_string()],
-        })
+        .initialize_mem_wal()
+        .maintained_indexes([VECTOR_INDEX_NAME])
+        .execute()
         .await?;
     let dataset = Arc::new(dataset);
 

--- a/rust/lance/benches/mem_wal_index_micro.rs
+++ b/rust/lance/benches/mem_wal_index_micro.rs
@@ -188,6 +188,7 @@ async fn main() -> lance_core::Result<()> {
     let mut dataset = build_base_dataset(&uri, dim).await?;
     dataset
         .initialize_mem_wal(MemWalConfig {
+            writer_defaults: Default::default(),
             sharding_spec: None,
             maintained_indexes: vec![VECTOR_INDEX_NAME.to_string()],
         })

--- a/rust/lance/benches/mem_wal_read.rs
+++ b/rust/lance/benches/mem_wal_read.rs
@@ -61,7 +61,7 @@ use lance::dataset::mem_wal::scanner::{
     ActiveMemTableRef, LsmDataSourceCollector, LsmPointLookupPlanner, LsmScanner,
     LsmVectorSearchPlanner, ShardSnapshot,
 };
-use lance::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig, ShardWriterConfig};
+use lance::dataset::mem_wal::{DatasetMemWalExt, ShardWriterConfig};
 use lance::dataset::{Dataset, WriteParams};
 use lance_linalg::distance::DistanceType;
 #[cfg(target_os = "linux")]
@@ -230,14 +230,7 @@ async fn setup_benchmark(
         .unwrap();
 
     // Initialize MemWAL
-    lsm_dataset
-        .initialize_mem_wal(MemWalConfig {
-            writer_defaults: Default::default(),
-            sharding_spec: None,
-            maintained_indexes: vec![],
-        })
-        .await
-        .unwrap();
+    lsm_dataset.initialize_mem_wal().execute().await.unwrap();
 
     let lsm_dataset = Arc::new(lsm_dataset);
 
@@ -840,14 +833,7 @@ async fn setup_vector_benchmark(
         .unwrap();
 
     // Initialize MemWAL
-    lsm_dataset
-        .initialize_mem_wal(MemWalConfig {
-            writer_defaults: Default::default(),
-            sharding_spec: None,
-            maintained_indexes: vec![],
-        })
-        .await
-        .unwrap();
+    lsm_dataset.initialize_mem_wal().execute().await.unwrap();
 
     let lsm_dataset = Arc::new(lsm_dataset);
 

--- a/rust/lance/benches/mem_wal_read.rs
+++ b/rust/lance/benches/mem_wal_read.rs
@@ -232,6 +232,7 @@ async fn setup_benchmark(
     // Initialize MemWAL
     lsm_dataset
         .initialize_mem_wal(MemWalConfig {
+            writer_defaults: Default::default(),
             sharding_spec: None,
             maintained_indexes: vec![],
         })
@@ -841,6 +842,7 @@ async fn setup_vector_benchmark(
     // Initialize MemWAL
     lsm_dataset
         .initialize_mem_wal(MemWalConfig {
+            writer_defaults: Default::default(),
             sharding_spec: None,
             maintained_indexes: vec![],
         })

--- a/rust/lance/benches/mem_wal_recall_hnsw.rs
+++ b/rust/lance/benches/mem_wal_recall_hnsw.rs
@@ -27,8 +27,8 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use futures::TryStreamExt;
+use lance::dataset::mem_wal::DatasetMemWalExt;
 use lance::dataset::mem_wal::write::{MemTableScanner, ShardWriterConfig};
-use lance::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig};
 use lance::dataset::{Dataset, WriteParams};
 use lance::index::DatasetIndexExt;
 use lance::index::vector::VectorIndexParams;
@@ -312,11 +312,9 @@ async fn build_base_dataset(uri: &str, schema: Arc<ArrowSchema>) -> lance_core::
         )
         .await?;
     dataset
-        .initialize_mem_wal(MemWalConfig {
-            writer_defaults: Default::default(),
-            sharding_spec: None,
-            maintained_indexes: vec![VECTOR_INDEX_NAME.to_string()],
-        })
+        .initialize_mem_wal()
+        .maintained_indexes([VECTOR_INDEX_NAME])
+        .execute()
         .await?;
     Ok(())
 }

--- a/rust/lance/benches/mem_wal_recall_hnsw.rs
+++ b/rust/lance/benches/mem_wal_recall_hnsw.rs
@@ -313,6 +313,7 @@ async fn build_base_dataset(uri: &str, schema: Arc<ArrowSchema>) -> lance_core::
         .await?;
     dataset
         .initialize_mem_wal(MemWalConfig {
+            writer_defaults: Default::default(),
             sharding_spec: None,
             maintained_indexes: vec![VECTOR_INDEX_NAME.to_string()],
         })

--- a/rust/lance/benches/mem_wal_replay.rs
+++ b/rust/lance/benches/mem_wal_replay.rs
@@ -42,7 +42,7 @@ use std::time::{Duration, Instant};
 use arrow_array::{Int64Array, RecordBatch, StringArray};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use lance::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig, ShardWriterConfig, WalTailer};
+use lance::dataset::mem_wal::{DatasetMemWalExt, ShardWriterConfig, WalTailer};
 use lance::dataset::{Dataset, WriteParams};
 use lance_io::object_store::ObjectStore;
 use uuid::Uuid;
@@ -156,11 +156,8 @@ async fn setup_dataset(schema: &Arc<ArrowSchema>, name: &str, dataset_prefix: &s
     .expect("Failed to seed dataset");
 
     dataset
-        .initialize_mem_wal(MemWalConfig {
-            writer_defaults: Default::default(),
-            sharding_spec: None,
-            maintained_indexes: vec![],
-        })
+        .initialize_mem_wal()
+        .execute()
         .await
         .expect("Failed to initialize MemWAL");
 

--- a/rust/lance/benches/mem_wal_replay.rs
+++ b/rust/lance/benches/mem_wal_replay.rs
@@ -157,6 +157,7 @@ async fn setup_dataset(schema: &Arc<ArrowSchema>, name: &str, dataset_prefix: &s
 
     dataset
         .initialize_mem_wal(MemWalConfig {
+            writer_defaults: Default::default(),
             sharding_spec: None,
             maintained_indexes: vec![],
         })

--- a/rust/lance/benches/mem_wal_shard_writer_backpressure.rs
+++ b/rust/lance/benches/mem_wal_shard_writer_backpressure.rs
@@ -40,7 +40,7 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use lance::dataset::mem_wal::write::{MemTableStats, WriteStatsSnapshot};
-use lance::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig, ShardWriterConfig};
+use lance::dataset::mem_wal::{DatasetMemWalExt, ShardWriterConfig};
 use lance::dataset::{Dataset, WriteParams};
 use lance::index::DatasetIndexExt;
 use lance::index::vector::VectorIndexParams;
@@ -282,15 +282,13 @@ async fn run(args: Args) -> Result<()> {
     let index_setup_s = index_start.elapsed().as_secs_f64();
 
     dataset
-        .initialize_mem_wal(MemWalConfig {
-            writer_defaults: Default::default(),
-            sharding_spec: None,
-            maintained_indexes: if args.mode.indexed() {
-                vec![VECTOR_INDEX_NAME.to_string()]
-            } else {
-                vec![]
-            },
+        .initialize_mem_wal()
+        .maintained_indexes(if args.mode.indexed() {
+            vec![VECTOR_INDEX_NAME.to_string()]
+        } else {
+            vec![]
         })
+        .execute()
         .await?;
 
     let shard_id = Uuid::new_v4();

--- a/rust/lance/benches/mem_wal_shard_writer_backpressure.rs
+++ b/rust/lance/benches/mem_wal_shard_writer_backpressure.rs
@@ -283,6 +283,7 @@ async fn run(args: Args) -> Result<()> {
 
     dataset
         .initialize_mem_wal(MemWalConfig {
+            writer_defaults: Default::default(),
             sharding_spec: None,
             maintained_indexes: if args.mode.indexed() {
                 vec![VECTOR_INDEX_NAME.to_string()]

--- a/rust/lance/benches/mem_wal_vector.rs
+++ b/rust/lance/benches/mem_wal_vector.rs
@@ -248,6 +248,7 @@ async fn setup_benchmark(
     .await;
     lsm_dataset
         .initialize_mem_wal(MemWalConfig {
+            writer_defaults: Default::default(),
             sharding_spec: None,
             maintained_indexes: vec![VECTOR_INDEX_NAME.to_string()],
         })

--- a/rust/lance/benches/mem_wal_vector.rs
+++ b/rust/lance/benches/mem_wal_vector.rs
@@ -50,7 +50,7 @@ use futures::TryStreamExt;
 use lance::dataset::mem_wal::scanner::{
     ActiveMemTableRef, LsmDataSourceCollector, LsmVectorSearchPlanner, ShardSnapshot,
 };
-use lance::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig, ShardWriterConfig};
+use lance::dataset::mem_wal::{DatasetMemWalExt, ShardWriterConfig};
 use lance::dataset::{Dataset, WriteParams};
 use lance::index::DatasetIndexExt;
 use lance::index::vector::VectorIndexParams;
@@ -247,11 +247,9 @@ async fn setup_benchmark(
     )
     .await;
     lsm_dataset
-        .initialize_mem_wal(MemWalConfig {
-            writer_defaults: Default::default(),
-            sharding_spec: None,
-            maintained_indexes: vec![VECTOR_INDEX_NAME.to_string()],
-        })
+        .initialize_mem_wal()
+        .maintained_indexes([VECTOR_INDEX_NAME])
+        .execute()
         .await
         .unwrap();
     let lsm_dataset = Arc::new(lsm_dataset);

--- a/rust/lance/benches/mem_wal_write.rs
+++ b/rust/lance/benches/mem_wal_write.rs
@@ -59,7 +59,7 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use lance::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig, ShardWriterConfig};
+use lance::dataset::mem_wal::{DatasetMemWalExt, ShardWriterConfig};
 use lance::dataset::{Dataset, WriteParams};
 use lance::index::DatasetIndexExt;
 use lance::index::vector::VectorIndexParams;
@@ -406,11 +406,9 @@ async fn create_dataset(
 
     // Initialize MemWAL with specified maintained indexes
     dataset
-        .initialize_mem_wal(MemWalConfig {
-            writer_defaults: Default::default(),
-            sharding_spec: None,
-            maintained_indexes: maintained_indexes.to_vec(),
-        })
+        .initialize_mem_wal()
+        .maintained_indexes(maintained_indexes.to_vec())
+        .execute()
         .await
         .expect("Failed to initialize MemWAL");
 

--- a/rust/lance/benches/mem_wal_write.rs
+++ b/rust/lance/benches/mem_wal_write.rs
@@ -407,6 +407,7 @@ async fn create_dataset(
     // Initialize MemWAL with specified maintained indexes
     dataset
         .initialize_mem_wal(MemWalConfig {
+            writer_defaults: Default::default(),
             sharding_spec: None,
             maintained_indexes: maintained_indexes.to_vec(),
         })

--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -42,7 +42,7 @@ pub mod util;
 mod wal;
 pub mod write;
 
-pub use api::{DatasetMemWalExt, MemWalConfig, MemWalShardConfig};
+pub use api::{DatasetMemWalExt, InitializeMemWalBuilder};
 pub use manifest::ShardManifestStore;
 pub use memtable::scanner::MemTableScanner;
 pub use scanner::{LsmDataSource, LsmGeneration, LsmScanner, ShardSnapshot};

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -9,16 +9,16 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::index::DatasetIndexExt;
 use async_trait::async_trait;
 use lance_core::{Error, Result};
-use lance_index::mem_wal::{MEM_WAL_INDEX_NAME, MemWalIndexDetails, ShardingSpec};
+use lance_index::mem_wal::{MEM_WAL_INDEX_NAME, MemWalIndexDetails, ShardingField, ShardingSpec};
 use lance_io::object_store::ObjectStore;
 use uuid::Uuid;
 
 use crate::Dataset;
 use crate::dataset::CommitBuilder;
 use crate::dataset::transaction::{Operation, Transaction};
+use crate::index::DatasetIndexExt;
 use crate::index::DatasetIndexInternalExt;
 use crate::index::mem_wal::{load_mem_wal_index_details, new_mem_wal_index_meta};
 
@@ -26,68 +26,277 @@ use super::ShardWriterConfig;
 use super::write::MemIndexConfig;
 use super::write::ShardWriter;
 
-/// Configuration for initializing MemWAL on a Dataset.
-#[derive(Debug, Clone, Default)]
-pub struct MemWalConfig {
-    /// Optional shard specification for partitioning writes.
-    ///
-    /// If None, MemWAL is initialized without any sharding spec (manual shard management).
-    ///
-    /// TODO: Add `add_sharding_spec()` API to add sharding specs after initialization.
-    pub sharding_spec: Option<ShardingSpec>,
-    /// Index names to maintain in MemTables.
-    /// These must reference indexes already defined on the base table.
-    pub maintained_indexes: Vec<String>,
-    /// Default `ShardWriter` configuration values to record in the MemWAL
-    /// index, so every writer starts from the same defaults. Empty means no
-    /// defaults are recorded.
-    pub writer_defaults: HashMap<String, String>,
+/// Spec id of the sole sharding spec installed by [`InitializeMemWalBuilder`].
+const SHARDING_SPEC_ID: u32 = 1;
+
+/// Field id, within the sharding spec, of the derived shard-routing value.
+const SHARDING_FIELD_ID: &str = "bucket";
+
+/// Result type of the derived shard-routing value.
+const SHARDING_RESULT_TYPE: &str = "int32";
+
+/// Transform name for [`InitializeMemWalBuilder::bucket_sharding`]. Matches
+/// Iceberg's `bucket(col, N)` partition transform name.
+const BUCKET_TRANSFORM: &str = "bucket";
+
+/// Transform name for [`InitializeMemWalBuilder::unsharded`]: every row maps to
+/// a single shard.
+const UNSHARDED_TRANSFORM: &str = "unsharded";
+
+/// Parameter key holding the bucket count `N` on the bucket transform.
+const NUM_BUCKETS_PARAM: &str = "num_buckets";
+
+/// Inclusive upper bound for `num_buckets`. Bounds the number of distinct
+/// MemWAL shards a single bucket spec can address, which caps how many shard
+/// manifests the dataset has to manage.
+const MAX_NUM_BUCKETS: u32 = 1024;
+
+/// How writes are partitioned into MemWAL shards.
+#[derive(Debug)]
+enum Sharding {
+    /// No sharding spec is recorded; shards are managed manually.
+    Manual,
+    /// A single shard; every row is routed to it.
+    Unsharded,
+    /// Hash-bucket the single-column unenforced primary key into `num_buckets`
+    /// shards.
+    Bucket { column: String, num_buckets: u32 },
 }
 
-/// Shard initialization options for MemWAL.
-#[derive(Debug, Clone, Default)]
-pub struct MemWalShardConfig {
-    /// Number of shards managed by the MemWAL index.
-    pub num_shards: u32,
+/// Builder for initializing MemWAL on a [`Dataset`].
+///
+/// Created by [`DatasetMemWalExt::initialize_mem_wal`]. Choose a sharding
+/// strategy and the indexes to maintain, then call [`execute`](Self::execute).
+///
+/// # Example
+///
+/// ```ignore
+/// use lance::dataset::mem_wal::DatasetMemWalExt;
+///
+/// dataset
+///     .initialize_mem_wal()
+///     .bucket_sharding("id", 16)
+///     .maintained_indexes(["id_btree"])
+///     .execute()
+///     .await?;
+/// ```
+#[must_use = "InitializeMemWalBuilder does nothing unless `.execute()` is awaited"]
+pub struct InitializeMemWalBuilder<'a> {
+    dataset: &'a mut Dataset,
+    sharding: Sharding,
+    maintained_indexes: Vec<String>,
+    writer_defaults: HashMap<String, String>,
+}
+
+impl<'a> InitializeMemWalBuilder<'a> {
+    fn new(dataset: &'a mut Dataset) -> Self {
+        Self {
+            dataset,
+            sharding: Sharding::Manual,
+            maintained_indexes: Vec::new(),
+            writer_defaults: HashMap::new(),
+        }
+    }
+
+    /// Route every row to a single MemWAL shard.
+    pub fn unsharded(mut self) -> Self {
+        self.sharding = Sharding::Unsharded;
+        self
+    }
+
+    /// Hash-bucket the unenforced primary key into `num_buckets` shards.
+    ///
+    /// `column` must name the dataset's single-column unenforced primary key;
+    /// `num_buckets` must be in `[1, 1024]`. Both are validated by
+    /// [`execute`](Self::execute).
+    pub fn bucket_sharding(mut self, column: impl Into<String>, num_buckets: u32) -> Self {
+        self.sharding = Sharding::Bucket {
+            column: column.into(),
+            num_buckets,
+        };
+        self
+    }
+
+    /// Set the base-table indexes to maintain in MemTables, replacing any
+    /// previously set list.
+    ///
+    /// Each name must reference an index that already exists on the dataset.
+    /// The primary key btree is maintained implicitly and must not be listed.
+    pub fn maintained_indexes<I, S>(mut self, indexes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.maintained_indexes = indexes.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set the default `ShardWriter` configuration recorded in the MemWAL
+    /// index, replacing any previously set defaults.
+    ///
+    /// These are defaults only; an individual writer may still override any
+    /// value at runtime in its own (non-persisted) `ShardWriterConfig`.
+    pub fn writer_defaults<I, K, V>(mut self, defaults: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.writer_defaults = defaults
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect();
+        self
+    }
+
+    /// Record a single default `ShardWriter` configuration entry.
+    pub fn writer_default(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.writer_defaults.insert(key.into(), value.into());
+        self
+    }
+
+    /// Initialize MemWAL on the dataset, committing the MemWAL system index.
+    ///
+    /// Fails if the dataset has no unenforced primary key, if any maintained
+    /// index does not exist, or if MemWAL is already initialized.
+    pub async fn execute(self) -> Result<()> {
+        let Self {
+            dataset,
+            sharding,
+            maintained_indexes,
+            writer_defaults,
+        } = self;
+
+        if dataset.schema().unenforced_primary_key().is_empty() {
+            return Err(Error::invalid_input(
+                "MemWAL requires a primary key on the dataset. \
+                 Define a primary key using the 'lance-schema:unenforced-primary-key' Arrow field metadata.",
+            ));
+        }
+
+        // Resolve (and validate) the sharding choice before any I/O.
+        let (sharding_specs, num_shards) = resolve_sharding(dataset, sharding)?;
+
+        let indices = dataset.load_indices().await?;
+        for index_name in &maintained_indexes {
+            if !indices.iter().any(|idx| &idx.name == index_name) {
+                return Err(Error::invalid_input(format!(
+                    "Index '{}' not found on dataset. maintained_indexes must reference existing indexes.",
+                    index_name
+                )));
+            }
+        }
+        if indices.iter().any(|idx| idx.name == MEM_WAL_INDEX_NAME) {
+            return Err(Error::invalid_input(
+                "MemWAL is already initialized on this dataset.",
+            ));
+        }
+
+        let details = MemWalIndexDetails {
+            num_shards,
+            sharding_specs,
+            maintained_indexes,
+            writer_defaults,
+            ..Default::default()
+        };
+
+        let index_meta = new_mem_wal_index_meta(dataset.manifest.version, details)?;
+        let transaction = Transaction::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![index_meta],
+                removed_indices: vec![],
+            },
+            None,
+        );
+
+        let new_dataset = CommitBuilder::new(Arc::new(dataset.clone()))
+            .execute(transaction)
+            .await?;
+        *dataset = new_dataset;
+
+        Ok(())
+    }
+}
+
+/// Resolve a [`Sharding`] choice into the sharding specs and shard count to
+/// persist in [`MemWalIndexDetails`].
+fn resolve_sharding(dataset: &Dataset, sharding: Sharding) -> Result<(Vec<ShardingSpec>, u32)> {
+    match sharding {
+        Sharding::Manual => Ok((Vec::new(), 0)),
+        Sharding::Unsharded => Ok((vec![unsharded_sharding_spec()], 1)),
+        Sharding::Bucket {
+            column,
+            num_buckets,
+        } => Ok((
+            vec![bucket_sharding_spec(dataset, &column, num_buckets)?],
+            num_buckets,
+        )),
+    }
+}
+
+/// Build the sharding spec for [`InitializeMemWalBuilder::unsharded`].
+fn unsharded_sharding_spec() -> ShardingSpec {
+    ShardingSpec {
+        spec_id: SHARDING_SPEC_ID,
+        fields: vec![ShardingField {
+            field_id: SHARDING_FIELD_ID.to_string(),
+            source_ids: Vec::new(),
+            transform: Some(UNSHARDED_TRANSFORM.to_string()),
+            expression: None,
+            result_type: SHARDING_RESULT_TYPE.to_string(),
+            parameters: HashMap::new(),
+        }],
+    }
+}
+
+/// Build the sharding spec for [`InitializeMemWalBuilder::bucket_sharding`].
+fn bucket_sharding_spec(dataset: &Dataset, column: &str, num_buckets: u32) -> Result<ShardingSpec> {
+    if num_buckets == 0 || num_buckets > MAX_NUM_BUCKETS {
+        return Err(Error::invalid_input(format!(
+            "bucket_sharding: num_buckets must be in [1, {}], got {}",
+            MAX_NUM_BUCKETS, num_buckets
+        )));
+    }
+
+    let pk_fields = dataset.schema().unenforced_primary_key();
+    let pk = match pk_fields.as_slice() {
+        [single] => *single,
+        _ => {
+            return Err(Error::invalid_input(
+                "bucket_sharding requires a single-column unenforced primary key; \
+                 use unsharded() for a multi-column key",
+            ));
+        }
+    };
+    if pk.name.as_str() != column {
+        return Err(Error::invalid_input(format!(
+            "bucket_sharding: column '{}' does not match the unenforced primary key column '{}'",
+            column, pk.name
+        )));
+    }
+
+    Ok(ShardingSpec {
+        spec_id: SHARDING_SPEC_ID,
+        fields: vec![ShardingField {
+            field_id: SHARDING_FIELD_ID.to_string(),
+            source_ids: vec![pk.id],
+            transform: Some(BUCKET_TRANSFORM.to_string()),
+            expression: None,
+            result_type: SHARDING_RESULT_TYPE.to_string(),
+            parameters: HashMap::from([(NUM_BUCKETS_PARAM.to_string(), num_buckets.to_string())]),
+        }],
+    })
 }
 
 /// Extension trait for Dataset to support MemWAL operations.
 #[async_trait]
 pub trait DatasetMemWalExt {
-    /// Initialize MemWAL on this dataset.
+    /// Begin initializing MemWAL on this dataset.
     ///
-    /// Creates the MemWalIndex system index with the given configuration.
-    /// All indexes in `maintained_indexes` must already exist on the dataset.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let mut dataset = Dataset::open("s3://bucket/dataset").await?;
-    /// dataset.initialize_mem_wal(MemWalConfig {
-    ///     sharding_spec: None,
-    ///     maintained_indexes: vec!["id_btree".to_string()],
-    /// }).await?;
-    /// ```
-    async fn initialize_mem_wal(&mut self, config: MemWalConfig) -> Result<()>;
-
-    /// Initialize MemWAL with explicit shard state.
-    ///
-    /// This preserves [`MemWalConfig`] struct-literal compatibility while
-    /// allowing callers that need precomputed shard mappings to initialize the
-    /// MemWAL index with inline shard snapshots.
-    async fn initialize_mem_wal_with_shards(
-        &mut self,
-        config: MemWalConfig,
-        shard_config: MemWalShardConfig,
-    ) -> Result<()> {
-        if shard_config.num_shards == 0 {
-            self.initialize_mem_wal(config).await
-        } else {
-            Err(Error::invalid_input(
-                "initialize_mem_wal_with_shards is not implemented for this DatasetMemWalExt implementer",
-            ))
-        }
-    }
+    /// Returns an [`InitializeMemWalBuilder`]; configure the sharding strategy
+    /// and maintained indexes, then call [`InitializeMemWalBuilder::execute`].
+    fn initialize_mem_wal(&mut self) -> InitializeMemWalBuilder<'_>;
 
     /// Return the MemWAL index details for this dataset, if MemWAL is initialized.
     async fn mem_wal_index_details(&self) -> Result<Option<MemWalIndexDetails>> {
@@ -127,16 +336,8 @@ pub trait DatasetMemWalExt {
 
 #[async_trait]
 impl DatasetMemWalExt for Dataset {
-    async fn initialize_mem_wal(&mut self, config: MemWalConfig) -> Result<()> {
-        initialize_mem_wal_impl(self, config, MemWalShardConfig::default()).await
-    }
-
-    async fn initialize_mem_wal_with_shards(
-        &mut self,
-        config: MemWalConfig,
-        shard_config: MemWalShardConfig,
-    ) -> Result<()> {
-        initialize_mem_wal_impl(self, config, shard_config).await
+    fn initialize_mem_wal(&mut self) -> InitializeMemWalBuilder<'_> {
+        InitializeMemWalBuilder::new(self)
     }
 
     async fn mem_wal_index_details(&self) -> Result<Option<MemWalIndexDetails>> {
@@ -256,63 +457,6 @@ impl DatasetMemWalExt for Dataset {
         )
         .await
     }
-}
-
-async fn initialize_mem_wal_impl(
-    dataset: &mut Dataset,
-    config: MemWalConfig,
-    shard_config: MemWalShardConfig,
-) -> Result<()> {
-    let pk_fields = dataset.schema().unenforced_primary_key();
-    if pk_fields.is_empty() {
-        return Err(Error::invalid_input(
-            "MemWAL requires a primary key on the dataset. \
-             Define a primary key using the 'lance-schema:unenforced-primary-key' Arrow field metadata.",
-        ));
-    }
-
-    let indices = dataset.load_indices().await?;
-    for index_name in &config.maintained_indexes {
-        if !indices.iter().any(|idx| &idx.name == index_name) {
-            return Err(Error::invalid_input(format!(
-                "Index '{}' not found on dataset. maintained_indexes must reference existing indexes.",
-                index_name
-            )));
-        }
-    }
-
-    if indices.iter().any(|idx| idx.name == MEM_WAL_INDEX_NAME) {
-        return Err(Error::invalid_input(
-            "MemWAL is already initialized on this dataset. Use update methods instead.",
-        ));
-    }
-
-    let details = MemWalIndexDetails {
-        num_shards: shard_config.num_shards,
-        inline_snapshots: None,
-        sharding_specs: config.sharding_spec.into_iter().collect(),
-        maintained_indexes: config.maintained_indexes,
-        writer_defaults: config.writer_defaults,
-        ..Default::default()
-    };
-
-    let index_meta = new_mem_wal_index_meta(dataset.manifest.version, details)?;
-    let transaction = Transaction::new(
-        dataset.manifest.version,
-        Operation::CreateIndex {
-            new_indices: vec![index_meta],
-            removed_indices: vec![],
-        },
-        None,
-    );
-
-    let new_dataset = CommitBuilder::new(Arc::new(dataset.clone()))
-        .execute(transaction)
-        .await?;
-
-    *dataset = new_dataset;
-
-    Ok(())
 }
 
 /// Build an in-memory HNSW vector index configuration from a base-table

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -6,6 +6,7 @@
 //! This module provides the user-facing API for initializing and using MemWAL
 //! on a Dataset.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::index::DatasetIndexExt;
@@ -37,6 +38,10 @@ pub struct MemWalConfig {
     /// Index names to maintain in MemTables.
     /// These must reference indexes already defined on the base table.
     pub maintained_indexes: Vec<String>,
+    /// Default `ShardWriter` configuration values to record in the MemWAL
+    /// index, so every writer starts from the same defaults. Empty means no
+    /// defaults are recorded.
+    pub writer_defaults: HashMap<String, String>,
 }
 
 /// Shard initialization options for MemWAL.
@@ -287,6 +292,7 @@ async fn initialize_mem_wal_impl(
         inline_snapshots: None,
         sharding_specs: config.sharding_spec.into_iter().collect(),
         maintained_indexes: config.maintained_indexes,
+        writer_defaults: config.writer_defaults,
         ..Default::default()
     };
 

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -92,7 +92,7 @@ pub struct InitializeMemWalBuilder<'a> {
     dataset: &'a mut Dataset,
     sharding: Sharding,
     maintained_indexes: Vec<String>,
-    writer_defaults: HashMap<String, String>,
+    writer_config_defaults: HashMap<String, String>,
 }
 
 impl<'a> InitializeMemWalBuilder<'a> {
@@ -101,7 +101,7 @@ impl<'a> InitializeMemWalBuilder<'a> {
             dataset,
             sharding: Sharding::Manual,
             maintained_indexes: Vec::new(),
-            writer_defaults: HashMap::new(),
+            writer_config_defaults: HashMap::new(),
         }
     }
 
@@ -162,9 +162,9 @@ impl<'a> InitializeMemWalBuilder<'a> {
     /// (non-persisted) `ShardWriterConfig`.
     ///
     /// Merges into any defaults already set; a key set via
-    /// [`add_writer_default`](Self::add_writer_default) afterwards wins.
+    /// [`add_writer_config_default`](Self::add_writer_config_default) afterwards wins.
     pub fn writer_config_defaults(mut self, config: ShardWriterConfig) -> Self {
-        self.writer_defaults
+        self.writer_config_defaults
             .extend(writer_config_to_defaults(&config));
         self
     }
@@ -173,8 +173,12 @@ impl<'a> InitializeMemWalBuilder<'a> {
     ///
     /// Use this for keys not covered by
     /// [`writer_config_defaults`](Self::writer_config_defaults).
-    pub fn add_writer_default(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.writer_defaults.insert(key.into(), value.into());
+    pub fn add_writer_config_default(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.writer_config_defaults.insert(key.into(), value.into());
         self
     }
 
@@ -187,7 +191,7 @@ impl<'a> InitializeMemWalBuilder<'a> {
             dataset,
             sharding,
             maintained_indexes,
-            writer_defaults,
+            writer_config_defaults,
         } = self;
 
         if dataset.schema().unenforced_primary_key().is_empty() {
@@ -219,7 +223,7 @@ impl<'a> InitializeMemWalBuilder<'a> {
             num_shards,
             sharding_specs,
             maintained_indexes,
-            writer_defaults,
+            writer_config_defaults,
             ..Default::default()
         };
 

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use arrow_schema::DataType;
 use async_trait::async_trait;
 use lance_core::{Error, Result};
 use lance_index::mem_wal::{MEM_WAL_INDEX_NAME, MemWalIndexDetails, ShardingField, ShardingSpec};
@@ -43,6 +44,10 @@ const BUCKET_TRANSFORM: &str = "bucket";
 /// a single shard.
 const UNSHARDED_TRANSFORM: &str = "unsharded";
 
+/// Transform name for [`InitializeMemWalBuilder::identity_sharding`]: the shard
+/// value is the raw value of the source column.
+const IDENTITY_TRANSFORM: &str = "identity";
+
 /// Parameter key holding the bucket count `N` on the bucket transform.
 const NUM_BUCKETS_PARAM: &str = "num_buckets";
 
@@ -61,6 +66,8 @@ enum Sharding {
     /// Hash-bucket the single-column unenforced primary key into `num_buckets`
     /// shards.
     Bucket { column: String, num_buckets: u32 },
+    /// Shard by the raw value of `column` (identity transform).
+    Identity { column: String },
 }
 
 /// Builder for initializing MemWAL on a [`Dataset`].
@@ -113,6 +120,20 @@ impl<'a> InitializeMemWalBuilder<'a> {
         self.sharding = Sharding::Bucket {
             column: column.into(),
             num_buckets,
+        };
+        self
+    }
+
+    /// Shard by the raw value of `column` (the identity transform).
+    ///
+    /// Each distinct value of `column` becomes its own shard; use this when the
+    /// data is already partitioned by that column. The caller is responsible
+    /// for ensuring every primary key maps consistently to a single value of
+    /// `column`. `column` must be a scalar column that exists on the dataset;
+    /// it is validated by [`execute`](Self::execute).
+    pub fn identity_sharding(mut self, column: impl Into<String>) -> Self {
+        self.sharding = Sharding::Identity {
+            column: column.into(),
         };
         self
     }
@@ -232,6 +253,7 @@ fn resolve_sharding(dataset: &Dataset, sharding: Sharding) -> Result<(Vec<Shardi
             vec![bucket_sharding_spec(dataset, &column, num_buckets)?],
             num_buckets,
         )),
+        Sharding::Identity { column } => Ok((vec![identity_sharding_spec(dataset, &column)?], 0)),
     }
 }
 
@@ -286,6 +308,55 @@ fn bucket_sharding_spec(dataset: &Dataset, column: &str, num_buckets: u32) -> Re
             result_type: SHARDING_RESULT_TYPE.to_string(),
             parameters: HashMap::from([(NUM_BUCKETS_PARAM.to_string(), num_buckets.to_string())]),
         }],
+    })
+}
+
+/// Build the sharding spec for [`InitializeMemWalBuilder::identity_sharding`].
+fn identity_sharding_spec(dataset: &Dataset, column: &str) -> Result<ShardingSpec> {
+    let field = dataset.schema().field(column).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "identity_sharding: column '{}' not found on the dataset",
+            column
+        ))
+    })?;
+
+    let data_type = field.data_type();
+    let result_type = scalar_result_type(&data_type).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "identity_sharding: column '{}' has type {:?}, which cannot be used as a shard key",
+            column, data_type
+        ))
+    })?;
+
+    Ok(ShardingSpec {
+        spec_id: SHARDING_SPEC_ID,
+        fields: vec![ShardingField {
+            field_id: SHARDING_FIELD_ID.to_string(),
+            source_ids: vec![field.id],
+            transform: Some(IDENTITY_TRANSFORM.to_string()),
+            expression: None,
+            result_type: result_type.to_string(),
+            parameters: HashMap::new(),
+        }],
+    })
+}
+
+/// The Arrow type name for a scalar column usable as a shard key, or `None`
+/// for types that cannot be a shard key.
+fn scalar_result_type(data_type: &DataType) -> Option<&'static str> {
+    Some(match data_type {
+        DataType::Int8 => "int8",
+        DataType::Int16 => "int16",
+        DataType::Int32 => "int32",
+        DataType::Int64 => "int64",
+        DataType::UInt8 => "uint8",
+        DataType::UInt16 => "uint16",
+        DataType::UInt32 => "uint32",
+        DataType::UInt64 => "uint64",
+        DataType::Utf8 => "utf8",
+        DataType::LargeUtf8 => "large_utf8",
+        DataType::Boolean => "boolean",
+        _ => return None,
     })
 }
 

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -152,26 +152,28 @@ impl<'a> InitializeMemWalBuilder<'a> {
         self
     }
 
-    /// Set the default `ShardWriter` configuration recorded in the MemWAL
-    /// index, replacing any previously set defaults.
+    /// Record `config` as the default `ShardWriter` configuration.
     ///
-    /// These are defaults only; an individual writer may still override any
-    /// value at runtime in its own (non-persisted) `ShardWriterConfig`.
-    pub fn writer_defaults<I, K, V>(mut self, defaults: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.writer_defaults = defaults
-            .into_iter()
-            .map(|(k, v)| (k.into(), v.into()))
-            .collect();
+    /// Every tunable field is persisted into the MemWAL index so that all
+    /// writers — across processes and restarts — start from the same
+    /// defaults. Shard identity (`shard_id`, `shard_spec_id`) is not a
+    /// configuration default and is not recorded. These remain defaults only:
+    /// an individual writer may still override any value at runtime in its own
+    /// (non-persisted) `ShardWriterConfig`.
+    ///
+    /// Merges into any defaults already set; a key set via
+    /// [`add_writer_default`](Self::add_writer_default) afterwards wins.
+    pub fn writer_config_defaults(mut self, config: ShardWriterConfig) -> Self {
+        self.writer_defaults
+            .extend(writer_config_to_defaults(&config));
         self
     }
 
-    /// Record a single default `ShardWriter` configuration entry.
-    pub fn writer_default(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+    /// Record a single arbitrary writer-configuration default.
+    ///
+    /// Use this for keys not covered by
+    /// [`writer_config_defaults`](Self::writer_config_defaults).
+    pub fn add_writer_default(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.writer_defaults.insert(key.into(), value.into());
         self
     }
@@ -358,6 +360,75 @@ fn scalar_result_type(data_type: &DataType) -> Option<&'static str> {
         DataType::Boolean => "boolean",
         _ => return None,
     })
+}
+
+/// Extract the tunable defaults from a [`ShardWriterConfig`] into the persisted
+/// string map. Shard identity (`shard_id`, `shard_spec_id`) is not a default.
+/// `Duration` knobs are recorded in milliseconds with a `_ms` key suffix.
+fn writer_config_to_defaults(config: &ShardWriterConfig) -> HashMap<String, String> {
+    let mut defaults = HashMap::from([
+        (
+            "durable_write".to_string(),
+            config.durable_write.to_string(),
+        ),
+        (
+            "sync_indexed_write".to_string(),
+            config.sync_indexed_write.to_string(),
+        ),
+        (
+            "max_wal_buffer_size".to_string(),
+            config.max_wal_buffer_size.to_string(),
+        ),
+        (
+            "max_memtable_size".to_string(),
+            config.max_memtable_size.to_string(),
+        ),
+        (
+            "max_memtable_rows".to_string(),
+            config.max_memtable_rows.to_string(),
+        ),
+        (
+            "max_memtable_batches".to_string(),
+            config.max_memtable_batches.to_string(),
+        ),
+        (
+            "manifest_scan_batch_size".to_string(),
+            config.manifest_scan_batch_size.to_string(),
+        ),
+        (
+            "max_unflushed_memtable_bytes".to_string(),
+            config.max_unflushed_memtable_bytes.to_string(),
+        ),
+        (
+            "backpressure_log_interval_ms".to_string(),
+            config.backpressure_log_interval.as_millis().to_string(),
+        ),
+        (
+            "async_index_buffer_rows".to_string(),
+            config.async_index_buffer_rows.to_string(),
+        ),
+        (
+            "async_index_interval_ms".to_string(),
+            config.async_index_interval.as_millis().to_string(),
+        ),
+        (
+            "enable_memtable".to_string(),
+            config.enable_memtable.to_string(),
+        ),
+    ]);
+    if let Some(interval) = config.max_wal_flush_interval {
+        defaults.insert(
+            "max_wal_flush_interval_ms".to_string(),
+            interval.as_millis().to_string(),
+        );
+    }
+    if let Some(interval) = config.stats_log_interval {
+        defaults.insert(
+            "stats_log_interval_ms".to_string(),
+            interval.as_millis().to_string(),
+        );
+    }
+    defaults
 }
 
 /// Extension trait for Dataset to support MemWAL operations.

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -4083,14 +4083,14 @@ mod shard_writer_tests {
             .await
             .expect("Failed to create dataset");
 
-        let writer_defaults = std::collections::HashMap::from([
-            ("max_wal_buffer_size".to_string(), "8388608".to_string()),
-            ("durable_write".to_string(), "true".to_string()),
-        ]);
+        let writer_config = ShardWriterConfig::default()
+            .with_durable_write(false)
+            .with_max_memtable_size(8 * 1024 * 1024);
 
         dataset
             .initialize_mem_wal()
-            .writer_defaults(writer_defaults.clone())
+            .writer_config_defaults(writer_config)
+            .add_writer_default("custom_knob", "custom_value")
             .execute()
             .await
             .expect("Failed to initialize MemWAL");
@@ -4102,7 +4102,35 @@ mod shard_writer_tests {
             .expect("Failed to read MemWAL index details")
             .expect("MemWAL index details should exist");
 
-        assert_eq!(details.writer_defaults, writer_defaults);
+        let defaults = &details.writer_defaults;
+        // ShardWriterConfig tunables are recorded under their field names.
+        assert_eq!(
+            defaults.get("durable_write").map(String::as_str),
+            Some("false")
+        );
+        assert_eq!(
+            defaults.get("max_memtable_size").map(String::as_str),
+            Some("8388608")
+        );
+        // Duration knobs are recorded in milliseconds with a `_ms` suffix.
+        assert_eq!(
+            defaults
+                .get("max_wal_flush_interval_ms")
+                .map(String::as_str),
+            Some("100")
+        );
+        // Every tunable field is present.
+        assert!(defaults.contains_key("sync_indexed_write"));
+        assert!(defaults.contains_key("enable_memtable"));
+        assert!(defaults.contains_key("async_index_interval_ms"));
+        // add_writer_default records arbitrary keys.
+        assert_eq!(
+            defaults.get("custom_knob").map(String::as_str),
+            Some("custom_value")
+        );
+        // Shard identity is not a configuration default.
+        assert!(!defaults.contains_key("shard_id"));
+        assert!(!defaults.contains_key("shard_spec_id"));
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -4192,6 +4192,62 @@ mod shard_writer_tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_initialize_mem_wal_identity_sharding() {
+        let vector_dim = 128;
+        let schema = create_test_schema(vector_dim);
+        let uri = format!("memory://test_identity_sharding_{}", Uuid::new_v4());
+
+        let initial_batch = create_test_batch(&schema, 0, 100, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial_batch)], schema.clone());
+        let mut dataset = Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .expect("Failed to create dataset");
+
+        // A column that does not exist is rejected.
+        let result = dataset
+            .initialize_mem_wal()
+            .identity_sharding("nonexistent")
+            .execute()
+            .await;
+        assert!(
+            result.is_err(),
+            "an unknown identity column should be rejected"
+        );
+
+        // A non-scalar column cannot be a shard key.
+        let result = dataset
+            .initialize_mem_wal()
+            .identity_sharding("vector")
+            .execute()
+            .await;
+        assert!(
+            result.is_err(),
+            "a non-scalar identity column should be rejected"
+        );
+
+        dataset
+            .initialize_mem_wal()
+            .identity_sharding("text")
+            .execute()
+            .await
+            .expect("Failed to initialize MemWAL");
+
+        let details = dataset
+            .mem_wal_index_details()
+            .await
+            .expect("Failed to read MemWAL index details")
+            .expect("MemWAL index details should exist");
+
+        // Identity sharding has an open-ended shard count.
+        assert_eq!(details.num_shards, 0);
+        assert_eq!(details.sharding_specs.len(), 1);
+        let field = &details.sharding_specs[0].fields[0];
+        assert_eq!(field.transform.as_deref(), Some("identity"));
+        assert_eq!(field.result_type.as_str(), "utf8");
+        assert_eq!(field.source_ids.len(), 1);
+    }
+
     /// Quick smoke test for shard writer - runs against memory://
     /// Run with: cargo test -p lance shard_writer_tests::test_shard_writer_smoke -- --nocapture
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -4071,6 +4071,42 @@ mod shard_writer_tests {
         .unwrap()
     }
 
+    #[tokio::test]
+    async fn test_initialize_mem_wal_records_writer_defaults() {
+        let vector_dim = 128;
+        let schema = create_test_schema(vector_dim);
+        let uri = format!("memory://test_writer_defaults_{}", Uuid::new_v4());
+
+        let initial_batch = create_test_batch(&schema, 0, 100, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial_batch)], schema.clone());
+        let mut dataset = Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .expect("Failed to create dataset");
+
+        let writer_defaults = std::collections::HashMap::from([
+            ("max_wal_buffer_size".to_string(), "8388608".to_string()),
+            ("durable_write".to_string(), "true".to_string()),
+        ]);
+
+        dataset
+            .initialize_mem_wal(MemWalConfig {
+                writer_defaults: writer_defaults.clone(),
+                sharding_spec: None,
+                maintained_indexes: vec![],
+            })
+            .await
+            .expect("Failed to initialize MemWAL");
+
+        // Defaults must survive the manifest round-trip so all writers share them.
+        let details = dataset
+            .mem_wal_index_details()
+            .await
+            .expect("Failed to read MemWAL index details")
+            .expect("MemWAL index details should exist");
+
+        assert_eq!(details.writer_defaults, writer_defaults);
+    }
+
     /// Quick smoke test for shard writer - runs against memory://
     /// Run with: cargo test -p lance shard_writer_tests::test_shard_writer_smoke -- --nocapture
     #[tokio::test]
@@ -4092,6 +4128,7 @@ mod shard_writer_tests {
         // Initialize MemWAL (no indexes for smoke test)
         dataset
             .initialize_mem_wal(MemWalConfig {
+                writer_defaults: Default::default(),
                 sharding_spec: None,
                 maintained_indexes: vec![],
             })
@@ -4149,6 +4186,7 @@ mod shard_writer_tests {
 
         dataset
             .initialize_mem_wal(MemWalConfig {
+                writer_defaults: Default::default(),
                 sharding_spec: None,
                 maintained_indexes: vec!["vector_idx".to_string()],
             })
@@ -4290,6 +4328,7 @@ mod shard_writer_tests {
         // Initialize MemWAL with all three indexes
         dataset
             .initialize_mem_wal(MemWalConfig {
+                writer_defaults: Default::default(),
                 sharding_spec: None,
                 maintained_indexes: vec![
                     "id_btree".to_string(),
@@ -4372,6 +4411,7 @@ mod shard_writer_tests {
         // Initialize MemWAL with BTree index only (simpler for this test)
         dataset
             .initialize_mem_wal(MemWalConfig {
+                writer_defaults: Default::default(),
                 sharding_spec: None,
                 maintained_indexes: vec!["id_btree".to_string()],
             })

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -4072,10 +4072,10 @@ mod shard_writer_tests {
     }
 
     #[tokio::test]
-    async fn test_initialize_mem_wal_records_writer_defaults() {
+    async fn test_initialize_mem_wal_records_writer_config_defaults() {
         let vector_dim = 128;
         let schema = create_test_schema(vector_dim);
-        let uri = format!("memory://test_writer_defaults_{}", Uuid::new_v4());
+        let uri = format!("memory://test_writer_config_defaults_{}", Uuid::new_v4());
 
         let initial_batch = create_test_batch(&schema, 0, 100, vector_dim);
         let batches = RecordBatchIterator::new([Ok(initial_batch)], schema.clone());
@@ -4090,7 +4090,7 @@ mod shard_writer_tests {
         dataset
             .initialize_mem_wal()
             .writer_config_defaults(writer_config)
-            .add_writer_default("custom_knob", "custom_value")
+            .add_writer_config_default("custom_knob", "custom_value")
             .execute()
             .await
             .expect("Failed to initialize MemWAL");
@@ -4102,7 +4102,7 @@ mod shard_writer_tests {
             .expect("Failed to read MemWAL index details")
             .expect("MemWAL index details should exist");
 
-        let defaults = &details.writer_defaults;
+        let defaults = &details.writer_config_defaults;
         // ShardWriterConfig tunables are recorded under their field names.
         assert_eq!(
             defaults.get("durable_write").map(String::as_str),
@@ -4123,7 +4123,7 @@ mod shard_writer_tests {
         assert!(defaults.contains_key("sync_indexed_write"));
         assert!(defaults.contains_key("enable_memtable"));
         assert!(defaults.contains_key("async_index_interval_ms"));
-        // add_writer_default records arbitrary keys.
+        // add_writer_config_default records arbitrary keys.
         assert_eq!(
             defaults.get("custom_knob").map(String::as_str),
             Some("custom_value")

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -4007,7 +4007,7 @@ mod shard_writer_tests {
     use lance_linalg::distance::MetricType;
     use uuid::Uuid;
 
-    use crate::dataset::mem_wal::{DatasetMemWalExt, MemWalConfig};
+    use crate::dataset::mem_wal::DatasetMemWalExt;
     use crate::dataset::{Dataset, WriteParams};
     use crate::index::vector::VectorIndexParams;
 
@@ -4089,11 +4089,9 @@ mod shard_writer_tests {
         ]);
 
         dataset
-            .initialize_mem_wal(MemWalConfig {
-                writer_defaults: writer_defaults.clone(),
-                sharding_spec: None,
-                maintained_indexes: vec![],
-            })
+            .initialize_mem_wal()
+            .writer_defaults(writer_defaults.clone())
+            .execute()
             .await
             .expect("Failed to initialize MemWAL");
 
@@ -4105,6 +4103,93 @@ mod shard_writer_tests {
             .expect("MemWAL index details should exist");
 
         assert_eq!(details.writer_defaults, writer_defaults);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_mem_wal_bucket_sharding() {
+        let vector_dim = 128;
+        let schema = create_test_schema(vector_dim);
+        let uri = format!("memory://test_bucket_sharding_{}", Uuid::new_v4());
+
+        let initial_batch = create_test_batch(&schema, 0, 100, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial_batch)], schema.clone());
+        let mut dataset = Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .expect("Failed to create dataset");
+
+        // num_buckets out of range is rejected.
+        let result = dataset
+            .initialize_mem_wal()
+            .bucket_sharding("id", 0)
+            .execute()
+            .await;
+        assert!(result.is_err(), "num_buckets = 0 should be rejected");
+
+        // The bucket column must be the unenforced primary key column.
+        let result = dataset
+            .initialize_mem_wal()
+            .bucket_sharding("text", 8)
+            .execute()
+            .await;
+        assert!(
+            result.is_err(),
+            "a non-primary-key bucket column should be rejected"
+        );
+
+        dataset
+            .initialize_mem_wal()
+            .bucket_sharding("id", 8)
+            .execute()
+            .await
+            .expect("Failed to initialize MemWAL");
+
+        let details = dataset
+            .mem_wal_index_details()
+            .await
+            .expect("Failed to read MemWAL index details")
+            .expect("MemWAL index details should exist");
+
+        assert_eq!(details.num_shards, 8);
+        assert_eq!(details.sharding_specs.len(), 1);
+        let field = &details.sharding_specs[0].fields[0];
+        assert_eq!(field.transform.as_deref(), Some("bucket"));
+        assert_eq!(
+            field.parameters.get("num_buckets").map(String::as_str),
+            Some("8")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_initialize_mem_wal_unsharded() {
+        let vector_dim = 128;
+        let schema = create_test_schema(vector_dim);
+        let uri = format!("memory://test_unsharded_{}", Uuid::new_v4());
+
+        let initial_batch = create_test_batch(&schema, 0, 100, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial_batch)], schema.clone());
+        let mut dataset = Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .expect("Failed to create dataset");
+
+        dataset
+            .initialize_mem_wal()
+            .unsharded()
+            .execute()
+            .await
+            .expect("Failed to initialize MemWAL");
+
+        let details = dataset
+            .mem_wal_index_details()
+            .await
+            .expect("Failed to read MemWAL index details")
+            .expect("MemWAL index details should exist");
+
+        assert_eq!(details.num_shards, 1);
+        assert_eq!(details.sharding_specs.len(), 1);
+        assert_eq!(
+            details.sharding_specs[0].fields[0].transform.as_deref(),
+            Some("unsharded")
+        );
     }
 
     /// Quick smoke test for shard writer - runs against memory://
@@ -4127,11 +4212,8 @@ mod shard_writer_tests {
 
         // Initialize MemWAL (no indexes for smoke test)
         dataset
-            .initialize_mem_wal(MemWalConfig {
-                writer_defaults: Default::default(),
-                sharding_spec: None,
-                maintained_indexes: vec![],
-            })
+            .initialize_mem_wal()
+            .execute()
             .await
             .expect("Failed to initialize MemWAL");
 
@@ -4185,11 +4267,9 @@ mod shard_writer_tests {
             .expect("Failed to create base vector index");
 
         dataset
-            .initialize_mem_wal(MemWalConfig {
-                writer_defaults: Default::default(),
-                sharding_spec: None,
-                maintained_indexes: vec!["vector_idx".to_string()],
-            })
+            .initialize_mem_wal()
+            .maintained_indexes(["vector_idx"])
+            .execute()
             .await
             .expect("Failed to initialize MemWAL");
 
@@ -4327,15 +4407,9 @@ mod shard_writer_tests {
 
         // Initialize MemWAL with all three indexes
         dataset
-            .initialize_mem_wal(MemWalConfig {
-                writer_defaults: Default::default(),
-                sharding_spec: None,
-                maintained_indexes: vec![
-                    "id_btree".to_string(),
-                    "text_fts".to_string(),
-                    "vector_idx".to_string(),
-                ],
-            })
+            .initialize_mem_wal()
+            .maintained_indexes(["id_btree", "text_fts", "vector_idx"])
+            .execute()
             .await
             .expect("Failed to initialize MemWAL");
 
@@ -4410,11 +4484,9 @@ mod shard_writer_tests {
 
         // Initialize MemWAL with BTree index only (simpler for this test)
         dataset
-            .initialize_mem_wal(MemWalConfig {
-                writer_defaults: Default::default(),
-                sharding_spec: None,
-                maintained_indexes: vec!["id_btree".to_string()],
-            })
+            .initialize_mem_wal()
+            .maintained_indexes(["id_btree"])
+            .execute()
             .await
             .expect("Failed to initialize MemWAL");
 


### PR DESCRIPTION
## Summary

Replaces the struct-based MemWAL initialization API with a fluent builder on
`Dataset`, and persists default `ShardWriter` configuration in the MemWAL index.

`Dataset::initialize_mem_wal()` returns an `InitializeMemWalBuilder`:

```rust
dataset
    .initialize_mem_wal()
    .bucket_sharding("id", 16)
    .maintained_indexes(["id_btree"])
    .writer_config_defaults(ShardWriterConfig::default().with_durable_write(false))
    .execute()
    .await?;
```

- `bucket_sharding(column, num_buckets)`, `unsharded()`, and
  `identity_sharding(column)` are high-level sharding strategies. They own the
  `ShardingSpec` construction and validation that callers previously did by
  hand; `num_shards` is derived from the sharding choice.
- `writer_config_defaults(ShardWriterConfig)` records the tunable writer
  configuration as the persisted defaults — a new `map<string, string>
  writer_config_defaults` field on the `MemWalIndexDetails` protobuf message —
  so every writer, across processes and restarts, starts from the same
  defaults. `add_writer_config_default` records arbitrary extra keys.
- The Python `initialize_mem_wal` binding accepts the full builder surface
  (sharding, maintained indexes, writer-config defaults) and invokes the
  builder; a new `mem_wal_index_details` binding reads the recorded details back.
- Removed: `MemWalConfig`, `MemWalShardConfig`, `initialize_mem_wal_with_shards`.

## Context

While reviewing lancedb/lancedb#3396, @jackye1995 noted that per-writer tuning
knobs are runtime configuration and should not be persisted as part of the
sharding spec. That holds for a writer's *live* `ShardWriterConfig`, which stays
non-persisted. This PR records only the *defaults*: without a persisted
default, writers would be configured independently and could silently drift
apart.

@jackye1995 also asked for a builder style so bucket sharding is easy to set,
moving the hash-bucket spec logic out of the LanceDB layer into Lance. The
builder owns all three sharding strategies (bucket, unsharded, identity), so
LanceDB's `set_lsm_write_spec` can call the builder directly instead of
hand-building shard specs.
