### PR TITLE
feat: add distributed build support for ZoneMap index

### DIFF
--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3633,6 +3633,7 @@ dependencies = [
  "async-trait",
  "async_cell",
  "aws-credential-types",
+ "bitpacking",
  "byteorder",
  "bytes",
  "chrono",

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3531,16 +3531,11 @@ fn inner_get_zonemap_stats<'local>(
                                 .await
                                 .map_err(Error::from)?,
                         );
-                        let index_file = match index_store
-                            .open_index_file("zonemap.lance")
-                            .await
-                        {
+                        let index_file = match index_store.open_index_file("zonemap.lance").await {
                             Ok(file) => file,
                             Err(e) => {
-                                let is_not_found = matches!(
-                                    &e,
-                                    lance_core::Error::NotFound { .. }
-                                ) || e.to_string().contains("not found");
+                                let is_not_found = matches!(&e, lance_core::Error::NotFound { .. })
+                                    || e.to_string().contains("not found");
                                 if !is_not_found {
                                     return Err(Error::from(e));
                                 }

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3531,10 +3531,40 @@ fn inner_get_zonemap_stats<'local>(
                                 .await
                                 .map_err(Error::from)?,
                         );
-                        let index_file = index_store
+                        let index_file = match index_store
                             .open_index_file("zonemap.lance")
                             .await
-                            .map_err(Error::from)?;
+                        {
+                            Ok(file) => file,
+                            Err(e) => {
+                                let is_not_found = matches!(
+                                    &e,
+                                    lance_core::Error::NotFound { .. }
+                                ) || e.to_string().contains("not found");
+                                if !is_not_found {
+                                    return Err(Error::from(e));
+                                }
+                                let files = index_store
+                                    .list_files_with_sizes()
+                                    .await
+                                    .map_err(Error::from)?;
+                                let part_files: Vec<_> = files
+                                    .iter()
+                                    .filter_map(|f| {
+                                        (f.path.starts_with("part_")
+                                            && f.path.ends_with("_zonemap.lance"))
+                                        .then_some(f.path.as_str())
+                                    })
+                                    .collect();
+                                if part_files.len() != 1 {
+                                    return Err(Error::from(e));
+                                }
+                                index_store
+                                    .open_index_file(part_files[0])
+                                    .await
+                                    .map_err(Error::from)?
+                            }
+                        };
                         if index_file.num_rows() == 0 {
                             continue;
                         }

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4003,7 +4003,7 @@ class LanceDataset(pa.dataset.Dataset):
         This method does NOT commit changes.
 
         This API merges temporary scalar index files (for example per-fragment
-        BTree or inverted index outputs).
+        BTree, inverted, or zonemap index outputs).
         After this method returns, callers MUST explicitly commit
         the index manifest using lance.LanceDataset.commit(...)
         with a LanceOperation.CreateIndex.

--- a/python/python/lance/indices/__init__.py
+++ b/python/python/lance/indices/__init__.py
@@ -34,6 +34,7 @@ class SupportedDistributedIndices(str, Enum):
     BTREE = "BTREE"
     BITMAP = "BITMAP"
     INVERTED = "INVERTED"
+    ZONEMAP = "ZONEMAP"
 
     # Precise vector index types supported by distributed merge
     IVF_FLAT = "IVF_FLAT"

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -45,9 +45,20 @@ use lance_core::Result;
 use roaring::RoaringBitmap;
 
 use super::zoned::{ZoneBound, ZoneProcessor, ZoneTrainer, rebuild_zones, search_zones};
+use crate::progress::IndexBuildProgress;
+use futures::StreamExt;
+use lance_io::object_store::ObjectStore;
+use object_store::path::Path;
+
 const ROWS_PER_ZONE_DEFAULT: u64 = 8192; // 1 zone every two batches
 
-const ZONEMAP_FILENAME: &str = "zonemap.lance";
+pub const ZONEMAP_FILENAME: &str = "zonemap.lance";
+/// Prefix used for per-worker partial files written during distributed
+/// zone-map index construction. Files have the form
+/// `part_<worker_id>_zonemap.lance` and are merged into the final
+/// `zonemap.lance` by [`merge_index_files`].
+pub const ZONEMAP_PART_FILE_PREFIX: &str = "part_";
+pub const ZONEMAP_PART_FILE_SUFFIX: &str = "_zonemap.lance";
 const ZONEMAP_SIZE_META_KEY: &str = "rows_per_zone";
 const ZONEMAP_INDEX_VERSION: u32 = 0;
 
@@ -733,6 +744,17 @@ impl ZoneMapIndexBuilder {
     }
 
     pub async fn write_index(self, index_store: &dyn IndexStore) -> Result<()> {
+        self.write_index_to(index_store, ZONEMAP_FILENAME).await
+    }
+
+    /// Write the zone-map record batch to a specific file name. Used by the
+    /// distributed build path where each worker writes a `part_<id>_zonemap.lance`
+    /// file that is later merged by [`merge_index_files`].
+    pub async fn write_index_to(
+        self,
+        index_store: &dyn IndexStore,
+        file_name: &str,
+    ) -> Result<()> {
         let record_batch = self.zonemap_stats_as_batch()?;
 
         let mut file_schema = record_batch.schema().as_ref().clone();
@@ -742,7 +764,7 @@ impl ZoneMapIndexBuilder {
         );
 
         let mut index_file = index_store
-            .new_index_file(ZONEMAP_FILENAME, Arc::new(file_schema))
+            .new_index_file(file_name, Arc::new(file_schema))
             .await?;
         index_file.write_record_batch(record_batch).await?;
         index_file.finish().await?;
@@ -835,19 +857,32 @@ impl ZoneProcessor for ZoneMapProcessor {
 pub struct ZoneMapIndexPlugin;
 
 impl ZoneMapIndexPlugin {
+    #[cfg(test)]
+    #[allow(dead_code)]
     async fn train_zonemap_index(
         batches_source: SendableRecordBatchStream,
         index_store: &dyn IndexStore,
         options: Option<ZoneMapIndexBuilderParams>,
     ) -> Result<()> {
-        // train_zonemap_index: calling scan_aligned_chunks
+        Self::train_zonemap_index_to(batches_source, index_store, options, ZONEMAP_FILENAME).await
+    }
+
+    /// Train the zone-map index and write it to the given file name.
+    /// Used by both the standalone path (writing `zonemap.lance`) and the
+    /// distributed build path (writing `part_<id>_zonemap.lance`).
+    async fn train_zonemap_index_to(
+        batches_source: SendableRecordBatchStream,
+        index_store: &dyn IndexStore,
+        options: Option<ZoneMapIndexBuilderParams>,
+        file_name: &str,
+    ) -> Result<()> {
         let value_type = batches_source.schema().field(0).data_type().clone();
 
         let mut builder = ZoneMapIndexBuilder::try_new(options.unwrap_or_default(), value_type)?;
 
         builder.train(batches_source).await?;
 
-        builder.write_index(index_store).await?;
+        builder.write_index_to(index_store, file_name).await?;
         Ok(())
     }
 }
@@ -922,7 +957,7 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
         data: SendableRecordBatchStream,
         index_store: &dyn IndexStore,
         request: Box<dyn TrainingRequest>,
-        _fragment_ids: Option<Vec<u32>>,
+        fragment_ids: Option<Vec<u32>>,
         _progress: Arc<dyn crate::progress::IndexBuildProgress>,
     ) -> Result<CreatedIndex> {
         let request = (request as Box<dyn std::any::Any>)
@@ -932,7 +967,19 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
                     "must provide training request created by new_training_request".into(),
                 )
             })?;
