### PR TITLE
feat(java): add Java bindings for MemWAL APIs

### DIFF
--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3996,6 +3996,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "datafusion",
  "datafusion-common",
  "env_logger",
  "jni 0.21.1",

--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -30,6 +30,7 @@ lance-table = { path = "../../rust/lance-table" }
 arrow = { version = "58.0.0", features = ["ffi"] }
 arrow-array = "58.0.0"
 arrow-schema = "58.0.0"
+datafusion = { version = "53.0.0", default-features = false }
 datafusion-common = "53.0.0"
 object_store = { version = "0.13.2" }
 tokio = { version = "1.23", features = [

--- a/java/lance-jni/src/lib.rs
+++ b/java/lance-jni/src/lib.rs
@@ -51,6 +51,7 @@ mod file_reader;
 mod file_writer;
 mod fragment;
 mod index;
+mod mem_wal;
 mod merge_insert;
 mod namespace;
 mod optimize;

--- a/java/lance-jni/src/mem_wal.rs
+++ b/java/lance-jni/src/mem_wal.rs
@@ -337,7 +337,7 @@ where
     let scanner = guard
         .inner
         .take()
-        .ok_or_else(|| Error::runtime_error("LsmScanner has already been consumed".to_string()))?;
+        .ok_or_else(|| Error::runtime_error("LsmScanner is no longer usable because an earlier builder call (e.g. filter) failed; create a new scanner".to_string()))?;
     guard.inner = Some(f(scanner)?);
     Ok(())
 }
@@ -431,7 +431,7 @@ fn inner_scanner_open_stream(env: &mut JNIEnv, this: JObject, stream_addr: jlong
         let guard =
             unsafe { env.get_rust_field::<_, _, BlockingLsmScanner>(&this, NATIVE_LSM_SCANNER) }?;
         let scanner = guard.inner.as_ref().ok_or_else(|| {
-            Error::runtime_error("LsmScanner has already been consumed".to_string())
+            Error::runtime_error("LsmScanner is no longer usable because an earlier builder call (e.g. filter) failed; create a new scanner".to_string())
         })?;
         RT.block_on(scanner.try_into_stream())?
     };
@@ -455,7 +455,7 @@ fn inner_scanner_count_rows(env: &mut JNIEnv, this: JObject) -> Result<u64> {
     let scanner = guard
         .inner
         .as_ref()
-        .ok_or_else(|| Error::runtime_error("LsmScanner has already been consumed".to_string()))?;
+        .ok_or_else(|| Error::runtime_error("LsmScanner is no longer usable because an earlier builder call (e.g. filter) failed; create a new scanner".to_string()))?;
     Ok(RT.block_on(scanner.count_rows())?)
 }
 
@@ -885,7 +885,7 @@ fn inner_initialize_mem_wal(env: &mut JNIEnv, jdataset: JObject, params: JObject
     let identity_column = env.get_optional_string_from_method(&params, "identityColumn")?;
     let unsharded = env.call_method(&params, "unsharded", "()Z", &[])?.z()?;
     let writer_config =
-        env.get_optional_from_method(&params, "writerConfig", |env, config_obj| {
+        env.get_optional_from_method(&params, "writerConfigDefaults", |env, config_obj| {
             build_writer_config(env, &config_obj)
         })?;
 
@@ -1280,15 +1280,21 @@ fn sharding_field_to_java<'a>(env: &mut JNIEnv<'a>, field: &ShardingField) -> Re
         Some(t) => env.new_string(t)?.into(),
         None => JObject::null(),
     };
+    let expression: JObject = match &field.expression {
+        Some(e) => env.new_string(e)?.into(),
+        None => JObject::null(),
+    };
     let result_type: JObject = env.new_string(&field.result_type)?.into();
     let parameters = field.parameters.clone().into_java(env)?;
     Ok(env.new_object(
         "org/lance/memwal/ShardingField",
-        "(Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V",
+        "(Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;\
+         Ljava/lang/String;Ljava/util/Map;)V",
         &[
             JValueGen::Object(&field_id),
             JValueGen::Object(&source_ids),
             JValueGen::Object(&transform),
+            JValueGen::Object(&expression),
             JValueGen::Object(&result_type),
             JValueGen::Object(&parameters),
         ],

--- a/java/lance-jni/src/mem_wal.rs
+++ b/java/lance-jni/src/mem_wal.rs
@@ -1,0 +1,1310 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! JNI bindings for the Lance MemWAL feature.
+//!
+//! Mirrors the Python MemWAL binding (`python/src/mem_wal.rs`): a stateful
+//! [`ShardWriter`], an LSM-aware [`LsmScanner`], an [`ExecutionPlan`] wrapper,
+//! and the point-lookup / vector-search planners.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema, from_ffi};
+use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
+use arrow_array::{
+    Array, ArrayRef, FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator,
+    RecordBatchReader, StructArray, make_array,
+};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use datafusion::common::ScalarValue;
+use datafusion::physical_plan::{ExecutionPlan, collect, displayable};
+use datafusion::prelude::SessionContext;
+use jni::JNIEnv;
+use jni::objects::{JClass, JObject, JString, JValueGen};
+use jni::sys::{jint, jlong};
+use lance::dataset::Dataset as LanceDataset;
+use lance::dataset::mem_wal::scanner::{
+    FlushedGeneration, LsmDataSourceCollector, LsmPointLookupPlanner, LsmVectorSearchPlanner,
+};
+use lance::dataset::mem_wal::write::{MemTableStats, WriteStatsSnapshot};
+use lance::dataset::mem_wal::{
+    DatasetMemWalExt, LsmScanner, ShardSnapshot, ShardWriter, ShardWriterConfig,
+};
+use lance::dataset::scanner::DatasetRecordBatchStream;
+use lance_index::mem_wal::{MemWalIndexDetails, ShardManifest, ShardingField, ShardingSpec};
+use lance_io::ffi::to_ffi_arrow_array_stream;
+use lance_linalg::distance::DistanceType;
+use uuid::Uuid;
+
+use crate::RT;
+use crate::blocking_dataset::{BlockingDataset, NATIVE_DATASET};
+use crate::error::{Error, Result};
+use crate::ffi::JNIEnvExt;
+use crate::traits::{IntoJava, export_vec, import_vec, import_vec_to_rust};
+
+const NATIVE_SHARD_WRITER: &str = "nativeShardWriterHandle";
+const NATIVE_LSM_SCANNER: &str = "nativeLsmScannerHandle";
+const NATIVE_EXECUTION_PLAN: &str = "nativeExecutionPlanHandle";
+const NATIVE_LOOKUP_PLANNER: &str = "nativeLookupPlannerHandle";
+const NATIVE_VECTOR_PLANNER: &str = "nativeVectorPlannerHandle";
+
+/// Native handle backing `org.lance.memwal.ShardWriter`.
+struct BlockingShardWriter {
+    writer: ShardWriter,
+    shard_id: Uuid,
+    dataset: Arc<LanceDataset>,
+}
+
+/// Native handle backing `org.lance.memwal.LsmScanner`.
+struct BlockingLsmScanner {
+    inner: Option<LsmScanner>,
+}
+
+/// Native handle backing `org.lance.memwal.ExecutionPlan`.
+struct BlockingExecutionPlan {
+    plan: Arc<dyn ExecutionPlan>,
+    dataset_schema: Arc<ArrowSchema>,
+}
+
+/// Native handle backing `org.lance.memwal.LsmPointLookupPlanner`.
+struct BlockingLsmPointLookupPlanner {
+    planner: LsmPointLookupPlanner,
+    dataset_schema: Arc<ArrowSchema>,
+    pk_columns: Vec<String>,
+}
+
+/// Native handle backing `org.lance.memwal.LsmVectorSearchPlanner`.
+struct BlockingLsmVectorSearchPlanner {
+    planner: LsmVectorSearchPlanner,
+    vector_dim: usize,
+    dataset_schema: Arc<ArrowSchema>,
+}
+
+///////////////////
+// ShardWriter  //
+///////////////////
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ShardWriter_createNative<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    dataset: JObject<'local>,
+    shard_id: JString<'local>,
+    config: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_create_shard_writer(&mut env, dataset, shard_id, config)
+    )
+}
+
+fn inner_create_shard_writer<'local>(
+    env: &mut JNIEnv<'local>,
+    dataset: JObject<'local>,
+    shard_id: JString<'local>,
+    config: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let shard_id: String = env.get_string(&shard_id)?.into();
+    let uuid = parse_uuid(&shard_id)?;
+    let writer_config = if config.is_null() {
+        ShardWriterConfig::default()
+    } else {
+        build_writer_config(env, &config)?
+    };
+
+    let dataset = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(&dataset, NATIVE_DATASET) }?;
+        Arc::new(guard.inner.clone())
+    };
+
+    let writer = RT.block_on(dataset.mem_wal_writer(uuid, writer_config))?;
+    let blocking = BlockingShardWriter {
+        writer,
+        shard_id: uuid,
+        dataset,
+    };
+
+    let java_obj = env.new_object("org/lance/memwal/ShardWriter", "()V", &[])?;
+    unsafe { env.set_rust_field(&java_obj, NATIVE_SHARD_WRITER, blocking) }?;
+    Ok(java_obj)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ShardWriter_nativeShardId<'local>(
+    mut env: JNIEnv<'local>,
+    this: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(env, inner_shard_id(&mut env, this))
+}
+
+fn inner_shard_id<'local>(
+    env: &mut JNIEnv<'local>,
+    this: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let shard_id = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingShardWriter>(&this, NATIVE_SHARD_WRITER) }?;
+        guard.shard_id.to_string()
+    };
+    Ok(env.new_string(shard_id)?.into())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ShardWriter_nativePut(
+    mut env: JNIEnv,
+    this: JObject,
+    stream_addr: jlong,
+) {
+    ok_or_throw_without_return!(env, inner_put(&mut env, this, stream_addr));
+}
+
+fn inner_put(env: &mut JNIEnv, this: JObject, stream_addr: jlong) -> Result<()> {
+    let stream_ptr = stream_addr as *mut FFI_ArrowArrayStream;
+    let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
+    let batches: Vec<RecordBatch> = reader.collect::<std::result::Result<_, _>>()?;
+    if batches.is_empty() {
+        return Ok(());
+    }
+
+    let guard =
+        unsafe { env.get_rust_field::<_, _, BlockingShardWriter>(&this, NATIVE_SHARD_WRITER) }?;
+    RT.block_on(guard.writer.put(batches))?;
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ShardWriter_nativeStats<'local>(
+    mut env: JNIEnv<'local>,
+    this: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(env, inner_writer_stats(&mut env, this))
+}
+
+fn inner_writer_stats<'local>(
+    env: &mut JNIEnv<'local>,
+    this: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let stats = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingShardWriter>(&this, NATIVE_SHARD_WRITER) }?;
+        guard.writer.stats()
+    };
+    write_stats_to_java(env, &stats)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ShardWriter_nativeMemtableStats<'local>(
+    mut env: JNIEnv<'local>,
+    this: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(env, inner_memtable_stats(&mut env, this))
+}
+
+fn inner_memtable_stats<'local>(
+    env: &mut JNIEnv<'local>,
+    this: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let stats = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingShardWriter>(&this, NATIVE_SHARD_WRITER) }?;
+        RT.block_on(guard.writer.memtable_stats())?
+    };
+    memtable_stats_to_java(env, &stats)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ShardWriter_nativeLsmScanner<'local>(
+    mut env: JNIEnv<'local>,
+    this: JObject<'local>,
+    shard_snapshots: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_writer_lsm_scanner(&mut env, this, shard_snapshots)
+    )
+}
+
+fn inner_writer_lsm_scanner<'local>(
+    env: &mut JNIEnv<'local>,
+    this: JObject<'local>,
+    shard_snapshots: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let mut snapshots = read_shard_snapshots(env, &shard_snapshots)?;
+
+    let (in_memory_memtables, writer_snapshot, dataset, shard_id, pk_columns) = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingShardWriter>(&this, NATIVE_SHARD_WRITER) }?;
+        let pk_columns = get_pk_columns(&guard.dataset)?;
+        // Capture the active memtable *and* any frozen-awaiting-flush memtables
+        // so a concurrent flush rollover cannot hide acknowledged writes from
+        // this read-your-writes scanner.
+        let in_memory_memtables = RT.block_on(guard.writer.in_memory_memtable_refs())?;
+        let writer_snapshot = RT
+            .block_on(guard.writer.manifest())?
+            .map(shard_snapshot_from_manifest)
+            .unwrap_or_else(|| ShardSnapshot::new(guard.shard_id));
+        (
+            in_memory_memtables,
+            writer_snapshot,
+            guard.dataset.clone(),
+            guard.shard_id,
+            pk_columns,
+        )
+    };
+
+    snapshots.retain(|snapshot| snapshot.shard_id != shard_id);
+    snapshots.push(writer_snapshot);
+
+    let scanner = LsmScanner::new(dataset, snapshots, pk_columns)
+        .with_in_memory_memtables(shard_id, in_memory_memtables);
+    attach_lsm_scanner(env, scanner)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ShardWriter_releaseNativeShardWriter(
+    mut env: JNIEnv,
+    this: JObject,
+    _handle: jlong,
+) {
+    ok_or_throw_without_return!(env, inner_release_shard_writer(&mut env, this));
+}
+
+fn inner_release_shard_writer(env: &mut JNIEnv, this: JObject) -> Result<()> {
+    let blocking: BlockingShardWriter = unsafe { env.take_rust_field(&this, NATIVE_SHARD_WRITER) }?;
+    RT.block_on(blocking.writer.close())?;
+    Ok(())
+}
+
+///////////////////
+// LsmScanner    //
+///////////////////
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmScanner_createFromSnapshots<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    dataset: JObject<'local>,
+    shard_snapshots: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_lsm_scanner_from_snapshots(&mut env, dataset, shard_snapshots)
+    )
+}
+
+fn inner_lsm_scanner_from_snapshots<'local>(
+    env: &mut JNIEnv<'local>,
+    dataset: JObject<'local>,
+    shard_snapshots: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let snapshots = read_shard_snapshots(env, &shard_snapshots)?;
+    let dataset = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(&dataset, NATIVE_DATASET) }?;
+        Arc::new(guard.inner.clone())
+    };
+    let pk_columns = get_pk_columns(&dataset)?;
+    let scanner = LsmScanner::new(dataset, snapshots, pk_columns);
+    attach_lsm_scanner(env, scanner)
+}
+
+fn attach_lsm_scanner<'local>(
+    env: &mut JNIEnv<'local>,
+    scanner: LsmScanner,
+) -> Result<JObject<'local>> {
+    let java_obj = env.new_object("org/lance/memwal/LsmScanner", "()V", &[])?;
+    unsafe {
+        env.set_rust_field(
+            &java_obj,
+            NATIVE_LSM_SCANNER,
+            BlockingLsmScanner {
+                inner: Some(scanner),
+            },
+        )
+    }?;
+    Ok(java_obj)
+}
+
+/// Take the wrapped scanner out, apply `f`, then store the result back.
+fn with_lsm_scanner<F>(env: &mut JNIEnv, this: &JObject, f: F) -> Result<()>
+where
+    F: FnOnce(LsmScanner) -> Result<LsmScanner>,
+{
+    let mut guard =
+        unsafe { env.get_rust_field::<_, _, BlockingLsmScanner>(this, NATIVE_LSM_SCANNER) }?;
+    let scanner = guard
+        .inner
+        .take()
+        .ok_or_else(|| Error::runtime_error("LsmScanner has already been consumed".to_string()))?;
+    guard.inner = Some(f(scanner)?);
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmScanner_nativeProject(
+    mut env: JNIEnv,
+    this: JObject,
+    columns: JObject,
+) {
+    ok_or_throw_without_return!(env, inner_scanner_project(&mut env, this, columns));
+}
+
+fn inner_scanner_project(env: &mut JNIEnv, this: JObject, columns: JObject) -> Result<()> {
+    let columns = env.get_strings(&columns)?;
+    with_lsm_scanner(env, &this, |scanner| {
+        let cols: Vec<&str> = columns.iter().map(String::as_str).collect();
+        Ok(scanner.project(&cols))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmScanner_nativeFilter(
+    mut env: JNIEnv,
+    this: JObject,
+    expr: JString,
+) {
+    ok_or_throw_without_return!(env, inner_scanner_filter(&mut env, this, expr));
+}
+
+fn inner_scanner_filter(env: &mut JNIEnv, this: JObject, expr: JString) -> Result<()> {
+    let expr: String = env.get_string(&expr)?.into();
+    with_lsm_scanner(env, &this, |scanner| Ok(scanner.filter(&expr)?))
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmScanner_nativeLimit(
+    mut env: JNIEnv,
+    this: JObject,
+    limit: jlong,
+    offset: JObject,
+) {
+    ok_or_throw_without_return!(env, inner_scanner_limit(&mut env, this, limit, offset));
+}
+
+fn inner_scanner_limit(
+    env: &mut JNIEnv,
+    this: JObject,
+    limit: jlong,
+    offset: JObject,
+) -> Result<()> {
+    let offset = env.get_u64_opt(&offset)?.map(|v| v as usize);
+    with_lsm_scanner(env, &this, |scanner| {
+        Ok(scanner.limit(limit as usize, offset))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmScanner_nativeWithRowAddress(
+    mut env: JNIEnv,
+    this: JObject,
+) {
+    ok_or_throw_without_return!(
+        env,
+        with_lsm_scanner(&mut env, &this, |scanner| Ok(scanner.with_row_address()))
+    );
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmScanner_nativeWithMemtableGen(
+    mut env: JNIEnv,
+    this: JObject,
+) {
+    ok_or_throw_without_return!(
+        env,
+        with_lsm_scanner(&mut env, &this, |scanner| Ok(scanner.with_memtable_gen()))
+    );
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmScanner_nativeOpenStream(
+    mut env: JNIEnv,
+    this: JObject,
+    stream_addr: jlong,
+) {
+    ok_or_throw_without_return!(env, inner_scanner_open_stream(&mut env, this, stream_addr));
+}
+
+fn inner_scanner_open_stream(env: &mut JNIEnv, this: JObject, stream_addr: jlong) -> Result<()> {
+    let stream = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingLsmScanner>(&this, NATIVE_LSM_SCANNER) }?;
+        let scanner = guard.inner.as_ref().ok_or_else(|| {
+            Error::runtime_error("LsmScanner has already been consumed".to_string())
+        })?;
+        RT.block_on(scanner.try_into_stream())?
+    };
+    let ffi_stream =
+        to_ffi_arrow_array_stream(DatasetRecordBatchStream::new(stream), RT.handle().clone())?;
+    unsafe { std::ptr::write_unaligned(stream_addr as *mut FFI_ArrowArrayStream, ffi_stream) }
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmScanner_nativeCountRows(
+    mut env: JNIEnv,
+    this: JObject,
+) -> jlong {
+    ok_or_throw_with_return!(env, inner_scanner_count_rows(&mut env, this), -1) as jlong
+}
+
+fn inner_scanner_count_rows(env: &mut JNIEnv, this: JObject) -> Result<u64> {
+    let guard =
+        unsafe { env.get_rust_field::<_, _, BlockingLsmScanner>(&this, NATIVE_LSM_SCANNER) }?;
+    let scanner = guard
+        .inner
+        .as_ref()
+        .ok_or_else(|| Error::runtime_error("LsmScanner has already been consumed".to_string()))?;
+    Ok(RT.block_on(scanner.count_rows())?)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmScanner_releaseNativeLsmScanner(
+    mut env: JNIEnv,
+    this: JObject,
+    _handle: jlong,
+) {
+    ok_or_throw_without_return!(env, inner_release_lsm_scanner(&mut env, this));
+}
+
+fn inner_release_lsm_scanner(env: &mut JNIEnv, this: JObject) -> Result<()> {
+    let _: BlockingLsmScanner = unsafe { env.take_rust_field(&this, NATIVE_LSM_SCANNER) }?;
+    Ok(())
+}
+
+///////////////////
+// ExecutionPlan //
+///////////////////
+
+fn attach_execution_plan<'local>(
+    env: &mut JNIEnv<'local>,
+    plan: Arc<dyn ExecutionPlan>,
+    dataset_schema: Arc<ArrowSchema>,
+) -> Result<JObject<'local>> {
+    let java_obj = env.new_object("org/lance/memwal/ExecutionPlan", "()V", &[])?;
+    unsafe {
+        env.set_rust_field(
+            &java_obj,
+            NATIVE_EXECUTION_PLAN,
+            BlockingExecutionPlan {
+                plan,
+                dataset_schema,
+            },
+        )
+    }?;
+    Ok(java_obj)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ExecutionPlan_nativeImportSchema(
+    mut env: JNIEnv,
+    this: JObject,
+    schema_addr: jlong,
+) {
+    ok_or_throw_without_return!(env, inner_plan_import_schema(&mut env, this, schema_addr));
+}
+
+fn inner_plan_import_schema(env: &mut JNIEnv, this: JObject, schema_addr: jlong) -> Result<()> {
+    let schema = {
+        let guard = unsafe {
+            env.get_rust_field::<_, _, BlockingExecutionPlan>(&this, NATIVE_EXECUTION_PLAN)
+        }?;
+        guard.plan.schema()
+    };
+    let ffi_schema = FFI_ArrowSchema::try_from(schema.as_ref())?;
+    unsafe { std::ptr::write_unaligned(schema_addr as *mut FFI_ArrowSchema, ffi_schema) }
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ExecutionPlan_nativeImportDatasetSchema(
+    mut env: JNIEnv,
+    this: JObject,
+    schema_addr: jlong,
+) {
+    ok_or_throw_without_return!(
+        env,
+        inner_plan_import_dataset_schema(&mut env, this, schema_addr)
+    );
+}
+
+fn inner_plan_import_dataset_schema(
+    env: &mut JNIEnv,
+    this: JObject,
+    schema_addr: jlong,
+) -> Result<()> {
+    let schema = {
+        let guard = unsafe {
+            env.get_rust_field::<_, _, BlockingExecutionPlan>(&this, NATIVE_EXECUTION_PLAN)
+        }?;
+        guard.dataset_schema.clone()
+    };
+    let ffi_schema = FFI_ArrowSchema::try_from(schema.as_ref())?;
+    unsafe { std::ptr::write_unaligned(schema_addr as *mut FFI_ArrowSchema, ffi_schema) }
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ExecutionPlan_nativeExplain<'local>(
+    mut env: JNIEnv<'local>,
+    this: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(env, inner_plan_explain(&mut env, this))
+}
+
+fn inner_plan_explain<'local>(
+    env: &mut JNIEnv<'local>,
+    this: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let explained = {
+        let guard = unsafe {
+            env.get_rust_field::<_, _, BlockingExecutionPlan>(&this, NATIVE_EXECUTION_PLAN)
+        }?;
+        format!("{}", displayable(guard.plan.as_ref()).indent(true))
+    };
+    Ok(env.new_string(explained)?.into())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ExecutionPlan_nativeOpenStream(
+    mut env: JNIEnv,
+    this: JObject,
+    stream_addr: jlong,
+) {
+    ok_or_throw_without_return!(env, inner_plan_open_stream(&mut env, this, stream_addr));
+}
+
+fn inner_plan_open_stream(env: &mut JNIEnv, this: JObject, stream_addr: jlong) -> Result<()> {
+    let plan = {
+        let guard = unsafe {
+            env.get_rust_field::<_, _, BlockingExecutionPlan>(&this, NATIVE_EXECUTION_PLAN)
+        }?;
+        guard.plan.clone()
+    };
+    let schema = plan.schema();
+    let batches = RT
+        .block_on(async move {
+            let ctx = SessionContext::new();
+            collect(plan, ctx.task_ctx()).await
+        })
+        .map_err(|e| Error::io_error(format!("Plan execution failed: {}", e)))?;
+
+    let reader: Box<dyn RecordBatchReader + Send> = Box::new(RecordBatchIterator::new(
+        batches.into_iter().map(Ok),
+        schema,
+    ));
+    let ffi_stream = FFI_ArrowArrayStream::new(reader);
+    unsafe { std::ptr::write_unaligned(stream_addr as *mut FFI_ArrowArrayStream, ffi_stream) }
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_ExecutionPlan_releaseNativeExecutionPlan(
+    mut env: JNIEnv,
+    this: JObject,
+    _handle: jlong,
+) {
+    ok_or_throw_without_return!(env, inner_release_execution_plan(&mut env, this));
+}
+
+fn inner_release_execution_plan(env: &mut JNIEnv, this: JObject) -> Result<()> {
+    let _: BlockingExecutionPlan = unsafe { env.take_rust_field(&this, NATIVE_EXECUTION_PLAN) }?;
+    Ok(())
+}
+
+/////////////////////////
+// LsmPointLookupPlanner //
+/////////////////////////
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmPointLookupPlanner_nativeCreate(
+    mut env: JNIEnv,
+    this: JObject,
+    dataset: JObject,
+    shard_snapshots: JObject,
+    pk_columns: JObject,
+) {
+    ok_or_throw_without_return!(
+        env,
+        inner_create_lookup_planner(&mut env, this, dataset, shard_snapshots, pk_columns)
+    );
+}
+
+fn inner_create_lookup_planner(
+    env: &mut JNIEnv,
+    this: JObject,
+    dataset: JObject,
+    shard_snapshots: JObject,
+    pk_columns: JObject,
+) -> Result<()> {
+    let snapshots = read_shard_snapshots(env, &shard_snapshots)?;
+    let pk_columns = env.get_strings_opt(&pk_columns)?;
+    let dataset = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(&dataset, NATIVE_DATASET) }?;
+        Arc::new(guard.inner.clone())
+    };
+    let pk_columns = match pk_columns {
+        Some(cols) => cols,
+        None => get_pk_columns(&dataset)?,
+    };
+    let base_schema = Arc::new(ArrowSchema::from(dataset.schema()));
+    let collector = LsmDataSourceCollector::new(dataset, snapshots);
+    let planner = LsmPointLookupPlanner::new(collector, pk_columns.clone(), base_schema.clone());
+
+    let blocking = BlockingLsmPointLookupPlanner {
+        planner,
+        dataset_schema: base_schema,
+        pk_columns,
+    };
+    unsafe { env.set_rust_field(&this, NATIVE_LOOKUP_PLANNER, blocking) }?;
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmPointLookupPlanner_nativePlanLookup<'local>(
+    mut env: JNIEnv<'local>,
+    this: JObject<'local>,
+    array_addr: jlong,
+    schema_addr: jlong,
+    columns: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_plan_lookup(&mut env, this, array_addr, schema_addr, columns)
+    )
+}
+
+fn inner_plan_lookup<'local>(
+    env: &mut JNIEnv<'local>,
+    this: JObject<'local>,
+    array_addr: jlong,
+    schema_addr: jlong,
+    columns: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let pk_value = import_ffi_array(array_addr, schema_addr)?;
+    let columns = env.get_strings_opt(&columns)?;
+
+    let (plan, dataset_schema) = {
+        let guard = unsafe {
+            env.get_rust_field::<_, _, BlockingLsmPointLookupPlanner>(&this, NATIVE_LOOKUP_PLANNER)
+        }?;
+        let pk_values = scalar_values_from_pk_value(pk_value.as_ref(), &guard.pk_columns)?;
+        let plan = RT.block_on(guard.planner.plan_lookup(&pk_values, columns.as_deref()))?;
+        (plan, guard.dataset_schema.clone())
+    };
+    attach_execution_plan(env, plan, dataset_schema)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmPointLookupPlanner_releaseNativeLookupPlanner(
+    mut env: JNIEnv,
+    this: JObject,
+    _handle: jlong,
+) {
+    ok_or_throw_without_return!(env, inner_release_lookup_planner(&mut env, this));
+}
+
+fn inner_release_lookup_planner(env: &mut JNIEnv, this: JObject) -> Result<()> {
+    let _: BlockingLsmPointLookupPlanner =
+        unsafe { env.take_rust_field(&this, NATIVE_LOOKUP_PLANNER) }?;
+    Ok(())
+}
+
+///////////////////////////
+// LsmVectorSearchPlanner //
+///////////////////////////
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmVectorSearchPlanner_nativeCreate(
+    mut env: JNIEnv,
+    this: JObject,
+    dataset: JObject,
+    shard_snapshots: JObject,
+    vector_column: JString,
+    pk_columns: JObject,
+    distance_type: JObject,
+) {
+    ok_or_throw_without_return!(
+        env,
+        inner_create_vector_planner(
+            &mut env,
+            this,
+            dataset,
+            shard_snapshots,
+            vector_column,
+            pk_columns,
+            distance_type,
+        )
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inner_create_vector_planner(
+    env: &mut JNIEnv,
+    this: JObject,
+    dataset: JObject,
+    shard_snapshots: JObject,
+    vector_column: JString,
+    pk_columns: JObject,
+    distance_type: JObject,
+) -> Result<()> {
+    let snapshots = read_shard_snapshots(env, &shard_snapshots)?;
+    let vector_column: String = env.get_string(&vector_column)?.into();
+    let pk_columns = env.get_strings_opt(&pk_columns)?;
+    let distance_type = env.get_string_opt(&distance_type)?;
+    let dataset = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(&dataset, NATIVE_DATASET) }?;
+        Arc::new(guard.inner.clone())
+    };
+    let pk_columns = match pk_columns {
+        Some(cols) => cols,
+        None => get_pk_columns(&dataset)?,
+    };
+    let base_schema = Arc::new(ArrowSchema::from(dataset.schema()));
+    let dist_type = parse_distance_type(distance_type.as_deref().unwrap_or("l2"))?;
+    let vector_dim = get_vector_dim(&dataset, &vector_column)?;
+
+    let collector = LsmDataSourceCollector::new(dataset, snapshots);
+    let planner = LsmVectorSearchPlanner::new(
+        collector,
+        pk_columns,
+        base_schema.clone(),
+        vector_column,
+        dist_type,
+    );
+
+    let blocking = BlockingLsmVectorSearchPlanner {
+        planner,
+        vector_dim,
+        dataset_schema: base_schema,
+    };
+    unsafe { env.set_rust_field(&this, NATIVE_VECTOR_PLANNER, blocking) }?;
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmVectorSearchPlanner_nativePlanSearch<'local>(
+    mut env: JNIEnv<'local>,
+    this: JObject<'local>,
+    array_addr: jlong,
+    schema_addr: jlong,
+    k: jint,
+    nprobes: jint,
+    columns: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_plan_search(&mut env, this, array_addr, schema_addr, k, nprobes, columns)
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inner_plan_search<'local>(
+    env: &mut JNIEnv<'local>,
+    this: JObject<'local>,
+    array_addr: jlong,
+    schema_addr: jlong,
+    k: jint,
+    nprobes: jint,
+    columns: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let query = import_ffi_array(array_addr, schema_addr)?;
+    let columns = env.get_strings_opt(&columns)?;
+    let float32_array = query
+        .as_any()
+        .downcast_ref::<Float32Array>()
+        .ok_or_else(|| Error::input_error("query must be a Float32 array".to_string()))?;
+
+    let (plan, dataset_schema) = {
+        let guard = unsafe {
+            env.get_rust_field::<_, _, BlockingLsmVectorSearchPlanner>(&this, NATIVE_VECTOR_PLANNER)
+        }?;
+        if float32_array.len() != guard.vector_dim {
+            return Err(Error::input_error(format!(
+                "Query vector has {} dimensions, expected {}",
+                float32_array.len(),
+                guard.vector_dim
+            )));
+        }
+        let field = Arc::new(Field::new("item", DataType::Float32, true));
+        let fsl = FixedSizeListArray::try_new(
+            field,
+            guard.vector_dim as i32,
+            Arc::new(float32_array.clone()),
+            None,
+        )?;
+        let plan = RT.block_on(guard.planner.plan_search(
+            &fsl,
+            k as usize,
+            nprobes as usize,
+            columns.as_deref(),
+        ))?;
+        (plan, guard.dataset_schema.clone())
+    };
+    attach_execution_plan(env, plan, dataset_schema)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_memwal_LsmVectorSearchPlanner_releaseNativeVectorPlanner(
+    mut env: JNIEnv,
+    this: JObject,
+    _handle: jlong,
+) {
+    ok_or_throw_without_return!(env, inner_release_vector_planner(&mut env, this));
+}
+
+fn inner_release_vector_planner(env: &mut JNIEnv, this: JObject) -> Result<()> {
+    let _: BlockingLsmVectorSearchPlanner =
+        unsafe { env.take_rust_field(&this, NATIVE_VECTOR_PLANNER) }?;
+    Ok(())
+}
+
+///////////////////////////
+// Dataset MemWAL methods //
+///////////////////////////
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeInitializeMemWal(
+    mut env: JNIEnv,
+    jdataset: JObject,
+    params: JObject,
+) {
+    ok_or_throw_without_return!(env, inner_initialize_mem_wal(&mut env, jdataset, params));
+}
+
+fn inner_initialize_mem_wal(env: &mut JNIEnv, jdataset: JObject, params: JObject) -> Result<()> {
+    let maintained_list = env
+        .call_method(&params, "maintainedIndexes", "()Ljava/util/List;", &[])?
+        .l()?;
+    let maintained_indexes = env.get_strings(&maintained_list)?;
+    let bucket_column = env.get_optional_string_from_method(&params, "bucketColumn")?;
+    let num_buckets = env.get_optional_u32_from_method(&params, "numBuckets")?;
+    let identity_column = env.get_optional_string_from_method(&params, "identityColumn")?;
+    let unsharded = env.call_method(&params, "unsharded", "()Z", &[])?.z()?;
+    let writer_config =
+        env.get_optional_from_method(&params, "writerConfig", |env, config_obj| {
+            build_writer_config(env, &config_obj)
+        })?;
+
+    let bucket = match (bucket_column.as_deref(), num_buckets) {
+        (Some(_), Some(_)) => true,
+        (None, None) => false,
+        _ => {
+            return Err(Error::input_error(
+                "bucket sharding requires both bucketColumn and numBuckets".to_string(),
+            ));
+        }
+    };
+    let modes = [bucket, identity_column.is_some(), unsharded]
+        .into_iter()
+        .filter(|&m| m)
+        .count();
+    if modes > 1 {
+        return Err(Error::input_error(
+            "at most one of bucket sharding, identityColumn, or unsharded may be set".to_string(),
+        ));
+    }
+
+    let mut guard =
+        unsafe { env.get_rust_field::<_, _, BlockingDataset>(&jdataset, NATIVE_DATASET) }?;
+    let mut builder = guard.inner.initialize_mem_wal();
+    if let (Some(column), Some(n)) = (bucket_column, num_buckets) {
+        builder = builder.bucket_sharding(column, n);
+    } else if let Some(column) = identity_column {
+        builder = builder.identity_sharding(column);
+    } else if unsharded {
+        builder = builder.unsharded();
+    }
+    builder = builder.maintained_indexes(maintained_indexes);
+    if let Some(config) = writer_config {
+        builder = builder.writer_config_defaults(config);
+    }
+    RT.block_on(builder.execute())?;
+    Ok(())
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeMemWalIndexDetails<'local>(
+    mut env: JNIEnv<'local>,
+    jdataset: JObject<'local>,
+) -> JObject<'local> {
+    ok_or_throw!(env, inner_mem_wal_index_details(&mut env, jdataset))
+}
+
+fn inner_mem_wal_index_details<'local>(
+    env: &mut JNIEnv<'local>,
+    jdataset: JObject<'local>,
+) -> Result<JObject<'local>> {
+    let details = {
+        let guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(&jdataset, NATIVE_DATASET) }?;
+        RT.block_on(guard.inner.mem_wal_index_details())?
+    };
+    match details {
+        Some(details) => index_details_to_java(env, &details),
+        None => Ok(JObject::null()),
+    }
+}
+
+///////////////
+// Helpers   //
+///////////////
+
+fn parse_uuid(shard_id: &str) -> Result<Uuid> {
+    Uuid::parse_str(shard_id)
+        .map_err(|e| Error::input_error(format!("Invalid shard_id UUID: {}", e)))
+}
+
+/// Read a `List<ShardSnapshot>` Java object into Rust `ShardSnapshot`s.
+fn read_shard_snapshots(env: &mut JNIEnv, list_obj: &JObject) -> Result<Vec<ShardSnapshot>> {
+    import_vec_to_rust(env, list_obj, |env, obj| {
+        let shard_id = env.get_string_from_method(&obj, "shardId")?;
+        let uuid = parse_uuid(&shard_id)?;
+        let spec_id = env.get_u32_from_method(&obj, "specId")?;
+        let current_generation = env.get_u64_from_method(&obj, "currentGeneration")?;
+        let mut snapshot = ShardSnapshot::new(uuid)
+            .with_spec_id(spec_id)
+            .with_current_generation(current_generation);
+
+        let flushed_list = env
+            .call_method(&obj, "flushedGenerations", "()Ljava/util/List;", &[])?
+            .l()?;
+        for flushed in import_vec(env, &flushed_list)? {
+            let generation = env.get_u64_from_method(&flushed, "generation")?;
+            let path = env.get_string_from_method(&flushed, "path")?;
+            snapshot = snapshot.with_flushed_generation(generation, path);
+        }
+        Ok(snapshot)
+    })
+}
+
+/// Reconstruct a [`ShardSnapshot`] from a writer's [`ShardManifest`].
+fn shard_snapshot_from_manifest(manifest: ShardManifest) -> ShardSnapshot {
+    ShardSnapshot {
+        shard_id: manifest.shard_id,
+        spec_id: manifest.shard_spec_id,
+        current_generation: manifest.current_generation,
+        flushed_generations: manifest
+            .flushed_generations
+            .into_iter()
+            .map(|generation| FlushedGeneration {
+                generation: generation.generation,
+                path: generation.path,
+            })
+            .collect(),
+    }
+}
+
+/// Extract primary key column names from the dataset schema.
+fn get_pk_columns(dataset: &LanceDataset) -> Result<Vec<String>> {
+    let pk_fields = dataset.schema().unenforced_primary_key();
+    if pk_fields.is_empty() {
+        return Err(Error::input_error(
+            "Dataset has no primary key. Set 'lance-schema:unenforced-primary-key' metadata \
+             on the primary key field(s)."
+                .to_string(),
+        ));
+    }
+    Ok(pk_fields.iter().map(|f| f.name.clone()).collect())
+}
+
+/// Parse a distance type string into a [`DistanceType`].
+fn parse_distance_type(s: &str) -> Result<DistanceType> {
+    match s.to_lowercase().as_str() {
+        "l2" | "euclidean" => Ok(DistanceType::L2),
+        "cosine" => Ok(DistanceType::Cosine),
+        "dot" | "inner_product" => Ok(DistanceType::Dot),
+        "hamming" => Ok(DistanceType::Hamming),
+        _ => Err(Error::input_error(format!(
+            "Unknown distanceType '{}'. Valid values: 'l2', 'cosine', 'dot', 'hamming'",
+            s
+        ))),
+    }
+}
+
+/// Get the vector dimension of a `FixedSizeList` column from the dataset schema.
+fn get_vector_dim(dataset: &LanceDataset, column: &str) -> Result<usize> {
+    let schema = ArrowSchema::from(dataset.schema());
+    let field = schema.field_with_name(column).map_err(|_| {
+        Error::input_error(format!("Column '{}' not found in dataset schema", column))
+    })?;
+    match field.data_type() {
+        DataType::FixedSizeList(_, size) => Ok(*size as usize),
+        other => Err(Error::input_error(format!(
+            "Column '{}' is not a FixedSizeList (got {:?}). \
+             Vector columns must be FixedSizeList<float32>.",
+            column, other
+        ))),
+    }
+}
+
+/// Convert a primary key Arrow array (single row) into DataFusion scalars.
+fn scalar_values_from_pk_value(
+    pk_value: &dyn Array,
+    pk_columns: &[String],
+) -> Result<Vec<ScalarValue>> {
+    if pk_value.len() != 1 {
+        return Err(Error::input_error(format!(
+            "pkValue must contain exactly one row, got {}",
+            pk_value.len()
+        )));
+    }
+
+    if pk_columns.len() == 1 {
+        let scalar = ScalarValue::try_from_array(pk_value, 0)
+            .map_err(|e| Error::input_error(format!("Cannot convert pkValue: {}", e)))?;
+        return Ok(vec![scalar]);
+    }
+
+    let struct_array = pk_value
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| {
+            Error::input_error(format!(
+                "Composite primary key lookup requires a struct vector with one row and {} fields",
+                pk_columns.len()
+            ))
+        })?;
+
+    if struct_array.num_columns() != pk_columns.len() {
+        return Err(Error::input_error(format!(
+            "Composite primary key lookup expected {} fields, got {}",
+            pk_columns.len(),
+            struct_array.num_columns()
+        )));
+    }
+
+    let mut pk_values = Vec::with_capacity(pk_columns.len());
+    for column_name in pk_columns {
+        let column = struct_array.column_by_name(column_name).ok_or_else(|| {
+            Error::input_error(format!(
+                "Composite primary key lookup requires field '{}' in pkValue",
+                column_name
+            ))
+        })?;
+        let scalar = ScalarValue::try_from_array(column.as_ref(), 0)
+            .map_err(|e| Error::input_error(format!("Cannot convert composite pkValue: {}", e)))?;
+        pk_values.push(scalar);
+    }
+    Ok(pk_values)
+}
+
+/// Import an Arrow array exported through the C Data Interface.
+///
+/// The FFI structs at the given addresses are moved out and replaced with empty
+/// placeholders, so the producer's `close()` on the Java side is a safe no-op.
+fn import_ffi_array(array_addr: jlong, schema_addr: jlong) -> Result<ArrayRef> {
+    let ffi_array =
+        unsafe { std::ptr::replace(array_addr as *mut FFI_ArrowArray, FFI_ArrowArray::empty()) };
+    let ffi_schema = unsafe {
+        std::ptr::replace(
+            schema_addr as *mut FFI_ArrowSchema,
+            FFI_ArrowSchema::empty(),
+        )
+    };
+    let array_data = unsafe { from_ffi(ffi_array, &ffi_schema) }?;
+    Ok(make_array(array_data))
+}
+
+/// Build a [`ShardWriterConfig`] from a Java `ShardWriterConfig` object.
+fn build_writer_config(env: &mut JNIEnv, config: &JObject) -> Result<ShardWriterConfig> {
+    let mut writer_config = ShardWriterConfig::default();
+    if let Some(v) = read_optional_bool(env, config, "durableWrite")? {
+        writer_config = writer_config.with_durable_write(v);
+    }
+    if let Some(v) = read_optional_bool(env, config, "syncIndexedWrite")? {
+        writer_config = writer_config.with_sync_indexed_write(v);
+    }
+    if let Some(v) = read_optional_u64(env, config, "maxWalBufferSize")? {
+        writer_config = writer_config.with_max_wal_buffer_size(v as usize);
+    }
+    if let Some(v) = read_optional_u64(env, config, "maxWalFlushIntervalMs")? {
+        writer_config = writer_config.with_max_wal_flush_interval(Duration::from_millis(v));
+    }
+    if let Some(v) = read_optional_u64(env, config, "maxMemtableSize")? {
+        writer_config = writer_config.with_max_memtable_size(v as usize);
+    }
+    if let Some(v) = read_optional_u64(env, config, "maxMemtableRows")? {
+        writer_config = writer_config.with_max_memtable_rows(v as usize);
+    }
+    if let Some(v) = read_optional_u64(env, config, "maxMemtableBatches")? {
+        writer_config = writer_config.with_max_memtable_batches(v as usize);
+    }
+    if let Some(v) = read_optional_u64(env, config, "maxUnflushedMemtableBytes")? {
+        writer_config = writer_config.with_max_unflushed_memtable_bytes(v as usize);
+    }
+    if let Some(v) = read_optional_u64(env, config, "manifestScanBatchSize")? {
+        writer_config = writer_config.with_manifest_scan_batch_size(v as usize);
+    }
+    if let Some(v) = read_optional_u64(env, config, "asyncIndexBufferRows")? {
+        writer_config = writer_config.with_async_index_buffer_rows(v as usize);
+    }
+    if let Some(v) = read_optional_u64(env, config, "asyncIndexIntervalMs")? {
+        writer_config = writer_config.with_async_index_interval(Duration::from_millis(v));
+    }
+    if let Some(v) = read_optional_u64(env, config, "backpressureLogIntervalMs")? {
+        writer_config = writer_config.with_backpressure_log_interval(Duration::from_millis(v));
+    }
+    if let Some(v) = read_optional_u64(env, config, "statsLogIntervalMs")? {
+        let interval = if v == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(v))
+        };
+        writer_config = writer_config.with_stats_log_interval(interval);
+    }
+    Ok(writer_config)
+}
+
+fn read_optional_bool(env: &mut JNIEnv, obj: &JObject, method: &str) -> Result<Option<bool>> {
+    env.get_optional_from_method(obj, method, |env, value| {
+        Ok(env.call_method(&value, "booleanValue", "()Z", &[])?.z()?)
+    })
+}
+
+fn read_optional_u64(env: &mut JNIEnv, obj: &JObject, method: &str) -> Result<Option<u64>> {
+    env.get_optional_from_method(obj, method, |env, value| {
+        Ok(env.call_method(&value, "longValue", "()J", &[])?.j()? as u64)
+    })
+}
+
+fn write_stats_to_java<'a>(
+    env: &mut JNIEnv<'a>,
+    stats: &WriteStatsSnapshot,
+) -> Result<JObject<'a>> {
+    Ok(env.new_object(
+        "org/lance/memwal/WriteStats",
+        "(JJJJJJJJ)V",
+        &[
+            JValueGen::Long(stats.put_count as i64),
+            JValueGen::Long(stats.put_time.as_millis() as i64),
+            JValueGen::Long(stats.wal_flush_count as i64),
+            JValueGen::Long(stats.wal_flush_bytes as i64),
+            JValueGen::Long(stats.wal_flush_time.as_millis() as i64),
+            JValueGen::Long(stats.memtable_flush_count as i64),
+            JValueGen::Long(stats.memtable_flush_rows as i64),
+            JValueGen::Long(stats.memtable_flush_time.as_millis() as i64),
+        ],
+    )?)
+}
+
+fn memtable_stats_to_java<'a>(env: &mut JNIEnv<'a>, stats: &MemTableStats) -> Result<JObject<'a>> {
+    let max_buffered = box_u64_opt(env, stats.max_buffered_batch_position)?;
+    let max_flushed = box_u64_opt(env, stats.max_flushed_batch_position)?;
+    let pending_start = box_u64_opt(env, stats.pending_wal_start_batch_position)?;
+    let pending_end = box_u64_opt(env, stats.pending_wal_end_batch_position)?;
+    Ok(env.new_object(
+        "org/lance/memwal/MemTableStats",
+        "(JJJJLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;JJJ)V",
+        &[
+            JValueGen::Long(stats.row_count as i64),
+            JValueGen::Long(stats.batch_count as i64),
+            JValueGen::Long(stats.estimated_size as i64),
+            JValueGen::Long(stats.generation as i64),
+            JValueGen::Object(&max_buffered),
+            JValueGen::Object(&max_flushed),
+            JValueGen::Object(&pending_start),
+            JValueGen::Object(&pending_end),
+            JValueGen::Long(stats.pending_wal_batch_count as i64),
+            JValueGen::Long(stats.pending_wal_row_count as i64),
+            JValueGen::Long(stats.pending_wal_estimated_bytes as i64),
+        ],
+    )?)
+}
+
+fn box_u64_opt<'a>(env: &mut JNIEnv<'a>, value: Option<usize>) -> Result<JObject<'a>> {
+    match value {
+        Some(v) => Ok(env.new_object("java/lang/Long", "(J)V", &[JValueGen::Long(v as i64)])?),
+        None => Ok(JObject::null()),
+    }
+}
+
+fn index_details_to_java<'a>(
+    env: &mut JNIEnv<'a>,
+    details: &MemWalIndexDetails,
+) -> Result<JObject<'a>> {
+    let maintained_indexes = export_vec(env, &details.maintained_indexes)?;
+    let writer_config_defaults = details.writer_config_defaults.clone().into_java(env)?;
+
+    let sharding_specs = env.new_object("java/util/ArrayList", "()V", &[])?;
+    for spec in &details.sharding_specs {
+        let spec_obj = sharding_spec_to_java(env, spec)?;
+        env.call_method(
+            &sharding_specs,
+            "add",
+            "(Ljava/lang/Object;)Z",
+            &[JValueGen::Object(&spec_obj)],
+        )?;
+    }
+
+    Ok(env.new_object(
+        "org/lance/memwal/MemWalIndexDetails",
+        "(JLjava/util/List;Ljava/util/Map;Ljava/util/List;)V",
+        &[
+            JValueGen::Long(details.num_shards as i64),
+            JValueGen::Object(&maintained_indexes),
+            JValueGen::Object(&writer_config_defaults),
+            JValueGen::Object(&sharding_specs),
+        ],
+    )?)
+}
+
+fn sharding_spec_to_java<'a>(env: &mut JNIEnv<'a>, spec: &ShardingSpec) -> Result<JObject<'a>> {
+    let fields = env.new_object("java/util/ArrayList", "()V", &[])?;
+    for field in &spec.fields {
+        let field_obj = sharding_field_to_java(env, field)?;
+        env.call_method(
+            &fields,
+            "add",
+            "(Ljava/lang/Object;)Z",
+            &[JValueGen::Object(&field_obj)],
+        )?;
+    }
+    Ok(env.new_object(
+        "org/lance/memwal/ShardingSpec",
+        "(ILjava/util/List;)V",
+        &[
+            JValueGen::Int(spec.spec_id as i32),
+            JValueGen::Object(&fields),
+        ],
+    )?)
+}
+
+fn sharding_field_to_java<'a>(env: &mut JNIEnv<'a>, field: &ShardingField) -> Result<JObject<'a>> {
+    let field_id: JObject = env.new_string(&field.field_id)?.into();
+    let source_ids = int_list_to_java(env, &field.source_ids)?;
+    let transform: JObject = match &field.transform {
+        Some(t) => env.new_string(t)?.into(),
+        None => JObject::null(),
+    };
+    let result_type: JObject = env.new_string(&field.result_type)?.into();
+    let parameters = field.parameters.clone().into_java(env)?;
+    Ok(env.new_object(
+        "org/lance/memwal/ShardingField",
+        "(Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V",
+        &[
+            JValueGen::Object(&field_id),
+            JValueGen::Object(&source_ids),
+            JValueGen::Object(&transform),
+            JValueGen::Object(&result_type),
+            JValueGen::Object(&parameters),
+        ],
+    )?)
+}
+
+fn int_list_to_java<'a>(env: &mut JNIEnv<'a>, ints: &[i32]) -> Result<JObject<'a>> {
+    let list = env.new_object("java/util/ArrayList", "()V", &[])?;
+    for &value in ints {
+        let integer = env.new_object("java/lang/Integer", "(I)V", &[JValueGen::Int(value)])?;
+        env.call_method(
+            &list,
+            "add",
+            "(Ljava/lang/Object;)Z",
+            &[JValueGen::Object(&integer)],
+        )?;
+    }
+    Ok(list)
+}

