### PR TITLE
fix(java): resolve JNI classloader bug on dispatcher thread in Spark

### DIFF
--- a/java/lance-jni/src/dispatcher.rs
+++ b/java/lance-jni/src/dispatcher.rs
@@ -23,8 +23,12 @@ pub struct Dispatcher {
 }
 
 impl Dispatcher {
-    /// Initialize the dispatcher with a persistent JNI thread
-    pub fn initialize(jvm: Arc<JavaVM>) -> Arc<Self> {
+    /// Initialize the dispatcher with a persistent JNI thread.
+    ///
+    /// `async_scanner_class` must be a `GlobalRef` to the `AsyncScanner`
+    /// Java class, resolved on a thread that has the correct application
+    /// classloader (typically the `JNI_OnLoad` thread).
+    pub fn initialize(jvm: Arc<JavaVM>, async_scanner_class: GlobalRef) -> Arc<Self> {
         let (tx, mut rx) = mpsc::unbounded_channel::<DispatcherMessage>();
 
         // Spawn persistent dispatcher thread
@@ -40,10 +44,9 @@ impl Dispatcher {
 
                 log::info!("JNI dispatcher thread started");
 
-                // Cache method IDs for completeTask and failTask
-                let async_scanner_class = env
-                    .find_class("org/lance/ipc/AsyncScanner")
-                    .expect("AsyncScanner class not found");
+                // Cache method IDs for completeTask and failTask.
+                // Use the pre-resolved GlobalRef instead of find_class to
+                // avoid classloader issues on this native thread.
                 let complete_method = env
                     .get_method_id(&async_scanner_class, "completeTask", "(JJ)V")
                     .expect("completeTask method not found");

--- a/java/lance-jni/src/lib.rs
+++ b/java/lance-jni/src/lib.rs
@@ -162,10 +162,25 @@ pub extern "system" fn JNI_OnLoad(
     vm: jni::JavaVM,
     _reserved: *mut std::ffi::c_void,
 ) -> jni::sys::jint {
+    // Resolve AsyncScanner class on the current thread which has the correct
+    // application classloader. A newly spawned native thread only gets the
+    // system classloader after attach_current_thread_permanently(), which
+    // cannot find application classes in environments like Spark, web
+    // containers, or shaded JARs.
+    let mut env = vm.get_env().expect("Failed to get JNIEnv in JNI_OnLoad");
+    let async_scanner_local = env
+        .find_class("org/lance/ipc/AsyncScanner")
+        .expect("AsyncScanner class not found");
+    let async_scanner_class = env
+        .new_global_ref(async_scanner_local)
+        .expect("Failed to create GlobalRef for AsyncScanner class");
+
     let jvm_arc = Arc::new(vm);
 
-    // Initialize global dispatcher with persistent thread
-    let dispatcher = dispatcher::Dispatcher::initialize(jvm_arc);
+    // Initialize global dispatcher with persistent thread, passing the
+    // pre-resolved class reference so the dispatcher thread does not need
+    // to look up the class with the wrong classloader.
+    let dispatcher = dispatcher::Dispatcher::initialize(jvm_arc, async_scanner_class);
 
     // Set the global DISPATCHER (will panic if called more than once)
     dispatcher::DISPATCHER

--- a/java/src/test/java/org/lance/AsyncScannerTest.java
+++ b/java/src/test/java/org/lance/AsyncScannerTest.java
@@ -30,13 +30,20 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -320,6 +327,98 @@ public class AsyncScannerTest {
   }
 
   /**
+   * Regression test for classloader isolation.
+   *
+   * <p>Verifies that AsyncScanner works correctly when the calling thread has an isolated
+   * (non-system) context classloader, simulating environments like Spark executors, web containers,
+   * or shaded JARs where application classes are loaded by a custom classloader.
+   *
+   * <p>The fix under test moved class resolution from the JNI dispatcher thread (which only has the
+   * system classloader after attach_current_thread_permanently()) to JNI_OnLoad (which has the
+   * correct application classloader), passing a GlobalRef to the dispatcher.
+   */
+  @Test
+  void testAsyncScanWithIsolatedClassloader(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("async_scanner_classloader").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+      int totalRows = 40;
+
+      try (Dataset dataset = testDataset.write(1, totalRows)) {
+        ScanOptions options = new ScanOptions.Builder().batchSize(20L).build();
+
+        // Use a classloader that delegates only to the bootstrap classloader,
+        // making it unable to find any org.lance.* classes on its own.
+        ClassLoader originalCl = Thread.currentThread().getContextClassLoader();
+        ClassLoader restrictedCl = new ClassLoader(null) {
+              // Intentionally empty: parent is null (bootstrap only)
+            };
+
+        // --- Part 1: Swap context classloader on the current thread ---
+        try {
+          Thread.currentThread().setContextClassLoader(restrictedCl);
+
+          try (AsyncScanner scanner = AsyncScanner.create(dataset, options, allocator)) {
+            CompletableFuture<ArrowReader> future = scanner.scanBatchesAsync();
+            ArrowReader reader = future.get(10, TimeUnit.SECONDS);
+            assertNotNull(reader);
+
+            int rowCount = 0;
+            while (reader.loadNextBatch()) {
+              VectorSchemaRoot root = reader.getVectorSchemaRoot();
+              rowCount += root.getRowCount();
+            }
+
+            assertEquals(
+                totalRows, rowCount, "Async scan should succeed despite restrictive classloader");
+            reader.close();
+          }
+        } finally {
+          Thread.currentThread().setContextClassLoader(originalCl);
+        }
+
+        // --- Part 2: Run from a thread with an isolated classloader ---
+        // Simulates Spark executor threads that have a non-system classloader.
+        ExecutorService isolatedExecutor =
+            Executors.newSingleThreadExecutor(
+                r -> {
+                  Thread t = new Thread(r, "isolated-classloader-thread");
+                  t.setContextClassLoader(restrictedCl);
+                  return t;
+                });
+        try {
+          CompletableFuture<Integer> result =
+              CompletableFuture.supplyAsync(
+                  () -> {
+                    try (AsyncScanner scanner = AsyncScanner.create(dataset, options, allocator)) {
+                      CompletableFuture<ArrowReader> future = scanner.scanBatchesAsync();
+                      ArrowReader reader = future.get(10, TimeUnit.SECONDS);
+                      int rowCount = 0;
+                      while (reader.loadNextBatch()) {
+                        rowCount += reader.getVectorSchemaRoot().getRowCount();
+                      }
+                      reader.close();
+                      return rowCount;
+                    } catch (Exception e) {
+                      throw new RuntimeException(e);
+                    }
+                  },
+                  isolatedExecutor);
+
+          assertEquals(
+              totalRows,
+              result.get(15, TimeUnit.SECONDS),
+              "Async scan from isolated classloader thread should succeed");
+        } finally {
+          isolatedExecutor.shutdown();
+        }
+      }
+    }
+  }
+
+  /**
    * Example 6: Using thenCompose for sequential async operations.
    *
    * <p>Shows how to chain multiple async operations together.
@@ -363,5 +462,138 @@ public class AsyncScannerTest {
         }
       }
     }
+  }
+
+  /**
+   * Regression test: reproduce the JNI classloader bug via a forked JVM.
+   *
+   * <p>Launches a child JVM where only {@code target/test-classes/} is on the system classpath. All
+   * lance classes are loaded by an isolated {@link URLClassLoader} with a null parent (bootstrap
+   * classloader only). This means JNI's {@code FindClass} on a native thread attached via {@code
+   * attach_current_thread_permanently()} will use the system classloader, which <b>cannot</b> find
+   * {@code org.lance.ipc.AsyncScanner}.
+   *
+   * <p>With the fix, {@code JNI_OnLoad} pre-resolves the class on the loading thread (which has the
+   * correct classloader) and passes a {@code GlobalRef} to the dispatcher — so the dispatcher never
+   * calls {@code FindClass}.
+   */
+  @Test
+  void testClassloaderIsolationWithForkedJvm(@TempDir Path tempDir) throws Exception {
+    // --- Collect full classpath from the current classloader hierarchy ---
+    List<String> classpathEntries = new ArrayList<>();
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    if (cl == null) {
+      cl = AsyncScannerTest.class.getClassLoader();
+    }
+    while (cl != null) {
+      if (cl instanceof URLClassLoader) {
+        for (URL url : ((URLClassLoader) cl).getURLs()) {
+          classpathEntries.add(url.getPath());
+        }
+      }
+      cl = cl.getParent();
+    }
+
+    // Fallback: if no URLClassLoader found (Java 9+ AppClassLoader), use java.class.path
+    if (classpathEntries.isEmpty()) {
+      String cp = System.getProperty("java.class.path");
+      if (cp != null) {
+        for (String entry : cp.split(java.io.File.pathSeparator)) {
+          classpathEntries.add(entry);
+        }
+      }
+    }
+
+    // Find the test-classes directory
+    String testClassesDir = null;
+    for (String entry : classpathEntries) {
+      if (entry.contains("test-classes")) {
+        testClassesDir = entry;
+        break;
+      }
+    }
+    assertNotNull(testClassesDir, "Could not find test-classes directory in classpath");
+
+    // Full classpath for the isolated URLClassLoader inside the forked JVM
+    String fullClasspath = String.join(java.io.File.pathSeparator, classpathEntries);
+
+    // --- Build the forked JVM command ---
+    String javaHome = System.getProperty("java.home");
+    String javaBin = javaHome + java.io.File.separator + "bin" + java.io.File.separator + "java";
+
+    List<String> command = new ArrayList<>();
+    command.add(javaBin);
+
+    // Add --add-opens flags matching surefire config (required by Arrow/Netty)
+    command.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
+    command.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
+    command.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
+    command.add("--add-opens=java.base/java.io=ALL-UNNAMED");
+    command.add("--add-opens=java.base/java.net=ALL-UNNAMED");
+    command.add("--add-opens=java.base/java.nio=ALL-UNNAMED");
+    command.add("--add-opens=java.base/java.util=ALL-UNNAMED");
+    command.add("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED");
+    command.add("--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED");
+    command.add("--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED");
+    command.add("--add-opens=java.base/sun.nio.ch=ALL-UNNAMED");
+    command.add("--add-opens=java.base/sun.nio.cs=ALL-UNNAMED");
+    command.add("--add-opens=java.base/sun.security.action=ALL-UNNAMED");
+    command.add("--add-opens=java.base/sun.util.calendar=ALL-UNNAMED");
+    command.add("--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED");
+    command.add("-XX:+IgnoreUnrecognizedVMOptions");
+    command.add("-Dio.netty.tryReflectionSetAccessible=true");
+
+    // System classpath: ONLY test-classes (no lance main classes)
+    command.add("-cp");
+    command.add(testClassesDir);
+
+    command.add("org.lance.ClassloaderBugBootstrap");
+    command.add(fullClasspath);
+    command.add(tempDir.toString());
+
+    ProcessBuilder pb = new ProcessBuilder(command);
+    pb.redirectErrorStream(false);
+
+    Process process = pb.start();
+
+    // Read stdout and stderr concurrently to avoid deadlock when buffers fill
+    CompletableFuture<String> stderrFuture =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try (BufferedReader errReader =
+                  new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+                return errReader.lines().collect(Collectors.joining("\n"));
+              } catch (Exception e) {
+                return "Failed to read stderr: " + e.getMessage();
+              }
+            });
+
+    String stdout;
+    try (BufferedReader outReader =
+        new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+      stdout = outReader.lines().collect(Collectors.joining("\n"));
+    }
+
+    String stderr = stderrFuture.get(60, TimeUnit.SECONDS);
+
+    boolean exited = process.waitFor(60, TimeUnit.SECONDS);
+    assertTrue(exited, "Forked JVM did not exit within 60 seconds");
+
+    int exitCode = process.exitValue();
+    assertEquals(
+        0,
+        exitCode,
+        "Forked JVM exited with code "
+            + exitCode
+            + "\n--- stdout ---\n"
+            + stdout
+            + "\n--- stderr ---\n"
+            + stderr);
+    assertTrue(
+        stdout.contains("SUCCESS"),
+        "Expected SUCCESS in stdout but got:\n--- stdout ---\n"
+            + stdout
+            + "\n--- stderr ---\n"
+            + stderr);
   }
 }

--- a/java/src/test/java/org/lance/ClassloaderBugBootstrap.java
+++ b/java/src/test/java/org/lance/ClassloaderBugBootstrap.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Standalone bootstrap for the forked-JVM classloader bug test.
+ *
+ * <p>This class has <b>zero</b> lance imports. It lives on the forked JVM's system classpath
+ * ({@code target/test-classes/} only). All lance classes are loaded through an isolated {@link
+ * URLClassLoader} whose parent is {@code null} (bootstrap classloader), so the JVM's system
+ * classloader cannot see them.
+ *
+ * <p>Usage: {@code java -cp target/test-classes org.lance.ClassloaderBugBootstrap <full-classpath>
+ * <temp-dir>}
+ *
+ * <p>Exit code 0 + "SUCCESS" on stdout = pass; non-zero = failure.
+ */
+public class ClassloaderBugBootstrap {
+
+  public static void main(String[] args) {
+    if (args.length < 2) {
+      System.err.println("Usage: ClassloaderBugBootstrap <classpath> <tempDir>");
+      System.exit(2);
+    }
+
+    String classpath = args[0];
+    String tempDir = args[1];
+
+    try {
+      // Build URL array from the full classpath
+      String[] entries = classpath.split(File.pathSeparator);
+      URL[] urls = new URL[entries.length];
+      for (int i = 0; i < entries.length; i++) {
+        urls[i] = new File(entries[i]).toURI().toURL();
+      }
+
+      // Parent is null => only bootstrap classloader is the parent.
+      // The system classloader (which only has target/test-classes/) is bypassed.
+      URLClassLoader isolatedCl = new URLClassLoader(urls, null);
+
+      // Set as context classloader for consistency
+      Thread.currentThread().setContextClassLoader(isolatedCl);
+
+      // Load and invoke the helper class through the isolated classloader
+      Class<?> helperClass = Class.forName("org.lance.ClassloaderBugHelper", true, isolatedCl);
+      Method runMethod = helperClass.getMethod("run", String.class);
+      runMethod.invoke(null, tempDir);
+
+      // Force exit: the JNI dispatcher thread is non-daemon and would keep the JVM alive
+      System.exit(0);
+
+    } catch (Throwable t) {
+      System.err.println("ClassloaderBugBootstrap FAILED:");
+      t.printStackTrace(System.err);
+      System.exit(1);
+    }
+  }
+}

--- a/java/src/test/java/org/lance/ClassloaderBugHelper.java
+++ b/java/src/test/java/org/lance/ClassloaderBugHelper.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+import org.lance.ipc.AsyncScanner;
+import org.lance.ipc.ScanOptions;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Helper loaded by the isolated {@link java.net.URLClassLoader} in the forked JVM.
+ *
+ * <p>This class has normal lance imports. It is <b>not</b> on the system classpath of the forked
+ * JVM — the system classloader cannot find it (or any other {@code org.lance.*} class). Only the
+ * isolated classloader can.
+ *
+ * <p>If the JNI dispatcher thread tries to {@code FindClass("org/lance/ipc/AsyncScanner")} after
+ * {@code attach_current_thread_permanently()}, it will use the system classloader and fail —
+ * reproducing the bug. With the fix, the class is pre-resolved in {@code JNI_OnLoad} (which runs on
+ * a thread with the correct classloader) and passed as a {@code GlobalRef}.
+ */
+public class ClassloaderBugHelper {
+
+  /**
+   * Entry point invoked reflectively from {@link ClassloaderBugBootstrap}.
+   *
+   * @param tempDir temporary directory for the lance dataset
+   */
+  public static void run(String tempDir) throws Exception {
+    String datasetPath = tempDir + "/classloader_bug_test";
+
+    try (BufferAllocator allocator = new RootAllocator()) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+      int totalRows = 40;
+
+      try (Dataset dataset = testDataset.write(1, totalRows)) {
+        ScanOptions options = new ScanOptions.Builder().batchSize(20L).build();
+
+        try (AsyncScanner scanner = AsyncScanner.create(dataset, options, allocator)) {
+          CompletableFuture<ArrowReader> future = scanner.scanBatchesAsync();
+
+          // Use a generous timeout — the bug causes the dispatcher thread to panic,
+          // so the future will never complete.
+          ArrowReader reader = future.get(30, TimeUnit.SECONDS);
+
+          int rowCount = 0;
+          while (reader.loadNextBatch()) {
+            VectorSchemaRoot root = reader.getVectorSchemaRoot();
+            rowCount += root.getRowCount();
+          }
+          reader.close();
+
+          if (rowCount != totalRows) {
+            throw new AssertionError("Expected " + totalRows + " rows but got " + rowCount);
+          }
+        }
+      }
+    }
+
+    // Signal success to the parent process
+    System.out.println("SUCCESS");
+  }
+}


