### PR TITLE
fix: increase nprobes in test_query_delta_indices for deterministic recall

### DIFF
--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -979,6 +979,7 @@ mod tests {
             .unwrap()
             .nearest("vector", array.value(0).as_primitive::<Float32Type>(), 2)
             .unwrap()
+            .nprobes(2)
             .refine(1)
             .try_into_batch()
             .await


### PR DESCRIPTION
## Summary

Increase `nprobes` from the default (1) to 2 in `test_query_delta_indices` to fix a non-deterministic test failure.

## Problem

The test creates an IVF index with 2 partitions but uses the default `nprobes=1`, which only probes 1 partition per segment. After `optimize_indices`, the index has 2 delta segments. With `nprobes=1`, the search may miss the partition containing ID 0 in the first segment, causing the assertion `id_arr == [0, 1000]` to fail non-deterministically (e.g., returning `[889, 1000]` instead).

This flaky failure was observed during development of PR #6890, where CI runs would intermittently fail on this test.

## Fix

Setting `nprobes=2` ensures all partitions are probed in every segment, making the vector search exhaustive and the test deterministic.

## Test Plan

The fix is itself a test fix. The test `test_query_delta_indices` should no longer fail intermittently on CI.