### PR TITLE
perf: use roaring's range iter to speedup mask_to_offset_ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
+ "criterion",
  "datafusion-common",
  "datafusion-sql",
  "deepsize",

--- a/rust/lance-core/Cargo.toml
+++ b/rust/lance-core/Cargo.toml
@@ -48,11 +48,16 @@ log.workspace = true
 libc = { version = "0.2" }
 
 [dev-dependencies]
+criterion.workspace = true
 proptest.workspace = true
 rstest.workspace = true
 
 [features]
 datafusion = ["dep:datafusion-common", "dep:datafusion-sql"]
+
+[[bench]]
+name = "row_addr_mask"
+harness = false
 
 [lints]
 workspace = true

--- a/rust/lance-core/benches/row_addr_mask.rs
+++ b/rust/lance-core/benches/row_addr_mask.rs
@@ -108,6 +108,31 @@ fn bench_iter_runs(c: &mut Criterion) {
     group.finish();
 }
 
+/// Range-aware consumer cost via the public `RowAddrTreeMap::iter_runs`
+/// API. The map is built the ordinary way (`insert_range` → Partial
+/// bitmap); `iter_runs` walks the bitmap's run containers via
+/// `Iter::next_range`. Compare against `into_addr_iter_single_run` to see
+/// the consumer-side speedup callers get without changing the underlying
+/// representation.
+fn bench_iter_runs_partial(c: &mut Criterion) {
+    let mut group = c.benchmark_group("iter_runs_partial_single_run");
+    for &n in ROW_COUNTS {
+        let map = make_range_mask(n);
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                // SAFETY: map only contains Partial selections.
+                let mut runs: u64 = 0;
+                for _ in unsafe { map.iter_runs() } {
+                    runs += 1;
+                }
+                std::hint::black_box(runs);
+            });
+        });
+    }
+    group.finish();
+}
+
 /// Set intersection of two range-shaped masks.
 ///
 /// Both inputs are single contiguous runs that overlap in their middle
@@ -164,6 +189,32 @@ fn bench_range_to_ranges_round_trip(c: &mut Criterion) {
     group.finish();
 }
 
+/// Same end-to-end shape as `mask_to_offset_ranges_inner_loop`, but the
+/// final per-bit walk is replaced by `iter_runs`. Quantifies the speedup
+/// the consumer side gets purely from switching iteration APIs — no
+/// representation change.
+fn bench_range_to_ranges_round_trip_runs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mask_to_offset_ranges_inner_loop_runs");
+    for &n in ROW_COUNTS {
+        let mask_range = n..(2 * n);
+        let mask = RowAddrMask::AllowList(RowAddrTreeMap::from(mask_range));
+        let src: Range<u64> = 0..(2 * n);
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let mut ids = RowAddrTreeMap::from(src.clone());
+                ids.mask(&mask);
+                // SAFETY: only Partial selections in play.
+                let count: u64 = unsafe { ids.iter_runs() }
+                    .map(|(_, r)| (*r.end() as u64) - (*r.start() as u64) + 1)
+                    .sum();
+                std::hint::black_box(count);
+            });
+        });
+    }
+    group.finish();
+}
+
 /// Many small runs vs one big run with the same total cardinality.
 ///
 /// A range-aware representation should be O(num_runs), so the
@@ -206,8 +257,10 @@ criterion_group!(
     bench_insert_range,
     bench_iter_addrs,
     bench_iter_runs,
+    bench_iter_runs_partial,
     bench_intersect_ranges,
     bench_range_to_ranges_round_trip,
+    bench_range_to_ranges_round_trip_runs,
     bench_runs_vs_rows,
 );
 criterion_main!(benches);

