### PR TITLE
feat(mem_wal): local-scoring FTS search for LSM scanner

### DIFF
--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -259,6 +259,11 @@ path = "benches/mem_wal/fts/mem_wal_fts_bench.rs"
 harness = false
 
 [[bench]]
+name = "mem_wal_fts_read_bench"
+path = "benches/mem_wal/fts/mem_wal_fts_read_bench.rs"
+harness = false
+
+[[bench]]
 name = "manifest_commit"
 harness = false
 

--- a/rust/lance/benches/mem_wal/fts/mem_wal_fts_read_bench.rs
+++ b/rust/lance/benches/mem_wal/fts/mem_wal_fts_read_bench.rs
@@ -1,0 +1,873 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Standalone CLI benchmark for FTS read across LSM levels.
+//!
+//! Sibling of `mem_wal_vector_bench.rs` / `mem_wal_point_lookup_bench.rs`:
+//! same `--phase prepare|search` shape, same `ShardWriter`-based ingestion
+//! of flushed generations + an active memtable, same `--uri` cloud/local
+//! detection, and the same JSON output contract. The payload is real
+//! HuggingFace FineWeb `text` and the query path is
+//! [`LsmFtsSearchPlanner`] (local scoring) over the base table + flushed
+//! generations + active memtable.
+//!
+//! Each `search` invocation times a query set against the LSM hierarchy
+//! and reports latency percentiles. With `--with-baseline`, it also builds
+//! a single-merged-index ground truth (all rows in one Lance dataset with
+//! one FTS index, queried via `scanner.full_text_search`) and reports the
+//! top-k Jaccard between local-LSM scoring and the merged index — i.e. how
+//! far per-source local BM25 drifts from a globally-consistent ranking.
+//! The merged baseline is always built on local disk under `--cache-dir`,
+//! independent of the LSM `--uri` storage tier.
+//!
+//! Two phases, selected with `--phase`:
+//!
+//!   --phase prepare   Load FineWeb text, write the base dataset, create an
+//!                     inverted (FTS) index, and initialize MemWAL with the
+//!                     index maintained.
+//!   --phase search    Ingest rows across LSM levels via ShardWriter, then run
+//!                     the local-scoring FTS query panel (+ optional baseline).
+//!
+//! Example:
+//!
+//! ```bash
+//! cargo bench -p lance --bench mem_wal_fts_read_bench -- \
+//!   --phase prepare --uri /tmp/fts_read_bench \
+//!   --base-rows 1000000 --cache-dir /tmp/fineweb-cache
+//!
+//! cargo bench -p lance --bench mem_wal_fts_read_bench -- \
+//!   --phase search --uri /tmp/fts_read_bench \
+//!   --base-rows 1000000 --max-memtable-rows 100000 \
+//!   --queries 200 --k 10 --with-baseline \
+//!   --cache-dir /tmp/fineweb-cache --output result.json
+//! ```
+
+#![recursion_limit = "256"]
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow_array::{Array, Int64Array, RecordBatch, RecordBatchIterator, StringArray};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use datafusion::prelude::SessionContext;
+use futures::TryStreamExt;
+use lance::dataset::mem_wal::scanner::{
+    LsmDataSourceCollector, LsmFtsSearchPlanner, ShardSnapshot,
+};
+use lance::dataset::mem_wal::{DatasetMemWalExt, ShardWriterConfig};
+use lance::dataset::{Dataset, WriteParams};
+use lance::index::DatasetIndexExt;
+use lance_core::Result;
+use lance_index::IndexType;
+use lance_index::scalar::FullTextSearchQuery;
+use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+use lance_tokenizer::TokenStream;
+use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
+use serde_json::json;
+use uuid::Uuid;
+
+const TEXT_COL: &str = "text";
+const FTS_INDEX_NAME: &str = "text_fts";
+const HF_API_LISTING: &str =
+    "https://huggingface.co/api/datasets/HuggingFaceFW/fineweb/tree/main/sample/10BT";
+const HF_FILE_BASE: &str = "https://huggingface.co/datasets/HuggingFaceFW/fineweb/resolve/main/";
+
+// ----------------------------------------------------------------------
+// Phase / Args
+// ----------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    Prepare,
+    Search,
+}
+
+impl Phase {
+    fn parse(value: &str) -> std::result::Result<Self, String> {
+        match value {
+            "prepare" => Ok(Self::Prepare),
+            "search" => Ok(Self::Search),
+            _ => Err(format!("unknown phase '{value}', expected prepare|search")),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Prepare => "prepare",
+            Self::Search => "search",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Args {
+    phase: Phase,
+    uri: String,
+    base_rows: usize,
+    max_memtable_rows: usize,
+    flushed_generations: usize,
+    batch_rows: usize,
+    queries: usize,
+    k: usize,
+    /// Build a single-merged-index ground truth and report the top-k
+    /// Jaccard between local-LSM scoring and the merged index.
+    with_baseline: bool,
+    cache_dir: PathBuf,
+    output: Option<PathBuf>,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            phase: Phase::Search,
+            uri: String::new(),
+            base_rows: 1_000_000,
+            max_memtable_rows: 100_000,
+            flushed_generations: 2,
+            batch_rows: 1_000,
+            queries: 200,
+            k: 10,
+            with_baseline: false,
+            cache_dir: std::env::temp_dir().join("mem_wal_fineweb_fts_cache"),
+            output: None,
+        }
+    }
+}
+
+fn parse_val<T>(flag: &str, value: &str) -> Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    value
+        .parse()
+        .map_err(|e| lance_core::Error::invalid_input(format!("invalid {flag}: {value} ({e})")))
+}
+
+fn parse_args() -> Result<Args> {
+    let mut args = Args::default();
+    let mut iter = std::env::args().skip(1);
+    let mut has_phase = false;
+    let mut has_uri = false;
+    while let Some(flag) = iter.next() {
+        if flag == "--bench" {
+            continue;
+        }
+        // Value-less boolean flags handled before consuming a value.
+        if flag == "--with-baseline" {
+            args.with_baseline = true;
+            continue;
+        }
+        let value = iter
+            .next()
+            .ok_or_else(|| lance_core::Error::invalid_input(format!("missing value for {flag}")))?;
+        match flag.as_str() {
+            "--phase" => {
+                args.phase = Phase::parse(&value).map_err(lance_core::Error::invalid_input)?;
+                has_phase = true;
+            }
+            "--uri" => {
+                args.uri = value;
+                has_uri = true;
+            }
+            "--base-rows" => args.base_rows = parse_val(&flag, &value)?,
+            "--max-memtable-rows" => args.max_memtable_rows = parse_val(&flag, &value)?,
+            "--flushed-generations" => args.flushed_generations = parse_val(&flag, &value)?,
+            "--batch-rows" => args.batch_rows = parse_val(&flag, &value)?,
+            "--queries" => args.queries = parse_val(&flag, &value)?,
+            "--k" => args.k = parse_val(&flag, &value)?,
+            "--cache-dir" => args.cache_dir = PathBuf::from(value),
+            "--output" => args.output = Some(PathBuf::from(value)),
+            _ => {
+                return Err(lance_core::Error::invalid_input(format!(
+                    "unknown argument: {flag}"
+                )));
+            }
+        }
+    }
+    if !has_phase {
+        return Err(lance_core::Error::invalid_input(
+            "--phase is required (prepare|search)",
+        ));
+    }
+    if !has_uri {
+        return Err(lance_core::Error::invalid_input("--uri is required"));
+    }
+    if args.batch_rows == 0 || args.base_rows == 0 || args.max_memtable_rows == 0 {
+        return Err(lance_core::Error::invalid_input(
+            "base-rows, max-memtable-rows, batch-rows must be > 0",
+        ));
+    }
+    Ok(args)
+}
+
+fn is_cloud_uri(uri: &str) -> bool {
+    uri.starts_with("s3://") || uri.starts_with("gs://") || uri.starts_with("az://")
+}
+
+// ----------------------------------------------------------------------
+// FineWeb loading (mirrors mem_wal_fineweb_fts.rs)
+// ----------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+struct HfTreeEntry {
+    #[serde(rename = "type")]
+    kind: String,
+    path: String,
+}
+
+async fn list_shard_paths() -> Result<Vec<String>> {
+    let entries: Vec<HfTreeEntry> = reqwest::get(HF_API_LISTING)
+        .await
+        .map_err(|e| lance_core::Error::io(format!("listing HTTP: {e}")))?
+        .json()
+        .await
+        .map_err(|e| lance_core::Error::io(format!("listing JSON: {e}")))?;
+    let mut shards: Vec<String> = entries
+        .into_iter()
+        .filter(|e| e.kind == "file" && e.path.ends_with(".parquet"))
+        .map(|e| e.path)
+        .collect();
+    shards.sort();
+    Ok(shards)
+}
+
+async fn download_shard(rel_path: &str, dest: &std::path::Path) -> Result<()> {
+    if dest.exists() {
+        return Ok(());
+    }
+    let url = format!("{HF_FILE_BASE}{rel_path}");
+    let tmp = dest.with_extension("part");
+    for attempt in 1..=5u32 {
+        println!("downloading {rel_path} (attempt {attempt}/5) ...");
+        let result: Result<bytes::Bytes> = async {
+            let resp = reqwest::get(&url)
+                .await
+                .map_err(|e| lance_core::Error::io(format!("download HTTP: {e}")))?;
+            if !resp.status().is_success() {
+                return Err(lance_core::Error::io(format!(
+                    "download {url} -> status {}",
+                    resp.status()
+                )));
+            }
+            resp.bytes()
+                .await
+                .map_err(|e| lance_core::Error::io(format!("read body: {e}")))
+        }
+        .await;
+        match result {
+            Ok(bytes) => {
+                std::fs::write(&tmp, &bytes)
+                    .map_err(|e| lance_core::Error::io(format!("write: {e}")))?;
+                std::fs::rename(&tmp, dest)
+                    .map_err(|e| lance_core::Error::io(format!("rename: {e}")))?;
+                return Ok(());
+            }
+            Err(e) if attempt < 5 => {
+                eprintln!("  attempt {attempt} failed: {e}; retrying");
+                tokio::time::sleep(Duration::from_secs(2u64.pow(attempt))).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!()
+}
+
+async fn read_shard_text(
+    path: &std::path::Path,
+    out: &mut Vec<String>,
+    max_rows: usize,
+) -> Result<usize> {
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| lance_core::Error::io(format!("open parquet: {e}")))?;
+    let builder = ParquetRecordBatchStreamBuilder::new(file)
+        .await
+        .map_err(|e| lance_core::Error::io(format!("parquet builder: {e}")))?;
+    let mut stream = builder
+        .build()
+        .map_err(|e| lance_core::Error::io(format!("parquet stream: {e}")))?;
+    let mut taken = 0usize;
+    while taken < max_rows {
+        let Some(rb) = stream
+            .try_next()
+            .await
+            .map_err(|e| lance_core::Error::io(format!("parquet read: {e}")))?
+        else {
+            break;
+        };
+        let col = rb
+            .column_by_name(TEXT_COL)
+            .ok_or_else(|| lance_core::Error::io("text column missing".to_string()))?;
+        let strs = col
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| lance_core::Error::io("text not StringArray".to_string()))?;
+        for i in 0..strs.len() {
+            if taken >= max_rows {
+                break;
+            }
+            if strs.is_null(i) {
+                continue;
+            }
+            out.push(strs.value(i).to_string());
+            taken += 1;
+        }
+    }
+    Ok(taken)
+}
+
+async fn load_corpus(needed_rows: usize, cache_dir: &std::path::Path) -> Result<Vec<String>> {
+    std::fs::create_dir_all(cache_dir)
+        .map_err(|e| lance_core::Error::io(format!("mkdir cache: {e}")))?;
+    let shards = list_shard_paths().await?;
+    println!("fineweb sample/10BT: {} shards", shards.len());
+    let mut buf: Vec<String> = Vec::with_capacity(needed_rows);
+    for rel in &shards {
+        if buf.len() >= needed_rows {
+            break;
+        }
+        let name = rel.rsplit('/').next().unwrap_or(rel);
+        let local = cache_dir.join(name);
+        download_shard(rel, &local).await?;
+        let want = needed_rows - buf.len();
+        let got = read_shard_text(&local, &mut buf, want).await?;
+        println!("  shard {name} -> {got} rows (cumulative {})", buf.len());
+    }
+    if buf.len() < needed_rows {
+        return Err(lance_core::Error::io(format!(
+            "fineweb yielded only {} rows, need {needed_rows}",
+            buf.len()
+        )));
+    }
+    Ok(buf)
+}
+
+// ----------------------------------------------------------------------
+// Schema / batch helpers
+// ----------------------------------------------------------------------
+
+fn make_schema() -> Arc<ArrowSchema> {
+    let mut id_meta = HashMap::new();
+    id_meta.insert(
+        "lance-schema:unenforced-primary-key".to_string(),
+        "true".to_string(),
+    );
+    Arc::new(ArrowSchema::new(vec![
+        Field::new("id", DataType::Int64, false).with_metadata(id_meta),
+        Field::new(TEXT_COL, DataType::Utf8, true),
+    ]))
+}
+
+fn make_batch(schema: Arc<ArrowSchema>, start_id: i64, texts: &[String]) -> RecordBatch {
+    let ids = Int64Array::from_iter_values(start_id..start_id + texts.len() as i64);
+    let text = StringArray::from_iter_values(texts.iter().map(String::as_str));
+    RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(text)]).unwrap()
+}
+
+// ----------------------------------------------------------------------
+// Latency stats
+// ----------------------------------------------------------------------
+
+fn percentile(sorted: &[f64], pct: f64) -> f64 {
+    if sorted.is_empty() {
+        return f64::NAN;
+    }
+    let idx = ((pct / 100.0) * (sorted.len().saturating_sub(1)) as f64).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+struct LatencyStats {
+    p50_us: u64,
+    p95_us: u64,
+    p99_us: u64,
+    mean_us: f64,
+    qps: f64,
+}
+
+fn compute_stats(mut latencies_us: Vec<f64>) -> LatencyStats {
+    latencies_us.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mean = latencies_us.iter().sum::<f64>() / latencies_us.len().max(1) as f64;
+    let total_s = latencies_us.iter().sum::<f64>() / 1_000_000.0;
+    let qps = if total_s > 0.0 {
+        latencies_us.len() as f64 / total_s
+    } else {
+        0.0
+    };
+    LatencyStats {
+        p50_us: percentile(&latencies_us, 50.0) as u64,
+        p95_us: percentile(&latencies_us, 95.0) as u64,
+        p99_us: percentile(&latencies_us, 99.0) as u64,
+        mean_us: mean,
+        qps,
+    }
+}
+
+// ----------------------------------------------------------------------
+// Query set: mid-frequency single terms from the corpus
+// ----------------------------------------------------------------------
+
+const STOPWORDS: &[&str] = &[
+    "the", "a", "an", "and", "or", "of", "to", "in", "on", "for", "with", "as", "by", "is", "was",
+    "are", "were", "be", "been", "being", "this", "that", "these", "those", "it", "its", "but",
+    "not", "no", "if", "then", "than", "so", "do", "does", "did", "have", "has", "had", "will",
+    "would", "should", "could", "can", "may", "might", "must", "i", "you", "he", "she", "we",
+    "they", "them", "his", "her", "their", "our", "us", "me", "my", "your", "him", "at", "from",
+];
+
+fn build_query_terms(sample: &[String], n: usize) -> Vec<String> {
+    let mut tokenizer = InvertedIndexParams::default()
+        .build()
+        .expect("default tokenizer builds");
+    let mut freq: HashMap<String, u64> = HashMap::new();
+    for t in sample.iter().take(50_000) {
+        let mut stream = tokenizer.token_stream_for_doc(t);
+        while let Some(tok) = stream.next() {
+            if tok.text.len() < 3 || tok.text.len() > 24 || STOPWORDS.contains(&tok.text.as_str()) {
+                continue;
+            }
+            *freq.entry(tok.text.clone()).or_default() += 1;
+        }
+    }
+    let mut by_freq: Vec<(String, u64)> = freq.into_iter().collect();
+    by_freq.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    // Skip the most-frequent tokens (near-ties in BM25), keep mid-frequency.
+    let skip = (by_freq.len() / 4).min(300);
+    by_freq
+        .into_iter()
+        .skip(skip)
+        .map(|(t, _)| t)
+        .take(n)
+        .collect()
+}
+
+// ----------------------------------------------------------------------
+// Prepare phase
+// ----------------------------------------------------------------------
+
+async fn run_prepare(args: &Args) -> Result<()> {
+    let start = Instant::now();
+    let corpus = load_corpus(args.base_rows, &args.cache_dir).await?;
+    let schema = make_schema();
+
+    let total_batches = corpus.len().div_ceil(args.batch_rows);
+    let mut batches = Vec::with_capacity(total_batches);
+    let mut lo = 0usize;
+    while lo < corpus.len() {
+        let hi = (lo + args.batch_rows).min(corpus.len());
+        batches.push(Ok(make_batch(schema.clone(), lo as i64, &corpus[lo..hi])));
+        lo = hi;
+    }
+    let reader = RecordBatchIterator::new(batches.into_iter(), schema.clone());
+    let write_start = Instant::now();
+    let mut dataset = Dataset::write(reader, &args.uri, Some(WriteParams::default())).await?;
+    println!(
+        "wrote {} base rows in {:.1}s",
+        args.base_rows,
+        write_start.elapsed().as_secs_f64()
+    );
+
+    let index_start = Instant::now();
+    dataset
+        .create_index(
+            &[TEXT_COL],
+            IndexType::Inverted,
+            Some(FTS_INDEX_NAME.to_string()),
+            &InvertedIndexParams::default(),
+            true,
+        )
+        .await?;
+    println!(
+        "created FTS index in {:.1}s",
+        index_start.elapsed().as_secs_f64()
+    );
+
+    dataset
+        .initialize_mem_wal()
+        .maintained_indexes([FTS_INDEX_NAME])
+        .execute()
+        .await?;
+    println!(
+        "prepare complete in {:.1}s: uri={}",
+        start.elapsed().as_secs_f64(),
+        args.uri
+    );
+    Ok(())
+}
+
+// ----------------------------------------------------------------------
+// Search phase
+// ----------------------------------------------------------------------
+
+/// Per-query top-k row-id sets + the latency distribution.
+struct ModeRun {
+    top_ids: Vec<HashSet<i64>>,
+    latencies_us: Vec<f64>,
+}
+
+/// Run the local-scoring FTS panel through the LSM planner.
+async fn run_local(planner: &LsmFtsSearchPlanner, queries: &[String], k: usize) -> Result<ModeRun> {
+    let ctx = SessionContext::new();
+    let mut top_ids = Vec::with_capacity(queries.len());
+    let mut latencies_us = Vec::with_capacity(queries.len());
+    for q in queries {
+        let t0 = Instant::now();
+        let plan = planner
+            .plan_search(TEXT_COL, FullTextSearchQuery::new(q.clone()), k, None)
+            .await?;
+        let stream = plan.execute(0, ctx.task_ctx())?;
+        let batches: Vec<RecordBatch> = stream.try_collect().await?;
+        latencies_us.push(t0.elapsed().as_micros() as f64);
+        top_ids.push(collect_ids(&batches));
+    }
+    Ok(ModeRun {
+        top_ids,
+        latencies_us,
+    })
+}
+
+fn collect_ids(batches: &[RecordBatch]) -> HashSet<i64> {
+    let mut ids: HashSet<i64> = HashSet::new();
+    for b in batches {
+        if let Some(col) = b
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int64Array>())
+        {
+            for i in 0..col.len() {
+                ids.insert(col.value(i));
+            }
+        }
+    }
+    ids
+}
+
+/// Build a single-merged-index ground truth on local disk and return the
+/// top-k row-id set per query.
+///
+/// The merged dataset is the union of every LSM row — base-table rows
+/// (scanned back from `base_dataset`) plus the memtable rows (ids
+/// `id_base..`, text `mt_text`) — written into one Lance dataset with one
+/// FTS index, then queried via the standard `scanner.full_text_search`.
+/// Always built on local disk under `cache_dir` regardless of the LSM
+/// storage tier, since this measures ranking accuracy, not storage perf.
+async fn build_and_query_baseline(
+    base_dataset: &Dataset,
+    mt_text: &[String],
+    id_base: i64,
+    queries: &[String],
+    k: usize,
+    cache_dir: &std::path::Path,
+    batch_rows: usize,
+) -> Result<Vec<HashSet<i64>>> {
+    let schema = make_schema();
+
+    // 1. Pull base rows (id, text) back out of the base dataset.
+    let mut base_scanner = base_dataset.scan();
+    base_scanner.project(&["id", TEXT_COL])?;
+    let base_batches: Vec<RecordBatch> =
+        base_scanner.try_into_stream().await?.try_collect().await?;
+
+    let merged_uri = cache_dir
+        .join(format!("merged_baseline_{}", Uuid::new_v4()))
+        .to_string_lossy()
+        .to_string();
+
+    // 2. Write base rows + memtable rows into one dataset.
+    let mut batches: Vec<RecordBatch> = base_batches;
+    let mut lo = 0usize;
+    while lo < mt_text.len() {
+        let hi = (lo + batch_rows).min(mt_text.len());
+        batches.push(make_batch(
+            schema.clone(),
+            id_base + lo as i64,
+            &mt_text[lo..hi],
+        ));
+        lo = hi;
+    }
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+    let mut merged = Dataset::write(reader, &merged_uri, Some(WriteParams::default())).await?;
+    merged
+        .create_index(
+            &[TEXT_COL],
+            IndexType::Inverted,
+            Some(FTS_INDEX_NAME.to_string()),
+            &InvertedIndexParams::default(),
+            true,
+        )
+        .await?;
+
+    // 3. Query the merged index with the same query set.
+    let mut top_ids = Vec::with_capacity(queries.len());
+    for q in queries {
+        let mut scanner = merged.scan();
+        scanner.project(&["id", TEXT_COL])?;
+        scanner.full_text_search(
+            FullTextSearchQuery::new(q.clone())
+                .with_column(TEXT_COL.to_string())?
+                .limit(Some(k as i64)),
+        )?;
+        let batches: Vec<RecordBatch> = scanner.try_into_stream().await?.try_collect().await?;
+        top_ids.push(collect_ids(&batches));
+    }
+    Ok(top_ids)
+}
+
+fn mean_jaccard(a: &[HashSet<i64>], b: &[HashSet<i64>]) -> f64 {
+    let pairs: Vec<f64> = a
+        .iter()
+        .zip(b.iter())
+        .filter_map(|(x, y)| {
+            if x.is_empty() && y.is_empty() {
+                None
+            } else {
+                let inter = x.intersection(y).count() as f64;
+                let union = x.union(y).count() as f64;
+                Some(inter / union)
+            }
+        })
+        .collect();
+    if pairs.is_empty() {
+        0.0
+    } else {
+        pairs.iter().sum::<f64>() / pairs.len() as f64
+    }
+}
+
+async fn run_search(args: &Args) -> Result<serde_json::Value> {
+    let dataset = Arc::new(Dataset::open(&args.uri).await?);
+    let arrow_schema: Arc<ArrowSchema> = Arc::new(ArrowSchema::from(dataset.schema()));
+    let schema = make_schema();
+
+    // Memtable text is drawn from FineWeb; row *ids* are assigned past the
+    // base slice (via `id_base`) so they don't collide with base-table ids,
+    // but the *text content* can reuse FineWeb rows freely — BM25 latency
+    // doesn't depend on content novelty. Load just enough rows once,
+    // covering both the memtable payload and the query-term sample, instead
+    // of re-reading the whole base corpus from parquet.
+    let active_rows = args.max_memtable_rows / 2;
+    let total_memtable_rows = args.flushed_generations * args.max_memtable_rows + active_rows;
+    let sample_rows = args.base_rows.min(50_000);
+    let load_rows = total_memtable_rows.max(sample_rows);
+    println!("loading {load_rows} FineWeb rows for memtable payload + query sample ...");
+    let mt_corpus = load_corpus(load_rows, &args.cache_dir).await?;
+    let mt_text = &mt_corpus[..total_memtable_rows];
+
+    let shard_id = Uuid::new_v4();
+    let row_bytes = 2048; // rough FineWeb text row size
+    // The memtable flush trigger is `estimated_size >= max_memtable_size ||
+    // batch_store_full`. FineWeb text rows vary in size, so a byte threshold
+    // is an unreliable way to flush exactly one generation per
+    // `max_memtable_rows`. Instead make the *batch-count* cap the trigger:
+    // set `max_memtable_batches` to one generation's worth of batches so the
+    // store fills (and flushes) precisely at each generation boundary,
+    // independent of text length. Keep `max_memtable_size` high so it never
+    // pre-empts the batch-count trigger.
+    let batches_per_gen = (args.max_memtable_rows / args.batch_rows).max(1);
+    let config = ShardWriterConfig {
+        shard_id,
+        shard_spec_id: 0,
+        durable_write: false,
+        sync_indexed_write: false,
+        max_memtable_size: args.max_memtable_rows * row_bytes * 100,
+        max_memtable_rows: args.max_memtable_rows,
+        max_memtable_batches: batches_per_gen,
+        max_unflushed_memtable_bytes: args.max_memtable_rows * row_bytes * 20,
+        max_wal_flush_interval: Some(Duration::from_secs(60)),
+        ..ShardWriterConfig::default()
+    };
+    let writer = dataset.mem_wal_writer(shard_id, config).await?;
+
+    let flush_wait = if is_cloud_uri(&args.uri) {
+        Duration::from_secs(5)
+    } else {
+        Duration::from_millis(500)
+    };
+
+    // Ingest flushed generations + 1 active (50% full).
+    let mut gen_sizes: Vec<usize> = (0..args.flushed_generations)
+        .map(|_| args.max_memtable_rows)
+        .collect();
+    gen_sizes.push(active_rows);
+
+    let id_base = args.base_rows as i64;
+    let mut cursor = 0usize;
+    let ingest_start = Instant::now();
+    for (gen_idx, &gen_rows) in gen_sizes.iter().enumerate() {
+        let mut written = 0usize;
+        while written < gen_rows {
+            let chunk = args.batch_rows.min(gen_rows - written);
+            let start = id_base + (cursor) as i64;
+            let slice = &mt_text[cursor..cursor + chunk];
+            let batch = make_batch(schema.clone(), start, slice);
+            writer.put(vec![batch]).await?;
+            cursor += chunk;
+            written += chunk;
+        }
+        let is_flushed = gen_idx < args.flushed_generations;
+        println!(
+            "  gen {}: wrote {} rows ({})",
+            gen_idx + 1,
+            gen_rows,
+            if is_flushed { "flushed" } else { "active" }
+        );
+        if is_flushed {
+            tokio::time::sleep(flush_wait).await;
+        }
+    }
+    // Wait for any triggered (sealed) memtable flushes to commit to the
+    // manifest before we snapshot it — otherwise the flushed generations
+    // race the read and may not all be visible yet.
+    writer.wait_for_flush_drain().await?;
+    println!(
+        "ingested {} memtable rows in {:.1}s",
+        cursor,
+        ingest_start.elapsed().as_secs_f64()
+    );
+
+    let manifest = writer.manifest().await?;
+    let in_memory_refs = writer.in_memory_memtable_refs().await?;
+    let mut shard_snapshot = ShardSnapshot::new(shard_id);
+    if let Some(ref m) = manifest {
+        shard_snapshot = shard_snapshot.with_current_generation(m.current_generation);
+        for fg in &m.flushed_generations {
+            shard_snapshot = shard_snapshot.with_flushed_generation(fg.generation, fg.path.clone());
+        }
+    }
+    let num_flushed = manifest
+        .as_ref()
+        .map(|m| m.flushed_generations.len())
+        .unwrap_or(0);
+    println!("manifest: {num_flushed} flushed generations");
+
+    // Flushed generations carry the same maintained secondary indexes as
+    // the active memtable: the flush handler builds them during flush
+    // (lance #6901), so each generation already has the FTS index and
+    // both scoring modes use the fast indexed path. No manual indexing
+    // step is needed here. (The index-less flat fallback in the rescore
+    // planner is still exercised by unit tests for the no-maintained-index
+    // case.)
+
+    let collector = LsmDataSourceCollector::new(dataset.clone(), vec![shard_snapshot])
+        .with_in_memory_memtables(shard_id, in_memory_refs);
+    let pk_columns = vec!["id".to_string()];
+    let planner = LsmFtsSearchPlanner::new(collector, pk_columns, arrow_schema);
+
+    // Query set: mid-frequency terms from a sample of the loaded corpus.
+    println!("building query set ...");
+    let sample_end = mt_corpus
+        .len()
+        .min(sample_rows.max(total_memtable_rows.min(50_000)));
+    let queries = build_query_terms(&mt_corpus[..sample_end], args.queries);
+    println!("picked {} query terms", queries.len());
+
+    // Run the local-scoring panel.
+    println!(
+        "running Local mode ({} queries, k={}) ...",
+        queries.len(),
+        args.k
+    );
+    let local = run_local(&planner, &queries, args.k).await?;
+    let local_stats = compute_stats(local.latencies_us.clone());
+    println!(
+        "local:   p50={}us p95={}us p99={}us mean={:.0}us qps={:.0}",
+        local_stats.p50_us,
+        local_stats.p95_us,
+        local_stats.p99_us,
+        local_stats.mean_us,
+        local_stats.qps
+    );
+
+    // Optional accuracy: top-k Jaccard vs a single-merged-index ground truth.
+    let baseline_jaccard = if args.with_baseline {
+        println!("building merged-index baseline (local disk) ...");
+        let baseline_ids = build_and_query_baseline(
+            &dataset,
+            mt_text,
+            id_base,
+            &queries,
+            args.k,
+            &args.cache_dir,
+            args.batch_rows,
+        )
+        .await?;
+        let j = mean_jaccard(&local.top_ids, &baseline_ids);
+        println!("top-{} jaccard local-vs-merged = {:.4}", args.k, j);
+        Some(j)
+    } else {
+        None
+    };
+
+    // Keep writer alive so the active memtable stays reachable.
+    std::mem::forget(writer);
+
+    Ok(json!({
+        "bench": "mem_wal_fts_read",
+        "phase": "search",
+        "uri_kind": if is_cloud_uri(&args.uri) { "cloud" } else { "local" },
+        "base_rows": args.base_rows,
+        "max_memtable_rows": args.max_memtable_rows,
+        "flushed_generations": num_flushed,
+        "active_rows": active_rows,
+        "k": args.k,
+        "queries": queries.len(),
+        "jaccard_local_vs_merged": baseline_jaccard,
+        "local": {
+            "p50_us": local_stats.p50_us,
+            "p95_us": local_stats.p95_us,
+            "p99_us": local_stats.p99_us,
+            "mean_us": local_stats.mean_us as u64,
+            "qps": local_stats.qps as u64,
+        },
+    }))
+}
+
+// ----------------------------------------------------------------------
+// Entrypoint
+// ----------------------------------------------------------------------
+
+async fn run(args: Args) -> Result<()> {
+    println!(
+        "bench=mem_wal_fts_read phase={} uri={} base_rows={} max_memtable_rows={} flushed_generations={} queries={} k={} with_baseline={}",
+        args.phase.as_str(),
+        args.uri,
+        args.base_rows,
+        args.max_memtable_rows,
+        args.flushed_generations,
+        args.queries,
+        args.k,
+        args.with_baseline,
+    );
+
+    match args.phase {
+        Phase::Prepare => run_prepare(&args).await?,
+        Phase::Search => {
+            let result = run_search(&args).await?;
+            let text = serde_json::to_string_pretty(&result)
+                .map_err(|e| lance_core::Error::io(format!("serialize: {e}")))?;
+            println!("{text}");
+            if let Some(path) = &args.output {
+                if let Some(parent) = path.parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    std::fs::create_dir_all(parent).ok();
+                }
+                std::fs::write(path, text.as_bytes())
+                    .map_err(|e| lance_core::Error::io(format!("write {}: {e}", path.display())))?;
+            }
+        }
+    }
+    println!("=== DONE ===");
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args = parse_args()?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| lance_core::Error::io(format!("build runtime: {e}")))?;
+    runtime.block_on(run(args))
+}

