### PR TITLE
chore: regenerate third party license documents

### DIFF
--- a/RUST_THIRD_PARTY_LICENSES.html
+++ b/RUST_THIRD_PARTY_LICENSES.html
@@ -44,16 +44,16 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (565)</li>
-            <li><a href="#MIT">MIT License</a> (153)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (615)</li>
+            <li><a href="#MIT">MIT License</a> (157)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
-            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (8)</li>
-            <li><a href="#ISC">ISC License</a> (6)</li>
-            <li><a href="#Zlib">zlib License</a> (3)</li>
+            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (9)</li>
+            <li><a href="#ISC">ISC License</a> (8)</li>
+            <li><a href="#Zlib">zlib License</a> (7)</li>
+            <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (3)</li>
+            <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a> (3)</li>
+            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (3)</li>
             <li><a href="#0BSD">BSD Zero Clause License</a> (2)</li>
-            <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a> (2)</li>
-            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (2)</li>
-            <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (1)</li>
             <li><a href="#BSL-1.0">Boost Software License 1.0</a> (1)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
             <li><a href="#CDDL-1.0">Common Development and Distribution License 1.0</a> (1)</li>
@@ -99,216 +99,6 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
 AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.0</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2023 Jacob Pratt
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
 </pre>
             </li>
             <li class="license">
@@ -525,7 +315,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.5.5</a></li>
+                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.5.8</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -735,28 +525,240 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-arith 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-array 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-buffer 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-cast 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-csv 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-data 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ipc 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-json 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ord 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-row 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-schema 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-select 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-string 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow 57.2.0</a></li>
+                    <li><a href=" https://github.com/oxidecomputer/serde_tokenstream ">serde_tokenstream 0.2.3</a></li>
+                </ul>
+                <pre class="license-text">
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-arith 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-array 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-buffer 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-cast 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-csv 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-data 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ipc 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-json 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ord 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-row 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-schema 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-select 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-string 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow 58.3.0</a></li>
                     <li><a href=" https://github.com/tormol/encode_unicode ">encode_unicode 1.0.0</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
-                    <li><a href=" https://github.com/mitsuhiko/fragile ">fragile 2.0.1</a></li>
-                    <li><a href=" https://github.com/lo48576/iri-string ">iri-string 0.7.10</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">parquet 57.2.0</a></li>
-                    <li><a href=" https://github.com/Stoeoef/spade ">spade 2.15.0</a></li>
+                    <li><a href=" https://github.com/mitsuhiko/fragile ">fragile 2.1.0</a></li>
+                    <li><a href=" https://github.com/thomcc/rust-more-asserts ">more-asserts 0.3.1</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">parquet 58.3.0</a></li>
+                    <li><a href=" https://github.com/Stoeoef/spade ">spade 2.15.1</a></li>
+                    <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
+                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.11.0</a></li>
                     <li><a href=" https://github.com/hsivonen/utf8_iter ">utf8_iter 1.0.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">zeroize 1.8.2</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize/derive ">zeroize_derive 1.4.3</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1177,7 +1179,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apache/arrow-rs-object-store ">object_store 0.12.5</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs-object-store ">object_store 0.13.2</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1389,34 +1391,38 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog-listing 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common-runtime 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-arrow 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-csv 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-json 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-doc 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-execution 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-nested 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-table 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-macros 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-optimizer 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-optimizer 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-plan 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-session 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-sql 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion 51.0.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog-listing 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common-runtime 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-arrow 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-csv 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-json 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-parquet 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-doc 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-execution 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-nested 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-table 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-macros 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-optimizer 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-adapter 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-optimizer 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-plan 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-pruning 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-session 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-sql 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-substrait 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion 53.1.0</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1637,9 +1643,7 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/la10736/rstest ">rstest 0.23.0</a></li>
-                    <li><a href=" https://github.com/la10736/rstest ">rstest 0.26.1</a></li>
                     <li><a href=" https://github.com/la10736/rstest ">rstest_macros 0.23.0</a></li>
-                    <li><a href=" https://github.com/la10736/rstest ">rstest_macros 0.26.1</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -2258,42 +2262,236 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/wvwwvwwv/scalable-delayed-dealloc/ ">sdd 3.0.10</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, April 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024-present Changgyoo Park
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-collections 0.3.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.62.2</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-future 0.3.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-implement 0.60.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-interface 0.59.3</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.2.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-numerics 0.3.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-registry 0.6.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.4.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.5.1</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.48.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.59.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.60.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.61.2</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.48.5</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.53.5</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.48.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-threading 0.2.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.62.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.53.1</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.48.5</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.53.1</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.48.5</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.53.1</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.48.5</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.53.1</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.48.5</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.53.1</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.48.5</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.53.1</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.48.5</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.52.6</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.53.1</a></li>
                 </ul>
@@ -2504,7 +2702,7 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/akhilles/crc-catalog.git ">crc-catalog 2.4.0</a></li>
+                    <li><a href=" https://github.com/akhilles/crc-catalog.git ">crc-catalog 2.5.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3132,7 +3330,7 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/moka-rs/moka ">moka 0.12.13</a></li>
+                    <li><a href=" https://github.com/moka-rs/moka ">moka 0.12.15</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3322,7 +3520,7 @@ License: http://www.apache.org/licenses/LICENSE-2.0
       same &quot;printed page&quot; as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 - 2025 Tatsuya Kawano
+   Copyright 2020 - 2026 Tatsuya Kawano
 
    Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
    you may not use this file except in compliance with the License.
@@ -3341,8 +3539,217 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/Soveu/tinyvec_macros ">tinyvec_macros 0.1.1</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Tomasz &quot;Soveu&quot; Marx
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/Xuanwo/backon ">backon 1.6.0</a></li>
-                    <li><a href=" https://github.com/Xuanwo/reqsign ">reqsign 0.16.5</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3550,8 +3957,8 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.38</a></li>
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.38</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.48</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.48</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3970,222 +4377,22 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mheffner/rust-sketches-ddsketch ">sketches-ddsketch 0.3.0</a></li>
-                </ul>
-                <pre class="license-text">                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [2019] [Mike Heffner]
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/enarx/ciborium ">ciborium-io 0.2.2</a></li>
                     <li><a href=" https://github.com/enarx/ciborium ">ciborium-ll 0.2.2</a></li>
                     <li><a href=" https://github.com/enarx/ciborium ">ciborium 0.2.2</a></li>
                     <li><a href=" https://github.com/awesomized/crc-fast-rust ">crc-fast 1.9.0</a></li>
                     <li><a href=" https://github.com/Narsil/esaxx-rs ">esaxx-rs 0.1.10</a></li>
-                    <li><a href=" https://github.com/databendlabs/jsonb ">jsonb 0.5.5</a></li>
-                    <li><a href=" https://github.com/apache/opendal ">opendal 0.55.0</a></li>
+                    <li><a href=" https://github.com/databendlabs/jsonb ">jsonb 0.5.6</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal 0.56.0</a></li>
+                    <li><a href=" https://github.com/cberner/redb ">redb 3.1.3</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-aliyun-oss 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-aws-v4 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-azure-storage 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-core 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-file-read-tokio 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-google 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-tencent-cos 3.0.0</a></li>
+                    <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.7.0</a></li>
                     <li><a href=" https://github.com/huggingface/spm_precompiled ">spm_precompiled 0.1.4</a></li>
                     <li><a href=" https://github.com/huggingface/tokenizers ">tokenizers 0.15.2</a></li>
                     <li><a href=" https://github.com/cameron1024/unarray ">unarray 0.1.4</a></li>
@@ -4398,7 +4605,216 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.11.0</a></li>
+                    <li><a href=" https://github.com/MSxDOS/ntapi ">ntapi 0.4.3</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   </pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.12.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -4819,9 +5235,6 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/utkarshkukreti/diff.rs ">diff 0.1.13</a></li>
-                    <li><a href=" https://github.com/assert-rs/predicates-rs/tree/master/crates/core ">predicates-core 1.0.9</a></li>
-                    <li><a href=" https://github.com/assert-rs/predicates-rs/tree/master/crates/tree ">predicates-tree 1.0.12</a></li>
-                    <li><a href=" https://github.com/assert-rs/predicates-rs ">predicates 3.1.3</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi 0.3.9</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -5031,37 +5444,42 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.21</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 1.0.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 1.0.0</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.57</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.57</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.5.55</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.7</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.14</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.1</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.0</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.6.1</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.1.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.5</a></li>
                     <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder 0.12.0</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder_core 0.12.0</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder_macro 0.12.0</a></li>
-                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.4</a></li>
-                    <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.8</a></li>
+                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 1.0.1</a></li>
+                    <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.10</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types-shared 0.1.1</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types 0.3.2</a></li>
+                    <li><a href=" https://github.com/srijs/rust-gearhash ">gearhash 0.1.3</a></li>
                     <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
                     <li><a href=" https://github.com/chronotope/humantime ">humantime 2.3.0</a></li>
                     <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.2</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-native-tls ">native-tls 0.2.14</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.4.1</a></li>
+                    <li><a href=" https://github.com/rust-native-tls/rust-native-tls ">native-tls 0.2.18</a></li>
                     <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
                     <li><a href=" https://crates.io/crates/openssl-macros ">openssl-macros 0.1.1</a></li>
-                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl 0.10.75</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl 0.10.80</a></li>
+                    <li><a href=" https://github.com/assert-rs/predicates-rs ">predicates-core 1.0.10</a></li>
+                    <li><a href=" https://github.com/assert-rs/predicates-rs ">predicates-tree 1.0.13</a></li>
+                    <li><a href=" https://github.com/assert-rs/predicates-rs ">predicates 3.1.4</a></li>
                     <li><a href=" https://github.com/rust-pretty-assertions/rust-pretty-assertions ">pretty_assertions 1.4.1</a></li>
                     <li><a href=" http://github.com/tailhook/quick-error ">quick-error 1.2.3</a></li>
                     <li><a href=" https://github.com/sfackler/rust-socks ">socks 0.3.4</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.7.5+spec-1.1.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.23.10+spec-1.0.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.6+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.1+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.11+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.2+spec-1.1.0</a></li>
                     <li><a href=" https://github.com/swgillespie/unicode-categories ">unicode_categories 0.1.1</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -5470,10 +5888,208 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 1.122.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.93.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.95.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.97.0</a></li>
+                    <li><a href=" https://github.com/wvwwvwwv/scalable-concurrent-containers/ ">scc 2.4.0</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2020-2024 Changgyoo Park
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-s3 1.124.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.95.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.97.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.99.0</a></li>
                 </ul>
                 <pre class="license-text">                                Apache License
                            Version 2.0, January 2004
@@ -6101,15 +6717,15 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.31</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.32</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6319,7 +6935,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.19.0</a></li>
+                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.20.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6528,6 +7144,7 @@ limitations under the License.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.12.28</a></li>
+                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.13.3</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7155,7 +7772,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/tokio-rustls ">tokio-rustls 0.24.1</a></li>
                     <li><a href=" https://github.com/rustls/tokio-rustls ">tokio-rustls 0.26.4</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -7783,216 +8399,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/RustCrypto/signatures/tree/master/ecdsa ">ecdsa 0.14.8</a></li>
-                    <li><a href=" https://github.com/RustCrypto/signatures/tree/master/rfc6979 ">rfc6979 0.3.1</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2018-2022 RustCrypto Developers
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/cryptocorrosion/cryptocorrosion ">ppv-lite86 0.2.21</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -8202,8 +8608,217 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/shepmaster/snafu ">snafu-derive 0.8.9</a></li>
-                    <li><a href=" https://github.com/shepmaster/snafu ">snafu 0.8.9</a></li>
+                    <li><a href=" https://github.com/tokio-rs/io-uring ">io-uring 0.7.12</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2019 quininer kel
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/shepmaster/snafu ">snafu-derive 0.9.0</a></li>
+                    <li><a href=" https://github.com/shepmaster/snafu ">snafu 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -8622,6 +9237,215 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/ridiculousfish/regress ">regress 0.10.5</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2020 ridiculous_fish
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/Alexhuszagh/fast-float-rust ">fast-float2 0.2.3</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -8831,7 +9655,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.0</a></li>
+                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9251,7 +10075,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.9</a></li>
+                    <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.10</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9671,9 +10495,10 @@ limitations under the License.</pre>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                     <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
-                    <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.1</a></li>
+                    <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.1</a></li>
                     <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                     <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.42</a></li>
                     <li><a href=" https://github.com/smol-rs/async-lock ">async-lock 3.4.2</a></li>
                     <li><a href=" https://github.com/smol-rs/atomic-waker ">atomic-waker 1.1.2</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
@@ -9681,19 +10506,24 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.13.1</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.10.0</a></li>
-                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.1</a></li>
+                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.1</a></li>
+                    <li><a href=" https://github.com/BurntSushi/bstr ">bstr 1.12.1</a></li>
+                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
                     <li><a href=" https://github.com/vorner/bytes-utils ">bytes-utils 0.1.4</a></li>
                     <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.55</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.62</a></li>
+                    <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if 0.1.10</a></li>
                     <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
+                    <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.58</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.38</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.32</a></li>
                     <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue 2.5.0</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random-macro 0.1.16</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random 0.1.18</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys 0.8.7</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.10.1</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.9.4</a></li>
-                    <li><a href=" https://github.com/gimli-rs/cpp_demangle ">cpp_demangle 0.5.1</a></li>
+                    <li><a href=" https://github.com/gimli-rs/cpp_demangle ">cpp_demangle 0.4.5</a></li>
                     <li><a href=" https://github.com/bheisler/criterion.rs ">criterion-plot 0.5.0</a></li>
                     <li><a href=" https://github.com/bheisler/criterion.rs ">criterion 0.5.1</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-channel 0.5.15</a></li>
@@ -9709,43 +10539,40 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener-strategy ">event-listener-strategy 0.5.4</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
-                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
+                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.4.1</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                     <li><a href=" https://github.com/gimli-rs/findshlibs ">findshlibs 0.10.2</a></li>
                     <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset 0.5.7</a></li>
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
-                    <li><a href=" https://github.com/al8n/fs4-rs ">fs4 0.8.4</a></li>
                     <li><a href=" https://github.com/async-rs/futures-timer ">futures-timer 3.0.3</a></li>
                     <li><a href=" https://github.com/georust/geohash.rs ">geohash 0.13.1</a></li>
                     <li><a href=" https://github.com/gimli-rs/gimli ">gimli 0.32.3</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.3</a></li>
-                    <li><a href=" https://github.com/zkcrypto/group ">group 0.12.1</a></li>
                     <li><a href=" https://github.com/japaric/hash32 ">hash32 0.3.1</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.14.5</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.17.1</a></li>
                     <li><a href=" https://github.com/rust-embedded/heapless ">heapless 0.8.0</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                     <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
-                    <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.24.2</a></li>
-                    <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.7</a></li>
+                    <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.9</a></li>
                     <li><a href=" https://github.com/hyperium/hyper-tls ">hyper-tls 0.6.0</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
-                    <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.1</a></li>
-                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.13.0</a></li>
+                    <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.2</a></li>
+                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.14.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.10.5</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.11.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.12.1</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.13.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
                     <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.34</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.85</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.98</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
-                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.11.0</a></li>
-                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
+                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
                     <li><a href=" https://github.com/alexcrichton/xz2-rs ">lzma-sys 0.1.20</a></li>
@@ -9763,16 +10590,15 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
                     <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
-                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
-                    <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe 0.1.6</a></li>
+                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.4</a></li>
                     <li><a href=" https://github.com/rustls/openssl-probe ">openssl-probe 0.2.1</a></li>
                     <li><a href=" https://github.com/smol-rs/parking ">parking 2.2.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.5</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.12</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
                     <li><a href=" https://github.com/petgraph/petgraph ">petgraph 0.8.3</a></li>
-                    <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.32</a></li>
-                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.10.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.33</a></li>
+                    <li><a href=" https://github.com/proptest-rs/proptest ">proptest 1.11.0</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-build 0.14.3</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-derive 0.14.3</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-types 0.14.3</a></li>
@@ -9780,61 +10606,64 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/bluss/rawpointer/ ">rawpointer 0.2.1</a></li>
                     <li><a href=" https://github.com/cuviper/rayon-cond ">rayon-cond 0.3.0</a></li>
                     <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
-                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.11.0</a></li>
+                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.12.0</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-lite 0.1.9</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.9</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.3</a></li>
                     <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
+                    <li><a href=" https://github.com/RoaringBitmap/roaring-rs ">roaring 0.11.4</a></li>
                     <li><a href=" https://github.com/georust/robust ">robust 1.2.0</a></li>
                     <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.27</a></li>
                     <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.3</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.4</a></li>
                     <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.3</a></li>
-                    <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.2.0</a></li>
-                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.21.12</a></li>
-                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.36</a></li>
+                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.40</a></li>
                     <li><a href=" https://github.com/altsysrq/rusty-fork ">rusty-fork 0.3.1</a></li>
                     <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
