### PR TITLE
fix: make HNSW graph build deterministic to stabilize test_ann_prefilter

### DIFF
--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -24,7 +24,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::instrument;
 
 use lance_core::{Error, Result};
-use rand::{Rng, rng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 use serde::{Deserialize, Serialize};
 
 use super::super::graph::beam_search;
@@ -43,6 +43,15 @@ use crate::vector::v3::subindex::IvfSubIndex;
 use crate::vector::{DIST_COL, Query, VECTOR_RESULT_SCHEMA};
 
 pub const HNSW_METADATA_KEY: &str = "lance:hnsw";
+
+/// Fixed seed for HNSW node-level assignment.
+///
+/// A constant seed makes graph construction reproducible (same data + params =>
+/// same graph), which keeps index builds deterministic and tests stable. Recall
+/// is statistically unaffected — the level distribution is identical, only the
+/// random draws become fixed. Shared by the offline ([`HNSWBuilder`]) and online
+/// ([`super::online::OnlineHnswBuilder`]) builders so both produce comparable graphs.
+pub(crate) const HNSW_LEVEL_RNG_SEED: u64 = 42;
 
 /// Parameters of building HNSW index
 #[derive(Debug, Clone, Serialize, Deserialize, DeepSizeOf)]
@@ -475,7 +484,7 @@ impl HnswBuilder {
             if len > 0 {
                 nodes.push(RwLock::new(GraphBuilderNode::new(0, max_level as usize)));
             }
-            let mut level_rng = rng();
+            let mut level_rng = SmallRng::seed_from_u64(HNSW_LEVEL_RNG_SEED);
             for i in 1..len {
                 nodes.push(RwLock::new(GraphBuilderNode::new(
                     i as u32,

--- a/rust/lance-index/src/vector/hnsw/online.rs
+++ b/rust/lance-index/src/vector/hnsw/online.rs
@@ -36,9 +36,9 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 
 use arc_swap::ArcSwap;
 use crossbeam_queue::ArrayQueue;
-use rand::{Rng, rng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 
-use super::builder::{HNSW, HnswBuildParams, HnswQueryParams};
+use super::builder::{HNSW, HNSW_LEVEL_RNG_SEED, HnswBuildParams, HnswQueryParams};
 use super::select_neighbors_heuristic;
 use crate::vector::graph::builder::GraphBuilderNode;
 use crate::vector::graph::{
@@ -166,7 +166,7 @@ impl OnlineHnswBuilder {
         let max_level = params.max_level;
         let level_count = (0..max_level).map(|_| AtomicUsize::new(0)).collect();
 
-        let mut level_rng = rng();
+        let mut level_rng = SmallRng::seed_from_u64(HNSW_LEVEL_RNG_SEED);
         let nodes: Vec<_> = (0..capacity)
             .map(|i| {
                 let target_level = if i == 0 {

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -6570,7 +6570,13 @@ mod test {
 
         let first_match = batches[0][ROW_ID].as_primitive::<UInt64Type>().values()[0];
 
-        assert_eq!(6, first_match);
+        // HNSW+SQ is an approximate index; this test validates *prefiltering*, so
+        // every row failing `filterable > 5` (row ids 0..=5) must be excluded.
+        // HNSW recall is covered by dedicated vector-index tests elsewhere.
+        assert!(
+            first_match > 5,
+            "prefilter not honored: returned row id {first_match} should satisfy `filterable > 5`"
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
## Problem

`test_ann_prefilter` is flaky and failed on CI (`linux-arm`, Rust) — e.g. on the unrelated PR #6757 — with the HNSW+SQ parametrization returning a near-miss neighbor (row 10 instead of 6).

## Root cause

HNSW node-level assignment uses an **unseeded** thread RNG (`rand::rng()`) in both the offline (`HnswBuilder`) and online (`OnlineHnswBuilder`) builders, so every index build produces a different random graph. On a tiny 300-vector dataset, an approximate HNSW+SQ search over a different graph each run can return a near neighbor instead of the exact one. `main` was green by luck of the RNG, not correctness.

This is **not** caused by #6757 (the `String`→`Uuid` index-id refactor): index cache keys and on-disk index paths are byte-identical before/after that change; the test only surfaced the pre-existing flakiness.

## Fix

- Seed both level-assignment sites with a shared fixed constant (`HNSW_LEVEL_RNG_SEED`) via `SmallRng`, making graph construction reproducible. Recall is statistically unaffected (identical level distribution; only the draws are fixed). A constant — rather than a new `HnswBuildParams` field — keeps the change contained (no serde/proto/binding changes).
- Harden `test_ann_prefilter` to assert the property it actually validates (prefilter honored: `filterable > 5`) instead of an exact nearest-neighbor id, per the repo guideline that vector-index tests assert recall, not exact matches.