--- a/rust/lance/benches/mem_wal/fts/run_fts_read_sweep.sh
+++ b/rust/lance/benches/mem_wal/fts/run_fts_read_sweep.sh
@@ -28,7 +28,9 @@
 #   QUERIES         queries per config (default 200)
 #   WITH_BASELINE   "1" to also build the merged-index accuracy baseline
 #                   and report local-vs-merged Jaccard (default off)
-#   BACKENDS        space-separated subset of "nvme s3" (default both)
+#   BACKENDS        space-separated subset of "nvme s3 s3express" (default all)
+#   S3EXPRESS_PREFIX  s3:// directory-bucket prefix (must be in instance AZ)
+#   BASELINE_BACKEND  only build the merged accuracy baseline on this backend
 #   CONFIG_TIMEOUT  per-config seconds (default 5400)
 
 set -uo pipefail
@@ -40,6 +42,10 @@ cd "$REPO_ROOT"
 RUN_ID="${1:-$(date -u +%Y%m%dT%H%M%SZ)}"
 NVME_PREFIX="${NVME_PREFIX:-${TMPDIR:-/tmp}/lsm-fts-nvme}"
 S3_PREFIX="${S3_PREFIX:-s3://jack-devland-build/lsm-fts}"
+# S3 Express One Zone directory bucket (must be in the instance's AZ to get
+# the latency benefit). Auto-detected as S3 Express by lance via the
+# `--x-s3` suffix.
+S3EXPRESS_PREFIX="${S3EXPRESS_PREFIX:-s3://jack-lancedb-devland--use1-az4--x-s3/lsm-fts}"
 CACHE_DIR="${CACHE_DIR:-${TMPDIR:-/tmp}/lance-fineweb-cache}"
 BASE_ROWS_LIST="${BASE_ROWS_LIST:-100000 1000000}"
 K_LIST="${K_LIST:-10 100}"
