### PR TITLE
fix(mem_wal): persist composite WAL recency key in flushed L0 generations

### DIFF
--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -43,6 +43,24 @@ mod wal;
 pub mod write;
 
 pub use api::{DatasetMemWalExt, InitializeMemWalBuilder};
+
+/// Column name for the WAL entry position stamped per row into flushed L0
+/// generation files.
+///
+/// Together with [`WAL_POS_COLUMN`] this forms the composite recency key
+/// `(_wal_seq, _wal_pos)` that L0→base compaction uses to select the per-PK
+/// survivor by the authoritative WAL write order (the WAL appender packs
+/// multiple batches into one entry, so the entry position alone is monotonic
+/// but *not* per-write unique — [`WAL_POS_COLUMN`] discriminates same-entry
+/// duplicates).
+///
+/// This is internal to the L0 file layout: it is never part of the user/base
+/// schema, never reported by `is_system_column`, and never projected by the
+/// read path, so it is invisible to readers.
+pub const WAL_SEQ_COLUMN: &str = "_wal_seq";
+
+/// Column name for the within-WAL-entry position. See [`WAL_SEQ_COLUMN`].
+pub const WAL_POS_COLUMN: &str = "_wal_pos";
 pub use manifest::ShardManifestStore;
 pub use memtable::scanner::MemTableScanner;
 pub use scanner::{LsmDataSource, LsmGeneration, LsmScanner, ShardSnapshot};