--- a/java/lance-jni/src/merge_insert.rs
+++ b/java/lance-jni/src/merge_insert.rs
@@ -3,6 +3,7 @@
 
 use crate::blocking_dataset::{BlockingDataset, NATIVE_DATASET};
 use crate::error::Result;
+use crate::traits::import_vec_to_rust;
 use crate::traits::{FromJString, IntoJava};
 use crate::{Error, JNIEnvExt, RT};
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
@@ -14,8 +15,10 @@ use lance::dataset::{
     MergeInsertBuilder, MergeStats, WhenMatched, WhenNotMatched, WhenNotMatchedBySource,
 };
 use lance_core::datatypes::Schema;
+use lance_index::mem_wal::MergedGeneration;
 use std::sync::Arc;
 use std::time::Duration;
+use uuid::Uuid;
 
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_org_lance_Dataset_nativeMergeInsert<'a>(
@@ -48,6 +51,7 @@ fn inner_merge_insert<'local>(
     let conflict_retries = extract_conflict_retries(env, &jparam)?;
     let retry_timeout_ms = extract_retry_timeout_ms(env, &jparam)?;
     let skip_auto_cleanup = extract_skip_auto_cleanup(env, &jparam)?;
+    let marked_generations = extract_marked_generations(env, &jparam)?;
 
     let (new_ds, merge_stats) = unsafe {
         let dataset = env.get_rust_field::<_, _, BlockingDataset>(jdataset, NATIVE_DATASET)?;
@@ -65,6 +69,7 @@ fn inner_merge_insert<'local>(
             .conflict_retries(conflict_retries)
             .retry_timeout(Duration::from_millis(retry_timeout_ms as u64))
             .skip_auto_cleanup(skip_auto_cleanup)
+            .mark_generations_as_merged(marked_generations)
             .try_build()?;
 
         let stream_ptr = batch_address as *mut FFI_ArrowArrayStream;
@@ -227,6 +232,26 @@ fn extract_skip_auto_cleanup<'local>(env: &mut JNIEnv<'local>, jparam: &JObject)
         .call_method(jparam, "skipAutoCleanup", "()Z", &[])?
         .z()?;
     Ok(skip_auto_cleanup)
