### PR TITLE
feat(mem_wal): add overfetch_factor and refine_base_table to LSM vector search

### DIFF
--- a/java/lance-jni/src/mem_wal.rs
+++ b/java/lance-jni/src/mem_wal.rs
@@ -23,7 +23,7 @@ use datafusion::physical_plan::{ExecutionPlan, collect, displayable};
 use datafusion::prelude::SessionContext;
 use jni::JNIEnv;
 use jni::objects::{JClass, JMap, JObject, JString, JValueGen};
-use jni::sys::{jint, jlong};
+use jni::sys::{jdouble, jint, jlong};
 use lance::dataset::Dataset as LanceDataset;
 use lance::dataset::mem_wal::scanner::{
     FlushedGeneration, LsmDataSourceCollector, LsmPointLookupPlanner, LsmVectorSearchPlanner,
@@ -855,10 +855,11 @@ pub extern "system" fn Java_org_lance_memwal_LsmVectorSearchPlanner_nativePlanSe
     k: jint,
     nprobes: jint,
     columns: JObject<'local>,
-    refine_factor: jint,
+    refine_base_table: bool,
+    overfetch_factor: jdouble,
 ) -> JObject<'local> {
-    let refine = if refine_factor > 0 {
-        Some(refine_factor as u32)
+    let overfetch = if overfetch_factor > 0.0 {
+        Some(overfetch_factor)
     } else {
         None
     };
@@ -872,7 +873,8 @@ pub extern "system" fn Java_org_lance_memwal_LsmVectorSearchPlanner_nativePlanSe
             k,
             nprobes,
             columns,
-            refine
+            refine_base_table,
+            overfetch
         )
     )
 }
@@ -886,7 +888,8 @@ fn inner_plan_search<'local>(
     k: jint,
     nprobes: jint,
     columns: JObject<'local>,
-    refine_factor: Option<u32>,
+    refine_base_table: bool,
+    overfetch_factor: Option<f64>,
 ) -> Result<JObject<'local>> {
     let query = import_ffi_array(array_addr, schema_addr)?;
     let columns = env.get_strings_opt(&columns)?;
@@ -918,7 +921,8 @@ fn inner_plan_search<'local>(
             k as usize,
             nprobes as usize,
             columns.as_deref(),
-            refine_factor,
+            refine_base_table,
+            overfetch_factor,
         ))?;
         (plan, guard.dataset_schema.clone())
     };

--- a/java/src/main/java/org/lance/memwal/LsmVectorSearchPlanner.java
+++ b/java/src/main/java/org/lance/memwal/LsmVectorSearchPlanner.java
@@ -93,12 +93,20 @@ public class LsmVectorSearchPlanner implements AutoCloseable {
    * @param nprobes number of IVF partitions to probe
    * @param columns columns to project; pass {@code null} to return all columns plus {@code
    *     _distance}
-   * @param refineFactor when positive, the base-table arm over-fetches {@code k * refineFactor}
-   *     candidates and re-ranks them with exact distances. Pass {@code 0} or negative to disable.
+   * @param refineBaseTable when true, the base-table arm re-ranks candidates with exact distances
+   *     (refine factor 1). Useful when the base table uses an approximate index (IVF-PQ).
+   * @param overfetchFactor when positive, each source fetches {@code ceil(k * overfetchFactor)}
+   *     candidates to mitigate stale reads from LSM dedup. Pass {@code 0} or negative to disable.
+   *     When active, base-table refine is also enabled automatically.
    * @return an executable plan
    */
   public ExecutionPlan planSearch(
-      Float4Vector query, int k, int nprobes, List<String> columns, int refineFactor) {
+      Float4Vector query,
+      int k,
+      int nprobes,
+      List<String> columns,
+      boolean refineBaseTable,
+      double overfetchFactor) {
     Preconditions.checkNotNull(query, "query must not be null");
     Preconditions.checkArgument(k > 0, "k must be positive, got %s", k);
     Preconditions.checkArgument(nprobes > 0, "nprobes must be positive, got %s", nprobes);
@@ -115,7 +123,8 @@ public class LsmVectorSearchPlanner implements AutoCloseable {
                 k,
                 nprobes,
                 Optional.ofNullable(columns),
-                refineFactor);
+                refineBaseTable,
+                overfetchFactor);
         plan.allocator = allocator;
         return plan;
       }