-        Self::train_zonemap_index(data, index_store, Some(request.params)).await?;
+        let file_name = match fragment_ids.as_deref() {
+            // Distributed build: each worker writes a per-worker file. We use the
+            // smallest fragment id in the worker's assignment to name the file.
+            // ZoneTrainer already partitions zones strictly by fragment_id, so
+            // worker files never share zones across the same fragment_id and the
+            // final merge step is a pure concatenation.
+            Some(ids) if !ids.is_empty() => {
+                let worker_id = ids.iter().copied().min().expect("non-empty fragment_ids");
+                zonemap_part_file_name(worker_id)
+            }
+            _ => ZONEMAP_FILENAME.to_string(),
+        };
+        Self::train_zonemap_index_to(data, index_store, Some(request.params), &file_name).await?;
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails::default())
                 .unwrap(),
@@ -950,6 +997,139 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
     ) -> Result<Arc<dyn ScalarIndex>> {
         Ok(ZoneMapIndex::load(index_store, frag_reuse_index, cache).await? as Arc<dyn ScalarIndex>)
     }
+}
+
+fn zonemap_part_file_name(worker_id: u32) -> String {
+    format!("{ZONEMAP_PART_FILE_PREFIX}{worker_id}{ZONEMAP_PART_FILE_SUFFIX}")
+}
+
+/// List per-worker zonemap part files written during distributed builds.
+async fn list_zonemap_part_files(
+    object_store: &ObjectStore,
+    index_dir: &Path,
+) -> Result<Vec<String>> {
+    let mut part_files = Vec::new();
+    let mut list_stream = object_store.list(Some(index_dir.clone()));
+    while let Some(item) = list_stream.next().await {
+        match item {
+            Ok(meta) => {
+                let file_name = meta.location.filename().unwrap_or_default();
+                if file_name.starts_with(ZONEMAP_PART_FILE_PREFIX)
+                    && file_name.ends_with(ZONEMAP_PART_FILE_SUFFIX)
+                {
+                    part_files.push(file_name.to_string());
+                }
+            }
+            Err(err) => {
+                return Err(Error::io(format!(
+                    "Failed to list zonemap part files in {}: {err}",
+                    index_dir
+                )));
+            }
+        }
+    }
+    if part_files.is_empty() {
+        return Err(Error::invalid_input(format!(
+            "No zonemap part files found in index directory: {}; \
+             call build_index for each fragment group before calling merge_index_metadata",
+            index_dir
+        )));
+    }
+    // Stable order (by worker id) so the merged output is deterministic.
+    // Sort numerically by the worker_id embedded in the filename, not
+    // lexicographically, so that part_10_* comes after part_2_*.
+    part_files.sort_by_key(|name| {
+        name.strip_prefix(ZONEMAP_PART_FILE_PREFIX)
+            .and_then(|s| s.strip_suffix(ZONEMAP_PART_FILE_SUFFIX))
+            .and_then(|id| id.parse::<u32>().ok())
+            .unwrap_or(u32::MAX)
+    });
+    Ok(part_files)
+}
+
+/// Merge per-worker zonemap part files into a single `zonemap.lance`.
+///
+/// Each worker writes a `part_<worker_id>_zonemap.lance` containing zones for
+/// its assigned fragments. Because zones are independent and never span
+/// fragments, the merge is a pure concatenation of record batches with no
+/// sorting, deduplication, or rewrite of zone payloads.
+pub async fn merge_index_files(
+    object_store: &ObjectStore,
+    index_dir: &Path,
+    store: Arc<dyn IndexStore>,
+    progress: Arc<dyn IndexBuildProgress>,
+) -> Result<()> {
+    progress
+        .stage_start("scan_zonemap_parts", None, "files")
+        .await?;
+    let part_files = list_zonemap_part_files(object_store, index_dir).await?;
+    progress
+        .stage_progress("scan_zonemap_parts", part_files.len() as u64)
+        .await?;
+    progress.stage_complete("scan_zonemap_parts").await?;
+
+    progress
+        .stage_start(
+            "concat_zonemap_parts",
+            Some(part_files.len() as u64),
+            "files",
+        )
+        .await?;
+
+    // Read the first part to recover the arrow schema (including the
+    // ZONEMAP_SIZE_META_KEY metadata) for the merged output. Subsequent parts
+    // are appended in order.
+    let first_reader = store.open_index_file(&part_files[0]).await?;
+    let first_num_rows = first_reader.num_rows();
+    let first_batch = first_reader.read_range(0..first_num_rows, None).await?;
+    let merged_schema = first_batch.schema();
+    let mut writer = store
+        .new_index_file(ZONEMAP_FILENAME, merged_schema)
+        .await?;
+    if first_num_rows > 0 {
+        writer.write_record_batch(first_batch).await?;
+    }
+    progress
+        .stage_progress("concat_zonemap_parts", 1)
+        .await?;
+
+    for (idx, file_name) in part_files.iter().enumerate().skip(1) {
+        let reader = store.open_index_file(file_name).await?;
+        let num_rows = reader.num_rows();
+        if num_rows > 0 {
+            let batch = reader.read_range(0..num_rows, None).await?;
+            writer.write_record_batch(batch).await?;
+        }
+        progress
+            .stage_progress("concat_zonemap_parts", (idx + 1) as u64)
+            .await?;
+    }
+    writer.finish().await?;
+    progress.stage_complete("concat_zonemap_parts").await?;
+
+    progress
+        .stage_start(
+            "cleanup_zonemap_parts",
+            Some(part_files.len() as u64),
+            "files",
+        )
+        .await?;
+    for (idx, file_name) in part_files.iter().enumerate() {
+        if let Err(error) = store.delete_index_file(file_name).await {
+            tracing::warn!(
+                "Failed to delete zonemap part file '{}': {}. \
+                 This does not affect the merged zonemap index, but the part file \
+                 may need manual cleanup.",
+                file_name,
+                error
+            );
+        }
+        progress
+            .stage_progress("cleanup_zonemap_parts", (idx + 1) as u64)
+            .await?;
+    }
+    progress.stage_complete("cleanup_zonemap_parts").await?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -750,11 +750,7 @@ impl ZoneMapIndexBuilder {
     /// Write the zone-map record batch to a specific file name. Used by the
     /// distributed build path where each worker writes a `part_<id>_zonemap.lance`
     /// file that is later merged by [`merge_index_files`].
-    pub async fn write_index_to(
-        self,
-        index_store: &dyn IndexStore,
-        file_name: &str,
-    ) -> Result<()> {
+    pub async fn write_index_to(self, index_store: &dyn IndexStore, file_name: &str) -> Result<()> {
         let record_batch = self.zonemap_stats_as_batch()?;
 
         let mut file_schema = record_batch.schema().as_ref().clone();
@@ -1089,9 +1085,7 @@ pub async fn merge_index_files(
     if first_num_rows > 0 {
         writer.write_record_batch(first_batch).await?;
     }
-    progress
-        .stage_progress("concat_zonemap_parts", 1)
-        .await?;
+    progress.stage_progress("concat_zonemap_parts", 1).await?;
 
     for (idx, file_name) in part_files.iter().enumerate().skip(1) {
         let reader = store.open_index_file(file_name).await?;

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -59,7 +59,7 @@ pub const ZONEMAP_FILENAME: &str = "zonemap.lance";
 /// `zonemap.lance` by [`merge_index_files`].
 pub const ZONEMAP_PART_FILE_PREFIX: &str = "part_";
 pub const ZONEMAP_PART_FILE_SUFFIX: &str = "_zonemap.lance";
-const ZONEMAP_SIZE_META_KEY: &str = "rows_per_zone";
+pub const ZONEMAP_SIZE_META_KEY: &str = "rows_per_zone";
 const ZONEMAP_INDEX_VERSION: u32 = 0;
 
 /// Basic stats about zonemap index
@@ -974,15 +974,12 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
                 )
             })?;
         let file_name = match fragment_ids.as_deref() {
-            // Distributed build: each worker writes a per-worker file. We use the
-            // smallest fragment id in the worker's assignment to name the file.
-            // ZoneTrainer already partitions zones strictly by fragment_id, so
-            // worker files never share zones across the same fragment_id and the
-            // final merge step is a pure concatenation.
-            Some(ids) if !ids.is_empty() => {
-                let worker_id = ids.iter().copied().min().expect("non-empty fragment_ids");
-                zonemap_part_file_name(worker_id)
-            }
+            // Distributed build: each worker writes a per-worker file named
+            // after all its assigned fragment IDs (sorted, dash-separated).
+            // Encoding every fragment ID in the filename makes collisions
+            // impossible by construction, even if the orchestrator
+            // accidentally assigns overlapping fragments to two workers.
+            Some(ids) if !ids.is_empty() => zonemap_part_file_name(ids),
             _ => ZONEMAP_FILENAME.to_string(),
         };
         Self::train_zonemap_index_to(data, index_store, Some(request.params), &file_name).await?;
@@ -1005,8 +1002,15 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
     }
 }
 
-fn zonemap_part_file_name(worker_id: u32) -> String {
-    format!("{ZONEMAP_PART_FILE_PREFIX}{worker_id}{ZONEMAP_PART_FILE_SUFFIX}")
+fn zonemap_part_file_name(fragment_ids: &[u32]) -> String {
+    let mut sorted = fragment_ids.to_vec();
+    sorted.sort();
+    let id_str = sorted
+        .iter()
+        .map(|id| id.to_string())
+        .collect::<Vec<_>>()
+        .join("-");
+    format!("{ZONEMAP_PART_FILE_PREFIX}{id_str}{ZONEMAP_PART_FILE_SUFFIX}")
 }
 
 fn is_missing_zonemap_error(err: &Error) -> bool {
@@ -1070,13 +1074,14 @@ async fn list_zonemap_part_files(
             index_dir
         )));
     }