@@ -47,7 +53,10 @@ MAX_MEMTABLE_ROWS="${MAX_MEMTABLE_ROWS:-100000}"
 GENS_LIST="${GENS_LIST:-1 2 5}"
 QUERIES="${QUERIES:-200}"
 WITH_BASELINE="${WITH_BASELINE:-}"
-BACKENDS="${BACKENDS:-nvme s3}"
+# Accuracy (merged baseline) is storage-independent, so only build it on
+# this backend to avoid redundant rebuilds across the storage tiers.
+BASELINE_BACKEND="${BASELINE_BACKEND:-nvme}"
+BACKENDS="${BACKENDS:-nvme s3 s3express}"
 CONFIG_TIMEOUT="${CONFIG_TIMEOUT:-5400}"
 
 LOCAL_DIR="$REPO_ROOT/target/lsm-fts-read-results/${RUN_ID}"
@@ -67,9 +76,10 @@ echo ""
 
 backend_prefix() {
     case "$1" in
-        nvme) echo "$NVME_PREFIX/$RUN_ID" ;;
-        s3)   echo "$S3_PREFIX/$RUN_ID" ;;
-        *)    echo "ERROR unknown backend $1" >&2; exit 1 ;;
+        nvme)      echo "$NVME_PREFIX/$RUN_ID" ;;
+        s3)        echo "$S3_PREFIX/$RUN_ID" ;;
+        s3express) echo "$S3EXPRESS_PREFIX/$RUN_ID" ;;
+        *)         echo "ERROR unknown backend $1" >&2; exit 1 ;;
     esac
 }
 