@@ -123,7 +132,23 @@ public class LsmVectorSearchPlanner implements AutoCloseable {
   }
 
   /**
-   * Plan a KNN vector search without refine.
+   * Plan a KNN vector search without overfetch.
+   *
+   * @param query a flat float32 vector of length {@code vectorDim}
+   * @param k number of nearest neighbours to return
+   * @param nprobes number of IVF partitions to probe
+   * @param columns columns to project; pass {@code null} to return all columns plus {@code
+   *     _distance}
+   * @param refineBaseTable when true, the base-table arm re-ranks candidates with exact distances.
+   * @return an executable plan
+   */
+  public ExecutionPlan planSearch(
+      Float4Vector query, int k, int nprobes, List<String> columns, boolean refineBaseTable) {
+    return planSearch(query, k, nprobes, columns, refineBaseTable, 0);
+  }
+
+  /**
+   * Plan a KNN vector search without refine or overfetch.
    *
    * @param query a flat float32 vector of length {@code vectorDim}
    * @param k number of nearest neighbours to return
@@ -133,12 +158,12 @@ public class LsmVectorSearchPlanner implements AutoCloseable {
    * @return an executable plan
    */
   public ExecutionPlan planSearch(Float4Vector query, int k, int nprobes, List<String> columns) {
-    return planSearch(query, k, nprobes, columns, 0);
+    return planSearch(query, k, nprobes, columns, false, 0);
   }
 
   /** Plan a KNN vector search with default {@code nprobes} of 20. */
   public ExecutionPlan planSearch(Float4Vector query, int k) {
-    return planSearch(query, k, 20, null, 0);
+    return planSearch(query, k, 20, null, false, 0);
   }
 
   private native ExecutionPlan nativePlanSearch(
@@ -147,7 +172,8 @@ public class LsmVectorSearchPlanner implements AutoCloseable {
       int k,
       int nprobes,
       Optional<List<String>> columns,
-      int refineFactor);
+      boolean refineBaseTable,
+      double overfetchFactor);
 
   /**
    * Close the planner and release native resources. If the planner is already closed, invoking this

--- a/python/src/mem_wal.rs
+++ b/python/src/mem_wal.rs
@@ -747,7 +747,8 @@ impl PyLsmVectorSearchPlanner {
     /// Plan a KNN vector search.
     ///
     /// `query` should be a flat PyArrow Float32Array with `vector_dim` elements.
-    #[pyo3(signature = (query, k=10, nprobes=20, columns=None, refine_factor=None))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (query, k=10, nprobes=20, columns=None, refine_base_table=false, overfetch_factor=None))]
     pub fn plan_search(
         &self,
         py: Python<'_>,
@@ -755,7 +756,8 @@ impl PyLsmVectorSearchPlanner {
         k: usize,
         nprobes: usize,
         columns: Option<Vec<String>>,
-        refine_factor: Option<u32>,
+        refine_base_table: bool,
+        overfetch_factor: Option<f64>,
     ) -> PyResult<PyExecutionPlan> {
         let query_array = make_array(query.0);
         let float32_array = query_array
@@ -789,7 +791,14 @@ impl PyLsmVectorSearchPlanner {
         let plan = rt()
             .block_on(Some(py), async {
                 planner_ref
-                    .plan_search(&fsl, k, nprobes, columns.as_deref(), refine_factor)
+                    .plan_search(
+                        &fsl,
+                        k,
+                        nprobes,
+                        columns.as_deref(),
+                        refine_base_table,
+                        overfetch_factor,
+                    )
                     .await
             })?
             .map_err(|e| PyIOError::new_err(e.to_string()))?;

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -172,11 +172,19 @@ impl LsmVectorSearchPlanner {
     /// * `k` - Number of nearest neighbors to return
     /// * `nprobes` - Number of IVF partitions to search (for IVF-based indexes)
     /// * `projection` - Columns to include in output (None = all columns)
-    /// * `refine_factor` - When set, the base-table arm of the KNN plan fetches
-    ///   `k * refine_factor` candidates and re-ranks them with exact distances.
-    ///   Useful when the base table uses an approximate index (IVF-PQ) so that
-    ///   cross-source distance comparison is exact. Memtable arms use exact
-    ///   HNSW search and do not need refine.
+    /// * `refine_base_table` - When true, the base-table arm re-ranks its
+    ///   candidates with exact distances (refine factor 1). Useful when the
+    ///   base table uses an approximate index (IVF-PQ) so that cross-source
+    ///   distance comparison is exact. Memtable arms use exact HNSW search
+    ///   and never need refine.
+    /// * `overfetch_factor` - When set, each source fetches `ceil(k * factor)`
+    ///   candidates instead of `k`. After cross-source global PK dedup, the
+    ///   final top-k is taken from the larger candidate pool. This mitigates
+    ///   stale reads: when a PK's fresh version falls out of its source's
+    ///   top-k, the extra candidates increase the chance that the global dedup
+    ///   still sees it and can suppress the stale copy. For the base table,
+    ///   overfetching also enables refine so that approximate index distances
+    ///   are re-ranked to exact before the cross-source merge.
     ///
     /// # Returns
     ///
@@ -189,7 +197,8 @@ impl LsmVectorSearchPlanner {
         k: usize,
         nprobes: usize,
         projection: Option<&[String]>,
-        refine_factor: Option<u32>,
+        refine_base_table: bool,
+        overfetch_factor: Option<f64>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let sources = self.collector.collect()?;
 
@@ -209,12 +218,29 @@ impl LsmVectorSearchPlanner {
         let internal_schema =
             canonical_internal_schema(projection, &self.base_schema, &self.pk_columns, true);
 
+        let fetch_k = match overfetch_factor {
+            Some(factor) => ((k as f64) * factor).ceil() as usize,
+            None => k,
+        };
+
+        // Refine the base table when explicitly requested or when overfetching
+        // (overfetch widens the candidate pool so approximate distances must be
+        // re-ranked to exact before the cross-source merge).
+        let refine_base = refine_base_table || overfetch_factor.is_some();
+
         let mut knn_plans = Vec::new();
         for source in &sources {
             let generation = source.generation();
             let is_base = matches!(source, LsmDataSource::BaseTable { .. });
             let knn = self
-                .build_knn_plan(source, query_vector, k, nprobes, projection, refine_factor)
+                .build_knn_plan(
+                    source,
+                    query_vector,
+                    fetch_k,
+                    nprobes,
+                    projection,
+                    is_base && refine_base,
+                )
                 .await?;
             // Tag rows with `(_memtable_gen, _freshness)`. Polarity differs
             // per source — see [`LsmSourceTagExec`] / [`FreshnessPolarity`]:
@@ -339,7 +365,7 @@ impl LsmVectorSearchPlanner {
         k: usize,
         nprobes: usize,
         projection: Option<&[String]>,
-        refine_factor: Option<u32>,
+        refine: bool,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         match source {
             LsmDataSource::BaseTable { dataset } => {
@@ -360,10 +386,10 @@ impl LsmVectorSearchPlanner {
                 scanner.distance_metric(self.distance_type);
                 // Memtables cover unindexed rows; only search indexed data here.
                 scanner.fast_search();
-                // Re-rank base candidates with exact distances when set, so
-                // they're directly comparable to MemTable distances in the merge.
-                if let Some(factor) = refine_factor {
-                    scanner.refine(factor);
+                // Re-rank base candidates with exact distances so they're
+                // directly comparable to memtable distances in the merge.
+                if refine {
+                    scanner.refine(1);
                 }
                 scanner.create_plan().await
             }
@@ -532,7 +558,7 @@ mod tests {
         );
 
         let query = create_query_vector();
-        let plan = planner.plan_search(&query, 10, 8, None, None).await;
+        let plan = planner.plan_search(&query, 10, 8, None, false, None).await;
 
         // Plan construction must succeed. Execution against empty data is a
         // separate concern handled by integration tests.
@@ -620,7 +646,7 @@ mod tests {
 
         let query = create_query_vector();
         let plan = planner
-            .plan_search(&query, 3, 1, None, None)
+            .plan_search(&query, 3, 1, None, false, None)
             .await
             .expect("planner should produce a plan");
 
@@ -741,7 +767,7 @@ mod tests {
         let query = create_query_vector();
         let projection = vec!["vector".to_string()];
         let plan = planner
-            .plan_search(&query, 3, 1, Some(&projection), None)
+            .plan_search(&query, 3, 1, Some(&projection), false, None)
             .await
             .expect("planner should produce a plan");
 
@@ -823,7 +849,7 @@ mod tests {
             "_rowid".to_string(),
         ];
         let plan = planner
-            .plan_search(&query, 3, 1, Some(&projection), None)
+            .plan_search(&query, 3, 1, Some(&projection), false, None)
             .await
             .expect(
                 "planner must accept `_distance`/`_rowid` in projection without breaking the plan",
@@ -934,7 +960,7 @@ mod tests {
 
         let query = create_query_vector();
         let plan = planner
-            .plan_search(&query, 3, 1, None, None)
+            .plan_search(&query, 3, 1, None, false, None)
             .await
             .expect("planner should produce a plan");
 
@@ -1076,7 +1102,10 @@ mod tests {
         );
 
         let query = create_query_vector();
-        let plan = planner.plan_search(&query, 5, 1, None, None).await.unwrap();
+        let plan = planner
+            .plan_search(&query, 5, 1, None, false, None)
+            .await
+            .unwrap();
         let ctx = SessionContext::new();
         let stream = plan.execute(0, ctx.task_ctx()).unwrap();
         let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
@@ -1196,7 +1225,7 @@ mod tests {
             "vector".to_string(),
         ];
         let plan = planner
-            .plan_search(&query, 3, 1, Some(&projection), None)
+            .plan_search(&query, 3, 1, Some(&projection), false, None)
             .await
             .expect("planner should produce a plan");
 
@@ -1272,7 +1301,7 @@ mod tests {
         ];
         let query = create_query_vector();
         let plan = planner
-            .plan_search(&query, 5, 1, Some(&projection), None)
+            .plan_search(&query, 5, 1, Some(&projection), false, None)
             .await
             .expect("empty plan must accept system columns in projection");
 
@@ -1317,7 +1346,7 @@ mod tests {
 
         let query = create_query_vector();
         let plan = planner
-            .plan_search(&query, 10, 8, None, None)
+            .plan_search(&query, 10, 8, None, false, None)
             .await
             .expect("planner should produce a plan without a base table");
 
@@ -1444,7 +1473,10 @@ mod tests {
         // the older row's vector is far from the query but still a graph
         // node. After dedup we should see pk=1 exactly once.
         let query = create_query_vector();
-        let plan = planner.plan_search(&query, 5, 1, None, None).await.unwrap();
+        let plan = planner
+            .plan_search(&query, 5, 1, None, false, None)
+            .await
+            .unwrap();
 
         let ctx = SessionContext::new();
         let stream = plan.execute(0, ctx.task_ctx()).unwrap();


### PR DESCRIPTION
## Summary

- Add configurable `overfetch_factor` to `plan_search()` — each LSM source fetches `ceil(k * factor)` candidates instead of `k`, mitigating stale reads when a PK's fresh version falls out of its source's top-k and the global dedup can't suppress the stale copy.
- Simplify `refine_factor: Option<u32>` to `refine_base_table: bool` — refine is always factor=1 and only applies to the base table. When overfetch is active, base-table refine is auto-enabled so approximate index distances are re-ranked to exact before the cross-source merge.
- Exposed in Python and Java bindings with backward-compatible overloads.