--- a/rust/lance/src/dataset/mem_wal/memtable.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable.rs
@@ -78,8 +78,6 @@ pub struct MemTable {
     /// Generation number (incremented on flush).
     generation: u64,
 
-    /// WAL batch mapping: batch_position -> (wal_entry_position, position within WAL entry).
-    wal_batch_mapping: HashMap<usize, (u64, usize)>,
     /// Last WAL entry position that has been flushed.
     last_flushed_wal_entry_position: u64,
     /// Set of batch IDs that have been flushed to WAL.
@@ -218,7 +216,6 @@ impl MemTable {
             cache_config,
             cached_dataset: RwLock::new(None),
             generation,
-            wal_batch_mapping: HashMap::new(),
             last_flushed_wal_entry_position: 0,
             flushed_batch_positions: HashSet::new(),
             pk_bloom_filter,
@@ -561,17 +558,21 @@ impl MemTable {
 
     /// Mark batches as flushed to WAL.
     ///
-    /// Updates the WAL batch mapping for use during MemTable flush.
-    /// Also updates the batch_store's watermark to the highest flushed batch_position.
+    /// Records the per-batch WAL mapping (on the shared `BatchStore`, so the
+    /// memtable-flush path can read it) and advances the batch_store
+    /// watermark to the highest flushed batch_position. Production drives
+    /// the mapping via [`BatchStore::record_wal_mapping`] directly from the
+    /// WAL-flush path; this method is the equivalent entry point used by
+    /// tests that don't go through `WalFlusher`.
     pub fn mark_wal_flushed(
         &mut self,
         batch_positions: &[usize],
         wal_entry_position: u64,
         positions: &[usize],
     ) {
-        for (idx, &batch_position) in batch_positions.iter().enumerate() {
-            self.wal_batch_mapping
-                .insert(batch_position, (wal_entry_position, positions[idx]));
+        self.batch_store
+            .record_wal_mapping(batch_positions, wal_entry_position, positions);
+        for &batch_position in batch_positions {
             self.flushed_batch_positions.insert(batch_position);
         }
         self.last_flushed_wal_entry_position = wal_entry_position;
@@ -724,9 +725,9 @@ impl MemTable {
         self.batch_store.estimated_bytes() + self.pk_bloom_filter.estimated_memory_size()
     }
 
-    /// Get the WAL batch mapping.
-    pub fn wal_batch_mapping(&self) -> &HashMap<usize, (u64, usize)> {
-        &self.wal_batch_mapping
+    /// Snapshot of the WAL batch mapping (owned by the shared `BatchStore`).
+    pub fn wal_batch_mapping(&self) -> HashMap<usize, (u64, usize)> {
+        self.batch_store.wal_batch_mapping()
     }
 
     /// Get the last flushed WAL entry position.

--- a/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
@@ -40,7 +40,9 @@
 //! ```
 
 use std::cell::UnsafeCell;
+use std::collections::HashMap;
 use std::mem::MaybeUninit;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use arrow_array::RecordBatch;
@@ -155,6 +157,15 @@ pub struct BatchStore {
     /// Uses usize::MAX as sentinel for "nothing flushed yet".
     /// This is per-memtable tracking, not global.
     max_flushed_batch_position: AtomicUsize,
+
+    /// Per-batch WAL write position: `batch_position -> (wal_entry_position,
+    /// within-WAL-entry index)`. Recorded at WAL-flush time, read at
+    /// memtable-flush time to stamp the composite recency key
+    /// `(_wal_seq, _wal_pos)` into the flushed L0 file. It lives here rather
+    /// than on `MemTable` because the WAL-flush path only ever holds the
+    /// shared `BatchStore`, never `&mut MemTable`; this is the single
+    /// structure reachable from both phases.
+    wal_batch_mapping: Mutex<HashMap<usize, (u64, usize)>>,
 }
 
 // SAFETY: Safe to share across threads because:
@@ -192,6 +203,7 @@ impl BatchStore {
             total_rows: AtomicUsize::new(0),
             estimated_bytes: AtomicUsize::new(0),
             max_flushed_batch_position: AtomicUsize::new(usize::MAX), // Nothing flushed yet
+            wal_batch_mapping: Mutex::new(HashMap::new()),
         }
     }
 
@@ -418,6 +430,35 @@ impl BatchStore {
         );
         self.max_flushed_batch_position
             .store(batch_position, Ordering::Release);
+    }
+
+    /// Record the WAL write position of a set of just-flushed batches.
+    /// `batch_positions[i]` was appended into WAL entry `wal_entry_position`
+    /// at within-entry index `within_entry_positions[i]`. The within-entry
+    /// index MUST be each batch's FIFO order within the entry — that is what
+    /// makes the composite `(_wal_seq, _wal_pos)` key write-order-monotonic
+    /// (the WAL appender coalesces multiple batches into one entry, so the
+    /// entry position alone is not per-write unique).
+    pub fn record_wal_mapping(
+        &self,
+        batch_positions: &[usize],
+        wal_entry_position: u64,
+        within_entry_positions: &[usize],
+    ) {
+        debug_assert_eq!(
+            batch_positions.len(),
+            within_entry_positions.len(),
+            "batch_positions and within_entry_positions must be parallel"
+        );
+        let mut map = self.wal_batch_mapping.lock().unwrap();
+        for (&bp, &wp) in batch_positions.iter().zip(within_entry_positions) {
+            map.insert(bp, (wal_entry_position, wp));
+        }
+    }
+
+    /// Snapshot of the per-batch WAL mapping. Cloned (called once per flush).
+    pub fn wal_batch_mapping(&self) -> HashMap<usize, (u64, usize)> {
+        self.wal_batch_mapping.lock().unwrap().clone()
     }
 
     /// Get the number of batches pending WAL flush.

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -185,7 +185,10 @@ impl MemTableFlusher {
             return Ok(0);
         }
         let total_rows = batch_store.total_rows();
-        let wal_mapping = memtable.wal_batch_mapping();
+        // Authoritative per-batch WAL recency key, recorded by the WAL-flush
+        // path (`BatchStore::record_wal_mapping`). Flush is hard-gated on
+        // `all_flushed_to_wal()`, so every batch here has an entry.
+        let wal_mapping = batch_store.wal_batch_mapping();
 
         let base_schema = memtable.schema();
         let mut fields: Vec<Arc<Field>> = base_schema.fields().iter().cloned().collect();

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -149,15 +149,27 @@ impl MemTableFlusher {
         })
     }
 
-    /// Write data file with batches in reverse order (newest first).
+    /// Write data file with batches in reverse order (newest first), stamping
+    /// the composite WAL recency key `(_wal_seq, _wal_pos)` per row.
+    ///
+    /// `_wal_seq` is the row's `wal_entry_position` and `_wal_pos` its
+    /// within-WAL-entry position, looked up per batch from the memtable's
+    /// `wal_batch_mapping`. Both are per-batch constants — invariant under the
+    /// in-batch row reversal applied here — and form the authoritative recency
+    /// key L0→base compaction uses to pick the per-PK survivor by true WAL
+    /// write order. They are internal to the L0 file and never read back (see
+    /// [`crate::dataset::mem_wal::WAL_SEQ_COLUMN`]).
     ///
     /// Returns the total number of rows written, which is needed for
     /// reversing row positions in indexes.
     #[instrument(name = "mt_write_data_file", level = "debug", skip_all, fields(path = %path))]
     async fn write_data_file(&self, path: &Path, memtable: &MemTable) -> Result<usize> {
-        use arrow_array::RecordBatchIterator;
+        use arrow::compute::kernels::take::take;
+        use arrow_array::{ArrayRef, RecordBatch, RecordBatchIterator, UInt32Array, UInt64Array};
+        use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 
         use crate::dataset::WriteParams;
+        use crate::dataset::mem_wal::{WAL_POS_COLUMN, WAL_SEQ_COLUMN};
 
         if memtable.row_count() == 0 {
             return Ok(0);
@@ -165,15 +177,67 @@ impl MemTableFlusher {
 
         // Scan batches in reverse order (newest first) so that the flushed
         // data is ordered from newest to oldest. This enables more efficient
-        // K-way merge during LSM scan.
-        let (batches, total_rows) = memtable.scan_batches_reversed().await?;
-        if batches.is_empty() {
+        // K-way merge during LSM scan. Use the StoredBatch variant so each
+        // batch's `batch_position` is available for the WAL-mapping lookup.
+        let batch_store = memtable.batch_store();
+        let stored = batch_store.to_stored_vec_reversed();
+        if stored.is_empty() {
             return Ok(0);
+        }
+        let total_rows = batch_store.total_rows();
+        let wal_mapping = memtable.wal_batch_mapping();
+
+        let base_schema = memtable.schema();
+        let mut fields: Vec<Arc<Field>> = base_schema.fields().iter().cloned().collect();
+        fields.push(Arc::new(Field::new(
+            WAL_SEQ_COLUMN,
+            DataType::UInt64,
+            false,
+        )));
+        fields.push(Arc::new(Field::new(
+            WAL_POS_COLUMN,
+            DataType::UInt64,
+            false,
+        )));
+        let out_schema = Arc::new(ArrowSchema::new_with_metadata(
+            fields,
+            base_schema.metadata().clone(),
+        ));
+
+        let mut batches = Vec::with_capacity(stored.len());
+        for sb in stored {
+            // Flush is hard-gated on `all_flushed_to_wal()`, so every batch
+            // is guaranteed a mapping entry; a miss is an invariant violation.
+            let (wal_seq, wal_pos) = *wal_mapping.get(&sb.batch_position).ok_or_else(|| {
+                Error::internal(format!(
+                    "Batch {} reached flush without a WAL mapping entry (flush must be \
+                     gated on all_flushed_to_wal())",
+                    sb.batch_position
+                ))
+            })?;
+
+            let num_rows = sb.data.num_rows();
+            // Reverse rows within the batch (newest first), matching the
+            // historical `to_vec_reversed` ordering the LSM merge and index
+            // row-position reversal rely on. `_wal_seq`/`_wal_pos` are batch
+            // constants, so the reversal does not affect them.
+            let mut columns: Vec<ArrayRef> = if num_rows == 0 {
+                sb.data.columns().to_vec()
+            } else {
+                let indices = UInt32Array::from_iter_values((0..num_rows as u32).rev());
+                sb.data
+                    .columns()
+                    .iter()
+                    .map(|col| take(col.as_ref(), &indices, None))
+                    .collect::<std::result::Result<_, _>>()?
+            };
+            columns.push(Arc::new(UInt64Array::from(vec![wal_seq; num_rows])));
+            columns.push(Arc::new(UInt64Array::from(vec![wal_pos as u64; num_rows])));
+            batches.push(RecordBatch::try_new(out_schema.clone(), columns)?);
         }
 
         let uri = self.path_to_uri(path);
-        let reader =
-            RecordBatchIterator::new(batches.into_iter().map(Ok), memtable.schema().clone());
+        let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), out_schema.clone());
 
         // Use very large max_rows_per_file to ensure 1 fragment per flushed memtable
         let write_params = WriteParams {
@@ -1365,8 +1429,14 @@ mod tests {
             "Should find document with 'quick brown fox'"
         );
 
-        // Verify the query plan uses the FTS index
+        // Verify the query plan uses the FTS index. Project only the user
+        // columns: a flushed generation also physically carries the internal
+        // `_wal_seq`/`_wal_pos` recency columns, and production never reads a
+        // generation with a default (all-column) projection — `build_source_scan`
+        // always projects explicitly. Asserting the plan under an explicit
+        // projection keeps this FTS test from coupling to L0 internals.
         let mut scan = dataset.scan();
+        scan.project(&["id", "text"]).unwrap();
         scan.full_text_search(FullTextSearchQuery::new("hello".to_owned()))
             .unwrap();
         let plan = scan.create_plan().await.unwrap();
@@ -1379,5 +1449,192 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    // -- Composite WAL recency key (`_wal_seq`, `_wal_pos`) ------------------
+
+    use arrow_array::{Array, UInt64Array};
+
+    use crate::dataset::mem_wal::{WAL_POS_COLUMN, WAL_SEQ_COLUMN};
+
+    fn pk_value_schema() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Int32, true),
+        ]))
+    }
+
+    fn row_batch(schema: &Arc<ArrowSchema>, id: i32, value: Option<i32>) -> RecordBatch {
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![id])),
+                Arc::new(Int32Array::from(vec![value])),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Flush `memtable` and return its rows as `(id, value, _wal_seq,
+    /// _wal_pos)`, sorted by the composite recency key.
+    async fn flush_and_scan(
+        memtable: &MemTable,
+        covered_wal_entry_position: u64,
+    ) -> Vec<(i32, Option<i32>, u64, u64)> {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+        let manifest_store = Arc::new(ShardManifestStore::new(
+            store.clone(),
+            &base_path,
+            shard_id,
+            2,
+        ));
+        let (epoch, _m) = manifest_store.claim_epoch(0).await.unwrap();
+
+        let flusher =
+            MemTableFlusher::new(store, base_path, base_uri.clone(), shard_id, manifest_store);
+        let result = flusher
+            .flush(memtable, epoch, covered_wal_entry_position)
+            .await
+            .unwrap();
+
+        let gen_uri = format!(
+            "{}/_mem_wal/{}/{}",
+            base_uri, shard_id, result.generation.path
+        );
+        let dataset = Dataset::open(&gen_uri).await.unwrap();
+        let batch = dataset.scan().try_into_batch().await.unwrap();
+
+        let id = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let value = batch
+            .column_by_name("value")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let seq = batch
+            .column_by_name(WAL_SEQ_COLUMN)
+            .expect("flushed L0 file must carry _wal_seq")
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        let pos = batch
+            .column_by_name(WAL_POS_COLUMN)
+            .expect("flushed L0 file must carry _wal_pos")
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+
+        let mut rows: Vec<(i32, Option<i32>, u64, u64)> = (0..batch.num_rows())
+            .map(|i| {
+                let v = if value.is_null(i) {
+                    None
+                } else {
+                    Some(value.value(i))
+                };
+                (id.value(i), v, seq.value(i), pos.value(i))
+            })
+            .collect();
+        rows.sort_by_key(|r| (r.2, r.3));
+        rows
+    }
+
+    /// Insert-then-update of the same PK flushed as two *separate* WAL
+    /// entries: `_wal_seq` alone discriminates; the NULL update is the
+    /// max-key survivor.
+    #[tokio::test]
+    async fn test_flush_composite_key_separate_wal_entries() {
+        let schema = pk_value_schema();
+        let mut memtable = MemTable::new(schema.clone(), 1, vec![]).unwrap();
+        let b0 = memtable
+            .insert(row_batch(&schema, 182, Some(3156)))
+            .await
+            .unwrap();
+        let b1 = memtable
+            .insert(row_batch(&schema, 182, None))
+            .await
+            .unwrap();
+        memtable.mark_wal_flushed(&[b0], 1, &[0]);
+        memtable.mark_wal_flushed(&[b1], 2, &[0]);
+
+        let rows = flush_and_scan(&memtable, 2).await;
+
+        assert_eq!(
+            rows,
+            vec![(182, Some(3156), 1, 0), (182, None, 2, 0)],
+            "both same-PK rows must survive into L0 with strictly-ordered \
+             composite keys; the NULL update has the max (_wal_seq, _wal_pos)"
+        );
+    }
+
+    /// The precise regression guard. Insert-then-update of the same PK
+    /// coalesced into *one* WAL entry: the two rows share a `_wal_seq` and
+    /// are ordered only by `_wal_pos`. A single-`u64` key (entry position
+    /// alone) ties here and cannot pick the update — that is the bug.
+    #[tokio::test]
+    async fn test_flush_composite_key_same_wal_entry() {
+        let schema = pk_value_schema();
+        let mut memtable = MemTable::new(schema.clone(), 1, vec![]).unwrap();
+        let b0 = memtable
+            .insert(row_batch(&schema, 182, Some(3156)))
+            .await
+            .unwrap();
+        let b1 = memtable
+            .insert(row_batch(&schema, 182, None))
+            .await
+            .unwrap();
+        // One WAL entry (position 1), within-entry positions 0 and 1.
+        memtable.mark_wal_flushed(&[b0, b1], 1, &[0, 1]);
+
+        let rows = flush_and_scan(&memtable, 1).await;
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], (182, Some(3156), 1, 0));
+        assert_eq!(rows[1], (182, None, 1, 1));
+        assert_eq!(rows[0].2, rows[1].2, "same WAL entry => identical _wal_seq");
+        assert!(
+            rows[1].3 > rows[0].3,
+            "within-entry position must order the duplicate by write order"
+        );
+        assert_eq!(
+            rows.iter().max_by_key(|r| (r.2, r.3)).unwrap().1,
+            None,
+            "max composite key must select the NULL update, not the insert"
+        );
+    }
+
+    /// Replay determinism: re-applying the identical write/WAL sequence
+    /// produces byte-identical `(_wal_seq, _wal_pos)` stamps, so a
+    /// re-flushed generation is stable across restart/replay.
+    #[tokio::test]
+    async fn test_flush_composite_key_replay_deterministic() {
+        let schema = pk_value_schema();
+
+        let build = || async {
+            let mut mt = MemTable::new(schema.clone(), 1, vec![]).unwrap();
+            let b0 = mt.insert(row_batch(&schema, 1, Some(10))).await.unwrap();
+            let b1 = mt.insert(row_batch(&schema, 2, Some(20))).await.unwrap();
+            let b2 = mt.insert(row_batch(&schema, 1, None)).await.unwrap();
+            mt.mark_wal_flushed(&[b0, b1], 7, &[0, 1]);
+            mt.mark_wal_flushed(&[b2], 8, &[0]);
+            mt
+        };
+
+        let rows_a = flush_and_scan(&build().await, 8).await;
+        let rows_b = flush_and_scan(&build().await, 8).await;
+
+        assert_eq!(
+            rows_a, rows_b,
+            "identical replay must stamp identical composite keys"
+        );
+        assert_eq!(
+            rows_a,
+            vec![(1, Some(10), 7, 0), (2, Some(20), 7, 1), (1, None, 8, 0),]
+        );
     }
 }

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -474,6 +474,12 @@ impl WalFlusher {
         let rows_to_index: usize = stored_batches.iter().map(|b| b.num_rows).sum();
         let record_batches: Vec<RecordBatch> =
             stored_batches.iter().map(|s| s.data.clone()).collect();
+        // Batch positions in append order. `WalAppender::append` writes
+        // `record_batches` as one WAL entry, so the i-th element here is at
+        // within-entry index i. Captured before `stored_batches` is moved
+        // into the index task below; used to stamp the composite recency key.
+        let flushed_positions: Vec<usize> =
+            stored_batches.iter().map(|s| s.batch_position).collect();
 
         let appender = self.wal_appender.clone();
         let (append_result, index_result) = if let Some(idx_registry) = indexes {
@@ -509,6 +515,20 @@ impl WalFlusher {
 
         // Update per-memtable watermark (inclusive: last batch ID that was flushed)
         batch_store.set_max_flushed_batch_position(end_batch_position - 1);
+
+        // Stamp the composite WAL recency key. Every batch in this append
+        // shares `entry_position`; the within-entry index is the batch's
+        // FIFO order in `record_batches` (== order in `flushed_positions`),
+        // which is what makes `(_wal_seq, _wal_pos)` write-order-monotonic
+        // and per-write unique. The memtable-flush path reads this back via
+        // `BatchStore::wal_batch_mapping` to write the L0 file's recency
+        // columns; without it the flush would have no authoritative key.
+        let within_entry: Vec<usize> = (0..flushed_positions.len()).collect();
+        batch_store.record_wal_mapping(
+            &flushed_positions,
+            append_result.entry_position,
+            &within_entry,
+        );
 
         // Notify durability waiters (global channel)
         let _ = self.durable_watermark_tx.send(end_batch_position);


### PR DESCRIPTION
## Problem

Insert-then-update of a primary key whose update sets a new value (NULL is the easily-observed case, but the defect is value-agnostic) can be silently dropped by L0→base compaction: the post-compaction base row reverts to a prior version of the same PK.

`merge_insert` with `when_matched_update_all` does **not** supersede a matched row that is still memtable-resident (it has no base `_rowaddr`), so a single frozen memtable — and therefore a single flushed L0 generation file — can legitimately contain two live rows for the same PK (the pre-update and post-update row). This is normal append-only-LSM state. The defect is that the flushed file carried **no write-order information**, so any consumer that deduplicates by PK (e.g. L0→base compaction) had no authoritative recency key and could keep the stale row non-deterministically.

## Fix

Stamp each row of a flushed generation with the composite WAL write position `(_wal_seq, _wal_pos)` = `(wal_entry_position, within-WAL-entry position)`. Both values are already tracked per batch in `MemTable::wal_batch_mapping` and the flush is hard-gated on `all_flushed_to_wal()`, so every batch is guaranteed an entry. This is the globally-monotonic, per-write-unique order in which writes were durably accepted; a consumer that keeps the max-key row per PK selects the true latest write.

`wal_entry_position` alone is **not** sufficient: `WalAppender::append` coalesces every batch pending at flush time into one WAL entry under one position, so an insert and a later same-PK update routinely share a `wal_entry_position`. The within-entry position discriminates them.

## Scope / safety

- **Additive and read-invisible.** The two columns are internal to the L0 file layout. They are never in the user/base schema, never reported by `is_system_column`, and never projected by the read path — `build_source_scan` projects explicitly via `build_scanner_projection`, so reads never see them. Zero read-path changes.
- `write_data_file` switches from `scan_batches_reversed()` to the `StoredBatch` variant to recover each batch's `batch_position` for the mapping lookup. The historical newest-first batch order and in-batch row reversal (relied on by the LSM k-way merge and index row-position math) are preserved — the keys are per-batch constants, invariant under the reversal.

## Tests

`dataset::mem_wal::memtable::flush::tests`:
- `test_flush_composite_key_separate_wal_entries` — insert/update flushed as two WAL entries; `_wal_seq` discriminates.
- `test_flush_composite_key_same_wal_entry` — insert/update coalesced into **one** WAL entry; only `_wal_pos` discriminates. This is the precise guard a single-`u64` key would fail.
- `test_flush_composite_key_replay_deterministic` — identical replay stamps identical keys.

Existing `flush` tests (success, btree/hnsw/fts index) still pass; the FTS plan-assertion was updated to project user columns explicitly (mirroring how production reads flushed generations) rather than couple a generic FTS test to L0 internals.

`cargo test -p lance --lib dataset::mem_wal::memtable::flush`, `cargo fmt`, and `cargo clippy -p lance --lib --tests -- -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)