+}
+
+fn extract_marked_generations<'local>(
+    env: &mut JNIEnv<'local>,
+    jparam: &JObject,
+) -> Result<Vec<MergedGeneration>> {
+    let list = env
+        .call_method(jparam, "markedGenerations", "()Ljava/util/List;", &[])?
+        .l()?;
+    import_vec_to_rust(env, &list, |env, obj| {
+        let shard_id: JString = env
+            .call_method(&obj, "shardId", "()Ljava/lang/String;", &[])?
+            .l()?
+            .into();
+        let shard_id = shard_id.extract(env)?;
+        let generation = env.call_method(&obj, "generation", "()J", &[])?.j()? as u64;
+        let uuid = Uuid::parse_str(&shard_id)
+            .map_err(|e| Error::input_error(format!("Invalid shard_id UUID: {}", e)))?;
+        Ok(MergedGeneration::new(uuid, generation))
+    })
 }
 
 const MERGE_STATS_CLASS: &str = "org/lance/merge/MergeInsertStats";

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -28,6 +28,10 @@ import org.lance.index.scalar.ZoneStats;
 import org.lance.ipc.DataStatistics;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
+import org.lance.memwal.InitializeMemWalParams;
+import org.lance.memwal.MemWalIndexDetails;
+import org.lance.memwal.ShardWriter;
+import org.lance.memwal.ShardWriterConfig;
 import org.lance.merge.MergeInsertParams;
 import org.lance.merge.MergeInsertResult;
 import org.lance.namespace.LanceNamespace;