### PR DESCRIPTION
Reopens the work from #6549, which was closed on 2026-05-20 with a "deduplicate with #6633" note. PR #6633 (merged) makes the dispatcher thread a daemon, but does **not** touch `find_class`. The classloader bug therefore remains unfixed on `main` — verified at `java/lance-jni/src/dispatcher.rs:45` on `lance-format/lance@main`:

```rust
.find_class("org/lance/ipc/AsyncScanner")
.expect("AsyncScanner class not found");
```

Tracking issue #6577 is still open. Detailed reproducer, full panic traces, and Databricks Runtime cluster setup at lance-format/lance-spark#538.

## Why this is broken on Databricks

On a Databricks cluster, the bundle JAR (`org.lance:lance-spark-bundle-*`) is installed via the cluster Libraries → Maven UI. Per Databricks' library-loading model, user-installed JARs end up under `/local_disk0/tmp/addedFile*` and are loaded into an **isolated** classloader chain (`MutableURLClassLoader` → `ChildFirstURLClassLoader`) installed per-task by `Executor.TaskRunner.run()`. Importantly, this classloader is installed as the **thread-context classloader on Java application threads only** — the JVM `AppClassLoader` is never updated.

When lance-jni does:

```rust
let dispatcher_thread = thread::Builder::new()
    .spawn(move || { /* ... */ env.find_class("org/lance/ipc/AsyncScanner") })
```