-                    <li><a href=" https://github.com/rustls/sct.rs ">sct 0.7.1</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.15.0</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 2.11.1</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.5.1</a></li>
-                    <li><a href=" https://gitlab.com/ijackson/rust-shellexpand ">shellexpand 3.1.1</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.20.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.20.0</a></li>
+                    <li><a href=" https://gitlab.com/ijackson/rust-shellexpand ">shellexpand 3.1.2</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
+                    <li><a href=" https://github.com/seancroach/simd_cesu8 ">simd_cesu8 1.1.1</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.10</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.2</a></li>
-                    <li><a href=" https://github.com/apache/datafusion-sqlparser-rs ">sqlparser 0.59.0</a></li>
-                    <li><a href=" https://github.com/sqlparser-rs/sqlparser-rs ">sqlparser_derive 0.3.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
+                    <li><a href=" https://github.com/apache/datafusion-sqlparser-rs ">sqlparser 0.61.0</a></li>
+                    <li><a href=" https://github.com/sqlparser-rs/sqlparser-rs ">sqlparser_derive 0.5.0</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
-                    <li><a href=" https://github.com/Stebalien/str_stack ">str_stack 0.1.0</a></li>
+                    <li><a href=" https://github.com/Stebalien/str_stack ">str_stack 0.1.1</a></li>
+                    <li><a href=" https://gitlab.com/chris-morgan/symlink ">symlink 0.1.0</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.109</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration-sys 0.6.0</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration 0.7.0</a></li>
-                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.24.0</a></li>
+                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.27.0</a></li>
                     <li><a href=" https://github.com/bluss/thread-tree ">thread-tree 0.3.3</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.9</a></li>
                     <li><a href=" https://github.com/bheisler/TinyTemplate ">tinytemplate 1.2.1</a></li>
                     <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.9.0</a></li>
                     <li><a href=" https://github.com/n1t0/unicode-normalization ">unicode-normalization-alignments 0.1.12</a></li>
-                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.12.0</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-normalization ">unicode-normalization 0.1.25</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.13.2</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.20.0</a></li>
+                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.1</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/alexcrichton/wait-timeout ">wait-timeout 0.2.1</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.58</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.85</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasi 0.14.7+wasi-0.2.4</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.3+wasi-0.2.9</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.71</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.98</a></li>
                     <li><a href=" https://github.com/LukeMathWalker/wiremock-rs ">wiremock 0.6.5</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.57.1</a></li>
                     <li><a href=" https://github.com/georust/wkb ">wkb 0.9.2</a></li>
                     <li><a href=" https://github.com/georust/wkt ">wkt 0.14.0</a></li>
                     <li><a href=" https://github.com/RazrFalcon/xmlparser ">xmlparser 0.13.6</a></li>
@@ -10046,219 +10875,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/zkcrypto/ff ">ff 0.12.1</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.8.0</a></li>
                     <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec 0.8.0</a></li>
-                    <li><a href=" https://github.com/marcianx/downcast-rs ">downcast-rs 2.0.2</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-core 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-parse-float 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-parse-integer 1.0.6</a></li>
@@ -10475,40 +11093,32 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/RustCrypto/block-ciphers ">aes 0.8.4</a></li>
-                    <li><a href=" https://github.com/RustCrypto/formats/tree/master/base16ct ">base16ct 0.1.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.10.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.3.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/block-modes ">cbc 0.1.2</a></li>
+                    <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.10.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">cipher 0.4.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/const-oid ">const-oid 0.9.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.17</a></li>
-                    <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.4.9</a></li>
-                    <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.5.5</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.3.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
-                    <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.6.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.7.10</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
-                    <li><a href=" https://github.com/RustCrypto/traits/tree/master/elliptic-curve ">elliptic-curve 0.12.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.12.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">inout 0.1.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">md-5 0.10.6</a></li>
-                    <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p256 ">p256 0.11.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2 ">pbkdf2 0.12.2</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/pem-rfc7468 ">pem-rfc7468 0.7.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/pkcs1 ">pkcs1 0.7.5</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/pkcs5 ">pkcs5 0.7.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/pkcs8 ">pkcs8 0.10.2</a></li>
-                    <li><a href=" https://github.com/RustCrypto/formats/tree/master/pkcs8 ">pkcs8 0.9.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/stream-ciphers ">salsa20 0.10.2</a></li>
                     <li><a href=" https://github.com/RustCrypto/password-hashes/tree/master/scrypt ">scrypt 0.11.0</a></li>
-                    <li><a href=" https://github.com/RustCrypto/formats/tree/master/sec1 ">sec1 0.3.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha1 0.10.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.10.9</a></li>
-                    <li><a href=" https://github.com/RustCrypto/traits/tree/master/signature ">signature 1.6.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits/tree/master/signature ">signature 2.2.0</a></li>
-                    <li><a href=" https://github.com/RustCrypto/formats/tree/master/spki ">spki 0.6.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/spki ">spki 0.7.3</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -10718,9 +11328,9 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-random/rand_core ">rand_core 0.10.1</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.5</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand_distr 0.4.3</a></li>
                     <li><a href=" https://github.com/rust-random/rand_distr ">rand_distr 0.5.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -10918,9 +11528,11 @@ APPENDIX: How to apply the Apache License to your work.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
+                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.2</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
-                    <li><a href=" https://github.com/d-e-s-o/test-log.git ">test-log-macros 0.2.19</a></li>
-                    <li><a href=" https://github.com/d-e-s-o/test-log.git ">test-log 0.2.19</a></li>
+                    <li><a href=" https://github.com/d-e-s-o/test-log.git ">test-log-core 0.2.20</a></li>
+                    <li><a href=" https://github.com/d-e-s-o/test-log.git ">test-log-macros 0.2.20</a></li>
+                    <li><a href=" https://github.com/d-e-s-o/test-log.git ">test-log 0.2.20</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -11129,8 +11741,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/cargo ">home 0.5.12</a></li>
-                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.4.0</a></li>
+                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.5.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -11549,6 +12160,218 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor-proc-macro 0.0.7</a></li>
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor 0.6.3</a></li>
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor-proc-macro 0.0.6</a></li>
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor 0.1.1</a></li>
+                </ul>
+                <pre class="license-text">Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.25.0</a></li>
                 </ul>
                 <pre class="license-text">Apache License
@@ -11828,121 +12651,147 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/lance-format/lance ">lance-bitpacking 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">fsst 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-examples 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-arrow 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-core 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-datafusion 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-datagen 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-encoding 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-file 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-geo 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-index 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-io 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-linalg 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace-datafusion 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace-impls 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-table 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-test-macros 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-testing 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-tools 3.0.0-beta.2</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-arrow-scalar 58.0.0</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-arrow-stats 58.0.0</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-bitpacking 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">fsst 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-examples 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-arrow 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-core 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-datafusion 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-datagen 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-encoding 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-file 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-geo 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-index 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-io 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-linalg 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace-datafusion 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace-impls 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-table 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-test-macros 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-testing 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-tokenizer 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-tools 7.0.0-beta.14</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
                     <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.101</a></li>
-                    <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.37</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.8.13</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.11</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.6.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.3.8</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.11</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-checksums 0.64.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-eventstream 0.60.18</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http-client 1.1.9</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.63.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.62.3</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-observability 0.2.4</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.13</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.11.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.10.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.4.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.13</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.11</a></li>
-                    <li><a href=" https://github.com/BLAKE3-team/BLAKE3 ">blake3 1.8.3</a></li>
-                    <li><a href=" https://github.com/elastio/bon ">bon-macros 3.8.2</a></li>
-                    <li><a href=" https://github.com/elastio/bon ">bon 3.8.2</a></li>
-                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.36</a></li>
-                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.31</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.8.14</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.13</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.7.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.4.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.13</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-checksums 0.64.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-eventstream 0.60.19</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http-client 1.1.11</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.63.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.62.4</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-observability 0.2.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.14</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.11.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.10.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.4.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.14</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.13</a></li>
+                    <li><a href=" https://github.com/BLAKE3-team/BLAKE3 ">blake3 1.8.5</a></li>
                     <li><a href=" https://github.com/cesarb/constant_time_eq ">constant_time_eq 0.4.2</a></li>
                     <li><a href=" https://github.com/zowens/crc32c ">crc32c 0.6.8</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-adapter 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-pruning 51.0.0</a></li>
-                    <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.4.1</a></li>
                     <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
-                    <li><a href=" https://github.com/soc/dirs-rs ">dirs 5.0.1</a></li>
                     <li><a href=" https://github.com/soc/dirs-rs ">dirs 6.0.0</a></li>
-                    <li><a href=" https://github.com/nlordell/ethnum-rs ">ethnum 1.5.2</a></li>
+                    <li><a href=" https://github.com/sgodwincs/dlv-list-rs ">dlv-list 0.5.2</a></li>
+                    <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
+                    <li><a href=" https://github.com/dtolnay/dyn-clone ">dyn-clone 1.0.20</a></li>
+                    <li><a href=" https://github.com/nlordell/ethnum-rs ">ethnum 1.5.3</a></li>
                     <li><a href=" https://github.com/google/flatbuffers ">flatbuffers 25.12.19</a></li>
                     <li><a href=" https://github.com/georust/geo ">geo-traits 0.3.0</a></li>
-                    <li><a href=" https://github.com/georust/geo ">geo-types 0.7.18</a></li>
+                    <li><a href=" https://github.com/georust/geo ">geo-types 0.7.19</a></li>
                     <li><a href=" https://github.com/georust/geo ">geo 0.31.0</a></li>
-                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-array 0.7.0</a></li>
-                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-expr-geo 0.7.0</a></li>
-                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-schema 0.7.0</a></li>
-                    <li><a href=" https://github.com/datafusion-contrib/geodatafusion ">geodatafusion 0.2.0</a></li>
+                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-array 0.8.0</a></li>
+                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-expr-geo 0.8.0</a></li>
+                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-schema 0.8.0</a></li>
+                    <li><a href=" https://github.com/datafusion-contrib/geodatafusion ">geodatafusion 0.4.0</a></li>
                     <li><a href=" https://github.com/rustwasm/gloo/tree/master/crates/timers ">gloo-timers 0.3.0</a></li>
                     <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
-                    <li><a href=" https://github.com/veddan/rust-htmlescape ">htmlescape 0.3.1</a></li>
+                    <li><a href=" https://github.com/ethereal-sheep/heapify ">heapify 0.2.0</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">hf-xet 1.5.2</a></li>
                     <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
-                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.17</a></li>
-                    <li><a href=" https://crates.io/crates/lance-namespace-reqwest-client ">lance-namespace-reqwest-client 0.4.5</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.180</a></li>
+                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni-macros 0.22.4</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.22.4</a></li>
+                    <li><a href=" https://crates.io/crates/lance-namespace-reqwest-client ">lance-namespace-reqwest-client 0.7.6</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.186</a></li>
+                    <li><a href=" https://github.com/fast/mea ">mea 0.6.3</a></li>
                     <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
                     <li><a href=" https://github.com/dtolnay/monostate ">monostate-impl 0.1.18</a></li>
                     <li><a href=" https://github.com/dtolnay/monostate ">monostate 0.1.18</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.5</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.5</a></li>
-                    <li><a href=" https://github.com/apache/opendal ">object_store_opendal 0.55.0</a></li>
+                    <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.2</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.6</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.6</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-foundation 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-io-kit 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-system-configuration 0.3.2</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">object_store_opendal 0.56.0</a></li>
                     <li><a href=" https://github.com/faern/oneshot ">oneshot 0.1.13</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-core 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-concurrent-limit 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-logging 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-retry 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-timeout 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-azblob 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-azdls 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-azure-common 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-cos 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-gcs 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-hf 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-oss 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-s3 0.56.0</a></li>
+                    <li><a href=" https://github.com/dylni/os_str_bytes ">os_str_bytes 6.6.1</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
                     <li><a href=" https://github.com/vitiral/path_abs ">path_abs 0.5.1</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.10</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.10</a></li>
-                    <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic-util 0.2.5</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.13</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.13</a></li>
+                    <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.7</a></li>
                     <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
                     <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
-                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.44</a></li>
+                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.45</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
+                    <li><a href=" https://github.com/r-efi/r-efi ">r-efi 6.0.0</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.10.1</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.6</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                     <li><a href=" https://github.com/rust-random/rngs ">rand_xorshift 0.4.0</a></li>
                     <li><a href=" https://github.com/rust-random/rngs ">rand_xoshiro 0.7.0</a></li>
                     <li><a href=" https://github.com/udoprog/relative-path ">relative-path 1.9.3</a></li>
-                    <li><a href=" https://github.com/RoaringBitmap/roaring-rs ">roaring 0.10.12</a></li>
+                    <li><a href=" https://github.com/TrueLayer/reqwest-middleware ">reqwest-middleware 0.5.1</a></li>
                     <li><a href=" https://github.com/georust/rstar ">rstar 0.12.2</a></li>
-                    <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.1</a></li>
+                    <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier-android 0.1.1</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
-                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.22</a></li>
-                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
+                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.23</a></li>
+                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.28</a></li>
                     <li><a href=" https://github.com/dtolnay/seq-macro ">seq-macro 0.3.6</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.228</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive_internals 0.29.1</a></li>
                     <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.149</a></li>
                     <li><a href=" https://github.com/dtolnay/serde-repr ">serde_repr 0.1.20</a></li>
                     <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
+                    <li><a href=" https://github.com/dtolnay/serde-yaml ">serde_yaml 0.9.34+deprecated</a></li>
                     <li><a href=" https://github.com/comex/rust-shlex ">shlex 1.3.0</a></li>
                     <li><a href=" https://github.com/rusticstuff/simdutf8 ">simdutf8 0.1.5</a></li>
-                    <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.2</a></li>
+                    <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.3</a></li>
                     <li><a href=" https://github.com/vitiral/stfu8 ">stfu8 0.2.7</a></li>
-                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.114</a></li>
+                    <li><a href=" https://github.com/substrait-io/substrait-rs ">substrait 0.62.2</a></li>
+                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
                     <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                     <li><a href=" https://github.com/oliver-giersch/tagptr.git ">tagptr 0.2.0</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
@@ -11953,12 +12802,22 @@ limitations under the License.
                     <li><a href=" https://github.com/time-rs/time ">time-core 0.1.8</a></li>
                     <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.27</a></li>
                     <li><a href=" https://github.com/time-rs/time ">time 0.3.47</a></li>
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
+                    <li><a href=" https://github.com/oxidecomputer/typify ">typify-impl 0.5.0</a></li>
+                    <li><a href=" https://github.com/oxidecomputer/typify ">typify-macro 0.5.0</a></li>
+                    <li><a href=" https://github.com/oxidecomputer/typify ">typify 0.5.0</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.2+wasi-0.2.9</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06</a></li>
+                    <li><a href=" https://github.com/ardaku/wasite ">wasite 1.0.2</a></li>
                     <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams 0.4.2</a></li>
+                    <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams 0.5.0</a></li>
+                    <li><a href=" https://github.com/ardaku/whoami ">whoami 2.1.2</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu 0.4.0</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-client 1.5.2</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-core-structures 1.5.2</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-data 1.5.2</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-runtime 1.5.2</a></li>
                     <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-safe 7.2.4</a></li>
                     <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-sys 2.0.16+zstd.1.5.7</a></li>
                 </ul>
@@ -12277,7 +13136,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.43</a></li>
+                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.44</a></li>
                 </ul>
                 <pre class="license-text">Rust-chrono is dual-licensed under The MIT License [1] and
 Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
@@ -12556,6 +13415,37 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </pre>
             </li>
             <li class="license">
+                <h3 id="BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/fusion-engineering/rust-git-version ">git-version-macro 0.3.9</a></li>
+                    <li><a href=" https://github.com/fusion-engineering/rust-git-version ">git-version 0.3.9</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2017-2020
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
+            </li>
+            <li class="license">
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
@@ -12652,6 +13542,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.2</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
                     <li><a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.2</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
@@ -13292,8 +14183,9 @@ venue lying in Santa Clara County, California.
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.7</a></li>
                     <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 0.26.11</a></li>
-                    <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.6</a></li>
+                    <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.7</a></li>
                 </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -13362,6 +14254,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.7.1</a></li>
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">// Copyright 2015-2016 Brian Smith.
@@ -13383,37 +14276,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.101.7</a></li>
-                </ul>
-                <pre class="license-text">// Copyright 2021 Brian Smith.
-//
-// Permission to use, copy, modify, and/or distribute this software for any
-// purpose with or without fee is hereby granted, provided that the above
-// copyright notice and this permission notice appear in all copies.
-//
-// THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHORS DISCLAIM ALL WARRANTIES
-// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
-// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-#[test]
-fn cert_without_extensions_test() {
-    // Check the certificate is valid with
-    // &#x60;openssl x509 -in cert_without_extensions.der -inform DER -text -noout&#x60;
-    const CERT_WITHOUT_EXTENSIONS_DER: &amp;[u8] &#x3D; include_bytes!(&quot;cert_without_extensions.der&quot;);
-
-    assert!(webpki::EndEntityCert::try_from(CERT_WITHOUT_EXTENSIONS_DER).is_ok());
-}
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="ISC">ISC License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/acw/simple_asn1 ">simple_asn1 0.6.3</a></li>
+                    <li><a href=" https://github.com/acw/simple_asn1 ">simple_asn1 0.6.4</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 Adam Wick
 
@@ -13455,7 +14318,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.9</a></li>
+                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.13</a></li>
                 </ul>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -13503,10 +14366,27 @@ THIS SOFTWARE.
 </pre>
             </li>
             <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.17.0</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                </ul>
+                <pre class="license-text">ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. (&quot;ISC&quot;)
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/iwillspeak/rust-onig ">onig_sys 69.9.1</a></li>
+                    <li><a href=" https://github.com/rust-onig/rust-onig ">onig_sys 69.9.3</a></li>
                 </ul>
                 <pre class="license-text"># Rust-Onig is Open Source!
 
@@ -13544,7 +14424,7 @@ information.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/iwillspeak/rust-onig ">onig 6.5.1</a></li>
+                    <li><a href=" https://github.com/iwillspeak/rust-onig ">onig 6.5.3</a></li>
                 </ul>
                 <pre class="license-text"># Rust-Onig is Open Source!
 