@@ -2022,6 +2026,60 @@ public class Dataset implements Closeable {
 
   private native MergeInsertResult nativeMergeInsert(
       MergeInsertParams mergeInsert, long arrowStreamMemoryAddress);
+
+  /**
+   * Initialize MemWAL on this dataset.
+   *
+   * <p>Must be called once before any call to {@link #memWalWriter}. The dataset schema must have
+   * at least one field carrying the {@code lance-schema:unenforced-primary-key} metadata.
+   *
+   * @param params MemWAL initialization parameters
+   */
+  public void initializeMemWal(InitializeMemWalParams params) {
+    Preconditions.checkNotNull(params, "params must not be null");
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      nativeInitializeMemWal(params);
+    }
+  }
+
+  private native void nativeInitializeMemWal(InitializeMemWalParams params);
+
+  /**
+   * Return the MemWAL index details for this dataset, or {@link Optional#empty()} if MemWAL has not
+   * been initialized.
+   *
+   * @return the MemWAL index details, if any
+   */
+  public Optional<MemWalIndexDetails> memWalIndexDetails() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      return Optional.ofNullable(nativeMemWalIndexDetails());
+    }
+  }
+
+  private native MemWalIndexDetails nativeMemWalIndexDetails();
+
+  /**
+   * Get a {@link ShardWriter} for the specified shard.
+   *
+   * <p>{@link #initializeMemWal} must be called before using this method.
+   *
+   * @param shardId UUID string identifying the write shard
+   * @param config writer configuration; pass {@code null} to use the Lance default configuration
+   * @return a ShardWriter for the shard
+   */
+  public ShardWriter memWalWriter(String shardId, ShardWriterConfig config) {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      return ShardWriter.create(this, shardId, config);
+    }
+  }
+
+  /** Get a {@link ShardWriter} for the specified shard using the Lance default configuration. */
+  public ShardWriter memWalWriter(String shardId) {
+    return memWalWriter(shardId, null);
+  }
 
   private native void nativeCreateTag(String tag, Ref ref);
 

--- a/java/src/main/java/org/lance/memwal/ExecutionPlan.java
+++ b/java/src/main/java/org/lance/memwal/ExecutionPlan.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import org.lance.JniLoader;
+import org.lance.LockManager;
+
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+/**
+ * An executable physical plan produced by a MemWAL planner.
+ *
+ * <p>Planner classes only build plans; execution happens through this class. Obtain instances from
+ * {@link LsmPointLookupPlanner#planLookup} or {@link LsmVectorSearchPlanner#planSearch}.
+ */
+public class ExecutionPlan implements AutoCloseable {
+  static {
+    JniLoader.ensureLoaded();
+  }
+
+  private long nativeExecutionPlanHandle;
+  BufferAllocator allocator;
+  private final LockManager lockManager = new LockManager();
+
+  private ExecutionPlan() {}
+
+  /** Output schema of this physical plan. */
+  public Schema schema() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeExecutionPlanHandle != 0, "ExecutionPlan is closed");
+      try (ArrowSchema ffiSchema = ArrowSchema.allocateNew(allocator)) {
+        nativeImportSchema(ffiSchema.memoryAddress());
+        return Data.importSchema(allocator, ffiSchema, null);
+      }
+    }
+  }
+
+  private native void nativeImportSchema(long schemaAddress);
+
+  /** Schema of the base dataset this plan was constructed from. */
+  public Schema datasetSchema() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeExecutionPlanHandle != 0, "ExecutionPlan is closed");
+      try (ArrowSchema ffiSchema = ArrowSchema.allocateNew(allocator)) {
+        nativeImportDatasetSchema(ffiSchema.memoryAddress());
+        return Data.importSchema(allocator, ffiSchema, null);
+      }
+    }
+  }
+
+  private native void nativeImportDatasetSchema(long schemaAddress);
+
+  /** Return the physical plan rendered as an indented string. */
+  public String explain() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeExecutionPlanHandle != 0, "ExecutionPlan is closed");
+      return nativeExplain();
+    }
+  }
+
+  private native String nativeExplain();
+
+  /** Execute the plan and return a streaming reader over the results. */
+  public ArrowReader toReader() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeExecutionPlanHandle != 0, "ExecutionPlan is closed");
+      try (ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator)) {
+        nativeOpenStream(stream.memoryAddress());
+        return Data.importArrayStream(allocator, stream);
+      }
+    }
+  }
+
+  private native void nativeOpenStream(long streamAddress);
+
+  /**
+   * Close the plan and release native resources. If the plan is already closed, invoking this
+   * method has no effect.
+   */
+  @Override
+  public void close() {
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      if (nativeExecutionPlanHandle != 0) {
+        releaseNativeExecutionPlan(nativeExecutionPlanHandle);
+        nativeExecutionPlanHandle = 0;
+      }
+    }
+  }
+
+  private native void releaseNativeExecutionPlan(long handle);
+}

--- a/java/src/main/java/org/lance/memwal/FlushedGeneration.java
+++ b/java/src/main/java/org/lance/memwal/FlushedGeneration.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import com.google.common.base.MoreObjects;
+
+/** A flushed MemWAL generation and the storage path of its Lance files. */
+public class FlushedGeneration {
+  private final long generation;
+  private final String path;
+
+  public FlushedGeneration(long generation, String path) {
+    this.generation = generation;
+    this.path = path;
+  }
+
+  /** The generation number of this flushed MemTable. */
+  public long generation() {
+    return generation;
+  }
+
+  /** The storage path of the flushed Lance files. */
+  public String path() {
+    return path;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("generation", generation)
+        .add("path", path)
+        .toString();
+  }
+}