@@ -116,8 +126,12 @@ for backend in $BACKENDS; do
                     echo ">>> $name (already done, skipping)"
                     continue
                 fi
+                # Accuracy is storage-independent → only build the merged
+                # baseline on BASELINE_BACKEND to avoid redundant rebuilds.
                 baseline_flag=()
-                [ -n "$WITH_BASELINE" ] && baseline_flag=(--with-baseline)
+                if [ -n "$WITH_BASELINE" ] && [ "$backend" = "$BASELINE_BACKEND" ]; then
+                    baseline_flag=(--with-baseline)
+                fi
                 run_phase "$name" \
                     --phase search --uri "$uri" \
                     --base-rows "$base_rows" \

--- a/rust/lance/benches/mem_wal/fts/run_fts_read_sweep.sh
+++ b/rust/lance/benches/mem_wal/fts/run_fts_read_sweep.sh
@@ -24,7 +24,7 @@
 #   BASE_ROWS_LIST  space-separated base sizes (default "100000 1000000")
 #   K_LIST          space-separated top-k values (default "10 100")
 #   MAX_MEMTABLE_ROWS  active/flushed memtable cap (default 100000)
-#   FLUSHED_GENERATIONS number of flushed gens (default 2)
+#   GENS_LIST       space-separated flushed-generation counts (default "1 2 5")
 #   QUERIES         queries per config (default 200)
 #   WITH_BASELINE   "1" to also build the merged-index accuracy baseline
 #                   and report local-vs-merged Jaccard (default off)