-    // Stable order (by worker id) so the merged output is deterministic.
-    // Sort numerically by the worker_id embedded in the filename, not
-    // lexicographically, so that part_10_* comes after part_2_*.
+    // Stable order so the merged output is deterministic.
+    // Sort numerically by the first fragment ID embedded in the filename,
+    // not lexicographically, so that part_10_* comes after part_2_*.
     part_files.sort_by_key(|name| {
         name.strip_prefix(ZONEMAP_PART_FILE_PREFIX)
             .and_then(|s| s.strip_suffix(ZONEMAP_PART_FILE_SUFFIX))
-            .and_then(|id| id.parse::<u32>().ok())
+            .and_then(|id| id.split('-').next())
+            .and_then(|first| first.parse::<u32>().ok())
             .unwrap_or(u32::MAX)
     });
     Ok(part_files)
@@ -1084,10 +1089,12 @@ async fn list_zonemap_part_files(
 
 /// Merge per-worker zonemap part files into a single `zonemap.lance`.
 ///
-/// Each worker writes a `part_<worker_id>_zonemap.lance` containing zones for
-/// its assigned fragments. Because zones are independent and never span
-/// fragments, the merge is a pure concatenation of record batches with no
-/// sorting, deduplication, or rewrite of zone payloads.
+/// Each worker writes a `part_<fragment_ids>_zonemap.lance` (where
+/// `<fragment_ids>` is the sorted, dash-separated list of assigned fragment
+/// IDs) containing zones for its assigned fragments. Because zones are
+/// independent and never span fragments, the merge is a pure concatenation
+/// of record batches with no sorting, deduplication, or rewrite of zone
+/// payloads.
 pub async fn merge_index_files(
     object_store: &ObjectStore,
     index_dir: &Path,
@@ -1111,15 +1118,21 @@ pub async fn merge_index_files(
         )
         .await?;
 
-    // Read the first part to recover the arrow schema (including the
-    // ZONEMAP_SIZE_META_KEY metadata) for the merged output. Subsequent parts
-    // are appended in order.
+    // Read the first part to recover the arrow schema for the merged output.
+    // The RecordBatch schema does not carry file-level metadata (such as
+    // ZONEMAP_SIZE_META_KEY), so we must copy it from the IndexReader schema
+    // into the batch schema before creating the merged file.
     let first_reader = store.open_index_file(&part_files[0]).await?;
     let first_num_rows = first_reader.num_rows();
     let first_batch = first_reader.read_range(0..first_num_rows, None).await?;
-    let merged_schema = first_batch.schema();
+    let mut merged_schema = first_batch.schema().as_ref().clone();
+    if let Some(rows_per_zone) = first_reader.schema().metadata.get(ZONEMAP_SIZE_META_KEY) {
+        merged_schema
+            .metadata
+            .insert(ZONEMAP_SIZE_META_KEY.to_string(), rows_per_zone.clone());
+    }
     let mut writer = store
-        .new_index_file(ZONEMAP_FILENAME, merged_schema)
+        .new_index_file(ZONEMAP_FILENAME, Arc::new(merged_schema))
         .await?;
     if first_num_rows > 0 {
         writer.write_record_batch(first_batch).await?;

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -48,7 +48,7 @@ use super::zoned::{ZoneBound, ZoneProcessor, ZoneTrainer, rebuild_zones, search_
 use crate::progress::IndexBuildProgress;
 use futures::StreamExt;
 use lance_io::object_store::ObjectStore;
-use object_store::path::Path;
+use object_store::{Error as ObjectStoreError, path::Path};
 
 const ROWS_PER_ZONE_DEFAULT: u64 = 8192; // 1 zone every two batches
 
@@ -396,7 +396,17 @@ impl ZoneMapIndex {
     where
         Self: Sized,
     {
-        let index_file = store.open_index_file(ZONEMAP_FILENAME).await?;
+        let index_file = match store.open_index_file(ZONEMAP_FILENAME).await {
+            Ok(file) => file,
+            Err(original_err) if is_missing_zonemap_error(&original_err) => {
+                let files = store.list_files_with_sizes().await?;
+                let Some(part_file) = find_single_zonemap_part_file(&files)? else {
+                    return Err(original_err);
+                };
+                store.open_index_file(part_file).await?
+            }
+            Err(other_err) => return Err(other_err),
+        };
         let zone_maps = index_file
             .read_range(0..index_file.num_rows(), None)
             .await?;
@@ -997,6 +1007,35 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
 
 fn zonemap_part_file_name(worker_id: u32) -> String {
     format!("{ZONEMAP_PART_FILE_PREFIX}{worker_id}{ZONEMAP_PART_FILE_SUFFIX}")
+}
+
+fn is_missing_zonemap_error(err: &Error) -> bool {
+    matches!(err, Error::NotFound { .. })
+        || matches!(
+            err,
+            Error::IO { source, .. }
+                if source
+                    .downcast_ref::<ObjectStoreError>()
+                    .map(|os_err| matches!(os_err, ObjectStoreError::NotFound { .. }))
+                    .unwrap_or(false)
+        )
+}
+
+fn find_single_zonemap_part_file(files: &[lance_table::format::IndexFile]) -> Result<Option<&str>> {
+    let part_files: Vec<_> = files
+        .iter()
+        .filter_map(|file| {
+            (file.path.starts_with(ZONEMAP_PART_FILE_PREFIX)
+                && file.path.ends_with(ZONEMAP_PART_FILE_SUFFIX))
+            .then_some(file.path.as_str())
+        })
+        .collect();
+
+    if part_files.len() == 1 {
+        Ok(Some(part_files[0]))
+    } else {
+        Ok(None)
+    }
 }
 
 /// List per-worker zonemap part files written during distributed builds.

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3072,6 +3072,15 @@ impl Dataset {
                 )
                 .await
             }
+            IndexType::ZoneMap => {
+                lance_index::scalar::zonemap::merge_index_files(
+                    self.object_store.as_ref(),
+                    &index_dir,
+                    Arc::new(store),
+                    progress,
+                )
+                .await
+            }
             IndexType::IvfFlat | IndexType::IvfPq | IndexType::IvfSq | IndexType::Vector => {
                 Err(Error::invalid_input(
                     "Vector distributed indexing no longer supports merge_index_metadata; \

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -1520,9 +1520,7 @@ mod tests {
     #[tokio::test]
     async fn test_distributed_build_zonemap() {
         use datafusion::common::ScalarValue;
-        use lance_index::scalar::{
-            SargableQuery, SearchResult, zonemap::ZONEMAP_FILENAME,
-        };
+        use lance_index::scalar::{SargableQuery, SearchResult, zonemap::ZONEMAP_FILENAME};
         use std::ops::Bound;
 
         let tmpdir = TempStrDir::default();
@@ -1563,8 +1561,7 @@ mod tests {
         .await
         .unwrap();
 
-        let params =
-            ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::ZoneMap);
+        let params = ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::ZoneMap);
         let fragments = dataset.get_fragments();
         let fragment_ids: Vec<u32> = fragments.iter().map(|f| f.id() as u32).collect();
         assert!(fragment_ids.len() >= 2);
@@ -1651,14 +1648,10 @@ mod tests {
         // Open the merged zonemap and exercise pruning. Range [150, 250] only
         // overlaps fragment 1 (100..115) and fragment 2 (200..215), so the
         // returned mask should be a strict subset of the dataset.
-        let scalar_index = crate::index::scalar::open_scalar_index(
-            &dataset,
-            "id",
-            index,
-            &NoOpMetricsCollector,
-        )
-        .await
-        .unwrap();
+        let scalar_index =
+            crate::index::scalar::open_scalar_index(&dataset, "id", index, &NoOpMetricsCollector)
+                .await
+                .unwrap();
         assert_eq!(scalar_index.index_type(), IndexType::ZoneMap);
 
         let result = scalar_index

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -1645,7 +1645,7 @@ mod tests {
             "committed zonemap index should only reference merged files"
         );
 
-        // Open the merged zonemap and exercise pruning. Range [150, 250] only
+        // Open the merged zonemap and exercise pruning. Range [110, 210]
         // overlaps fragment 1 (100..115) and fragment 2 (200..215), so the
         // returned mask should be a strict subset of the dataset.
         let scalar_index =
@@ -1657,8 +1657,8 @@ mod tests {
         let result = scalar_index
             .search(
                 &SargableQuery::Range(
-                    Bound::Included(ScalarValue::Int32(Some(150))),
-                    Bound::Included(ScalarValue::Int32(Some(250))),
+                    Bound::Included(ScalarValue::Int32(Some(110))),
+                    Bound::Included(ScalarValue::Int32(Some(210))),
                 ),
                 &NoOpMetricsCollector,
             )
@@ -1670,16 +1670,132 @@ mod tests {
                 let kept = mask.len().unwrap_or(total_rows);
                 assert!(
                     kept < total_rows,
-                    "zonemap should prune at least one zone for the [150, 250] range, \
+                    "zonemap should prune at least one zone for the [110, 210] range, \
                      got kept={kept} total={total_rows}"
                 );
                 assert!(
                     kept > 0,
-                    "zonemap should keep the zones overlapping [150, 250]"
+                    "zonemap should keep the zones overlapping [110, 210]"
                 );
             }
             SearchResult::AtLeast(_) => panic!("zonemap unexpectedly produced AtLeast result"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_distributed_build_zonemap_custom_rows_per_zone() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let batches = (0..4)
+            .map(
+                |fragment_id| -> std::result::Result<_, arrow_schema::ArrowError> {
+                    let base = fragment_id * 100;
+                    let values: Vec<i32> = (0..16).map(|i| base + i).collect();
+                    Ok(RecordBatch::try_new(
+                        schema.clone(),
+                        vec![Arc::new(Int32Array::from(values))],
+                    )
+                    .unwrap())
+                },
+            )
+            .collect::<Vec<_>>();
+        let reader = RecordBatchIterator::new(batches.into_iter(), schema);
+
+        let mut dataset = Dataset::write(
+            reader,
+            &dataset_uri,
+            Some(WriteParams {
+                max_rows_per_file: 16,
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let custom_rows_per_zone = 4u64;
+        let params = ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::ZoneMap)
+            .with_params(&lance_index::scalar::zonemap::ZoneMapIndexBuilderParams::new(
+                custom_rows_per_zone,
+            ));
+        let fragments = dataset.get_fragments();
+        let fragment_ids: Vec<u32> = fragments.iter().map(|f| f.id() as u32).collect();
+        let shared_uuid = Uuid::new_v4().to_string();
+        let mut shard_metadata = None;
+
+        for &fragment_id in &fragment_ids {
+            let index_metadata =
+                CreateIndexBuilder::new(&mut dataset, &["id"], IndexType::ZoneMap, &params)
+                    .name("distributed_zonemap_custom".to_string())
+                    .fragments(vec![fragment_id])
+                    .index_uuid(shared_uuid.clone())
+                    .execute_uncommitted()
+                    .await
+                    .unwrap();
+            if shard_metadata.is_none() {
+                shard_metadata = Some(index_metadata);
+            }
+        }
+
+        dataset
+            .merge_index_metadata(
+                &shared_uuid,
+                IndexType::ZoneMap,
+                None,
+                Arc::new(NoopIndexBuildProgress),
+            )
+            .await
+            .unwrap();
+
+        let mut committed_index_metadata = shard_metadata.unwrap();
+        committed_index_metadata.fragment_bitmap = Some(fragment_ids.iter().copied().collect());
+        committed_index_metadata.files = Some(
+            list_index_files_with_sizes(
+                dataset.object_store.as_ref(),
+                &dataset.indices_dir().clone().join(shared_uuid.clone()),
+            )
+            .await
+            .unwrap(),
+        );
+        committed_index_metadata.dataset_version = dataset.manifest.version;
+
+        let transaction = TransactionBuilder::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![committed_index_metadata],
+                removed_indices: vec![],
+            },
+        )
+        .build();
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+
+        let dataset = Dataset::open(&dataset_uri).await.unwrap();
+        let indices = dataset
+            .load_indices_by_name("distributed_zonemap_custom")
+            .await
+            .unwrap();
+        let index = &indices[0];
+
+        let scalar_index =
+            crate::index::scalar::open_scalar_index(&dataset, "id", index, &NoOpMetricsCollector)
+                .await
+                .unwrap();
+
+        let stats = scalar_index.statistics().unwrap();
+        let loaded_rows_per_zone = stats["rows_per_zone"].as_u64().unwrap();
+        assert_eq!(
+            loaded_rows_per_zone, custom_rows_per_zone,
+            "merged zonemap should preserve custom rows_per_zone metadata"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -1518,6 +1518,178 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_distributed_build_zonemap() {
+        use datafusion::common::ScalarValue;
+        use lance_index::scalar::{
+            SargableQuery, SearchResult, zonemap::ZONEMAP_FILENAME,
+        };
+        use std::ops::Bound;
+
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+
+        // Four fragments, 16 rows each. Values are distinct per fragment so that
+        // each fragment's zone(s) cover a non-overlapping numeric range, which
+        // makes zone pruning easy to assert.
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let batches = (0..4)
+            .map(
+                |fragment_id| -> std::result::Result<_, arrow_schema::ArrowError> {
+                    let base = fragment_id * 100;
+                    let values: Vec<i32> = (0..16).map(|i| base + i).collect();
+                    Ok(RecordBatch::try_new(
+                        schema.clone(),
+                        vec![Arc::new(Int32Array::from(values))],
+                    )
+                    .unwrap())
+                },
+            )
+            .collect::<Vec<_>>();
+        let reader = RecordBatchIterator::new(batches.into_iter(), schema);
+
+        let mut dataset = Dataset::write(
+            reader,
+            &dataset_uri,
+            Some(WriteParams {
+                max_rows_per_file: 16,
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let params =
+            ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::ZoneMap);
+        let fragments = dataset.get_fragments();
+        let fragment_ids: Vec<u32> = fragments.iter().map(|f| f.id() as u32).collect();
+        assert!(fragment_ids.len() >= 2);
+        let shared_uuid = Uuid::new_v4().to_string();
+        let mut shard_metadata = None;
+
+        // Build one per-fragment zonemap shard. Each worker writes a
+        // `part_<frag_id>_zonemap.lance` file under the shared index directory.
+        for &fragment_id in &fragment_ids {
+            let index_metadata =
+                CreateIndexBuilder::new(&mut dataset, &["id"], IndexType::ZoneMap, &params)
+                    .name("distributed_zonemap".to_string())
+                    .fragments(vec![fragment_id])
+                    .index_uuid(shared_uuid.clone())
+                    .execute_uncommitted()
+                    .await
+                    .unwrap();
+            if shard_metadata.is_none() {
+                shard_metadata = Some(index_metadata);
+            }
+        }
+
+        // Concatenate the per-worker part files into the final zonemap.lance.
+        dataset
+            .merge_index_metadata(
+                &shared_uuid,
+                IndexType::ZoneMap,
+                None,
+                Arc::new(NoopIndexBuildProgress),
+            )
+            .await
+            .unwrap();
+
+        let mut committed_index_metadata = shard_metadata.unwrap();
+        committed_index_metadata.fragment_bitmap = Some(fragment_ids.iter().copied().collect());
+        committed_index_metadata.files = Some(
+            list_index_files_with_sizes(
+                dataset.object_store.as_ref(),
+                &dataset.indices_dir().clone().join(shared_uuid.clone()),
+            )
+            .await
+            .unwrap(),
+        );
+        committed_index_metadata.dataset_version = dataset.manifest.version;
+
+        let transaction = TransactionBuilder::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![committed_index_metadata],
+                removed_indices: vec![],
+            },
+        )
+        .build();
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+
+        // Re-open and verify only the merged zonemap.lance is referenced and that
+        // the part files have been cleaned up.
+        let dataset = Dataset::open(&dataset_uri).await.unwrap();
+        let indices = dataset
+            .load_indices_by_name("distributed_zonemap")
+            .await
+            .unwrap();
+        assert_eq!(indices.len(), 1);
+        let index = &indices[0];
+        assert_eq!(
+            index
+                .fragment_bitmap
+                .as_ref()
+                .unwrap()
+                .iter()
+                .collect::<Vec<_>>(),
+            fragment_ids
+        );
+        let files = index.files.as_ref().unwrap();
+        assert!(files.iter().any(|file| file.path == ZONEMAP_FILENAME));
+        assert!(
+            files.iter().all(|file| !file.path.starts_with("part_")),
+            "committed zonemap index should only reference merged files"
+        );
+
+        // Open the merged zonemap and exercise pruning. Range [150, 250] only
+        // overlaps fragment 1 (100..115) and fragment 2 (200..215), so the
+        // returned mask should be a strict subset of the dataset.
+        let scalar_index = crate::index::scalar::open_scalar_index(
+            &dataset,
+            "id",
+            index,
+            &NoOpMetricsCollector,
+        )
+        .await
+        .unwrap();
+        assert_eq!(scalar_index.index_type(), IndexType::ZoneMap);
+
+        let result = scalar_index
+            .search(
+                &SargableQuery::Range(
+                    Bound::Included(ScalarValue::Int32(Some(150))),
+                    Bound::Included(ScalarValue::Int32(Some(250))),
+                ),
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        match result {
+            SearchResult::AtMost(mask) | SearchResult::Exact(mask) => {
+                let total_rows = dataset.count_rows(None).await.unwrap() as u64;
+                let kept = mask.len().unwrap_or(total_rows);
+                assert!(
+                    kept < total_rows,
+                    "zonemap should prune at least one zone for the [150, 250] range, \
+                     got kept={kept} total={total_rows}"
+                );
+                assert!(
+                    kept > 0,
+                    "zonemap should keep the zones overlapping [150, 250]"
+                );
+            }
+            SearchResult::AtLeast(_) => panic!("zonemap unexpectedly produced AtLeast result"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_vector_execute_uncommitted_segments_commit_without_staging() {
         let tmpdir = TempStrDir::default();
         let dataset_uri = format!("file://{}", tmpdir.as_str());

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -1721,9 +1721,9 @@ mod tests {
 
         let custom_rows_per_zone = 4u64;
         let params = ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::ZoneMap)
-            .with_params(&lance_index::scalar::zonemap::ZoneMapIndexBuilderParams::new(
-                custom_rows_per_zone,
-            ));
+            .with_params(
+                &lance_index::scalar::zonemap::ZoneMapIndexBuilderParams::new(custom_rows_per_zone),
+            );
         let fragments = dataset.get_fragments();
         let fragment_ids: Vec<u32> = fragments.iter().map(|f| f.id() as u32).collect();
         let shared_uuid = Uuid::new_v4().to_string();


### PR DESCRIPTION
- Add distributed build path: each worker writes a per-fragment part_<id>_zonemap.lance file, later merged into zonemap.lance
- Add merge_index_files() for concatenating part files with progress tracking and cleanup
- Wire ZoneMap into Dataset::merge_index_metadata dispatch
- Register ZONEMAP in Python SupportedDistributedIndices enum
- Add write_index_to() to ZoneMapIndexBuilder for custom file names
- Add integration test test_distributed_build_zonemap
- Fix part file sorting to use numeric worker_id order instead of lexicographic order (prevents wrong merge order with 10+ fragments)