### PR TITLE
fix(java): add diagnostics for imported Arrow streams

### DIFF
--- a/java/src/main/java/org/lance/SqlQuery.java
+++ b/java/src/main/java/org/lance/SqlQuery.java
@@ -13,9 +13,10 @@
  */
 package org.lance;
 
+import org.lance.ipc.LanceArrowReaders;
+
 import com.google.common.base.MoreObjects;
 import org.apache.arrow.c.ArrowArrayStream;
-import org.apache.arrow.c.Data;
 import org.apache.arrow.vector.ipc.ArrowReader;
 
 import java.io.IOException;
@@ -54,7 +55,8 @@ public class SqlQuery {
     try (ArrowArrayStream s = ArrowArrayStream.allocateNew(dataset.allocator())) {
       intoBatchRecords(
           dataset, sql, Optional.ofNullable(table), withRowId, withRowAddr, s.memoryAddress());
-      return Data.importArrayStream(dataset.allocator(), s);
+      return LanceArrowReaders.importArrayStream(
+          dataset.allocator(), s, "SqlQuery.intoBatchRecords");
     }
   }
 

--- a/java/src/main/java/org/lance/delta/DatasetDelta.java
+++ b/java/src/main/java/org/lance/delta/DatasetDelta.java
@@ -17,9 +17,9 @@ import org.lance.Dataset;
 import org.lance.JniLoader;
 import org.lance.LockManager;
 import org.lance.Transaction;
+import org.lance.ipc.LanceArrowReaders;
 
 import org.apache.arrow.c.ArrowArrayStream;
-import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.ipc.ArrowReader;
@@ -70,7 +70,7 @@ public class DatasetDelta implements Closeable {
       BufferAllocator allocator = dataset.allocator();
       try (ArrowArrayStream s = ArrowArrayStream.allocateNew(allocator)) {
         nativeGetInsertedRows(s.memoryAddress());
-        return Data.importArrayStream(allocator, s);
+        return LanceArrowReaders.importArrayStream(allocator, s, "DatasetDelta.getInsertedRows");
       }
     }
   }
@@ -84,7 +84,7 @@ public class DatasetDelta implements Closeable {
       BufferAllocator allocator = dataset.allocator();
       try (ArrowArrayStream s = ArrowArrayStream.allocateNew(allocator)) {
         nativeGetUpdatedRows(s.memoryAddress());
-        return Data.importArrayStream(allocator, s);
+        return LanceArrowReaders.importArrayStream(allocator, s, "DatasetDelta.getUpdatedRows");
       }
     }
   }

--- a/java/src/main/java/org/lance/file/LanceFileReader.java
+++ b/java/src/main/java/org/lance/file/LanceFileReader.java
@@ -14,6 +14,7 @@
 package org.lance.file;
 
 import org.lance.JniLoader;
+import org.lance.ipc.LanceArrowReaders;
 import org.lance.util.Range;
 
 import org.apache.arrow.c.ArrowArrayStream;
@@ -164,7 +165,8 @@ public class LanceFileReader implements AutoCloseable {
           ranges,
           ffiArrowArrayStream.memoryAddress(),
           options.getBlobReadMode().getValue());
-      return Data.importArrayStream(allocator, ffiArrowArrayStream);
+      return LanceArrowReaders.importArrayStream(
+          allocator, ffiArrowArrayStream, "LanceFileReader.readAll");
     }
   }
 }

