### PR TITLE
fix: coerce filter expressions before simplifying

### DIFF
--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -917,7 +917,7 @@ impl Planner {
     pub fn optimize_expr(&self, expr: Expr) -> Result<Expr> {
         let df_schema = Arc::new(DFSchema::try_from(self.schema.as_ref().clone())?);
 
-        // DataFusion needs the simplify and coerce passes to be applied before
+        // DataFusion needs the coerce and simplify passes to be applied before
         // expressions can be handled by the physical planner.
         let simplify_context = SimplifyContext::default()
             .with_schema(df_schema.clone())
@@ -925,8 +925,9 @@ impl Planner {
         let simplifier =
             datafusion::optimizer::simplify_expressions::ExprSimplifier::new(simplify_context);
 
-        let expr = simplifier.simplify(expr)?;
+        // Coerce before simplify to match DataFusion's analyzer-before-optimizer pipeline.
         let expr = simplifier.coerce(expr, &df_schema)?;
+        let expr = simplifier.simplify(expr)?;
 
         Ok(expr)
     }
@@ -1011,6 +1012,7 @@ impl TreeNodeVisitor<'_> for ColumnCapturingVisitor {
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
 
     use crate::logical_expr::ExprExt;
 
@@ -1098,6 +1100,59 @@ mod tests {
                 false, false, false, false, true, true, false, false, false, false
             ])
         );
+    }
+
+    #[derive(Debug, Eq, PartialEq, Hash)]
+    struct StrictFloat64Udf {
+        signature: Signature,
+    }
+
+    impl StrictFloat64Udf {
+        fn new() -> Self {
+            Self {
+                signature: Signature::exact(vec![DataType::Float64], Volatility::Immutable),
+            }
+        }
+    }
+
+    impl ScalarUDFImpl for StrictFloat64Udf {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn name(&self) -> &str {
+            "strict_float64"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+
+        fn return_type(&self, _arg_types: &[DataType]) -> DFResult<DataType> {
+            Ok(DataType::Float64)
+        }
+
+        fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DFResult<ColumnarValue> {
+            let data_type = args.args[0].data_type();
+            assert_eq!(
+                data_type,
+                DataType::Float64,
+                "strict_float64 expected Float64, got {data_type}"
+            );
+            Ok(ColumnarValue::Scalar(ScalarValue::Float64(Some(0.0))))
+        }
+    }
+
+    #[test]
+    fn test_coerce_before_simplify() {
+        let planner = Planner::new(Arc::new(Schema::empty()));
+        let strict_float64 = Arc::new(ScalarUDF::new_from_impl(StrictFloat64Udf::new()));
+        let expr = Expr::ScalarFunction(ScalarFunction::new_udf(strict_float64, vec![lit(0_i64)]))
+            .eq(lit(0.0_f64));
+
+        let optimized = planner.optimize_expr(expr).unwrap();
+
+        planner.create_physical_expr(&optimized).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix `Planner::optimize_expr` so expression type coercion runs before simplification. This matches DataFusion's normal plan pipeline where analyzer type coercion runs before optimizer simplification.

This matters for immutable UDFs with literal arguments. With the previous order, simplification could evaluate a constant UDF call before `Int64` literals were coerced to the UDF's expected `Float64` inputs. For geospatial filters, `st_point(0, 0)` could reach the geo UDF as integer arrays and panic during the UDF's strict float downcast. `st_point(0.0, 0.0)` worked because the literals were already `Float64`.

## Repro Demo

This is a standalone Python repro script. It is not added to the repo.

```python
import tempfile

import lance
import numpy as np
import pyarrow as pa
from geoarrow.rust.core import point, points


def run_filter(ds, expr):
    table = ds.to_table(filter=expr)
    values = table.to_pydict()
    print(f"{expr} -> {table.num_rows} rows: {values}")
    assert table.num_rows == 1


with tempfile.TemporaryDirectory() as tmpdir:
    point_array = points([np.array([1.0, 10.0]), np.array([2.0, 10.0])])
    schema = pa.schema([pa.field(point("xy")).with_name("point")])
    table = pa.Table.from_arrays([point_array], schema=schema)
    ds = lance.write_dataset(table, f"{tmpdir}/geo_filter.lance")

    run_filter(ds, "st_distance(point, st_point(0.0, 0.0)) < 5")
    run_filter(ds, "st_distance(point, st_point(0, 0)) < 5")
```

Observed before the fix:

```text
st_distance(point, st_point(0.0, 0.0)) < 5 -> 1 rows: {'point': [{'x': 1.0, 'y': 2.0}]}
thread 'lance_background_thread' panicked at .../arrow-array-58.3.0/src/cast.rs:849:33:
primitive array
RuntimeError: Task was aborted
```

Observed after the fix:

```text
st_distance(point, st_point(0.0, 0.0)) < 5 -> 1 rows: {'point': [{'x': 1.0, 'y': 2.0}]}
st_distance(point, st_point(0, 0)) < 5 -> 1 rows: {'point': [{'x': 1.0, 'y': 2.0}]}
```
