### PR TITLE
fix(mem_wal): dedupe duplicate primary keys in LSM point lookup

### DIFF
--- a/rust/lance/src/dataset/mem_wal/scanner/exec.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec.rs
@@ -12,13 +12,16 @@
 //! - [`CoalesceFirstExec`]: Returns first non-empty result with short-circuit
 //! - [`LsmSourceTagExec`]: Tags rows with `_memtable_gen` + `_freshness` for the vector-search global dedup
 //! - [`LsmGlobalPkDedupExec`]: Single-pass cross-source PK dedup over the merged vector-search stream
+//! - [`WithinSourceDedupExec`]: Deduplicates rows with the same PK from a single source (used by point lookup)
 
 mod bloom_guard;
 mod coalesce_first;
 mod deduplicate;
 mod generation_tag;
 mod global_pk_dedup;
+mod pk;
 mod source_tag;
+mod within_source_dedup;
 
 pub use bloom_guard::{BloomFilterGuardExec, compute_pk_hash_from_scalars};
 pub use coalesce_first::CoalesceFirstExec;
@@ -26,3 +29,4 @@ pub use deduplicate::{DeduplicateExec, ROW_ADDRESS_COLUMN};
 pub use generation_tag::{MEMTABLE_GEN_COLUMN, MemtableGenTagExec};
 pub use global_pk_dedup::LsmGlobalPkDedupExec;
 pub use source_tag::{FRESHNESS_COLUMN, FreshnessPolarity, LsmSourceTagExec};
+pub use within_source_dedup::{DedupDirection, WithinSourceDedupExec};

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/global_pk_dedup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/global_pk_dedup.rs
@@ -38,6 +38,8 @@ use datafusion::physical_plan::{
 };
 use futures::{Stream, StreamExt, ready};
 
+use super::pk::{compute_pk_hash, resolve_pk_indices};
+
 /// Cross-source PK dedup. Keeps one row per primary key — the one with
 /// the largest `(generation, freshness)` tuple.
 ///
@@ -269,56 +271,6 @@ impl GlobalPkDedupStream {
         arrow_select::concat::concat_batches(&self.schema, batch_refs)
             .map_err(|e| datafusion::error::DataFusionError::ArrowError(Box::new(e), None))
     }