--- a/java/src/main/java/org/lance/ipc/AsyncScanner.java
+++ b/java/src/main/java/org/lance/ipc/AsyncScanner.java
@@ -138,7 +138,8 @@ public class AsyncScanner implements AutoCloseable {
 
             try {
               ArrowArrayStream stream = ArrowArrayStream.wrap(streamPtr);
-              return Data.importArrayStream(allocator, stream);
+              return LanceArrowReaders.importArrayStream(
+                  allocator, stream, "AsyncScanner.scanBatchesAsync");
             } catch (Exception e) {
               throw new RuntimeException(e);
             }

--- a/java/src/main/java/org/lance/ipc/LanceArrowReaders.java
+++ b/java/src/main/java/org/lance/ipc/LanceArrowReaders.java
@@ -46,6 +46,7 @@ public final class LanceArrowReaders {
   private static final class DiagnosticArrowReader extends ArrowReader {
     private final ArrowReader delegate;
     private final String source;
+    private Schema schema;
 
     private DiagnosticArrowReader(BufferAllocator allocator, ArrowReader delegate, String source) {
       super(allocator);
@@ -55,7 +56,9 @@ public final class LanceArrowReaders {
 
     @Override
     public VectorSchemaRoot getVectorSchemaRoot() throws IOException {
-      return delegate.getVectorSchemaRoot();
+      VectorSchemaRoot root = delegate.getVectorSchemaRoot();
+      schema = root.getSchema();
+      return root;
     }
 
     @Override
@@ -76,11 +79,17 @@ public final class LanceArrowReaders {
     @Override
     public boolean loadNextBatch() throws IOException {
       try {
-        return delegate.loadNextBatch();
+        boolean loaded = delegate.loadNextBatch();
+        if (loaded) {
+          schema = delegate.getVectorSchemaRoot().getSchema();
+        }
+        return loaded;
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(loadFailureMessage(source, e), e);
       } catch (IOException e) {
         throw new IOException(loadFailureMessage(source, e), e);
+      } catch (RuntimeException e) {
+        throw new RuntimeException(loadFailureMessage(source, e), e);
       }
     }
 
@@ -91,6 +100,8 @@ public final class LanceArrowReaders {
 
     @Override
     public void close() throws IOException {
+      // This reader is a pass-through diagnostics wrapper. It never initializes
+      // ArrowReader's private root, so closing the delegate is the only owner cleanup needed.
       delegate.close();
     }
 
@@ -101,12 +112,15 @@ public final class LanceArrowReaders {
 
     @Override
     protected void closeReadSource() throws IOException {
-      delegate.close();
+      delegate.close(false);
     }
 
     @Override
     protected Schema readSchema() throws IOException {
-      return delegate.getVectorSchemaRoot().getSchema();
+      if (schema == null) {
+        throw new IOException("Diagnostic Arrow reader does not own a schema");
+      }
+      return schema;
     }
   }
 

--- a/java/src/main/java/org/lance/ipc/LanceArrowReaders.java
+++ b/java/src/main/java/org/lance/ipc/LanceArrowReaders.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.ipc;
+
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+/** Utilities for importing Arrow readers from Lance-owned Arrow C Data streams. */
+public final class LanceArrowReaders {
+  private static final String CHILD_MISMATCH_ERROR =
+      "should have as many children as in the schema";
+
+  private LanceArrowReaders() {}
+
+  /** Import a C Data stream and attach Lance-specific diagnostics to batch-load failures. */
+  public static ArrowReader importArrayStream(
+      BufferAllocator allocator, ArrowArrayStream stream, String source) {
+    return withDiagnostics(allocator, Data.importArrayStream(allocator, stream), source);
+  }
+
+  static ArrowReader withDiagnostics(
+      BufferAllocator allocator, ArrowReader delegate, String source) {
+    return new DiagnosticArrowReader(allocator, delegate, source);
+  }
+
+  private static final class DiagnosticArrowReader extends ArrowReader {
+    private final ArrowReader delegate;
+    private final String source;
+
+    private DiagnosticArrowReader(BufferAllocator allocator, ArrowReader delegate, String source) {
+      super(allocator);
+      this.delegate = delegate;
+      this.source = source;
+    }
+
+    @Override
+    public VectorSchemaRoot getVectorSchemaRoot() throws IOException {
+      return delegate.getVectorSchemaRoot();
+    }
+
+    @Override
+    public Map<Long, Dictionary> getDictionaryVectors() throws IOException {
+      return delegate.getDictionaryVectors();
+    }
+
+    @Override
+    public Dictionary lookup(long id) {
+      return delegate.lookup(id);
+    }
+
+    @Override
+    public Set<Long> getDictionaryIds() {
+      return delegate.getDictionaryIds();
+    }
+
+    @Override
+    public boolean loadNextBatch() throws IOException {
+      try {
+        return delegate.loadNextBatch();
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(loadFailureMessage(source, e), e);
+      } catch (IOException e) {
+        throw new IOException(loadFailureMessage(source, e), e);
+      }
+    }
+
+    @Override
+    public long bytesRead() {
+      return delegate.bytesRead();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+
+    @Override
+    public void close(boolean closeReadSource) throws IOException {
+      delegate.close(closeReadSource);
+    }
+
+    @Override
+    protected void closeReadSource() throws IOException {
+      delegate.close();
+    }
+
+    @Override
+    protected Schema readSchema() throws IOException {
+      return delegate.getVectorSchemaRoot().getSchema();
+    }
+  }
+
+  private static String loadFailureMessage(String source, Exception error) {
+    String arrowMessage = error.getMessage();
+    if (arrowMessage != null && arrowMessage.contains(CHILD_MISMATCH_ERROR)) {
+      return String.format(
+          "Failed to load next Arrow batch from %s: Arrow vector children did not match "
+              + "the schema. This usually means the Arrow C Data stream emitted a malformed "
+              + "nested batch, or the reader-owned VectorSchemaRoot was closed or mutated before "
+              + "loading the next batch. Arrow error: %s",
+          source, arrowMessage);
+    }
+    return String.format("Failed to load next Arrow batch from %s: %s", source, arrowMessage);
+  }
+}

--- a/java/src/main/java/org/lance/ipc/LanceScanner.java
+++ b/java/src/main/java/org/lance/ipc/LanceScanner.java
@@ -130,7 +130,7 @@ public class LanceScanner implements org.apache.arrow.dataset.scanner.Scanner {
       Preconditions.checkArgument(nativeScannerHandle != 0, "Scanner is closed");
       try (ArrowArrayStream s = ArrowArrayStream.allocateNew(allocator)) {
         openStream(s.memoryAddress());
-        return Data.importArrayStream(allocator, s);
+        return LanceArrowReaders.importArrayStream(allocator, s, "LanceScanner.scanBatches");
       } catch (IOException e) {
         // TODO: handle IO exception?
         throw new RuntimeException(e);

--- a/java/src/test/java/org/lance/ScannerTest.java
+++ b/java/src/test/java/org/lance/ScannerTest.java
@@ -22,6 +22,8 @@ import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
 import org.lance.ipc.ScanStats;
 
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.Data;
 import org.apache.arrow.dataset.scanner.Scanner;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -29,9 +31,11 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -215,6 +219,107 @@ public class ScannerTest {
         }
       }
     }
+  }
+
+  @Test
+  void testDatasetScannerAllNullStructColumnMultipleBatches(@TempDir Path tempDir)
+      throws Exception {
+    String datasetPath = tempDir.resolve("all_null_struct_scanner").toString();
+    int totalRows = 6;
+    int batchRows = 2;
+
+    try (BufferAllocator allocator = new RootAllocator()) {
+      Schema schema =
+          new Schema(
+              Arrays.asList(
+                  Field.nullable("id", new ArrowType.Int(32, true)),
+                  new Field(
+                      "metadata",
+                      FieldType.nullable(new ArrowType.Struct()),
+                      Arrays.asList(
+                          Field.nullable("field0", new ArrowType.Int(32, true)),
+                          Field.nullable("field1", new ArrowType.Int(32, true)),
+                          Field.nullable("field2", new ArrowType.Int(32, true)),
+                          Field.nullable("field3", new ArrowType.Int(32, true)),
+                          Field.nullable("field4", new ArrowType.Int(32, true)),
+                          Field.nullable("field5", new ArrowType.Int(32, true))))));
+
+      try (VectorSchemaRoot inputRoot = VectorSchemaRoot.create(schema, allocator);
+          ArrowReader inputReader = singleBatchReader(allocator, schema, inputRoot);
+          ArrowArrayStream inputStream = ArrowArrayStream.allocateNew(allocator)) {
+        inputRoot.allocateNew();
+        IntVector idVector = (IntVector) inputRoot.getVector("id");
+        StructVector structVector = (StructVector) inputRoot.getVector("metadata");
+        for (int i = 0; i < totalRows; i++) {
+          idVector.setSafe(i, i);
+          structVector.setNull(i);
+        }
+        inputRoot.setRowCount(totalRows);
+
+        Data.exportArrayStream(allocator, inputReader, inputStream);
+
+        try (Dataset dataset =
+                Dataset.create(
+                    allocator, inputStream, datasetPath, new WriteParams.Builder().build());
+            LanceScanner scanner =
+                dataset.newScan(new ScanOptions.Builder().batchSize(batchRows).build());
+            ArrowReader reader = scanner.scanBatches()) {
+          VectorSchemaRoot root = reader.getVectorSchemaRoot();
+          int batches = 0;
+          int rows = 0;
+
+          while (reader.loadNextBatch()) {
+            int rowCount = root.getRowCount();
+            StructVector metadata = (StructVector) root.getVector("metadata");
+            assertEquals(6, metadata.getField().getChildren().size());
+            assertEquals(6, metadata.getChildrenFromFields().size());
+            assertEquals(rowCount, metadata.getValueCount());
+            for (int i = 0; i < rowCount; i++) {
+              assertTrue(metadata.isNull(i));
+            }
+            batches++;
+            rows += rowCount;
+          }
+
+          assertEquals(3, batches);
+          assertEquals(totalRows, rows);
+        }
+      }
+    }
+  }
+
+  private static ArrowReader singleBatchReader(
+      BufferAllocator allocator, Schema schema, VectorSchemaRoot root) {
+    return new ArrowReader(allocator) {
+      private boolean batchLoaded = false;
+
+      @Override
+      public boolean loadNextBatch() {
+        if (batchLoaded) {
+          return false;
+        }
+        batchLoaded = true;
+        return true;
+      }
+
+      @Override
+      public VectorSchemaRoot getVectorSchemaRoot() {
+        return root;
+      }
+
+      @Override
+      public long bytesRead() {
+        return root.getFieldVectors().stream().mapToLong(FieldVector::getBufferSize).sum();
+      }
+
+      @Override
+      protected void closeReadSource() {}
+
+      @Override
+      protected Schema readSchema() {
+        return schema;
+      }
+    };
   }
 
   @Test

--- a/java/src/test/java/org/lance/ipc/LanceArrowReadersTest.java
+++ b/java/src/test/java/org/lance/ipc/LanceArrowReadersTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.ipc;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LanceArrowReadersTest {
+
+  @Test
+  public void loadNextBatchAddsContextToArrowChildMismatch() throws Exception {
+    try (BufferAllocator allocator = new RootAllocator();
+        ArrowReader reader =
+            LanceArrowReaders.withDiagnostics(
+                allocator, childMismatchReader(allocator), "unit-test stream")) {
+      IllegalArgumentException error =
+          assertThrows(IllegalArgumentException.class, reader::loadNextBatch);
+
+      assertTrue(error.getMessage().contains("unit-test stream"));
+      assertTrue(error.getMessage().contains("reader-owned VectorSchemaRoot"));
+      assertTrue(error.getMessage().contains("found 0 expected 6"));
+    }
+  }
+
+  private ArrowReader childMismatchReader(BufferAllocator allocator) {
+    return new ArrowReader(allocator) {
+      @Override
+      public boolean loadNextBatch() {
+        throw new IllegalArgumentException(
+            "should have as many children as in the schema: found 0 expected 6");
+      }
+
+      @Override
+      public long bytesRead() {
+        return 0;
+      }
+
+      @Override
+      protected void closeReadSource() {}
+
+      @Override
+      protected Schema readSchema() {
+        return new Schema(Collections.emptyList());
+      }
+    };
+  }
+}

--- a/java/src/test/java/org/lance/ipc/LanceArrowReadersTest.java
+++ b/java/src/test/java/org/lance/ipc/LanceArrowReadersTest.java
@@ -15,12 +15,15 @@ package org.lance.ipc;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,6 +41,45 @@ public class LanceArrowReadersTest {
       assertTrue(error.getMessage().contains("unit-test stream"));
       assertTrue(error.getMessage().contains("reader-owned VectorSchemaRoot"));
       assertTrue(error.getMessage().contains("found 0 expected 6"));
+    }
+  }
+
+  @Test
+  public void loadNextBatchAddsContextToRuntimeException() throws Exception {
+    try (BufferAllocator allocator = new RootAllocator();
+        ArrowReader reader =
+            LanceArrowReaders.withDiagnostics(
+                allocator, runtimeFailureReader(allocator), "runtime stream")) {
+      RuntimeException error = assertThrows(RuntimeException.class, reader::loadNextBatch);
+
+      assertTrue(error.getMessage().contains("runtime stream"));
+      assertTrue(error.getMessage().contains("delegate failed"));
+    }
+  }
+
+  @Test
+  public void getVectorSchemaRootInitializesDelegateOnlyOnce() throws Exception {
+    try (BufferAllocator allocator = new RootAllocator()) {
+      CountingReader delegate = new CountingReader(allocator);
+      try (ArrowReader reader = LanceArrowReaders.withDiagnostics(allocator, delegate, "source")) {
+        VectorSchemaRoot root = reader.getVectorSchemaRoot();
+
+        assertSame(root, reader.getVectorSchemaRoot());
+        assertEquals(1, delegate.readSchemaCount);
+      }
+    }
+  }
+
+  @Test
+  public void closeForwardsToDelegateOnce() throws Exception {
+    try (BufferAllocator allocator = new RootAllocator()) {
+      CloseCountingReader delegate = new CloseCountingReader(allocator);
+      ArrowReader reader = LanceArrowReaders.withDiagnostics(allocator, delegate, "source");
+
+      reader.close();
+
+      assertEquals(1, delegate.closeCount);
+      assertTrue(delegate.closeReadSource);
     }
   }
 
@@ -62,5 +104,87 @@ public class LanceArrowReadersTest {
         return new Schema(Collections.emptyList());
       }
     };
+  }
+
+  private ArrowReader runtimeFailureReader(BufferAllocator allocator) {
+    return new ArrowReader(allocator) {
+      @Override
+      public boolean loadNextBatch() {
+        throw new IllegalStateException("delegate failed");
+      }
+
+      @Override
+      public long bytesRead() {
+        return 0;
+      }
+
+      @Override
+      protected void closeReadSource() {}
+
+      @Override
+      protected Schema readSchema() {
+        return new Schema(Collections.emptyList());
+      }
+    };
+  }
+
+  private static class CountingReader extends ArrowReader {
+    private int readSchemaCount = 0;
+
+    private CountingReader(BufferAllocator allocator) {
+      super(allocator);
+    }
+
+    @Override
+    public boolean loadNextBatch() {
+      return false;
+    }
+
+    @Override
+    public long bytesRead() {
+      return 0;
+    }
+
+    @Override
+    protected void closeReadSource() {}
+
+    @Override
+    protected Schema readSchema() {
+      readSchemaCount++;
+      return new Schema(Collections.emptyList());
+    }
+  }
+
+  private static class CloseCountingReader extends ArrowReader {
+    private int closeCount = 0;
+    private boolean closeReadSource = false;
+
+    private CloseCountingReader(BufferAllocator allocator) {
+      super(allocator);
+    }
+
+    @Override
+    public boolean loadNextBatch() {
+      return false;
+    }
+
+    @Override
+    public long bytesRead() {
+      return 0;
+    }
+
+    @Override
+    public void close(boolean closeReadSource) {
+      closeCount++;
+      this.closeReadSource = closeReadSource;
+    }
+
+    @Override
+    protected void closeReadSource() {}
+
+    @Override
+    protected Schema readSchema() {
+      return new Schema(Collections.emptyList());
+    }
   }
 }


### PR DESCRIPTION
## Summary

Add Lance Java diagnostics around Arrow C Data stream readers and a scanner regression for the nested struct case that motivated the lance-spark fix.

## Findings

The original `VectorLoader` failure can be caused by consumers closing or mutating the reader-owned `VectorSchemaRoot` between `loadNextBatch()` calls. When the damaged vector is a `StructVector`, Arrow Java may see schema children still present while the reused vector has zero children, producing `should have as many children as in the schema: found 0 expected N`.

## Changes

- Add `LanceArrowReaders`, a small wrapper for Arrow readers imported from Lance Arrow C Data streams.
- Use the wrapper for Java APIs that call `Data.importArrayStream(...)`, including `LanceScanner`, `AsyncScanner`, SQL query output, delta output, and file reads.
- Preserve the underlying reader behavior while adding Lance context to batch-load failures, including the child-count mismatch diagnostic.
- Add a Java scanner regression that writes a six-field all-null struct and scans it across multiple batches.
- Add a unit test for the diagnostic message.

## Testing

```bash
cd java
./mvnw -Dtest=org.lance.ScannerTest#testDatasetScannerAllNullStructColumnMultipleBatches,org.lance.ipc.LanceArrowReadersTest test
```

This run passed Java checkstyle, Spotless, both targeted Java tests, the JNI build, and the rust-maven-plugin JNI test.