--- a/java/src/main/java/org/lance/memwal/InitializeMemWalParams.java
+++ b/java/src/main/java/org/lance/memwal/InitializeMemWalParams.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Parameters for {@link org.lance.Dataset#initializeMemWal}.
+ *
+ * <p>At most one sharding mode may be selected: bucket sharding ({@link #withBucketSharding}),
+ * identity sharding ({@link #withIdentitySharding}), or {@link #withUnsharded()}. With none
+ * selected, shards are managed manually by passing shard IDs to {@link
+ * org.lance.Dataset#memWalWriter}.
+ */
+public class InitializeMemWalParams {
+  private List<String> maintainedIndexes = Collections.emptyList();
+  private Optional<String> bucketColumn = Optional.empty();
+  private Optional<Integer> numBuckets = Optional.empty();
+  private Optional<String> identityColumn = Optional.empty();
+  private boolean unsharded = false;
+  private Optional<ShardWriterConfig> writerConfig = Optional.empty();
+
+  /** Names of the indexes to maintain through the MemWAL. Must already exist on the dataset. */
+  public InitializeMemWalParams withMaintainedIndexes(List<String> maintainedIndexes) {
+    Preconditions.checkNotNull(maintainedIndexes, "maintainedIndexes must not be null");
+    this.maintainedIndexes = maintainedIndexes;
+    return this;
+  }
+
+  /** Use bucket sharding, deriving shard IDs by hashing {@code column} into {@code numBuckets}. */
+  public InitializeMemWalParams withBucketSharding(String column, int numBuckets) {
+    Preconditions.checkNotNull(column, "column must not be null");
+    this.bucketColumn = Optional.of(column);
+    this.numBuckets = Optional.of(numBuckets);
+    return this;
+  }
+
+  /** Use identity sharding, deriving shard IDs directly from {@code column}. */
+  public InitializeMemWalParams withIdentitySharding(String column) {
+    Preconditions.checkNotNull(column, "column must not be null");
+    this.identityColumn = Optional.of(column);
+    return this;
+  }
+
+  /** Use a single unsharded shard for all writes. */
+  public InitializeMemWalParams withUnsharded() {
+    this.unsharded = true;
+    return this;
+  }
+
+  /** Default {@link ShardWriterConfig} recorded in the MemWAL index for all writers. */
+  public InitializeMemWalParams withWriterConfig(ShardWriterConfig writerConfig) {
+    Preconditions.checkNotNull(writerConfig, "writerConfig must not be null");
+    this.writerConfig = Optional.of(writerConfig);
+    return this;
+  }
+
+  public List<String> maintainedIndexes() {
+    return maintainedIndexes;
+  }
+
+  public Optional<String> bucketColumn() {
+    return bucketColumn;
+  }
+
+  public Optional<Integer> numBuckets() {
+    return numBuckets;
+  }
+
+  public Optional<String> identityColumn() {
+    return identityColumn;
+  }
+
+  public boolean unsharded() {
+    return unsharded;
+  }
+
+  public Optional<ShardWriterConfig> writerConfig() {
+    return writerConfig;
+  }
+}

--- a/java/src/main/java/org/lance/memwal/InitializeMemWalParams.java
+++ b/java/src/main/java/org/lance/memwal/InitializeMemWalParams.java
@@ -33,7 +33,7 @@ public class InitializeMemWalParams {
   private Optional<Integer> numBuckets = Optional.empty();
   private Optional<String> identityColumn = Optional.empty();
   private boolean unsharded = false;
-  private Optional<ShardWriterConfig> writerConfig = Optional.empty();
+  private Optional<ShardWriterConfig> writerConfigDefaults = Optional.empty();
 
   /** Names of the indexes to maintain through the MemWAL. Must already exist on the dataset. */
   public InitializeMemWalParams withMaintainedIndexes(List<String> maintainedIndexes) {
@@ -64,9 +64,9 @@ public class InitializeMemWalParams {
   }
 
   /** Default {@link ShardWriterConfig} recorded in the MemWAL index for all writers. */
-  public InitializeMemWalParams withWriterConfig(ShardWriterConfig writerConfig) {
-    Preconditions.checkNotNull(writerConfig, "writerConfig must not be null");
-    this.writerConfig = Optional.of(writerConfig);
+  public InitializeMemWalParams withWriterConfigDefaults(ShardWriterConfig writerConfigDefaults) {
+    Preconditions.checkNotNull(writerConfigDefaults, "writerConfigDefaults must not be null");
+    this.writerConfigDefaults = Optional.of(writerConfigDefaults);
     return this;
   }
 
@@ -90,7 +90,7 @@ public class InitializeMemWalParams {
     return unsharded;
   }
 
-  public Optional<ShardWriterConfig> writerConfig() {
-    return writerConfig;
+  public Optional<ShardWriterConfig> writerConfigDefaults() {
+    return writerConfigDefaults;
   }
 }

--- a/java/src/main/java/org/lance/memwal/LsmPointLookupPlanner.java
+++ b/java/src/main/java/org/lance/memwal/LsmPointLookupPlanner.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import org.lance.Dataset;
+import org.lance.JniLoader;
+import org.lance.LockManager;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.FieldVector;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Plans primary-key point lookups across all MemWAL LSM levels.
+ *
+ * <p>More efficient than {@link LsmScanner} for known-primary-key lookups thanks to bloom filter
+ * optimizations and short-circuit evaluation.
+ */
+public class LsmPointLookupPlanner implements AutoCloseable {
+  static {
+    JniLoader.ensureLoaded();
+  }
+
+  private long nativeLookupPlannerHandle;
+  private final BufferAllocator allocator;
+  private final LockManager lockManager = new LockManager();
+
+  /**
+   * @param dataset the base dataset
+   * @param shardSnapshots shard snapshots specifying the flushed generations to include
+   */
+  public LsmPointLookupPlanner(Dataset dataset, List<ShardSnapshot> shardSnapshots) {
+    this(dataset, shardSnapshots, null);
+  }
+
+  /**
+   * @param dataset the base dataset
+   * @param shardSnapshots shard snapshots specifying the flushed generations to include
+   * @param pkColumns primary key column names; inferred from schema metadata when {@code null}
+   */
+  public LsmPointLookupPlanner(
+      Dataset dataset, List<ShardSnapshot> shardSnapshots, List<String> pkColumns) {
+    Preconditions.checkNotNull(dataset, "dataset must not be null");
+    Preconditions.checkNotNull(shardSnapshots, "shardSnapshots must not be null");
+    this.allocator = dataset.allocator();
+    nativeCreate(dataset, shardSnapshots, Optional.ofNullable(pkColumns));
+  }
+
+  private native void nativeCreate(
+      Dataset dataset, List<ShardSnapshot> shardSnapshots, Optional<List<String>> pkColumns);
+
+  /**
+   * Plan a point lookup by primary key value.
+   *
+   * @param pkValue for a single-column primary key, a vector with exactly one element; for a
+   *     composite primary key, a {@code StructVector} with one row and one child per key column
+   * @param columns columns to project; pass {@code null} to return all columns
+   * @return an executable plan
+   */
+  public ExecutionPlan planLookup(FieldVector pkValue, List<String> columns) {
+    Preconditions.checkNotNull(pkValue, "pkValue must not be null");
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(
+          nativeLookupPlannerHandle != 0, "LsmPointLookupPlanner is closed");
+      try (ArrowArray array = ArrowArray.allocateNew(allocator);
+          ArrowSchema schema = ArrowSchema.allocateNew(allocator)) {
+        Data.exportVector(allocator, pkValue, null, array, schema);
+        ExecutionPlan plan =
+            nativePlanLookup(
+                array.memoryAddress(), schema.memoryAddress(), Optional.ofNullable(columns));
+        plan.allocator = allocator;
+        return plan;
+      }
+    }
+  }
+
+  /** Plan a point lookup by primary key value, returning all columns. */
+  public ExecutionPlan planLookup(FieldVector pkValue) {
+    return planLookup(pkValue, null);
+  }
+
+  private native ExecutionPlan nativePlanLookup(
+      long arrayAddress, long schemaAddress, Optional<List<String>> columns);
+
+  /**
+   * Close the planner and release native resources. If the planner is already closed, invoking this
+   * method has no effect.
+   */
+  @Override
+  public void close() {
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      if (nativeLookupPlannerHandle != 0) {
+        releaseNativeLookupPlanner(nativeLookupPlannerHandle);
+        nativeLookupPlannerHandle = 0;
+      }
+    }
+  }
+
+  private native void releaseNativeLookupPlanner(long handle);
+}

--- a/java/src/main/java/org/lance/memwal/LsmScanner.java
+++ b/java/src/main/java/org/lance/memwal/LsmScanner.java
@@ -80,7 +80,15 @@ public class LsmScanner implements Closeable {
 
   private native void nativeProject(List<String> columns);
 
-  /** Set a SQL filter expression, for example {@code "value > 0.5"}. */
+  /**
+   * Set a SQL filter expression, for example {@code "value > 0.5"}.
+   *
+   * <p>If {@code expr} fails to parse, an {@link IllegalArgumentException} is thrown and this
+   * scanner becomes unusable — build a new scanner rather than retrying on this instance.
+   *
+   * @param expr a SQL filter expression
+   * @return this scanner
+   */
   public LsmScanner filter(String expr) {
     Preconditions.checkNotNull(expr, "expr must not be null");
     try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {

--- a/java/src/main/java/org/lance/memwal/LsmScanner.java
+++ b/java/src/main/java/org/lance/memwal/LsmScanner.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import org.lance.Dataset;
+import org.lance.JniLoader;
+import org.lance.LockManager;
+
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.ipc.ArrowReader;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * LSM-aware scanner covering all MemWAL data levels.
+ *
+ * <p>Results are deduplicated by primary key, always returning the newest version of each row
+ * across the base table, flushed MemTables, and (when created from a {@link ShardWriter}) the
+ * active MemTable.
+ *
+ * <p>The builder methods ({@link #project}, {@link #filter}, {@link #limit}, {@link
+ * #withRowAddress}, {@link #withMemtableGen}) mutate this scanner and return it for chaining.
+ */
+public class LsmScanner implements Closeable {
+  static {
+    JniLoader.ensureLoaded();
+  }
+
+  private long nativeLsmScannerHandle;
+  BufferAllocator allocator;
+  private final LockManager lockManager = new LockManager();
+
+  private LsmScanner() {}
+
+  /**
+   * Create a scanner from a dataset and shard snapshots.
+   *
+   * <p>The scanner does not include any active MemTable; use {@link ShardWriter#lsmScanner} for
+   * read-your-writes consistency.
+   *
+   * @param dataset the base dataset to scan
+   * @param shardSnapshots shard snapshots specifying the flushed generations to include
+   * @return an LSM scanner
+   */
+  public static LsmScanner fromSnapshots(Dataset dataset, List<ShardSnapshot> shardSnapshots) {
+    Preconditions.checkNotNull(dataset, "dataset must not be null");
+    Preconditions.checkNotNull(shardSnapshots, "shardSnapshots must not be null");
+    LsmScanner scanner = createFromSnapshots(dataset, shardSnapshots);
+    scanner.allocator = dataset.allocator();
+    return scanner;
+  }
+
+  static native LsmScanner createFromSnapshots(Dataset dataset, List<ShardSnapshot> shardSnapshots);
+
+  /** Select specific columns to return. */
+  public LsmScanner project(List<String> columns) {
+    Preconditions.checkNotNull(columns, "columns must not be null");
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      Preconditions.checkArgument(nativeLsmScannerHandle != 0, "LsmScanner is closed");
+      nativeProject(columns);
+      return this;
+    }
+  }
+
+  private native void nativeProject(List<String> columns);
+
+  /** Set a SQL filter expression, for example {@code "value > 0.5"}. */
+  public LsmScanner filter(String expr) {
+    Preconditions.checkNotNull(expr, "expr must not be null");
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      Preconditions.checkArgument(nativeLsmScannerHandle != 0, "LsmScanner is closed");
+      nativeFilter(expr);
+      return this;
+    }
+  }
+
+  private native void nativeFilter(String expr);
+
+  /** Limit the number of rows returned, optionally skipping {@code offset} rows first. */
+  public LsmScanner limit(long limit, Optional<Long> offset) {
+    Preconditions.checkNotNull(offset, "offset must not be null");
+    Preconditions.checkArgument(limit >= 0, "limit must not be negative, got %s", limit);
+    offset.ifPresent(
+        o -> Preconditions.checkArgument(o >= 0, "offset must not be negative, got %s", o));
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      Preconditions.checkArgument(nativeLsmScannerHandle != 0, "LsmScanner is closed");
+      nativeLimit(limit, offset);
+      return this;
+    }
+  }
+
+  /** Limit the number of rows returned. */
+  public LsmScanner limit(long limit) {
+    return limit(limit, Optional.empty());
+  }
+
+  private native void nativeLimit(long limit, Optional<Long> offset);
+
+  /** Include the {@code _rowaddr} internal column in results. */
+  public LsmScanner withRowAddress() {
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      Preconditions.checkArgument(nativeLsmScannerHandle != 0, "LsmScanner is closed");
+      nativeWithRowAddress();
+      return this;
+    }
+  }
+
+  private native void nativeWithRowAddress();
+
+  /** Include the {@code _memtable_gen} internal column in results. */
+  public LsmScanner withMemtableGen() {
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      Preconditions.checkArgument(nativeLsmScannerHandle != 0, "LsmScanner is closed");
+      nativeWithMemtableGen();
+      return this;
+    }
+  }
+
+  private native void nativeWithMemtableGen();
+
+  /** Execute the scan and return a streaming reader over the merged results. */
+  public ArrowReader scanBatches() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeLsmScannerHandle != 0, "LsmScanner is closed");
+      try (ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator)) {
+        nativeOpenStream(stream.memoryAddress());
+        return Data.importArrayStream(allocator, stream);
+      }
+    }
+  }
+
+  private native void nativeOpenStream(long streamAddress);
+
+  /** Return the row count without materializing all column data. */
+  public long countRows() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeLsmScannerHandle != 0, "LsmScanner is closed");
+      return nativeCountRows();
+    }
+  }
+
+  private native long nativeCountRows();
+
+  /**
+   * Close the scanner and release native resources. If the scanner is already closed, invoking this
+   * method has no effect.
+   */
+  @Override
+  public void close() {
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      if (nativeLsmScannerHandle != 0) {
+        releaseNativeLsmScanner(nativeLsmScannerHandle);
+        nativeLsmScannerHandle = 0;
+      }
+    }
+  }
+
+  private native void releaseNativeLsmScanner(long handle);
+}

--- a/java/src/main/java/org/lance/memwal/LsmVectorSearchPlanner.java
+++ b/java/src/main/java/org/lance/memwal/LsmVectorSearchPlanner.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import org.lance.Dataset;
+import org.lance.JniLoader;
+import org.lance.LockManager;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.Float4Vector;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Plans IVF-PQ vector KNN search across all MemWAL LSM levels.
+ *
+ * <p>Results include staleness filtering so only the latest version of each row is returned. The
+ * output schema includes a {@code _distance} column.
+ */
+public class LsmVectorSearchPlanner implements AutoCloseable {
+  static {
+    JniLoader.ensureLoaded();
+  }
+
+  private long nativeVectorPlannerHandle;
+  private final BufferAllocator allocator;
+  private final LockManager lockManager = new LockManager();
+
+  /**
+   * @param dataset the base dataset
+   * @param shardSnapshots shard snapshots specifying the flushed generations to include
+   * @param vectorColumn name of the {@code FixedSizeList<float32>} vector column
+   */
+  public LsmVectorSearchPlanner(
+      Dataset dataset, List<ShardSnapshot> shardSnapshots, String vectorColumn) {
+    this(dataset, shardSnapshots, vectorColumn, null, null);
+  }
+
+  /**
+   * @param dataset the base dataset
+   * @param shardSnapshots shard snapshots specifying the flushed generations to include
+   * @param vectorColumn name of the {@code FixedSizeList<float32>} vector column
+   * @param pkColumns primary key column names; inferred from schema metadata when {@code null}
+   * @param distanceType distance metric, one of {@code "l2"}, {@code "cosine"}, {@code "dot"},
+   *     {@code "hamming"}; defaults to {@code "l2"} when {@code null}
+   */
+  public LsmVectorSearchPlanner(
+      Dataset dataset,
+      List<ShardSnapshot> shardSnapshots,
+      String vectorColumn,
+      List<String> pkColumns,
+      String distanceType) {
+    Preconditions.checkNotNull(dataset, "dataset must not be null");
+    Preconditions.checkNotNull(shardSnapshots, "shardSnapshots must not be null");
+    Preconditions.checkNotNull(vectorColumn, "vectorColumn must not be null");
+    this.allocator = dataset.allocator();
+    nativeCreate(
+        dataset,
+        shardSnapshots,
+        vectorColumn,
+        Optional.ofNullable(pkColumns),
+        Optional.ofNullable(distanceType));
+  }
+
+  private native void nativeCreate(
+      Dataset dataset,
+      List<ShardSnapshot> shardSnapshots,
+      String vectorColumn,
+      Optional<List<String>> pkColumns,
+      Optional<String> distanceType);
+
+  /**
+   * Plan a KNN vector search.
+   *
+   * @param query a flat float32 vector of length {@code vectorDim}
+   * @param k number of nearest neighbours to return
+   * @param nprobes number of IVF partitions to probe
+   * @param columns columns to project; pass {@code null} to return all columns plus {@code
+   *     _distance}
+   * @return an executable plan
+   */
+  public ExecutionPlan planSearch(Float4Vector query, int k, int nprobes, List<String> columns) {
+    Preconditions.checkNotNull(query, "query must not be null");
+    Preconditions.checkArgument(k > 0, "k must be positive, got %s", k);
+    Preconditions.checkArgument(nprobes > 0, "nprobes must be positive, got %s", nprobes);
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(
+          nativeVectorPlannerHandle != 0, "LsmVectorSearchPlanner is closed");
+      try (ArrowArray array = ArrowArray.allocateNew(allocator);
+          ArrowSchema schema = ArrowSchema.allocateNew(allocator)) {
+        Data.exportVector(allocator, query, null, array, schema);
+        ExecutionPlan plan =
+            nativePlanSearch(
+                array.memoryAddress(),
+                schema.memoryAddress(),
+                k,
+                nprobes,
+                Optional.ofNullable(columns));
+        plan.allocator = allocator;
+        return plan;
+      }
+    }
+  }
+
+  /** Plan a KNN vector search with default {@code nprobes} of 20. */
+  public ExecutionPlan planSearch(Float4Vector query, int k) {
+    return planSearch(query, k, 20, null);
+  }
+
+  private native ExecutionPlan nativePlanSearch(
+      long arrayAddress, long schemaAddress, int k, int nprobes, Optional<List<String>> columns);
+
+  /**
+   * Close the planner and release native resources. If the planner is already closed, invoking this
+   * method has no effect.
+   */
+  @Override
+  public void close() {
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      if (nativeVectorPlannerHandle != 0) {
+        releaseNativeVectorPlanner(nativeVectorPlannerHandle);
+        nativeVectorPlannerHandle = 0;
+      }
+    }
+  }
+
+  private native void releaseNativeVectorPlanner(long handle);
+}

