### PR TITLE
fix(mem_wal): allow append-only tables without primary keys

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -3,7 +3,7 @@ name = "lance-docs"
 version = "0.1.0"
 description = "Documentation for Lance - Modern columnar data format for ML and LLMs"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10,<3.11"
 dependencies = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.4.0",

--- a/docs/src/format/index/system/mem_wal.md
+++ b/docs/src/format/index/system/mem_wal.md
@@ -4,6 +4,8 @@ The MemWAL Index is a system index that serves as the centralized structure for 
 It stores configuration (shard specs, indexes to maintain), merge progress, and shard state snapshots.
 
 A table has at most one MemWAL index.
+The table may be a primary-key table or an append-only table without primary-key metadata.
+Primary-key-dependent lookup and deduplication semantics only apply when a primary key is defined.
 
 For the complete specification, see:
 

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -8,7 +8,9 @@ scan, point lookup, vector search and full-text search.
 ![MemWAL Overview](../../images/mem_wal_overview.png)
 
 A Lance table is called a **base table** under the context of the MemWAL spec.
-It must have an [unenforced primary key](index.md#unenforced-primary-key) defined in the table schema.
+It may have an [unenforced primary key](index.md#unenforced-primary-key) defined in the table schema.
+Primary keys are required for primary-key lookups and last-write-wins upsert semantics,
+but append-only MemWAL tables may omit them.
 
 On top of the base table, the MemWAL spec defines a set of shards.
 Writers write to shards, and data in each shard is merged into the base table asynchronously.
@@ -22,7 +24,7 @@ Each shard has exactly one active writer at any time.
 Writers claim a shard and then write data to that shard.
 Data in each shard is expected to be merged into the base table asynchronously.
 
-Rows of the same primary key must be written to one and only one shard.
+For tables with a primary key, rows of the same primary key must be written to one and only one shard.
 If two shards contain rows with the same primary key, the following scenario can cause data corruption:
 
 1. Shard A receives a write with primary key `pk=1` at time T1
@@ -34,6 +36,8 @@ If two shards contain rows with the same primary key, the following scenario can
 This violates the expected "last write wins" semantics.
 By ensuring each primary key is assigned to exactly one shard via the sharding spec,
 merge order between shards becomes irrelevant for correctness.
+Append-only tables without a primary key do not rely on last-write-wins conflict resolution
+and may shard by any deterministic append key or partitioning column.
 
 See [MemWAL Shard Architecture](#shard-architecture) for the complete shard architecture.
 
@@ -162,8 +166,9 @@ The content within the generation directory follows the [Lance table storage lay
 Generation numbers determine merge order of flushed MemTable into base table:
 lower numbers represent older data and must be merged to the base table first to preserve correct upsert semantics.
 
-Within a single flushed MemTable, if there are multiple rows of the same primary key,
-the row that is last inserted wins.
+Within a single flushed MemTable for a primary-key table,
+if there are multiple rows of the same primary key, the row that is last inserted wins.
+Append-only tables without a primary key retain all inserted rows.
 
 ### Shard Manifest
 
@@ -479,7 +484,8 @@ The garbage collector removes obsolete data from shard directories. Flushed MemT
 
 ### LSM Tree Merging Read
 
-Readers **MUST** merge results from multiple data sources (base table, flushed MemTables, in-memory MemTables) by primary key to ensure correctness.
+For tables with a primary key, readers **MUST** merge results from multiple data sources
+(base table, flushed MemTables, in-memory MemTables) by primary key to ensure correctness.
 
 When the same primary key exists in multiple sources, the reader must keep only the newest version based on:
 
@@ -495,6 +501,10 @@ This deduplication is essential because:
 - A single write batch may contain multiple updates to the same primary key
 
 Without proper merging, queries would return duplicate or stale rows.
+
+Append-only tables without a primary key do not perform primary-key deduplication.
+Readers should include the relevant base table, flushed MemTables, and in-memory MemTables
+according to the requested consistency level; duplicate values are treated as distinct appended rows.
 
 ### Reader Consistency
 
@@ -526,7 +536,9 @@ Datasets come from:
 
 Each dataset is tagged with a generation number: 0 for the base table, and positive integers for MemTable generations.
 Within a shard, the generation number determines data freshness, with higher numbers representing newer data.
-Rows from different shards do not need deduplication since each primary key maps to exactly one shard.
+For primary-key tables, rows from different shards do not need deduplication
+since each primary key maps to exactly one shard.
+Append-only tables without a primary key do not require cross-shard primary-key deduplication.
 
 The planner also collects bloom filters from each generation for staleness detection during search queries.
 

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -2030,8 +2030,9 @@ public class Dataset implements Closeable {
   /**
    * Initialize MemWAL on this dataset.
    *
-   * <p>Must be called once before any call to {@link #memWalWriter}. The dataset schema must have
-   * at least one field carrying the {@code lance-schema:unenforced-primary-key} metadata.
+   * <p>Must be called once before any call to {@link #memWalWriter}. Append-only tables may omit
+   * primary-key metadata; primary keys are only required for primary-key lookup and last-write-wins
+   * deduplication workflows.
    *
    * @param params MemWAL initialization parameters
    */

--- a/java/src/test/java/org/lance/memwal/MemWalTest.java
+++ b/java/src/test/java/org/lance/memwal/MemWalTest.java
@@ -72,10 +72,34 @@ public class MemWalTest {
               new Field(
                   "id", new FieldType(false, new ArrowType.Int(64, true), null, PK_META), null),
               Field.nullable("name", new ArrowType.Utf8())));
+  private static final Schema APPEND_ONLY_SCHEMA =
+      new Schema(
+          Arrays.asList(
+              new Field(
+                  "id",
+                  new FieldType(false, new ArrowType.Int(64, true), null, Collections.emptyMap()),
+                  null),
+              Field.nullable("name", new ArrowType.Utf8())));
 
   /** Build a single-batch root where {@code name = "{prefix}_{id}"}. */
   private static VectorSchemaRoot lookupRoot(BufferAllocator allocator, long[] ids, String prefix) {
     VectorSchemaRoot root = VectorSchemaRoot.create(LOOKUP_SCHEMA, allocator);
+    BigIntVector idVector = (BigIntVector) root.getVector("id");
+    VarCharVector nameVector = (VarCharVector) root.getVector("name");
+    idVector.allocateNew(ids.length);
+    nameVector.allocateNew();
+    for (int i = 0; i < ids.length; i++) {
+      idVector.set(i, ids[i]);
+      nameVector.setSafe(i, (prefix + "_" + ids[i]).getBytes(StandardCharsets.UTF_8));
+    }
+    root.setRowCount(ids.length);
+    return root;
+  }
+
+  /** Build a single-batch append-only root without primary-key metadata. */
+  private static VectorSchemaRoot appendOnlyRoot(
+      BufferAllocator allocator, long[] ids, String prefix) {
+    VectorSchemaRoot root = VectorSchemaRoot.create(APPEND_ONLY_SCHEMA, allocator);
     BigIntVector idVector = (BigIntVector) root.getVector("id");
     VarCharVector nameVector = (VarCharVector) root.getVector("name");
     idVector.allocateNew(ids.length);
@@ -104,6 +128,15 @@ public class MemWalTest {
   private static Dataset writeLookupDataset(
       BufferAllocator allocator, String path, long[] ids, String prefix) throws Exception {
     try (VectorSchemaRoot root = lookupRoot(allocator, ids, prefix);
+        ArrowReader reader = toReader(allocator, root)) {
+      return Dataset.write().allocator(allocator).reader(reader).uri(path).execute();
+    }
+  }
+
+  /** Write an append-only base dataset of `(id, name)` rows at {@code path}. */
+  private static Dataset writeAppendOnlyDataset(
+      BufferAllocator allocator, String path, long[] ids, String prefix) throws Exception {
+    try (VectorSchemaRoot root = appendOnlyRoot(allocator, ids, prefix);
         ArrowReader reader = toReader(allocator, root)) {
       return Dataset.write().allocator(allocator).reader(reader).uri(path).execute();
     }
@@ -142,6 +175,22 @@ public class MemWalTest {
       Optional<MemWalIndexDetails> details = dataset.memWalIndexDetails();
       assertTrue(details.isPresent());
       assertEquals(Collections.emptyList(), details.get().maintainedIndexes());
+    }
+  }
+
+  @Test
+  void testInitializeMemWalBucketShardingWithoutPrimaryKey(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("append_only").toString();
+    try (BufferAllocator allocator = new RootAllocator();
+        Dataset dataset = writeAppendOnlyDataset(allocator, path, new long[] {1, 2, 3}, "base")) {
+      dataset.initializeMemWal(new InitializeMemWalParams().withBucketSharding("id", 4));
+
+      Optional<MemWalIndexDetails> details = dataset.memWalIndexDetails();
+      assertTrue(details.isPresent());
+      assertEquals(4L, details.get().numShards());
+      ShardingField field = details.get().shardingSpecs().get(0).fields().get(0);
+      assertEquals("bucket", field.transform().get());
+      assertEquals("4", field.parameters().get("num_buckets"));
     }
   }
 

--- a/python/python/tests/test_mem_wal.py
+++ b/python/python/tests/test_mem_wal.py
@@ -21,6 +21,12 @@ _LOOKUP_SCHEMA = pa.schema(
         pa.field("name", pa.utf8()),
     ]
 )
+_APPEND_ONLY_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.int64(), nullable=False),
+        pa.field("name", pa.utf8()),
+    ]
+)
 
 
 def _lookup_table(ids, prefix: str) -> pa.Table:
@@ -31,6 +37,17 @@ def _lookup_table(ids, prefix: str) -> pa.Table:
             "name": pa.array([f"{prefix}_{i}" for i in ids], pa.utf8()),
         },
         schema=_LOOKUP_SCHEMA,
+    )
+
+
+def _append_only_table(ids, prefix: str) -> pa.Table:
+    """Build a table without primary-key metadata."""
+    return pa.table(
+        {
+            "id": pa.array(ids, pa.int64()),
+            "name": pa.array([f"{prefix}_{i}" for i in ids], pa.utf8()),
+        },
+        schema=_APPEND_ONLY_SCHEMA,
     )
 
 
