### PR TITLE
fix(index): preserve range partition structure in BTree index update during optimize

### DIFF
--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -29,7 +29,7 @@ use crate::{metrics::NoOpMetricsCollector, scalar::registry::TrainingCriteria};
 use crate::{pbold, scalar::btree::flat::FlatIndex};
 use arrow_arith::numeric::add;
 use arrow_array::{Array, RecordBatch, UInt32Array, new_empty_array};
-use arrow_schema::{DataType, Field, Schema, SortOptions};
+use arrow_schema::{DataType, Field, Schema, SchemaRef, SortOptions};
 use async_trait::async_trait;
 use datafusion::physical_plan::{
     ExecutionPlan, SendableRecordBatchStream,
@@ -1914,16 +1914,25 @@ impl ScalarIndex for BTreeIndex {
 
         let num_partitions = ranges_to_files.iter().count();
 
-        let collected = collect_sorted_batches(merged_data_source).await?;
-        if collected.is_empty() {
+        let schema = merged_data_source.schema();
+        let mut stream = Box::pin(merged_data_source);
+
+        let mut total_rows = 0usize;
+        let mut all_batches: Vec<RecordBatch> = Vec::new();
+        while let Some(batch) = stream.try_next().await? {
+            total_rows += batch.num_rows();
+            all_batches.push(batch);
+        }
+
+        if total_rows == 0 {
             return Err(Error::internal(
                 "no data to train range-partitioned BTree index".to_string(),
             ));
         }
 
-        let total_rows: usize = collected.iter().map(|b| b.num_rows()).sum();
         let rows_per_partition = total_rows.div_ceil(num_partitions);
 
+        let mut trained_partition_ids: Vec<u64> = Vec::new();
         let mut row_offset = 0usize;
         for part_idx in 0..num_partitions {
             let range_id = part_idx as u32;
@@ -1935,11 +1944,11 @@ impl ScalarIndex for BTreeIndex {
             };
             row_offset = end;
 
-            let part_batches = slice_batches(&collected, start, end)?;
+            let part_batches = slice_batches(&all_batches, start, end)?;
             if part_batches.is_empty() {
                 continue;
             }
-            let part_stream = batches_to_stream(part_batches);
+            let part_stream = batches_to_stream(part_batches, schema.clone());
             train_btree_index(
                 part_stream,
                 dest_store,
@@ -1948,12 +1957,17 @@ impl ScalarIndex for BTreeIndex {
                 Some(range_id),
             )
             .await?;
+            trained_partition_ids.push((range_id as u64) << 32);
         }
 
-        let partition_ids: Vec<u64> = (0..num_partitions as u32)
-            .map(|range_id| (range_id as u64) << 32)
-            .collect();
-        merge_range_partition_lookups_in_place(dest_store, &partition_ids, self.batch_size).await?;
+        if trained_partition_ids.len() > 1 {
+            merge_range_partition_lookups_in_place(
+                dest_store,
+                &trained_partition_ids,
+                self.batch_size,
+            )
+            .await?;
+        }
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pbold::BTreeIndexDetails::default())
@@ -1974,10 +1988,6 @@ impl ScalarIndex for BTreeIndex {
         })?;
         Ok(ScalarIndexParams::for_builtin(BuiltinIndexType::BTree).with_params(&params))
     }
-}
-
-async fn collect_sorted_batches(stream: SendableRecordBatchStream) -> Result<Vec<RecordBatch>> {
-    stream.try_collect::<Vec<_>>().await.map_err(Into::into)
 }
 
 fn slice_batches(batches: &[RecordBatch], start: usize, end: usize) -> Result<Vec<RecordBatch>> {
@@ -2002,8 +2012,7 @@ fn slice_batches(batches: &[RecordBatch], start: usize, end: usize) -> Result<Ve
     Ok(result)
 }
 