the spawned thread is a **native thread** that lance-jni then attaches to the JVM via `attach_current_thread_permanently()`. Per the JNI spec (https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/invocation.html#wp1539), `FindClass` on an attached native thread uses the JVM's *system* classloader (`AppClassLoader`) — which on Databricks only sees `/databricks/jars/*` (Spark itself + DBR-managed JARs), **not** the user library directory. The lookup returns null, the Rust unwrap panics, the panic propagates to the JVM as a Java exception, `SparkUncaughtExceptionHandler` catches it and calls `System.exit(50)`, and the executor dies.

The same trap bites every JNI library that does `FindClass` from a Rust-spawned thread. The canonical fix (used by RocksDB JNI, netty-tcnative, Arrow's own JNI) is to resolve user classes once during `JNI_OnLoad` — which is invoked by `System.loadLibrary` on the *calling Java thread*, where the thread-context classloader is still the user's classloader chain — and pin the resulting `jclass` reference as a `GlobalRef`.

## What this PR does

This is a clean cherry-pick of @summaryzb's fix commit ([b9ab00c](https://github.com/lance-format/lance/commit/b9ab00c5)) onto current `main`, **without** the daemon-thread changes (already merged via #6633). Authorship preserved.

```
java/lance-jni/src/dispatcher.rs   |  +13/-2  use cached GlobalRef instead of FindClass
java/lance-jni/src/lib.rs          |  +20/-1  resolve AsyncScanner once in JNI_OnLoad
java/src/test/java/org/lance/AsyncScannerTest.java     | +232 (new)  classloader regression test
java/src/test/java/org/lance/ClassloaderBugBootstrap.java | +74 (new)
java/src/test/java/org/lance/ClassloaderBugHelper.java | +82 (new)
```

Changes in `lib.rs`:

```rust
pub extern "system" fn JNI_OnLoad(vm: JavaVM, _reserved: *mut c_void) -> jint {
    let env = vm.get_env().expect("Failed to get JNIEnv in JNI_OnLoad");
    let async_scanner_class = env
        .find_class("org/lance/ipc/AsyncScanner")     // runs on Java thread; user CL visible
        .expect("AsyncScanner class not found");
    let global_ref = env
        .new_global_ref(async_scanner_class)          // pin across thread boundary
        .expect("Failed to create GlobalRef for AsyncScanner class");
    DISPATCHER.set(Dispatcher::initialize(Arc::new(vm), global_ref)).unwrap();
    JNI_VERSION_1_8
}
```

Changes in `dispatcher.rs`: store the `GlobalRef` on the `Dispatcher` struct and use it in place of the `FindClass` call. The native thread no longer touches the JVM classloader.

The new tests under `java/src/test/java/org/lance/` (`AsyncScannerTest`, `ClassloaderBugBootstrap`, `ClassloaderBugHelper`) reproduce the classloader scenario in unit tests by loading lance classes through a custom `URLClassLoader` and exercising the dispatcher path — the same pattern that fails on Databricks.

## Validation

Cross-compiled this branch's `liblance_jni.so` to linux-x86-64, swapped it into `lance-spark-bundle-3.5_2.12:0.4.0-beta.4`, and re-ran the original repro on Databricks Runtime: stock bundle still hits the `AsyncScanner class not found` panic / executor exit 50; patched build resolves end-to-end. Reproducer details, panic traces, cluster setup, and the bundle-version matrix are in lance-format/lance-spark#538.

## Notes for reviewers

- The `FindClass` lookup in `JNI_OnLoad` itself is safe because `JNI_OnLoad` runs on a Java thread whose context classloader sees the user bundle JAR — same pattern as RocksDB / netty-tcnative / Arrow's JNI bindings.
- `attach_current_thread_as_daemon` (from #6633) is necessary for clean JVM shutdown but is **not sufficient** to fix the classloader bug. Both fixes are needed; the daemon fix alone leaves the JNI lookup broken.
- If lance-jni adds more `FindClass` lookups later (for other Java classes the dispatcher needs), they should follow the same `JNI_OnLoad` + `GlobalRef` pattern. Worth a code-review check on future JNI additions.

Addresses the classloader half of #6577 (the JVM-shutdown half is already fixed via #6633). Tracking from the lance-spark side at lance-format/lance-spark#538.

Co-Authored-By: zhoubin11 <zhoubin11@baidu.com>
