### PR TITLE
docs: fix preview pylance install instructions

### DIFF
--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -19,11 +19,24 @@ pip install pylance
 
 For the latest features and bug fixes, you can install the preview version:
 
-```bash
-pip install --pre --extra-index-url https://pypi.fury.io/lance-format/pylance
-```
+=== "pip"
 
-> Note: Preview releases receive the same level of testing as regular releases.
+    ```bash
+    pip install --pre --extra-index-url https://pypi.fury.io/lance-format/ pylance
+    ```
+
+=== "uv"
+
+    ```bash
+    uv venv
+    uv pip install --prerelease allow --index https://pypi.fury.io/lance-format/ pylance
+
+    # To add to pyproject.toml, just do:
+    uv add --prerelease allow --index https://pypi.fury.io/lance-format/ pylance
+    ```
+
+!!! note
+    Preview releases receive the same level of testing as regular releases.
 
 ## Set Up Your Environment
 


### PR DESCRIPTION
## Summary
- Fix the earlier broken preview pip install command by adding the missing space before pylance.
- Add pip and uv tabs for preview install instructions (let's help uv users, too!).
- Format the preview-release note as a MkDocs admonition.

Tested on a local build.