### PR TITLE
docs: document PR publishing requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,10 @@ AWS_DEFAULT_REGION=us-east-1 pytest --run-integration python/tests/test_s3_ddb.p
 - Indent content under MkDocs admonition directives (`!!! note`, etc.) with 4 spaces.
 - Proofread comments and docs for typos before committing.
 
+## Pull Requests
+
+- PR titles must follow the Conventional Commits specification because `.github/workflows/pr-title.yml` validates the PR title and body with commitlint. Use prefixes like `feat:`, `fix:`, `docs:`, `perf:`, `ci:`, `test:`, `build:`, `style:`, or `chore:`; add a scope when useful.
+
 ## Review Guidelines
 
 Contributor and maintainer attention is the most valuable resource. Less is more.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ AWS_DEFAULT_REGION=us-east-1 pytest --run-integration python/tests/test_s3_ddb.p
 ## Pull Requests
 
 - PR titles must follow the Conventional Commits specification because `.github/workflows/pr-title.yml` validates the PR title and body with commitlint. Use prefixes like `feat:`, `fix:`, `docs:`, `perf:`, `ci:`, `test:`, `build:`, `style:`, or `chore:`; add a scope when useful.
+- Before creating or updating a PR, run the lint checks for every touched language surface, even when they are expensive. For Rust changes, run `cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings`. For Python changes, follow the environment workflow in `python/AGENTS.md` and run `uv run make lint` from `python/`. If a required lint check cannot be run, state the blocker explicitly in the PR summary.
 
 ## Review Guidelines
 


### PR DESCRIPTION
Document the PR publishing requirements in `AGENTS.md` so agent-created PRs match the checks enforced by CI before they are opened or updated.

This records two required gates:

- PR titles must follow Conventional Commits because `.github/workflows/pr-title.yml` validates the title and body with commitlint.
- PRs must run lint checks for every touched language surface before creation or update. Rust changes require `cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings`; Python changes require the `python/AGENTS.md` environment workflow and `uv run make lint` from `python/`.

If a required lint check cannot be run, the blocker must be stated explicitly in the PR summary.
