### PR TITLE
docs: add new index page for integrations and fix broken build

### DIFF
--- a/docs/clean-full-website.sh
+++ b/docs/clean-full-website.sh
@@ -35,6 +35,7 @@ EOF
 
 cat > "$docs_src/integrations/.pages" <<'EOF'
 nav:
+  - Overview: index.md
   - Apache DataFusion: datafusion.md
   - PostgreSQL: https://github.com/lancedb/pglance
   - PyTorch: pytorch.md

--- a/docs/make-full-website.sh
+++ b/docs/make-full-website.sh
@@ -88,6 +88,25 @@ copy_file_if_exists() {
     return 1
 }
 
+copy_duckdb_docs() {
+    local source_dir="$1"
+    local target_dir="$2"
+
+    if [ ! -d "$source_dir" ]; then
+        return 1
+    fi
+
+    rm -rf "$target_dir"
+    mkdir -p "$target_dir"
+    cp "$source_dir/.pages" "$target_dir/.pages"
+    cp "$source_dir/index.md" "$target_dir/index.md"
+    cp "$source_dir/sql.md" "$target_dir/sql.md"
+    cp "$source_dir/rest.md" "$target_dir/rest.md"
+    cp "$source_dir/cloud.md" "$target_dir/cloud.md"
+
+    return 0
+}
+
 resolve_repo_dir() {
     local repo_path="$1"
 
@@ -207,10 +226,10 @@ while IFS= read -r line; do
     integration_entries+=("$line")
 done < <(sed -n '2,$p' "$docs_src/integrations/.pages")
 
-if copy_docs_dir "$duckdb_repo/docs/src" "$docs_src/integrations/duckdb"; then
+if copy_duckdb_docs "$duckdb_repo/docs" "$docs_src/integrations/duckdb"; then
     integration_entries+=("  - DuckDB: duckdb")
 else
-    warn_missing_repo "Lance DuckDB docs" "$duckdb_repo/docs/src"
+    warn_missing_repo "Lance DuckDB docs" "$duckdb_repo/docs"
 fi
 
 if copy_docs_dir "$huggingface_repo/docs/src" "$docs_src/integrations/huggingface"; then

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -277,7 +277,7 @@
             Connect with leading query engines like Apache DataFusion, DuckDB, Apache Spark, Trino, and Apache Flink/Fluss
             to run SQL analytics and distributed processing on your Lance datasets.
           </p>
-          <a href="integrations/datafusion" class="md-button">View Integrations</a>
+          <a href="integrations/" class="md-button">View Integrations</a>
         </div>
         <div class="lance-feature-demo">
           <img src="assets/images/ecosystem-integrations.png" alt="Lance Ecosystem Integrations" style="max-width: 500px; width: 100%; height: auto; border-radius: 8px;">

--- a/docs/src/integrations/.pages
+++ b/docs/src/integrations/.pages
@@ -1,4 +1,5 @@
 nav:
+  - Overview: index.md
   - Apache DataFusion: datafusion.md
   - PostgreSQL: https://github.com/lancedb/pglance
   - PyTorch: pytorch.md

--- a/docs/src/integrations/index.md
+++ b/docs/src/integrations/index.md
@@ -1,0 +1,67 @@
+---
+title: Integrations
+description: Connect Lance to query engines, ML frameworks, databases, and catalogs across the data ecosystem.
+---
+
+# Integrations
+
+Because Lance is built on Apache Arrow and exposes
+a stable Rust core with Python and Java bindings, it can be consumed from query engines, ML frameworks, databases,
+and catalog systems without copying or converting data.
+
+This page lists the integrations maintained by the Lance community. Some live in this repository as first-party
+Rust/Python APIs; others are maintained as dedicated subprojects under the [lance-format](https://github.com/lance-format)
+GitHub organization.
+
+## Query Engines and SQL
+
+| Integration | Description | Source |
+|---|---|---|
+| [Apache DataFusion](datafusion.md) | Register Lance datasets as DataFusion tables and run SQL with predicate/projection pushdown. Available in both Rust and Python. | Built-in |
+| [Apache Spark](spark/index.md) | Read and write Lance datasets from Spark SQL and DataFrames. | [lance-format/lance-spark](https://github.com/lance-format/lance-spark) |
+| [DuckDB](duckdb) | Query Lance datasets directly from DuckDB. | [lance-format/lance-duckdb](https://github.com/lance-format/lance-duckdb) |
+| [Trino](trino) | Federate Lance into Trino alongside other connectors. | [lance-format/lance-trino](https://github.com/lance-format/lance-trino) |
+
+## Machine Learning and AI
+
+| Integration | Description | Source |
+|---|---|---|
+| [PyTorch](pytorch.md) | Use `lance.torch.data.LanceDataset` as a `torch.utils.data.IterableDataset` for training and inference. | Built-in |
+| [TensorFlow](tensorflow.md) | Use `lance.tf.data.from_lance` to stream Lance data into `tf.data.Dataset` pipelines. | Built-in |
+| [Ray](ray) | Distributed read/write of Lance datasets with Ray Data. | [lance-format/lance-ray](https://github.com/lance-format/lance-ray) |
+| [Hugging Face](huggingface) | Convert and load Hugging Face datasets to and from Lance in a single call. | [lance-format/lance-huggingface](https://github.com/lance-format/lance-huggingface) |
+
+## Databases and Stream Processing
+
+| Integration | Description | Source |
+|---|---|---|
+| PostgreSQL | Read Lance datasets from PostgreSQL via the `pglance` extension. | [lance-format/pglance](https://github.com/lance-format/pglance) |
+| Apache Flink | Stream data into Lance from Flink jobs. | [lance-format/lance-flink](https://github.com/lance-format/lance-flink) |
+
+## Catalogs and Namespaces
+
+| Integration | Description | Source |
+|---|---|---|
+| [Lance Namespace](../format/namespace) | Specification and codegen SDKs (Rust, Python, Java) for catalog-backed Lance tables. | [lance-format/lance-namespace](https://github.com/lance-format/lance-namespace) |
+| [Catalog implementations](../format/namespace/supported-catalogs) | Reference implementations for Apache Hive, Apache Polaris, Apache Gravitino, Unity Catalog, AWS Glue, and others. | [lance-format/lance-namespace-impls](https://github.com/lance-format/lance-namespace-impls) |
+
+## Other Ecosystem Projects
+
+| Integration | Description | Source |
+|---|---|---|
+| Lance Graph | Cypher-capable graph query engine on top of Lance. | [lance-format/lance-graph](https://github.com/lance-format/lance-graph) |
+| Lance Data Viewer | Read-only web interface for browsing Lance datasets. | [lance-format/lance-data-viewer](https://github.com/lance-format/lance-data-viewer) |
+| Lance Context | Manage multimodal agentic context lifecycle with Lance. | [lance-format/lance-context](https://github.com/lance-format/lance-context) |
+
+!!! note "Stability"
+
+    Subprojects in the [lance-format](https://github.com/lance-format) organization graduate from incubating
+    status once they meet the project's quality bar (CI, tests, established use cases, community adoption).
+    Incubating subprojects may have changing APIs — check the project README for the current status. See
+    [Community Governance](../community#projects) for details on how integrations are organized.
+
+## Additional Integrations
+
+If there's an integration you'd like to see, but isn't listed above, please
+[open an issue](https://github.com/lance-format/lance/issues/new) describing the use case. PRs are always
+welcome, though it's recommended to alert the maintainers to avoid duplicated work.


### PR DESCRIPTION
The Lance-DuckDB documentation build is broken due to an incorrect URL. This PR fixes that to render correctly in the sidebar via the `.pages` card. The build scripts have been updated to only include the relevant docs files from the `lance-duckdb/docs` folder.

Also adds a new `index.md` page that users will now land on, rather than landing on the DataFusion page. The index page contains links to all the other relevant integrations.