-}
-
-fn resolve_pk_indices(batch: &RecordBatch, pk_columns: &[String]) -> DFResult<Vec<usize>> {
-    pk_columns
-        .iter()
-        .map(|col| {
-            batch
-                .schema()
-                .column_with_name(col)
-                .map(|(idx, _)| idx)
-                .ok_or_else(|| {
-                    datafusion::error::DataFusionError::Internal(format!(
-                        "Primary key column '{}' not found",
-                        col
-                    ))
-                })
-        })
-        .collect()
-}
-
-/// Hash a row's primary key. Mirrors the variants supported by
-/// [`super::WithinSourceDedupExec`] / `BloomFilterGuardExec`, so a single
-/// PK produces the same hash everywhere in the LSM scanner.
-fn compute_pk_hash(batch: &RecordBatch, pk_indices: &[usize], row_idx: usize) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    let mut hasher = DefaultHasher::new();
-    for &col_idx in pk_indices {
-        let col = batch.column(col_idx);
-        let is_null = col.is_null(row_idx);
-        is_null.hash(&mut hasher);
-
-        if !is_null {
-            if let Some(arr) = col.as_any().downcast_ref::<arrow_array::Int32Array>() {
-                arr.value(row_idx).hash(&mut hasher);
-            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::Int64Array>() {
-                arr.value(row_idx).hash(&mut hasher);
-            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::StringArray>() {
-                arr.value(row_idx).hash(&mut hasher);
-            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::BinaryArray>() {
-                arr.value(row_idx).hash(&mut hasher);
-            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::UInt32Array>() {
-                arr.value(row_idx).hash(&mut hasher);
-            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::UInt64Array>() {
-                arr.value(row_idx).hash(&mut hasher);
-            }
-        }
-    }
-    hasher.finish()
 }
 
 impl Stream for GlobalPkDedupStream {

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/pk.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/pk.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Shared primary-key helpers for the LSM scanner execution nodes.
+//!
+//! Centralizes PK column resolution and per-row hashing so that every dedup
+//! node ([`super::WithinSourceDedupExec`] and [`super::LsmGlobalPkDedupExec`])
+//! resolves and hashes a primary key the same way. The row hash is kept
+//! consistent with the variants supported by [`super::compute_pk_hash_from_scalars`]
+//! so a single PK produces the same hash regardless of which exec consumes it.
+
+use arrow_array::{Array, RecordBatch};
+use datafusion::error::{DataFusionError, Result as DFResult};
+
+/// Resolve the column index of each primary-key column in `batch`.
+pub fn resolve_pk_indices(batch: &RecordBatch, pk_columns: &[String]) -> DFResult<Vec<usize>> {
+    pk_columns
+        .iter()
+        .map(|col| {
+            batch
+                .schema()
+                .column_with_name(col)
+                .map(|(idx, _)| idx)
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!("Primary key column '{}' not found", col))
+                })
+        })
+        .collect()
+}
+
+/// Hash a single row's primary key, identified by the `pk_indices` column
+/// positions and `row_idx`.
+pub fn compute_pk_hash(batch: &RecordBatch, pk_indices: &[usize], row_idx: usize) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    for &col_idx in pk_indices {
+        let col = batch.column(col_idx);
+        let is_null = col.is_null(row_idx);
+        is_null.hash(&mut hasher);
+
+        if !is_null {
+            if let Some(arr) = col.as_any().downcast_ref::<arrow_array::Int32Array>() {
+                arr.value(row_idx).hash(&mut hasher);
+            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::Int64Array>() {
+                arr.value(row_idx).hash(&mut hasher);
+            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::StringArray>() {
+                arr.value(row_idx).hash(&mut hasher);
+            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::BinaryArray>() {
+                arr.value(row_idx).hash(&mut hasher);
+            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::UInt32Array>() {
+                arr.value(row_idx).hash(&mut hasher);
+            } else if let Some(arr) = col.as_any().downcast_ref::<arrow_array::UInt64Array>() {
+                arr.value(row_idx).hash(&mut hasher);
+            }
+        }
+    }
+    hasher.finish()
+}

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/within_source_dedup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/within_source_dedup.rs
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! WithinSourceDedupExec - Deduplicates rows with the same primary key from a
+//! single LSM source, keeping the newest insert.
+//!
+//! In MemWAL/LSM mode the same primary key can be written multiple times into
+//! the same memtable. The active memtable stores rows in insert order (larger
+//! `_rowaddr` = newer), while flushed memtables are reverse-written so that
+//! within a flushed file the smallest `_rowid` is the newest insert (see
+//! `memtable/flush.rs:152` and `hnsw/storage.rs:307`). Point lookup uses this
+//! node to collapse such duplicates *within a single source* so that the
+//! downstream `CoalesceFirstExec` / `LIMIT` sees at most one row per primary
+//! key per source.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow_array::{Array, RecordBatch, UInt64Array};
+use arrow_schema::SchemaRef;
+use datafusion::error::Result as DFResult;
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    SendableRecordBatchStream,
+};
+use futures::{Stream, StreamExt, ready};
+
+use super::pk::{compute_pk_hash, resolve_pk_indices};
+
+/// Among rows that share a primary key, which row-address extreme identifies
+/// the newest insert to keep. The kept row is always the freshest; only the
+/// row address (`_rowaddr`/`_rowid`) used to find it differs by source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DedupDirection {
+    /// Keep the row with the largest row-address value (active memtable: larger
+    /// `_rowaddr` = inserted later).
+    KeepMaxRowAddr,
+    /// Keep the row with the smallest row-address value (flushed memtable under
+    /// reverse-write: smaller `_rowid` = inserted later).
+    KeepMinRowAddr,
+}
+
+/// Deduplicates rows from a single source by primary key, keeping the row
+/// whose `row_addr_column` value wins per [`DedupDirection`].
+///
+/// # Required columns
+///
+/// The input must expose:
+/// - All `pk_columns`
+/// - `row_addr_column` of `UInt64` type
+///
+/// The output schema is unchanged from the input. Callers that need to hide
+/// the row-address column from downstream consumers should compose this node
+/// with `project_to_canonical` or `null_columns`.
+///
+/// # Performance
+///
+/// Memory: `O(unique primary keys in input)`. For point lookup the input is
+/// already filtered to a single primary key so the map holds at most one
+/// entry.
+#[derive(Debug)]
+pub struct WithinSourceDedupExec {
+    input: Arc<dyn ExecutionPlan>,
+    pk_columns: Vec<String>,
+    row_addr_column: String,
+    direction: DedupDirection,
+    schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+}
+
+impl WithinSourceDedupExec {
+    pub fn new(
+        input: Arc<dyn ExecutionPlan>,
+        pk_columns: Vec<String>,
+        row_addr_column: impl Into<String>,
+        direction: DedupDirection,
+    ) -> Self {
+        let schema = input.schema();
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(schema.clone()),
+            Partitioning::UnknownPartitioning(1),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        ));
+        Self {
+            input,
+            pk_columns,
+            row_addr_column: row_addr_column.into(),
+            direction,
+            schema,
+            properties,
+        }
+    }
+
+    pub fn pk_columns(&self) -> &[String] {
+        &self.pk_columns
+    }
+
+    pub fn row_addr_column(&self) -> &str {
+        &self.row_addr_column
+    }
+
+    pub fn direction(&self) -> DedupDirection {
+        self.direction
+    }
+}
+
+impl DisplayAs for WithinSourceDedupExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default
+            | DisplayFormatType::Verbose
+            | DisplayFormatType::TreeRender => {
+                write!(
+                    f,
+                    "WithinSourceDedupExec: pk=[{}], row_addr={}, direction={:?}",
+                    self.pk_columns.join(", "),
+                    self.row_addr_column,
+                    self.direction,
+                )
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for WithinSourceDedupExec {
+    fn name(&self) -> &str {
+        "WithinSourceDedupExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(datafusion::error::DataFusionError::Internal(
+                "WithinSourceDedupExec requires exactly one child".to_string(),
+            ));
+        }
+        Ok(Arc::new(Self::new(
+            children[0].clone(),
+            self.pk_columns.clone(),
+            self.row_addr_column.clone(),
+            self.direction,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let input_stream = self.input.execute(partition, context)?;
+        Ok(Box::pin(WithinSourceDedupStream {
+            input: input_stream,
+            pk_columns: self.pk_columns.clone(),
+            row_addr_column: self.row_addr_column.clone(),
+            direction: self.direction,
+            schema: self.schema.clone(),
+            winners: HashMap::new(),
+            emitted: false,
+        }))
+    }
+}
+
+/// One winning row, materialized as a single-row `RecordBatch` so we don't
+/// have to keep the source batch alive after we've picked the winner.
+struct Winner {
+    batch: RecordBatch,
+    row_addr: u64,
+}
+
+struct WithinSourceDedupStream {
+    input: SendableRecordBatchStream,
+    pk_columns: Vec<String>,
+    row_addr_column: String,
+    direction: DedupDirection,
+    schema: SchemaRef,
+    winners: HashMap<u64, Winner>,
+    emitted: bool,
+}
+
+impl WithinSourceDedupStream {
+    fn consume_batch(&mut self, batch: RecordBatch) -> DFResult<()> {
+        if batch.num_rows() == 0 {
+            return Ok(());
+        }
+        let pk_indices = resolve_pk_indices(&batch, &self.pk_columns)?;
+        let row_addr_array = batch
+            .column_by_name(&self.row_addr_column)
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Internal(format!(
+                    "Row-address column '{}' not found in batch",
+                    self.row_addr_column
+                ))
+            })?
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| {
+                datafusion::error::DataFusionError::Internal(format!(
+                    "Row-address column '{}' is not UInt64",
+                    self.row_addr_column
+                ))
+            })?;
+
+        for row_idx in 0..batch.num_rows() {
+            if row_addr_array.is_null(row_idx) {
+                // A NULL row address can't be ordered against a real one. Skip
+                // rather than guess — callers should always project a real
+                // row-address column for dedup-eligible sources.
+                continue;
+            }
+            let row_addr = row_addr_array.value(row_idx);
+            let pk_hash = compute_pk_hash(&batch, &pk_indices, row_idx);
+
+            let take_row = match self.winners.get(&pk_hash) {
+                None => true,
+                Some(existing) => match self.direction {
+                    DedupDirection::KeepMaxRowAddr => row_addr > existing.row_addr,
+                    DedupDirection::KeepMinRowAddr => row_addr < existing.row_addr,
+                },
+            };
+
+            if take_row {
+                let single = batch.slice(row_idx, 1);
+                self.winners.insert(
+                    pk_hash,
+                    Winner {
+                        batch: single,
+                        row_addr,
+                    },
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn finalize(&mut self) -> DFResult<RecordBatch> {
+        if self.winners.is_empty() {
+            return Ok(RecordBatch::new_empty(self.schema.clone()));
+        }
+        let batches: Vec<RecordBatch> = self.winners.drain().map(|(_, w)| w.batch).collect();
+        let batch_refs: Vec<&RecordBatch> = batches.iter().collect();
+        arrow_select::concat::concat_batches(&self.schema, batch_refs)
+            .map_err(|e| datafusion::error::DataFusionError::ArrowError(Box::new(e), None))
+    }
+}
+
+impl Stream for WithinSourceDedupStream {
+    type Item = DFResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            if self.emitted {
+                return Poll::Ready(None);
+            }
+            match ready!(self.input.poll_next_unpin(cx)) {
+                Some(Ok(batch)) => {
+                    if let Err(e) = self.consume_batch(batch) {
+                        self.emitted = true;
+                        return Poll::Ready(Some(Err(e)));
+                    }
+                }
+                Some(Err(e)) => {
+                    self.emitted = true;
+                    return Poll::Ready(Some(Err(e)));
+                }
+                None => {
+                    self.emitted = true;
+                    return Poll::Ready(Some(self.finalize()));
+                }
+            }
+        }
+    }
+}
+
+impl datafusion::physical_plan::RecordBatchStream for WithinSourceDedupStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Float32Array, Int32Array, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::prelude::SessionContext;
+    use datafusion_physical_plan::test::TestMemoryExec;
+    use futures::TryStreamExt;
+
+    fn create_test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("_distance", DataType::Float32, true),
+            Field::new("_row_addr", DataType::UInt64, true),
+        ]))
+    }
+
+    fn batch(ids: &[i32], names: &[&str], distances: &[f32], row_addr: &[u64]) -> RecordBatch {
+        let schema = create_test_schema();
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(ids.to_vec())),
+                Arc::new(StringArray::from(names.to_vec())),
+                Arc::new(Float32Array::from(distances.to_vec())),
+                Arc::new(UInt64Array::from(row_addr.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    async fn run(batches: Vec<RecordBatch>, direction: DedupDirection) -> Vec<RecordBatch> {
+        let schema = create_test_schema();
+        let input = TestMemoryExec::try_new_exec(&[batches], schema, None).unwrap();
+        let exec =
+            WithinSourceDedupExec::new(input, vec!["id".to_string()], "_row_addr", direction);
+        let ctx = SessionContext::new();
+        let stream = exec.execute(0, ctx.task_ctx()).unwrap();
+        stream.try_collect().await.unwrap()
+    }
+
+    fn extract(batches: &[RecordBatch]) -> Vec<(i32, String, u64)> {
+        let mut out = Vec::new();
+        for b in batches {
+            let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+            let names = b.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+            let addr = b.column(3).as_any().downcast_ref::<UInt64Array>().unwrap();
+            for i in 0..b.num_rows() {
+                out.push((ids.value(i), names.value(i).to_string(), addr.value(i)));
+            }
+        }
+        out.sort_by_key(|(id, _, _)| *id);
+        out
+    }
+
+    #[tokio::test]
+    async fn keep_max_picks_largest_row_addr() {
+        // Active-memtable case: same pk inserted twice; newer = larger _rowaddr.
+        let b1 = batch(
+            &[1, 1, 2],
+            &["old", "new", "two"],
+            &[0.1, 0.2, 0.3],
+            &[10, 99, 5],
+        );
+        let out = run(vec![b1], DedupDirection::KeepMaxRowAddr).await;
+        let rows = extract(&out);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], (1, "new".to_string(), 99));
+        assert_eq!(rows[1], (2, "two".to_string(), 5));
+    }
+
+    #[tokio::test]
+    async fn keep_min_picks_smallest_row_addr() {
+        // Flushed-memtable case under reverse-write: newer = smaller _rowid.
+        let b1 = batch(
+            &[1, 1, 2],
+            &["old", "new", "two"],
+            &[0.1, 0.2, 0.3],
+            &[99, 10, 5],
+        );
+        let out = run(vec![b1], DedupDirection::KeepMinRowAddr).await;
+        let rows = extract(&out);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], (1, "new".to_string(), 10));
+        assert_eq!(rows[1], (2, "two".to_string(), 5));
+    }
+
+    #[tokio::test]
+    async fn dedup_across_batches() {
+        let b1 = batch(&[1, 2], &["a", "b"], &[0.1, 0.2], &[1, 1]);
+        let b2 = batch(&[1, 3], &["a_new", "c"], &[0.5, 0.4], &[7, 1]);
+        let out = run(vec![b1, b2], DedupDirection::KeepMaxRowAddr).await;
+        let rows = extract(&out);
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0], (1, "a_new".to_string(), 7));
+        assert_eq!(rows[1], (2, "b".to_string(), 1));
+        assert_eq!(rows[2], (3, "c".to_string(), 1));
+    }
+
+    #[tokio::test]
+    async fn empty_input() {
+        let out = run(vec![], DedupDirection::KeepMaxRowAddr).await;
+        let total: usize = out.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 0);
+    }
+
+    #[tokio::test]
+    async fn null_row_addr_skipped() {
+        // Rows with NULL row address can't be ordered — they're dropped so they
+        // don't accidentally become winners against real values.
+        let schema = create_test_schema();
+        let b = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 1])),
+                Arc::new(StringArray::from(vec!["nulladdr", "real"])),
+                Arc::new(Float32Array::from(vec![0.1, 0.2])),
+                Arc::new(UInt64Array::from(vec![None, Some(5)])),
+            ],
+        )
+        .unwrap();
+        let out = run(vec![b], DedupDirection::KeepMaxRowAddr).await;
+        let rows = extract(&out);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0], (1, "real".to_string(), 5));
+    }
+}

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -18,11 +18,14 @@ use tracing::instrument;
 
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
-use super::exec::{BloomFilterGuardExec, CoalesceFirstExec, compute_pk_hash_from_scalars};
+use super::exec::{
+    BloomFilterGuardExec, CoalesceFirstExec, DedupDirection, WithinSourceDedupExec,
+    compute_pk_hash_from_scalars,
+};
 use super::flushed_cache::{FlushedMemTableCache, open_flushed_dataset};
 use super::projection::{
-    build_scanner_projection, canonical_output_schema, project_to_canonical, wants_row_address,
-    wants_row_id,
+    build_scanner_projection, canonical_output_schema, null_columns, project_to_canonical,
+    wants_row_address, wants_row_id,
 };
 use crate::session::Session;
 
