### PR TITLE
feat(rust): support datafusion expressions for merge insert predicates

### DIFF
--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -2091,25 +2091,15 @@ impl Merger {
             None
         };
         let match_filter_expr = match &params.when_matched {
-            WhenMatched::UpdateIf(expr_str) => {
+            WhenMatched::UpdateIf(_) | WhenMatched::UpdateIfExpr(_) => {
                 let combined_schema = Arc::new(combined_schema(&schema));
                 let planner = Planner::new(combined_schema.clone());
-                let expr = planner.parse_filter(expr_str)?;
+                let expr = match &params.when_matched {
+                    WhenMatched::UpdateIf(expr_str) => planner.parse_filter(expr_str)?,
+                    WhenMatched::UpdateIfExpr(expr) => expr.clone(),
+                    _ => unreachable!(),
+                };
                 let expr = planner.optimize_expr(expr)?;
-                let match_expr = planner.create_physical_expr(&expr)?;
-                let data_type = match_expr.data_type(combined_schema.as_ref())?;
-                if data_type != DataType::Boolean {
-                    return Err(Error::invalid_input(format!(
-                        "Merge insert conditions must be expressions that return a boolean value, received a 'when matched update if' expression ({}) which has data type {}",
-                        expr, data_type
-                    )));
-                }
-                Some(match_expr)
-            }
-            WhenMatched::UpdateIfExpr(expr) => {
-                let combined_schema = Arc::new(combined_schema(&schema));
-                let planner = Planner::new(combined_schema.clone());
-                let expr = planner.optimize_expr(expr.clone())?;
                 let match_expr = planner.create_physical_expr(&expr)?;
                 let data_type = match_expr.data_type(combined_schema.as_ref())?;
                 if data_type != DataType::Boolean {

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -270,6 +270,9 @@ pub enum WhenMatched {
     /// The row is updated (similar to UpdateAll) only for rows where the expression evaluates to
     /// true
     UpdateIf(String),
+    /// The row is updated (similar to UpdateAll) only for rows where the expression evaluates to
+    /// true
+    UpdateIfExpr(Expr),
     /// Fail the operation if a match is found
     ///
     /// This can be used to ensure that no existing rows are overwritten or modified after inserted.
@@ -285,6 +288,10 @@ impl WhenMatched {
     pub fn update_if(_dataset: &Dataset, expr: &str) -> Result<Self> {
         // Store the expression string and defer parsing until we know which path to take
         Ok(Self::UpdateIf(expr.to_string()))
+    }
+
+    pub fn update_if_expr(expr: Expr) -> Self {
+        Self::UpdateIfExpr(expr)
     }
 }
 
@@ -1635,6 +1642,7 @@ impl MergeInsertJob {
             self.params.when_matched,
             WhenMatched::UpdateAll
                 | WhenMatched::UpdateIf(_)
+                | WhenMatched::UpdateIfExpr(_)
                 | WhenMatched::Fail
                 | WhenMatched::Delete
                 | WhenMatched::DoNothing
@@ -2082,22 +2090,37 @@ impl Merger {
         } else {
             None
         };
-        let match_filter_expr = if let WhenMatched::UpdateIf(expr_str) = &params.when_matched {
-            let combined_schema = Arc::new(combined_schema(&schema));
-            let planner = Planner::new(combined_schema.clone());
-            let expr = planner.parse_filter(expr_str)?;
-            let expr = planner.optimize_expr(expr)?;
-            let match_expr = planner.create_physical_expr(&expr)?;
-            let data_type = match_expr.data_type(combined_schema.as_ref())?;
-            if data_type != DataType::Boolean {
-                return Err(Error::invalid_input(format!(
-                    "Merge insert conditions must be expressions that return a boolean value, received a 'when matched update if' expression ({}) which has data type {}",
-                    expr, data_type
-                )));
+        let match_filter_expr = match &params.when_matched {
+            WhenMatched::UpdateIf(expr_str) => {
+                let combined_schema = Arc::new(combined_schema(&schema));
+                let planner = Planner::new(combined_schema.clone());
+                let expr = planner.parse_filter(expr_str)?;
+                let expr = planner.optimize_expr(expr)?;
+                let match_expr = planner.create_physical_expr(&expr)?;
+                let data_type = match_expr.data_type(combined_schema.as_ref())?;
+                if data_type != DataType::Boolean {
+                    return Err(Error::invalid_input(format!(
+                        "Merge insert conditions must be expressions that return a boolean value, received a 'when matched update if' expression ({}) which has data type {}",
+                        expr, data_type
+                    )));
+                }
+                Some(match_expr)
             }
-            Some(match_expr)
-        } else {
-            None
+            WhenMatched::UpdateIfExpr(expr) => {
+                let combined_schema = Arc::new(combined_schema(&schema));
+                let planner = Planner::new(combined_schema.clone());
+                let expr = planner.optimize_expr(expr.clone())?;
+                let match_expr = planner.create_physical_expr(&expr)?;
+                let data_type = match_expr.data_type(combined_schema.as_ref())?;
+                if data_type != DataType::Boolean {
+                    return Err(Error::invalid_input(format!(
+                        "Merge insert conditions must be expressions that return a boolean value, received a 'when matched update if' expression ({}) which has data type {}",
+                        expr, data_type
+                    )));
+                }
+                Some(match_expr)
+            }
+            _ => None,
         };
         let output_schema = if with_row_addr {
             Arc::new(schema.try_with_column(ROW_ADDR_FIELD.clone())?)

--- a/rust/lance/src/dataset/write/merge_insert/assign_action.rs
+++ b/rust/lance/src/dataset/write/merge_insert/assign_action.rs
@@ -125,6 +125,12 @@ pub fn merge_insert_action(
                 ));
             }
         }
+        WhenMatched::UpdateIfExpr(condition) => {
+            cases.push((
+                matched.and(condition.clone()),
+                Action::UpdateAll.as_literal_expr(),
+            ));
+        }
         WhenMatched::DoNothing => {}
         WhenMatched::Fail => {
             cases.push((matched, Action::Fail.as_literal_expr()));

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -740,7 +740,7 @@ impl DisplayAs for FullSchemaMergeInsertExec {
                         format!("UpdateIf({})", condition)
                     }
                     crate::dataset::WhenMatched::UpdateIfExpr(expr) => {
-                        format!("UpdateIfExpr({})", expr)
+                        format!("UpdateIf({})", expr.human_display())
                     }
                     crate::dataset::WhenMatched::Fail => "Fail".to_string(),
                     crate::dataset::WhenMatched::Delete => "Delete".to_string(),

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -739,6 +739,9 @@ impl DisplayAs for FullSchemaMergeInsertExec {
                     crate::dataset::WhenMatched::UpdateIf(condition) => {
                         format!("UpdateIf({})", condition)
                     }
+                    crate::dataset::WhenMatched::UpdateIfExpr(expr) => {
+                        format!("UpdateIfExpr({})", expr)
+                    }
                     crate::dataset::WhenMatched::Fail => "Fail".to_string(),
                     crate::dataset::WhenMatched::Delete => "Delete".to_string(),
                 };

--- a/rust/lance/src/dataset/write/merge_insert/logical_plan.rs
+++ b/rust/lance/src/dataset/write/merge_insert/logical_plan.rs
@@ -102,6 +102,7 @@ impl UserDefinedLogicalNodeCore for MergeInsertWriteNode {
             crate::dataset::WhenMatched::DoNothing => "DoNothing",
             crate::dataset::WhenMatched::UpdateAll => "UpdateAll",
             crate::dataset::WhenMatched::UpdateIf(_) => "UpdateIf",
+            crate::dataset::WhenMatched::UpdateIfExpr(_) => "UpdateIfExpr",
             crate::dataset::WhenMatched::Fail => "Fail",
             crate::dataset::WhenMatched::Delete => "Delete",
         };


### PR DESCRIPTION
### Description
This PR adds support for passing logical DataFusion expressions (`datafusion_expr::Expr`) directly to the merge insert query planner for conditional updates (`WhenMatched::UpdateIfExpr`). Currently, matched update predicates only accept SQL strings which are parsed at plan creation time, introducing serialize-deserialize round-trip overhead when callers build expressions programmatically.

### Key Changes
 - **`WhenMatched` Enum**: Added the `UpdateIfExpr(datafusion_expr::Expr)` variant and the associated constructor helper `WhenMatched::update_if_expr(expr: Expr)`.
 - **Query Planner (`merge_insert.rs`)**: Updated plan generation to optimize the DataFusion logical expression and convert it directly to a physical expression.
 - **Physical & Logical Layouts**: Handled the new variant exhaustively in `assign_action.rs` (action determination), `exec/write.rs` (DisplayAs), and `logical_plan.rs` (Explain formatting).

### Verification
 - Verified compile-safety and workspace formatting checks.
 - Verified via downstream integration tests in `lancedb`.

Closes #6861 