--- a/java/src/main/java/org/lance/memwal/MemTableStats.java
+++ b/java/src/main/java/org/lance/memwal/MemTableStats.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Optional;
+
+/** Statistics of the active MemTable held by a {@link ShardWriter}. */
+public class MemTableStats {
+  private final long rowCount;
+  private final long batchCount;
+  private final long estimatedSizeBytes;
+  private final long generation;
+  private final Optional<Long> maxBufferedBatchPosition;
+  private final Optional<Long> maxFlushedBatchPosition;
+  private final Optional<Long> pendingWalStartBatchPosition;
+  private final Optional<Long> pendingWalEndBatchPosition;
+  private final long pendingWalBatchCount;
+  private final long pendingWalRowCount;
+  private final long pendingWalEstimatedBytes;
+
+  public MemTableStats(
+      long rowCount,
+      long batchCount,
+      long estimatedSizeBytes,
+      long generation,
+      Long maxBufferedBatchPosition,
+      Long maxFlushedBatchPosition,
+      Long pendingWalStartBatchPosition,
+      Long pendingWalEndBatchPosition,
+      long pendingWalBatchCount,
+      long pendingWalRowCount,
+      long pendingWalEstimatedBytes) {
+    this.rowCount = rowCount;
+    this.batchCount = batchCount;
+    this.estimatedSizeBytes = estimatedSizeBytes;
+    this.generation = generation;
+    this.maxBufferedBatchPosition = Optional.ofNullable(maxBufferedBatchPosition);
+    this.maxFlushedBatchPosition = Optional.ofNullable(maxFlushedBatchPosition);
+    this.pendingWalStartBatchPosition = Optional.ofNullable(pendingWalStartBatchPosition);
+    this.pendingWalEndBatchPosition = Optional.ofNullable(pendingWalEndBatchPosition);
+    this.pendingWalBatchCount = pendingWalBatchCount;
+    this.pendingWalRowCount = pendingWalRowCount;
+    this.pendingWalEstimatedBytes = pendingWalEstimatedBytes;
+  }
+
+  /** Number of rows currently buffered in the active MemTable. */
+  public long rowCount() {
+    return rowCount;
+  }
+
+  /** Number of record batches currently buffered in the active MemTable. */
+  public long batchCount() {
+    return batchCount;
+  }
+
+  /** Estimated in-memory size of the active MemTable, in bytes. */
+  public long estimatedSizeBytes() {
+    return estimatedSizeBytes;
+  }
+
+  /** Generation number of the active MemTable. */
+  public long generation() {
+    return generation;
+  }
+
+  /** Highest WAL batch position buffered into the MemTable, if any. */
+  public Optional<Long> maxBufferedBatchPosition() {
+    return maxBufferedBatchPosition;
+  }
+
+  /** Highest WAL batch position flushed from the MemTable, if any. */
+  public Optional<Long> maxFlushedBatchPosition() {
+    return maxFlushedBatchPosition;
+  }
+
+  /** First WAL batch position pending flush, if any. */
+  public Optional<Long> pendingWalStartBatchPosition() {
+    return pendingWalStartBatchPosition;
+  }
+
+  /** Last WAL batch position pending flush, if any. */
+  public Optional<Long> pendingWalEndBatchPosition() {
+    return pendingWalEndBatchPosition;
+  }
+
+  /** Number of WAL batches pending flush. */
+  public long pendingWalBatchCount() {
+    return pendingWalBatchCount;
+  }
+
+  /** Number of rows in WAL batches pending flush. */
+  public long pendingWalRowCount() {
+    return pendingWalRowCount;
+  }
+
+  /** Estimated bytes of WAL batches pending flush. */
+  public long pendingWalEstimatedBytes() {
+    return pendingWalEstimatedBytes;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("rowCount", rowCount)
+        .add("batchCount", batchCount)
+        .add("estimatedSizeBytes", estimatedSizeBytes)
+        .add("generation", generation)
+        .add("maxBufferedBatchPosition", maxBufferedBatchPosition.orElse(null))
+        .add("maxFlushedBatchPosition", maxFlushedBatchPosition.orElse(null))
+        .add("pendingWalStartBatchPosition", pendingWalStartBatchPosition.orElse(null))
+        .add("pendingWalEndBatchPosition", pendingWalEndBatchPosition.orElse(null))
+        .add("pendingWalBatchCount", pendingWalBatchCount)
+        .add("pendingWalRowCount", pendingWalRowCount)
+        .add("pendingWalEstimatedBytes", pendingWalEstimatedBytes)
+        .toString();
+  }
+}

--- a/java/src/main/java/org/lance/memwal/MemWalIndexDetails.java
+++ b/java/src/main/java/org/lance/memwal/MemWalIndexDetails.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** Details of the MemWAL index attached to a dataset. */
+public class MemWalIndexDetails {
+  private final long numShards;
+  private final List<String> maintainedIndexes;
+  private final Map<String, String> writerConfigDefaults;
+  private final List<ShardingSpec> shardingSpecs;
+
+  public MemWalIndexDetails(
+      long numShards,
+      List<String> maintainedIndexes,
+      Map<String, String> writerConfigDefaults,
+      List<ShardingSpec> shardingSpecs) {
+    this.numShards = numShards;
+    this.maintainedIndexes =
+        maintainedIndexes == null ? Collections.emptyList() : maintainedIndexes;
+    this.writerConfigDefaults =
+        writerConfigDefaults == null ? Collections.emptyMap() : writerConfigDefaults;
+    this.shardingSpecs = shardingSpecs == null ? Collections.emptyList() : shardingSpecs;
+  }
+
+  /** Number of shards tracked by the MemWAL index. */
+  public long numShards() {
+    return numShards;
+  }
+
+  /** Names of the indexes maintained through the MemWAL. */
+  public List<String> maintainedIndexes() {
+    return maintainedIndexes;
+  }
+
+  /** Default {@link ShardWriterConfig} values persisted in the MemWAL index. */
+  public Map<String, String> writerConfigDefaults() {
+    return writerConfigDefaults;
+  }
+
+  /** The sharding specifications recorded in the MemWAL index. */
+  public List<ShardingSpec> shardingSpecs() {
+    return shardingSpecs;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("numShards", numShards)
+        .add("maintainedIndexes", maintainedIndexes)
+        .add("writerConfigDefaults", writerConfigDefaults)
+        .add("shardingSpecs", shardingSpecs)
+        .toString();
+  }
+}

--- a/java/src/main/java/org/lance/memwal/MergedGeneration.java
+++ b/java/src/main/java/org/lance/memwal/MergedGeneration.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+
+/**
+ * Identifies a flushed MemWAL generation that has been merged into the base table.
+ *
+ * <p>Pass a list of these to {@link org.lance.merge.MergeInsertParams#markGenerationsAsMerged} so
+ * Lance knows which generations are now part of the base table.
+ */
+public class MergedGeneration {
+  private final String shardId;
+  private final long generation;
+
+  /**
+   * @param shardId UUID string for the write shard
+   * @param generation generation number from {@link ShardSnapshot#flushedGenerations()}
+   */
+  public MergedGeneration(String shardId, long generation) {
+    Preconditions.checkNotNull(shardId, "shardId must not be null");
+    this.shardId = shardId;
+    this.generation = generation;
+  }
+
+  /** UUID string for the write shard. */
+  public String shardId() {
+    return shardId;
+  }
+
+  /** The merged generation number. */
+  public long generation() {
+    return generation;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("shardId", shardId)
+        .add("generation", generation)
+        .toString();
+  }
+}

--- a/java/src/main/java/org/lance/memwal/ShardSnapshot.java
+++ b/java/src/main/java/org/lance/memwal/ShardSnapshot.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Snapshot of a MemWAL shard's state, used when constructing scanners and planners.
+ *
+ * <p>The builder methods ({@link #withSpecId}, {@link #withCurrentGeneration}, {@link
+ * #withFlushedGeneration}) mutate this instance and return it for chaining.
+ */
+public class ShardSnapshot {
+  private final String shardId;
+  private int specId = 0;
+  private long currentGeneration = 0;
+  private final List<FlushedGeneration> flushedGenerations = new ArrayList<>();
+
+  /**
+   * @param shardId UUID string for the write shard
+   */
+  public ShardSnapshot(String shardId) {
+    Preconditions.checkNotNull(shardId, "shardId must not be null");
+    this.shardId = shardId;
+  }
+
+  /** Set the {@link ShardingSpec} ID for this snapshot. */
+  public ShardSnapshot withSpecId(int specId) {
+    this.specId = specId;
+    return this;
+  }
+
+  /** Set the current (active) generation number. */
+  public ShardSnapshot withCurrentGeneration(long currentGeneration) {
+    this.currentGeneration = currentGeneration;
+    return this;
+  }
+
+  /** Add a flushed generation with its storage path. */
+  public ShardSnapshot withFlushedGeneration(long generation, String path) {
+    Preconditions.checkNotNull(path, "path must not be null");
+    this.flushedGenerations.add(new FlushedGeneration(generation, path));
+    return this;
+  }
+
+  /** UUID string for this shard. */
+  public String shardId() {
+    return shardId;
+  }
+
+  /** The {@link ShardingSpec} ID for this snapshot. */
+  public int specId() {
+    return specId;
+  }
+
+  /** The current (active) generation number. */
+  public long currentGeneration() {
+    return currentGeneration;
+  }
+
+  /** The flushed generations included in this snapshot. */
+  public List<FlushedGeneration> flushedGenerations() {
+    return Collections.unmodifiableList(flushedGenerations);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("shardId", shardId)
+        .add("specId", specId)
+        .add("currentGeneration", currentGeneration)
+        .add("flushedGenerations", flushedGenerations)
+        .toString();
+  }
+}

--- a/java/src/main/java/org/lance/memwal/ShardWriter.java
+++ b/java/src/main/java/org/lance/memwal/ShardWriter.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import org.lance.Dataset;
+import org.lance.JniLoader;
+import org.lance.LockManager;
+
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.ipc.ArrowReader;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Stateful writer for one MemWAL shard.
+ *
+ * <p>Obtain an instance via {@link Dataset#memWalWriter}. The writer must be closed when no longer
+ * needed; using it inside a try-with-resources block is recommended:
+ *
+ * <pre>{@code
+ * try (ShardWriter writer = dataset.memWalWriter(shardId)) {
+ *   writer.put(reader);
+ * }
+ * }</pre>
+ *
+ * <p>{@link #close()} flushes pending data and releases native resources. Statistics must be read
+ * before the writer is closed.
+ */
+public class ShardWriter implements Closeable {
+  static {
+    JniLoader.ensureLoaded();
+  }
+
+  private long nativeShardWriterHandle;
+  private BufferAllocator allocator;
+  private final LockManager lockManager = new LockManager();
+
+  private ShardWriter() {}
+
+  /**
+   * Create a writer for {@code shardId} on the given dataset.
+   *
+   * @param dataset the dataset MemWAL has been initialized on
+   * @param shardId UUID string identifying the write shard
+   * @param config writer configuration; pass {@code null} to use the Lance default configuration
+   * @return a new ShardWriter
+   */
+  public static ShardWriter create(Dataset dataset, String shardId, ShardWriterConfig config) {
+    Preconditions.checkNotNull(dataset, "dataset must not be null");
+    Preconditions.checkNotNull(shardId, "shardId must not be null");
+    ShardWriter writer = createNative(dataset, shardId, config);
+    writer.allocator = dataset.allocator();
+    return writer;
+  }
+
+  static native ShardWriter createNative(Dataset dataset, String shardId, ShardWriterConfig config);
+
+  /** UUID string for this writer's shard. */
+  public String shardId() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeShardWriterHandle != 0, "ShardWriter is closed");
+      return nativeShardId();
+    }
+  }
+
+  private native String nativeShardId();
+
+  /**
+   * Write data to the MemWAL.
+   *
+   * @param reader the source data; consumed fully by this call
+   */
+  public void put(ArrowReader reader) {
+    Preconditions.checkNotNull(reader, "reader must not be null");
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeShardWriterHandle != 0, "ShardWriter is closed");
+      try (ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator)) {
+        Data.exportArrayStream(allocator, reader, stream);
+        nativePut(stream.memoryAddress());
+      }
+    }
+  }
+
+  private native void nativePut(long streamAddress);
+
+  /** Return a snapshot of cumulative write statistics. */
+  public WriteStats stats() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeShardWriterHandle != 0, "ShardWriter is closed");
+      return nativeStats();
+    }
+  }
+
+  private native WriteStats nativeStats();
+
+  /** Return current statistics of the active MemTable. */
+  public MemTableStats memtableStats() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeShardWriterHandle != 0, "ShardWriter is closed");
+      return nativeMemtableStats();
+    }
+  }
+
+  private native MemTableStats nativeMemtableStats();
+
+  /**
+   * Create an LSM scanner that includes this writer's active MemTable.
+   *
+   * <p>The scanner covers the base table, the given flushed generations, and the current active
+   * MemTable, providing read-your-writes consistency. This writer's own shard is included
+   * automatically.
+   *
+   * @param shardSnapshots snapshots of other shards to include
+   * @return an LSM scanner
+   */
+  public LsmScanner lsmScanner(List<ShardSnapshot> shardSnapshots) {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeShardWriterHandle != 0, "ShardWriter is closed");
+      LsmScanner scanner =
+          nativeLsmScanner(shardSnapshots == null ? Collections.emptyList() : shardSnapshots);
+      scanner.allocator = allocator;
+      return scanner;
+    }
+  }
+
+  /** Create an LSM scanner that includes this writer's active MemTable. */
+  public LsmScanner lsmScanner() {
+    return lsmScanner(Collections.emptyList());
+  }
+
+  private native LsmScanner nativeLsmScanner(List<ShardSnapshot> shardSnapshots);
+
+  /**
+   * Flush pending data and close the writer, releasing native resources. If the writer is already
+   * closed, invoking this method has no effect.
+   */
+  @Override
+  public void close() {
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      if (nativeShardWriterHandle != 0) {
+        releaseNativeShardWriter(nativeShardWriterHandle);
+        nativeShardWriterHandle = 0;
+      }
+    }
+  }
+
+  private native void releaseNativeShardWriter(long handle);
+}

--- a/java/src/main/java/org/lance/memwal/ShardWriterConfig.java
+++ b/java/src/main/java/org/lance/memwal/ShardWriterConfig.java
@@ -13,6 +13,8 @@
  */
 package org.lance.memwal;
 