@@ -276,7 +279,26 @@ impl LsmPointLookupPlanner {
                     MemTableScanner::new(batch_store.clone(), index_store.clone(), schema.clone());
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>());
                 scanner.filter_expr(filter.clone());
-                scanner.create_plan().await?
+                // Expose `_rowid` (the BatchStore row offset, monotonic with
+                // insert order) so we can pick the most recently inserted
+                // duplicate below. Without this, a `FilterExec → LIMIT 1`
+                // over insert-ordered scan would return the *oldest* of
+                // multiple rows sharing the target primary key.
+                scanner.with_row_id();
+                let raw = scanner.create_plan().await?;
+                // Within the active memtable, larger `_rowid` = newer
+                // insert. After dedup there is exactly one row per PK.
+                let deduped: Arc<dyn ExecutionPlan> = Arc::new(WithinSourceDedupExec::new(
+                    raw,
+                    self.pk_columns.clone(),
+                    lance_core::ROW_ID,
+                    DedupDirection::KeepMaxRowAddr,
+                ));
+                // Per-source `_rowid` would collide with the base table's;
+                // NULL it before canonicalization (the value is internal to
+                // this arm). project_to_canonical drops it entirely when
+                // the user didn't request `_rowid` in the projection.
+                null_columns(deduped, &[lance_core::ROW_ID])?
             }
         };
         project_to_canonical(scan, &target)