-fn batches_to_stream(batches: Vec<RecordBatch>) -> SendableRecordBatchStream {
-    let schema = batches[0].schema();
+fn batches_to_stream(batches: Vec<RecordBatch>, schema: SchemaRef) -> SendableRecordBatchStream {
     Box::pin(RecordBatchStreamAdapter::new(
         schema,
         futures::stream::iter(batches.into_iter().map(Ok)),

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1897,12 +1897,63 @@ impl ScalarIndex for BTreeIndex {
         dest_store: &dyn IndexStore,
         old_data_filter: Option<OldIndexDataFilter>,
     ) -> Result<CreatedIndex> {
-        // Merge the existing index data with the new data and then retrain the index on the merged stream
         let merged_data_source = self
             .clone()
             .combine_old_new(new_data, self.batch_size, old_data_filter)
             .await?;
-        train_btree_index(merged_data_source, dest_store, self.batch_size, None, None).await?;
+
+        let Some(ranges_to_files) = &self.ranges_to_files else {
+            train_btree_index(merged_data_source, dest_store, self.batch_size, None, None).await?;
+            return Ok(CreatedIndex {
+                index_details: prost_types::Any::from_msg(&pbold::BTreeIndexDetails::default())
+                    .unwrap(),
+                index_version: BTREE_INDEX_VERSION,
+                files: Some(dest_store.list_files_with_sizes().await?),
+            });
+        };
+
+        let num_partitions = ranges_to_files.iter().count();
+
+        let collected = collect_sorted_batches(merged_data_source).await?;
+        if collected.is_empty() {
+            return Err(Error::internal(
+                "no data to train range-partitioned BTree index".to_string(),
+            ));
+        }
+
+        let total_rows: usize = collected.iter().map(|b| b.num_rows()).sum();
+        let rows_per_partition = total_rows.div_ceil(num_partitions);
+
+        let mut row_offset = 0usize;
+        for part_idx in 0..num_partitions {
+            let range_id = part_idx as u32;
+            let start = row_offset;
+            let end = if part_idx == num_partitions - 1 {
+                total_rows
+            } else {
+                std::cmp::min(row_offset + rows_per_partition, total_rows)
+            };
+            row_offset = end;
+
+            let part_batches = slice_batches(&collected, start, end)?;
+            if part_batches.is_empty() {
+                continue;
+            }
+            let part_stream = batches_to_stream(part_batches);
+            train_btree_index(
+                part_stream,
+                dest_store,
+                self.batch_size,
+                None,
+                Some(range_id),
+            )
+            .await?;
+        }
+
+        let partition_ids: Vec<u64> = (0..num_partitions as u32)
+            .map(|range_id| (range_id as u64) << 32)
+            .collect();
+        merge_range_partition_lookups_in_place(dest_store, &partition_ids, self.batch_size).await?;
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pbold::BTreeIndexDetails::default())
@@ -1923,6 +1974,106 @@ impl ScalarIndex for BTreeIndex {
         })?;
         Ok(ScalarIndexParams::for_builtin(BuiltinIndexType::BTree).with_params(&params))
     }
+}
+
+async fn collect_sorted_batches(stream: SendableRecordBatchStream) -> Result<Vec<RecordBatch>> {
+    stream.try_collect::<Vec<_>>().await.map_err(Into::into)
+}
+
+fn slice_batches(batches: &[RecordBatch], start: usize, end: usize) -> Result<Vec<RecordBatch>> {
+    if start >= end {
+        return Ok(vec![]);
+    }
+    let mut result = Vec::new();
+    let mut offset = 0usize;
+    for batch in batches {
+        let batch_len = batch.num_rows();
+        let batch_start = offset;
+        let batch_end = offset + batch_len;
+        if batch_end <= start || batch_start >= end {
+            offset += batch_len;
+            continue;
+        }
+        let slice_start = start.saturating_sub(batch_start);
+        let slice_end = std::cmp::min(end - batch_start, batch_len);
+        result.push(batch.slice(slice_start, slice_end - slice_start));
+        offset += batch_len;
+    }
+    Ok(result)
+}
+
+fn batches_to_stream(batches: Vec<RecordBatch>) -> SendableRecordBatchStream {
+    let schema = batches[0].schema();
+    Box::pin(RecordBatchStreamAdapter::new(
+        schema,
+        futures::stream::iter(batches.into_iter().map(Ok)),
+    ))
+}
+
+async fn merge_range_partition_lookups_in_place(
+    store: &dyn IndexStore,
+    partition_ids: &[u64],
+    batch_size: u64,
+) -> Result<()> {
+    let value_type = {
+        let first_lookup = store
+            .open_index_file(&part_lookup_file_path(partition_ids[0]))
+            .await?;
+        first_lookup
+            .schema()
+            .fields
+            .first()
+            .unwrap()
+            .data_type()
+            .clone()
+    };
+
+    let lookup_schema = Arc::new(Schema::new(vec![
+        Field::new("min", value_type.clone(), true),
+        Field::new("max", value_type.clone(), true),
+        Field::new("null_count", DataType::UInt32, false),
+        Field::new("page_idx", DataType::UInt32, false),
+    ]));
+
+    let mut metadata = HashMap::new();
+    metadata.insert(BATCH_SIZE_META_KEY.to_string(), batch_size.to_string());
+    metadata.insert(RANGE_PARTITIONED_META_KEY.to_string(), "true".to_string());
+
+    let mut lookup_file = store
+        .new_index_file(BTREE_LOOKUP_NAME, lookup_schema.clone())
+        .await?;
+
+    let mut pages_per_file: Vec<(u64, u32)> = Vec::with_capacity(partition_ids.len());
+    let mut num_pages_written = 0u32;
+
+    for &partition_id in partition_ids {
+        let lookup_name = part_lookup_file_path(partition_id);
+        let lookup_reader = store.open_index_file(&lookup_name).await?;
+        let num_rows = lookup_reader.num_rows();
+        let reader_stream = IndexReaderStream::new(lookup_reader.clone(), batch_size).await;
+        let mut stream = reader_stream.buffered(1).boxed();
+        while let Some(batch) = stream.next().await {
+            let original_batch = batch?;
+            let modified_batch = add_offset_to_page_idx(&original_batch, num_pages_written)?;
+            lookup_file.write_record_batch(modified_batch).await?;
+        }
+        pages_per_file.push((partition_id, num_rows as u32));
+        num_pages_written += num_rows as u32;
+    }
+
+    metadata.insert(
+        PAGE_NUM_PER_RANGE_PARTITION_META_KEY.to_string(),
+        serde_json::to_string(&pages_per_file)?,
+    );
+
+    lookup_file.finish_with_metadata(metadata).await?;
+
+    for &partition_id in partition_ids {
+        let lookup_name = part_lookup_file_path(partition_id);
+        store.delete_index_file(&lookup_name).await.ok();
+    }
+
+    Ok(())
 }
 
 struct BatchStats {

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -4810,8 +4810,8 @@ mod tests {
             .unwrap();
 
         assert!(
-            updated_index.ranges_to_files.is_none(),
-            "Updated ranged-btree-index should fall back to non-ranged"
+            updated_index.ranges_to_files.is_some(),
+            "Updated ranged-btree-index should preserve range partition structure"
         );
 
         let updated_value = (DEFAULT_BTREE_BATCH_SIZE * 2 + (DEFAULT_BTREE_BATCH_SIZE / 2)) as i32;

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -1580,7 +1580,200 @@ mod tests {
             .num_rows();
         assert_eq!(
             count_all, 100,
-            "data should still be correct after optimize even though range structure is lost"
+            "all data should be queryable after optimize"
+        );
+
+        let count_range: usize = dataset
+            .scan()
+            .filter("value >= 10 AND value < 20")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(
+            count_range, 10,
+            "range query should return correct results using the index"
+        );
+
+        let count_point: usize = dataset
+            .scan()
+            .filter("value = 75")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(
+            count_point, 1,
+            "point query should return correct result using the index"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimize_btree_range_partition_with_three_partitions() {
+        use lance_index::scalar::BuiltinIndexType;
+        use lance_index::scalar::btree::BTreeParameters;
+        use lance_table::format::list_index_files_with_sizes;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            arrow::datatypes::DataType::Int32,
+            false,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from_iter_values(0..90))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 30,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let fragments = dataset.get_fragments();
+        assert_eq!(fragments.len(), 3, "should have 3 fragments");
+        let frag_ids: Vec<u32> = fragments.iter().map(|f| f.id() as u32).collect();
+        let shared_uuid = Uuid::new_v4().to_string();
+
+        let mut index_metas = Vec::new();
+        for (range_id, &frag_id) in frag_ids.iter().enumerate() {
+            let btree_params = ScalarIndexParams::for_builtin(BuiltinIndexType::BTree).with_params(
+                &serde_json::to_value(BTreeParameters {
+                    zone_size: None,
+                    range_id: Some(range_id as u32),
+                })
+                .unwrap(),
+            );
+            let meta =
+                CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::BTree, &btree_params)
+                    .name("value_idx".to_string())
+                    .fragments(vec![frag_id])
+                    .index_uuid(shared_uuid.clone())
+                    .execute_uncommitted()
+                    .await
+                    .unwrap();
+            index_metas.push(meta);
+        }
+
+        dataset
+            .merge_index_metadata(
+                &shared_uuid,
+                IndexType::BTree,
+                None,
+                Arc::new(NoopIndexBuildProgress),
+            )
+            .await
+            .unwrap();
+
+        let mut committed_meta = index_metas.into_iter().next().unwrap();
+        committed_meta.fragment_bitmap = Some(frag_ids.iter().copied().collect());
+        committed_meta.files = Some(
+            list_index_files_with_sizes(
+                dataset.object_store.as_ref(),
+                &dataset.indices_dir().join(shared_uuid.as_str()),
+            )
+            .await
+            .unwrap(),
+        );
+        committed_meta.dataset_version = dataset.manifest.version;
+
+        let transaction = crate::dataset::transaction::TransactionBuilder::new(
+            dataset.manifest.version,
+            crate::dataset::transaction::Operation::CreateIndex {
+                new_indices: vec![committed_meta],
+                removed_indices: vec![],
+            },
+        )
+        .build();
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+
+        let new_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from_iter_values(90..150))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(new_batch)], schema.clone());
+        let mut dataset = dataset;
+        dataset.append(reader, None).await.unwrap();
+
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+
+        let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+
+        let indices = dataset.load_indices_by_name("value_idx").await.unwrap();
+        let index_uuid_str = indices[0].uuid.to_string();
+        let index_dir = dataset.indices_dir().join(index_uuid_str.as_str());
+        let files = list_index_files_with_sizes(dataset.object_store.as_ref(), &index_dir)
+            .await
+            .unwrap();
+        let has_part_files = files.iter().any(|f| f.path.contains("part_"));
+        assert!(
+            has_part_files,
+            "range-partitioned BTree should preserve range structure after optimize, found: {:?}",
+            files
+        );
+
+        assert!(
+            dataset
+                .unindexed_fragments("value_idx")
+                .await
+                .unwrap()
+                .is_empty(),
+            "all fragments should be indexed after optimize"
+        );
+
+        let count_all: usize = dataset
+            .scan()
+            .filter("value >= 0 AND value < 150")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(count_all, 150, "all data should be queryable");
+
+        let count_range: usize = dataset
+            .scan()
+            .filter("value >= 45 AND value < 55")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(
+            count_range, 10,
+            "range query across partition boundary should return correct results"
+        );
+
+        let count_point: usize = dataset
+            .scan()
+            .filter("value = 120")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(
+            count_point, 1,
+            "point query on appended data should return correct result"
         );
     }
 }

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -657,6 +657,7 @@ mod tests {
     use crate::dataset::builder::DatasetBuilder;
     use crate::dataset::optimize::compact_files;
     use crate::dataset::{MergeInsertBuilder, WhenMatched, WhenNotMatched, WriteParams};
+    use crate::index::create::CreateIndexBuilder;
     use crate::index::vector::VectorIndexParams;
     use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
 
@@ -1288,5 +1289,298 @@ mod tests {
 
         let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
         assert_eq!(query_id_count(&dataset, "song-42").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_optimize_btree_after_append_preserves_data() {
+        use lance_index::scalar::BuiltinIndexType;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            arrow::datatypes::DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from_iter_values(0..100))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 50,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::BTree);
+        dataset
+            .create_index(
+                &["value"],
+                IndexType::BTree,
+                Some("value_idx".into()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+        assert!(
+            dataset
+                .unindexed_fragments("value_idx")
+                .await
+                .unwrap()
+                .is_empty(),
+            "all fragments should be indexed after initial build"
+        );
+
+        let count_before: usize = dataset
+            .scan()
+            .filter("value >= 40 AND value < 60")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(count_before, 20);
+
+        let new_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from_iter_values(
+                100..150,
+            ))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(new_batch)], schema.clone());
+        let mut dataset = dataset;
+        dataset.append(reader, None).await.unwrap();
+
+        assert!(
+            !dataset
+                .unindexed_fragments("value_idx")
+                .await
+                .unwrap()
+                .is_empty(),
+            "new fragments should be unindexed after append"
+        );
+
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+
+        let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+        assert!(
+            dataset
+                .unindexed_fragments("value_idx")
+                .await
+                .unwrap()
+                .is_empty(),
+            "all fragments should be indexed after optimize"
+        );
+
+        let count_old: usize = dataset
+            .scan()
+            .filter("value >= 40 AND value < 60")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(count_old, 20, "old data should be preserved after optimize");
+
+        let count_new: usize = dataset
+            .scan()
+            .filter("value >= 120 AND value < 140")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(count_new, 20, "new data should be indexed after optimize");
+
+        let count_all: usize = dataset
+            .scan()
+            .filter("value >= 0 AND value < 150")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(
+            count_all, 150,
+            "all data should be queryable after optimize"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optimize_btree_index_update_preserves_range_partition_structure() {
+        use lance_index::scalar::BuiltinIndexType;
+        use lance_index::scalar::btree::BTreeParameters;
+        use lance_table::format::list_index_files_with_sizes;
+
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            arrow::datatypes::DataType::Int32,
+            false,
+        )]));
+
+        let batch1 = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from_iter_values(0..50))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch1)], schema.clone());
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 25,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let fragments = dataset.get_fragments();
+        let frag_0: Vec<u32> = vec![fragments[0].id() as u32];
+        let frag_1: Vec<u32> = vec![fragments[1].id() as u32];
+        let all_frag_ids: Vec<u32> = fragments.iter().map(|f| f.id() as u32).collect();
+        let shared_uuid = Uuid::new_v4().to_string();
+
+        let btree_params_0 = ScalarIndexParams::for_builtin(BuiltinIndexType::BTree).with_params(
+            &serde_json::to_value(BTreeParameters {
+                zone_size: None,
+                range_id: Some(0),
+            })
+            .unwrap(),
+        );
+        let index_meta_0 =
+            CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::BTree, &btree_params_0)
+                .name("value_idx".to_string())
+                .fragments(frag_0)
+                .index_uuid(shared_uuid.clone())
+                .execute_uncommitted()
+                .await
+                .unwrap();
+
+        let btree_params_1 = ScalarIndexParams::for_builtin(BuiltinIndexType::BTree).with_params(
+            &serde_json::to_value(BTreeParameters {
+                zone_size: None,
+                range_id: Some(1),
+            })
+            .unwrap(),
+        );
+        let _index_meta_1 =
+            CreateIndexBuilder::new(&mut dataset, &["value"], IndexType::BTree, &btree_params_1)
+                .name("value_idx".to_string())
+                .fragments(frag_1)
+                .index_uuid(shared_uuid.clone())
+                .execute_uncommitted()
+                .await
+                .unwrap();
+
+        dataset
+            .merge_index_metadata(
+                &shared_uuid,
+                IndexType::BTree,
+                None,
+                Arc::new(NoopIndexBuildProgress),
+            )
+            .await
+            .unwrap();
+
+        let mut committed_meta = index_meta_0;
+        committed_meta.fragment_bitmap = Some(all_frag_ids.iter().copied().collect());
+        committed_meta.files = Some(
+            list_index_files_with_sizes(
+                dataset.object_store.as_ref(),
+                &dataset.indices_dir().join(shared_uuid.as_str()),
+            )
+            .await
+            .unwrap(),
+        );
+        committed_meta.dataset_version = dataset.manifest.version;
+
+        let transaction = crate::dataset::transaction::TransactionBuilder::new(
+            dataset.manifest.version,
+            crate::dataset::transaction::Operation::CreateIndex {
+                new_indices: vec![committed_meta],
+                removed_indices: vec![],
+            },
+        )
+        .build();
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+
+        let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+        let indices = dataset.load_indices_by_name("value_idx").await.unwrap();
+        assert_eq!(indices.len(), 1);
+
+        let index_uuid_str = indices[0].uuid.to_string();
+        let index_dir = dataset.indices_dir().join(index_uuid_str.as_str());
+        let files_before = list_index_files_with_sizes(dataset.object_store.as_ref(), &index_dir)
+            .await
+            .unwrap();
+        let has_part_files_before = files_before.iter().any(|f| f.path.contains("part_"));
+        assert!(
+            has_part_files_before,
+            "range-partitioned BTree should have part_* files before optimize, found: {:?}",
+            files_before
+        );
+
+        let new_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from_iter_values(50..100))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(new_batch)], schema.clone());
+        let mut dataset = dataset;
+        dataset.append(reader, None).await.unwrap();
+
+        dataset
+            .optimize_indices(&OptimizeOptions::append())
+            .await
+            .unwrap();
+
+        let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
+        let indices = dataset.load_indices_by_name("value_idx").await.unwrap();
+        let index_uuid_str = indices[0].uuid.to_string();
+        let index_dir = dataset.indices_dir().join(index_uuid_str.as_str());
+        let files_after = list_index_files_with_sizes(dataset.object_store.as_ref(), &index_dir)
+            .await
+            .unwrap();
+        let has_part_files_after = files_after.iter().any(|f| f.path.contains("part_"));
+        assert!(
+            has_part_files_after,
+            "range-partitioned BTree should preserve range structure after optimize, found: {:?}",
+            files_after
+        );
+
+        let count_all: usize = dataset
+            .scan()
+            .filter("value >= 0 AND value < 100")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert_eq!(
+            count_all, 100,
+            "data should still be correct after optimize even though range structure is lost"
+        );
     }
 }


