### PR TITLE
perf: avoid extra stat for ranged OpenDAL reads

### DIFF
--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -188,25 +188,29 @@ impl Reader for CloudObjectReader {
 
     #[instrument(level = "debug", skip(self))]
     fn get_range(&self, range: Range<usize>) -> BoxFuture<'static, OSResult<Bytes>> {
-        let get_request = Arc::new(GetRequest {
-            object_store: self.object_store.clone(),
-            path: self.path.clone(),
-            options: GetOptions {
-                range: Some(
-                    Range {
-                        start: range.start as u64,
-                        end: range.end as u64,
-                    }
-                    .into(),
-                ),
-                ..Default::default()
-            },
-        });
-        Box::pin(do_get_with_outer_retry(
-            self.download_retry_count,
-            get_request,
-            move || format!("range {:?}", range),
-        ))
+        let object_store = self.object_store.clone();
+        let path = self.path.clone();
+        let get_range = Range {
+            start: range.start as u64,
+            end: range.end as u64,
+        };
+        Box::pin(async move {
+            let bytes = do_with_retry(move || {
+                let object_store = object_store.clone();
+                let path = path.clone();
+                let get_range = get_range.clone();
+                Box::pin(async move { object_store.get_ranges(&path, &[get_range]).await })
+            })
+            .await?;
+
+            bytes
+                .into_iter()
+                .next()
+                .ok_or_else(|| object_store::Error::Generic {
+                    store: "CloudObjectReader",
+                    source: "get_ranges returned no bytes".into(),
+                })
+        })
     }
 
     #[instrument(level = "debug", skip_all)]

--- a/rust/lance-io/src/object_store/dynamic_opendal.rs
+++ b/rust/lance-io/src/object_store/dynamic_opendal.rs
@@ -3,8 +3,10 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::ops::Range;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt, stream, stream::BoxStream};
 use object_store::path::Path;
 use object_store::{
@@ -167,6 +169,18 @@ impl OSObjectStore for DynamicOpenDalStore {
             .await
             .map_err(|e| self.map_store_error(e))?
             .get_opts(location, options)
+            .await
+    }
+
+    async fn get_ranges(
+        &self,
+        location: &Path,
+        ranges: &[Range<u64>],
+    ) -> object_store::Result<Vec<Bytes>> {
+        self.current_store()
+            .await
+            .map_err(|e| self.map_store_error(e))?
+            .get_ranges(location, ranges)
             .await
     }
 


### PR DESCRIPTION
OpenDAL-backed object stores route Lance's bounded `CloudObjectReader` reads through `get_opts`, and `object_store_opendal` resolves those requests with a `stat_with` before reading bytes.

This changes the bounded read path to use `get_ranges` and forwards `get_ranges` through `DynamicOpenDalStore`, letting OpenDAL issue range reads without the extra metadata call. Full-object reads and stream paths still use `get_opts` where metadata and stream semantics are needed.