@@ -13608,7 +14488,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl-sys 0.9.111</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl-sys 0.9.116</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Alex Crichton
 
@@ -13641,7 +14521,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.1.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.2.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -13697,36 +14577,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.32</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.9.0</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.8.1</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
+                <pre class="license-text">Copyright (c) 2014-2026 Sean McArthur
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -13752,7 +14605,7 @@ THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 2.10.1</a></li>
-                    <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.1.0</a></li>
+                    <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.3.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 Jonathan Reem
 
@@ -13785,7 +14638,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.28</a></li>
+                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.29</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 steffengy
 
@@ -13845,8 +14698,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.3.27</a></li>
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.13</a></li>
+                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.14</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -13912,46 +14764,28 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tantivy-search/levenshtein-automata ">levenshtein_automata 0.2.1</a></li>
+                    <li><a href=" https://github.com/palfrey/serial_test/ ">serial_test 3.4.0</a></li>
+                    <li><a href=" https://github.com/palfrey/serial_test/ ">serial_test_derive 3.4.0</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2018 Paul Masurel
+                <pre class="license-text">Copyright (c) 2018 Tom Parker-Shemilt
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-inc/census ">census 0.4.2</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2018 by Quickwit, Inc. 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy 0.24.2</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2018 by the project authors, as listed in the AUTHORS file. 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -14151,10 +14985,13 @@ DEALINGS IN THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tls ">tokio-native-tls 0.3.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-appender 0.2.5</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.31</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.36</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-log 0.2.0</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.22</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-mock 0.1.0-beta.3</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-serde 0.2.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.23</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.44</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors
@@ -14223,7 +15060,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tower-rs/tower-http ">tower-http 0.6.8</a></li>
+                    <li><a href=" https://github.com/tower-rs/tower-http ">tower-http 0.6.11</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019-2021 Tower Contributors
 
@@ -14322,6 +15159,40 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/RustCrypto/asm-hashes ">sha2-asm 0.6.4</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2020 RustCrypto Developers
+Copyright (c) 2017 Project Nayuki, Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.20</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2023-2025 Sean McArthur
@@ -14343,36 +15214,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-inc/murmurhash32 ">murmurhash32 0.3.1</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2024 by Quickwit Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/fulmicoton/fastdivide ">fastdivide 0.4.2</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2024-Present Paul Masurel
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -14421,26 +15262,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/PSeitz/rust_measure_time ">measure_time 0.9.0</a></li>
-                </ul>
-                <pre class="license-text">Includes portions of humantime
-Copyright (c) 2016 The humantime Developers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.12.5</a></li>
-                    <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.16.3</a></li>
+                    <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.16.4</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -14468,11 +15290,69 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/statrs-dev/statrs ">statrs 0.18.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2016 Michael Ma
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/pacman82/atoi-rs ">atoi 2.0.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
 Copyright (c) 2017 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/webdesus/fs_extra ">fs_extra 1.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2017 Denis Kurilenko
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -14556,6 +15436,35 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/djc/tokio-retry ">tokio-retry 0.3.1</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2017 Sam Rijs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/TedDriggs/darling ">darling 0.14.4</a></li>
                     <li><a href=" https://github.com/TedDriggs/darling ">darling 0.23.0</a></li>
                     <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.14.4</a></li>
@@ -14620,7 +15529,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/georust/geographiclib-rs ">geographiclib-rs 0.2.5</a></li>
+                    <li><a href=" https://github.com/sgodwincs/ordered-multimap-rs ">ordered-multimap 0.7.3</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2018 sgodwincs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/georust/geographiclib-rs ">geographiclib-rs 0.2.7</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -14649,7 +15587,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/xacrimon/dashmap ">dashmap 6.1.0</a></li>
+                    <li><a href=" https://github.com/xacrimon/dashmap ">dashmap 6.2.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -14736,7 +15674,37 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/kornelski/rust-rgb ">rgb 0.8.52</a></li>
+                    <li><a href=" https://github.com/GREsau/schemars ">schemars 0.8.22</a></li>
+                    <li><a href=" https://github.com/GREsau/schemars ">schemars_derive 0.8.22</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2019 Graham Esau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/kornelski/rust-rgb ">rgb 0.8.53</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -14795,7 +15763,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.7.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -14960,6 +15928,64 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-array 58.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2020-2022 Oliver Margetts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/Nugine/const-str ">const-str 1.1.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2020-2026 Nugine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://gitlab.com/samsartor/async_cell ">async_cell 0.2.3</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -15046,7 +16072,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.12</a></li>
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.16</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15135,6 +16161,35 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/spire-rs/countio ">countio 0.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2024 Spire Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/iShape-Rust/iKeySort ">i_key_sort 0.6.0</a></li>
                     <li><a href=" https://github.com/iShape-Rust/iTree ">i_tree 0.16.0</a></li>
                 </ul>
@@ -15170,20 +16225,15 @@ SOFTWARE.
                     <li><a href=" https://github.com/iShape-Rust/iOverlay ">i_overlay 4.0.7</a></li>
                     <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.16</a></li>
                     <li><a href=" https://github.com/ogham/rust-number-prefix ">number_prefix 0.4.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">ownedbytes 0.9.0</a></li>
+                    <li><a href=" https://github.com/influxdata/pbjson ">pbjson-build 0.8.0</a></li>
+                    <li><a href=" https://github.com/influxdata/pbjson ">pbjson-types 0.8.0</a></li>
+                    <li><a href=" https://github.com/influxdata/pbjson ">pbjson 0.8.0</a></li>
                     <li><a href=" https://github.com/plotters-rs/plotters ">plotters-backend 0.3.7</a></li>
                     <li><a href=" https://github.com/plotters-rs/plotters.git ">plotters-svg 0.3.7</a></li>
                     <li><a href=" https://github.com/plotters-rs/plotters ">plotters 0.3.7</a></li>
                     <li><a href=" https://github.com/MitchellRhysHall/random_word ">random_word 0.5.2</a></li>
-                    <li><a href=" https://github.com/getsentry/symbolic ">symbolic-common 12.17.2</a></li>
-                    <li><a href=" https://github.com/getsentry/symbolic ">symbolic-demangle 12.17.2</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-bitpacker 0.8.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-columnar 0.5.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-common 0.9.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-query-grammar 0.24.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-sstable 0.5.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-stacker 0.5.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-tokenizer-api 0.5.0</a></li>
+                    <li><a href=" https://github.com/getsentry/symbolic ">symbolic-common 12.18.3</a></li>
+                    <li><a href=" https://github.com/getsentry/symbolic ">symbolic-demangle 12.18.3</a></li>
                     <li><a href=" https://github.com/Nugine/simd ">vsimd 0.8.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -15212,7 +16262,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.18</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.49.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.52.3</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15241,7 +16291,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.8</a></li>
+                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.9</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15288,7 +16338,8 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/sunfishcode/is-terminal ">is-terminal 0.4.17</a></li>
-                    <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.19</a></li>
+                    <li><a href=" https://github.com/dtolnay/unsafe-libyaml ">unsafe-libyaml 0.2.11</a></li>
+                    <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.21</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -15319,7 +16370,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.14</a></li>
+                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.3</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -15374,6 +16425,23 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/zonyitoo/rust-ini ">rust-ini 0.21.3</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2014 Y. T. CHUNG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-phf/rust-phf ">phf 0.12.1</a></li>
                     <li><a href=" https://github.com/rust-phf/rust-phf ">phf_shared 0.12.1</a></li>
                 </ul>
@@ -15409,45 +16477,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     <li><a href=" https://github.com/BurntSushi/rust-csv ">csv 1.4.0</a></li>
                     <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
                     <li><a href=" https://github.com/BurntSushi/jiff ">jiff-tzdb-platform 0.1.3</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff-tzdb 0.1.5</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.19</a></li>
-                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff-tzdb 0.1.6</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.24</a></li>
+                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.0</a></li>
                     <li><a href=" https://github.com/BurntSushi/utf8-ranges ">utf8-ranges 1.0.5</a></li>
                     <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2015 Andrew Gallant
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-inc/fst ">tantivy-fst 0.5.0</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2015 Andrew Gallant
-Copyright (c) 2019 Paul Masurel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -15564,6 +16602,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/GuillaumeGomez/sysinfo ">sysinfo 0.38.4</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015 Guillaume Gomez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/shepmaster/twox-hash ">twox-hash 2.1.2</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -15593,11 +16661,71 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/Keats/jsonwebtoken ">jsonwebtoken 9.3.1</a></li>
+                    <li><a href=" https://github.com/Marwes/combine ">combine 4.6.7</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015 Markus Westerlind
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/Keats/jsonwebtoken ">jsonwebtoken 10.4.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2015 Vincent Prouillet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015-2020 the fiat-crypto authors (see
+https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -15658,6 +16786,35 @@ IN THE SOFTWARE.
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2016 Jonathan Creekmore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/nabijaczleweli/safe-transmute-rs ">safe-transmute 0.11.3</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2016 nabijaczleweli
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -15743,7 +16900,6 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://gitlab.redox-os.org/redox-os/users ">redox_users 0.4.6</a></li>
                     <li><a href=" https://gitlab.redox-os.org/redox-os/users ">redox_users 0.5.2</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -15802,8 +16958,7 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/pseitz/lz4_flex ">lz4_flex 0.11.5</a></li>
-                    <li><a href=" https://github.com/pseitz/lz4_flex ">lz4_flex 0.12.0</a></li>
+                    <li><a href=" https://github.com/pseitz/lz4_flex ">lz4_flex 0.13.1</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -15965,8 +17120,8 @@ SOFTWARE.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.26.0</a></li>
-                    <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.37.5</a></li>
                     <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.38.4</a></li>
+                    <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.39.4</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16405,6 +17560,387 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/mackwic/colored ">colored 3.1.1</a></li>
+                </ul>
+                <pre class="license-text">Mozilla Public License Version 2.0
+&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+
+1. Definitions
+--------------
+
+1.1. &quot;Contributor&quot;
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. &quot;Contributor Version&quot;
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor&#x27;s Contribution.
+
+1.3. &quot;Contribution&quot;
+    means Covered Software of a particular Contributor.
+
+1.4. &quot;Covered Software&quot;
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. &quot;Incompatible With Secondary Licenses&quot;
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. &quot;Executable Form&quot;
+    means any form of the work other than Source Code Form.
+
+1.7. &quot;Larger Work&quot;
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. &quot;License&quot;
+    means this document.
+
+1.9. &quot;Licensable&quot;
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. &quot;Modifications&quot;
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. &quot;Patent Claims&quot; of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. &quot;Secondary License&quot;
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. &quot;Source Code Form&quot;
+    means the form of the work preferred for making modifications.
+
+1.14. &quot;You&quot; (or &quot;Your&quot;)
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, &quot;You&quot; includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, &quot;control&quot; means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party&#x27;s
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients&#x27; rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients&#x27; rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an &quot;as is&quot;       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party&#x27;s negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party&#x27;s ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
+---------------------------------------------------------
+
+  This Source Code Form is &quot;Incompatible With Secondary Licenses&quot;, as
+  defined by the Mozilla Public License, v. 2.0.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                 </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
@@ -16786,7 +18322,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 
@@ -16833,24 +18369,24 @@ authorization of the copyright holder.
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.1.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.1.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.4</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.6</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.6</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.3</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.7</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.8</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.4</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.6</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 
@@ -16904,7 +18440,7 @@ ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation a
                 <h3 id="Zlib">zlib License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/trifectatechfoundation/zlib-rs ">zlib-rs 0.6.0</a></li>
+                    <li><a href=" https://github.com/trifectatechfoundation/zlib-rs ">zlib-rs 0.6.3</a></li>
                 </ul>
                 <pre class="license-text">(C) 2024 Trifecta Tech Foundation 
 
@@ -16926,6 +18462,56 @@ freely, subject to the following restrictions:
 
 3. This notice may not be removed or altered from any source distribution.
 </pre>
+            </li>
+            <li class="license">
+                <h3 id="Zlib">zlib License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/rodrimati1992/const_panic/ ">const_panic 0.2.15</a></li>
+                    <li><a href=" https://github.com/rodrimati1992/konst/ ">konst 0.4.3</a></li>
+                    <li><a href=" https://github.com/rodrimati1992/konst/ ">konst_proc_macros 0.4.1</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2021 Matias Rodriguez.
+
+This software is provided &#x27;as-is&#x27;, without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.</pre>
+            </li>
+            <li class="license">
+                <h3 id="Zlib">zlib License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/rodrimati1992/typewit/ ">typewit 1.15.2</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2023 Matias Rodriguez.
+
+This software is provided &#x27;as-is&#x27;, without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.</pre>
             </li>
             <li class="license">
                 <h3 id="Zlib">zlib License</h3>

--- a/java/RUST_THIRD_PARTY_LICENSES.html
+++ b/java/RUST_THIRD_PARTY_LICENSES.html
@@ -44,42 +44,22 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (466)</li>
-            <li><a href="#MIT">MIT License</a> (131)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (525)</li>
+            <li><a href="#MIT">MIT License</a> (127)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
-            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (9)</li>
-            <li><a href="#ISC">ISC License</a> (5)</li>
-            <li><a href="#Zlib">zlib License</a> (3)</li>
-            <li><a href="#0BSD">BSD Zero Clause License</a> (2)</li>
-            <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (1)</li>
+            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (10)</li>
+            <li><a href="#ISC">ISC License</a> (8)</li>
+            <li><a href="#Zlib">zlib License</a> (7)</li>
+            <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (3)</li>
+            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (2)</li>
+            <li><a href="#0BSD">BSD Zero Clause License</a> (1)</li>
             <li><a href="#BSL-1.0">Boost Software License 1.0</a> (1)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
             <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a> (1)</li>
-            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (1)</li>
         </ul>
 
         <h2>All license text:</h2>
         <ul class="licenses-list">
-            <li class="license">
-                <h3 id="0BSD">BSD Zero Clause License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/museun/mock_instant ">mock_instant 0.6.0</a></li>
-                </ul>
-                <pre class="license-text">Copyright (C) 2020 by museun &lt;museun@outlook.com&gt;
-
-Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
-</pre>
-            </li>
             <li class="license">
                 <h3 id="0BSD">BSD Zero Clause License</h3>
                 <h4>Used by:</h4>
@@ -98,216 +78,6 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
 AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.0</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2023 Jacob Pratt
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
 </pre>
             </li>
             <li class="license">
@@ -524,7 +294,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.5.5</a></li>
+                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.5.8</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -734,7 +504,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/oxidecomputer/serde_tokenstream ">serde_tokenstream 0.2.2</a></li>
+                    <li><a href=" https://github.com/oxidecomputer/serde_tokenstream ">serde_tokenstream 0.2.3</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -943,26 +713,29 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-arith 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-array 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-buffer 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-cast 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-csv 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-data 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ipc 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-json 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ord 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-row 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-schema 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-select 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-string 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow 57.2.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-arith 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-array 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-buffer 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-cast 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-csv 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-data 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ipc 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-json 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ord 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-row 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-schema 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-select 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-string 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow 58.3.0</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
-                    <li><a href=" https://github.com/lo48576/iri-string ">iri-string 0.7.10</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">parquet 57.2.0</a></li>
-                    <li><a href=" https://github.com/Stoeoef/spade ">spade 2.15.0</a></li>
+                    <li><a href=" https://github.com/thomcc/rust-more-asserts ">more-asserts 0.3.1</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">parquet 58.3.0</a></li>
+                    <li><a href=" https://github.com/Stoeoef/spade ">spade 2.15.1</a></li>
+                    <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
+                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.11.0</a></li>
                     <li><a href=" https://github.com/hsivonen/utf8_iter ">utf8_iter 1.0.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">zeroize 1.8.2</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize/derive ">zeroize_derive 1.4.3</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1172,7 +945,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apache/arrow-rs-object-store ">object_store 0.12.5</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs-object-store ">object_store 0.13.2</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1384,36 +1157,38 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog-listing 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common-runtime 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-arrow 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-csv 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-json 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-parquet 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-doc 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-execution 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-nested 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-table 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-macros 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-optimizer 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-optimizer 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-plan 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-session 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-sql 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-substrait 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion 51.0.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog-listing 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common-runtime 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-arrow 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-csv 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-json 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-parquet 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-doc 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-execution 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-nested 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-table 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-macros 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-optimizer 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-adapter 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-optimizer 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-plan 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-pruning 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-session 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-sql 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-substrait 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion 53.1.0</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1627,217 +1402,6 @@ This project includes code from Apache Aurora.
 Copyright: 2016 The Apache Software Foundation.
 Home page: https://aurora.apache.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/la10736/rstest ">rstest 0.26.1</a></li>
-                    <li><a href=" https://github.com/la10736/rstest ">rstest_macros 0.26.1</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-   
-   Copyright 2018-19 Michele d&#x27;Amico
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
 </pre>
             </li>
             <li class="license">
@@ -2253,43 +1817,38 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-collections 0.3.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.62.2</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-future 0.3.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-implement 0.60.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-interface 0.59.3</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.2.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-numerics 0.3.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-registry 0.6.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.4.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.5.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.45.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.59.0</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.60.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.61.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.53.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-threading 0.2.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.62.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.53.1</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2498,7 +2057,7 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/moka-rs/moka ">moka 0.12.13</a></li>
+                    <li><a href=" https://github.com/moka-rs/moka ">moka 0.12.15</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2688,7 +2247,7 @@ License: http://www.apache.org/licenses/LICENSE-2.0
       same &quot;printed page&quot; as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 - 2025 Tatsuya Kawano