### PR DESCRIPTION
## Problem

When a BTree index is built with range partitioning (distributed mode), the `update()` method previously called `combine_old_new()` which is unaware of the range partition structure. This caused the retrained index to lose its range partition layout during optimize, producing a single monolithic index instead of per-partition page data and lookup files.

## Root Cause

`BTreeIndex::update()` unconditionally calls `combine_old_new()` + `train_btree_index()` without checking whether the index was built with range partitioning. The `train_btree_index()` function with `range_id=None` generates a non-partitioned index, destroying the original range partition structure.

## Fix

Detect range-partitioned indices by checking `ranges_to_files` in `update()`. When present:

1. Combine old and new data as before via `combine_old_new()`
2. Collect all merged data into sorted batches
3. Re-train each partition independently with the correct `range_id`
4. Merge per-partition lookup files into a unified lookup with correct `page_idx` offsets via `merge_range_partition_lookups_in_place()`

## New Helper Functions

- `collect_sorted_batches()` — collects a `SendableRecordBatchStream` into `Vec<RecordBatch>`
- `slice_batches()` — slices a batch vector by row range `[start, end)`
- `batches_to_stream()` — converts `Vec<RecordBatch>` back to `SendableRecordBatchStream`
- `merge_range_partition_lookups_in_place()` — merges per-partition lookup files into a unified lookup, adjusting `page_idx` offsets and writing `pages_per_range_partition` metadata

## Tests

- `test_optimize_btree_after_append_preserves_data` — verifies regular BTree index data correctness after append + optimize
- `test_optimize_btree_index_update_preserves_range_partition_structure` — verifies range partition structure (`part_*` files) is preserved after optimize