### PR TITLE
feat(java): allow schema override for fragment writes

### DIFF
--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -360,6 +360,8 @@ fn create_fragment<'a>(
         let c_schema_ptr = schema_addr as *mut FFI_ArrowSchema;
         let c_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema_ptr) };
         let arrow_schema = ArrowSchema::try_from(&c_schema)?;
+        // Schema::try_from restores Lance field IDs from the LANCE_FIELD_ID_KEY
+        // metadata inserted by LanceSchema.asArrowSchemaWithFieldIds().
         schema = Schema::try_from(&arrow_schema)?;
         builder = builder.schema(&schema);
     }

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -4,7 +4,7 @@
 use arrow::array::{RecordBatch, RecordBatchIterator, StructArray};
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema, from_ffi_and_data_type};
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
-use arrow_schema::DataType;
+use arrow_schema::{DataType, Schema as ArrowSchema};
 use jni::objects::{JIntArray, JValue, JValueGen};
 use jni::{
     JNIEnv,
@@ -19,7 +19,7 @@ use lance_io::utils::CachedFileSize;
 use lance_table::rowids::{RowIdSequence, write_row_ids};
 use std::iter::once;
 
-use lance::dataset::fragment::FileFragment;
+use lance::dataset::fragment::write::FragmentCreateBuilder;
 use lance::io::ObjectStoreParams;
 use lance_datafusion::utils::StreamingWriteSource;
 use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOptionsProvider};
@@ -108,6 +108,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiArray<'local>(
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
     blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    schema_addr: jlong,
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -130,6 +131,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiArray<'local>(
             table_id_obj,
             allow_external_blob_outside_bases,
             blob_pack_file_size_threshold,
+            schema_addr,
         ),
         JObject::default()
     )
@@ -155,6 +157,7 @@ fn inner_create_with_ffi_array<'local>(
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
     blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    schema_addr: jlong,
 ) -> Result<JObject<'local>> {
     let c_array_ptr = arrow_array_addr as *mut FFI_ArrowArray;
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
@@ -186,6 +189,7 @@ fn inner_create_with_ffi_array<'local>(
         table_id_obj,
         allow_external_blob_outside_bases,
         blob_pack_file_size_threshold,
+        schema_addr,
         reader,
     )
 }
@@ -210,6 +214,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiStream<'a>(
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
     blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    schema_addr: jlong,
 ) -> JObject<'a> {
     ok_or_throw_with_return!(
         env,
@@ -231,6 +236,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiStream<'a>(
             table_id_obj,
             allow_external_blob_outside_bases,
             blob_pack_file_size_threshold,
+            schema_addr,
         ),
         JObject::null()
     )
@@ -255,6 +261,7 @@ fn inner_create_with_ffi_stream<'local>(
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
     blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    schema_addr: jlong,
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -276,6 +283,7 @@ fn inner_create_with_ffi_stream<'local>(
         table_id_obj,
         allow_external_blob_outside_bases,
         blob_pack_file_size_threshold,
+        schema_addr,
         reader,
     )
 }
@@ -298,6 +306,7 @@ fn create_fragment<'a>(
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
     blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    schema_addr: jlong,
     source: impl StreamingWriteSource,
 ) -> Result<JObject<'a>> {
     let path_str = dataset_uri.extract(env)?;
@@ -345,11 +354,17 @@ fn create_fragment<'a>(
         });
     }
 
-    let fragments = RT.block_on(FileFragment::create_fragments(
-        &path_str,
-        source,
-        Some(write_params),
-    ))?;
+    let mut builder = FragmentCreateBuilder::new(&path_str).write_params(&write_params);
+    let schema;
+    if schema_addr != 0 {
+        let c_schema_ptr = schema_addr as *mut FFI_ArrowSchema;
+        let c_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema_ptr) };
+        let arrow_schema = ArrowSchema::try_from(&c_schema)?;
+        schema = Schema::try_from(&arrow_schema)?;
+        builder = builder.schema(&schema);
+    }
+
+    let fragments = RT.block_on(builder.write_fragments(source))?;
     export_vec(env, &fragments)
 }
 

