### PR TITLE
fix(index): skip scalar index optimize when no unindexed fragments

### DIFF
--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -517,9 +517,6 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                 ))
             }
             it if it.is_scalar() => {
-                // Skip work when the caller has nothing to do: no unindexed
-                // fragments AND no explicit request to consolidate more than
-                // one old segment.
                 let num_to_merge = options
                     .num_indices_to_merge
                     .unwrap_or(1)

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -517,6 +517,17 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                 ))
             }
             it if it.is_scalar() => {
+                // Skip work when the caller has nothing to do: no unindexed
+                // fragments AND no explicit request to consolidate more than
+                // one old segment.
+                let num_to_merge = options
+                    .num_indices_to_merge
+                    .unwrap_or(1)
+                    .min(old_indices.len());
+                if unindexed.is_empty() && num_to_merge <= 1 {
+                    return Ok(None);
+                }
+
                 // Use effective bitmap (intersected with existing dataset fragments)
                 // to avoid carrying stale data from pruned indices.
                 let effective_old_frags: RoaringBitmap = old_indices
@@ -1288,5 +1299,62 @@ mod tests {
 
         let dataset = DatasetBuilder::from_uri(test_uri).load().await.unwrap();
         assert_eq!(query_id_count(&dataset, "song-42").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_optimize_scalar_no_unindexed_fragments() {
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));
+        let ids = StringArray::from_iter_values((0..32).map(|i| format!("song-{i}")));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(ids)]).unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+
+        dataset
+            .create_index(
+                &["id"],
+                IndexType::BTree,
+                Some("id_idx".into()),
+                &ScalarIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+
+        let before = dataset.load_indices_by_name("id_idx").await.unwrap();
+        assert_eq!(before.len(), 1);
+        let original_uuid = before[0].uuid;
+        let original_version = dataset.manifest.version;
+
+        // `merge(1)` would historically rebuild the single existing segment
+        // (steady state, nothing unindexed) and replace its UUID; with the
+        // short-circuit it must skip work entirely.
+        dataset
+            .optimize_indices(&OptimizeOptions::merge(1))
+            .await
+            .unwrap();
+
+        let after = dataset.load_indices_by_name("id_idx").await.unwrap();
+        assert_eq!(after.len(), 1, "no new segment should be produced");
+        assert_eq!(
+            after[0].uuid, original_uuid,
+            "no-op optimize must not churn the index UUID"
+        );
+        assert_eq!(
+            dataset.manifest.version, original_version,
+            "no-op optimize must not advance the dataset version"
+        );
+
+        // The default options also short-circuit (num_to_merge defaults to 1
+        // when there is a single old segment).
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+        let after_default = dataset.load_indices_by_name("id_idx").await.unwrap();
+        assert_eq!(after_default[0].uuid, original_uuid);
+        assert_eq!(dataset.manifest.version, original_version);
     }
 }


### PR DESCRIPTION
Closes: https://github.com/lance-format/lance/issues/6932

## Summary

When `optimize_indices` was called on a scalar index in steady state (no unindexed fragments, and num_indices_to_merge <=1 ), the scalar branch of `merge_indices_with_unindexed_frags` still rebuilt the segment and assigned it a new UUID, churning the dataset version on every call. **But in fact, the index content remains unchanged at all.**

This adds the same no-op short-circuit that already exists for the `Inverted` branch: when `unindexed` is empty and `num_indices_to_merge` resolves to `<= 1`, return `Ok(None)` and skip the rewrite.

## Behavior change

- `OptimizeOptions::default()` / `append()` / `merge(1)` with no pending fragments is now a true no-op
  (UUID and manifest version are preserved).

Same as the logic in inverted index
```
        match index_type {
            IndexType::Inverted => {
                let num_to_merge = options
                    .num_indices_to_merge
                    .unwrap_or(1)
                    .min(old_indices.len());
                if unindexed.is_empty() && num_to_merge <= 1 {
                    return Ok(None);
                }
```