+   Copyright 2020 - 2026 Tatsuya Kawano
 
    Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
    you may not use this file except in compliance with the License.
@@ -2707,8 +2266,217 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/Soveu/tinyvec_macros ">tinyvec_macros 0.1.1</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Tomasz &quot;Soveu&quot; Marx
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/Xuanwo/backon ">backon 1.6.0</a></li>
-                    <li><a href=" https://github.com/Xuanwo/reqsign ">reqsign 0.16.5</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2916,8 +2684,8 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.38</a></li>
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.38</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.48</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.48</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3336,217 +3104,17 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mheffner/rust-sketches-ddsketch ">sketches-ddsketch 0.3.0</a></li>
-                </ul>
-                <pre class="license-text">                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [2019] [Mike Heffner]
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/databendlabs/jsonb ">jsonb 0.5.5</a></li>
-                    <li><a href=" https://github.com/apache/opendal ">opendal 0.55.0</a></li>
+                    <li><a href=" https://github.com/databendlabs/jsonb ">jsonb 0.5.6</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal 0.56.0</a></li>
+                    <li><a href=" https://github.com/cberner/redb ">redb 3.1.3</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-aliyun-oss 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-aws-v4 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-azure-storage 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-core 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-file-read-tokio 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-google 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-tencent-cos 3.0.0</a></li>
+                    <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.7.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3755,7 +3323,216 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.11.0</a></li>
+                    <li><a href=" https://github.com/MSxDOS/ntapi ">ntapi 0.4.3</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   </pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.12.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -4173,23 +3950,29 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.21</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 1.0.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 1.0.0</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.14</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.1</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.0</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.6.1</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.1.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.5</a></li>
                     <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
-                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.4</a></li>
-                    <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.8</a></li>
+                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 1.0.1</a></li>
+                    <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.10</a></li>
+                    <li><a href=" https://github.com/srijs/rust-gearhash ">gearhash 0.1.3</a></li>
                     <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
                     <li><a href=" https://github.com/chronotope/humantime ">humantime 2.3.0</a></li>
                     <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.2</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-jni-sys ">jni-sys 0.3.0</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.3.1</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.4.1</a></li>
                     <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.7.5+spec-1.1.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.23.10+spec-1.0.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.6+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.1+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.11+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.2+spec-1.1.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -4399,9 +4182,9 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.93.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.95.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.97.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.95.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.97.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.99.0</a></li>
                 </ul>
                 <pre class="license-text">                                Apache License
                            Version 2.0, January 2004
@@ -4820,15 +4603,15 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.31</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.32</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5038,7 +4821,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.19.0</a></li>
+                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.20.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5247,6 +5030,7 @@ limitations under the License.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.12.28</a></li>
+                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.13.3</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6292,8 +6076,217 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/shepmaster/snafu ">snafu-derive 0.8.9</a></li>
-                    <li><a href=" https://github.com/shepmaster/snafu ">snafu 0.8.9</a></li>
+                    <li><a href=" https://github.com/tokio-rs/io-uring ">io-uring 0.7.12</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2019 quininer kel
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/shepmaster/snafu ">snafu-derive 0.9.0</a></li>
+                    <li><a href=" https://github.com/shepmaster/snafu ">snafu 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7130,7 +7123,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.0</a></li>
+                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7550,215 +7543,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.9</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [2015] [Dan Burkert]
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/dcchut/async-recursion ">async-recursion 1.1.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.9.10</a></li>
                 </ul>
@@ -7969,23 +7753,30 @@ limitations under the License.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
-                    <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.1</a></li>
+                    <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.1</a></li>
                     <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                     <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.42</a></li>
                     <li><a href=" https://github.com/smol-rs/async-lock ">async-lock 3.4.2</a></li>
                     <li><a href=" https://github.com/smol-rs/atomic-waker ">atomic-waker 1.1.2</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
-                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.10.0</a></li>
-                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.1</a></li>
+                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.1</a></li>
+                    <li><a href=" https://github.com/BurntSushi/bstr ">bstr 1.12.1</a></li>
+                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
                     <li><a href=" https://github.com/vorner/bytes-utils ">bytes-utils 0.1.4</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.55</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.62</a></li>
+                    <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if 0.1.10</a></li>
                     <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
+                    <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.58</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.38</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.32</a></li>
                     <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue 2.5.0</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random-macro 0.1.16</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random 0.1.18</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys 0.8.7</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.10.1</a></li>
+                    <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.9.4</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-channel 0.5.15</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.6</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.18</a></li>
@@ -7998,37 +7789,35 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener-strategy ">event-listener-strategy 0.5.4</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
-                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
+                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.4.1</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                     <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset 0.5.7</a></li>
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
-                    <li><a href=" https://github.com/al8n/fs4-rs ">fs4 0.8.4</a></li>
-                    <li><a href=" https://github.com/async-rs/futures-timer ">futures-timer 3.0.3</a></li>
                     <li><a href=" https://github.com/georust/geohash.rs ">geohash 0.13.1</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.3</a></li>
                     <li><a href=" https://github.com/japaric/hash32 ">hash32 0.3.1</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.14.5</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.17.1</a></li>
                     <li><a href=" https://github.com/rust-embedded/heapless ">heapless 0.8.0</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                     <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
-                    <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.7</a></li>
+                    <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.9</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
-                    <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.1</a></li>
-                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.13.0</a></li>
+                    <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.2</a></li>
+                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.14.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.11.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.13.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
                     <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.21.1</a></li>
                     <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.34</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.85</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.98</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
-                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.11.0</a></li>
-                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
+                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
                     <li><a href=" https://github.com/bluss/matrixmultiply/ ">matrixmultiply 0.3.10</a></li>
@@ -8042,62 +7831,71 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-num/num-iter ">num-iter 0.1.45</a></li>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
-                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
+                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.4</a></li>
                     <li><a href=" https://github.com/rustls/openssl-probe ">openssl-probe 0.2.1</a></li>
                     <li><a href=" https://github.com/smol-rs/parking ">parking 2.2.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.5</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.12</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
                     <li><a href=" https://github.com/petgraph/petgraph ">petgraph 0.8.3</a></li>
-                    <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.33</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-build 0.14.3</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-derive 0.14.3</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-types 0.14.3</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost 0.14.3</a></li>
                     <li><a href=" https://github.com/bluss/rawpointer/ ">rawpointer 0.2.1</a></li>
                     <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
-                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.11.0</a></li>
+                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.12.0</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-lite 0.1.9</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.9</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.3</a></li>
                     <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
+                    <li><a href=" https://github.com/RoaringBitmap/roaring-rs ">roaring 0.11.4</a></li>
                     <li><a href=" https://github.com/georust/robust ">robust 1.2.0</a></li>
                     <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.3</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.4</a></li>
                     <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.3</a></li>
-                    <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.2.0</a></li>
-                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.36</a></li>
+                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.40</a></li>
                     <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.15.0</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.5.1</a></li>
-                    <li><a href=" https://gitlab.com/ijackson/rust-shellexpand ">shellexpand 3.1.1</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.20.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.20.0</a></li>
+                    <li><a href=" https://gitlab.com/ijackson/rust-shellexpand ">shellexpand 3.1.2</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
+                    <li><a href=" https://github.com/seancroach/simd_cesu8 ">simd_cesu8 1.1.1</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.2</a></li>
-                    <li><a href=" https://github.com/apache/datafusion-sqlparser-rs ">sqlparser 0.59.0</a></li>
-                    <li><a href=" https://github.com/sqlparser-rs/sqlparser-rs ">sqlparser_derive 0.3.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
+                    <li><a href=" https://github.com/apache/datafusion-sqlparser-rs ">sqlparser 0.61.0</a></li>
+                    <li><a href=" https://github.com/sqlparser-rs/sqlparser-rs ">sqlparser_derive 0.5.0</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
+                    <li><a href=" https://gitlab.com/chris-morgan/symlink ">symlink 0.1.0</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.109</a></li>
-                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.24.0</a></li>
+                    <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration-sys 0.6.0</a></li>
+                    <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration 0.7.0</a></li>
+                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.27.0</a></li>
                     <li><a href=" https://github.com/bluss/thread-tree ">thread-tree 0.3.3</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.9</a></li>
                     <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.9.0</a></li>
-                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.12.0</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-normalization ">unicode-normalization 0.1.25</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.13.2</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.20.0</a></li>
+                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.1</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.58</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.85</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasi 0.14.7+wasi-0.2.4</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.3+wasi-0.2.9</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.71</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.98</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.57.1</a></li>
                     <li><a href=" https://github.com/georust/wkb ">wkb 0.9.2</a></li>
                     <li><a href=" https://github.com/georust/wkt ">wkt 0.14.0</a></li>
                     <li><a href=" https://github.com/RazrFalcon/xmlparser ">xmlparser 0.13.6</a></li>
@@ -8309,14 +8107,12 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/marcianx/downcast-rs ">downcast-rs 2.0.2</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-core 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-parse-float 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-parse-integer 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-util 1.0.7</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-write-float 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-write-integer 1.0.6</a></li>
-                    <li><a href=" https://github.com/Alexhuszagh/minimal-lexical ">minimal-lexical 0.2.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -8531,9 +8327,11 @@ limitations under the License.
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.3.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/block-modes ">cbc 0.1.2</a></li>
+                    <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.10.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">cipher 0.4.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/const-oid ">const-oid 0.9.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.17</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.3.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.7.10</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
@@ -8759,9 +8557,9 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-random/rand_core ">rand_core 0.10.1</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.5</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand_distr 0.4.3</a></li>
                     <li><a href=" https://github.com/rust-random/rand_distr ">rand_distr 0.5.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -8959,6 +8757,7 @@ APPENDIX: How to apply the Apache License to your work.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
+                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.2</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -9168,8 +8967,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/cargo ">home 0.5.12</a></li>
-                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.4.0</a></li>
+                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.5.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9372,6 +9170,218 @@ distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor-proc-macro 0.0.7</a></li>
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor 0.6.3</a></li>
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor-proc-macro 0.0.6</a></li>
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor 0.1.1</a></li>
+                </ul>
+                <pre class="license-text">Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 </pre>
             </li>
             <li class="license">
@@ -9657,99 +9667,120 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/lance-format/lance ">lance-jni 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-bitpacking 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">fsst 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-arrow 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-core 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-datafusion 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-datagen 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-encoding 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-file 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-geo 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-index 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-io 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-linalg 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace-impls 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-table 3.0.0-beta.2</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-jni 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-bitpacking 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">fsst 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-arrow 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-core 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-datafusion 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-datagen 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-encoding 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-file 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-geo 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-index 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-io 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-linalg 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace-impls 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-table 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-tokenizer 7.0.0-beta.14</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.101</a></li>
-                    <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.37</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.8.13</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.11</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.6.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.3.8</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.11</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http-client 1.1.9</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.63.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.62.3</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-observability 0.2.4</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.13</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.11.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.10.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.4.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.13</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.11</a></li>
-                    <li><a href=" https://github.com/BLAKE3-team/BLAKE3 ">blake3 1.8.3</a></li>
-                    <li><a href=" https://github.com/elastio/bon ">bon-macros 3.8.2</a></li>
-                    <li><a href=" https://github.com/elastio/bon ">bon 3.8.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.8.14</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.13</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.7.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.4.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.13</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http-client 1.1.11</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.63.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.62.4</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-observability 0.2.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.14</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.11.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.10.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.4.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.14</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.13</a></li>
+                    <li><a href=" https://github.com/BLAKE3-team/BLAKE3 ">blake3 1.8.5</a></li>
                     <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
-                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.36</a></li>
-                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.31</a></li>
                     <li><a href=" https://github.com/cesarb/constant_time_eq ">constant_time_eq 0.4.2</a></li>
                     <li><a href=" https://github.com/zowens/crc32c ">crc32c 0.6.8</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-adapter 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-pruning 51.0.0</a></li>
                     <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
                     <li><a href=" https://github.com/soc/dirs-rs ">dirs 6.0.0</a></li>
+                    <li><a href=" https://github.com/sgodwincs/dlv-list-rs ">dlv-list 0.5.2</a></li>
+                    <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
                     <li><a href=" https://github.com/dtolnay/dyn-clone ">dyn-clone 1.0.20</a></li>
-                    <li><a href=" https://github.com/nlordell/ethnum-rs ">ethnum 1.5.2</a></li>
+                    <li><a href=" https://github.com/nlordell/ethnum-rs ">ethnum 1.5.3</a></li>
                     <li><a href=" https://github.com/google/flatbuffers ">flatbuffers 25.12.19</a></li>
                     <li><a href=" https://github.com/georust/geo ">geo-traits 0.3.0</a></li>
-                    <li><a href=" https://github.com/georust/geo ">geo-types 0.7.18</a></li>
+                    <li><a href=" https://github.com/georust/geo ">geo-types 0.7.19</a></li>
                     <li><a href=" https://github.com/georust/geo ">geo 0.31.0</a></li>
-                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-array 0.7.0</a></li>
-                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-expr-geo 0.7.0</a></li>
-                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-schema 0.7.0</a></li>
-                    <li><a href=" https://github.com/datafusion-contrib/geodatafusion ">geodatafusion 0.2.0</a></li>
+                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-array 0.8.0</a></li>
+                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-expr-geo 0.8.0</a></li>
+                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-schema 0.8.0</a></li>
+                    <li><a href=" https://github.com/datafusion-contrib/geodatafusion ">geodatafusion 0.4.0</a></li>
                     <li><a href=" https://github.com/rustwasm/gloo/tree/master/crates/timers ">gloo-timers 0.3.0</a></li>
                     <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
-                    <li><a href=" https://github.com/veddan/rust-htmlescape ">htmlescape 0.3.1</a></li>
+                    <li><a href=" https://github.com/ethereal-sheep/heapify ">heapify 0.2.0</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">hf-xet 1.5.2</a></li>
                     <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
-                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.17</a></li>
-                    <li><a href=" https://crates.io/crates/lance-namespace-reqwest-client ">lance-namespace-reqwest-client 0.4.5</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.180</a></li>
+                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni-macros 0.22.4</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.22.4</a></li>
+                    <li><a href=" https://crates.io/crates/lance-namespace-reqwest-client ">lance-namespace-reqwest-client 0.7.6</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.186</a></li>
+                    <li><a href=" https://github.com/fast/mea ">mea 0.6.3</a></li>
                     <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.5</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.5</a></li>
-                    <li><a href=" https://github.com/apache/opendal ">object_store_opendal 0.55.0</a></li>
+                    <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.2</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.6</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.6</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-foundation 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-io-kit 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-system-configuration 0.3.2</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">object_store_opendal 0.56.0</a></li>
                     <li><a href=" https://github.com/faern/oneshot ">oneshot 0.1.13</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-core 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-concurrent-limit 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-logging 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-retry 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-timeout 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-azblob 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-azdls 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-azure-common 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-cos 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-gcs 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-hf 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-oss 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-s3 0.56.0</a></li>
+                    <li><a href=" https://github.com/dylni/os_str_bytes ">os_str_bytes 6.6.1</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
                     <li><a href=" https://github.com/vitiral/path_abs ">path_abs 0.5.1</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.10</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.10</a></li>
-                    <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic-util 0.2.5</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.13</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.13</a></li>
+                    <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.7</a></li>
                     <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
                     <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
-                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.44</a></li>
+                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.45</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
+                    <li><a href=" https://github.com/r-efi/r-efi ">r-efi 6.0.0</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.10.1</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.6</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                     <li><a href=" https://github.com/rust-random/rngs ">rand_xoshiro 0.7.0</a></li>
-                    <li><a href=" https://github.com/udoprog/relative-path ">relative-path 1.9.3</a></li>
-                    <li><a href=" https://github.com/RoaringBitmap/roaring-rs ">roaring 0.10.12</a></li>
+                    <li><a href=" https://github.com/TrueLayer/reqwest-middleware ">reqwest-middleware 0.5.1</a></li>
                     <li><a href=" https://github.com/georust/rstar ">rstar 0.12.2</a></li>
-                    <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.1</a></li>
+                    <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier-android 0.1.1</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
-                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.22</a></li>
-                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
+                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.23</a></li>
+                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.28</a></li>
                     <li><a href=" https://github.com/dtolnay/seq-macro ">seq-macro 0.3.6</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
@@ -9762,10 +9793,10 @@ limitations under the License.
                     <li><a href=" https://github.com/dtolnay/serde-yaml ">serde_yaml 0.9.34+deprecated</a></li>
                     <li><a href=" https://github.com/comex/rust-shlex ">shlex 1.3.0</a></li>
                     <li><a href=" https://github.com/rusticstuff/simdutf8 ">simdutf8 0.1.5</a></li>
-                    <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.2</a></li>
+                    <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.3</a></li>
                     <li><a href=" https://github.com/vitiral/stfu8 ">stfu8 0.2.7</a></li>
                     <li><a href=" https://github.com/substrait-io/substrait-rs ">substrait 0.62.2</a></li>
-                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.114</a></li>
+                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
                     <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                     <li><a href=" https://github.com/oliver-giersch/tagptr.git ">tagptr 0.2.0</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
@@ -9779,12 +9810,19 @@ limitations under the License.
                     <li><a href=" https://github.com/oxidecomputer/typify ">typify-impl 0.5.0</a></li>
                     <li><a href=" https://github.com/oxidecomputer/typify ">typify-macro 0.5.0</a></li>
                     <li><a href=" https://github.com/oxidecomputer/typify ">typify 0.5.0</a></li>
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.2+wasi-0.2.9</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06</a></li>
+                    <li><a href=" https://github.com/ardaku/wasite ">wasite 1.0.2</a></li>
                     <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams 0.4.2</a></li>