--- a/rust/lance-core/benches/row_addr_mask.rs
+++ b/rust/lance-core/benches/row_addr_mask.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Benchmarks for `RowAddrMask` / `RowAddrTreeMap`.
+//!
+//! These benchmarks are deliberately structured to expose the row-cardinality
+//! scaling weakness of the current per-row bitmap representation. Producers
+//! (e.g. scalar-index `search` implementations) and consumers (e.g.
+//! `mask_to_offset_ranges`) are frequently range-shaped, but every operation
+//! must round-trip through `Partial(RoaringBitmap)` and therefore costs O(N)
+//! in the number of rows, not O(R) in the number of distinct ranges.
+//!
+//! Each benchmark varies the number of rows while keeping the number of
+//! ranges fixed at 1. A range-aware representation should make these
+//! near-constant time; today they are linear in N.
+//!
+//! Run with `cargo bench -p lance-core --bench row_addr_mask`.
+
+use std::ops::Range;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use lance_core::utils::mask::{RowAddrMask, RowAddrTreeMap};
+
+/// Row counts we sweep across. Chosen to cover the realistic range of
+/// matches a zonemap produces for an `IS NULL`-like predicate on a single
+/// fragment: a few thousand rows up through tens of millions.
+const ROW_COUNTS: &[u64] = &[10_000, 100_000, 1_000_000, 10_000_000];
+
+fn make_range_mask(num_rows: u64) -> RowAddrTreeMap {
+    // Build a mask covering a single contiguous run in fragment 0.
+    // This is the exact shape a scalar-index search produces when it
+    // determines a contiguous chunk of zones matches.
+    let mut map = RowAddrTreeMap::new();
+    map.insert_range(0..num_rows);
+    map
+}
+
+/// Producer cost: building a mask from one contiguous Range.
+///
+/// Today this is O(N) — every bit gets inserted into a roaring bitmap.
+/// With a range-aware representation it would be O(1) (push a single run).
+fn bench_insert_range(c: &mut Criterion) {
+    let mut group = c.benchmark_group("insert_range_single_run");
+    for &n in ROW_COUNTS {
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter(|| {
+                let mut map = RowAddrTreeMap::new();
+                map.insert_range(0..n);
+                std::hint::black_box(map);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Consumer cost: iterating every row address in a dense mask.
+///
+/// `into_addr_iter` walks set bits one at a time. For a contiguous run
+/// of N rows this is O(N) — even though the rows are trivially
+/// representable as a single Range. This is what `mask_to_offset_ranges`
+/// does after intersecting with a source segment: it pays per-row
+/// iteration cost only to immediately collapse the addresses back into
+/// ranges via `GroupingIterator`.
+fn bench_iter_addrs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("into_addr_iter_single_run");
+    for &n in ROW_COUNTS {
+        let map = make_range_mask(n);
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                // SAFETY: the map only contains Partial selections; no Full entries.
+                let count: u64 = unsafe { map.clone().into_addr_iter() }.count() as u64;
+                std::hint::black_box(count);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Best-achievable iteration over the same data.
+///
+/// `Iter::next_range` walks the bitmap's run containers in O(num_runs).
+/// For a single contiguous run this should be ~constant time — the
+/// public `RowAddrMask` API gives no way to surface that today, so the
+/// performance is currently inaccessible to callers. Comparing this to
+/// `into_addr_iter_single_run` quantifies the speedup a range-aware
+/// representation could deliver to consumers.
+fn bench_iter_runs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("next_range_iter_single_run");
+    for &n in ROW_COUNTS {
+        // Use the same underlying roaring bitmap shape that `make_range_mask`
+        // produces internally (one fragment, one contiguous run).
+        let mut bitmap = roaring::RoaringBitmap::new();
+        bitmap.insert_range(0..(n as u32));
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let mut iter = bitmap.iter();
+                let mut runs: u64 = 0;
+                while iter.next_range().is_some() {
+                    runs += 1;
+                }
+                std::hint::black_box(runs);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Set intersection of two range-shaped masks.
+///
+/// Both inputs are single contiguous runs that overlap in their middle
+/// half (so the output is itself a single contiguous run). With per-row
+/// bitmaps this is O(N) — the entire bitmap participates in the AND.
+/// With ranges it would be O(1).
+fn bench_intersect_ranges(c: &mut Criterion) {
+    let mut group = c.benchmark_group("intersect_two_runs");
+    for &n in ROW_COUNTS {
+        let lhs = make_range_mask(n);
+        let rhs_range = (n / 4)..(3 * n / 4);
+        let mut rhs = RowAddrTreeMap::new();
+        rhs.insert_range(rhs_range);
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let mut tmp = lhs.clone();
+                tmp &= &rhs;
+                std::hint::black_box(tmp);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Full round trip: build a source range bitmap, AND with a mask, iterate
+/// each surviving bit. This is the exact slow path of
+/// `mask_to_offset_ranges` in `lance-table/src/rowids.rs:387`. Profiling
+/// a 10M-row zonemap `IS NULL` query showed this consuming ~55% of the
+/// hot-loop time (~495 ms of 889 ms). The benchmark separates the
+/// per-row producer/consumer cost from the rest of the scan pipeline so
+/// it can be tracked in isolation.
+fn bench_range_to_ranges_round_trip(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mask_to_offset_ranges_inner_loop");
+    for &n in ROW_COUNTS {
+        // The mask selects the back half of a 2N-row fragment.
+        let mask_range = n..(2 * n);
+        let mask = RowAddrMask::AllowList(RowAddrTreeMap::from(mask_range));
+        // The source segment covers the whole fragment.
+        let src: Range<u64> = 0..(2 * n);
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                // Mimic the slow path: materialize source range, AND with mask,
+                // iterate to count survivors (a stand-in for whatever the
+                // consumer actually does — e.g. GroupingIterator).
+                let mut ids = RowAddrTreeMap::from(src.clone());
+                ids.mask(&mask);
+                let count = unsafe { ids.into_addr_iter() }.count();
+                std::hint::black_box(count);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Many small runs vs one big run with the same total cardinality.
+///
+/// A range-aware representation should be O(num_runs), so the
+/// `single_run` case should be ~K times faster than the `K_runs` case.
+/// Today they are essentially equal: the cost is dictated by the number
+/// of rows, not the number of runs.
+fn bench_runs_vs_rows(c: &mut Criterion) {
+    let total_rows: u64 = 1_000_000;
+    let mut group = c.benchmark_group("insert_runs_constant_cardinality");
+
+    group.throughput(Throughput::Elements(total_rows));
+    group.bench_function("single_run_1M", |b| {
+        b.iter(|| {
+            let mut map = RowAddrTreeMap::new();
+            map.insert_range(0..total_rows);
+            std::hint::black_box(map);
+        });
+    });
+
+    for k in [10u64, 100, 1_000, 10_000] {
+        let run_size = total_rows / k;
+        // Stride between runs is 2 * run_size so the bitmap is half full.
+        let stride = run_size * 2;
+        group.bench_function(format!("{k}_runs_1M_total"), |b| {
+            b.iter(|| {
+                let mut map = RowAddrTreeMap::new();
+                for i in 0..k {
+                    let start = i * stride;
+                    map.insert_range(start..(start + run_size));
+                }
+                std::hint::black_box(map);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_insert_range,
+    bench_iter_addrs,
+    bench_iter_runs,
+    bench_intersect_ranges,
+    bench_range_to_ranges_round_trip,
+    bench_runs_vs_rows,
+);
+criterion_main!(benches);

--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -659,6 +659,29 @@ impl RowAddrTreeMap {
                 }),
             })
     }
+
+    /// Iterate the selected row addresses as `(fragment_id, run)` pairs.
+    ///
+    /// Range-shaped counterpart to [`Self::into_addr_iter`]. A contiguous
+    /// run of N selected rows yields one item, not N. Uses roaring's
+    /// `Iter::next_range`, which walks each underlying container's runs
+    /// rather than its individual bits, so dense ranges cost
+    /// O(num_containers) (roughly num_rows / 65536) instead of O(num_rows).
+    ///
+    /// # Safety
+    /// Same contract as [`Self::into_addr_iter`]: panics if any entry is
+    /// `Full`, since the fragment size is unknown at this layer.
+    pub unsafe fn iter_runs(&self) -> impl Iterator<Item = (u32, RangeInclusive<u32>)> + '_ {
+        self.inner
+            .iter()
+            .flat_map(|(&fragment, selection)| match selection {
+                RowAddrSelection::Full => panic!("Size of full fragment is unknown"),
+                RowAddrSelection::Partial(bitmap) => {
+                    let mut iter = bitmap.iter();
+                    std::iter::from_fn(move || iter.next_range().map(|r| (fragment, r)))
+                }
+            })
+    }
 }
 
 impl std::ops::BitOr<Self> for RowAddrTreeMap {
@@ -1553,6 +1576,38 @@ mod tests {
         let expected = vec![0u64, 1, 1 << 32 | 5, 2 << 32 | 10];
         let actual: Vec<u64> = unsafe { mask.into_addr_iter().collect() };
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_map_iter_runs() {
+        // Three contiguous regions across two fragments.
+        let mut mask = RowAddrTreeMap::default();
+        mask.insert_range(0..3);
+        mask.insert_range(10..15);
+        mask.insert_range((1u64 << 32) + 100..(1u64 << 32) + 103);
+
+        // SAFETY: only Partial entries.
+        let runs: Vec<(u32, RangeInclusive<u32>)> = unsafe { mask.iter_runs().collect() };
+        assert_eq!(runs, vec![(0, 0..=2), (0, 10..=14), (1, 100..=102)]);
+    }
+
+    #[test]
+    fn test_map_iter_runs_matches_into_addr_iter() {
+        // Confirm iter_runs and into_addr_iter agree on a non-trivial shape.
+        let mut mask = RowAddrTreeMap::default();
+        mask.insert_range(5..7);
+        mask.insert_range(11..12);
+        mask.insert_range(20..25);
+        mask.insert_range((1u64 << 32)..(1u64 << 32) + 3);
+
+        let from_runs: Vec<u64> = unsafe { mask.iter_runs() }
+            .flat_map(|(frag, run)| {
+                let frag = u64::from(frag);
+                (*run.start()..=*run.end()).map(move |v| (frag << 32) | u64::from(v))
+            })
+            .collect();
+        let from_bits: Vec<u64> = unsafe { mask.clone().into_addr_iter() }.collect();
+        assert_eq!(from_runs, from_bits);
     }
 
     #[test]

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -392,9 +392,27 @@ impl RowIdSequence {
                 U64Segment::Range(range) => {
                     let mut ids = RowAddrTreeMap::from(range.clone());
                     ids.mask(mask);
-                    ranges.extend(GroupingIterator::new(
-                        unsafe { ids.into_addr_iter() }.map(|addr| addr - range.start + offset),
-                    ));
+                    // Range-aware path: walk the bitmap's runs directly via
+                    // iter_runs so the per-row cost collapses to per-run cost.
+                    // SAFETY: built from a u64 range; no Full entries possible.
+                    let mut cur: Option<Range<u64>> = None;
+                    for (fragment, run) in unsafe { ids.iter_runs() } {
+                        let frag = u64::from(fragment);
+                        let run_start = (frag << 32) | u64::from(*run.start());
+                        let run_end_excl = (frag << 32) | (u64::from(*run.end()) + 1);
+                        let start = run_start - range.start + offset;
+                        let end = run_end_excl - range.start + offset;
+                        match cur.as_mut() {
+                            Some(c) if c.end == start => c.end = end,
+                            Some(c) => {
+                                ranges.push(std::mem::replace(c, start..end));
+                            }
+                            None => cur = Some(start..end),
+                        }
+                    }
+                    if let Some(c) = cur {
+                        ranges.push(c);
+                    }
                     offset += range.end - range.start;
                 }
                 U64Segment::RangeWithHoles { range, holes } => {


### PR DESCRIPTION
The function `mask_to_offset_ranges` is used at scan planning time to determine which rows to read from the file.  This was a bottleneck when the mask was the result of a zonal index search because the old implementation materialized all of the offsets only to convert them back into ranges.

Luckily, roaring recently implemented a range-based iterator.  Using this we can skip the materialization step.  On my zonemap benchmark this doubles the speed of the search and, perhaps more importantly, removes a penalty I observed when the index is used even on queries that are not highly selective.

Generated with the assistance of Claude code.