@@ -358,6 +375,22 @@ def test_initialize_mem_wal_unsharded(tmp_path):
 
 def test_initialize_mem_wal_bucket_sharding(tmp_path):
     ds = _mem_wal_dataset(tmp_path)
+    ds.initialize_mem_wal(bucket_column="id", num_buckets=8)
+
+    details = ds.mem_wal_index_details()
+    assert details["num_shards"] == 8
+    field = details["sharding_specs"][0]["fields"][0]
+    assert field["transform"] == "bucket"
+    assert field["parameters"]["num_buckets"] == "8"
+
+
+def test_initialize_mem_wal_bucket_sharding_without_primary_key(tmp_path):
+    ds_path = str(tmp_path / "append_only")
+    ds = lance.write_dataset(
+        _append_only_table([1, 2, 3], "base"),
+        ds_path,
+        schema=_APPEND_ONLY_SCHEMA,
+    )
     ds.initialize_mem_wal(bucket_column="id", num_buckets=8)
 
     details = ds.mem_wal_index_details()

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3228,9 +3228,9 @@ impl Dataset {
 
     /// Initialize MemWAL on this dataset.
     ///
-    /// Must be called once before any `mem_wal_writer()` calls. Requires the
-    /// dataset schema to have at least one field with the
-    /// `lance-schema:unenforced-primary-key` metadata.
+    /// Must be called once before any `mem_wal_writer()` calls. Append-only
+    /// tables may omit primary-key metadata; primary keys are only required
+    /// for primary-key lookup and last-write-wins deduplication workflows.
     ///
     /// At most one sharding mode may be selected: bucket sharding
     /// (`bucket_column` + `num_buckets`), identity sharding (`identity_column`),

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -63,8 +63,7 @@ enum Sharding {
     Manual,
     /// A single shard; every row is routed to it.
     Unsharded,
-    /// Hash-bucket the single-column unenforced primary key into `num_buckets`
-    /// shards.
+    /// Hash-bucket a shard key into `num_buckets` shards.
     Bucket { column: String, num_buckets: u32 },
     /// Shard by the raw value of `column` (identity transform).
     Identity { column: String },
@@ -111,11 +110,13 @@ impl<'a> InitializeMemWalBuilder<'a> {
         self
     }
 
-    /// Hash-bucket the unenforced primary key into `num_buckets` shards.
+    /// Hash-bucket `column` into `num_buckets` shards.
     ///
-    /// `column` must name the dataset's single-column unenforced primary key;
-    /// `num_buckets` must be in `[1, 1024]`. Both are validated by
-    /// [`execute`](Self::execute).
+    /// For primary-key tables, `column` must name the dataset's single-column
+    /// unenforced primary key so every update for the same key routes to the
+    /// same shard. Append-only tables without a primary key may use any scalar
+    /// column. `num_buckets` must be in `[1, 1024]`. These constraints are
+    /// validated by [`execute`](Self::execute).
     pub fn bucket_sharding(mut self, column: impl Into<String>, num_buckets: u32) -> Self {
         self.sharding = Sharding::Bucket {
             column: column.into(),
@@ -127,10 +128,10 @@ impl<'a> InitializeMemWalBuilder<'a> {
     /// Shard by the raw value of `column` (the identity transform).
     ///
     /// Each distinct value of `column` becomes its own shard; use this when the
-    /// data is already partitioned by that column. The caller is responsible
-    /// for ensuring every primary key maps consistently to a single value of
-    /// `column`. `column` must be a scalar column that exists on the dataset;
-    /// it is validated by [`execute`](Self::execute).
+    /// data is already partitioned by that column. For primary-key tables, the
+    /// caller is responsible for ensuring every primary key maps consistently
+    /// to a single value of `column`. `column` must be a scalar column that
+    /// exists on the dataset; it is validated by [`execute`](Self::execute).
     pub fn identity_sharding(mut self, column: impl Into<String>) -> Self {
         self.sharding = Sharding::Identity {
             column: column.into(),
@@ -142,7 +143,8 @@ impl<'a> InitializeMemWalBuilder<'a> {
     /// previously set list.
     ///
     /// Each name must reference an index that already exists on the dataset.
-    /// The primary key btree is maintained implicitly and must not be listed.
+    /// The primary key btree, when present, is maintained implicitly and must
+    /// not be listed.
     pub fn maintained_indexes<I, S>(mut self, indexes: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -184,8 +186,8 @@ impl<'a> InitializeMemWalBuilder<'a> {
 
     /// Initialize MemWAL on the dataset, committing the MemWAL system index.
     ///
-    /// Fails if the dataset has no unenforced primary key, if any maintained
-    /// index does not exist, or if MemWAL is already initialized.
+    /// Fails if any maintained index does not exist, if the selected sharding
+    /// configuration is invalid, or if MemWAL is already initialized.
     pub async fn execute(self) -> Result<()> {
         let Self {
             dataset,
@@ -193,13 +195,6 @@ impl<'a> InitializeMemWalBuilder<'a> {
             maintained_indexes,
             writer_config_defaults,
         } = self;
-
-        if dataset.schema().unenforced_primary_key().is_empty() {
-            return Err(Error::invalid_input(
-                "MemWAL requires a primary key on the dataset. \
-                 Define a primary key using the 'lance-schema:unenforced-primary-key' Arrow field metadata.",
-            ));
-        }
 
         // Resolve (and validate) the sharding choice before any I/O.
         let (sharding_specs, num_shards) = resolve_sharding(dataset, sharding)?;
@@ -288,8 +283,23 @@ fn bucket_sharding_spec(dataset: &Dataset, column: &str, num_buckets: u32) -> Re
     }
 
     let pk_fields = dataset.schema().unenforced_primary_key();
-    let pk = match pk_fields.as_slice() {
-        [single] => *single,
+    let source_field = match pk_fields.as_slice() {
+        [single] => {
+            let pk = *single;
+            if pk.name.as_str() != column {
+                return Err(Error::invalid_input(format!(
+                    "bucket_sharding: column '{}' does not match the unenforced primary key column '{}'",
+                    column, pk.name
+                )));
+            }
+            pk
+        }
+        [] => dataset.schema().field(column).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "bucket_sharding: column '{}' not found on the dataset",
+                column
+            ))
+        })?,
         _ => {
             return Err(Error::invalid_input(
                 "bucket_sharding requires a single-column unenforced primary key; \
@@ -297,10 +307,12 @@ fn bucket_sharding_spec(dataset: &Dataset, column: &str, num_buckets: u32) -> Re
             ));
         }
     };
-    if pk.name.as_str() != column {
+
+    let data_type = source_field.data_type();
+    if data_type.is_nested() || data_type.is_null() {
         return Err(Error::invalid_input(format!(
-            "bucket_sharding: column '{}' does not match the unenforced primary key column '{}'",
-            column, pk.name
+            "bucket_sharding: column '{}' has type {:?}, which cannot be used as a shard key",
+            column, data_type
         )));
     }
 
@@ -308,7 +320,7 @@ fn bucket_sharding_spec(dataset: &Dataset, column: &str, num_buckets: u32) -> Re
         spec_id: SHARDING_SPEC_ID,
         fields: vec![ShardingField {
             field_id: SHARDING_FIELD_ID.to_string(),
-            source_ids: vec![pk.id],
+            source_ids: vec![source_field.id],
             transform: Some(BUCKET_TRANSFORM.to_string()),
             expression: None,
             result_type: SHARDING_RESULT_TYPE.to_string(),

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -4213,6 +4213,21 @@ mod shard_writer_tests {
         ]))
     }
 
+    fn create_append_only_schema(vector_dim: i32) -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    vector_dim,
+                ),
+                true,
+            ),
+            Field::new("text", DataType::Utf8, true),
+        ]))
+    }
+
     fn create_test_batch(
         schema: &ArrowSchema,
         start_id: i64,
@@ -4346,6 +4361,44 @@ mod shard_writer_tests {
             .execute()
             .await
             .expect("Failed to initialize MemWAL");
+
+        let details = dataset
+            .mem_wal_index_details()
+            .await
+            .expect("Failed to read MemWAL index details")
+            .expect("MemWAL index details should exist");
+
+        assert_eq!(details.num_shards, 8);
+        assert_eq!(details.sharding_specs.len(), 1);
+        let field = &details.sharding_specs[0].fields[0];
+        assert_eq!(field.transform.as_deref(), Some("bucket"));
+        assert_eq!(
+            field.parameters.get("num_buckets").map(String::as_str),
+            Some("8")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_initialize_mem_wal_bucket_sharding_without_primary_key() {
+        let vector_dim = 128;
+        let schema = create_append_only_schema(vector_dim);
+        let uri = format!(
+            "memory://test_bucket_sharding_no_primary_key_{}",
+            Uuid::new_v4()
+        );
+
+        let initial_batch = create_test_batch(&schema, 0, 100, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial_batch)], schema.clone());
+        let mut dataset = Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .expect("Failed to create dataset");
+
+        dataset
+            .initialize_mem_wal()
+            .bucket_sharding("id", 8)
+            .execute()
+            .await
+            .expect("Failed to initialize append-only MemWAL");
 
         let details = dataset
             .mem_wal_index_details()


### PR DESCRIPTION
## Summary
- allow MemWAL initialization on append-only tables without unenforced primary key metadata
- keep bucket sharding constrained to the primary key when a primary key exists, but allow no-PK tables to bucket by a non-nested column
- update Rust, Python, and Java tests plus MemWAL docs

Fixes #6846

## Tests
- cargo fmt --all
- cargo test -p lance test_initialize_mem_wal_bucket_sharding
- uv run make build
- uv run pytest python/tests/test_mem_wal.py::test_initialize_mem_wal_bucket_sharding_without_primary_key
- git diff --check

Java tests were not run locally because this machine has no Java runtime installed.