--- a/java/src/main/java/org/lance/Fragment.java
+++ b/java/src/main/java/org/lance/Fragment.java
@@ -18,6 +18,7 @@ import org.lance.fragment.FragmentUpdateResult;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
 import org.lance.namespace.LanceNamespace;
+import org.lance.schema.LanceSchema;
 
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowArrayStream;
@@ -260,6 +261,18 @@ public class Fragment {
       WriteParams params,
       LanceNamespace namespaceClient,
       List<String> tableId) {
+    return create(datasetUri, allocator, root, params, namespaceClient, tableId, null);
+  }
+
+  /** Create a fragment from the given arrow array and schema. */
+  static List<FragmentMetadata> create(
+      String datasetUri,
+      BufferAllocator allocator,
+      VectorSchemaRoot root,
+      WriteParams params,
+      LanceNamespace namespaceClient,
+      List<String> tableId,
+      LanceSchema schema) {
     Preconditions.checkNotNull(datasetUri);
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(root);
@@ -267,6 +280,30 @@ public class Fragment {
     try (ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
         ArrowArray arrowArray = ArrowArray.allocateNew(allocator)) {
       Data.exportVectorSchemaRoot(allocator, root, null, arrowArray, arrowSchema);
+      if (schema != null) {
+        try (ArrowSchema lanceSchema = ArrowSchema.allocateNew(allocator)) {
+          Data.exportSchema(allocator, schema.asArrowSchemaWithFieldIds(), null, lanceSchema);
+          return createWithFfiArray(
+              datasetUri,
+              arrowArray.memoryAddress(),
+              arrowSchema.memoryAddress(),
+              params.getMaxRowsPerFile(),
+              params.getMaxRowsPerGroup(),
+              params.getMaxBytesPerFile(),
+              params.getMode(),
+              params.getEnableStableRowIds(),
+              params.getDataStorageVersion(),
+              params.getStorageOptions(),
+              params.getBaseStoreParams(),
+              params.getInitialBases(),
+              params.getTargetBases(),
+              namespaceClient,
+              tableId,
+              params.getAllowExternalBlobOutsideBases(),
+              params.getBlobPackFileSizeThreshold(),
+              lanceSchema.memoryAddress());
+        }
+      }
       return createWithFfiArray(
           datasetUri,
           arrowArray.memoryAddress(),
@@ -284,7 +321,8 @@ public class Fragment {
           namespaceClient,
           tableId,
           params.getAllowExternalBlobOutsideBases(),
-          params.getBlobPackFileSizeThreshold());
+          params.getBlobPackFileSizeThreshold(),
+          0L);
     }
   }
 
@@ -295,9 +333,45 @@ public class Fragment {
       WriteParams params,
       LanceNamespace namespaceClient,
       List<String> tableId) {
+    return create(datasetUri, null, stream, params, namespaceClient, tableId, null);
+  }
+
+  /** Create a fragment from the given arrow stream. */
+  static List<FragmentMetadata> create(
+      String datasetUri,
+      BufferAllocator allocator,
+      ArrowArrayStream stream,
+      WriteParams params,
+      LanceNamespace namespaceClient,
+      List<String> tableId,
+      LanceSchema schema) {
     Preconditions.checkNotNull(datasetUri);
     Preconditions.checkNotNull(stream);
     Preconditions.checkNotNull(params);
+    if (schema != null) {
+      Preconditions.checkNotNull(allocator, "allocator is required with schema");
+      try (ArrowSchema lanceSchema = ArrowSchema.allocateNew(allocator)) {
+        Data.exportSchema(allocator, schema.asArrowSchemaWithFieldIds(), null, lanceSchema);
+        return createWithFfiStream(
+            datasetUri,
+            stream.memoryAddress(),
+            params.getMaxRowsPerFile(),
+            params.getMaxRowsPerGroup(),
+            params.getMaxBytesPerFile(),
+            params.getMode(),
+            params.getEnableStableRowIds(),
+            params.getDataStorageVersion(),
+            params.getStorageOptions(),
+            params.getBaseStoreParams(),
+            params.getInitialBases(),
+            params.getTargetBases(),
+            namespaceClient,
+            tableId,
+            params.getAllowExternalBlobOutsideBases(),
+            params.getBlobPackFileSizeThreshold(),
+            lanceSchema.memoryAddress());
+      }
+    }
     return createWithFfiStream(
         datasetUri,
         stream.memoryAddress(),
@@ -314,7 +388,8 @@ public class Fragment {
         namespaceClient,
         tableId,
         params.getAllowExternalBlobOutsideBases(),
-        params.getBlobPackFileSizeThreshold());
+        params.getBlobPackFileSizeThreshold(),
+        0L);
   }
 
   /** Create a fragment from the given arrow array and schema. */
@@ -335,7 +410,8 @@ public class Fragment {
       LanceNamespace namespaceClient,
       List<String> tableId,
       Optional<Boolean> allowExternalBlobOutsideBases,
-      Optional<Long> blobPackFileSizeThreshold);
+      Optional<Long> blobPackFileSizeThreshold,
+      long schemaMemoryAddress);
 
   /** Create a fragment from the given arrow stream. */
   private static native List<FragmentMetadata> createWithFfiStream(
@@ -354,5 +430,6 @@ public class Fragment {
       LanceNamespace namespaceClient,
       List<String> tableId,
       Optional<Boolean> allowExternalBlobOutsideBases,
-      Optional<Long> blobPackFileSizeThreshold);
+      Optional<Long> blobPackFileSizeThreshold,
+      long schemaMemoryAddress);
 }

