### PR TITLE
spike: action-based conflict resolution prototype

### DIFF
--- a/rust/lance-table/design/action_based_conflict_resolution.md
+++ b/rust/lance-table/design/action_based_conflict_resolution.md
@@ -1,0 +1,470 @@
+# Action-Based Conflict Resolution
+
+## 1. Background & Motivation
+
+Today, conflict resolution lives in per-`Operation` methods in
+`rust/lance/src/io/commit/conflict_resolver.rs` (`check_delete_txn`,
+`check_rewrite_txn`, `check_create_index_txn`, ...). Each method has full
+knowledge of the semantic intent of the `Operation` it handles.
+
+Under action-based transactions, a transaction is a flat list of `Action`s
+with no enclosing operation. Conflict detection and rebasing must work
+from `Action` type + payload alone.
+
+### Isolation level — current behavior
+
+We have not been rigorous about specifying an isolation level. This section
+documents what we actually do today (per-operation, by inspection) so we can
+ask whether action-based resolution can preserve it — and what it would take
+to offer stronger or weaker levels later.
+
+TODO: characterize current behavior per operation. Likely somewhere between
+snapshot isolation and serializable, with operation-specific carve-outs.
+
+### Goal of this doc
+
+1. Show whether conflict detection is possible purely from `Action` type +
+   payload (no semantic intent).
+2. Specify the conflict matrix and rebasing strategy.
+3. Call out what each `Action` payload must carry to make (1) work.
+4. Leave the door open to multiple isolation levels in the future.
+
+## 2. Scope & Non-Goals
+
+In scope:
+- Conflict detection between concurrent transactions.
+- Rebasing one transaction onto another.
+- Compound transactions (multi-action, with intra-txn dependencies).
+
+Out of scope:
+- Physical commit protocol / manifest layout.
+- Retry policy and backoff.
+- API surface for submitting transactions.
+
+## 3. Design Principles
+
+Two patterns govern how actions are shaped. Both exist to avoid committing
+too early to concrete values that may not survive concurrent commits.
+
+### 3.1 Criterion-based targeting
+
+Some actions act on an *open set* — entities a writer may not be able to
+enumerate when the transaction is constructed, because a concurrent writer
+can introduce new matching entities before commit.
+
+Example: a transaction updates column X on fragment 5. Concurrently another
+writer creates a new index over column X. Both land. If the first writer
+named indices by UUID, the new index would end up covering stale data.
+
+Rule: such actions carry a **predicate**, not an identity list. At
+`try_apply` time the predicate is evaluated against the *current* manifest
+and every matching entity is acted on. `InvalidateIndexCoverage` carries
+`{ fragment_ids, field_ids }`, not index UUIDs.
+
+Three tiers of consistency, with different homes:
+
+| Tier | Example | Enforced by |
+|------|---------|-------------|
+| Local | "this fragment exists" | `try_apply` |
+| Closed-set cross-resource | schema ↔ data files in the same txn | Builder at write time |
+| Open-set cross-resource | column update ↔ any index over that column | Criterion-based actions |
+
+### 3.2 Late binding of action output
+
+Some actions *produce* new entities (fragments, row IDs, index UUIDs).
+Their payload should declare the intent to produce, not the concrete
+identity. IDs are assigned at apply time from the manifest's counters.
+
+Contrast with a "rebasable IDs" design where the payload carries a
+provisional ID that gets rewritten on rebase. Late binding is preferred
+because:
+
+- Transactions are serialized for conflict resolution and recovery.
+  Carrying provisional IDs means the serialized form contains state that
+  is stale on read.
+- Rebase becomes a no-op for these fields — there is nothing to rewrite.
+
+Type-level consequence: payloads use `FragmentTemplate` (no ID) rather
+than `Fragment`. `apply` materializes the concrete `Fragment`.
+
+Late binding applies to **outputs the action produces** (allocated IDs,
+counter values). It does *not* apply to **inputs the action depends on**
+(e.g. which rows it intends to mark deleted) — those are mutated by
+`rebase` when concurrent changes shift them. See §7.
+
+### 3.3 Symbolic intra-transaction references
+
+A direct consequence of 3.2. If action *i* produces a fragment and action
+*j* > *i* needs to reference it, *j* cannot use a concrete ID. References
+are symbolic: `FragmentRef::ProducedBy { action_idx, output_idx }`,
+resolved as actions are applied in order. This pins the compound-txn
+dependency model to an **ordered list**, not a DAG.
+
+## 4. Action Catalog
+
+Enumerate each `Action` with:
+
+- Payload fields
+- Read-set (state it depends on)
+- Write-set (state it modifies)
+- Commutativity notes
+
+* RemoveFragments { fragment_ids: Vec<u32> }
+    - Read: fragment metadata (e.g. row counts, field coverage)
+    - Write: fragment metadata, row addresses (implicitly)
+    - Commutativity: commutes with non-overlapping RemoveFragments; conflicts with
+        any action that reads/writes the same fragment metadata or row addresses
+        (e.g. Update, AddIndex referencing those fragments)
+
+* AddFragments { fragments: Vec<FragmentTemplate>,
+                  preserved_row_ids: Option<Vec<PreservedRows>> }
+    - `FragmentTemplate` carries data files / row counts / deletion file —
+      *no* fragment ID and *no* row ID metadata (§3.2 late binding).
+    - `preserved_row_ids` (optional) names source `(fragment_id, offset_range)`
+      whose row IDs and `created_at_version_meta` should be carried into
+      the new fragments — used by Update RewriteRows.
+    - Read: NextFragmentId counter, NextRowId counter (if stable IDs on),
+      source fragments named in `preserved_row_ids` (if any).
+    - Write: fragment list (append), NextFragmentId, NextRowId.
+    - Commutativity: commutes with anything that does not read the new
+      fragments. Two concurrent AddFragments intersect on the counters →
+      slow path → `try_apply` assigns fresh IDs.
+
+* UpdateDeletionVector { fragment_id: u32, new_deletion_file: DeletionFile,
+                         affected_rows: Option<RowAddressRanges> }
+    - Read: fragment row count, existing deletion file
+    - Write: fragment.deletion_file
+    - Commutativity: commutes on different fragments. On the same fragment,
+      two UpdateDeletionVectors merge by union iff both carry `affected_rows`
+      and data files are unchanged; otherwise conflict.
+    - Conflicts with: RemoveFragments(same id), ReplaceFragmentColumns(same id)
+      when the affected rows overlap modified offsets, RewriteFragments(same id),
+      Restore.
+
+* ReplaceFragmentColumns { fragment_id: u32, field_ids: Vec<u32>,
+                            new_data_files: Vec<DataFile>,
+                            updated_row_offsets: Option<RowOffsetBitmap> }
+    - Read: existing data files for these fields on this fragment
+    - Write: data_files for listed fields; last_updated_at_version for rows
+      in updated_row_offsets (or all rows if absent)
+    - Commutativity: commutes with ReplaceFragmentColumns on disjoint
+      (fragment_id, field_id) pairs. Conflicts with any reader/writer of
+      those fields on that fragment.
+    - Used by: Update RewriteColumns mode.
+
+* RewriteFragments { old_fragment_ids: Vec<u32>,
+                     new_fragments: Vec<FragmentTemplate>,
+                     preserves_row_ids: bool }
+    - Read: full contents of old fragments
+    - Write: fragment list (splice old → new). Row addresses change. Row IDs
+      preserved iff `preserves_row_ids`.
+    - Used by: Compact. Distinguished from RemoveFragments+AddFragments
+      because it asserts data equivalence — lets concurrent reads/index
+      coverage be salvaged via RebindIndexCoverage.
+    - Conflicts with: anything touching old_fragment_ids' data or deletion
+      vectors; another RewriteFragments overlapping the same set.
+
+* RebindIndexCoverage { remap: Vec<(old_frag_id, new_frag_id)>,
+                         preserved_fields: Vec<u32> }
+    - Read: index fragment_bitmap, index field membership
+    - Write: index fragment_bitmap (swap old IDs for new IDs) for indices
+      covering only `preserved_fields`
+    - Used by: Compact, Update RewriteRows in the pure-rewrite (no inserts,
+      no field changes) case.
+    - Conflicts with: AddIndex / RewriteIndex over a bitmap that straddles
+      a remap group; InvalidateIndexCoverage on the same (frag, field).
+
+* InvalidateIndexCoverage { fragment_ids: Vec<u32>, field_ids: Vec<u32> }
+    - Read: index field membership
+    - Write: remove listed fragments from fragment_bitmap of every index
+      covering any of `field_ids`
+    - Used by: Update — for each fragment whose `fields_modified` overlap
+      an index.
+
+* RewriteIndex { old_id: Uuid, new_id: Uuid, new_index_files,
+                  new_index_details, new_index_version }
+    - Read: existing index entry
+    - Write: replace index entry (uuid + files)
+    - Used by: Compact without stable row IDs (full index rebuild).
+    - Conflicts with: any concurrent RewriteIndex/AddIndex/DropIndex on the
+      same UUID.
+
+* RegisterFragReuse { entries: ... }
+    - Read: current frag_reuse_index
+    - Write: frag_reuse_index (deferred remap state)
+    - Used by: Compact with stable row IDs.
+    - Conflicts with: another RegisterFragReuse in the same commit window
+      (only one deferred remap can land at a time); AddIndex whose coverage
+      straddles a deferred-remap group.
+
+* UpdateMergedGenerations { generations: Vec<MergedGeneration> }
+    - Read: MemWAL index state
+    - Write: MemWAL index entry
+    - Used by: Update (when consuming a MemWAL generation), MemWAL flush.
+    - Conflicts with: another UpdateMergedGenerations touching the same
+      generation.
+
+### Operation → Action decomposition (Delete / Update / Compact)
+
+**Delete** =
+- `RemoveFragments` over fully-emptied fragments, plus
+- one `UpdateDeletionVector` per partially-deleted fragment.
+
+**Update (RewriteRows)** =
+- `RemoveFragments(removed_fragment_ids)` +
+- `AddFragments(new_fragments)` (carrying preserved row IDs and
+  created_at_version_meta for moved rows) +
+- `UpdateDeletionVector(updated_fragments)` for any leftover partial deletes +
+- For each fragment whose modified fields overlap an index:
+  `InvalidateIndexCoverage`. For pure rewrites on preserved fields:
+  `RebindIndexCoverage(old → new, preserved_fields)`. +
+- Optional `UpdateMergedGenerations`.
+- Merge-insert primary-key conflict detection (`inserted_rows_filter`) is
+  attached to AddFragments as conflict-detection metadata — see §7.
+
+**Update (RewriteColumns)** =
+- One `ReplaceFragmentColumns` per (fragment, field-set) pair +
+- `InvalidateIndexCoverage` for indices over those fields on those fragments.
+
+**Compact** =
+- One `RewriteFragments` per RewriteGroup +
+- With stable row IDs: `RebindIndexCoverage` for every index whose bitmap
+  intersects a group, plus optional `RegisterFragReuse`.
+- Without stable row IDs: `RewriteIndex` for each affected index.
+
+TODO: table, one row per action. Action list is still in flux — keep this
+table as the source of truth and update §5/§6 from it.
+
+TODO: still to enumerate — Append-only, AddIndex, DropIndex, UpdateConfig,
+Restore, ReserveFragments, Project, UpdateBases, Clone, DataReplacement,
+Merge.
+
+## 5. Conflict Matrix
+
+N×N table over the action catalog in §4. Each cell:
+
+- **C** — Compatible (commutes, no rebase needed)
+- **X** — Conflict (cannot be rebased; fail)
+- **R(n)** — Conditional, see rule *n* in §5
+
+TODO: fill matrix once §4 stabilizes.
+
+The intersection rule for criterion-based mask paths (§3.1): a criterion
+path (e.g. "all indices over field X") overlaps any concrete path that
+satisfies the criterion. This lets a column-update action and a concurrent
+AddIndex on that column correctly hit the slow path.
+
+## 6. Conflict Rules
+
+One subsection per `R(n)` cell. Each rule states:
+
+- Detection predicate over payload fields only
+- Resolution: rebase rewrite, fail, or auto-merge
+
+TODO.
+
+## 7. Action Lifecycle
+
+Each action has three phases. The split exists to gate IO to one phase
+and keep the others pure.
+
+```rust
+pub trait Action {
+    fn reads(&self) -> ManifestMask;
+    fn writes(&self) -> ManifestMask;
+
+    /// Pure. Is this action well-formed against `manifest`?
+    /// Catches structural problems: missing fragments, schema mismatch,
+    /// invalid field IDs. Not concerned with concurrency.
+    fn validate(&self, manifest: &Manifest) -> Result<(), TransactionError>;
+
+    /// Mutates self to absorb concurrent changes. May do IO.
+    /// Only called when the mask screen indicates overlap.
+    async fn rebase(
+        &mut self,
+        current: &Manifest,
+        concurrent: &[Box<dyn Action>],
+    ) -> Result<(), TransactionError>;
+
+    /// Pure. Apply changes; validates inline; no IO.
+    fn apply(
+        &self,
+        manifest: &mut Manifest,
+        ctx: &mut TxnContext,
+    ) -> Result<ActionOutput, TransactionError>;
+}
+```
+
+### What each phase owns
+
+| Phase | Pure? | IO? | Question it answers |
+|-------|-------|-----|---------------------|
+| `validate` | yes | no | Is this action well-formed against this manifest? |
+| `rebase`   | mutates self | yes | Can I absorb the changes that landed since base? |
+| `apply`    | mutates manifest | no | Mechanical write-through. |
+
+`validate` is decoupled from concurrency. Calling it against base catches
+writer bugs early; calling it against latest catches both writer bugs and
+concurrency-induced invalidity. The **mask** is the only thing that
+answers "did concurrency invalidate me?" cleanly — if the mask says no
+overlap and validate fails, it's a writer bug.
+
+### Single-action rebase
+
+Most "rebase" work is already absorbed by §3. Late-bound outputs (§3.2)
+need no rewriting; `apply` allocates from current counters. Criterion-
+based targeting (§3.1) re-evaluates against the current manifest
+automatically.
+
+What remains for `rebase` to actually do: payload fields naming row
+address ranges (e.g. `UpdateDeletionVector.affected_rows`,
+`ReplaceFragmentColumns.updated_row_offsets`). Row addresses are not
+stable across compaction. Conservative rebasing — failing closed when
+ranges may have shifted — is acceptable as a starting point.
+
+### Transaction driver
+
+A transaction is an ordered list of actions. The driver mutates a
+working clone of the manifest one action at a time:
+
+```rust
+async fn commit(
+    actions: &[Box<dyn Action>],
+    latest: &Manifest,
+    intervening_mask: &ManifestMask,
+    intervening_actions: &[Box<dyn Action>],
+) -> Result<Manifest, TransactionError> {
+    let mut working = latest.clone();
+    let mut ctx = TxnContext::default();
+
+    for action in actions {
+        let touches = action.reads().union(&action.writes());
+        if intervening_mask.intersects(&touches) {
+            action.rebase(&working, intervening_actions).await?;
+        }
+        let output = action.apply(&mut working, &mut ctx)?;
+        ctx.record(output);
+    }
+    Ok(working)
+}
+```
+
+Three consequences worth naming:
+
+1. **Per-action rebase**, not per-transaction. Each action sees the same
+   concurrent delta and reasons about it independently.
+
+2. **Per-action validate runs against the in-progress manifest.** Action
+   *j*'s `apply` (which validates inline) sees the effects of actions
+   *1..j-1* from the same transaction. This matters for Overwrite-style
+   transactions where a later `AddFragments` is valid only after an
+   earlier `ChangeSchema` lands. See §9.
+
+3. **Atomicity is free.** Mutations are on the in-memory `working`
+   clone, which is dropped on failure. No on-disk state is touched until
+   the commit protocol (out of scope here) writes the final manifest.
+
+### Symbolic references resolve through `TxnContext`
+
+Per §3.3, intra-txn references are `FragmentRef::ProducedBy { action_idx,
+output_idx }`. The `TxnContext` accumulates each action's output as the
+driver walks the list, so later actions can resolve them at `apply` time.
+
+TODO: pin down the runtime representation of `FragmentRef` and how it
+flows through the serialized form.
+
+## 8. Required Action Payload Changes
+
+Per action, what fields are needed for §6 detection predicates:
+
+- Fragment IDs touched (read / write)
+- Field IDs read / written
+- Row address ranges (with caveat from §6 on stability)
+- Index UUIDs / coverage sets
+- MemWAL generation, config keys, etc.
+
+Call out any proto-breaking changes.
+
+TODO.
+
+## 9. Worked Examples
+
+- Append || Append
+- Append || Delete
+- Update || Update — same row vs. different rows
+- Update || Compact
+- Delete || Compact
+- AddIndex || AddFragment — compound dependency case
+- UpdateConfig || UpdateConfig — same key
+- Restore || anything — ordering reset
+
+### Overwrite || Overwrite (compound transactions interacting)
+
+Two clients author against the same base M_0. Overwrite decomposes as:
+
+```
+[ RemoveFragments(criterion=All),
+  ChangeSchema(new_schema),
+  AddFragments(new_fragments) ]
+```
+
+A commits first → M_1 (schema=S_A, fragments=[F_A]). B then commits.
+B's actions walk the driver loop against M_1:
+
+| Step | Action | Mask vs. A | rebase | apply (validates inline against working) |
+|------|--------|-----------|--------|----------|
+| 1 | RemoveFragments(All) | overlaps FragmentList | re-resolve "all" against M_1 → `{F_A}` | removes F_A |
+| 2 | ChangeSchema(S_B)    | overlaps Schema | no-op (overwrite doesn't read prior) | sets schema = S_B |
+| 3 | AddFragments(F_B)    | overlaps NextFragmentId, FragmentList | reassign IDs | append F_B; validate sees schema S_B (from step 2) |
+
+B wins; the final state is `(schema=S_B, fragments=[F_B])`. This matches
+today's `check_overwrite_txn` semantics (overwrite is treated as
+compatible with most concurrent commits — last writer wins).
+
+**Property highlighted:** step 3's `validate` succeeds because step 2
+has already mutated the working manifest. If F_B references field IDs
+only present in S_B (and not S_0 or S_A), the action is still valid
+because its predecessors in the same transaction supplied them.
+
+**Policy question this raises (see §12):** is silent last-writer-wins
+on concurrent Overwrites the right default, or should the driver
+refuse to commit B when its base ≠ latest unless the user opted into
+"ignore concurrent writes"?
+
+## 10. Edge Cases
+
+- Restore (time travel resets the baseline)
+- Schema-altering actions vs. data actions
+- Actions that become no-ops after rebase
+- MemWAL state transitions
+- Replacement-of-replacement chains
+- Rebased transaction producing a different observable result than the
+  original — when is that acceptable?
+- Writer-blind index invalidation — handled by §3.1, called out here so
+  readers know it's a deliberate property of the layer.
+
+## 11. Migration from Operation-Level Checks
+
+Walk each existing `check_*_txn` in `conflict_resolver.rs` and show which
+action-level rule(s) replace it. Flag any check that cannot be expressed at
+action level — either lift the missing information into an action payload
+(§8) or document the lost semantics.
+
+TODO. Decide later whether this section ships in this doc or a follow-up.
+
+## 12. Future: Multiple Isolation Levels
+
+Once the matrix is in place, sketch what would change to offer:
+
+- A stricter level (e.g. serializable) — likely more `R`/`X` cells.
+- A looser level (e.g. read-committed-ish for high-throughput ingestion).
+
+Just a sketch; not a commitment.
+
+## Open Questions
+
+- Is the action list close enough to stable to freeze §4, or should we
+  parameterize the matrix?
+- Do we need a stable row-ID concept to make any §6 rules non-conservative,
+  or is conservative-fail acceptable indefinitely?
+- Does §11 (migration map) belong in this doc?