@@ -44,7 +44,7 @@ CACHE_DIR="${CACHE_DIR:-${TMPDIR:-/tmp}/lance-fineweb-cache}"
 BASE_ROWS_LIST="${BASE_ROWS_LIST:-100000 1000000}"
 K_LIST="${K_LIST:-10 100}"
 MAX_MEMTABLE_ROWS="${MAX_MEMTABLE_ROWS:-100000}"
-FLUSHED_GENERATIONS="${FLUSHED_GENERATIONS:-2}"
+GENS_LIST="${GENS_LIST:-1 2 5}"
 QUERIES="${QUERIES:-200}"
 WITH_BASELINE="${WITH_BASELINE:-}"
 BACKENDS="${BACKENDS:-nvme s3}"
@@ -100,34 +100,37 @@ for backend in $BACKENDS; do
         esac
         uri="$prefix/base_${btag}"
 
-        # prepare once per (backend, base_rows)
+        # prepare once per (backend, base_rows); reused across gens/k since
+        # each search ingests into its own fresh shard under _mem_wal.
         run_phase "prepare_${backend}_${btag}" \
             --phase prepare --uri "$uri" \
             --base-rows "$base_rows" --batch-rows 1000 \
             --cache-dir "$CACHE_DIR" || continue
 
-        # search for each k
-        for k in $K_LIST; do
-            name="search_${backend}_${btag}_k${k}"
-            out="$LOCAL_DIR/${name}.json"
-            if [ -f "$out" ]; then
-                echo ">>> $name (already done, skipping)"
-                continue
-            fi
-            baseline_flag=()
-            [ -n "$WITH_BASELINE" ] && baseline_flag=(--with-baseline)
-            run_phase "$name" \
-                --phase search --uri "$uri" \
-                --base-rows "$base_rows" \
-                --max-memtable-rows "$MAX_MEMTABLE_ROWS" \
-                --flushed-generations "$FLUSHED_GENERATIONS" \
-                --batch-rows 1000 \
-                --queries "$QUERIES" --k "$k" \
-                "${baseline_flag[@]}" \
-                --cache-dir "$CACHE_DIR" \
-                --output "$out"
-            # mirror result to s3 for durability regardless of backend
-            [ -f "$out" ] && aws s3 cp "$out" "$S3_PREFIX/$RUN_ID/results/${name}.json" >/dev/null 2>&1
+        # search for each (flushed-generations, k)
+        for gens in $GENS_LIST; do
+            for k in $K_LIST; do
+                name="search_${backend}_${btag}_g${gens}_k${k}"
+                out="$LOCAL_DIR/${name}.json"
+                if [ -f "$out" ]; then
+                    echo ">>> $name (already done, skipping)"
+                    continue
+                fi
+                baseline_flag=()
+                [ -n "$WITH_BASELINE" ] && baseline_flag=(--with-baseline)
+                run_phase "$name" \
+                    --phase search --uri "$uri" \
+                    --base-rows "$base_rows" \
+                    --max-memtable-rows "$MAX_MEMTABLE_ROWS" \
+                    --flushed-generations "$gens" \
+                    --batch-rows 1000 \
+                    --queries "$QUERIES" --k "$k" \
+                    "${baseline_flag[@]}" \
+                    --cache-dir "$CACHE_DIR" \
+                    --output "$out"
+                # mirror result to s3 for durability regardless of backend
+                [ -f "$out" ] && aws s3 cp "$out" "$S3_PREFIX/$RUN_ID/results/${name}.json" >/dev/null 2>&1
+            done
         done
     done
 done