--- a/java/src/main/java/org/lance/WriteFragmentBuilder.java
+++ b/java/src/main/java/org/lance/WriteFragmentBuilder.java
@@ -14,6 +14,7 @@
 package org.lance;
 
 import org.lance.namespace.LanceNamespace;
+import org.lance.schema.LanceSchema;
 
 import org.apache.arrow.c.ArrowArrayStream;
 import org.apache.arrow.memory.BufferAllocator;
@@ -45,6 +46,7 @@ public class WriteFragmentBuilder {
   private BufferAllocator allocator;
   private VectorSchemaRoot vectorSchemaRoot;
   private ArrowArrayStream arrowArrayStream;
+  private LanceSchema schema;
   private WriteParams writeParams;
   private WriteParams.Builder writeParamsBuilder;
   private LanceNamespace namespaceClient;
@@ -97,6 +99,22 @@ public class WriteFragmentBuilder {
     Preconditions.checkState(
         this.vectorSchemaRoot == null, "Cannot set both VectorSchemaRoot and ArrowArrayStream");
     this.arrowArrayStream = stream;
+    return this;
+  }
+
+  /**
+   * Set the Lance dataset schema to use when writing fragments.
+   *
+   * <p>This is useful for distributed writes where workers create uncommitted fragments and a
+   * coordinator commits them later. When this schema is supplied, lance-core does not need to open
+   * the existing dataset to infer the schema in APPEND mode. The schema should come from the target
+   * dataset so Lance field IDs are preserved.
+   *
+   * @param schema the target Lance dataset schema
+   * @return this builder
+   */
+  public WriteFragmentBuilder schema(LanceSchema schema) {
+    this.schema = schema;
     return this;
   }
 
@@ -278,10 +296,22 @@ public class WriteFragmentBuilder {
     // storage options provider when these are non-null for credential refresh
     if (vectorSchemaRoot != null) {
       return Fragment.create(
-          datasetUri, allocator, vectorSchemaRoot, finalWriteParams, namespaceClient, tableId);
+          datasetUri,
+          allocator,
+          vectorSchemaRoot,
+          finalWriteParams,
+          namespaceClient,
+          tableId,
+          schema);
     } else {
       return Fragment.create(
-          datasetUri, arrowArrayStream, finalWriteParams, namespaceClient, tableId);
+          datasetUri,
+          allocator,
+          arrowArrayStream,
+          finalWriteParams,
+          namespaceClient,
+          tableId,
+          schema);
     }
   }
 
