### PR TITLE
feat: add ICU FTS tokenizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,6 +3864,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3871,10 +3886,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -3924,12 +3946,35 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -5013,6 +5058,7 @@ dependencies = [
 name = "lance-tokenizer"
 version = "7.1.0-beta.3"
 dependencies = [
+ "icu_segmenter",
  "jieba-rs",
  "lindera",
  "rust-stemmers",
@@ -6522,6 +6568,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -8640,6 +8688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -10238,6 +10287,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -10246,6 +10296,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ geo-types = "0.7.16"
 http = "1.1.0"
 humantime = "2.2.0"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }
+icu_segmenter = { version = "2.2", default-features = false, features = ["compiled_data"] }
 io-uring = "0.7"
 itertools = "0.13"
 jieba-rs = { version = "0.9.0", default-features = false }

--- a/RUST_THIRD_PARTY_LICENSES.html
+++ b/RUST_THIRD_PARTY_LICENSES.html
@@ -18370,12 +18370,16 @@ authorization of the copyright holder.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_data 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_segmenter 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_segmenter_data 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.2</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.5</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.3</a></li>

--- a/docs/src/format/index/scalar/fts.md
+++ b/docs/src/format/index/scalar/fts.md
@@ -80,8 +80,20 @@ The full text search index supports multiple tokenizer types for different text 
 | **whitespace** | Splits only on whitespace characters                                      | Preserve punctuation   |
 | **raw**        | No tokenization, treats entire text as single token                       | Exact matching         |
 | **ngram**      | Breaks text into overlapping character sequences                          | Substring/fuzzy search |
+| **icu**        | ICU dictionary-based Unicode word segmentation                            | Mixed-language text    |
 | **jieba/***    | Chinese text tokenizer with word segmentation                             | Chinese text           |
 | **lindera/***  | Japanese text tokenizer with morphological analysis                       | Japanese text          |
+
+#### ICU Tokenizer (Mixed-language text)
+
+The ICU tokenizer uses Unicode word boundary rules and dictionary-based segmentation for complex scripts. It is useful for mixed-language text where the default `simple` tokenizer would keep an unspaced CJK span as one large token.
+
+- **Models**: Uses compiled ICU4X segmenter data bundled with Lance
+- **Usage**: Specify as `icu`
+- **Features**:
+  - Unicode-aware word boundary detection
+  - Dictionary-based segmentation for Chinese, Japanese, Khmer, Lao, Myanmar, and Thai
+  - No external language model download required
 
 #### Jieba Tokenizer (Chinese)
 

--- a/docs/src/guide/tokenizer.md
+++ b/docs/src/guide/tokenizer.md
@@ -1,6 +1,6 @@
 # Tokenizers
 
-Currently, Lance has built-in support for Jieba and Lindera. However, it doesn't come with its own language models.
+Currently, Lance has built-in support for ICU, Jieba, and Lindera. ICU uses built-in segmenter data. Jieba and Lindera require external language models.
 If tokenization is needed, you can download language models by yourself.
 You can specify the location where the language models are stored by setting the environment variable LANCE_LANGUAGE_MODEL_HOME.
 If it's not set, the default value is
@@ -11,6 +11,14 @@ ${system data directory}/lance/language_models
 
 It also supports configuring user dictionaries,
 which makes it convenient for users to expand their own dictionaries without retraining the language models.
+
+## ICU Tokenizer
+
+ICU uses Unicode word boundary rules and bundled dictionary data for complex scripts. It is useful for mixed-language text and does not require downloading a language model.
+
+```python
+ds.create_scalar_index("text", "INVERTED", base_tokenizer="icu")
+```
 
 ## Language Models of Jieba
 

--- a/docs/src/quickstart/full-text-search.md
+++ b/docs/src/quickstart/full-text-search.md
@@ -90,7 +90,7 @@ ds.create_scalar_index(
     index_type="INVERTED",
     name="text_idx",              # Optional index name (if omitted, default is "text_idx")
     with_position=False,          # Set True to enable phrase queries (stores token positions)
-    base_tokenizer="simple",      # Tokenizer: "simple" (whitespace+punct), "whitespace", or "raw" (no tokenization)
+    base_tokenizer="simple",      # Tokenizer: "simple" (whitespace+punct), "icu", "whitespace", or "raw" (no tokenization)
     language="English",           # Language used for stemming + stop words (only used if `stem` or `remove_stop_words` is True)
     max_token_length=40,          # Drop tokens longer than this length
     lower_case=True,              # Lowercase text before tokenization
@@ -109,6 +109,7 @@ ds.create_scalar_index(
 
 Lance also supports multilingual tokenization:
 
+- **icu**: Unicode word segmentation with built-in ICU dictionaries
 - **jieba/default**: Chinese text tokenization using Jieba
 - **lindera/ipadic**: Japanese text tokenization using Lindera with IPAdic dictionary
 - **lindera/ko-dic**: Korean text tokenization using Lindera with Ko-dic dictionary

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -3578,6 +3578,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,10 +3600,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -3638,12 +3660,35 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -4481,6 +4526,7 @@ dependencies = [
 name = "lance-tokenizer"
 version = "7.1.0-beta.3"
 dependencies = [
+ "icu_segmenter",
  "jieba-rs",
  "lindera",
  "rust-stemmers",
@@ -5770,6 +5816,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -7728,6 +7776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -9162,6 +9211,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -9170,6 +9220,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -40,6 +40,7 @@ lance-datagen = { path = "../rust/lance-datagen", optional = true }
 lance-encoding = { path = "../rust/lance-encoding" }
 lance-file = { path = "../rust/lance-file" }
 lance-index = { path = "../rust/lance-index", features = [
+    "tokenizer-icu",
     "tokenizer-lindera",
     "tokenizer-jieba",
 ] }

--- a/python/RUST_THIRD_PARTY_LICENSES.html
+++ b/python/RUST_THIRD_PARTY_LICENSES.html
@@ -15863,12 +15863,16 @@ authorization of the copyright holder.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_data 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_segmenter 2.2.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_segmenter_data 2.2.0</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.2</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.5</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.3</a></li>

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -1665,6 +1665,22 @@ def test_jieba_tokenizer(tmp_path):
     assert results["_rowid"].to_pylist() == [0]
 
 
+def test_icu_tokenizer(tmp_path):
+    data = pa.table(
+        {
+            "text": ["Hello, こんにちは世界!", "Hello, こんにちは!"],
+        }
+    )
+    ds = lance.write_dataset(data, tmp_path, mode="overwrite")
+    ds.create_scalar_index("text", "INVERTED", base_tokenizer="icu")
+    results = ds.to_table(
+        full_text_query="世界",
+        prefilter=True,
+        with_row_id=True,
+    )
+    assert results["_rowid"].to_pylist() == [0]
+
+
 def test_jieba_invalid_user_dict_tokenizer(tmp_path):
     set_language_model_path()
     data = pa.table(

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -91,8 +91,10 @@ geo = ["dep:lance-geo", "lance-geo/geo", "dep:geoarrow-array", "dep:geoarrow-sch
 protoc = ["dep:protobuf-src"]
 jieba-rs = ["tokenizer-jieba"]
 lindera = ["tokenizer-lindera"]
+icu = ["tokenizer-icu"]
 tokenizer-lindera = ["lance-tokenizer/tokenizer-lindera"]
 tokenizer-jieba = ["dep:jieba-rs", "lance-tokenizer/tokenizer-jieba"]
+tokenizer-icu = ["lance-tokenizer/tokenizer-icu"]
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-index/src/scalar/inverted/tokenizer.rs
+++ b/rust/lance-index/src/scalar/inverted/tokenizer.rs
@@ -22,6 +22,8 @@ use crate::pbold;
 use crate::scalar::inverted::tokenizer::document_tokenizer::{
     JsonTokenizer, LanceTokenizer, TextTokenizer,
 };
+#[cfg(feature = "tokenizer-icu")]
+use lance_tokenizer::IcuTokenizer;
 pub use lance_tokenizer::Language;
 use lance_tokenizer::{
     AsciiFoldingFilter, LowerCaser, NgramTokenizer, RawTokenizer, RemoveLongFilter,
@@ -41,6 +43,7 @@ pub struct InvertedIndexParams {
     /// - `simple`: splits tokens on whitespace and punctuation
     /// - `whitespace`: splits tokens on whitespace
     /// - `raw`: no tokenization
+    /// - `icu`: ICU dictionary-based word segmentation
     /// - `lindera/*`: Lindera tokenizer
     /// - `jieba/*`: Jieba tokenizer
     ///
@@ -195,6 +198,7 @@ impl InvertedIndexParams {
     /// - `whitespace`: splits tokens on whitespace
     /// - `raw`: no tokenization
     /// - `ngram`: N-Gram tokenizer
+    /// - `icu`: ICU dictionary-based word segmentation
     /// - `lindera/*`: Lindera tokenizer
     /// - `jieba/*`: Jieba tokenizer
     ///
@@ -385,6 +389,8 @@ impl InvertedIndexParams {
             "simple" => Ok(TextAnalyzer::builder(SimpleTokenizer::default()).dynamic()),
             "whitespace" => Ok(TextAnalyzer::builder(WhitespaceTokenizer::default()).dynamic()),
             "raw" => Ok(TextAnalyzer::builder(RawTokenizer::default()).dynamic()),
+            #[cfg(feature = "tokenizer-icu")]
+            "icu" => Ok(TextAnalyzer::builder(IcuTokenizer::default()).dynamic()),
             "ngram" => {
                 let tokenizer = NgramTokenizer::new(
                     self.min_ngram_length as usize,
@@ -437,6 +443,8 @@ pub fn language_model_home() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::InvertedIndexParams;
+    #[cfg(feature = "tokenizer-icu")]
+    use lance_tokenizer::TokenStream;
 
     #[test]
     fn test_build_only_fields_are_not_serialized() {
@@ -484,5 +492,20 @@ mod tests {
             Some(&serde_json::Value::from(4096))
         );
         assert_eq!(json.get("num_workers"), Some(&serde_json::Value::from(3)));
+    }
+
+    #[cfg(feature = "tokenizer-icu")]
+    #[test]
+    fn test_build_icu_tokenizer() {
+        let mut tokenizer = InvertedIndexParams::default()
+            .base_tokenizer("icu".to_string())
+            .stem(false)
+            .remove_stop_words(false)
+            .build()
+            .unwrap();
+        let mut stream = tokenizer.token_stream_for_doc("Hello, こんにちは世界!");
+        let mut tokens = Vec::new();
+        stream.process(&mut |token| tokens.push(token.text.clone()));
+        assert_eq!(tokens, vec!["hello", "こんにちは", "世界"]);
     }
 }

--- a/rust/lance-tokenizer/Cargo.toml
+++ b/rust/lance-tokenizer/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+icu_segmenter = { workspace = true, optional = true }
 jieba-rs = { workspace = true, optional = true }
 lindera = { workspace = true, optional = true }
 rust-stemmers = "1.2.0"
@@ -21,6 +22,7 @@ unicode-normalization = "0.1.25"
 [features]
 jieba-rs = ["dep:jieba-rs"]
 lindera = ["dep:lindera"]
+tokenizer-icu = ["dep:icu_segmenter"]
 tokenizer-jieba = ["jieba-rs"]
 tokenizer-lindera = ["lindera"]
 

--- a/rust/lance-tokenizer/src/icu.rs
+++ b/rust/lance-tokenizer/src/icu.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use icu_segmenter::{WordSegmenter, WordSegmenterBorrowed, options::WordBreakInvariantOptions};
+
+use crate::{TextAnalyzer, TextAnalyzerBuilder, Token, TokenStream, Tokenizer};
+
+#[derive(Clone)]
+pub struct IcuTokenizer {
+    segmenter: WordSegmenterBorrowed<'static>,
+}
+
+impl Default for IcuTokenizer {
+    fn default() -> Self {
+        Self {
+            segmenter: WordSegmenter::new_dictionary(WordBreakInvariantOptions::default()),
+        }
+    }
+}
+
+impl IcuTokenizer {
+    pub fn analyzer(self) -> TextAnalyzer {
+        TextAnalyzer::builder(self).build()
+    }
+
+    pub fn analyzer_builder(self) -> TextAnalyzerBuilder {
+        TextAnalyzer::builder(self).dynamic()
+    }
+}
+
+pub struct IcuTokenStream {
+    tokens: Vec<Token>,
+    index: usize,
+}
+
+impl TokenStream for IcuTokenStream {
+    fn advance(&mut self) -> bool {
+        if self.index < self.tokens.len() {
+            self.index += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn token(&self) -> &Token {
+        &self.tokens[self.index - 1]
+    }
+
+    fn token_mut(&mut self) -> &mut Token {
+        &mut self.tokens[self.index - 1]
+    }
+}
+
+impl Tokenizer for IcuTokenizer {
+    type TokenStream<'a> = IcuTokenStream;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+        let mut boundaries = self.segmenter.segment_str(text);
+        let mut tokens = Vec::new();
+        let Some(mut offset_from) = boundaries.next() else {
+            return IcuTokenStream { tokens, index: 0 };
+        };
+
+        for offset_to in boundaries {
+            let token_text = &text[offset_from..offset_to];
+            if token_text.chars().any(char::is_alphanumeric) {
+                tokens.push(Token {
+                    offset_from,
+                    offset_to,
+                    position: tokens.len(),
+                    text: token_text.to_owned(),
+                    position_length: 1,
+                });
+            }
+            offset_from = offset_to;
+        }
+
+        IcuTokenStream { tokens, index: 0 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{IcuTokenizer, Token, TokenStream, Tokenizer};
+
+    fn collect_tokens(text: &str) -> Vec<Token> {
+        let mut tokenizer = IcuTokenizer::default();
+        let mut stream = tokenizer.token_stream(text);
+        let mut tokens = Vec::new();
+        stream.process(&mut |token| tokens.push(token.clone()));
+        tokens
+    }
+
+    #[test]
+    fn test_icu_tokenizer_segments_mixed_text() {
+        let tokens = collect_tokens("Hello, こんにちは世界!");
+
+        assert_eq!(
+            tokens
+                .iter()
+                .map(|token| token.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Hello", "こんにちは", "世界"]
+        );
+        assert_eq!(
+            tokens
+                .iter()
+                .map(|token| (token.offset_from, token.offset_to, token.position))
+                .collect::<Vec<_>>(),
+            vec![(0, 5, 0), (7, 22, 1), (22, 28, 2)]
+        );
+    }
+
+    #[test]
+    fn test_icu_tokenizer_skips_non_word_segments() {
+        let tokens = collect_tokens("Mark'd ye his words?");
+
+        assert_eq!(
+            tokens
+                .iter()
+                .map(|token| token.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Mark'd", "ye", "his", "words"]
+        );
+    }
+}

--- a/rust/lance-tokenizer/src/lib.rs
+++ b/rust/lance-tokenizer/src/lib.rs
@@ -4,6 +4,8 @@
 mod alphanum_only;
 mod analyzer;
 mod ascii_folding_filter;
+#[cfg(feature = "tokenizer-icu")]
+mod icu;
 #[cfg(feature = "tokenizer-jieba")]
 mod jieba;
 mod lower_caser;
@@ -22,6 +24,8 @@ mod lindera;
 pub use alphanum_only::AlphaNumOnlyFilter;
 pub use analyzer::{TextAnalyzer, TextAnalyzerBuilder};
 pub use ascii_folding_filter::AsciiFoldingFilter;
+#[cfg(feature = "tokenizer-icu")]
+pub use icu::IcuTokenizer;
 #[cfg(feature = "tokenizer-jieba")]
 pub use jieba::JiebaTokenizer;
 #[cfg(feature = "tokenizer-lindera")]


### PR DESCRIPTION
Adds an optional ICU4X-based FTS tokenizer available as `base_tokenizer="icu"`, with bundled segmenter data so mixed-language text can be indexed without an external language model. The feature is wired through `lance-tokenizer`, `lance-index`, and the Python package, with docs, lockfiles, license metadata, and regression coverage updated accordingly.