--- a/rust/lance-table/src/format/transaction.rs
+++ b/rust/lance-table/src/format/transaction.rs
@@ -13,6 +13,9 @@
 
 use crate::format::pb;
 
+#[allow(dead_code)] // Prototype scaffolding; not yet wired into the public API.
+mod actions;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Transaction {
     /// Crate-local representation backing: protobuf Transaction.

--- a/rust/lance-table/src/format/transaction/actions.rs
+++ b/rust/lance-table/src/format/transaction/actions.rs
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Prototype: action-based transactions.
+//!
+//! See `rust/lance-table/design/action_based_conflict_resolution.md`.
+//!
+//! Lifecycle per action (§7 of the design):
+//! - `validate(state)` — pure, no IO. Well-formedness against `state`.
+//! - `rebase(current, concurrent)` — mutates self. Allowed to do IO in
+//!   production; this prototype's impls are sync. Only called when the
+//!   mask screen indicates overlap.
+//! - `apply(state, ctx)` — pure, no IO. Validates inline, then mutates.
+//!
+//! Principles exercised:
+//! - Mask as conservative screen (§3, §5).
+//! - Criterion-based targeting (§3.1) — see `IndicesCoveringFields`,
+//!   `FragmentSelector::All`.
+//! - Late binding (§3.2) — `FragmentTemplate` has no ID.
+//! - Symbolic intra-txn references (§3.3) — `FragmentRef::ProducedBy`.
+
+use std::collections::BTreeSet;
+
+use crate::format::{DataFile, DeletionFile, Fragment, IndexMetadata, Manifest};
+
+pub mod add_fragments;
+pub mod add_index;
+pub mod change_schema;
+pub mod invalidate_index_coverage;
+pub mod remove_fragments;
+pub mod update_deletion_vector;
+
+#[cfg(test)]
+mod conflict_tests;
+
+#[allow(unused_imports)] // Re-exports; consumers live in tests for now.
+pub use {
+    add_fragments::AddFragments, add_index::AddIndex, change_schema::ChangeSchema,
+    invalidate_index_coverage::InvalidateIndexCoverage, remove_fragments::RemoveFragments,
+    update_deletion_vector::UpdateDeletionVector,
+};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum TransactionError {
+    Incompatible(String),
+    Generic(String),
+}
+
+impl std::fmt::Display for TransactionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Incompatible(m) => write!(f, "action incompatible with state: {m}"),
+            Self::Generic(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl std::error::Error for TransactionError {}
+
+// ---------------------------------------------------------------------------
+// Working state
+// ---------------------------------------------------------------------------
+
+/// Prototype-only wrapper for the mutable dataset state an action operates on.
+/// In production this would be the `Manifest` plus whatever auxiliary stores
+/// (index list, frag-reuse index, MemWAL state) the action layer needs to
+/// reason about. Splitting it out here keeps the trait honest about the
+/// mutation surface without forcing every example through the real on-disk
+/// representation.
+#[derive(Debug, Clone)]
+pub struct WorkingState {
+    pub manifest: Manifest,
+    pub indices: Vec<IndexMetadata>,
+}
+
+impl WorkingState {
+    pub fn new(manifest: Manifest) -> Self {
+        Self {
+            manifest,
+            indices: Vec::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Manifest mask
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ManifestMask {
+    paths: BTreeSet<ManifestPath>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ManifestPath {
+    FragmentList,
+    Fragment { id: u32, scope: FragmentScope },
+
+    Index { uuid: [u8; 16], scope: IndexScope },
+    IndicesCoveringFields { fields: Vec<u32>, scope: IndexScope },
+
+    Schema,
+
+    NextFragmentId,
+    NextRowId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FragmentScope {
+    Whole,
+    DataFiles { fields: Option<Vec<u32>> },
+    DeletionVector,
+    RowIds,
+    VersionMeta,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IndexScope {
+    Whole,
+    Bitmap,
+    Files,
+}
+
+impl ManifestMask {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn singleton(path: ManifestPath) -> Self {
+        let mut paths = BTreeSet::new();
+        paths.insert(path);
+        Self { paths }
+    }
+
+    pub fn insert(&mut self, path: ManifestPath) {
+        self.paths.insert(path);
+    }
+
+    pub fn union(mut self, other: Self) -> Self {
+        self.paths.extend(other.paths);
+        self
+    }
+
+    pub fn intersects(&self, other: &Self) -> bool {
+        self.paths
+            .iter()
+            .any(|a| other.paths.iter().any(|b| paths_overlap(a, b)))
+    }
+}
+
+fn paths_overlap(a: &ManifestPath, b: &ManifestPath) -> bool {
+    use ManifestPath::*;
+    match (a, b) {
+        (FragmentList, FragmentList) => true,
+        (NextFragmentId, NextFragmentId) => true,
+        (NextRowId, NextRowId) => true,
+        (Schema, Schema) => true,
+        (Fragment { id: ia, scope: sa }, Fragment { id: ib, scope: sb }) => {
+            ia == ib && fragment_scopes_overlap(sa, sb)
+        }
+        (
+            Index {
+                uuid: ua,
+                scope: sa,
+            },
+            Index {
+                uuid: ub,
+                scope: sb,
+            },
+        ) => ua == ub && index_scopes_overlap(sa, sb),
+        (
+            IndicesCoveringFields {
+                fields: fa,
+                scope: sa,
+            },
+            IndicesCoveringFields {
+                fields: fb,
+                scope: sb,
+            },
+        ) => index_scopes_overlap(sa, sb) && fields_intersect(fa, fb),
+        (IndicesCoveringFields { scope: sa, .. }, Index { scope: sb, .. })
+        | (Index { scope: sb, .. }, IndicesCoveringFields { scope: sa, .. }) => {
+            // Conservative: criterion path matches any concrete index when scopes overlap.
+            index_scopes_overlap(sa, sb)
+        }
+        _ => false,
+    }
+}
+
+fn fragment_scopes_overlap(a: &FragmentScope, b: &FragmentScope) -> bool {
+    use FragmentScope::*;
+    match (a, b) {
+        (Whole, _) | (_, Whole) => true,
+        (DataFiles { fields: fa }, DataFiles { fields: fb }) => match (fa, fb) {
+            (None, _) | (_, None) => true,
+            (Some(xs), Some(ys)) => xs.iter().any(|x| ys.contains(x)),
+        },
+        (DeletionVector, DeletionVector) => true,
+        (RowIds, RowIds) => true,
+        (VersionMeta, VersionMeta) => true,
+        _ => false,
+    }
+}
+
+fn index_scopes_overlap(a: &IndexScope, b: &IndexScope) -> bool {
+    use IndexScope::*;
+    matches!((a, b), (Whole, _) | (_, Whole)) || a == b
+}
+
+fn fields_intersect(a: &[u32], b: &[u32]) -> bool {
+    a.iter().any(|x| b.contains(x))
+}
+
+// ---------------------------------------------------------------------------
+// Templates and refs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct FragmentTemplate {
+    pub files: Vec<DataFile>,
+    pub physical_rows: Option<usize>,
+    pub deletion_file: Option<DeletionFile>,
+}
+
+impl FragmentTemplate {
+    pub(crate) fn materialize(&self, id: u64) -> Fragment {
+        Fragment {
+            id,
+            files: self.files.clone(),
+            deletion_file: self.deletion_file.clone(),
+            row_id_meta: None,
+            physical_rows: self.physical_rows,
+            last_updated_at_version_meta: None,
+            created_at_version_meta: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum FragmentRef {
+    Existing(u32),
+    ProducedBy {
+        action_idx: usize,
+        output_idx: usize,
+    },
+}
+
+/// Criterion for selecting fragments. Resolved at apply time against the
+/// current manifest — `All` matches whatever fragments exist then.
+#[derive(Debug, Clone)]
+pub enum FragmentSelector {
+    Refs(Vec<FragmentRef>),
+    All,
+}
+
+// ---------------------------------------------------------------------------
+// Action trait + driver context
+// ---------------------------------------------------------------------------
+
+pub trait Action: std::fmt::Debug {
+    fn reads(&self) -> ManifestMask;
+    fn writes(&self) -> ManifestMask;
+
+    /// Pure. Is this action well-formed against `state`?
+    fn validate(&self, state: &WorkingState) -> Result<(), TransactionError>;
+
+    /// Mutates self to absorb concurrent changes. Sync in this prototype;
+    /// the production trait would be async to allow IO. Only called when
+    /// the mask screen indicates the action overlaps concurrent writes.
+    fn rebase(
+        &mut self,
+        current: &WorkingState,
+        concurrent: &[Box<dyn Action>],
+    ) -> Result<(), TransactionError>;
+
+    /// Pure. Validates inline, then applies.
+    fn apply(
+        &self,
+        state: &mut WorkingState,
+        ctx: &mut TxnContext,
+    ) -> Result<ActionOutput, TransactionError>;
+
+    /// Downcasting hook used by per-action rebase logic to inspect peers in
+    /// the concurrent set. Each action overrides with `Some(self)` so callers
+    /// can `downcast_ref` without depending on `Any` in the trait object's
+    /// vtable from outside the prototype.
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+#[derive(Debug, Default)]
+pub struct TxnContext {
+    outputs: Vec<ActionOutput>,
+}
+
+impl TxnContext {
+    pub fn fragment_ids_of(&self, action_idx: usize) -> &[u32] {
+        match self.outputs.get(action_idx) {
+            Some(ActionOutput::AddedFragmentIds(ids)) => ids,
+            _ => &[],
+        }
+    }
+
+    pub fn resolve(&self, r: &FragmentRef) -> Option<u32> {
+        match r {
+            FragmentRef::Existing(id) => Some(*id),
+            FragmentRef::ProducedBy {
+                action_idx,
+                output_idx,
+            } => self.fragment_ids_of(*action_idx).get(*output_idx).copied(),
+        }
+    }
+
+    fn record(&mut self, output: ActionOutput) {
+        self.outputs.push(output);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ActionOutput {
+    None,
+    AddedFragmentIds(Vec<u32>),
+}
+
+// ---------------------------------------------------------------------------
+// Transaction driver
+// ---------------------------------------------------------------------------
+
+/// Apply a compound transaction. Returns the resulting state; the input is
+/// cloned. Drops the working clone on failure.
+pub fn commit(
+    actions: &mut [Box<dyn Action>],
+    latest: &WorkingState,
+    intervening_mask: &ManifestMask,
+    intervening_actions: &[Box<dyn Action>],
+) -> Result<WorkingState, TransactionError> {
+    let mut working = latest.clone();
+    let mut ctx = TxnContext::default();
+
+    for action in actions.iter_mut() {
+        let touches = action.reads().union(action.writes());
+        if intervening_mask.intersects(&touches) {
+            action.rebase(&working, intervening_actions)?;
+        }
+        let output = action.apply(&mut working, &mut ctx)?;
+        ctx.record(output);
+    }
+
+    Ok(working)
+}
+
+/// Helper for tests: union of every action's writes mask.
+pub fn writes_mask_of(actions: &[Box<dyn Action>]) -> ManifestMask {
+    actions
+        .iter()
+        .fold(ManifestMask::empty(), |acc, a| acc.union(a.writes()))
+}
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+pub mod test_support {
+    use super::*;
+    use crate::format::Fragment;
+    use std::sync::Arc;
+
+    pub fn empty_manifest() -> Manifest {
+        let schema = lance_core::datatypes::Schema::default();
+        Manifest::new(
+            schema,
+            Arc::new(vec![]),
+            crate::format::DataStorageFormat::default(),
+            std::collections::HashMap::new(),
+        )
+    }
+
+    pub fn manifest_with_fragments(ids: &[u64]) -> Manifest {
+        let mut m = empty_manifest();
+        let frags: Vec<Fragment> = ids.iter().map(|id| Fragment::new(*id)).collect();
+        m.max_fragment_id = ids.iter().copied().max().map(|x| x as u32);
+        m.fragments = Arc::new(frags);
+        m
+    }
+
+    pub fn state_with_fragments(ids: &[u64]) -> WorkingState {
+        WorkingState::new(manifest_with_fragments(ids))
+    }
+
+    pub fn empty_template() -> FragmentTemplate {
+        FragmentTemplate {
+            files: vec![],
+            physical_rows: Some(0),
+            deletion_file: None,
+        }
+    }
+
+    pub fn dummy_deletion_file() -> DeletionFile {
+        DeletionFile {
+            read_version: 0,
+            id: 0,
+            file_type: crate::format::DeletionFileType::Bitmap,
+            num_deleted_rows: Some(0),
+            base_id: None,
+        }
+    }
+
+    pub fn run_one(
+        action: Box<dyn Action>,
+        state: &mut WorkingState,
+    ) -> Result<(), TransactionError> {
+        let mut actions = vec![action];
+        let mask = ManifestMask::empty();
+        let new = commit(&mut actions, state, &mask, &[])?;
+        *state = new;
+        Ok(())
+    }
+}

--- a/rust/lance-table/src/format/transaction/actions/add_fragments.rs
+++ b/rust/lance-table/src/format/transaction/actions/add_fragments.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! `AddFragments` — appends new fragments with late-bound IDs.
+
+use std::sync::Arc;
+
+use super::{
+    Action, ActionOutput, FragmentTemplate, ManifestMask, ManifestPath, TransactionError,
+    TxnContext, WorkingState,
+};
+use crate::format::Fragment;
+
+#[derive(Debug, Clone)]
+pub struct AddFragments {
+    pub fragments: Vec<FragmentTemplate>,
+}
+
+impl Action for AddFragments {
+    fn reads(&self) -> ManifestMask {
+        ManifestMask::singleton(ManifestPath::NextFragmentId)
+    }
+
+    fn writes(&self) -> ManifestMask {
+        ManifestMask::singleton(ManifestPath::FragmentList)
+            .union(ManifestMask::singleton(ManifestPath::NextFragmentId))
+    }
+
+    fn validate(&self, _state: &WorkingState) -> Result<(), TransactionError> {
+        // Real impl would check that each template's DataFiles reference
+        // field IDs present in state.manifest.schema. Out of scope here.
+        Ok(())
+    }
+
+    fn rebase(
+        &mut self,
+        _current: &WorkingState,
+        _concurrent: &[Box<dyn Action>],
+    ) -> Result<(), TransactionError> {
+        // Late-bound outputs: nothing to rewrite. IDs allocated in apply.
+        Ok(())
+    }
+
+    fn apply(
+        &self,
+        state: &mut WorkingState,
+        _ctx: &mut TxnContext,
+    ) -> Result<ActionOutput, TransactionError> {
+        let mut next = state.manifest.max_fragment_id.map_or(0u32, |m| m + 1);
+        let mut new_fragments: Vec<Fragment> = state.manifest.fragments.as_ref().clone();
+        let mut assigned = Vec::with_capacity(self.fragments.len());
+        for tpl in &self.fragments {
+            let id = next;
+            next += 1;
+            assigned.push(id);
+            new_fragments.push(tpl.materialize(id as u64));
+        }
+        state.manifest.max_fragment_id = Some(next.saturating_sub(1));
+        state.manifest.fragments = Arc::new(new_fragments);
+        Ok(ActionOutput::AddedFragmentIds(assigned))
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::*;
+    use super::super::{FragmentRef, RemoveFragments, commit};
+    use super::*;
+
+    #[test]
+    fn add_fragments_concurrent_get_distinct_ids() {
+        let mut a: Vec<Box<dyn Action>> = vec![Box::new(AddFragments {
+            fragments: vec![empty_template()],
+        })];
+        let mut b: Vec<Box<dyn Action>> = vec![Box::new(AddFragments {
+            fragments: vec![empty_template()],
+        })];
+
+        let s0 = state_with_fragments(&[5]);
+        let s1 = commit(&mut a, &s0, &ManifestMask::empty(), &[]).unwrap();
+        let mask_after_a = a[0].writes();
+        let s2 = commit(&mut b, &s1, &mask_after_a, &[]).unwrap();
+
+        let ids: Vec<u64> = s2.manifest.fragments.iter().map(|f| f.id).collect();
+        assert_eq!(ids, vec![5, 6, 7]);
+    }
+
+    #[test]
+    fn symbolic_ref_resolves_within_compound_txn() {
+        let mut actions: Vec<Box<dyn Action>> = vec![
+            Box::new(AddFragments {
+                fragments: vec![empty_template(), empty_template()],
+            }),
+            Box::new(RemoveFragments::refs(vec![FragmentRef::ProducedBy {
+                action_idx: 0,
+                output_idx: 0,
+            }])),
+        ];
+        let s = state_with_fragments(&[10]);
+        let s = commit(&mut actions, &s, &ManifestMask::empty(), &[]).unwrap();
+        let ids: Vec<u64> = s.manifest.fragments.iter().map(|f| f.id).collect();
+        assert_eq!(ids, vec![10, 12]);
+    }
+}

--- a/rust/lance-table/src/format/transaction/actions/add_index.rs
+++ b/rust/lance-table/src/format/transaction/actions/add_index.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! `AddIndex` — register a new index over a set of fields.
+//!
+//! Payload includes the concrete `fragment_bitmap` captured at build time
+//! (the writer has trained the index against those fragments). Rebase must
+//! reconcile that bitmap with the current state: fragments that were
+//! concurrently removed must be dropped; fragments that were concurrently
+//! added are *not* automatically covered — the writer trained without them.
+//!
+//! Conflict with `Update`/`InvalidateIndexCoverage` over the same fields is
+//! handled at the mask layer (criterion-based path intersects the new
+//! concrete index path). When `AddIndex` lands first, a later
+//! `InvalidateIndexCoverage` finds the new index at apply time and prunes
+//! it. When `Update` lands first, `AddIndex.rebase` trims any removed
+//! fragments and accepts (or fails) the new fragments per `on_new_fragments`.
+
+use roaring::RoaringBitmap;
+use uuid::Uuid;
+
+use super::{
+    Action, ActionOutput, IndexScope, ManifestMask, ManifestPath, TransactionError, TxnContext,
+    WorkingState,
+};
+use crate::format::IndexMetadata;
+
+/// What to do when concurrent writers added fragments after we trained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnNewFragments {
+    /// Leave them out of coverage. Common case: a later `Optimize` will
+    /// fold them in.
+    LeaveUncovered,
+    /// Fail — the writer demands full coverage of the latest fragments.
+    Fail,
+}
+
+#[derive(Debug, Clone)]
+pub struct AddIndex {
+    pub uuid: Uuid,
+    pub name: String,
+    pub fields: Vec<u32>,
+    pub fragment_bitmap: RoaringBitmap,
+    pub on_new_fragments: OnNewFragments,
+}
+
+impl AddIndex {
+    pub fn new(uuid: Uuid, name: impl Into<String>, fields: Vec<u32>, frags: &[u32]) -> Self {
+        Self {
+            uuid,
+            name: name.into(),
+            fields,
+            fragment_bitmap: RoaringBitmap::from_iter(frags.iter().copied()),
+            on_new_fragments: OnNewFragments::LeaveUncovered,
+        }
+    }
+}
+
+impl Action for AddIndex {
+    fn reads(&self) -> ManifestMask {
+        // The set of fragments we cover, plus the schema fields we index.
+        ManifestMask::singleton(ManifestPath::FragmentList).union(ManifestMask::singleton(
+            ManifestPath::IndicesCoveringFields {
+                fields: self.fields.clone(),
+                scope: IndexScope::Whole,
+            },
+        ))
+    }
+
+    fn writes(&self) -> ManifestMask {
+        // Adding a new concrete index. Criterion-path readers (e.g.
+        // InvalidateIndexCoverage on these fields) need to see this; the
+        // mask layer's IndicesCoveringFields↔Index cross-rule handles it.
+        ManifestMask::singleton(ManifestPath::Index {
+            uuid: *self.uuid.as_bytes(),
+            scope: IndexScope::Whole,
+        })
+        .union(ManifestMask::singleton(
+            ManifestPath::IndicesCoveringFields {
+                fields: self.fields.clone(),
+                scope: IndexScope::Whole,
+            },
+        ))
+    }
+
+    fn validate(&self, state: &WorkingState) -> Result<(), TransactionError> {
+        if state.indices.iter().any(|i| i.uuid == self.uuid) {
+            return Err(TransactionError::Incompatible(format!(
+                "AddIndex: uuid {} already registered",
+                self.uuid
+            )));
+        }
+        if state.indices.iter().any(|i| i.name == self.name) {
+            return Err(TransactionError::Incompatible(format!(
+                "AddIndex: name {:?} already in use",
+                self.name
+            )));
+        }
+        Ok(())
+    }
+
+    fn rebase(
+        &mut self,
+        current: &WorkingState,
+        _concurrent: &[Box<dyn Action>],
+    ) -> Result<(), TransactionError> {
+        let current_frags: RoaringBitmap = current
+            .manifest
+            .fragments
+            .iter()
+            .map(|f| f.id as u32)
+            .collect();
+
+        let new_frags = &current_frags - &self.fragment_bitmap;
+        if !new_frags.is_empty() && self.on_new_fragments == OnNewFragments::Fail {
+            return Err(TransactionError::Incompatible(format!(
+                "AddIndex: {} new fragments not covered by trained index",
+                new_frags.len()
+            )));
+        }
+
+        // Trim fragments that no longer exist (removed concurrently).
+        self.fragment_bitmap &= &current_frags;
+        Ok(())
+    }
+
+    fn apply(
+        &self,
+        state: &mut WorkingState,
+        _ctx: &mut TxnContext,
+    ) -> Result<ActionOutput, TransactionError> {
+        self.validate(state)?;
+        state.indices.push(IndexMetadata {
+            uuid: self.uuid,
+            fields: self.fields.iter().map(|f| *f as i32).collect(),
+            name: self.name.clone(),
+            dataset_version: state.manifest.version,
+            fragment_bitmap: Some(self.fragment_bitmap.clone()),
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+        });
+        Ok(ActionOutput::None)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::*;
+    use super::*;
+
+    #[test]
+    fn add_index_writes_to_indices() {
+        let mut s = state_with_fragments(&[1, 2]);
+        let a = AddIndex::new(Uuid::nil(), "idx", vec![7], &[1, 2]);
+        run_one(Box::new(a), &mut s).unwrap();
+        assert_eq!(s.indices.len(), 1);
+        assert_eq!(s.indices[0].fields, vec![7]);
+    }
+
+    #[test]
+    fn duplicate_uuid_rejected() {
+        let mut s = state_with_fragments(&[1]);
+        let a = AddIndex::new(Uuid::nil(), "idx", vec![7], &[1]);
+        run_one(Box::new(a), &mut s).unwrap();
+        let b = AddIndex::new(Uuid::nil(), "idx2", vec![7], &[1]);
+        let err = run_one(Box::new(b), &mut s).unwrap_err();
+        assert!(matches!(err, TransactionError::Incompatible(_)));
+    }
+
+    #[test]
+    fn rebase_trims_removed_fragments() {
+        let s = state_with_fragments(&[1, 3]); // 2 has been removed concurrently
+        let mut a = AddIndex::new(Uuid::nil(), "idx", vec![7], &[1, 2, 3]);
+        a.rebase(&s, &[]).unwrap();
+        assert_eq!(a.fragment_bitmap, RoaringBitmap::from_iter([1u32, 3]));
+    }
+
+    #[test]
+    fn rebase_fail_mode_rejects_new_fragments() {
+        let s = state_with_fragments(&[1, 2, 9]);
+        let mut a = AddIndex::new(Uuid::nil(), "idx", vec![7], &[1, 2]);
+        a.on_new_fragments = OnNewFragments::Fail;
+        let err = a.rebase(&s, &[]).unwrap_err();
+        assert!(matches!(err, TransactionError::Incompatible(_)));
+    }
+}

--- a/rust/lance-table/src/format/transaction/actions/change_schema.rs
+++ b/rust/lance-table/src/format/transaction/actions/change_schema.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! `ChangeSchema` — overwrite the manifest schema.
+
+use super::{
+    Action, ActionOutput, ManifestMask, ManifestPath, TransactionError, TxnContext, WorkingState,
+};
+
+/// Models Overwrite's schema-replacement step; no field-ID continuity check
+/// (the writer is asserting a clean reset).
+#[derive(Debug, Clone)]
+pub struct ChangeSchema {
+    pub new_schema: lance_core::datatypes::Schema,
+}
+
+impl Action for ChangeSchema {
+    fn reads(&self) -> ManifestMask {
+        ManifestMask::empty()
+    }
+
+    fn writes(&self) -> ManifestMask {
+        ManifestMask::singleton(ManifestPath::Schema)
+    }
+
+    fn validate(&self, _state: &WorkingState) -> Result<(), TransactionError> {
+        Ok(())
+    }
+
+    fn rebase(
+        &mut self,
+        _current: &WorkingState,
+        _concurrent: &[Box<dyn Action>],
+    ) -> Result<(), TransactionError> {
+        Ok(())
+    }
+
+    fn apply(
+        &self,
+        state: &mut WorkingState,
+        _ctx: &mut TxnContext,
+    ) -> Result<ActionOutput, TransactionError> {
+        state.manifest.schema = self.new_schema.clone();
+        Ok(ActionOutput::None)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/rust/lance-table/src/format/transaction/actions/conflict_tests.rs
+++ b/rust/lance-table/src/format/transaction/actions/conflict_tests.rs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Cross-action conflict resolution tests.
+//!
+//! Each test exercises the full `commit` driver: it stages a baseline state,
+//! commits transaction A, then commits transaction B against the post-A
+//! state with A's writes mask passed as the intervening mask. This is the
+//! shape a production conflict resolver would use — the question every test
+//! asks is "did the driver correctly accept, merge, or reject B?"
+//!
+//! Scenarios covered:
+//! - Update || Update on different fragments  → compatible
+//! - Update || Update on same fragment, different rows → compatible (UDVs
+//!   would merge by union; prototype skips the IO)
+//! - Update || Update on same fragment, same row → conflict
+//! - Update || CreateIndex (both orderings) — exercises the criterion-based
+//!   path crossing the new concrete index.
+
+use roaring::RoaringBitmap;
+use uuid::Uuid;
+
+use super::test_support::*;
+use super::{
+    Action, AddFragments, AddIndex, FragmentRef, FragmentTemplate, InvalidateIndexCoverage,
+    ManifestMask, RemoveFragments, TransactionError, UpdateDeletionVector, WorkingState, commit,
+    writes_mask_of,
+};
+use crate::format::DeletionFile;
+
+// ---------------------------------------------------------------------------
+// Update-as-actions helpers
+// ---------------------------------------------------------------------------
+
+/// Update via RewriteRows decomposition: remove old fragment, add the
+/// replacement, and (for any field covered by an index) invalidate that
+/// fragment's coverage. Returns the action list ready to feed `commit`.
+fn update_rewrite_rows(old_frag: u32, indexed_fields: &[u32]) -> Vec<Box<dyn Action>> {
+    let mut actions: Vec<Box<dyn Action>> = vec![
+        Box::new(RemoveFragments::refs(vec![FragmentRef::Existing(old_frag)])),
+        Box::new(AddFragments {
+            fragments: vec![empty_template()],
+        }),
+    ];
+    if !indexed_fields.is_empty() {
+        actions.push(Box::new(InvalidateIndexCoverage {
+            fragment_ids: vec![old_frag],
+            field_ids: indexed_fields.to_vec(),
+        }));
+    }
+    actions
+}
+
+/// Update via partial delete: just an UpdateDeletionVector.
+fn update_partial_delete(frag: u32, affected_rows: &[u32]) -> Vec<Box<dyn Action>> {
+    vec![Box::new(UpdateDeletionVector {
+        fragment: FragmentRef::Existing(frag),
+        new_deletion_file: DeletionFile {
+            read_version: 0,
+            id: 0,
+            file_type: crate::format::DeletionFileType::Bitmap,
+            num_deleted_rows: Some(affected_rows.len()),
+            base_id: None,
+        },
+        affected_rows: Some(RoaringBitmap::from_iter(affected_rows.iter().copied())),
+    })]
+}
+
+fn run_two_concurrent(
+    base: WorkingState,
+    mut a: Vec<Box<dyn Action>>,
+    mut b: Vec<Box<dyn Action>>,
+) -> Result<(WorkingState, WorkingState), TransactionError> {
+    let s1 = commit(&mut a, &base, &ManifestMask::empty(), &[]).unwrap();
+    let intervening = writes_mask_of(&a);
+    let s2 = commit(&mut b, &s1, &intervening, &a)?;
+    Ok((s1, s2))
+}
+
+// ---------------------------------------------------------------------------
+// Update || Update
+// ---------------------------------------------------------------------------
+
+/// Different fragments: A rewrites F1, B rewrites F2. No row overlap.
+/// Mask check shows that both touch FragmentList (via RemoveFragments and
+/// AddFragments), but the per-fragment paths are disjoint and AddFragments
+/// is rebase-tolerant (late-bound IDs). Both succeed; the final state has
+/// neither F1 nor F2 but two new fragments.
+#[test]
+fn update_update_different_fragments_succeeds() {
+    let base = state_with_fragments(&[1, 2]);
+    let a = update_rewrite_rows(1, &[]);
+    let b = update_rewrite_rows(2, &[]);
+    let (_, s2) = run_two_concurrent(base, a, b).unwrap();
+    let ids: Vec<u64> = s2.manifest.fragments.iter().map(|f| f.id).collect();
+    // Both originals gone; two new ones added with fresh IDs.
+    assert!(!ids.contains(&1));
+    assert!(!ids.contains(&2));
+    assert_eq!(ids.len(), 2);
+}
+
+/// Same fragment, different rows: A deletes row 0 on F1, B deletes row 5
+/// on F1. UDV rebase sees disjoint affected_rows on the same fragment and
+/// allows the merge (real impl would write a unioned deletion file).
+#[test]
+fn update_update_same_fragment_different_rows_merges() {
+    let base = state_with_fragments(&[1]);
+    let a = update_partial_delete(1, &[0, 1]);
+    let b = update_partial_delete(1, &[5, 6]);
+    let (_, s2) = run_two_concurrent(base, a, b).unwrap();
+    // B's UDV wrote through; the prototype's apply replaces rather than
+    // unions, so the assertion here is just "no error and the fragment
+    // is still present."
+    assert_eq!(s2.manifest.fragments.len(), 1);
+}
+
+/// Same fragment, same row: A deletes row 5, B deletes rows 3-7. Rebase
+/// detects the overlap and refuses to commit B.
+#[test]
+fn update_update_same_row_conflicts() {
+    let base = state_with_fragments(&[1]);
+    let a = update_partial_delete(1, &[5]);
+    let b = update_partial_delete(1, &[3, 4, 5, 6, 7]);
+    let err = run_two_concurrent(base, a, b).unwrap_err();
+    assert!(
+        matches!(err, TransactionError::Incompatible(_)),
+        "expected row-level conflict, got {err:?}"
+    );
+}
+
+/// Same fragment, full rewrite vs. full rewrite: A and B both
+/// RewriteRows F1. RemoveFragments(F1) collides with RemoveFragments(F1):
+/// the second one finds F1 already gone at apply time.
+#[test]
+fn update_update_same_fragment_full_rewrite_conflicts() {
+    let base = state_with_fragments(&[1]);
+    let a = update_rewrite_rows(1, &[]);
+    let b = update_rewrite_rows(1, &[]);
+    let err = run_two_concurrent(base, a, b).unwrap_err();
+    assert!(matches!(err, TransactionError::Incompatible(_)));
+}
+
+// ---------------------------------------------------------------------------
+// Update || CreateIndex
+// ---------------------------------------------------------------------------
+
+/// AddIndex commits first; Update then runs. The Update's
+/// InvalidateIndexCoverage is criterion-based (over field 7) — it doesn't
+/// need to know A added an index. At apply time it walks the index list
+/// and prunes the updated fragment from the bitmap.
+#[test]
+fn create_index_then_update_invalidates_coverage() {
+    let base = state_with_fragments(&[1, 2, 3]);
+    let a: Vec<Box<dyn Action>> = vec![Box::new(AddIndex::new(
+        Uuid::from_u128(1),
+        "idx_x",
+        vec![7],
+        &[1, 2, 3],
+    ))];
+    let b = update_rewrite_rows(2, &[7]); // F2 has field 7
+
+    let (_, s2) = run_two_concurrent(base, a, b).unwrap();
+    assert_eq!(s2.indices.len(), 1);
+    let bm = s2.indices[0].fragment_bitmap.as_ref().unwrap();
+    assert!(!bm.contains(2), "F2 should be invalidated, got {bm:?}");
+    assert!(bm.contains(1));
+    assert!(bm.contains(3));
+}
+
+/// Update commits first; AddIndex's bitmap was trained against the
+/// pre-update fragments (F1..F3). Rebase trims F2 (now removed) from the
+/// trained bitmap. The newly added replacement fragment is left
+/// uncovered — an Optimize later would fold it in.
+#[test]
+fn update_then_create_index_trims_removed_fragments() {
+    let base = state_with_fragments(&[1, 2, 3]);
+    let a = update_rewrite_rows(2, &[]); // no index existed yet, so no invalidate
+    let b: Vec<Box<dyn Action>> = vec![Box::new(AddIndex::new(
+        Uuid::from_u128(2),
+        "idx_x",
+        vec![7],
+        &[1, 2, 3], // trained when F2 was still around
+    ))];
+
+    let (_, s2) = run_two_concurrent(base, a, b).unwrap();
+    assert_eq!(s2.indices.len(), 1);
+    let bm = s2.indices[0].fragment_bitmap.as_ref().unwrap();
+    assert!(!bm.contains(2));
+    assert!(bm.contains(1));
+    assert!(bm.contains(3));
+}
+
+/// Two AddIndex on overlapping fields with distinct UUIDs: not a conflict.
+/// Both indices land in the index list independently.
+#[test]
+fn two_create_indices_same_field_both_land() {
+    let base = state_with_fragments(&[1, 2]);
+    let a: Vec<Box<dyn Action>> = vec![Box::new(AddIndex::new(
+        Uuid::from_u128(10),
+        "idx_a",
+        vec![7],
+        &[1, 2],
+    ))];
+    let b: Vec<Box<dyn Action>> = vec![Box::new(AddIndex::new(
+        Uuid::from_u128(11),
+        "idx_b",
+        vec![7],
+        &[1, 2],
+    ))];
+    let (_, s2) = run_two_concurrent(base, a, b).unwrap();
+    assert_eq!(s2.indices.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Carryover: Overwrite || Overwrite (kept from the earlier prototype).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn concurrent_overwrite_last_writer_wins() {
+    use super::ChangeSchema;
+    let schema_a = lance_core::datatypes::Schema::default();
+    let schema_b = lance_core::datatypes::Schema::default();
+
+    let s0 = WorkingState::new(empty_manifest());
+
+    let mut a: Vec<Box<dyn Action>> = vec![
+        Box::new(RemoveFragments::all()),
+        Box::new(ChangeSchema {
+            new_schema: schema_a,
+        }),
+        Box::new(AddFragments {
+            fragments: vec![empty_template()],
+        }),
+    ];
+    let s1 = commit(&mut a, &s0, &ManifestMask::empty(), &[]).unwrap();
+    let frag_a_id = s1.manifest.fragments[0].id;
+
+    let intervening = writes_mask_of(&a);
+
+    let mut b: Vec<Box<dyn Action>> = vec![
+        Box::new(RemoveFragments::all()),
+        Box::new(ChangeSchema {
+            new_schema: schema_b,
+        }),
+        Box::new(AddFragments {
+            fragments: vec![empty_template()],
+        }),
+    ];
+    let s2 = commit(&mut b, &s1, &intervening, &a).unwrap();
+
+    assert_eq!(s2.manifest.fragments.len(), 1);
+    assert_ne!(s2.manifest.fragments[0].id, frag_a_id);
+    assert!(s2.manifest.max_fragment_id.unwrap() as u64 >= frag_a_id);
+}
+
+// Unused-but-illustrative: `FragmentTemplate` import keeps doc cross-refs
+// honest if a future test wants to build a template inline.
+#[allow(dead_code)]
+fn _silence_unused_template_import(_: FragmentTemplate) {}

--- a/rust/lance-table/src/format/transaction/actions/invalidate_index_coverage.rs
+++ b/rust/lance-table/src/format/transaction/actions/invalidate_index_coverage.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! `InvalidateIndexCoverage` — prune fragments from any index over the named
+//! fields (criterion-based, §3.1).
+
+use roaring::RoaringBitmap;
+
+use super::{
+    Action, ActionOutput, IndexScope, ManifestMask, ManifestPath, TransactionError, TxnContext,
+    WorkingState,
+};
+
+#[derive(Debug, Clone)]
+pub struct InvalidateIndexCoverage {
+    pub fragment_ids: Vec<u32>,
+    pub field_ids: Vec<u32>,
+}
+
+impl Action for InvalidateIndexCoverage {
+    fn reads(&self) -> ManifestMask {
+        ManifestMask::singleton(ManifestPath::IndicesCoveringFields {
+            fields: self.field_ids.clone(),
+            scope: IndexScope::Whole,
+        })
+    }
+
+    fn writes(&self) -> ManifestMask {
+        ManifestMask::singleton(ManifestPath::IndicesCoveringFields {
+            fields: self.field_ids.clone(),
+            scope: IndexScope::Bitmap,
+        })
+    }
+
+    fn validate(&self, _state: &WorkingState) -> Result<(), TransactionError> {
+        Ok(())
+    }
+
+    fn rebase(
+        &mut self,
+        _current: &WorkingState,
+        _concurrent: &[Box<dyn Action>],
+    ) -> Result<(), TransactionError> {
+        // Criterion-based: nothing to rewrite. apply re-evaluates against the
+        // current index set, so a concurrent AddIndex that creates a matching
+        // index is automatically covered.
+        Ok(())
+    }
+
+    fn apply(
+        &self,
+        state: &mut WorkingState,
+        _ctx: &mut TxnContext,
+    ) -> Result<ActionOutput, TransactionError> {
+        let drop = RoaringBitmap::from_iter(self.fragment_ids.iter().copied());
+        let field_ids_i32: Vec<i32> = self.field_ids.iter().map(|f| *f as i32).collect();
+        for idx in state.indices.iter_mut() {
+            if !idx.fields.iter().any(|f| field_ids_i32.contains(f)) {
+                continue;
+            }
+            if let Some(bitmap) = idx.fragment_bitmap.as_mut() {
+                *bitmap -= &drop;
+            }
+        }
+        Ok(ActionOutput::None)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::*;
+    use super::super::{IndexScope, ManifestPath};
+    use super::*;
+
+    #[test]
+    fn criterion_mask_intersects_concrete_index_path() {
+        let invalidate = InvalidateIndexCoverage {
+            fragment_ids: vec![1],
+            field_ids: vec![7],
+        };
+        let concrete = ManifestMask::singleton(ManifestPath::Index {
+            uuid: [0u8; 16],
+            scope: IndexScope::Whole,
+        });
+        assert!(invalidate.writes().intersects(&concrete));
+    }
+
+    #[test]
+    fn criterion_masks_disjoint_when_fields_dont_overlap() {
+        let a = InvalidateIndexCoverage {
+            fragment_ids: vec![1],
+            field_ids: vec![7],
+        };
+        let b = InvalidateIndexCoverage {
+            fragment_ids: vec![1],
+            field_ids: vec![8],
+        };
+        assert!(!a.writes().intersects(&b.writes()));
+    }
+
+    #[test]
+    fn apply_drops_fragment_from_matching_index_bitmap() {
+        let mut s = state_with_fragments(&[1, 2]);
+        s.indices.push(crate::format::IndexMetadata {
+            uuid: uuid::Uuid::nil(),
+            fields: vec![7],
+            name: "idx".into(),
+            dataset_version: 0,
+            fragment_bitmap: Some(RoaringBitmap::from_iter([1, 2])),
+            index_details: None,
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+        });
+        let action = InvalidateIndexCoverage {
+            fragment_ids: vec![1],
+            field_ids: vec![7],
+        };
+        run_one(Box::new(action), &mut s).unwrap();
+        let bm = s.indices[0].fragment_bitmap.as_ref().unwrap();
+        assert!(!bm.contains(1));
+        assert!(bm.contains(2));
+    }
+}

--- a/rust/lance-table/src/format/transaction/actions/remove_fragments.rs
+++ b/rust/lance-table/src/format/transaction/actions/remove_fragments.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! `RemoveFragments` — drops fragments by id or by criterion (`All`).
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use super::{
+    Action, ActionOutput, FragmentRef, FragmentScope, FragmentSelector, ManifestMask, ManifestPath,
+    TransactionError, TxnContext, WorkingState,
+};
+use crate::format::Fragment;
+
+#[derive(Debug, Clone)]
+pub struct RemoveFragments {
+    pub selector: FragmentSelector,
+    /// Concrete set, filled in by rebase when selector is `All`.
+    resolved: Option<Vec<u32>>,
+}
+
+impl RemoveFragments {
+    pub fn refs(refs: Vec<FragmentRef>) -> Self {
+        Self {
+            selector: FragmentSelector::Refs(refs),
+            resolved: None,
+        }
+    }
+
+    pub fn all() -> Self {
+        Self {
+            selector: FragmentSelector::All,
+            resolved: None,
+        }
+    }
+
+    /// Concrete fragment ids targeted by this action, if knowable without ctx.
+    pub fn explicit_ids(&self) -> Option<Vec<u32>> {
+        if let Some(resolved) = &self.resolved {
+            return Some(resolved.clone());
+        }
+        if let FragmentSelector::Refs(refs) = &self.selector {
+            let mut out = Vec::with_capacity(refs.len());
+            for r in refs {
+                if let FragmentRef::Existing(id) = r {
+                    out.push(*id);
+                } else {
+                    return None;
+                }
+            }
+            return Some(out);
+        }
+        None
+    }
+}
+
+impl Action for RemoveFragments {
+    fn reads(&self) -> ManifestMask {
+        let mut mask = ManifestMask::singleton(ManifestPath::FragmentList);
+        if let FragmentSelector::Refs(refs) = &self.selector {
+            for r in refs {
+                if let FragmentRef::Existing(id) = r {
+                    mask.insert(ManifestPath::Fragment {
+                        id: *id,
+                        scope: FragmentScope::Whole,
+                    });
+                }
+            }
+        }
+        mask
+    }
+
+    fn writes(&self) -> ManifestMask {
+        self.reads()
+    }
+
+    fn validate(&self, state: &WorkingState) -> Result<(), TransactionError> {
+        if let FragmentSelector::Refs(refs) = &self.selector {
+            let ids: BTreeSet<u64> = state.manifest.fragments.iter().map(|f| f.id).collect();
+            for r in refs {
+                if let FragmentRef::Existing(id) = r
+                    && !ids.contains(&(*id as u64))
+                {
+                    return Err(TransactionError::Incompatible(format!(
+                        "RemoveFragments: fragment {id} not present"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn rebase(
+        &mut self,
+        current: &WorkingState,
+        _concurrent: &[Box<dyn Action>],
+    ) -> Result<(), TransactionError> {
+        // Criterion-based: re-evaluate `All` against current state.
+        if matches!(self.selector, FragmentSelector::All) {
+            self.resolved = Some(
+                current
+                    .manifest
+                    .fragments
+                    .iter()
+                    .map(|f| f.id as u32)
+                    .collect(),
+            );
+        }
+        Ok(())
+    }
+
+    fn apply(
+        &self,
+        state: &mut WorkingState,
+        ctx: &mut TxnContext,
+    ) -> Result<ActionOutput, TransactionError> {
+        let want: BTreeSet<u64> = match (&self.selector, &self.resolved) {
+            (_, Some(ids)) => ids.iter().map(|id| *id as u64).collect(),
+            (FragmentSelector::All, None) => {
+                state.manifest.fragments.iter().map(|f| f.id).collect()
+            }
+            (FragmentSelector::Refs(refs), None) => refs
+                .iter()
+                .map(|r| {
+                    ctx.resolve(r).map(u64::from).ok_or_else(|| {
+                        TransactionError::Incompatible(format!(
+                            "RemoveFragments: unresolved ref {r:?}"
+                        ))
+                    })
+                })
+                .collect::<Result<_, _>>()?,
+        };
+        let before = state.manifest.fragments.len();
+        let kept: Vec<Fragment> = state
+            .manifest
+            .fragments
+            .iter()
+            .filter(|f| !want.contains(&f.id))
+            .cloned()
+            .collect();
+        if before - kept.len() != want.len() {
+            return Err(TransactionError::Incompatible(format!(
+                "RemoveFragments: not all targets present ({want:?})"
+            )));
+        }
+        state.manifest.fragments = Arc::new(kept);
+        Ok(ActionOutput::None)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::*;
+    use super::*;
+
+    #[test]
+    fn remove_disjoint_fragments_both_apply() {
+        let a: Box<dyn Action> = Box::new(RemoveFragments::refs(vec![
+            FragmentRef::Existing(1),
+            FragmentRef::Existing(2),
+        ]));
+        let b: Box<dyn Action> = Box::new(RemoveFragments::refs(vec![
+            FragmentRef::Existing(3),
+            FragmentRef::Existing(4),
+        ]));
+        assert!(a.writes().intersects(&b.writes())); // shared FragmentList
+        let mut s = state_with_fragments(&[1, 2, 3, 4]);
+        run_one(a, &mut s).unwrap();
+        run_one(b, &mut s).unwrap();
+        assert_eq!(s.manifest.fragments.len(), 0);
+    }
+
+    #[test]
+    fn validate_catches_remove_of_missing_fragment() {
+        let a = RemoveFragments::refs(vec![FragmentRef::Existing(99)]);
+        let s = state_with_fragments(&[1, 2]);
+        let err = a.validate(&s).unwrap_err();
+        assert!(matches!(err, TransactionError::Incompatible(_)));
+    }
+
+    #[test]
+    fn all_selector_resolves_at_rebase() {
+        let mut a = RemoveFragments::all();
+        let s = state_with_fragments(&[7, 8]);
+        a.rebase(&s, &[]).unwrap();
+        assert_eq!(a.resolved, Some(vec![7, 8]));
+    }
+}

--- a/rust/lance-table/src/format/transaction/actions/update_deletion_vector.rs
+++ b/rust/lance-table/src/format/transaction/actions/update_deletion_vector.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! `UpdateDeletionVector` — replaces a fragment's deletion vector.
+//!
+//! Rebase logic implements the rule from §4 of the design doc:
+//! "two UpdateDeletionVectors on the same fragment merge by union iff both
+//! carry `affected_rows`; otherwise conflict." Same-row writes conflict.
+//! In production the merge would write a new deletion file (IO); here we
+//! detect the case and leave the file write as a `todo!`-equivalent.
+
+use std::sync::Arc;
+
+use roaring::RoaringBitmap;
+
+use super::{
+    Action, ActionOutput, FragmentRef, FragmentScope, ManifestMask, ManifestPath, TransactionError,
+    TxnContext, WorkingState,
+};
+use crate::format::{DeletionFile, Fragment};
+
+#[derive(Debug, Clone)]
+pub struct UpdateDeletionVector {
+    pub fragment: FragmentRef,
+    pub new_deletion_file: DeletionFile,
+    pub affected_rows: Option<RoaringBitmap>,
+}
+
+impl UpdateDeletionVector {
+    fn frag_id_if_concrete(&self) -> Option<u32> {
+        match self.fragment {
+            FragmentRef::Existing(id) => Some(id),
+            FragmentRef::ProducedBy { .. } => None,
+        }
+    }
+}
+
+impl Action for UpdateDeletionVector {
+    fn reads(&self) -> ManifestMask {
+        match &self.fragment {
+            FragmentRef::Existing(id) => ManifestMask::singleton(ManifestPath::Fragment {
+                id: *id,
+                scope: FragmentScope::DeletionVector,
+            }),
+            FragmentRef::ProducedBy { .. } => ManifestMask::singleton(ManifestPath::FragmentList),
+        }
+    }
+
+    fn writes(&self) -> ManifestMask {
+        self.reads()
+    }
+
+    fn validate(&self, state: &WorkingState) -> Result<(), TransactionError> {
+        if let FragmentRef::Existing(id) = &self.fragment
+            && !state.manifest.fragments.iter().any(|f| f.id == *id as u64)
+        {
+            return Err(TransactionError::Incompatible(format!(
+                "UpdateDeletionVector: fragment {id} not present"
+            )));
+        }
+        Ok(())
+    }
+
+    fn rebase(
+        &mut self,
+        _current: &WorkingState,
+        concurrent: &[Box<dyn Action>],
+    ) -> Result<(), TransactionError> {
+        // Need affected_rows on self to reason about row-level conflict.
+        let self_id = self.frag_id_if_concrete();
+        let self_rows = self.affected_rows.as_ref().ok_or_else(|| {
+            TransactionError::Incompatible(
+                "UpdateDeletionVector: cannot rebase without affected_rows".into(),
+            )
+        })?;
+
+        for other in concurrent {
+            // Same-fragment UDV: same-row → conflict, disjoint → ok (merge IO
+            // would happen here in production).
+            if let Some(udv) = other.as_any().downcast_ref::<Self>() {
+                let other_id = udv.frag_id_if_concrete();
+                if other_id != self_id || other_id.is_none() {
+                    continue;
+                }
+                let other_rows = udv.affected_rows.as_ref().ok_or_else(|| {
+                    TransactionError::Incompatible(
+                        "UpdateDeletionVector: concurrent UDV without affected_rows; \
+                         cannot determine row overlap"
+                            .into(),
+                    )
+                })?;
+                if !(self_rows & other_rows).is_empty() {
+                    return Err(TransactionError::Incompatible(format!(
+                        "UpdateDeletionVector: row-level conflict on fragment {:?}",
+                        self_id
+                    )));
+                }
+                // TODO: read concurrent deletion file and union into self.
+                // Conservative-fail kept here would block disjoint-row updates;
+                // we accept the success path for the prototype and leave the
+                // merge IO unimplemented.
+            }
+
+            // A concurrent RemoveFragments dropping our fragment is fatal.
+            if let Some(rf) = other
+                .as_any()
+                .downcast_ref::<super::remove_fragments::RemoveFragments>()
+                && let Some(ids) = rf.explicit_ids()
+                && self_id.is_some_and(|id| ids.contains(&id))
+            {
+                return Err(TransactionError::Incompatible(format!(
+                    "UpdateDeletionVector: fragment {:?} removed by concurrent txn",
+                    self_id
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn apply(
+        &self,
+        state: &mut WorkingState,
+        ctx: &mut TxnContext,
+    ) -> Result<ActionOutput, TransactionError> {
+        self.validate(state)?;
+        let frag_id = ctx.resolve(&self.fragment).ok_or_else(|| {
+            TransactionError::Incompatible(format!(
+                "UpdateDeletionVector: unresolved ref {:?}",
+                self.fragment
+            ))
+        })?;
+        let mut new_fragments: Vec<Fragment> = state.manifest.fragments.as_ref().clone();
+        let frag = new_fragments
+            .iter_mut()
+            .find(|f| f.id == frag_id as u64)
+            .ok_or_else(|| {
+                TransactionError::Incompatible(format!(
+                    "UpdateDeletionVector: fragment {frag_id} not present at apply"
+                ))
+            })?;
+        frag.deletion_file = Some(self.new_deletion_file.clone());
+        state.manifest.fragments = Arc::new(new_fragments);
+        Ok(ActionOutput::None)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::*;
+    use super::super::{RemoveFragments, commit};
+    use super::*;
+
+    fn udv(frag_id: u32, rows: &[u32]) -> UpdateDeletionVector {
+        UpdateDeletionVector {
+            fragment: FragmentRef::Existing(frag_id),
+            new_deletion_file: dummy_deletion_file(),
+            affected_rows: Some(RoaringBitmap::from_iter(rows.iter().copied())),
+        }
+    }
+
+    #[test]
+    fn validate_fails_on_apply_when_fragment_was_removed_concurrently() {
+        let mut a: Vec<Box<dyn Action>> = vec![Box::new(RemoveFragments::refs(vec![
+            FragmentRef::Existing(1),
+        ]))];
+        let s0 = state_with_fragments(&[1, 2]);
+        let s1 = commit(&mut a, &s0, &ManifestMask::empty(), &[]).unwrap();
+
+        let b = udv(1, &[0, 1]);
+        let err = b.validate(&s1).unwrap_err();
+        assert!(matches!(err, TransactionError::Incompatible(_)));
+    }
+
+    #[test]
+    fn rebase_detects_same_row_conflict() {
+        let s = state_with_fragments(&[1]);
+        let concurrent: Vec<Box<dyn Action>> = vec![Box::new(udv(1, &[0, 1, 2]))];
+        let mut me = udv(1, &[2, 3]); // row 2 overlaps
+        let err = me.rebase(&s, &concurrent).unwrap_err();
+        assert!(matches!(err, TransactionError::Incompatible(_)));
+    }
+
+    #[test]
+    fn rebase_passes_for_disjoint_rows_same_fragment() {
+        let s = state_with_fragments(&[1]);
+        let concurrent: Vec<Box<dyn Action>> = vec![Box::new(udv(1, &[0, 1, 2]))];
+        let mut me = udv(1, &[3, 4]);
+        me.rebase(&s, &concurrent).unwrap();
+    }
+
+    #[test]
+    fn rebase_passes_when_fragments_differ() {
+        let s = state_with_fragments(&[1, 2]);
+        let concurrent: Vec<Box<dyn Action>> = vec![Box::new(udv(2, &[0, 1]))];
+        let mut me = udv(1, &[0, 1]);
+        me.rebase(&s, &concurrent).unwrap();
+    }
+}


### PR DESCRIPTION
Spike for #6448. Not for merge — published for reference when doing future work.

Includes a design doc plus a working Rust prototype of action-based transactions and conflict resolution.

## What's here

- `rust/lance-table/design/action_based_conflict_resolution.md` — design doc covering principles (criterion-based targeting, late binding, symbolic intra-txn references), the action catalog, lifecycle, worked examples, a first-pass conflict matrix (§5/§6), and a classification of every existing `check_*_txn` rule against the design (§11).
- `rust/lance-table/src/format/transaction/actions{.rs,/}` — `Action` trait, `ManifestMask`, transaction driver, and six action implementations: `RemoveFragments`, `AddFragments`, `UpdateDeletionVector`, `InvalidateIndexCoverage`, `ChangeSchema`, `AddIndex`.
- Per-action unit tests + a conflict-resolution test suite covering:
  - update || update on different fragments → compatible
  - update || update same fragment, different rows → compatible
  - update || update same row → conflict
  - update || update same fragment, full rewrite → conflict
  - create_index then update (criterion path picks up new concrete index)
  - update then create_index (rebase trims removed fragments from trained bitmap)
  - two create_index over the same field with distinct UUIDs → both land
  - concurrent overwrite → last writer wins

24 tests, all passing. Clippy + fmt clean.

## Why this approach makes N×N rules unnecessary

The acceptance criteria on #6448 call for "a conflict matrix covering all 14 action types." The prototype's premise is that **the matrix is the wrong artifact** — it should be emergent, not hand-authored.

Three mechanisms, all derived from per-action `reads()` and `writes()` masks, cover the bulk of conflict cases:

1. **Mask overlap (pure).** Two actions' manifest paths intersect → driver fires `rebase`. Most fragment-id / field-id collisions resolve here without any per-pair logic.
2. **Criterion-based overlap (§3.1).** A path carries a predicate (`IndicesCoveringFields{fields=[7]}`); the mask layer evaluates it against the peer's concrete path. This is what lets a `Update(field=7)` correctly invalidate a concurrently-added `AddIndex(field=7)` without either action knowing about the other.
3. **Peer-inspecting rebase (§7).** When mask overlap fires, `rebase` can downcast the peer to make a finer decision — `UpdateDeletionVector` checking row-level overlap against a concurrent UDV is the canonical case.

Classifying the existing ~52 rules across all 14 `check_*_txn` methods (see §11):
- ~24 fit one of the three patterns directly.
- ~22 are *catalog gaps* — rules over actions §4 doesn't yet enumerate (`UpdateConfig`, `AddBases`, etc.). Add the action, the rule fits.
- ~6 are *true pattern gaps* and the most valuable finding of the spike.

For an N-action catalog, that's O(N) action declarations + O(small) special-case rebase impls, not O(N²) hand-curated cells. Adding a new action means adding its mask declarations and any necessary peer-inspection logic in `rebase`; existing actions are untouched.

### Worked example: merge-insert primary-key bloom filter

One existing rule that looks at first like it needs transaction-level metadata: `inserted_rows_filter`, the Bloom filter over primary keys a merge-insert claims as new. Two concurrent merge-inserts could both decide PK 42 doesn't exist and both insert it — the bloom detects the race.

This *appears* transaction-level because both txns need to compare blooms. In fact it fits pattern 3 cleanly: the bloom describes the PKs in the new rows of an `AddFragments`, so it lives on the action. `AddFragments::rebase` walks concurrent peers, finds other `AddFragments` actions, and:

- both have a bloom with matching field_ids and blooms intersect → `Retry`
- both have a bloom with non-matching field_ids → `Retry` (can't verify)
- self has a bloom, peer has none (plain Append) → `Retry` (peer's PKs unknowable)

No txn-level surface required. Same shape as UDV row-overlap, just with a bloom instead of a roaring bitmap.

## Genuine gaps that did surface

Three structural additions the prototype doesn't yet handle:

1. **Transaction-level conflict metadata for MemWAL `merged_generations`.** This field appears on three different operation shells (`Update`, `UpdateMemWalState`, `CreateIndex(MemWAL)`) — same data, different wrappers. Unlike the PK bloom, it genuinely doesn't belong to any one action. Wants a TxnContext-level metadata surface parallel to action masks.
2. **Retryable vs Incompatible verdict.** Today's resolver distinguishes "your transaction can't be made valid" from "your transaction is fine, just races; retry against the new manifest." The action trait collapses both into `TransactionError`. `rebase` should return `Ok | Retry | Fail` (or split the error type) so the driver can drive the retry loop.
3. **Restore as baseline reset.** Forward rebase is meaningless for a Restore — the entire base is replaced. Needs a driver-level short-circuit. The PRD already puts Restore at the top-level proto oneof, so this is more a §7 documentation issue than a design gap.

The bulk of the remaining work is mechanical catalog completion (~10 more actions: `RemoveIndex`, `UpdateConfig`, `AddFields`, etc.) plus enriching the trait to return the three-way verdict.

## Known TODOs / open questions (prototype-specific)

- UDV row-disjoint merge currently passes rebase but `apply` overwrites rather than unions — real impl needs IO in rebase.
- `AddIndex` introduces an `OnNewFragments::{LeaveUncovered, Fail}` policy knob that the design doc doesn't yet pin down.
- `InvalidateIndexCoverage`/`AddIndex` operate on a prototype-only `WorkingState { manifest, indices }` wrapper since the real `Manifest` doesn't carry the index list inline.