+import com.google.common.base.Preconditions;
+
 import java.util.Optional;
 
 /**
@@ -20,7 +22,7 @@ import java.util.Optional;
  *
  * <p>Every value is optional; unset values fall back to the Lance default writer configuration. Use
  * the {@code with*} methods to build a configuration, then pass it to {@link
- * org.lance.Dataset#memWalWriter} or {@link InitializeMemWalParams#withWriterConfig}.
+ * org.lance.Dataset#memWalWriter} or {@link InitializeMemWalParams#withWriterConfigDefaults}.
  */
 public class ShardWriterConfig {
   private Optional<Boolean> durableWrite = Optional.empty();
@@ -51,66 +53,104 @@ public class ShardWriterConfig {
 
   /** Maximum size of the in-memory WAL buffer, in bytes. */
   public ShardWriterConfig withMaxWalBufferSize(long maxWalBufferSize) {
+    Preconditions.checkArgument(
+        maxWalBufferSize >= 0, "maxWalBufferSize must not be negative, got %s", maxWalBufferSize);
     this.maxWalBufferSize = Optional.of(maxWalBufferSize);
     return this;
   }
 
   /** Maximum interval between WAL flushes, in milliseconds. */
   public ShardWriterConfig withMaxWalFlushIntervalMs(long maxWalFlushIntervalMs) {
+    Preconditions.checkArgument(
+        maxWalFlushIntervalMs >= 0,
+        "maxWalFlushIntervalMs must not be negative, got %s",
+        maxWalFlushIntervalMs);
     this.maxWalFlushIntervalMs = Optional.of(maxWalFlushIntervalMs);
     return this;
   }
 
   /** Maximum size of a MemTable before it is flushed, in bytes. */
   public ShardWriterConfig withMaxMemtableSize(long maxMemtableSize) {
+    Preconditions.checkArgument(
+        maxMemtableSize >= 0, "maxMemtableSize must not be negative, got %s", maxMemtableSize);
     this.maxMemtableSize = Optional.of(maxMemtableSize);
     return this;
   }
 
   /** Maximum number of rows in a MemTable before it is flushed. */
   public ShardWriterConfig withMaxMemtableRows(long maxMemtableRows) {
+    Preconditions.checkArgument(
+        maxMemtableRows >= 0, "maxMemtableRows must not be negative, got %s", maxMemtableRows);
     this.maxMemtableRows = Optional.of(maxMemtableRows);
     return this;
   }
 
   /** Maximum number of record batches in a MemTable before it is flushed. */
   public ShardWriterConfig withMaxMemtableBatches(long maxMemtableBatches) {
+    Preconditions.checkArgument(
+        maxMemtableBatches >= 0,
+        "maxMemtableBatches must not be negative, got %s",
+        maxMemtableBatches);
     this.maxMemtableBatches = Optional.of(maxMemtableBatches);
     return this;
   }
 
   /** Maximum unflushed MemTable bytes allowed before applying backpressure. */
   public ShardWriterConfig withMaxUnflushedMemtableBytes(long maxUnflushedMemtableBytes) {
+    Preconditions.checkArgument(
+        maxUnflushedMemtableBytes >= 0,
+        "maxUnflushedMemtableBytes must not be negative, got %s",
+        maxUnflushedMemtableBytes);
     this.maxUnflushedMemtableBytes = Optional.of(maxUnflushedMemtableBytes);
     return this;
   }
 
   /** Batch size used when scanning the WAL manifest. */
   public ShardWriterConfig withManifestScanBatchSize(long manifestScanBatchSize) {
+    Preconditions.checkArgument(
+        manifestScanBatchSize >= 0,
+        "manifestScanBatchSize must not be negative, got %s",
+        manifestScanBatchSize);
     this.manifestScanBatchSize = Optional.of(manifestScanBatchSize);
     return this;
   }
 
   /** Number of rows buffered before an asynchronous index update is triggered. */
   public ShardWriterConfig withAsyncIndexBufferRows(long asyncIndexBufferRows) {
+    Preconditions.checkArgument(
+        asyncIndexBufferRows >= 0,
+        "asyncIndexBufferRows must not be negative, got %s",
+        asyncIndexBufferRows);
     this.asyncIndexBufferRows = Optional.of(asyncIndexBufferRows);
     return this;
   }
 
   /** Interval between asynchronous index updates, in milliseconds. */
   public ShardWriterConfig withAsyncIndexIntervalMs(long asyncIndexIntervalMs) {
+    Preconditions.checkArgument(
+        asyncIndexIntervalMs >= 0,
+        "asyncIndexIntervalMs must not be negative, got %s",
+        asyncIndexIntervalMs);
     this.asyncIndexIntervalMs = Optional.of(asyncIndexIntervalMs);
     return this;
   }
 
   /** Interval between backpressure log messages, in milliseconds. */
   public ShardWriterConfig withBackpressureLogIntervalMs(long backpressureLogIntervalMs) {
+    Preconditions.checkArgument(
+        backpressureLogIntervalMs >= 0,
+        "backpressureLogIntervalMs must not be negative, got %s",
+        backpressureLogIntervalMs);
     this.backpressureLogIntervalMs = Optional.of(backpressureLogIntervalMs);
     return this;
   }
 
   /** Interval between statistics log messages, in milliseconds; {@code 0} disables logging. */
   public ShardWriterConfig withStatsLogIntervalMs(long statsLogIntervalMs) {
+    Preconditions.checkArgument(
+        statsLogIntervalMs >= 0,
+        "statsLogIntervalMs must not be negative, got %s",
+        statsLogIntervalMs);
     this.statsLogIntervalMs = Optional.of(statsLogIntervalMs);
     return this;
   }

--- a/java/src/main/java/org/lance/memwal/ShardWriterConfig.java
+++ b/java/src/main/java/org/lance/memwal/ShardWriterConfig.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import java.util.Optional;
+
+/**
+ * Optional configuration for a {@link ShardWriter}.
+ *
+ * <p>Every value is optional; unset values fall back to the Lance default writer configuration. Use
+ * the {@code with*} methods to build a configuration, then pass it to {@link
+ * org.lance.Dataset#memWalWriter} or {@link InitializeMemWalParams#withWriterConfig}.
+ */
+public class ShardWriterConfig {
+  private Optional<Boolean> durableWrite = Optional.empty();
+  private Optional<Boolean> syncIndexedWrite = Optional.empty();
+  private Optional<Long> maxWalBufferSize = Optional.empty();
+  private Optional<Long> maxWalFlushIntervalMs = Optional.empty();
+  private Optional<Long> maxMemtableSize = Optional.empty();
+  private Optional<Long> maxMemtableRows = Optional.empty();
+  private Optional<Long> maxMemtableBatches = Optional.empty();
+  private Optional<Long> maxUnflushedMemtableBytes = Optional.empty();
+  private Optional<Long> manifestScanBatchSize = Optional.empty();
+  private Optional<Long> asyncIndexBufferRows = Optional.empty();
+  private Optional<Long> asyncIndexIntervalMs = Optional.empty();
+  private Optional<Long> backpressureLogIntervalMs = Optional.empty();
+  private Optional<Long> statsLogIntervalMs = Optional.empty();
+
+  /** Whether each {@code put} is durably persisted to the WAL before returning. */
+  public ShardWriterConfig withDurableWrite(boolean durableWrite) {
+    this.durableWrite = Optional.of(durableWrite);
+    return this;
+  }
+
+  /** Whether indexed writes are applied synchronously. */
+  public ShardWriterConfig withSyncIndexedWrite(boolean syncIndexedWrite) {
+    this.syncIndexedWrite = Optional.of(syncIndexedWrite);
+    return this;
+  }
+
+  /** Maximum size of the in-memory WAL buffer, in bytes. */
+  public ShardWriterConfig withMaxWalBufferSize(long maxWalBufferSize) {
+    this.maxWalBufferSize = Optional.of(maxWalBufferSize);
+    return this;
+  }
+
+  /** Maximum interval between WAL flushes, in milliseconds. */
+  public ShardWriterConfig withMaxWalFlushIntervalMs(long maxWalFlushIntervalMs) {
+    this.maxWalFlushIntervalMs = Optional.of(maxWalFlushIntervalMs);
+    return this;
+  }
+
+  /** Maximum size of a MemTable before it is flushed, in bytes. */
+  public ShardWriterConfig withMaxMemtableSize(long maxMemtableSize) {
+    this.maxMemtableSize = Optional.of(maxMemtableSize);
+    return this;
+  }
+
+  /** Maximum number of rows in a MemTable before it is flushed. */
+  public ShardWriterConfig withMaxMemtableRows(long maxMemtableRows) {
+    this.maxMemtableRows = Optional.of(maxMemtableRows);
+    return this;
+  }
+
+  /** Maximum number of record batches in a MemTable before it is flushed. */
+  public ShardWriterConfig withMaxMemtableBatches(long maxMemtableBatches) {
+    this.maxMemtableBatches = Optional.of(maxMemtableBatches);
+    return this;
+  }
+
+  /** Maximum unflushed MemTable bytes allowed before applying backpressure. */
+  public ShardWriterConfig withMaxUnflushedMemtableBytes(long maxUnflushedMemtableBytes) {
+    this.maxUnflushedMemtableBytes = Optional.of(maxUnflushedMemtableBytes);
+    return this;
+  }
+
+  /** Batch size used when scanning the WAL manifest. */
+  public ShardWriterConfig withManifestScanBatchSize(long manifestScanBatchSize) {
+    this.manifestScanBatchSize = Optional.of(manifestScanBatchSize);
+    return this;
+  }
+
+  /** Number of rows buffered before an asynchronous index update is triggered. */
+  public ShardWriterConfig withAsyncIndexBufferRows(long asyncIndexBufferRows) {
+    this.asyncIndexBufferRows = Optional.of(asyncIndexBufferRows);
+    return this;
+  }
+
+  /** Interval between asynchronous index updates, in milliseconds. */
+  public ShardWriterConfig withAsyncIndexIntervalMs(long asyncIndexIntervalMs) {
+    this.asyncIndexIntervalMs = Optional.of(asyncIndexIntervalMs);
+    return this;
+  }
+
+  /** Interval between backpressure log messages, in milliseconds. */
+  public ShardWriterConfig withBackpressureLogIntervalMs(long backpressureLogIntervalMs) {
+    this.backpressureLogIntervalMs = Optional.of(backpressureLogIntervalMs);
+    return this;
+  }
+
+  /** Interval between statistics log messages, in milliseconds; {@code 0} disables logging. */
+  public ShardWriterConfig withStatsLogIntervalMs(long statsLogIntervalMs) {
+    this.statsLogIntervalMs = Optional.of(statsLogIntervalMs);
+    return this;
+  }
+
+  public Optional<Boolean> durableWrite() {
+    return durableWrite;
+  }
+
+  public Optional<Boolean> syncIndexedWrite() {
+    return syncIndexedWrite;
+  }
+
+  public Optional<Long> maxWalBufferSize() {
+    return maxWalBufferSize;
+  }
+
+  public Optional<Long> maxWalFlushIntervalMs() {
+    return maxWalFlushIntervalMs;
+  }
+
+  public Optional<Long> maxMemtableSize() {
+    return maxMemtableSize;
+  }
+
+  public Optional<Long> maxMemtableRows() {
+    return maxMemtableRows;
+  }
+
+  public Optional<Long> maxMemtableBatches() {
+    return maxMemtableBatches;
+  }
+
+  public Optional<Long> maxUnflushedMemtableBytes() {
+    return maxUnflushedMemtableBytes;
+  }
+
+  public Optional<Long> manifestScanBatchSize() {
+    return manifestScanBatchSize;
+  }
+
+  public Optional<Long> asyncIndexBufferRows() {
+    return asyncIndexBufferRows;
+  }
+
+  public Optional<Long> asyncIndexIntervalMs() {
+    return asyncIndexIntervalMs;
+  }
+
+  public Optional<Long> backpressureLogIntervalMs() {
+    return backpressureLogIntervalMs;
+  }
+
+  public Optional<Long> statsLogIntervalMs() {
+    return statsLogIntervalMs;
+  }
+}

--- a/java/src/main/java/org/lance/memwal/ShardingField.java
+++ b/java/src/main/java/org/lance/memwal/ShardingField.java
@@ -25,6 +25,7 @@ public class ShardingField {
   private final String fieldId;
   private final List<Integer> sourceIds;
   private final Optional<String> transform;
+  private final Optional<String> expression;
   private final String resultType;
   private final Map<String, String> parameters;
 
@@ -32,6 +33,7 @@ public class ShardingField {
    * @param fieldId identifier for the derived field
    * @param sourceIds source field IDs used as inputs
    * @param transform optional transform name applied to the source fields, may be {@code null}
+   * @param expression optional expression used to derive the field value, may be {@code null}
    * @param resultType output type name for the derived field
    * @param parameters extra transform parameters
    */
@@ -39,11 +41,13 @@ public class ShardingField {
       String fieldId,
       List<Integer> sourceIds,
       String transform,
+      String expression,
       String resultType,
       Map<String, String> parameters) {
     this.fieldId = fieldId;
     this.sourceIds = sourceIds == null ? Collections.emptyList() : sourceIds;
     this.transform = Optional.ofNullable(transform);
+    this.expression = Optional.ofNullable(expression);
     this.resultType = resultType;
     this.parameters = parameters == null ? Collections.emptyMap() : parameters;
   }
@@ -63,6 +67,11 @@ public class ShardingField {
     return transform;
   }
 
+  /** Optional expression used to derive the field value. */
+  public Optional<String> expression() {
+    return expression;
+  }
+
   /** Output type name for the derived field. */
   public String resultType() {
     return resultType;
@@ -79,6 +88,7 @@ public class ShardingField {
         .add("fieldId", fieldId)
         .add("sourceIds", sourceIds)
         .add("transform", transform.orElse(null))
+        .add("expression", expression.orElse(null))
         .add("resultType", resultType)
         .add("parameters", parameters)
         .toString();

--- a/java/src/main/java/org/lance/memwal/ShardingField.java
+++ b/java/src/main/java/org/lance/memwal/ShardingField.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** One derived field used in a MemWAL shard partitioning specification. */
+public class ShardingField {
+  private final String fieldId;
+  private final List<Integer> sourceIds;
+  private final Optional<String> transform;
+  private final String resultType;
+  private final Map<String, String> parameters;
+
+  /**
+   * @param fieldId identifier for the derived field
+   * @param sourceIds source field IDs used as inputs
+   * @param transform optional transform name applied to the source fields, may be {@code null}
+   * @param resultType output type name for the derived field
+   * @param parameters extra transform parameters
+   */
+  public ShardingField(
+      String fieldId,
+      List<Integer> sourceIds,
+      String transform,
+      String resultType,
+      Map<String, String> parameters) {
+    this.fieldId = fieldId;
+    this.sourceIds = sourceIds == null ? Collections.emptyList() : sourceIds;
+    this.transform = Optional.ofNullable(transform);
+    this.resultType = resultType;
+    this.parameters = parameters == null ? Collections.emptyMap() : parameters;
+  }
+
+  /** Identifier for the derived field. */
+  public String fieldId() {
+    return fieldId;
+  }
+
+  /** Source field IDs used as inputs. */
+  public List<Integer> sourceIds() {
+    return sourceIds;
+  }
+
+  /** Optional transform name applied to the source fields. */
+  public Optional<String> transform() {
+    return transform;
+  }
+
+  /** Output type name for the derived field. */
+  public String resultType() {
+    return resultType;
+  }
+
+  /** Extra transform parameters. */
+  public Map<String, String> parameters() {
+    return parameters;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("fieldId", fieldId)
+        .add("sourceIds", sourceIds)
+        .add("transform", transform.orElse(null))
+        .add("resultType", resultType)
+        .add("parameters", parameters)
+        .toString();
+  }
+}

--- a/java/src/main/java/org/lance/memwal/ShardingSpec.java
+++ b/java/src/main/java/org/lance/memwal/ShardingSpec.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Partitioning specification for deriving MemWAL shard IDs. */
+public class ShardingSpec {
+  private final int specId;
+  private final List<ShardingField> fields;
+
+  public ShardingSpec(int specId, List<ShardingField> fields) {
+    this.specId = specId;
+    this.fields = fields == null ? Collections.emptyList() : fields;
+  }
+
+  /** Identifier for this shard specification. */
+  public int specId() {
+    return specId;
+  }
+
+  /** The derived fields that make up this specification. */
+  public List<ShardingField> fields() {
+    return fields;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("specId", specId).add("fields", fields).toString();
+  }
+}

--- a/java/src/main/java/org/lance/memwal/WriteStats.java
+++ b/java/src/main/java/org/lance/memwal/WriteStats.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import com.google.common.base.MoreObjects;
+
+/** A snapshot of cumulative write statistics for a {@link ShardWriter}. */
+public class WriteStats {
+  private final long putCount;
+  private final long putTimeMs;
+  private final long walFlushCount;
+  private final long walFlushBytes;
+  private final long walFlushTimeMs;
+  private final long memtableFlushCount;
+  private final long memtableFlushRows;
+  private final long memtableFlushTimeMs;
+
+  public WriteStats(
+      long putCount,
+      long putTimeMs,
+      long walFlushCount,
+      long walFlushBytes,
+      long walFlushTimeMs,
+      long memtableFlushCount,
+      long memtableFlushRows,
+      long memtableFlushTimeMs) {
+    this.putCount = putCount;
+    this.putTimeMs = putTimeMs;
+    this.walFlushCount = walFlushCount;
+    this.walFlushBytes = walFlushBytes;
+    this.walFlushTimeMs = walFlushTimeMs;
+    this.memtableFlushCount = memtableFlushCount;
+    this.memtableFlushRows = memtableFlushRows;
+    this.memtableFlushTimeMs = memtableFlushTimeMs;
+  }
+
+  /** Number of {@link ShardWriter#put} calls. */
+  public long putCount() {
+    return putCount;
+  }
+
+  /** Total time spent in {@code put}, in milliseconds. */
+  public long putTimeMs() {
+    return putTimeMs;
+  }
+
+  /** Number of WAL flushes. */
+  public long walFlushCount() {
+    return walFlushCount;
+  }
+
+  /** Total bytes flushed to the WAL. */
+  public long walFlushBytes() {
+    return walFlushBytes;
+  }
+
+  /** Total time spent flushing the WAL, in milliseconds. */
+  public long walFlushTimeMs() {
+    return walFlushTimeMs;
+  }
+
+  /** Number of MemTable flushes. */
+  public long memtableFlushCount() {
+    return memtableFlushCount;
+  }
+
+  /** Total rows flushed from MemTables. */
+  public long memtableFlushRows() {
+    return memtableFlushRows;
+  }
+
+  /** Total time spent flushing MemTables, in milliseconds. */
+  public long memtableFlushTimeMs() {
+    return memtableFlushTimeMs;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("putCount", putCount)
+        .add("putTimeMs", putTimeMs)
+        .add("walFlushCount", walFlushCount)
+        .add("walFlushBytes", walFlushBytes)
+        .add("walFlushTimeMs", walFlushTimeMs)
+        .add("memtableFlushCount", memtableFlushCount)
+        .add("memtableFlushRows", memtableFlushRows)
+        .add("memtableFlushTimeMs", memtableFlushTimeMs)
+        .toString();
+  }
+}

--- a/java/src/main/java/org/lance/merge/MergeInsertParams.java
+++ b/java/src/main/java/org/lance/merge/MergeInsertParams.java
@@ -13,10 +13,13 @@
  */
 package org.lance.merge;
 
+import org.lance.memwal.MergedGeneration;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,6 +38,7 @@ public class MergeInsertParams {
   private int conflictRetries = 10;
   private long retryTimeoutMs = 30 * 1000;
   private boolean skipAutoCleanup = false;
+  private List<MergedGeneration> markedGenerations = Collections.emptyList();
 
   public MergeInsertParams(List<String> on) {
     this.on = on;
@@ -223,8 +227,27 @@ public class MergeInsertParams {
     return this;
   }
 
+  /**
+   * Mark MemWAL generations as merged into the base table.
+   *
+   * <p>Use this when the merge insert incorporates data from MemWAL flushed generations. It updates
+   * the MemWAL generation tracking to prevent the same generations from being merged again.
+   *
+   * @param generations the flushed generations being merged
+   * @return This MergeInsertParams instance
+   */
+  public MergeInsertParams markGenerationsAsMerged(List<MergedGeneration> generations) {
+    Preconditions.checkNotNull(generations, "generations must not be null");
+    this.markedGenerations = generations;
+    return this;
+  }
+
   public List<String> on() {
     return on;
+  }
+
+  public List<MergedGeneration> markedGenerations() {
+    return markedGenerations;
   }
 
   public WhenMatched whenMatched() {

--- a/java/src/test/java/org/lance/memwal/MemWalTest.java
+++ b/java/src/test/java/org/lance/memwal/MemWalTest.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.memwal;
+
+import org.lance.Dataset;
+import org.lance.index.DistanceType;
+import org.lance.index.IndexParams;
+import org.lance.index.IndexType;
+import org.lance.index.vector.VectorIndexParams;
+import org.lance.merge.MergeInsertParams;
+import org.lance.merge.MergeInsertResult;
+
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the MemWAL Java bindings, mirroring python/python/tests/test_mem_wal.py.
+ */
+public class MemWalTest {
+  private static final Map<String, String> PK_META =
+      Collections.singletonMap("lance-schema:unenforced-primary-key", "true");
+
+  private static final Schema LOOKUP_SCHEMA =
+      new Schema(
+          Arrays.asList(
+              new Field(
+                  "id", new FieldType(false, new ArrowType.Int(64, true), null, PK_META), null),
+              Field.nullable("name", new ArrowType.Utf8())));
+
+  /** Build a single-batch root where {@code name = "{prefix}_{id}"}. */
+  private static VectorSchemaRoot lookupRoot(BufferAllocator allocator, long[] ids, String prefix) {
+    VectorSchemaRoot root = VectorSchemaRoot.create(LOOKUP_SCHEMA, allocator);
+    BigIntVector idVector = (BigIntVector) root.getVector("id");
+    VarCharVector nameVector = (VarCharVector) root.getVector("name");
+    idVector.allocateNew(ids.length);
+    nameVector.allocateNew();
+    for (int i = 0; i < ids.length; i++) {
+      idVector.set(i, ids[i]);
+      nameVector.setSafe(i, (prefix + "_" + ids[i]).getBytes(StandardCharsets.UTF_8));
+    }
+    root.setRowCount(ids.length);
+    return root;
+  }
+
+  /** Wrap an in-memory root into an {@link ArrowReader} via the Arrow IPC stream format. */
+  private static ArrowReader toReader(BufferAllocator allocator, VectorSchemaRoot root)
+      throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(out))) {
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+    return new ArrowStreamReader(new ByteArrayInputStream(out.toByteArray()), allocator);
+  }
+
+  /** Write a base dataset of `(id, name)` rows at {@code path}. */
+  private static Dataset writeLookupDataset(
+      BufferAllocator allocator, String path, long[] ids, String prefix) throws Exception {
+    try (VectorSchemaRoot root = lookupRoot(allocator, ids, prefix);
+        ArrowReader reader = toReader(allocator, root)) {
+      return Dataset.write().allocator(allocator).reader(reader).uri(path).execute();
+    }
+  }
+
+  /** Read an LSM scanner fully into an {@code id -> name} map. */
+  private static Map<Long, String> readByName(ArrowReader reader) throws Exception {
+    Map<Long, String> byId = new HashMap<>();
+    while (reader.loadNextBatch()) {
+      VectorSchemaRoot root = reader.getVectorSchemaRoot();
+      BigIntVector idVector = (BigIntVector) root.getVector("id");
+      VarCharVector nameVector = (VarCharVector) root.getVector("name");
+      for (int i = 0; i < root.getRowCount(); i++) {
+        byId.put(idVector.get(i), new String(nameVector.get(i), StandardCharsets.UTF_8));
+      }
+    }
+    return byId;
+  }
+
+  @Test
+  void testMemWalIndexDetailsNoneBeforeInit(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("base").toString();
+    try (BufferAllocator allocator = new RootAllocator();
+        Dataset dataset = writeLookupDataset(allocator, path, new long[] {1, 2, 3}, "base")) {
+      assertFalse(dataset.memWalIndexDetails().isPresent());
+    }
+  }
+
+  @Test
+  void testInitializeMemWalUnsharded(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("base").toString();
+    try (BufferAllocator allocator = new RootAllocator();
+        Dataset dataset = writeLookupDataset(allocator, path, new long[] {1, 2, 3}, "base")) {
+      dataset.initializeMemWal(new InitializeMemWalParams().withUnsharded());
+
+      Optional<MemWalIndexDetails> details = dataset.memWalIndexDetails();
+      assertTrue(details.isPresent());
+      assertEquals(Collections.emptyList(), details.get().maintainedIndexes());
+    }
+  }
+
+  @Test
+  void testInitializeMemWalRejectsConflictingSharding(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("base").toString();
+    try (BufferAllocator allocator = new RootAllocator();
+        Dataset dataset = writeLookupDataset(allocator, path, new long[] {1}, "base")) {
+      InitializeMemWalParams params =
+          new InitializeMemWalParams().withUnsharded().withBucketSharding("id", 4);
+      assertThrows(IllegalArgumentException.class, () -> dataset.initializeMemWal(params));
+    }
+  }
+
+  @Test
+  void testShardWriterPutAndLsmScanner(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("base").toString();
+    String shardId = UUID.randomUUID().toString();
+    try (BufferAllocator allocator = new RootAllocator();
+        Dataset dataset = writeLookupDataset(allocator, path, new long[] {0}, "base")) {
+      dataset.initializeMemWal(new InitializeMemWalParams());
+
+      ShardWriterConfig config =
+          new ShardWriterConfig()
+              .withDurableWrite(true)
+              .withMaxWalBufferSize(1)
+              .withMaxWalFlushIntervalMs(10)
+              .withMaxMemtableBatches(1);
+
+      try (ShardWriter writer = dataset.memWalWriter(shardId, config)) {
+        assertEquals(shardId, writer.shardId());
+
+        try (VectorSchemaRoot root = lookupRoot(allocator, new long[] {1, 2}, "writer");
+            ArrowReader reader = toReader(allocator, root)) {
+          writer.put(reader);
+        }
+
+        Map<Long, String> byId = Collections.emptyMap();
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+          try (LsmScanner scanner = writer.lsmScanner();
+              ArrowReader reader = scanner.scanBatches()) {
+            byId = readByName(reader);
+          }
+          if ("writer_1".equals(byId.get(1L)) && "writer_2".equals(byId.get(2L))) {
+            break;
+          }
+          Thread.sleep(50);
+        }
+        assertEquals("writer_1", byId.get(1L), "writer.lsmScanner() must see written rows");
+        assertEquals("writer_2", byId.get(2L), "writer.lsmScanner() must see written rows");
+
+        WriteStats stats = writer.stats();
+        assertEquals(1, stats.putCount());
+
+        MemTableStats memtableStats = writer.memtableStats();
+        assertTrue(memtableStats.generation() >= 0);
+      }
+    }
+  }
+
+  @Test
+  void testLsmScannerFromSnapshots(@TempDir Path tempDir) throws Exception {
+    String basePath = tempDir.resolve("base").toString();
+    String shardId = UUID.randomUUID().toString();
+    try (BufferAllocator allocator = new RootAllocator();
+        Dataset dataset = writeLookupDataset(allocator, basePath, new long[] {1, 2, 3}, "base")) {
+      dataset.initializeMemWal(new InitializeMemWalParams());
+
+      // Flushed generation overwrites id=2.
+      String genPath = basePath + "/_mem_wal/" + shardId + "/gen_1";
+      writeLookupDataset(allocator, genPath, new long[] {2}, "gen1").close();
+
+      ShardSnapshot snapshot =
+          new ShardSnapshot(shardId).withFlushedGeneration(1, "gen_1").withCurrentGeneration(2);
+
+      try (LsmScanner scanner =
+              LsmScanner.fromSnapshots(dataset, Collections.singletonList(snapshot));
+          ArrowReader reader = scanner.scanBatches()) {
+        Map<Long, String> byId = readByName(reader);
+        assertEquals(3, byId.size(), "Expected 3 deduplicated rows");
+        assertEquals("base_1", byId.get(1L));
+        assertEquals("gen1_2", byId.get(2L), "Flushed generation must win over base");
+        assertEquals("base_3", byId.get(3L));
+      }
+    }
+  }
+
+  @Test
+  void testPointLookup(@TempDir Path tempDir) throws Exception {
+    String basePath = tempDir.resolve("base").toString();
+    String shardId = UUID.randomUUID().toString();
+    try (BufferAllocator allocator = new RootAllocator();
+        Dataset dataset = writeLookupDataset(allocator, basePath, new long[] {1, 2, 3}, "base")) {
+      dataset.initializeMemWal(new InitializeMemWalParams());
+
+      String genPath = basePath + "/_mem_wal/" + shardId + "/gen_1";
+      writeLookupDataset(allocator, genPath, new long[] {2}, "gen1").close();
+
+      ShardSnapshot snapshot =
+          new ShardSnapshot(shardId).withFlushedGeneration(1, "gen_1").withCurrentGeneration(2);
+
+      try (LsmPointLookupPlanner planner =
+          new LsmPointLookupPlanner(dataset, Collections.singletonList(snapshot))) {
+        // id=2 must resolve to the flushed-generation value.
+        assertEquals("gen1_2", lookup(planner, allocator, 2L));
+        // id=1 only exists in the base table.
+        assertEquals("base_1", lookup(planner, allocator, 1L));
+        // id=99 does not exist.
+        assertEquals(null, lookup(planner, allocator, 99L));
+      }
+    }
+  }
+
+  /** Run a single-key point lookup and return the resolved name, or {@code null} if absent. */
+  private static String lookup(LsmPointLookupPlanner planner, BufferAllocator allocator, long id)
+      throws Exception {
+    try (BigIntVector pkVector = new BigIntVector("id", allocator)) {
+      pkVector.allocateNew(1);
+      pkVector.set(0, id);
+      pkVector.setValueCount(1);
+      try (ExecutionPlan plan = planner.planLookup(pkVector);
+          ArrowReader reader = plan.toReader()) {
+        Map<Long, String> byId = readByName(reader);
+        return byId.get(id);
+      }
+    }
+  }
+
+  @Test
+  void testMergeInsertMarkGenerationsAsMerged(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("base").toString();
+    String shardId = UUID.randomUUID().toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      Dataset dataset = writeLookupDataset(allocator, path, new long[] {1, 2, 3}, "base");
+      try {
+        dataset.initializeMemWal(new InitializeMemWalParams());
+
+        MergeInsertParams params =
+            new MergeInsertParams(Collections.singletonList("id"))
+                .withMatchedUpdateAll()
+                .withNotMatched(MergeInsertParams.WhenNotMatched.InsertAll)
+                .markGenerationsAsMerged(
+                    Collections.singletonList(new MergedGeneration(shardId, 1)));
+
+        try (VectorSchemaRoot root = lookupRoot(allocator, new long[] {2, 4}, "merged");
+            ArrowReader reader = toReader(allocator, root);
+            ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator)) {
+          Data.exportArrayStream(allocator, reader, stream);
+          MergeInsertResult result = dataset.mergeInsert(params, stream);
+          Dataset merged = result.dataset();
+          try {
+            assertEquals(4, merged.countRows(), "merge insert should yield 4 rows");
+          } finally {
+            merged.close();
+          }
+        }
+      } finally {
+        dataset.close();
+      }
+    }
+  }
+
+  private static final int VDIM = 32;
+
+  private static Schema vectorSchema() {
+    Field idField =
+        new Field("id", new FieldType(false, new ArrowType.Int(32, true), null, PK_META), null);
+    Field vecField =
+        new Field(
+            "vec",
+            FieldType.nullable(new ArrowType.FixedSizeList(VDIM)),
+            Collections.singletonList(
+                new Field(
+                    "item",
+                    FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)),
+                    null)));
+    return new Schema(Arrays.asList(idField, vecField));
+  }
+
+  @Test
+  void testVectorSearch(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("vec").toString();
+    int rows = 400;
+    try (BufferAllocator allocator = new RootAllocator()) {
+      Schema schema = vectorSchema();
+      Dataset dataset;
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+        IntVector idVector = (IntVector) root.getVector("id");
+        FixedSizeListVector vecVector = (FixedSizeListVector) root.getVector("vec");
+        Float4Vector items = (Float4Vector) vecVector.getDataVector();
+        idVector.allocateNew(rows);
+        vecVector.allocateNew();
+        for (int i = 0; i < rows; i++) {
+          idVector.set(i, i);
+          vecVector.setNotNull(i);
+          for (int d = 0; d < VDIM; d++) {
+            items.setSafe(i * VDIM + d, (float) (i * VDIM + d));
+          }
+        }
+        root.setRowCount(rows);
+        try (ArrowReader reader = toReader(allocator, root)) {
+          dataset = Dataset.write().allocator(allocator).reader(reader).uri(path).execute();
+        }
+      }
+
+      try {
+        IndexParams params =
+            IndexParams.builder()
+                .setVectorIndexParams(VectorIndexParams.ivfPq(2, 8, 2, DistanceType.L2, 2))
+                .build();
+        dataset.createIndex(
+            Collections.singletonList("vec"),
+            IndexType.VECTOR,
+            Optional.of("vec_idx"),
+            params,
+            true);
+        dataset.initializeMemWal(
+            new InitializeMemWalParams()
+                .withMaintainedIndexes(Collections.singletonList("vec_idx")));
+
+        try (LsmVectorSearchPlanner planner =
+            new LsmVectorSearchPlanner(dataset, Collections.emptyList(), "vec")) {
+          int[] queryIds = {10, 50, 100, 200, 300, 350};
+          int found = 0;
+          for (int queryId : queryIds) {
+            try (Float4Vector query = new Float4Vector("q", allocator)) {
+              query.allocateNew(VDIM);
+              for (int d = 0; d < VDIM; d++) {
+                query.set(d, (float) (queryId * VDIM + d));
+              }
+              query.setValueCount(VDIM);
+              try (ExecutionPlan plan = planner.planSearch(query, 10);
+                  ArrowReader reader = plan.toReader()) {
+                while (reader.loadNextBatch()) {
+                  VectorSchemaRoot result = reader.getVectorSchemaRoot();
+                  IntVector ids = (IntVector) result.getVector("id");
+                  for (int i = 0; i < result.getRowCount(); i++) {
+                    if (ids.get(i) == queryId) {
+                      found++;
+                    }
+                  }
+                }
+              }
+            }
+          }
+          double recall = (double) found / queryIds.length;
+          assertTrue(recall >= 0.5, "vector search recall too low: " + recall);
+        }
+      } finally {
+        dataset.close();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds Java bindings for the MemWAL feature, mirroring the Python `lance.mem_wal` binding. Uses shard / sharding terminology consistent with the Rust core.

## Changes

- New `org.lance.memwal` package:
    - `ShardWriter`, `LsmScanner`, `ExecutionPlan`, `LsmPointLookupPlanner`, `LsmVectorSearchPlanner` (native-handle, `Closeable`).
    - Value classes: `ShardingField`, `ShardingSpec`, `FlushedGeneration`, `MergedGeneration`, `ShardSnapshot`, `WriteStats`, `MemTableStats`, `MemWalIndexDetails`, `ShardWriterConfig`, `InitializeMemWalParams`.
- `Dataset.initializeMemWal`, `Dataset.memWalIndexDetails`, `Dataset.memWalWriter`.
- `MergeInsertParams.markGenerationsAsMerged`.
- New `java/lance-jni/src/mem_wal.rs` JNI layer; Arrow data crosses the boundary via the C Data Interface.

The read-your-writes scanner uses `in_memory_memtable_refs()` so frozen-awaiting-flush memtables are not missed during a flush rollover.