@@ -627,6 +649,131 @@ mod tests {
                 "_rowid".to_string(),
             ],
             "empty point-lookup plan must honor user column order including system columns"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_point_lookup_active_memtable_returns_newest_duplicate() {
+        // Regression: same primary key inserted twice into one active
+        // memtable must return the *newest* row. The bug was that
+        // `FilterExec → LIMIT 1` over an insert-ordered scan returned the
+        // first (oldest) match. `WithinSourceDedupExec` collapses by PK,
+        // keeping the row with the largest `_rowid` (insert order).
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
+        use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+        use futures::TryStreamExt;
+
+        let schema = create_pk_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
+
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut index_store = IndexStore::new();
+        // BTree on the PK so that `max_visible_batch_position` advances as
+        // we insert, otherwise the scanner sees no batches at all.
+        index_store.add_btree("id_idx".to_string(), 0, "id".to_string());
+
+        // Two writes to pk=1, then an unrelated pk=2. The "new" row goes
+        // *second* so its `_rowid` is larger.
+        let b_old = create_test_batch(&schema, &[1], "old");
+        let b_new = create_test_batch(&schema, &[1], "new");
+        let b_other = create_test_batch(&schema, &[2], "two");
+        let (_, _, bp_old) = batch_store.append(b_old.clone()).unwrap();
+        index_store
+            .insert_with_batch_position(&b_old, 0, Some(bp_old))
+            .unwrap();
+        let (_, _, bp_new) = batch_store.append(b_new.clone()).unwrap();
+        index_store
+            .insert_with_batch_position(&b_new, 1, Some(bp_new))
+            .unwrap();
+        let (_, _, bp_other) = batch_store.append(b_other.clone()).unwrap();
+        index_store
+            .insert_with_batch_position(&b_other, 2, Some(bp_other))
+            .unwrap();
+        let index_store = Arc::new(index_store);
+
+        let shard_id = Uuid::new_v4();
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                shard_id,
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store,
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            );
+
+        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+
+        let plan = planner
+            .plan_lookup(&[ScalarValue::Int32(Some(1))], None)
+            .await
+            .unwrap();
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1, "expected exactly one row for pk=1");
+        let name_col = batches[0].column_by_name("name").unwrap();
+        let name_arr = name_col.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(
+            name_arr.value(0),
+            "new_1",
+            "active-arm lookup must return the newer insert, not the oldest"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_point_lookup_flushed_memtable_returns_newest_duplicate() {
+        // Regression / invariant pin: when a flushed memtable contains two
+        // rows for the same PK, the lookup must return the newer one. The
+        // flushed dataset is reverse-written (newest at the smallest
+        // physical position), so we simulate that here by writing the
+        // dataset with the new row first. The point-lookup plan today
+        // returns the first match (smallest `_rowid`) under reverse-write,
+        // and remains so after this change.
+        use futures::TryStreamExt;
+
+        let schema = create_pk_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_path = temp_dir.path().to_str().unwrap();
+        let base_uri = format!("{}/base", base_path);
+
+        // Simulated reverse-write: newest insert lives at row 0.
+        let shard_id = Uuid::new_v4();
+        let gen1_uri = format!("{}/_mem_wal/{}/gen_1", base_uri, shard_id);
+        let row_new = create_test_batch(&schema, &[1], "new");
+        let row_old = create_test_batch(&schema, &[1], "old");
+        create_dataset(&gen1_uri, vec![row_new, row_old]).await;
+
+        let shard_snapshot = ShardSnapshot::new(shard_id)
+            .with_current_generation(2)
+            .with_flushed_generation(1, "gen_1".to_string());
+
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![shard_snapshot]);
+        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+
+        let plan = planner
+            .plan_lookup(&[ScalarValue::Int32(Some(1))], None)
+            .await
+            .unwrap();
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1, "expected exactly one row for pk=1");
+        let name_col = batches[0].column_by_name("name").unwrap();
+        let name_arr = name_col.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(
+            name_arr.value(0),
+            "new_1",
+            "flushed-arm lookup must return the row at the smallest _rowid (newest under reverse-write)"
         );
     }
 }


### PR DESCRIPTION
Split from #6856 — point-lookup portion.

A primary key written multiple times into one active memtable used to leak through to the user as distinct rows: `FilterExec + LIMIT 1` over an insert-ordered scan returned the *oldest* match among duplicates.

The active arm now runs `WithinSourceDedupExec(KeepMaxFreshness)`, which collapses by PK and keeps the freshest row. Flushed and base arms still rely on `LIMIT 1` under the reverse-write / forward-write conventions.

Part of splitting #6856 into focused PRs. Co-authored with @jackye1995.