--- a/rust/lance/benches/mem_wal/fts/run_fts_read_sweep.sh
+++ b/rust/lance/benches/mem_wal/fts/run_fts_read_sweep.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Driver for the LSM FTS read benchmark panel across storage backends.
+#
+# Sweeps the `mem_wal_fts_read_bench` over:
+#   - storage backend : local NVMe path and an s3:// prefix
+#   - base table size  : configurable list (default 100k, 1M)
+#   - top-k            : configurable list (default 10, 100)
+#
+# For each (backend, base_rows) the bench's `prepare` phase runs once to
+# write the base dataset + FTS index + MemWAL; then for each k the `search`
+# phase ingests flushed generations + an active memtable through ShardWriter
+# and times the FTS query panel under both Local and LocalWithGlobalRescore
+# scoring modes.
+#
+# Each config runs under a `timeout` watchdog so a hang costs one window.
+#
+# Usage:
+#   rust/lance/benches/mem_wal/fts/run_fts_read_sweep.sh [run_id]
+#
+# Env:
+#   NVME_PREFIX     local scratch dir on fast disk (default <tmpdir>/lsm-fts-nvme)
+#   S3_PREFIX       s3:// dataset prefix (default s3://jack-devland-build/lsm-fts)
+#   CACHE_DIR       FineWeb shard download cache (default <tmpdir>/lance-fineweb-cache)
+#   BASE_ROWS_LIST  space-separated base sizes (default "100000 1000000")
+#   K_LIST          space-separated top-k values (default "10 100")
+#   MAX_MEMTABLE_ROWS  active/flushed memtable cap (default 100000)
+#   FLUSHED_GENERATIONS number of flushed gens (default 2)
+#   QUERIES         queries per config (default 200)
+#   WITH_BASELINE   "1" to also build the merged-index accuracy baseline
+#                   and report local-vs-merged Jaccard (default off)
+#   BACKENDS        space-separated subset of "nvme s3" (default both)
+#   CONFIG_TIMEOUT  per-config seconds (default 5400)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+RUN_ID="${1:-$(date -u +%Y%m%dT%H%M%SZ)}"
+NVME_PREFIX="${NVME_PREFIX:-${TMPDIR:-/tmp}/lsm-fts-nvme}"
+S3_PREFIX="${S3_PREFIX:-s3://jack-devland-build/lsm-fts}"
+CACHE_DIR="${CACHE_DIR:-${TMPDIR:-/tmp}/lance-fineweb-cache}"
+BASE_ROWS_LIST="${BASE_ROWS_LIST:-100000 1000000}"
+K_LIST="${K_LIST:-10 100}"
+MAX_MEMTABLE_ROWS="${MAX_MEMTABLE_ROWS:-100000}"
+FLUSHED_GENERATIONS="${FLUSHED_GENERATIONS:-2}"
+QUERIES="${QUERIES:-200}"
+WITH_BASELINE="${WITH_BASELINE:-}"
+BACKENDS="${BACKENDS:-nvme s3}"
+CONFIG_TIMEOUT="${CONFIG_TIMEOUT:-5400}"
+
+LOCAL_DIR="$REPO_ROOT/target/lsm-fts-read-results/${RUN_ID}"
+mkdir -p "$LOCAL_DIR" "$CACHE_DIR" "$NVME_PREFIX"
+
+BENCH=mem_wal_fts_read_bench
+BIN="$(find target/release/deps -maxdepth 1 -type f -perm -111 -name "${BENCH}-*" ! -name '*.d' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2-)"
+if [ -z "$BIN" ]; then
+    echo "building bench binary..."
+    cargo bench -p lance --bench "$BENCH" --no-run
+    BIN="$(find target/release/deps -maxdepth 1 -type f -perm -111 -name "${BENCH}-*" ! -name '*.d' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2-)"
+fi
+echo "bench binary: $BIN"
+echo "run id:       $RUN_ID"
+echo "backends:     $BACKENDS"
+echo ""
+
+backend_prefix() {
+    case "$1" in
+        nvme) echo "$NVME_PREFIX/$RUN_ID" ;;
+        s3)   echo "$S3_PREFIX/$RUN_ID" ;;
+        *)    echo "ERROR unknown backend $1" >&2; exit 1 ;;
+    esac
+}
+
+run_phase() {
+    local name="$1"; shift
+    local log="$LOCAL_DIR/${name}.log"
+    echo ">>> $name"
+    timeout "$CONFIG_TIMEOUT" "$BIN" --bench "$@" > "$log" 2>&1
+    local rc=$?
+    if [ "$rc" -eq 124 ]; then
+        echo "    !!! TIMED OUT after ${CONFIG_TIMEOUT}s (see $log)"
+        return 1
+    elif [ "$rc" -ne 0 ]; then
+        echo "    !!! failed rc=$rc (see $log)"
+        return 1
+    fi
+    echo "    ok"
+    return 0
+}
+
+for backend in $BACKENDS; do
+    prefix="$(backend_prefix "$backend")"
+    for base_rows in $BASE_ROWS_LIST; do
+        case "$base_rows" in
+            1000000) btag=1M ;;
+            100000)  btag=100k ;;
+            *)       btag="${base_rows}" ;;
+        esac
+        uri="$prefix/base_${btag}"
+
+        # prepare once per (backend, base_rows)
+        run_phase "prepare_${backend}_${btag}" \
+            --phase prepare --uri "$uri" \
+            --base-rows "$base_rows" --batch-rows 1000 \
+            --cache-dir "$CACHE_DIR" || continue
+
+        # search for each k
+        for k in $K_LIST; do
+            name="search_${backend}_${btag}_k${k}"
+            out="$LOCAL_DIR/${name}.json"
+            if [ -f "$out" ]; then
+                echo ">>> $name (already done, skipping)"
+                continue
+            fi
+            baseline_flag=()
+            [ -n "$WITH_BASELINE" ] && baseline_flag=(--with-baseline)
+            run_phase "$name" \
+                --phase search --uri "$uri" \
+                --base-rows "$base_rows" \
+                --max-memtable-rows "$MAX_MEMTABLE_ROWS" \
+                --flushed-generations "$FLUSHED_GENERATIONS" \
+                --batch-rows 1000 \
+                --queries "$QUERIES" --k "$k" \
+                "${baseline_flag[@]}" \
+                --cache-dir "$CACHE_DIR" \
+                --output "$out"
+            # mirror result to s3 for durability regardless of backend
+            [ -f "$out" ] && aws s3 cp "$out" "$S3_PREFIX/$RUN_ID/results/${name}.json" >/dev/null 2>&1
+        done
+    done
+done
+
+echo ""
+echo "=== summary ==="
+python3 - "$LOCAL_DIR" <<'PY'
+import glob, json, os, sys
+d = sys.argv[1]
+hdr = f"{'config':32s} {'local_p50_us':>13} {'local_p99_us':>13} {'local_qps':>10} {'jaccard_vs_merged':>18}"
+print(hdr)
+for p in sorted(glob.glob(os.path.join(d, "*.json"))):
+    try:
+        r = json.load(open(p))
+    except Exception as e:
+        print(f"  bad {p}: {e}"); continue
+    name = os.path.basename(p)[:-5]
+    lo = r.get("local", {})
+    j = r.get("jaccard_local_vs_merged")
+    j_str = f"{j:.4f}" if isinstance(j, (int, float)) else "-"
+    print(f"{name:32s} {lo.get('p50_us','-'):>13} {lo.get('p99_us','-'):>13} "
+          f"{lo.get('qps','-'):>10} {j_str:>18}")
+PY
+echo ""
+echo "results: $LOCAL_DIR  +  $S3_PREFIX/$RUN_ID/results/"

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
@@ -108,7 +108,7 @@ impl FtsIndexExec {
             .collect();
         // `_score` is nullable here to stay schema-compatible with
         // `lance_index::scalar::inverted::FTS_SCHEMA` (the schema base/flushed
-        // FTS exec nodes emit). The LSM `full_text_search` planner UNIONs the
+        // FTS exec nodes emit). The LSM `full_text_search` planner unions the
         // active arm with base/flushed arms; UnionExec requires schema equality
         // including nullability. The actual emitted column is always populated.
         fields.push(Field::new(SCORE_COLUMN, DataType::Float32, true));

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
@@ -106,7 +106,12 @@ impl FtsIndexExec {
             .iter()
             .map(|f| f.as_ref().clone())
             .collect();
-        fields.push(Field::new(SCORE_COLUMN, DataType::Float32, false));
+        // `_score` is nullable here to stay schema-compatible with
+        // `lance_index::scalar::inverted::FTS_SCHEMA` (the schema base/flushed
+        // FTS exec nodes emit). The LSM `full_text_search` planner UNIONs the
+        // active arm with base/flushed arms; UnionExec requires schema equality
+        // including nullability. The actual emitted column is always populated.
+        fields.push(Field::new(SCORE_COLUMN, DataType::Float32, true));
         if with_row_id {
             fields.push(Field::new(lance_core::ROW_ID, DataType::UInt64, true));
         }

--- a/rust/lance/src/dataset/mem_wal/scanner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner.rs
@@ -37,6 +37,7 @@ mod collector;
 mod data_source;
 pub mod exec;
 mod flushed_cache;
+mod fts_search;
 mod planner;
 mod point_lookup;
 mod projection;
@@ -48,6 +49,7 @@ pub use collector::{
 };
 pub use data_source::{FlushedGeneration, LsmDataSource, LsmGeneration, ShardSnapshot};
 pub use flushed_cache::FlushedMemTableCache;
+pub use fts_search::{LsmFtsSearchPlanner, SCORE_COLUMN};
 pub use point_lookup::LsmPointLookupPlanner;
 pub use projection::DISTANCE_COLUMN;
 pub use vector_search::LsmVectorSearchPlanner;

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -300,6 +300,27 @@ impl LsmScanner {
             .await
     }
 
+    /// Build a local-scoring FTS plan spanning base + flushed + active sources.
+    ///
+    /// Routes through [`super::LsmFtsSearchPlanner`]. Output schema is
+    /// `projection ∪ pk_columns + _score`; per-source local BM25 `_score`
+    /// is merged DESC and capped at `k`. `column` must be FTS-indexed on
+    /// the queried sources.
+    pub async fn full_text_search(
+        &self,
+        column: &str,
+        query: lance_index::scalar::FullTextSearchQuery,
+        k: usize,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let collector = self.build_collector();
+        let base_schema = self.schema();
+        let planner =
+            super::LsmFtsSearchPlanner::new(collector, self.pk_columns.clone(), base_schema);
+        planner
+            .plan_search(column, query, k, self.projection.as_deref())
+            .await
+    }
+
     /// Execute the scan and return a stream of record batches.
     pub async fn try_into_stream(&self) -> Result<SendableRecordBatchStream> {
         let plan = self.create_plan().await?;

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -314,8 +314,14 @@ impl LsmScanner {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let collector = self.build_collector();
         let base_schema = self.schema();
-        let planner =
+        let mut planner =
             super::LsmFtsSearchPlanner::new(collector, self.pk_columns.clone(), base_schema);
+        if let Some(session) = &self.session {
+            planner = planner.with_session(session.clone());
+        }
+        if let Some(cache) = &self.flushed_cache {
+            planner = planner.with_flushed_cache(cache.clone());
+        }
         planner
             .plan_search(column, query, k, self.projection.as_deref())
             .await

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -22,9 +22,13 @@
 //! benchmark in this PR shows it carries a real latency penalty, so the
 //! local path lands first and the global option is optimized separately.
 //!
-//! Staleness: per-source results are returned as-is. The same primary
-//! key may appear from multiple sources if it was updated across
-//! generations; the caller deduplicates downstream if needed.
+//! Staleness: within a flushed generation, the deletion vector written
+//! at flush time (see #6929) already masks rows superseded by a newer
+//! generation, so per-source results are clean within each tier. The
+//! same primary key can still appear across tiers (active vs flushed)
+//! when an updated row sits in the active memtable while the older
+//! copy lives in a flushed generation; cross-tier deduplication is
+//! left to the caller in local mode.
 //!
 //! Everything here is contained in the `mem_wal` module — it reuses the
 //! existing per-source FTS read paths (`scanner.full_text_search` for
@@ -47,8 +51,10 @@ use tracing::instrument;
 
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
+use super::flushed_cache::{FlushedMemTableCache, open_flushed_dataset};
 use super::projection::project_to_canonical;
 use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
+use crate::session::Session;
 
 /// `_score` column name in FTS results — kept aligned with
 /// `lance_index::scalar::inverted::SCORE_COL` so this module doesn't
@@ -60,6 +66,10 @@ pub struct LsmFtsSearchPlanner {
     collector: LsmDataSourceCollector,
     pk_columns: Vec<String>,
     base_schema: SchemaRef,
+    /// Session threaded into flushed-generation opens (shared caches).
+    session: Option<Arc<Session>>,
+    /// Cache of opened flushed-generation datasets.
+    flushed_cache: Option<Arc<FlushedMemTableCache>>,
 }
 
 impl LsmFtsSearchPlanner {
@@ -73,7 +83,23 @@ impl LsmFtsSearchPlanner {
             collector,
             pk_columns,
             base_schema,
+            session: None,
+            flushed_cache: None,
         }
+    }
+
+    /// Thread a session into flushed-generation opens so the first open
+    /// populates the shared index / file-metadata caches.
+    pub fn with_session(mut self, session: Arc<Session>) -> Self {
+        self.session = Some(session);
+        self
+    }
+
+    /// Inject a cache of opened flushed-generation datasets, making repeated
+    /// searches against the same generation a pure `Arc::clone`.
+    pub fn with_flushed_cache(mut self, cache: Arc<FlushedMemTableCache>) -> Self {
+        self.flushed_cache = Some(cache);
+        self
     }
 
     /// Build the FTS execution plan (local scoring).
@@ -183,9 +209,9 @@ impl LsmFtsSearchPlanner {
                 scanner.create_plan().await
             }
             LsmDataSource::FlushedMemTable { path, .. } => {
-                let dataset = crate::dataset::DatasetBuilder::from_uri(path)
-                    .load()
-                    .await?;
+                let dataset =
+                    open_flushed_dataset(path, self.session.as_ref(), self.flushed_cache.as_ref())
+                        .await?;
                 let mut scanner = dataset.scan();
                 let cols = self.fts_scanner_projection(projection);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -1,0 +1,538 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Full-text search planner for LSM scanner (local scoring).
+//!
+//! Builds an execution plan that scores an FTS query across the base
+//! table, flushed memtable generations, and the active/frozen-undrained
+//! in-memory memtables, returning rows ordered by BM25 `_score` DESC.
+//!
+//! # Scoring
+//!
+//! Each source scores with its own corpus statistics (local BM25), and
+//! the coordinator unions the per-source plans and merges by `_score`
+//! (per-partition top-k sort + sort-preserving merge). The plan is
+//! single-pass and never coordinates statistics across sources, so
+//! cross-source `_score` values are only approximately comparable — but
+//! within each source the ranking is exact. This mirrors the default
+//! `query_then_fetch` trade-off of distributed search systems.
+//!
+//! A globally-consistent scoring mode (aggregate corpus statistics
+//! across sources, then rescore) is a deliberate follow-up: the
+//! benchmark in this PR shows it carries a real latency penalty, so the
+//! local path lands first and the global option is optimized separately.
+//!
+//! Staleness: per-source results are returned as-is. The same primary
+//! key may appear from multiple sources if it was updated across
+//! generations; the caller deduplicates downstream if needed.
+//!
+//! Everything here is contained in the `mem_wal` module — it reuses the
+//! existing per-source FTS read paths (`scanner.full_text_search` for
+//! base/flushed Lance datasets, `MemTableScanner` for the active
+//! memtable) and requires no changes to `lance-index`.
+
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field, Schema, SchemaRef, SortOptions};
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+use datafusion::physical_plan::union::UnionExec;
+use lance_core::{Error, Result, is_system_column};
+use lance_index::scalar::FullTextSearchQuery;
+use lance_index::scalar::inverted::query::FtsQuery as IndexFtsQuery;
+use tracing::instrument;
+
+use super::collector::LsmDataSourceCollector;
+use super::data_source::LsmDataSource;
+use super::projection::project_to_canonical;
+use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
+
+/// `_score` column name in FTS results — kept aligned with
+/// `lance_index::scalar::inverted::SCORE_COL` so this module doesn't
+/// require an import for one string constant.
+pub const SCORE_COLUMN: &str = "_score";
+
+/// Plans local-scoring FTS queries over LSM data.
+pub struct LsmFtsSearchPlanner {
+    collector: LsmDataSourceCollector,
+    pk_columns: Vec<String>,
+    base_schema: SchemaRef,
+}
+
+impl LsmFtsSearchPlanner {
+    /// Create a new planner.
+    pub fn new(
+        collector: LsmDataSourceCollector,
+        pk_columns: Vec<String>,
+        base_schema: SchemaRef,
+    ) -> Self {
+        Self {
+            collector,
+            pk_columns,
+            base_schema,
+        }
+    }
+
+    /// Build the FTS execution plan (local scoring).
+    ///
+    /// # Arguments
+    ///
+    /// * `column` — text column to search.
+    /// * `query` — the FTS query (match / phrase / boolean / fuzzy for
+    ///   base/flushed Lance sources; the active memtable currently
+    ///   supports `MatchQuery`).
+    /// * `k` — global top-k to return.
+    /// * `projection` — user columns to project. PK columns are
+    ///   auto-included; `_score` is always appended.
+    ///
+    /// Each source is scored independently (local BM25), normalized to a
+    /// canonical schema, unioned, and merged by `_score` DESC with a
+    /// top-k cap pushed into each partition.
+    #[instrument(
+        name = "lsm_fts_search",
+        level = "info",
+        skip_all,
+        fields(column = %column, k)
+    )]
+    pub async fn plan_search(
+        &self,
+        column: &str,
+        query: FullTextSearchQuery,
+        k: usize,
+        projection: Option<&[String]>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let sources = self.collector.collect()?;
+        let target_schema = self.canonical_fts_schema(projection);
+
+        if sources.is_empty() {
+            return self.empty_plan(&target_schema);
+        }
+
+        let mut per_source_plans: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(sources.len());
+        for source in &sources {
+            let plan = self
+                .build_source_plan(source, column, &query, k, projection)
+                .await?;
+            let normalized = project_to_canonical(plan, &target_schema)?;
+            per_source_plans.push(normalized);
+        }
+
+        // Single source: skip Union and the merge.
+        let merged: Arc<dyn ExecutionPlan> = if per_source_plans.len() == 1 {
+            per_source_plans.into_iter().next().unwrap()
+        } else {
+            #[allow(deprecated)]
+            let union: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(per_source_plans));
+            union
+        };
+
+        let score_idx = merged.schema().index_of(SCORE_COLUMN).map_err(|_| {
+            Error::internal(format!(
+                "{SCORE_COLUMN} missing from canonical FTS schema after merge"
+            ))
+        })?;
+
+        let sort_expr = vec![PhysicalSortExpr {
+            expr: Arc::new(Column::new(SCORE_COLUMN, score_idx)),
+            options: SortOptions {
+                descending: true,
+                nulls_first: false,
+            },
+        }];
+        let lex_ordering = LexOrdering::new(sort_expr).ok_or_else(|| {
+            Error::internal("Failed to build LexOrdering for FTS _score sort".to_string())
+        })?;
+
+        // Per-partition sort with `fetch=k` so each upstream partition
+        // can early-terminate at k; the preserving merge then does a
+        // K-way heap merge also capped at k. Same pattern as
+        // LsmVectorSearchPlanner.
+        let per_partition_sorted: Arc<dyn ExecutionPlan> = Arc::new(
+            SortExec::new(lex_ordering.clone(), merged)
+                .with_preserve_partitioning(true)
+                .with_fetch(Some(k)),
+        );
+        let merged_sorted: Arc<dyn ExecutionPlan> = Arc::new(
+            SortPreservingMergeExec::new(lex_ordering, per_partition_sorted).with_fetch(Some(k)),
+        );
+
+        Ok(merged_sorted)
+    }
+
+    async fn build_source_plan(
+        &self,
+        source: &LsmDataSource,
+        column: &str,
+        query: &FullTextSearchQuery,
+        k: usize,
+        projection: Option<&[String]>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match source {
+            LsmDataSource::BaseTable { dataset } => {
+                let mut scanner = dataset.scan();
+                let cols = self.fts_scanner_projection(projection);
+                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                let bound_query = query
+                    .clone()
+                    .with_column(column.to_string())?
+                    .limit(Some(k as i64));
+                scanner.full_text_search(bound_query)?;
+                scanner.create_plan().await
+            }
+            LsmDataSource::FlushedMemTable { path, .. } => {
+                let dataset = crate::dataset::DatasetBuilder::from_uri(path)
+                    .load()
+                    .await?;
+                let mut scanner = dataset.scan();
+                let cols = self.fts_scanner_projection(projection);
+                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                let bound_query = query
+                    .clone()
+                    .with_column(column.to_string())?
+                    .limit(Some(k as i64));
+                scanner.full_text_search(bound_query)?;
+                scanner.create_plan().await
+            }
+            LsmDataSource::ActiveMemTable {
+                batch_store,
+                index_store,
+                schema,
+                ..
+            } => {
+                let mut scanner =
+                    MemTableScanner::new(batch_store.clone(), index_store.clone(), schema.clone());
+                let cols = self.fts_scanner_projection(projection);
+                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+                // `MemTableScanner::full_text_search` takes a raw match
+                // string; richer query shapes (phrase/boolean/fuzzy) can
+                // be plumbed through once the MemTable scanner accepts a
+                // structured query.
+                let match_str = match &query.query {
+                    IndexFtsQuery::Match(m) => m.terms.clone(),
+                    other => {
+                        return Err(Error::not_supported(format!(
+                            "Active memtable FTS via LsmFtsSearchPlanner currently only \
+                             supports MatchQuery, got: {other:?}"
+                        )));
+                    }
+                };
+                let _ = scanner.full_text_search(column, &match_str);
+                // Active arm doesn't take a top-K hint via the builder
+                // today; the per-partition Sort+fetch above bounds the
+                // emitted rows.
+                let _ = k;
+                scanner.create_plan().await
+            }
+        }
+    }
+
+    /// Columns to pass to the underlying scanner: user projection minus
+    /// system / `_score`, with PK columns appended.
+    fn fts_scanner_projection(&self, user_projection: Option<&[String]>) -> Vec<String> {
+        let mut cols: Vec<String> = if let Some(p) = user_projection {
+            p.iter()
+                .filter(|c| !is_system_column(c) && c.as_str() != SCORE_COLUMN)
+                .cloned()
+                .collect()
+        } else {
+            self.base_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect()
+        };
+        for pk in &self.pk_columns {
+            if !cols.contains(pk) {
+                cols.push(pk.clone());
+            }
+        }
+        cols
+    }
+
+    /// Canonical FTS output: user-projected cols + PK + `_score`.
+    fn canonical_fts_schema(&self, user_projection: Option<&[String]>) -> SchemaRef {
+        let mut ordered: Vec<String> = if let Some(p) = user_projection {
+            p.to_vec()
+        } else {
+            self.base_schema
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect()
+        };
+        for pk in &self.pk_columns {
+            if !ordered.contains(pk) {
+                ordered.push(pk.clone());
+            }
+        }
+        if !ordered.iter().any(|c| c == SCORE_COLUMN) {
+            ordered.push(SCORE_COLUMN.to_string());
+        }
+        let fields: Vec<Arc<Field>> = ordered
+            .iter()
+            .filter_map(|name| {
+                if name == SCORE_COLUMN {
+                    Some(Arc::new(Field::new(SCORE_COLUMN, DataType::Float32, true)))
+                } else if is_system_column(name) {
+                    Some(Arc::new(Field::new(name.clone(), DataType::UInt64, true)))
+                } else {
+                    self.base_schema
+                        .field_with_name(name)
+                        .ok()
+                        .map(|f| Arc::new(f.clone()))
+                }
+            })
+            .collect();
+        Arc::new(Schema::new(fields))
+    }
+
+    fn empty_plan(&self, schema: &SchemaRef) -> Result<Arc<dyn ExecutionPlan>> {
+        use datafusion::physical_plan::empty::EmptyExec;
+        Ok(Arc::new(EmptyExec::new(schema.clone())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
+    use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+    use crate::dataset::{Dataset, WriteParams};
+    use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator, StringArray};
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+    use futures::TryStreamExt;
+    use std::collections::HashMap;
+
+    fn fts_schema() -> Arc<ArrowSchema> {
+        let mut id_meta = HashMap::new();
+        id_meta.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        let id_field = Field::new("id", DataType::Int32, false).with_metadata(id_meta);
+        Arc::new(ArrowSchema::new(vec![
+            id_field,
+            Field::new("text", DataType::Utf8, true),
+        ]))
+    }
+
+    fn make_batch(schema: &ArrowSchema, ids: &[i32], texts: &[&str]) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(ids.to_vec())),
+                Arc::new(StringArray::from(texts.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    async fn write_dataset(uri: &str, batches: Vec<RecordBatch>) -> Dataset {
+        let schema = batches[0].schema();
+        let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+        Dataset::write(reader, uri, Some(WriteParams::default()))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn local_mode_unions_base_and_active_with_consistent_score_schema() {
+        // Regression for the `_score` nullability mismatch between
+        // FtsIndexExec (active arm) and FTS_SCHEMA (base/flushed). The
+        // active-only test below would not catch this — UnionExec rejects
+        // schema-inequality, so we need at least one base + one active
+        // source to exercise that code path.
+        use crate::index::DatasetIndexExt;
+        use lance_index::IndexType;
+        use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+
+        let schema = fts_schema();
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Base Lance dataset with FTS index on the `text` column.
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let mut base_ds = write_dataset(
+            &base_uri,
+            vec![make_batch(
+                &schema,
+                &[1, 2],
+                &["lance rocks", "unrelated text"],
+            )],
+        )
+        .await;
+        base_ds
+            .create_index(
+                &["text"],
+                IndexType::Inverted,
+                Some("text_fts".to_string()),
+                &InvertedIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+        let base_ds = Arc::new(Dataset::open(&base_uri).await.unwrap());
+
+        // Active memtable with its own FTS index, containing a matching row.
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let active_batch = make_batch(
+            &schema,
+            &[3, 4],
+            &["lance memwal goes fast", "completely unrelated"],
+        );
+        batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, 0, Some(0))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+
+        let collector = LsmDataSourceCollector::new(base_ds, vec![]).with_in_memory_memtables(
+            uuid::Uuid::new_v4(),
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store: indexes,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
+            },
+        );
+
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+        let plan = planner
+            .plan_search(
+                "text",
+                FullTextSearchQuery::new("lance".to_string()),
+                10,
+                None,
+            )
+            .await
+            .expect("planner should produce a base+active union plan");
+
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        // Both base id=1 ("lance rocks") and active id=3 ("lance memwal ...")
+        // should match. id=2 / id=4 do not contain "lance".
+        assert!(
+            total >= 2,
+            "expected at least the 2 'lance' rows from base+active, got {total}"
+        );
+
+        // Both sources must agree on _score nullability — verifies the fix.
+        let out = batches[0].schema();
+        let score_field = out
+            .field_with_name(SCORE_COLUMN)
+            .expect("_score column missing from output");
+        assert!(
+            score_field.is_nullable(),
+            "_score must be nullable to stay union-compatible across base+active"
+        );
+
+        // Sanity: ids contain at least one base hit (id=1) and one active hit (id=3).
+        let mut ids: Vec<i32> = Vec::new();
+        for b in &batches {
+            let col = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                ids.push(col.value(i));
+            }
+        }
+        assert!(ids.contains(&1), "missing base hit id=1; got ids={ids:?}");
+        assert!(ids.contains(&3), "missing active hit id=3; got ids={ids:?}");
+    }
+
+    #[tokio::test]
+    async fn local_mode_active_memtable_only_returns_score_sorted_hits() {
+        let schema = fts_schema();
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        // text column has field_id 1 in fts_schema()
+        indexes.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let batch = make_batch(
+            &schema,
+            &[1, 2, 3, 4],
+            &[
+                "lance is a columnar data format",
+                "memwal handles streaming writes",
+                "lance memwal lance lance",
+                "completely unrelated",
+            ],
+        );
+        batch_store.append(batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&batch, 0, Some(0))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                uuid::Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store: indexes,
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            );
+
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+        let plan = planner
+            .plan_search(
+                "text",
+                FullTextSearchQuery::new("lance".to_string()),
+                10,
+                None,
+            )
+            .await
+            .expect("local mode planner should produce a plan");
+
+        // Plan executes and emits _score-sorted rows.
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert!(
+            total >= 2,
+            "expected at least the 2 'lance' rows, got {total}"
+        );
+
+        // Schema must include _score and the PK id.
+        let out = batches[0].schema();
+        assert!(out.field_with_name(SCORE_COLUMN).is_ok());
+        assert!(out.field_with_name("id").is_ok());
+
+        // _score must be non-ascending across the result.
+        let mut prev_score: Option<f32> = None;
+        for batch in &batches {
+            let score = batch
+                .column_by_name(SCORE_COLUMN)
+                .unwrap()
+                .as_any()
+                .downcast_ref::<arrow_array::Float32Array>()
+                .unwrap();
+            for i in 0..batch.num_rows() {
+                let s = score.value(i);
+                if let Some(p) = prev_score {
+                    assert!(p >= s, "scores not sorted DESC: {p} then {s}");
+                }
+                prev_score = Some(s);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds local-scoring full-text search to the LSM scanner via `LsmScanner::full_text_search(column, query, k)`. Each LSM source — base table, flushed generations, and the active memtable — is scored independently with its own BM25 corpus stats, then the per-source results are unioned and merged by a top-k sort. Contained entirely within the `mem_wal` module, with no changes to `lance-index`.

Split out of #6910 per @jackye1995's review (https://github.com/lance-format/lance/pull/6910#issuecomment-4527573215): land the local mode first with minimal lance-index impact; the global-rescore mode stays as a follow-up.

## Changes

- `scanner/fts_search.rs` — `LsmFtsSearchPlanner`: per-source FTS plans → union → per-partition top-k sort → sort-preserving merge.
- `scanner/builder.rs` — `LsmScanner::full_text_search(column, query, k)`.
- `memtable/scanner/exec/fts.rs` — nullable `_score` so the active-memtable arm unions with base/flushed sources.
- `benches/mem_wal/fts/` — read benchmark + storage sweep (latency + local-vs-merged Jaccard accuracy across flushed-generation counts).