+                    <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams 0.5.0</a></li>
+                    <li><a href=" https://github.com/ardaku/whoami ">whoami 2.1.2</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu 0.4.0</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-client 1.5.2</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-core-structures 1.5.2</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-data 1.5.2</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-runtime 1.5.2</a></li>
                     <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-safe 7.2.4</a></li>
                     <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-sys 2.0.16+zstd.1.5.7</a></li>
                 </ul>
@@ -10103,7 +10141,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.43</a></li>
+                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.44</a></li>
                 </ul>
                 <pre class="license-text">Rust-chrono is dual-licensed under The MIT License [1] and
 Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
@@ -10382,6 +10420,37 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </pre>
             </li>
             <li class="license">
+                <h3 id="BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/fusion-engineering/rust-git-version ">git-version-macro 0.3.9</a></li>
+                    <li><a href=" https://github.com/fusion-engineering/rust-git-version ">git-version 0.3.9</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2017-2020
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
+            </li>
+            <li class="license">
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
@@ -10515,6 +10584,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.2</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
                     <li><a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.2</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
@@ -10763,7 +10833,7 @@ express Statement of Purpose.
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.6</a></li>
+                    <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.7</a></li>
                 </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -10832,6 +10902,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.7.1</a></li>
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">// Copyright 2015-2016 Brian Smith.
@@ -10853,7 +10924,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/acw/simple_asn1 ">simple_asn1 0.6.3</a></li>
+                    <li><a href=" https://github.com/acw/simple_asn1 ">simple_asn1 0.6.4</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 Adam Wick
 
@@ -10895,7 +10966,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.9</a></li>
+                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.13</a></li>
                 </ul>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -10943,6 +11014,23 @@ THIS SOFTWARE.
 </pre>
             </li>
             <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.17.0</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                </ul>
+                <pre class="license-text">ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. (&quot;ISC&quot;)
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
@@ -10973,7 +11061,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.1.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.2.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -11000,7 +11088,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/Geal/nom ">nom 7.1.3</a></li>
                     <li><a href=" https://github.com/rust-bakery/nom ">nom 8.0.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2019 Geoffroy Couprie
@@ -11029,9 +11116,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.8.1</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.9.0</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
+                <pre class="license-text">Copyright (c) 2014-2026 Sean McArthur
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -11057,7 +11144,7 @@ THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 2.10.1</a></li>
-                    <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.1.0</a></li>
+                    <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.3.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 Jonathan Reem
 
@@ -11090,7 +11177,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.28</a></li>
+                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.29</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 steffengy
 
@@ -11150,7 +11237,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.13</a></li>
+                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.14</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -11210,51 +11297,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/tantivy-search/levenshtein-automata ">levenshtein_automata 0.2.1</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2018 Paul Masurel
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-inc/census ">census 0.4.2</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2018 by Quickwit, Inc. 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy 0.24.2</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2018 by the project authors, as listed in the AUTHORS file. 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -11472,10 +11514,12 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-appender 0.2.5</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.31</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.36</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-log 0.2.0</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.22</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-serde 0.2.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.23</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.44</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors
@@ -11545,7 +11589,7 @@ DEALINGS IN THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tower-rs/tower-http ">tower-http 0.5.2</a></li>
-                    <li><a href=" https://github.com/tower-rs/tower-http ">tower-http 0.6.8</a></li>
+                    <li><a href=" https://github.com/tower-rs/tower-http ">tower-http 0.6.11</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019-2021 Tower Contributors
 
@@ -11644,6 +11688,40 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/RustCrypto/asm-hashes ">sha2-asm 0.6.4</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2020 RustCrypto Developers
+Copyright (c) 2017 Project Nayuki, Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.20</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2023-2025 Sean McArthur
@@ -11665,36 +11743,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-inc/murmurhash32 ">murmurhash32 0.3.1</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2024 by Quickwit Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/fulmicoton/fastdivide ">fastdivide 0.4.2</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2024-Present Paul Masurel
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -11731,29 +11779,11 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/PSeitz/rust_measure_time ">measure_time 0.9.0</a></li>
-                </ul>
-                <pre class="license-text">Includes portions of humantime
-Copyright (c) 2016 The humantime Developers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.12.5</a></li>
+                    <li><a href=" https://github.com/statrs-dev/statrs ">statrs 0.18.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
-Copyright (c) 2016 Jerome Froelich
+Copyright (c) 2016 Michael Ma
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -11771,7 +11801,8 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
+SOFTWARE.
+</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -11782,6 +11813,35 @@ SOFTWARE.</pre>
                 <pre class="license-text">MIT License
 
 Copyright (c) 2017 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/webdesus/fs_extra ">fs_extra 1.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2017 Denis Kurilenko
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -11865,6 +11925,35 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/djc/tokio-retry ">tokio-retry 0.3.1</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2017 Sam Rijs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/TedDriggs/darling ">darling 0.23.0</a></li>
                     <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.23.0</a></li>
                     <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.23.0</a></li>
@@ -11926,7 +12015,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/georust/geographiclib-rs ">geographiclib-rs 0.2.5</a></li>
+                    <li><a href=" https://github.com/sgodwincs/ordered-multimap-rs ">ordered-multimap 0.7.3</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2018 sgodwincs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/georust/geographiclib-rs ">geographiclib-rs 0.2.7</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -11955,7 +12073,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/xacrimon/dashmap ">dashmap 6.1.0</a></li>
+                    <li><a href=" https://github.com/xacrimon/dashmap ">dashmap 6.2.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -12102,7 +12220,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.7.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -12250,6 +12368,64 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-array 58.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2020-2022 Oliver Margetts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/Nugine/const-str ">const-str 1.1.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2020-2026 Nugine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://gitlab.com/samsartor/async_cell ">async_cell 0.2.3</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -12336,7 +12512,7 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.12</a></li>
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.16</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -12395,6 +12571,35 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/spire-rs/countio ">countio 0.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2024 Spire Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/iShape-Rust/iKeySort ">i_key_sort 0.6.0</a></li>
                     <li><a href=" https://github.com/iShape-Rust/iTree ">i_tree 0.16.0</a></li>
                 </ul>
@@ -12429,18 +12634,10 @@ SOFTWARE.
                     <li><a href=" https://github.com/Aeledfyr/deepsize/ ">deepsize_derive 0.1.2</a></li>
                     <li><a href=" https://github.com/iShape-Rust/iOverlay ">i_overlay 4.0.7</a></li>
                     <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.16</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">ownedbytes 0.9.0</a></li>
                     <li><a href=" https://github.com/influxdata/pbjson ">pbjson-build 0.8.0</a></li>
                     <li><a href=" https://github.com/influxdata/pbjson ">pbjson-types 0.8.0</a></li>
                     <li><a href=" https://github.com/influxdata/pbjson ">pbjson 0.8.0</a></li>
                     <li><a href=" https://github.com/MitchellRhysHall/random_word ">random_word 0.5.2</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-bitpacker 0.8.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-columnar 0.5.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-common 0.9.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-query-grammar 0.24.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-sstable 0.5.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-stacker 0.5.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-tokenizer-api 0.5.0</a></li>
                     <li><a href=" https://github.com/Nugine/simd ">vsimd 0.8.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -12469,7 +12666,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.18</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.49.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.52.3</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -12498,7 +12695,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.8</a></li>
+                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.9</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -12528,7 +12725,7 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/dtolnay/unsafe-libyaml ">unsafe-libyaml 0.2.11</a></li>
-                    <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.19</a></li>
+                    <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.21</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -12559,7 +12756,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.14</a></li>
+                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.3</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -12613,6 +12810,23 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/zonyitoo/rust-ini ">rust-ini 0.21.3</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2014 Y. T. CHUNG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-phf/rust-phf ">phf 0.12.1</a></li>
                     <li><a href=" https://github.com/rust-phf/rust-phf ">phf_shared 0.12.1</a></li>
                 </ul>
@@ -12648,45 +12862,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     <li><a href=" https://github.com/BurntSushi/rust-csv ">csv 1.4.0</a></li>
                     <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
                     <li><a href=" https://github.com/BurntSushi/jiff ">jiff-tzdb-platform 0.1.3</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff-tzdb 0.1.5</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.19</a></li>