@@ -312,6 +342,8 @@ public class WriteFragmentBuilder {
     Preconditions.checkState(
         vectorSchemaRoot == null || allocator != null,
         "allocator is required when using VectorSchemaRoot");
+    Preconditions.checkState(
+        schema == null || allocator != null, "allocator is required with schema");
     Preconditions.checkState(
         writeParams == null || writeParamsBuilder == null,
         "Cannot use both writeParams() and individual parameter methods");

--- a/java/src/main/java/org/lance/schema/LanceField.java
+++ b/java/src/main/java/org/lance/schema/LanceField.java
@@ -25,6 +25,7 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -154,6 +155,25 @@ public class LanceField {
 
     return new Field(
         name, new FieldType(nullable, type, dictionaryEncoding, metadata), arrowChildren);
+  }
+
+  Field asArrowFieldWithFieldIds() {
+    List<Field> arrowChildren =
+        children.stream().map(LanceField::asArrowFieldWithFieldIds).collect(Collectors.toList());
+
+    if (type instanceof ArrowType.FixedSizeList) {
+      arrowChildren.addAll(childrenForFixedSizeList());
+    }
+
+    if (id < 0) {
+      throw new IllegalStateException("Lance field id is required for schema override: " + name);
+    }
+    Map<String, String> metadataWithFieldId = new HashMap<>(metadata);
+    metadataWithFieldId.put(LanceSchema.LANCE_FIELD_ID_KEY, Integer.toString(id));
+    return new Field(
+        name,
+        new FieldType(nullable, type, dictionaryEncoding, metadataWithFieldId),
+        arrowChildren);
   }
 
   private List<Field> childrenForFixedSizeList() {

--- a/java/src/main/java/org/lance/schema/LanceSchema.java
+++ b/java/src/main/java/org/lance/schema/LanceSchema.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class LanceSchema {
+  static final String LANCE_FIELD_ID_KEY = "lance:field_id";
   private final List<LanceField> fields;
   private final Map<String, String> metadata;
 
@@ -66,6 +67,12 @@ public class LanceSchema {
   public Schema asArrowSchema() {
     return new Schema(
         fields.stream().map(LanceField::asArrowField).collect(Collectors.toList()), metadata);
+  }
+
+  public Schema asArrowSchemaWithFieldIds() {
+    return new Schema(
+        fields.stream().map(LanceField::asArrowFieldWithFieldIds).collect(Collectors.toList()),
+        metadata);
   }
 
   @Override

--- a/java/src/test/java/org/lance/FragmentTest.java
+++ b/java/src/test/java/org/lance/FragmentTest.java
@@ -17,9 +17,11 @@ import org.lance.fragment.FragmentMergeResult;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
 import org.lance.operation.Merge;
+import org.lance.operation.Project;
 import org.lance.operation.Update;
 
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,6 +79,65 @@ public class FragmentTest {
         try (LanceScanner scanner = fragment.newScan()) {
           Schema schemaRes = scanner.schema();
           assertEquals(testDataset.getSchema(), schemaRes);
+        }
+      }
+    }
+  }
+
+  @Test
+  void testWriteFragmentWithSchemaOverride(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("fragment_schema_override").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      try (Dataset dataset = testDataset.createEmptyDataset()) {
+        List<org.apache.arrow.vector.types.pojo.Field> fieldList =
+            new ArrayList<>(testDataset.getSchema().getFields());
+        Collections.reverse(fieldList);
+
+        try (Transaction projectTxn =
+                new Transaction.Builder()
+                    .readVersion(dataset.version())
+                    .operation(Project.builder().schema(new Schema(fieldList)).build())
+                    .build();
+            Dataset evolvedDataset = new CommitBuilder(dataset).execute(projectTxn);
+            VectorSchemaRoot root =
+                VectorSchemaRoot.create(evolvedDataset.getSchema(), allocator)) {
+          root.allocateNew();
+          VarCharVector nameVector = (VarCharVector) root.getVector("name");
+          IntVector idVector = (IntVector) root.getVector("id");
+          nameVector.setSafe(0, "Person 1".getBytes(StandardCharsets.UTF_8));
+          idVector.setSafe(0, 1);
+          root.setRowCount(1);
+
+          List<FragmentMetadata> fragments =
+              Fragment.write()
+                  .datasetUri(datasetPath)
+                  .allocator(allocator)
+                  .data(root)
+                  .schema(evolvedDataset.getLanceSchema())
+                  .mode(WriteParams.WriteMode.APPEND)
+                  .execute();
+
+          assertEquals(1, fragments.size());
+          assertEquals(1, fragments.get(0).getPhysicalRows());
+
+          FragmentOperation.Append appendOp = new FragmentOperation.Append(fragments);
+          try (Dataset appendedDataset =
+                  Dataset.commit(
+                      allocator, datasetPath, appendOp, Optional.of(evolvedDataset.version()));
+              ArrowReader reader = appendedDataset.newScan().scanBatches()) {
+            assertEquals(3, appendedDataset.version());
+            assertEquals(1, appendedDataset.countRows());
+            assertTrue(reader.loadNextBatch());
+            VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+            assertEquals(1, batch.getRowCount());
+            assertEquals(
+                "Person 1",
+                new String(
+                    ((VarCharVector) batch.getVector("name")).get(0), StandardCharsets.UTF_8));
+            assertEquals(1, ((IntVector) batch.getVector("id")).get(0));
+          }
         }
       }
     }

--- a/java/src/test/java/org/lance/FragmentTest.java
+++ b/java/src/test/java/org/lance/FragmentTest.java
@@ -19,6 +19,7 @@ import org.lance.ipc.ScanOptions;
 import org.lance.operation.Merge;
 import org.lance.operation.Project;
 import org.lance.operation.Update;
+import org.lance.schema.LanceField;
 
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -121,6 +123,11 @@ public class FragmentTest {
 
           assertEquals(1, fragments.size());
           assertEquals(1, fragments.get(0).getPhysicalRows());
+          assertArrayEquals(
+              evolvedDataset.getLanceSchema().fields().stream()
+                  .mapToInt(LanceField::getId)
+                  .toArray(),
+              fragments.get(0).getFiles().get(0).getFields());
 
           FragmentOperation.Append appendOp = new FragmentOperation.Append(fragments);
           try (Dataset appendedDataset =


### PR DESCRIPTION
## Issue
In distributed writes, workers can create uncommitted fragments and defer the final commit until all fragments are ready. The Java `WriteFragmentBuilder` only exposed `APPEND` mode without a way to pass the target dataset schema, so lance-core had to open the existing dataset to infer schema and field IDs before writing each fragment.

That dataset open is unnecessary when the caller already has the target schema, and it becomes expensive for datasets with very large fragment counts because opening the dataset has to load/read manifest metadata. This shows up as fragment writing getting slower as the dataset grows, even before the final commit step.

## Summary
- Add `WriteFragmentBuilder.schema(Schema)` so Java distributed writers can pass the target dataset schema when creating uncommitted fragments.
- Pass the optional schema through Arrow FFI/JNI into `FragmentCreateBuilder.schema(...)`, avoiding the append-mode dataset open used only for schema inference.
- Preserve current base path / object store write parameters when the schema override path is used.
- Add Java coverage for append fragment writes with a schema override.

## Benefits
- Lets Java callers avoid an expensive dataset open per fragment write in distributed append workflows.
- Keeps Lance field IDs from the target dataset schema instead of inferring from the incoming Arrow batches.
- Makes the Java API match the underlying Rust `FragmentCreateBuilder` capability.
- Reduces write-time overhead for datasets with high fragment counts, especially when many workers are writing fragments concurrently.

## Testing
- `cargo check --manifest-path /tmp/lance-write-fragment-schema-pr/java/lance-jni/Cargo.toml`
- `./mvnw -Dtest=org.lance.FragmentTest#testWriteFragmentWithSchemaOverride test`