-                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff-tzdb 0.1.6</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.24</a></li>
+                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.0</a></li>
                     <li><a href=" https://github.com/BurntSushi/utf8-ranges ">utf8-ranges 1.0.5</a></li>
                     <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2015 Andrew Gallant
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-inc/fst ">tantivy-fst 0.5.0</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2015 Andrew Gallant
-Copyright (c) 2019 Paul Masurel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -12773,6 +12957,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/GuillaumeGomez/sysinfo ">sysinfo 0.38.4</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015 Guillaume Gomez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/shepmaster/twox-hash ">twox-hash 2.1.2</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -12832,11 +13046,41 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/Keats/jsonwebtoken ">jsonwebtoken 9.3.1</a></li>
+                    <li><a href=" https://github.com/Keats/jsonwebtoken ">jsonwebtoken 10.4.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2015 Vincent Prouillet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015-2020 the fiat-crypto authors (see
+https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -12921,6 +13165,35 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/nabijaczleweli/safe-transmute-rs ">safe-transmute 0.11.3</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2016 nabijaczleweli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/BurntSushi/same-file ">same-file 1.0.6</a></li>
                     <li><a href=" https://github.com/BurntSushi/winapi-util ">winapi-util 0.1.11</a></li>
                 </ul>
@@ -12981,8 +13254,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/pseitz/lz4_flex ">lz4_flex 0.11.5</a></li>
-                    <li><a href=" https://github.com/pseitz/lz4_flex ">lz4_flex 0.12.0</a></li>
+                    <li><a href=" https://github.com/pseitz/lz4_flex ">lz4_flex 0.13.1</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -13143,8 +13415,8 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.37.5</a></li>
                     <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.38.4</a></li>
+                    <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.39.4</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -13197,6 +13469,387 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/mackwic/colored ">colored 3.1.1</a></li>
+                </ul>
+                <pre class="license-text">Mozilla Public License Version 2.0
+&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+
+1. Definitions
+--------------
+
+1.1. &quot;Contributor&quot;
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. &quot;Contributor Version&quot;
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor&#x27;s Contribution.
+
+1.3. &quot;Contribution&quot;
+    means Covered Software of a particular Contributor.
+
+1.4. &quot;Covered Software&quot;
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. &quot;Incompatible With Secondary Licenses&quot;
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. &quot;Executable Form&quot;
+    means any form of the work other than Source Code Form.
+
+1.7. &quot;Larger Work&quot;
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. &quot;License&quot;
+    means this document.
+
+1.9. &quot;Licensable&quot;
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. &quot;Modifications&quot;
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. &quot;Patent Claims&quot; of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. &quot;Secondary License&quot;
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. &quot;Source Code Form&quot;
+    means the form of the work preferred for making modifications.
+
+1.14. &quot;You&quot; (or &quot;Your&quot;)
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, &quot;You&quot; includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, &quot;control&quot; means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party&#x27;s
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients&#x27; rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients&#x27; rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an &quot;as is&quot;       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party&#x27;s negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party&#x27;s ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
+---------------------------------------------------------
+
+  This Source Code Form is &quot;Incompatible With Secondary Licenses&quot;, as
+  defined by the Mozilla Public License, v. 2.0.
 </pre>
             </li>
             <li class="license">
@@ -13584,7 +14237,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 
@@ -13631,24 +14284,24 @@ authorization of the copyright holder.
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.1.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.1.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.4</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.6</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.6</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.3</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.7</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.8</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.4</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.6</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 
@@ -13702,7 +14355,7 @@ ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation a
                 <h3 id="Zlib">zlib License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/trifectatechfoundation/zlib-rs ">zlib-rs 0.6.0</a></li>
+                    <li><a href=" https://github.com/trifectatechfoundation/zlib-rs ">zlib-rs 0.6.3</a></li>
                 </ul>
                 <pre class="license-text">(C) 2024 Trifecta Tech Foundation 
 
@@ -13724,6 +14377,56 @@ freely, subject to the following restrictions:
 
 3. This notice may not be removed or altered from any source distribution.
 </pre>
+            </li>
+            <li class="license">
+                <h3 id="Zlib">zlib License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/rodrimati1992/const_panic/ ">const_panic 0.2.15</a></li>
+                    <li><a href=" https://github.com/rodrimati1992/konst/ ">konst 0.4.3</a></li>
+                    <li><a href=" https://github.com/rodrimati1992/konst/ ">konst_proc_macros 0.4.1</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2021 Matias Rodriguez.
+
+This software is provided &#x27;as-is&#x27;, without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.</pre>
+            </li>
+            <li class="license">
+                <h3 id="Zlib">zlib License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/rodrimati1992/typewit/ ">typewit 1.15.2</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2023 Matias Rodriguez.
+
+This software is provided &#x27;as-is&#x27;, without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.</pre>
             </li>
             <li class="license">
                 <h3 id="Zlib">zlib License</h3>

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3633,6 +3633,7 @@ dependencies = [
  "async-trait",
  "async_cell",
  "aws-credential-types",
+ "bitpacking",
  "byteorder",
  "bytes",
  "chrono",

--- a/python/PYTHON_THIRD_PARTY_LICENSES.md
+++ b/python/PYTHON_THIRD_PARTY_LICENSES.md
@@ -5,7 +5,7 @@
 | PyYAML                         | 6.0.3       | MIT License                                       | https://pyyaml.org/                                                  |
 | Pygments                       | 2.19.2      | BSD License                                       | https://pygments.org                                                 |
 | aiohappyeyeballs               | 2.6.1       | Python Software Foundation License                | https://github.com/aio-libs/aiohappyeyeballs                         |
-| aiohttp                        | 3.12.15     | Apache-2.0 AND MIT                                | https://github.com/aio-libs/aiohttp                                  |
+| aiohttp                        | 3.13.4      | Apache-2.0 AND MIT                                | https://github.com/aio-libs/aiohttp                                  |
 | aiosignal                      | 1.4.0       | Apache Software License                           | https://github.com/aio-libs/aiosignal                                |
 | annotated-types                | 0.7.0       | MIT License                                       | https://github.com/annotated-types/annotated-types                   |
 | arro3-core                     | 0.6.5       | UNKNOWN                                           | https://kylebarron.dev/arro3                                         |
@@ -14,7 +14,7 @@
 | botocore                       | 1.40.43     | Apache Software License                           | https://github.com/boto/botocore                                     |
 | certifi                        | 2025.8.3    | Mozilla Public License 2.0 (MPL 2.0)              | https://github.com/certifi/python-certifi                            |
 | charset-normalizer             | 3.4.3       | MIT                                               | https://github.com/jawah/charset_normalizer/blob/master/CHANGELOG.md |
-| datafusion                     | 50.1.0      | Apache Software License                           | https://datafusion.apache.org/python                                 |
+| datafusion                     | 53.0.0      | Apache Software License                           | https://datafusion.apache.org/python                                 |
 | datasets                       | 4.1.1       | Apache Software License                           | https://github.com/huggingface/datasets                              |
 | dill                           | 0.4.0       | BSD License                                       | https://github.com/uqfoundation/dill                                 |
 | duckdb                         | 1.4.0       | MIT License                                       | https://github.com/duckdb/duckdb-python                              |
@@ -28,8 +28,9 @@
 | idna                           | 3.10        | BSD License                                       | https://github.com/kjd/idna                                          |
 | iniconfig                      | 2.1.0       | MIT                                               | https://github.com/pytest-dev/iniconfig                              |
 | jmespath                       | 1.0.1       | MIT License                                       | https://github.com/jmespath/jmespath.py                              |
-| lance-namespace                | 0.4.5       | Apache-2.0                                        | https://github.com/lance-format/lance-namespace                      |
-| lance-namespace-urllib3-client | 0.4.5       | Apache-2.0                                        | https://github.com/lance-format/lance-namespace                      |
+| lance-namespace                | 0.7.6       | Apache-2.0                                        | https://github.com/lance-format/lance-namespace                      |
+| lance-namespace-urllib3-client | 0.7.6       | Apache-2.0                                        | https://github.com/lance-format/lance-namespace                      |
+| maturin                        | 1.13.3      | MIT OR Apache-2.0                                 | https://github.com/pyo3/maturin                                      |
 | ml_dtypes                      | 0.5.3       | Apache-2.0                                        | https://github.com/jax-ml/ml_dtypes                                  |
 | mpmath                         | 1.3.0       | BSD License                                       | http://mpmath.org/                                                   |
 | multidict                      | 6.6.4       | Apache License 2.0                                | https://github.com/aio-libs/multidict                                |
@@ -46,18 +47,18 @@
 | propcache                      | 0.3.2       | Apache Software License                           | https://github.com/aio-libs/propcache                                |
 | psutil                         | 7.1.0       | BSD-3-Clause                                      | https://github.com/giampaolo/psutil                                  |
 | py-cpuinfo                     | 9.0.0       | MIT License                                       | https://github.com/workhorsy/py-cpuinfo                              |
-| pyarrow                        | 21.0.0      | Apache Software License                           | https://arrow.apache.org/                                            |
+| pyarrow                        | 23.0.1      | Apache-2.0                                        | https://arrow.apache.org/                                            |
 | pydantic                       | 2.12.4      | MIT                                               | https://github.com/pydantic/pydantic                                 |
 | pydantic_core                  | 2.41.5      | MIT                                               | https://github.com/pydantic/pydantic-core                            |
-| pylance                        | 3.0.0b2     | Apache Software License                           | UNKNOWN                                                              |
-| pyproj                         | 3.7.2       | MIT                                               | https://github.com/pyproj4/pyproj                                    |
+| pylance                        | 7.0.0b14    | Apache Software License                           | UNKNOWN                                                              |
+| pyproj                         | 3.7.2       | MIT                                               | https://pyproj4.github.io/pyproj/                                    |
 | pyright                        | 1.1.406     | MIT                                               | https://github.com/RobertCraigie/pyright-python                      |
 | pytest                         | 8.4.2       | MIT License                                       | https://docs.pytest.org/en/latest/                                   |
 | pytest-benchmark               | 5.1.0       | BSD License                                       | https://github.com/ionelmc/pytest-benchmark                          |
 | python-dateutil                | 2.9.0.post0 | Apache Software License; BSD License              | https://github.com/dateutil/dateutil                                 |
 | pytz                           | 2025.2      | MIT License                                       | http://pythonhosted.org/pytz                                         |
-| requests                       | 2.32.5      | Apache Software License                           | https://requests.readthedocs.io                                      |
-| ruff                           | 0.4.1       | MIT License                                       | https://docs.astral.sh/ruff                                          |
+| requests                       | 2.33.0      | Apache Software License                           | https://github.com/psf/requests                                      |
+| ruff                           | 0.11.2      | MIT License                                       | https://docs.astral.sh/ruff                                          |
 | s3transfer                     | 0.14.0      | Apache Software License                           | https://github.com/boto/s3transfer                                   |
 | six                            | 1.17.0      | MIT License                                       | https://github.com/benjaminp/six                                     |
 | sympy                          | 1.14.0      | BSD License                                       | https://sympy.org                                                    |

--- a/python/RUST_THIRD_PARTY_LICENSES.html
+++ b/python/RUST_THIRD_PARTY_LICENSES.html
@@ -44,43 +44,23 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (507)</li>
-            <li><a href="#MIT">MIT License</a> (161)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (545)</li>
+            <li><a href="#MIT">MIT License</a> (159)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
-            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (9)</li>
-            <li><a href="#Zlib">zlib License</a> (9)</li>
-            <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (7)</li>
-            <li><a href="#ISC">ISC License</a> (7)</li>
-            <li><a href="#0BSD">BSD Zero Clause License</a> (2)</li>
-            <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (2)</li>
-            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (2)</li>
+            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (10)</li>
+            <li><a href="#Zlib">zlib License</a> (10)</li>
+            <li><a href="#ISC">ISC License</a> (9)</li>
+            <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (4)</li>
+            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (3)</li>
+            <li><a href="#0BSD">BSD Zero Clause License</a> (1)</li>
             <li><a href="#BSL-1.0">Boost Software License 1.0</a> (1)</li>
+            <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
             <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a> (1)</li>
             <li><a href="#bzip2-1.0.6">bzip2 and libbzip2 License v1.0.6</a> (1)</li>
         </ul>
 
         <h2>All license text:</h2>
         <ul class="licenses-list">
-            <li class="license">
-                <h3 id="0BSD">BSD Zero Clause License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/museun/mock_instant ">mock_instant 0.6.0</a></li>
-                </ul>
-                <pre class="license-text">Copyright (C) 2020 by museun &lt;museun@outlook.com&gt;
-
-Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
-</pre>
-            </li>
             <li class="license">
                 <h3 id="0BSD">BSD Zero Clause License</h3>
                 <h4>Used by:</h4>
@@ -99,216 +79,6 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
 AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.0</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2023 Jacob Pratt
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
 </pre>
             </li>
             <li class="license">
@@ -525,7 +295,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.5.5</a></li>
+                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.5.8</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -735,8 +505,8 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/pylance ">pylance 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/oxidecomputer/serde_tokenstream ">serde_tokenstream 0.2.2</a></li>
+                    <li><a href=" https://crates.io/crates/pylance ">pylance 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/oxidecomputer/serde_tokenstream ">serde_tokenstream 0.2.3</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -945,28 +715,29 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-arith 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-array 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-buffer 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-cast 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-csv 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-data 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ipc 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-json 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ord 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-row 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-schema 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-select 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-string 57.2.0</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow 57.2.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-arith 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-array 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-buffer 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-cast 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-csv 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-data 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ipc 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-json 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-ord 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-row 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-schema 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-select 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-string 58.3.0</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow 58.3.0</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
-                    <li><a href=" https://github.com/SOF3/include-flate.git ">include-flate 0.3.1</a></li>
-                    <li><a href=" https://github.com/lo48576/iri-string ">iri-string 0.7.10</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">parquet 57.2.0</a></li>
-                    <li><a href=" https://github.com/Stoeoef/spade ">spade 2.15.0</a></li>
-                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.10.0</a></li>
+                    <li><a href=" https://github.com/thomcc/rust-more-asserts ">more-asserts 0.3.1</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">parquet 58.3.0</a></li>
+                    <li><a href=" https://github.com/Stoeoef/spade ">spade 2.15.1</a></li>
+                    <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
+                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.11.0</a></li>
                     <li><a href=" https://github.com/hsivonen/utf8_iter ">utf8_iter 1.0.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">zeroize 1.8.2</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize/derive ">zeroize_derive 1.4.3</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1176,7 +947,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apache/arrow-rs-object-store ">object_store 0.12.5</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs-object-store ">object_store 0.13.2</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1388,7 +1159,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.13.4</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.13.5</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1616,39 +1387,41 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog-listing 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common-runtime 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-arrow 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-csv 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-json 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-parquet 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-doc 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-execution 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-ffi 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-nested 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-table 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-macros 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-optimizer 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-optimizer 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-plan 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-proto-common 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-proto 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-session 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-sql 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-substrait 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion 51.0.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog-listing 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-catalog 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common-runtime 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-arrow 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-csv 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-json 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource-parquet 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-datasource 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-doc 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-execution 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-expr 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-ffi 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-aggregate 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-nested 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-table 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions-window 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-functions 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-macros 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-optimizer 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-adapter 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-optimizer 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-plan 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-proto-common 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-proto 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-pruning 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-session 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-sql 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion-substrait 53.1.0</a></li>
+                    <li><a href=" https://github.com/apache/datafusion ">datafusion 53.1.0</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1868,217 +1641,6 @@ License: http://www.apache.org/licenses/LICENSE-2.0
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/la10736/rstest ">rstest 0.26.1</a></li>
-                    <li><a href=" https://github.com/la10736/rstest ">rstest_macros 0.26.1</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-   
-   Copyright 2018-19 Michele d&#x27;Amico
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/jeffparsons/rangemap ">rangemap 1.7.1</a></li>
                 </ul>
                 <pre class="license-text">
@@ -2260,216 +1822,6 @@ License: http://www.apache.org/licenses/LICENSE-2.0
    END OF TERMS AND CONDITIONS
 
    Copyright 2019-2022 Jeff Parsons, and [contributors](https://github.com/jeffparsons/rangemap/contributors)
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/bincode-org/unty ">unty 0.0.4</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2023 Bincode 
 
    Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
    you may not use this file except in compliance with the License.
@@ -2925,34 +2277,29 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-collections 0.3.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.62.2</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-future 0.3.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-implement 0.60.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-interface 0.59.3</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.2.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-numerics 0.3.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-registry 0.6.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.4.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.5.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.59.0</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.60.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.61.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.53.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-threading 0.2.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.62.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.53.1</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3161,7 +2508,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/moka-rs/moka ">moka 0.12.13</a></li>
+                    <li><a href=" https://github.com/moka-rs/moka ">moka 0.12.15</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3351,7 +2698,7 @@ Software.
       same &quot;printed page&quot; as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 - 2025 Tatsuya Kawano
+   Copyright 2020 - 2026 Tatsuya Kawano
 
    Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
    you may not use this file except in compliance with the License.
@@ -3581,7 +2928,6 @@ Software.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/Xuanwo/backon ">backon 1.6.0</a></li>
-                    <li><a href=" https://github.com/Xuanwo/reqsign ">reqsign 0.16.5</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3789,8 +3135,8 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.38</a></li>
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.38</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.48</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.48</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -4209,217 +3555,17 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mheffner/rust-sketches-ddsketch ">sketches-ddsketch 0.3.0</a></li>
-                </ul>
-                <pre class="license-text">                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [2019] [Mike Heffner]
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/databendlabs/jsonb ">jsonb 0.5.5</a></li>
-                    <li><a href=" https://github.com/apache/opendal ">opendal 0.55.0</a></li>
+                    <li><a href=" https://github.com/databendlabs/jsonb ">jsonb 0.5.6</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal 0.56.0</a></li>
+                    <li><a href=" https://github.com/cberner/redb ">redb 3.1.3</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-aliyun-oss 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-aws-v4 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-azure-storage 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-core 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-file-read-tokio 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-google 3.0.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal-reqsign ">reqsign-tencent-cos 3.0.0</a></li>
+                    <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.7.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -4628,7 +3774,216 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.11.0</a></li>
+                    <li><a href=" https://github.com/MSxDOS/ntapi ">ntapi 0.4.3</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   </pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.12.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -5046,26 +4401,31 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.21</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 1.0.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 1.0.0</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
-                    <li><a href=" https://github.com/bbqsrc/core2 ">core2 0.4.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.14</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.1</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.0</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.6.1</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.1.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.5</a></li>
                     <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder 0.20.2</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder_core 0.20.2</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder_macro 0.20.2</a></li>
-                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.4</a></li>
-                    <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.8</a></li>
+                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 1.0.1</a></li>
+                    <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.10</a></li>
+                    <li><a href=" https://github.com/srijs/rust-gearhash ">gearhash 0.1.3</a></li>
                     <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
                     <li><a href=" https://github.com/chronotope/humantime ">humantime 2.3.0</a></li>
                     <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.2</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.4.1</a></li>
                     <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.7.5+spec-1.1.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.23.10+spec-1.0.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.6+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.1+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.11+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.2+spec-1.1.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -5275,10 +4635,10 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-dynamodb 1.104.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.93.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.95.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.97.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-dynamodb 1.107.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.95.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.97.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.99.0</a></li>
                 </ul>
                 <pre class="license-text">                                Apache License
                            Version 2.0, January 2004
@@ -5697,15 +5057,15 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.31</a></li>
-                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.31</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.32</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5915,7 +5275,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.19.0</a></li>
+                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.20.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6124,6 +5484,7 @@ limitations under the License.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.12.28</a></li>
+                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.13.3</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6542,7 +5903,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/tokio-rustls ">tokio-rustls 0.24.1</a></li>
                     <li><a href=" https://github.com/rustls/tokio-rustls ">tokio-rustls 0.26.4</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -7170,8 +6530,217 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/shepmaster/snafu ">snafu-derive 0.8.9</a></li>
-                    <li><a href=" https://github.com/shepmaster/snafu ">snafu 0.8.9</a></li>
+                    <li><a href=" https://github.com/tokio-rs/io-uring ">io-uring 0.7.12</a></li>
+                </ul>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2019 quininer kel
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/shepmaster/snafu ">snafu-derive 0.9.0</a></li>
+                    <li><a href=" https://github.com/shepmaster/snafu ">snafu 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7368,215 +6937,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://gitlab.com/CreepySkeleton/proc-macro-error ">proc-macro-error-attr 1.0.4</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2019-2020 CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
@@ -8217,7 +7577,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.0</a></li>
+                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -8637,7 +7997,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.9</a></li>
+                    <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.10</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9056,28 +8416,32 @@ limitations under the License.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
-                    <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.1</a></li>
+                    <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.1</a></li>
                     <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                     <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
-                    <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.19</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.42</a></li>
                     <li><a href=" https://github.com/smol-rs/async-lock ">async-lock 3.4.2</a></li>
                     <li><a href=" https://github.com/smol-rs/atomic-waker ">atomic-waker 1.1.2</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.10.0</a></li>
-                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.1</a></li>
+                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.1</a></li>
+                    <li><a href=" https://github.com/BurntSushi/bstr ">bstr 1.12.1</a></li>
+                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
                     <li><a href=" https://github.com/vorner/bytes-utils ">bytes-utils 0.1.4</a></li>
-                    <li><a href=" https://github.com/alexcrichton/bzip2-rs ">bzip2-sys 0.1.13+1.0.8</a></li>
-                    <li><a href=" https://github.com/trifectatechfoundation/bzip2-rs ">bzip2 0.5.2</a></li>
                     <li><a href=" https://github.com/trifectatechfoundation/bzip2-rs ">bzip2 0.6.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.55</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.62</a></li>
+                    <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if 0.1.10</a></li>
                     <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
+                    <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.58</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.38</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.32</a></li>
                     <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue 2.5.0</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random-macro 0.1.16</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random 0.1.18</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys 0.8.7</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.10.1</a></li>
+                    <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.9.4</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-channel 0.5.15</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.6</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.18</a></li>
@@ -9091,41 +8455,38 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener-strategy ">event-listener-strategy 0.5.4</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
-                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
-                    <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.27</a></li>
+                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.4.1</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                     <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset 0.5.7</a></li>
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
-                    <li><a href=" https://github.com/al8n/fs4-rs ">fs4 0.8.4</a></li>
-                    <li><a href=" https://github.com/async-rs/futures-timer ">futures-timer 3.0.3</a></li>
                     <li><a href=" https://github.com/georust/geohash.rs ">geohash 0.13.1</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.3</a></li>
                     <li><a href=" https://github.com/japaric/hash32 ">hash32 0.3.1</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.14.5</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.17.1</a></li>
                     <li><a href=" https://github.com/rust-embedded/heapless ">heapless 0.8.0</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                     <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
-                    <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.24.2</a></li>
-                    <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.7</a></li>
+                    <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.9</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
-                    <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.1</a></li>
-                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.13.0</a></li>
+                    <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.2</a></li>
+                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.14.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.11.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.13.0</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
                     <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.34</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.85</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.98</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
-                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.11.0</a></li>
-                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
+                    <li><a href=" https://github.com/portable-network-archive/liblzma-rs ">liblzma-sys 0.4.6</a></li>
+                    <li><a href=" https://github.com/portable-network-archive/liblzma-rs ">liblzma 0.4.6</a></li>
+                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
-                    <li><a href=" https://github.com/alexcrichton/xz2-rs ">lzma-sys 0.1.20</a></li>
                     <li><a href=" https://github.com/bluss/matrixmultiply/ ">matrixmultiply 0.3.10</a></li>
                     <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                     <li><a href=" https://github.com/havarnov/multimap ">multimap 0.10.1</a></li>
@@ -9138,73 +8499,75 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
                     <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
-                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
+                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.4</a></li>
                     <li><a href=" https://github.com/rustls/openssl-probe ">openssl-probe 0.2.1</a></li>
                     <li><a href=" https://github.com/smol-rs/parking ">parking 2.2.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.5</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.12</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
                     <li><a href=" https://github.com/petgraph/petgraph ">petgraph 0.8.3</a></li>
-                    <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.32</a></li>
+                    <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.33</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-build 0.14.3</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-derive 0.14.3</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-types 0.14.3</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost 0.14.3</a></li>
                     <li><a href=" https://github.com/bluss/rawpointer/ ">rawpointer 0.2.1</a></li>
                     <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
-                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.11.0</a></li>
+                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.12.0</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-lite 0.1.9</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.9</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.3</a></li>
                     <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
+                    <li><a href=" https://github.com/RoaringBitmap/roaring-rs ">roaring 0.11.4</a></li>
                     <li><a href=" https://github.com/georust/robust ">robust 1.2.0</a></li>
                     <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.3</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.4</a></li>
                     <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.3</a></li>
-                    <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.2.0</a></li>
-                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.21.12</a></li>
-                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.36</a></li>
+                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.40</a></li>
                     <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
-                    <li><a href=" https://github.com/rustls/sct.rs ">sct 0.7.1</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.15.0</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.5.1</a></li>
-                    <li><a href=" https://gitlab.com/ijackson/rust-shellexpand ">shellexpand 3.1.1</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.20.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.20.0</a></li>
+                    <li><a href=" https://gitlab.com/ijackson/rust-shellexpand ">shellexpand 3.1.2</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
+                    <li><a href=" https://github.com/seancroach/simd_cesu8 ">simd_cesu8 1.1.1</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.10</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.2</a></li>
-                    <li><a href=" https://github.com/apache/datafusion-sqlparser-rs ">sqlparser 0.59.0</a></li>
-                    <li><a href=" https://github.com/sqlparser-rs/sqlparser-rs ">sqlparser_derive 0.3.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
+                    <li><a href=" https://github.com/apache/datafusion-sqlparser-rs ">sqlparser 0.61.0</a></li>
+                    <li><a href=" https://github.com/sqlparser-rs/sqlparser-rs ">sqlparser_derive 0.5.0</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/stacker ">stacker 0.1.22</a></li>
+                    <li><a href=" https://github.com/rust-lang/stacker ">stacker 0.1.24</a></li>
+                    <li><a href=" https://gitlab.com/chris-morgan/symlink ">symlink 0.1.0</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.109</a></li>
-                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.44</a></li>
-                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.24.0</a></li>
+                    <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration-sys 0.6.0</a></li>
+                    <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration 0.7.0</a></li>
+                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.27.0</a></li>
                     <li><a href=" https://github.com/bluss/thread-tree ">thread-tree 0.3.3</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.9</a></li>
                     <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.9.0</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-normalization ">unicode-normalization 0.1.25</a></li>
-                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.12.0</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.13.2</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.20.0</a></li>
+                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.1</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.58</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.85</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasi 0.14.7+wasi-0.2.4</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.3+wasi-0.2.9</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.71</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.121</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.98</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.57.1</a></li>
                     <li><a href=" https://github.com/georust/wkb ">wkb 0.9.2</a></li>
                     <li><a href=" https://github.com/georust/wkt ">wkt 0.14.0</a></li>
-                    <li><a href=" https://github.com/Stebalien/xattr ">xattr 1.6.1</a></li>
                     <li><a href=" https://github.com/RazrFalcon/xmlparser ">xmlparser 0.13.6</a></li>
-                    <li><a href=" https://github.com/alexcrichton/xz2-rs ">xz2 0.1.7</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9413,14 +8776,12 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/marcianx/downcast-rs ">downcast-rs 2.0.2</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-core 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-parse-float 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-parse-integer 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-util 1.0.7</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-write-float 1.0.6</a></li>
                     <li><a href=" https://github.com/Alexhuszagh/rust-lexical ">lexical-write-integer 1.0.6</a></li>
-                    <li><a href=" https://github.com/Alexhuszagh/minimal-lexical ">minimal-lexical 0.2.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9635,9 +8996,11 @@ limitations under the License.
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.3.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/block-modes ">cbc 0.1.2</a></li>
+                    <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.10.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">cipher 0.4.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/const-oid ">const-oid 0.9.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.17</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.3.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.7.10</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
@@ -9863,9 +9226,9 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-random/rand_core ">rand_core 0.10.1</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.5</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand_distr 0.4.3</a></li>
                     <li><a href=" https://github.com/rust-random/rand_distr ">rand_distr 0.5.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -10063,6 +9426,7 @@ APPENDIX: How to apply the Apache License to your work.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
+                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.2</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -10272,8 +9636,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/cargo ">home 0.5.12</a></li>
-                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.4.0</a></li>
+                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.5.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -10482,216 +9845,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://gitlab.com/CreepySkeleton/proc-macro-error ">proc-macro-error 1.0.4</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2019-2020 CreepySkeleton &lt;creepy-skeleton@yandex.ru&gt;
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/stacker/ ">psm 0.1.29</a></li>
+                    <li><a href=" https://github.com/rust-lang/stacker/ ">psm 0.1.31</a></li>
                 </ul>
                 <pre class="license-text">                             Apache License
                        Version 2.0, January 2004
@@ -10894,6 +10048,218 @@ distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor-proc-macro 0.0.7</a></li>
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor 0.6.3</a></li>
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor-proc-macro 0.0.6</a></li>
+                    <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor 0.1.1</a></li>
+                </ul>
+                <pre class="license-text">Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 </pre>
             </li>
             <li class="license">
@@ -11179,112 +10545,132 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/lance-format/lance ">lance-bitpacking 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">fsst 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-arrow 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-core 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-datafusion 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-datagen 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-encoding 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-file 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-geo 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-index 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-io 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-linalg 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace-impls 3.0.0-beta.2</a></li>
-                    <li><a href=" https://github.com/lance-format/lance ">lance-table 3.0.0-beta.2</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-bitpacking 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">fsst 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-arrow 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-core 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-datafusion 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-datagen 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-encoding 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-file 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-geo 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-index 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-io 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-linalg 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-namespace-impls 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-table 7.0.0-beta.14</a></li>
+                    <li><a href=" https://github.com/lance-format/lance ">lance-tokenizer 7.0.0-beta.14</a></li>
                     <li><a href=" https://github.com/rodrimati1992/abi_stable_crates/ ">abi_stable 0.11.3</a></li>
                     <li><a href=" https://github.com/rodrimati1992/abi_stable_crates/ ">abi_stable_derive 0.11.3</a></li>
                     <li><a href=" https://github.com/rodrimati1992/abi_stable_crates/ ">abi_stable_shared 0.11.0</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.101</a></li>
-                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-pyarrow 57.2.0</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-pyarrow 58.3.0</a></li>
                     <li><a href=" https://github.com/rodrimati1992/abi_stable_crates/ ">as_derive_utils 0.11.0</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.8.13</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.11</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.6.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.3.8</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.11</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http-client 1.1.9</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.63.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.62.3</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-observability 0.2.4</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.13</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.11.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.10.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.4.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.13</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.11</a></li>
-                    <li><a href=" https://github.com/BLAKE3-team/BLAKE3 ">blake3 1.8.3</a></li>
-                    <li><a href=" https://github.com/elastio/bon ">bon-macros 3.8.2</a></li>
-                    <li><a href=" https://github.com/elastio/bon ">bon 3.8.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.8.14</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.13</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.7.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.4.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.13</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http-client 1.1.11</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.63.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.62.4</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-observability 0.2.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.14</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.11.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.10.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.4.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.14</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.13</a></li>
+                    <li><a href=" https://github.com/BLAKE3-team/BLAKE3 ">blake3 1.8.5</a></li>
                     <li><a href=" https://github.com/cesarb/constant_time_eq ">constant_time_eq 0.4.2</a></li>
                     <li><a href=" https://github.com/rodrimati1992/core_extensions ">core_extensions 1.5.4</a></li>
                     <li><a href=" https://github.com/rodrimati1992/core_extensions ">core_extensions_proc_macros 1.5.4</a></li>
                     <li><a href=" https://github.com/zowens/crc32c ">crc32c 0.6.8</a></li>
-                    <li><a href=" https://github.com/hanmertens/dary_heap ">dary_heap 0.3.8</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-physical-expr-adapter 51.0.0</a></li>
-                    <li><a href=" https://github.com/apache/datafusion ">datafusion-pruning 51.0.0</a></li>
+                    <li><a href=" https://github.com/daac-tools/daachorse ">daachorse 2.1.1</a></li>
                     <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
                     <li><a href=" https://github.com/soc/dirs-rs ">dirs 6.0.0</a></li>
+                    <li><a href=" https://github.com/sgodwincs/dlv-list-rs ">dlv-list 0.5.2</a></li>
+                    <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
                     <li><a href=" https://github.com/dtolnay/dyn-clone ">dyn-clone 1.0.20</a></li>
-                    <li><a href=" https://github.com/nlordell/ethnum-rs ">ethnum 1.5.2</a></li>
+                    <li><a href=" https://github.com/nlordell/ethnum-rs ">ethnum 1.5.3</a></li>
                     <li><a href=" https://github.com/google/flatbuffers ">flatbuffers 25.12.19</a></li>
                     <li><a href=" https://github.com/georust/geo ">geo-traits 0.3.0</a></li>
-                    <li><a href=" https://github.com/georust/geo ">geo-types 0.7.18</a></li>
+                    <li><a href=" https://github.com/georust/geo ">geo-types 0.7.19</a></li>
                     <li><a href=" https://github.com/georust/geo ">geo 0.31.0</a></li>
-                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-array 0.7.0</a></li>
-                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-expr-geo 0.7.0</a></li>
-                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-schema 0.7.0</a></li>
-                    <li><a href=" https://github.com/datafusion-contrib/geodatafusion ">geodatafusion 0.2.0</a></li>
+                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-array 0.8.0</a></li>
+                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-expr-geo 0.8.0</a></li>
+                    <li><a href=" https://github.com/geoarrow/geoarrow-rs ">geoarrow-schema 0.8.0</a></li>
+                    <li><a href=" https://github.com/datafusion-contrib/geodatafusion ">geodatafusion 0.4.0</a></li>
                     <li><a href=" https://github.com/rustwasm/gloo/tree/master/crates/timers ">gloo-timers 0.3.0</a></li>
                     <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
-                    <li><a href=" https://github.com/veddan/rust-htmlescape ">htmlescape 0.3.1</a></li>
+                    <li><a href=" https://github.com/ethereal-sheep/heapify ">heapify 0.2.0</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">hf-xet 1.5.2</a></li>
                     <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
-                    <li><a href=" https://github.com/SOF3/include-flate.git ">include-flate-codegen 0.3.1</a></li>
-                    <li><a href=" https://github.com/SOF3/include-flate.git ">include-flate-compress 0.3.1</a></li>
-                    <li><a href=" https://github.com/dtolnay/indoc ">indoc 2.0.7</a></li>
-                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.17</a></li>
-                    <li><a href=" https://crates.io/crates/lance-namespace-reqwest-client ">lance-namespace-reqwest-client 0.4.5</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.180</a></li>
-                    <li><a href=" https://github.com/stainless-steel/md5 ">md5 0.8.0</a></li>
+                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni-macros 0.22.4</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.22.4</a></li>
+                    <li><a href=" https://crates.io/crates/lance-namespace-reqwest-client ">lance-namespace-reqwest-client 0.7.6</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.186</a></li>
+                    <li><a href=" https://github.com/fast/mea ">mea 0.6.3</a></li>
                     <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.5</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.5</a></li>
-                    <li><a href=" https://github.com/apache/opendal ">object_store_opendal 0.55.0</a></li>
+                    <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.2</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.6</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.6</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-foundation 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-io-kit 0.3.2</a></li>
+                    <li><a href=" https://github.com/madsmtm/objc2 ">objc2-system-configuration 0.3.2</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">object_store_opendal 0.56.0</a></li>
                     <li><a href=" https://github.com/faern/oneshot ">oneshot 0.1.13</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-core 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-concurrent-limit 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-logging 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-retry 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-layer-timeout 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-azblob 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-azdls 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-azure-common 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-cos 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-gcs 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-hf 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-oss 0.56.0</a></li>
+                    <li><a href=" https://github.com/apache/opendal ">opendal-service-s3 0.56.0</a></li>
+                    <li><a href=" https://github.com/dylni/os_str_bytes ">os_str_bytes 6.6.1</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
                     <li><a href=" https://github.com/vitiral/path_abs ">path_abs 0.5.1</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.10</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.10</a></li>
-                    <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic-util 0.2.5</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.13</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.13</a></li>
+                    <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.7</a></li>
                     <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
                     <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
-                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3-build-config 0.26.0</a></li>
-                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3-ffi 0.26.0</a></li>
-                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3-macros-backend 0.26.0</a></li>
-                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3-macros 0.26.0</a></li>
-                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3 0.26.0</a></li>
-                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.44</a></li>
+                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3-build-config 0.28.3</a></li>
+                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3-ffi 0.28.3</a></li>
+                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3-macros-backend 0.28.3</a></li>
+                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3-macros 0.28.3</a></li>
+                    <li><a href=" https://github.com/pyo3/pyo3 ">pyo3 0.28.3</a></li>
+                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.45</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
+                    <li><a href=" https://github.com/r-efi/r-efi ">r-efi 6.0.0</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.10.1</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.6</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.9.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                     <li><a href=" https://github.com/rust-random/rngs ">rand_xoshiro 0.7.0</a></li>
-                    <li><a href=" https://github.com/udoprog/relative-path ">relative-path 1.9.3</a></li>
-                    <li><a href=" https://github.com/WanzenBug/rle-decode-helper ">rle-decode-fast 1.0.3</a></li>
-                    <li><a href=" https://github.com/RoaringBitmap/roaring-rs ">roaring 0.10.12</a></li>
+                    <li><a href=" https://github.com/TrueLayer/reqwest-middleware ">reqwest-middleware 0.5.1</a></li>
                     <li><a href=" https://github.com/georust/rstar ">rstar 0.12.2</a></li>
-                    <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.2</a></li>
+                    <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier-android 0.1.1</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
-                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.22</a></li>
-                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
+                    <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.23</a></li>
+                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.28</a></li>
                     <li><a href=" https://github.com/dtolnay/seq-macro ">seq-macro 0.3.6</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
@@ -11297,10 +10683,10 @@ limitations under the License.
                     <li><a href=" https://github.com/dtolnay/serde-yaml ">serde_yaml 0.9.34+deprecated</a></li>
                     <li><a href=" https://github.com/comex/rust-shlex ">shlex 1.3.0</a></li>
                     <li><a href=" https://github.com/rusticstuff/simdutf8 ">simdutf8 0.1.5</a></li>
-                    <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.2</a></li>
+                    <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.3</a></li>
                     <li><a href=" https://github.com/vitiral/stfu8 ">stfu8 0.2.7</a></li>
                     <li><a href=" https://github.com/substrait-io/substrait-rs ">substrait 0.62.2</a></li>
-                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.114</a></li>
+                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
                     <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                     <li><a href=" https://github.com/oliver-giersch/tagptr.git ">tagptr 0.2.0</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
@@ -11314,14 +10700,19 @@ limitations under the License.
                     <li><a href=" https://github.com/oxidecomputer/typify ">typify-impl 0.5.0</a></li>
                     <li><a href=" https://github.com/oxidecomputer/typify ">typify-macro 0.5.0</a></li>
                     <li><a href=" https://github.com/oxidecomputer/typify ">typify 0.5.0</a></li>
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
-                    <li><a href=" https://github.com/dtolnay/indoc ">unindent 0.2.4</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.2+wasi-0.2.9</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06</a></li>
+                    <li><a href=" https://github.com/ardaku/wasite ">wasite 1.0.2</a></li>
                     <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams 0.4.2</a></li>
+                    <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams 0.5.0</a></li>
+                    <li><a href=" https://github.com/ardaku/whoami ">whoami 2.1.2</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu 0.4.0</a></li>
-                    <li><a href=" https://github.com/takuyaa/yada ">yada 0.5.1</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-client 1.5.2</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-core-structures 1.5.2</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-data 1.5.2</a></li>
+                    <li><a href=" https://github.com/huggingface/xet-core ">xet-runtime 1.5.2</a></li>
                     <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-safe 7.2.4</a></li>
                     <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-sys 2.0.16+zstd.1.5.7</a></li>
                 </ul>
@@ -11640,7 +11031,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.43</a></li>
+                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.44</a></li>
                 </ul>
                 <pre class="license-text">Rust-chrono is dual-licensed under The MIT License [1] and
 Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
@@ -11953,6 +11344,37 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </pre>
             </li>
             <li class="license">
+                <h3 id="BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/fusion-engineering/rust-git-version ">git-version-macro 0.3.9</a></li>
+                    <li><a href=" https://github.com/fusion-engineering/rust-git-version ">git-version 0.3.9</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2017-2020
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
+            </li>
+            <li class="license">
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
@@ -12086,6 +11508,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.2</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
                     <li><a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.2</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
@@ -12205,12 +11628,6 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="CC0-1.0">Creative Commons Zero v1.0 Universal</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/encoding-index-japanese ">encoding-index-japanese 1.20141219.5</a></li>
-                    <li><a href=" https://crates.io/crates/encoding-index-korean ">encoding-index-korean 1.20141219.5</a></li>
-                    <li><a href=" https://crates.io/crates/encoding-index-simpchinese ">encoding-index-simpchinese 1.20141219.5</a></li>
-                    <li><a href=" https://crates.io/crates/encoding-index-singlebyte ">encoding-index-singlebyte 1.20141219.5</a></li>
-                    <li><a href=" https://crates.io/crates/encoding-index-tradchinese ">encoding-index-tradchinese 1.20141219.5</a></li>
-                    <li><a href=" https://crates.io/crates/encoding_index_tests ">encoding_index_tests 0.1.4</a></li>
                     <li><a href=" https://crates.io/crates/tiny-keccak ">tiny-keccak 2.0.2</a></li>
                 </ul>
                 <pre class="license-text">Creative Commons Legal Code
@@ -12340,7 +11757,7 @@ express Statement of Purpose.
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.6</a></li>
+                    <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.7</a></li>
                 </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -12409,6 +11826,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.7.1</a></li>
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.9.0</a></li>
                 </ul>
                 <pre class="license-text">// Copyright 2015-2016 Brian Smith.
@@ -12430,37 +11848,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.101.7</a></li>
-                </ul>
-                <pre class="license-text">// Copyright 2021 Brian Smith.
-//
-// Permission to use, copy, modify, and/or distribute this software for any
-// purpose with or without fee is hereby granted, provided that the above
-// copyright notice and this permission notice appear in all copies.
-//
-// THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHORS DISCLAIM ALL WARRANTIES
-// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR
-// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-#[test]
-fn cert_without_extensions_test() {
-    // Check the certificate is valid with
-    // &#x60;openssl x509 -in cert_without_extensions.der -inform DER -text -noout&#x60;
-    const CERT_WITHOUT_EXTENSIONS_DER: &amp;[u8] &#x3D; include_bytes!(&quot;cert_without_extensions.der&quot;);
-
-    assert!(webpki::EndEntityCert::try_from(CERT_WITHOUT_EXTENSIONS_DER).is_ok());
-}
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="ISC">ISC License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/acw/simple_asn1 ">simple_asn1 0.6.3</a></li>
+                    <li><a href=" https://github.com/acw/simple_asn1 ">simple_asn1 0.6.4</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 Adam Wick
 
@@ -12522,7 +11910,7 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.9</a></li>
+                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.13</a></li>
                 </ul>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -12570,6 +11958,53 @@ THIS SOFTWARE.
 </pre>
             </li>
             <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.17.0</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                </ul>
+                <pre class="license-text">ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. (&quot;ISC&quot;)
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/acatton/serde-yaml-ng ">serde_yaml_ng 0.10.0</a></li>
+                </ul>
+                <pre class="license-text">                                  MIT License
+
+Copyright 2024 Antoine Catton
+Copyright 2016-2024 David Tolnay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
@@ -12600,7 +12035,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.1.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.2.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -12627,7 +12062,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/Geal/nom ">nom 7.1.3</a></li>
                     <li><a href=" https://github.com/rust-bakery/nom ">nom 8.0.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2019 Geoffroy Couprie
@@ -12656,36 +12090,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.32</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.9.0</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.8.1</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
+                <pre class="license-text">Copyright (c) 2014-2026 Sean McArthur
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -12711,7 +12118,7 @@ THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 2.10.1</a></li>
-                    <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.1.0</a></li>
+                    <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.3.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 Jonathan Reem
 
@@ -12744,7 +12151,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.28</a></li>
+                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.29</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 steffengy
 
@@ -12769,32 +12176,6 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/Gilnaa/memoffset ">memoffset 0.9.1</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2017 Gilad Naaman
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -12830,8 +12211,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.3.27</a></li>
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.13</a></li>
+                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.14</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -12891,51 +12271,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/tantivy-search/levenshtein-automata ">levenshtein_automata 0.2.1</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2018 Paul Masurel
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-inc/census ">census 0.4.2</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2018 by Quickwit, Inc. 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy 0.24.2</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2018 by the project authors, as listed in the AUTHORS file. 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -13153,10 +12488,12 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-appender 0.2.5</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.31</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.36</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-log 0.2.0</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.22</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-serde 0.2.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.23</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.44</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors
@@ -13226,7 +12563,7 @@ DEALINGS IN THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tower-rs/tower-http ">tower-http 0.5.2</a></li>
-                    <li><a href=" https://github.com/tower-rs/tower-http ">tower-http 0.6.8</a></li>
+                    <li><a href=" https://github.com/tower-rs/tower-http ">tower-http 0.6.11</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019-2021 Tower Contributors
 
@@ -13325,7 +12662,41 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/davidhewitt/pythonize ">pythonize 0.26.0</a></li>
+                    <li><a href=" https://github.com/RustCrypto/asm-hashes ">sha2-asm 0.6.4</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2020 RustCrypto Developers
+Copyright (c) 2017 Project Nayuki, Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/davidhewitt/pythonize ">pythonize 0.28.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2022-present David Hewitt and Contributors
 
@@ -13379,36 +12750,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-inc/murmurhash32 ">murmurhash32 0.3.1</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2024 by Quickwit Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/fulmicoton/fastdivide ">fastdivide 0.4.2</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2024-Present Paul Masurel
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/mystor/synstructure ">synstructure 0.13.2</a></li>
                 </ul>
                 <pre class="license-text">Copyright 2016 Nika Layzell
@@ -13424,9 +12765,89 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rkyv/bytecheck ">bytecheck_derive 0.8.2</a></li>
+                </ul>
+                <pre class="license-text">Copyright 2020 David Koloski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/axum ">axum-core 0.4.5</a></li>
                 </ul>
                 <pre class="license-text">Copyright 2021 Axum Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/rkyv/ptr_meta ">ptr_meta 0.3.1</a></li>
+                    <li><a href=" https://github.com/rkyv/ptr_meta ">ptr_meta_derive 0.3.1</a></li>
+                    <li><a href=" https://github.com/djkoloski/rend ">rend 0.5.3</a></li>
+                    <li><a href=" https://github.com/rkyv/rkyv ">rkyv 0.8.16</a></li>
+                    <li><a href=" https://github.com/rkyv/rkyv ">rkyv_derive 0.8.16</a></li>
+                </ul>
+                <pre class="license-text">Copyright 2021 David Koloski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/rkyv/bytecheck ">bytecheck 0.8.2</a></li>
+                </ul>
+                <pre class="license-text">Copyright 2023 David Koloski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/rkyv/rancor ">rancor 0.1.1</a></li>
+                </ul>
+                <pre class="license-text">Copyright 2023 David Koloski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/djkoloski/munge ">munge 0.4.7</a></li>
+                    <li><a href=" https://github.com/djkoloski/munge ">munge_macro 0.4.7</a></li>
+                </ul>
+                <pre class="license-text">Copyright 2024 David Koloski
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -13465,29 +12886,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/PSeitz/rust_measure_time ">measure_time 0.9.0</a></li>
-                </ul>
-                <pre class="license-text">Includes portions of humantime
-Copyright (c) 2016 The humantime Developers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru 0.12.5</a></li>
+                    <li><a href=" https://github.com/statrs-dev/statrs ">statrs 0.18.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
-Copyright (c) 2016 Jerome Froelich
+Copyright (c) 2016 Michael Ma
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -13505,7 +12908,8 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
+SOFTWARE.
+</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -13516,6 +12920,35 @@ SOFTWARE.</pre>
                 <pre class="license-text">MIT License
 
 Copyright (c) 2017 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/webdesus/fs_extra ">fs_extra 1.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2017 Denis Kurilenko
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -13599,16 +13032,11 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling 0.20.11</a></li>
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling 0.23.0</a></li>
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.20.11</a></li>
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.23.0</a></li>
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.20.11</a></li>
-                    <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.23.0</a></li>
+                    <li><a href=" https://github.com/djc/tokio-retry ">tokio-retry 0.3.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
-Copyright (c) 2017 Ted Driggs
+Copyright (c) 2017 Sam Rijs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -13633,12 +13061,16 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/messense/jieba-rs ">jieba-rs 0.8.1</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling 0.20.11</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling 0.23.0</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.20.11</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_core 0.23.0</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.20.11</a></li>
+                    <li><a href=" https://github.com/TedDriggs/darling ">darling_macro 0.23.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
-Copyright (c) 2018 - 2019 messense
-Copyright (c) 2019 Paul Meng
+Copyright (c) 2017 Ted Driggs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -13722,7 +13154,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/georust/geographiclib-rs ">geographiclib-rs 0.2.5</a></li>
+                    <li><a href=" https://github.com/sgodwincs/ordered-multimap-rs ">ordered-multimap 0.7.3</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2018 sgodwincs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/georust/geographiclib-rs ">geographiclib-rs 0.2.7</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -13751,7 +13212,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/xacrimon/dashmap ">dashmap 6.1.0</a></li>
+                    <li><a href=" https://github.com/xacrimon/dashmap ">dashmap 6.2.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -13869,9 +13330,9 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/Peternator7/strum ">strum 0.26.3</a></li>
-                    <li><a href=" https://github.com/Peternator7/strum ">strum 0.27.2</a></li>
+                    <li><a href=" https://github.com/Peternator7/strum ">strum 0.28.0</a></li>
                     <li><a href=" https://github.com/Peternator7/strum ">strum_macros 0.26.4</a></li>
-                    <li><a href=" https://github.com/Peternator7/strum ">strum_macros 0.27.2</a></li>
+                    <li><a href=" https://github.com/Peternator7/strum ">strum_macros 0.28.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -13900,7 +13361,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.7.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -13925,34 +13386,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 </pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/lindera/lindera-tantivy ">lindera-tantivy 0.44.1</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2019 by the project authors, as listed in the AUTHORS file.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -14122,6 +13555,64 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/apache/arrow-rs ">arrow-array 58.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2020-2022 Oliver Margetts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/Nugine/const-str ">const-str 1.1.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2020-2026 Nugine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://gitlab.com/samsartor/async_cell ">async_cell 0.2.3</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -14208,7 +13699,7 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.12</a></li>
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.16</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -14267,6 +13758,35 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/spire-rs/countio ">countio 0.3.0</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2024 Spire Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/iShape-Rust/iKeySort ">i_key_sort 0.6.0</a></li>
                     <li><a href=" https://github.com/iShape-Rust/iTree ">i_tree 0.16.0</a></li>
                 </ul>
@@ -14300,23 +13820,16 @@ SOFTWARE.
                     <li><a href=" https://github.com/Nugine/simd ">base64-simd 0.8.0</a></li>
                     <li><a href=" https://github.com/Aeledfyr/deepsize/ ">deepsize_derive 0.1.2</a></li>
                     <li><a href=" https://github.com/iShape-Rust/iOverlay ">i_overlay 4.0.7</a></li>
-                    <li><a href=" https://github.com/messense/jieba-rs ">jieba-macros 0.8.1</a></li>
+                    <li><a href=" https://github.com/messense/jieba-rs ">jieba-macros 0.9.0</a></li>
+                    <li><a href=" https://github.com/messense/jieba-rs ">jieba-rs 0.9.0</a></li>
                     <li><a href=" https://github.com/sam-osamu/com.kanaria ">kanaria 0.2.0</a></li>
                     <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.16</a></li>
-                    <li><a href=" https://github.com/lindera/lindera ">lindera-dictionary 0.44.1</a></li>
-                    <li><a href=" https://github.com/lindera/lindera ">lindera 0.44.1</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">ownedbytes 0.9.0</a></li>
+                    <li><a href=" https://github.com/lindera/lindera ">lindera-dictionary 3.0.7</a></li>
+                    <li><a href=" https://github.com/lindera/lindera ">lindera 3.0.7</a></li>
                     <li><a href=" https://github.com/influxdata/pbjson ">pbjson-build 0.8.0</a></li>
                     <li><a href=" https://github.com/influxdata/pbjson ">pbjson-types 0.8.0</a></li>
                     <li><a href=" https://github.com/influxdata/pbjson ">pbjson 0.8.0</a></li>
                     <li><a href=" https://github.com/MitchellRhysHall/random_word ">random_word 0.5.2</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-bitpacker 0.8.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-columnar 0.5.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-common 0.9.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-query-grammar 0.24.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-sstable 0.5.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-stacker 0.5.0</a></li>
-                    <li><a href=" https://github.com/quickwit-oss/tantivy ">tantivy-tokenizer-api 0.5.0</a></li>
                     <li><a href=" https://github.com/Nugine/simd ">vsimd 0.8.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -14345,7 +13858,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.18</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.49.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.52.3</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -14374,7 +13887,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.8</a></li>
+                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.9</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -14405,7 +13918,7 @@ SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/oxalica/async-ffi ">async-ffi 0.5.0</a></li>
                     <li><a href=" https://github.com/dtolnay/unsafe-libyaml ">unsafe-libyaml 0.2.11</a></li>
-                    <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.19</a></li>
+                    <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.21</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -14436,7 +13949,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.14</a></li>
+                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.3</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -14456,66 +13969,6 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/sile/libflate ">libflate 2.2.1</a></li>
-                    <li><a href=" https://github.com/sile/libflate ">libflate_lz77 2.2.0</a></li>
-                </ul>
-                <pre class="license-text">The MIT License
-
-Copyright (c) 2016 Takeru Ohta &lt;phjgt308@gmail.com&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/lifthrasiir/rust-encoding ">encoding 0.2.33</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2013, Kang Seonghoon.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
 </pre>
             </li>
             <li class="license">
@@ -14550,30 +14003,17 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/bincode-org/bincode ">bincode 2.0.1</a></li>
-                    <li><a href=" https://github.com/bincode-org/bincode ">bincode_derive 2.0.1</a></li>
+                    <li><a href=" https://github.com/zonyitoo/rust-ini ">rust-ini 0.21.3</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
-Copyright (c) 2014 Ty Overby
+Copyright (c) 2014 Y. T. CHUNG
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -14619,45 +14059,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     <li><a href=" https://github.com/BurntSushi/rust-csv ">csv 1.4.0</a></li>
                     <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
                     <li><a href=" https://github.com/BurntSushi/jiff ">jiff-tzdb-platform 0.1.3</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff-tzdb 0.1.5</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.19</a></li>
-                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff-tzdb 0.1.6</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.24</a></li>
+                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.0</a></li>
                     <li><a href=" https://github.com/BurntSushi/utf8-ranges ">utf8-ranges 1.0.5</a></li>
                     <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2015 Andrew Gallant
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/quickwit-inc/fst ">tantivy-fst 0.5.0</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2015 Andrew Gallant
-Copyright (c) 2019 Paul Masurel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -14744,6 +14154,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/GuillaumeGomez/sysinfo ">sysinfo 0.38.4</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015 Guillaume Gomez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/shepmaster/twox-hash ">twox-hash 2.1.2</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -14773,11 +14213,71 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/Keats/jsonwebtoken ">jsonwebtoken 9.3.1</a></li>
+                    <li><a href=" https://github.com/Marwes/combine ">combine 4.6.7</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015 Markus Westerlind
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/Keats/jsonwebtoken ">jsonwebtoken 10.4.0</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2015 Vincent Prouillet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.41.0</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015-2020 the fiat-crypto authors (see
+https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -14862,6 +14362,35 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/nabijaczleweli/safe-transmute-rs ">safe-transmute 0.11.3</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2016 nabijaczleweli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/BurntSushi/same-file ">same-file 1.0.6</a></li>
                     <li><a href=" https://github.com/BurntSushi/winapi-util ">winapi-util 0.1.11</a></li>
                 </ul>
@@ -14922,8 +14451,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/pseitz/lz4_flex ">lz4_flex 0.11.5</a></li>
-                    <li><a href=" https://github.com/pseitz/lz4_flex ">lz4_flex 0.12.0</a></li>
+                    <li><a href=" https://github.com/pseitz/lz4_flex ">lz4_flex 0.13.1</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -15084,8 +14612,8 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.37.5</a></li>
                     <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.38.4</a></li>
+                    <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.39.4</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -15110,35 +14638,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/bincode-org/virtue ">virtue 0.0.18</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2021 Victor Koenders
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -15213,6 +14712,387 @@ THE SOFTWARE.
 
 1.7. &quot;Larger Work&quot;
     means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. &quot;License&quot;
+    means this document.
+
+1.9. &quot;Licensable&quot;
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. &quot;Modifications&quot;
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. &quot;Patent Claims&quot; of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. &quot;Secondary License&quot;
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. &quot;Source Code Form&quot;
+    means the form of the work preferred for making modifications.
+
+1.14. &quot;You&quot; (or &quot;Your&quot;)
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, &quot;You&quot; includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, &quot;control&quot; means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party&#x27;s
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients&#x27; rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients&#x27; rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an &quot;as is&quot;       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party&#x27;s negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party&#x27;s ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
+---------------------------------------------------------
+
+  This Source Code Form is &quot;Incompatible With Secondary Licenses&quot;, as
+  defined by the Mozilla Public License, v. 2.0.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/mackwic/colored ">colored 3.1.1</a></li>
+                </ul>
+                <pre class="license-text">Mozilla Public License Version 2.0
+&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+
+1. Definitions
+--------------
+
+1.1. &quot;Contributor&quot;
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. &quot;Contributor Version&quot;
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor&#x27;s Contribution.
+
+1.3. &quot;Contribution&quot;
+    means Covered Software of a particular Contributor.
+
+1.4. &quot;Covered Software&quot;
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. &quot;Incompatible With Secondary Licenses&quot;
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. &quot;Executable Form&quot;
+    means any form of the work other than Source Code Form.
+
+1.7. &quot;Larger Work&quot;
+    means a work that combines Covered Software with other material, in 
     a separate file or files, that is not Covered Software.
 
 1.8. &quot;License&quot;
@@ -15935,7 +15815,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 
@@ -15982,24 +15862,24 @@ authorization of the copyright holder.
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.1.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.1.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.1.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.4</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.6</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.6</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.3</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.5</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.7</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.8</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.4</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.6</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 
@@ -16053,7 +15933,7 @@ ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation a
                 <h3 id="Zlib">zlib License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/trifectatechfoundation/zlib-rs ">zlib-rs 0.6.0</a></li>
+                    <li><a href=" https://github.com/trifectatechfoundation/zlib-rs ">zlib-rs 0.6.3</a></li>
                 </ul>
                 <pre class="license-text">(C) 2024 Trifecta Tech Foundation 
 
@@ -16081,6 +15961,8 @@ freely, subject to the following restrictions:
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rodrimati1992/const_panic/ ">const_panic 0.2.15</a></li>
+                    <li><a href=" https://github.com/rodrimati1992/konst/ ">konst 0.4.3</a></li>
+                    <li><a href=" https://github.com/rodrimati1992/konst/ ">konst_proc_macros 0.4.1</a></li>
                     <li><a href=" https://github.com/rodrimati1992/tstr_crates/ ">tstr 0.2.4</a></li>
                     <li><a href=" https://github.com/rodrimati1992/tstr_crates/ ">tstr_proc_macros 0.2.2</a></li>
                 </ul>
@@ -16106,7 +15988,7 @@ freely, subject to the following restrictions:
                 <h3 id="Zlib">zlib License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rodrimati1992/typewit/ ">typewit 1.14.2</a></li>
+                    <li><a href=" https://github.com/rodrimati1992/typewit/ ">typewit 1.15.2</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2023 Matias Rodriguez.
 
@@ -16157,7 +16039,6 @@ the following restrictions:
                 <h3 id="Zlib">zlib License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/remram44/adler32-rs ">adler32 1.2.0</a></li>
                     <li><a href=" https://github.com/rodrimati1992/repr_offset_crates/ ">repr_offset 0.2.2</a></li>
                 </ul>
                 <pre class="license-text">zlib License
@@ -16177,7 +16058,7 @@ Permission is granted to anyone to use this software for any purpose, including 
                 <h3 id="bzip2-1.0.6">bzip2 and libbzip2 License v1.0.6</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/trifectatechfoundation/libbzip2-rs ">libbz2-rs-sys 0.2.2</a></li>
+                    <li><a href=" https://github.com/trifectatechfoundation/libbzip2-rs ">libbz2-rs-sys 0.2.5</a></li>
                 </ul>
                 <pre class="license-text">
 --------------------------------------------------------------------------


### PR DESCRIPTION
There was a [question](https://discord.com/channels/1030247538198061086/1030247538667827251/1497346646554579086) on the community Discord about upgrading Tantivy for a low-severity security advisory. Seems to me we've actually removed that dependency. Perhaps it's time to bump the third-party dependency documents.