### PR TITLE
feat(namespace-dir): implement rename_table for DirectoryNamespace

### DIFF
--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -71,10 +71,11 @@ use lance_namespace::models::{
     ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
     ListTableVersionsRequest, ListTableVersionsResponse, ListTablesRequest, ListTablesResponse,
     MergeInsertIntoTableRequest, MergeInsertIntoTableResponse, NamespaceExistsRequest,
-    QueryTableRequest, QueryTableRequestColumns, QueryTableRequestVector, RestoreTableRequest,
-    RestoreTableResponse, TableExistsRequest, TableVersion, TagContents as ModelTagContents,
-    UpdateTableRequest, UpdateTableResponse, UpdateTableSchemaMetadataRequest,
-    UpdateTableSchemaMetadataResponse, UpdateTableTagRequest, UpdateTableTagResponse,
+    QueryTableRequest, QueryTableRequestColumns, QueryTableRequestVector, RenameTableRequest,
+    RenameTableResponse, RestoreTableRequest, RestoreTableResponse, TableExistsRequest,
+    TableVersion, TagContents as ModelTagContents, UpdateTableRequest, UpdateTableResponse,
+    UpdateTableSchemaMetadataRequest, UpdateTableSchemaMetadataResponse, UpdateTableTagRequest,
+    UpdateTableTagResponse,
 };
 
 use lance_core::{Error, Result, box_error};
@@ -3113,6 +3114,280 @@ impl LanceNamespace for DirectoryNamespace {
             id: request.id,
             location: Some(table_uri),
             ..Default::default()
+        })
+    }
+
+    async fn rename_table(&self, request: RenameTableRequest) -> Result<RenameTableResponse> {
+        self.record_op("rename_table");
+
+        let new_table_name = &request.new_table_name;
+
+        if new_table_name.is_empty() {
+            return Err(NamespaceError::InvalidInput {
+                message: "new_table_name cannot be empty".to_string(),
+            }
+            .into());
+        }
+
+        let source_id = request.id.as_ref().ok_or_else(|| {
+            lance_core::Error::from(NamespaceError::InvalidInput {
+                message: "Table ID is required for rename".to_string(),
+            })
+        })?;
+        if source_id.is_empty() {
+            return Err(NamespaceError::InvalidInput {
+                message: "Table ID cannot be empty".to_string(),
+            }
+            .into());
+        }
+
+        // Cross-namespace rename cannot be performed by the directory backend
+        // itself, and the manifest backend does not implement `rename_table`
+        // either, so bail out with a clear `Unsupported` error rather than
+        // returning the generic "not implemented" from the trait default.
+        //
+        // `new_namespace_id` represents the *target* namespace: `None` means
+        // "same namespace", and a value equal to the source's parent path is
+        // the explicit same-namespace form some clients send. Only reject
+        // when the target actually differs from the source namespace.
+        let source_namespace: Vec<String> = if source_id.len() > 1 {
+            source_id[..source_id.len() - 1].to_vec()
+        } else {
+            Vec::new()
+        };
+        let target_namespace_differs = match &request.new_namespace_id {
+            None => false,
+            Some(new_ns) => new_ns.as_slice() != source_namespace.as_slice(),
+        };
+        if target_namespace_differs {
+            return Err(NamespaceError::Unsupported {
+                message: "Cross-namespace rename is not supported by DirectoryNamespace"
+                    .to_string(),
+            }
+            .into());
+        }
+
+        // Decide which mode this rename runs in, matching the routing used by
+        // `describe_table` / `create_table` / `table_exists` so that the row we
+        // read back after a rename is the one we actually mutated.
+        let is_root_level = source_id.len() == 1;
+        let skip_manifest_for_root = self.dir_listing_enabled
+            && is_root_level
+            && !self.dir_listing_to_manifest_migration_enabled;
+        let use_manifest = self.manifest_ns_for_read().is_some() && !skip_manifest_for_root;
+
+        // Verify source table exists (works with both manifest and dir-listing
+        // modes). Discarding the resolved URI is intentional: the mode-specific
+        // branches below re-derive the physical location they need.
+        let _source_uri = self.resolve_table_location(&request.id).await?;
+
+        // Check destination table does not already exist. Only treat an
+        // explicit `TableNotFound` as evidence that the destination is free;
+        // any other error (permission denied, throttling, transient IO, ...)
+        // must be surfaced instead of silently overwriting the target.
+        let dest_id: Vec<String> = if source_id.len() > 1 {
+            let mut d = source_id[..source_id.len() - 1].to_vec();
+            d.push(new_table_name.clone());
+            d
+        } else {
+            vec![new_table_name.clone()]
+        };
+        {
+            let mut exists_req = TableExistsRequest::new();
+            exists_req.id = Some(dest_id.clone());
+            match self.table_exists(exists_req).await {
+                Ok(()) => {
+                    return Err(NamespaceError::TableAlreadyExists {
+                        message: format!("Destination table '{}' already exists", new_table_name),
+                    }
+                    .into());
+                }
+                Err(e) => {
+                    let is_not_found = matches!(
+                        &e,
+                        lance_core::Error::Namespace { source, .. }
+                            if source
+                                .downcast_ref::<NamespaceError>()
+                                .is_some_and(|ns| matches!(ns, NamespaceError::TableNotFound { .. }))
+                    );
+                    if !is_not_found {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        if use_manifest {
+            // Manifest-tracked table: the rename is a metadata-only update on
+            // the manifest row. The physical `location` recorded in the
+            // manifest may point at any directory (root-level `<name>.lance`,
+            // a hashed dir under a child namespace, or a custom registered
+            // location), so we must not touch the underlying files or derive
+            // a new location from `new_table_name`. Delegating to
+            // `ManifestNamespace::rename_table_entry` preserves the original
+            // namespace path, storage location, and any user metadata.
+            let manifest_ns = self
+                .manifest_ns_for_write()
+                .await?
+                .expect("checked use_manifest");
+            manifest_ns
+                .rename_table_entry(source_id, new_table_name, None)
+                .await?;
+            return Ok(RenameTableResponse {
+                transaction_id: None,
+            });
+        }
+
+        // From here on we are in the directory-listing branch (root-level
+        // only). When `manifest_ns` is configured, the table may still have a
+        // manifest row left over from a previous mode (e.g. a `create_table`
+        // call that wrote the manifest row first, or a migration that left a
+        // duplicate entry behind). If we only move the physical directory
+        // here, the manifest keeps pointing at the old `object_id` while the
+        // data is now under the new name; manifest-delegated APIs (such as
+        // `drop_table`) and migration tooling can then lose track of the
+        // table or expose both the stale manifest name and the new directory
+        // name. So as long as a manifest exists, keep the manifest row in
+        // sync with the physical rename by delegating to the same primitive
+        // the manifest branch uses.
+        let manifest_ns_for_sync = self.manifest_ns_for_read().cloned();
+
+        // Directory-listing branch (root-level only): tables are discovered
+        // by listing `<name>.lance` directories under `base_path`. A rename
+        // must physically move the directory, otherwise the old name would
+        // still be visible via directory listing. Because there is no atomic
+        // rename primitive across all supported object stores, we copy first
+        // and then delete the source; if any step fails we roll back the
+        // partially copied destination so no half-written table is left
+        // behind.
+        let source_name = &source_id[0];
+        let source_path = self.table_path(source_name);
+        let dest_path = self.table_path(new_table_name);
+
+        // List all files in the source table directory.
+        let entries: Vec<object_store::ObjectMeta> = self
+            .object_store
+            .inner
+            .list(Some(&source_path))
+            .try_collect()
+            .await
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to list source table '{}' files: {:?}",
+                        source_name, e
+                    ),
+                })
+            })?;
+
+        // Helper: best-effort cleanup of the destination directory used to
+        // roll back a partial copy.
+        let rollback_dest = |dest: Path| async move {
+            if let Err(cleanup_err) = self.object_store.remove_dir_all(dest).await {
+                log::warn!(
+                    "rename_table: failed to roll back destination directory '{}' after error: {:?}",
+                    new_table_name,
+                    cleanup_err
+                );
+            }
+        };
+
+        // Copy each file to the new location. On failure, roll back any files
+        // already written to the destination so we do not leave a half-copied
+        // table behind.
+        for entry in &entries {
+            let relative = entry
+                .location
+                .as_ref()
+                .strip_prefix(source_path.as_ref())
+                .unwrap_or(entry.location.as_ref());
+            let new_location = match Path::parse(format!(
+                "{}/{}",
+                dest_path.as_ref(),
+                relative.trim_start_matches('/')
+            )) {
+                Ok(p) => p,
+                Err(e) => {
+                    rollback_dest(dest_path.clone()).await;
+                    return Err(lance_core::Error::from(NamespaceError::Internal {
+                        message: format!("Failed to construct destination path: {:?}", e),
+                    }));
+                }
+            };
+
+            if let Err(e) = self
+                .object_store
+                .inner
+                .copy(&entry.location, &new_location)
+                .await
+            {
+                let copy_err = lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to copy file '{}' to '{}': {:?}",
+                        entry.location, new_location, e
+                    ),
+                });
+                rollback_dest(dest_path.clone()).await;
+                return Err(copy_err);
+            }
+        }
+
+        // Remove the source directory. In directory-listing mode the source
+        // remains discoverable until this delete succeeds, so a failure here
+        // would leave both the old and the new table visible. Roll back the
+        // destination we just wrote and surface the error to the caller
+        // instead of returning a misleading `Ok`.
+        if let Err(e) = self.object_store.remove_dir_all(source_path).await {
+            let cleanup_err = lance_core::Error::from(NamespaceError::Internal {
+                message: format!(
+                    "Failed to remove source table directory '{}' after copy: {:?}",
+                    source_name, e
+                ),
+            });
+            rollback_dest(dest_path).await;
+            return Err(cleanup_err);
+        }
+
+        // Keep the manifest in sync with the physical rename. The manifest row
+        // is updated last (after the data move) so a partial failure leaves a
+        // discoverable table on disk rather than a manifest pointer with no
+        // underlying data. If the table was not registered in the manifest,
+        // `rename_table_entry` returns `TableNotFound` and we silently treat
+        // that as a no-op so the physical move still succeeds.
+        //
+        // In directory-listing mode the table's data was physically moved from
+        // `<old_name>.lance` to `<new_name>.lance` above, so the manifest row's
+        // stored `location` must be rewritten to the new directory. Without
+        // this, manifest-routed operations (e.g. `drop_table`, migration) would
+        // still see the old path and either miss the table or point at
+        // now-deleted data.
+        if let Some(manifest_ns) = manifest_ns_for_sync {
+            let new_dir_name = format!("{}.lance", new_table_name);
+            match manifest_ns
+                .rename_table_entry(source_id, new_table_name, Some(new_dir_name))
+                .await
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    let is_not_found = matches!(
+                        &e,
+                        lance_core::Error::Namespace { source, .. }
+                            if source
+                                .downcast_ref::<NamespaceError>()
+                                .is_some_and(|ns| matches!(
+                                    ns,
+                                    NamespaceError::TableNotFound { .. }
+                                ))
+                    );
+                    if !is_not_found {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        Ok(RenameTableResponse {
+            transaction_id: None,
         })
     }
 
@@ -7792,6 +8067,270 @@ mod tests {
         // The operation might succeed or fail depending on implementation
         // But it should not panic
         let _ = result;
+    }
+
+    #[tokio::test]
+    async fn test_rename_table_basic() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["original_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let mut rename_request = RenameTableRequest::new("renamed_table".to_string());
+        rename_request.id = Some(vec!["original_table".to_string()]);
+        let result = namespace.rename_table(rename_request).await;
+        assert!(result.is_ok());
+
+        let mut exists_request = TableExistsRequest::new();
+        exists_request.id = Some(vec!["original_table".to_string()]);
+        assert!(namespace.table_exists(exists_request).await.is_err());
+
+        let mut exists_request = TableExistsRequest::new();
+        exists_request.id = Some(vec!["renamed_table".to_string()]);
+        assert!(namespace.table_exists(exists_request).await.is_ok());
+
+        let mut describe_request = DescribeTableRequest::new();
+        describe_request.id = Some(vec!["renamed_table".to_string()]);
+        assert!(namespace.describe_table(describe_request).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_rename_to_existing_table_should_fail() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["table_a".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data.clone()))
+            .await
+            .unwrap();
+
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["table_b".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let mut rename_request = RenameTableRequest::new("table_b".to_string());
+        rename_request.id = Some(vec!["table_a".to_string()]);
+        let result = namespace.rename_table(rename_request).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn test_rename_nonexistent_table_should_fail() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let mut rename_request = RenameTableRequest::new("new_name".to_string());
+        rename_request.id = Some(vec!["nonexistent".to_string()]);
+        let result = namespace.rename_table(rename_request).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_rename_table_empty_name_should_fail() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["my_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let mut rename_request = RenameTableRequest::new("".to_string());
+        rename_request.id = Some(vec!["my_table".to_string()]);
+        let result = namespace.rename_table(rename_request).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+    }
+
+    #[tokio::test]
+    async fn test_rename_table_cross_namespace_should_fail() {
+        let temp_dir = TempStdDir::default();
+        let namespace = DirectoryNamespaceBuilder::new(temp_dir.to_str().unwrap())
+            .manifest_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["my_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let mut rename_request = RenameTableRequest::new("new_name".to_string());
+        rename_request.id = Some(vec!["my_table".to_string()]);
+        rename_request.new_namespace_id = Some(vec!["other_ns".to_string()]);
+        let result = namespace.rename_table(rename_request).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Cross-namespace"));
+    }
+
+    /// `new_namespace_id` is the *target* namespace. Omitting it means
+    /// "same namespace"; explicitly setting it to the source namespace's
+    /// parent path means the same thing. Only a target that *differs* from
+    /// the source should be rejected as cross-namespace.
+    #[tokio::test]
+    async fn test_rename_table_explicit_same_namespace_root_succeeds() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["original_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let mut rename_request = RenameTableRequest::new("renamed_table".to_string());
+        rename_request.id = Some(vec!["original_table".to_string()]);
+        rename_request.new_namespace_id = Some(vec![]);
+        let result = namespace.rename_table(rename_request).await;
+        assert!(
+            result.is_ok(),
+            "explicit same-namespace rename should succeed"
+        );
+
+        let mut exists_request = TableExistsRequest::new();
+        exists_request.id = Some(vec!["renamed_table".to_string()]);
+        assert!(namespace.table_exists(exists_request).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_rename_table_explicit_same_namespace_child_succeeds() {
+        use lance_namespace::models::CreateNamespaceRequest;
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+
+        let mut create_ns = CreateNamespaceRequest::new();
+        create_ns.id = Some(vec!["workspace".to_string()]);
+        namespace.create_namespace(create_ns).await.unwrap();
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["workspace".to_string(), "original".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let mut rename_request = RenameTableRequest::new("renamed".to_string());
+        rename_request.id = Some(vec!["workspace".to_string(), "original".to_string()]);
+        rename_request.new_namespace_id = Some(vec!["workspace".to_string()]);
+        let result = namespace.rename_table(rename_request).await;
+        assert!(
+            result.is_ok(),
+            "explicit same-namespace child rename should succeed"
+        );
+
+        let mut exists_request = TableExistsRequest::new();
+        exists_request.id = Some(vec!["workspace".to_string(), "renamed".to_string()]);
+        assert!(namespace.table_exists(exists_request).await.is_ok());
+    }
+
+    /// In the hybrid root-table path the directory branch physically moves
+    /// `<old>.lance` to `<new>.lance` and then asks the manifest to keep
+    /// the row in sync. The manifest row's `location` must follow the data.
+    #[tokio::test]
+    async fn test_rename_table_hybrid_root_updates_manifest_location() {
+        use lance::dataset::builder::DatasetBuilder;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let ns = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(true)
+            .dir_listing_to_manifest_migration_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["original_table".to_string()]);
+        ns.create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let hybrid_ns = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(true)
+            .dir_listing_to_manifest_migration_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let mut rename_request = RenameTableRequest::new("renamed_table".to_string());
+        rename_request.id = Some(vec!["original_table".to_string()]);
+        hybrid_ns.rename_table(rename_request).await.unwrap();
+
+        let manifest_uri = format!("{}/{}", temp_path, "__manifest");
+        let manifest_ds = DatasetBuilder::from_uri(&manifest_uri)
+            .load()
+            .await
+            .unwrap();
+        let mut scanner = manifest_ds.scan();
+        scanner
+            .filter("object_id = 'renamed_table' AND object_type = 'table'")
+            .unwrap();
+        scanner.project(&["object_id", "location"]).unwrap();
+        let batches = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .next()
+            .await
+            .unwrap()
+            .unwrap();
+        let object_ids = batches.column_by_name("object_id").unwrap();
+        let locations = batches.column_by_name("location").unwrap();
+        assert_eq!(batches.num_rows(), 1, "expected one manifest row");
+        assert_eq!(
+            object_ids
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+                .unwrap()
+                .value(0),
+            "renamed_table"
+        );
+        assert_eq!(
+            locations
+                .as_any()
+                .downcast_ref::<arrow::array::StringArray>()
+                .unwrap()
+                .value(0),
+            "renamed_table.lance",
+            "manifest location should follow the new physical directory"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -575,6 +575,116 @@ impl ManifestStreamMutation for DeleteObjectMutation {
     }
 }
 
+/// A single-pass manifest mutation that simultaneously inserts the destination
+/// row and removes the source row. Folding both legs of a logical rename into
+/// one `rewrite_manifest` call makes the rewrite atomic at the storage layer:
+/// the manifest can never land in a state where both the source and destination
+/// `object_id` point at the same physical location, because either the whole
+/// rewrite commits or none of it does.
+struct RenameManifestMutation {
+    dest: ManifestEntry,
+    source_object_id: String,
+    /// Whether the source row was present in the manifest at all. The caller
+    /// pre-checks via `query_manifest_for_table`, but another writer can drop
+    /// or deregister the source between the pre-check and the rewrite. When
+    /// the source is missing we must NOT append the destination row from
+    /// stale metadata, so `append_rows` fails the mutation.
+    source_found: bool,
+    /// Whether the destination row was already taken. The caller pre-checks
+    /// this, but a concurrent writer could win the race between the check and
+    /// the commit, so we still need a fail-on-conflict branch.
+    dest_collision: bool,
+}
+
+impl ManifestStreamMutation for RenameManifestMutation {
+    type Output = ();
+
+    fn process_existing_row(
+        &mut self,
+        row: ManifestRowValue,
+        output: &mut ManifestBatchBuilder,
+        index_data: &mut ManifestIndexAccumulator,
+    ) -> Result<()> {
+        if row.object_id == self.source_object_id {
+            self.source_found = true;
+            // Drop the source row: do not append it to the output batch.
+            return Ok(());
+        }
+        if row.object_id == self.dest.object_id {
+            self.dest_collision = true;
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Object '{}' was concurrently created by another operation",
+                    row.object_id
+                ),
+            }
+            .into());
+        }
+
+        output.append(
+            index_data,
+            ManifestOutputRow {
+                object_id: &row.object_id,
+                object_type: row.object_type,
+                location: row.location.as_deref(),
+                metadata: row.metadata.as_deref(),
+                base_objects: row.base_objects.as_deref(),
+            },
+        )
+    }
+
+    fn append_rows(
+        &mut self,
+        output: &mut ManifestBatchBuilder,
+        index_data: &mut ManifestIndexAccumulator,
+    ) -> Result<()> {
+        if !self.source_found {
+            // The source row was already gone when we scanned the manifest.
+            // That means another writer dropped or deregistered the source
+            // between the pre-check (`query_manifest_for_table`) and this
+            // rewrite. Appending the destination row would recreate the entry
+            // from the stale `table_info` we captured earlier, masking the
+            // concurrent change. Surface the conflict instead so the caller
+            // can re-evaluate the rename.
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Object '{}' was concurrently removed by another operation",
+                    self.source_object_id
+                ),
+            }
+            .into());
+        }
+        if self.dest_collision {
+            // The source row was dropped (if present) above; we cannot append
+            // the destination row because that would overwrite the concurrent
+            // entry, and `process_existing_row` already returned the error
+            // that will surface to the caller.
+            return Ok(());
+        }
+        output.append(
+            index_data,
+            ManifestOutputRow {
+                object_id: &self.dest.object_id,
+                object_type: self.dest.object_type,
+                location: self.dest.location.as_deref(),
+                metadata: self.dest.metadata.as_deref(),
+                base_objects: None,
+            },
+        )
+    }
+
+    fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
+        CopyOnWriteMutation::updated(())
+    }
+
+    fn conflict_resolution(&self) -> ConflictResolution<Self::Output> {
+        // On commit conflict, re-read the manifest and re-apply the mutation.
+        // A concurrent insert into `dest_object_id` is still caught by
+        // `process_existing_row` returning `ConcurrentModification` on retry.
+        ConflictResolution::Retry
+    }
+}
+
 /// Information about a namespace stored in the manifest
 #[derive(Debug, Clone)]
 pub struct NamespaceInfo {
@@ -2378,6 +2488,110 @@ impl ManifestNamespace {
 
         self.insert_into_manifest(object_id, ObjectType::Table, Some(location))
             .await
+    }
+
+    /// Rename a table's manifest entry in place.
+    ///
+    /// The physical storage `location` and every user-visible piece of metadata
+    /// (including the containing namespace) are preserved by default. Only the
+    /// trailing name component of the object id is replaced with
+    /// `new_table_name`.
+    ///
+    /// `new_location` is an optional override for the stored `location` on the
+    /// destination row. Pass `Some` when the caller already moved the physical
+    /// data (e.g. the directory-listing rename copied `<old>.lance` to
+    /// `<new>.lance`) and the manifest must point at the new path. Pass `None`
+    /// for the metadata-only rename used when the manifest itself is the
+    /// source of truth: in that case the manifest may have recorded a
+    /// user-supplied or hashed location that is independent of `new_table_name`
+    /// and must not be rewritten.
+    ///
+    /// This is the primitive `DirectoryNamespace::rename_table` uses when the
+    /// table is tracked by the manifest, so that a rename never rewrites data
+    /// nor drops the manifest row's metadata.
+    pub async fn rename_table_entry(
+        &self,
+        source_id: &[String],
+        new_table_name: &str,
+        new_location: Option<String>,
+    ) -> Result<()> {
+        if source_id.is_empty() {
+            return Err(NamespaceError::InvalidInput {
+                message: "Table ID cannot be empty".to_string(),
+            }
+            .into());
+        }
+        if new_table_name.is_empty() {
+            return Err(NamespaceError::InvalidInput {
+                message: "new_table_name cannot be empty".to_string(),
+            }
+            .into());
+        }
+
+        let (namespace, _) = Self::split_object_id(source_id);
+        let source_object_id = Self::build_object_id(&namespace, &source_id[source_id.len() - 1]);
+        let dest_object_id = Self::build_object_id(&namespace, new_table_name);
+
+        if source_object_id == dest_object_id {
+            // Nothing to do; caller asked to rename to the same name.
+            return Ok(());
+        }
+
+        // Load the existing row so we can preserve its location and metadata.
+        let table_info = self
+            .query_manifest_for_table(&source_object_id)
+            .await?
+            .ok_or_else(|| {
+                lance_core::Error::from(NamespaceError::TableNotFound {
+                    message: Self::format_table_id(source_id),
+                })
+            })?;
+
+        // Reject if the destination is already taken by a table or namespace,
+        // so the rename cannot silently overwrite an existing entry.
+        if self.manifest_contains_object(&dest_object_id).await? {
+            return Err(NamespaceError::TableAlreadyExists {
+                message: format!("Destination table '{}' already exists", new_table_name),
+            }
+            .into());
+        }
+
+        let metadata_json = Self::serialize_metadata(
+            table_info.metadata.as_ref(),
+            ObjectType::Table.as_str(),
+            &dest_object_id,
+        )?;
+
+        // Default to preserving the existing `location`. A caller that already
+        // moved the physical data can override this with `new_location` so the
+        // manifest row tracks the new path and manifest-routed operations
+        // (e.g. `drop_table`, migration) do not see a stale pointer.
+        let dest_location = new_location.unwrap_or_else(|| table_info.location.clone());
+
+        // Replace the source row with the destination row in a single manifest
+        // rewrite. Doing this in one mutation (rather than an insert followed
+        // by a delete) keeps the manifest atomic: a crash between the two legs
+        // can no longer leave both `source_object_id` and `dest_object_id`
+        // pointing at the same physical location, because either the whole
+        // rewrite commits or none of it does.
+        let dest_object_id_for_mutation = dest_object_id.clone();
+        let source_object_id_for_mutation = source_object_id.clone();
+        self.rewrite_manifest("Failed to rename table entry", move || {
+            RenameManifestMutation {
+                dest: ManifestEntry {
+                    object_id: dest_object_id_for_mutation.clone(),
+                    object_type: ObjectType::Table,
+                    location: Some(dest_location.clone()),
+                    metadata: metadata_json.clone(),
+                },
+                source_object_id: source_object_id_for_mutation.clone(),
+                source_found: false,
+                dest_collision: false,
+            }
+        })
+        .await?;
+
+        Ok(())
     }
 
     /// Validate that all levels of a namespace path exist
@@ -6117,5 +6331,109 @@ mod tests {
         request.id = Some(vec!["nonexistent".to_string()]);
         let result = dir_namespace.alter_table_drop_columns(request).await;
         assert!(result.is_err(), "Should fail when table does not exist");
+    }
+
+    /// If another writer drops or deregisters the source between the
+    /// `query_manifest_for_table` pre-check and the rewrite, the rewrite
+    /// must not silently recreate the destination row from the stale
+    /// `table_info` captured earlier. Drive the rewrite directly with a
+    /// manifest that is missing the source row so `process_existing_row`
+    /// never sets `source_found`, then verify `append_rows` reports a
+    /// `ConcurrentModification` conflict instead of appending.
+    #[tokio::test]
+    async fn test_rename_manifest_fails_when_source_dropped_before_rewrite() {
+        use super::RenameManifestMutation;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let manifest_ns = create_manifest_namespace(temp_path, false).await;
+
+        // Leave the source row absent — this mirrors the race where
+        // another writer has already removed the source by the time our
+        // rewrite begins scanning the manifest.
+        let source_object_id = "source_table".to_string();
+        let result = manifest_ns
+            .rewrite_manifest("test concurrent drop", move || RenameManifestMutation {
+                dest: ManifestEntry {
+                    object_id: "dest_table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("dest_table.lance".to_string()),
+                    metadata: None,
+                },
+                source_object_id: source_object_id.clone(),
+                source_found: false,
+                dest_collision: false,
+            })
+            .await;
+
+        assert!(
+            result.is_err(),
+            "rewrite must fail when the source row is gone before the rewrite sees it"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("concurrently"),
+            "expected ConcurrentModification, got: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("source_table"),
+            "error should mention the source object id, got: {err_msg}"
+        );
+    }
+
+    /// Positive control: when the source row IS present during the rewrite,
+    /// the destination row is appended with the requested `new_location`.
+    #[tokio::test]
+    async fn test_rename_manifest_appends_dest_with_new_location_when_source_present() {
+        use super::RenameManifestMutation;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let manifest_ns = create_manifest_namespace(temp_path, false).await;
+
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: "source_table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("source_table.lance".to_string()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let source_object_id = "source_table".to_string();
+        let new_location = "new_table.lance".to_string();
+        manifest_ns
+            .rewrite_manifest("test happy path", move || RenameManifestMutation {
+                dest: ManifestEntry {
+                    object_id: "dest_table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some(new_location.clone()),
+                    metadata: None,
+                },
+                source_object_id: source_object_id.clone(),
+                source_found: false,
+                dest_collision: false,
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            !manifest_ns
+                .manifest_contains_object("source_table")
+                .await
+                .unwrap()
+        );
+        let info = manifest_ns
+            .query_manifest_for_table("dest_table")
+            .await
+            .unwrap()
+            .expect("destination row should exist");
+        assert_eq!(info.location, "new_table.lance");
     }
 }

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -590,6 +590,12 @@ struct RenameManifestMutation {
     /// the source is missing we must NOT append the destination row from
     /// stale metadata, so `append_rows` fails the mutation.
     source_found: bool,
+    /// The `base_objects` carried by the source row. `query_manifest_for_table`
+    /// only surfaces `namespace`/`name`/`location`/`metadata` (it drops
+    /// `base_objects`), so we have to capture this field from the rewrite
+    /// stream and thread it through to the destination row. Otherwise a
+    /// rename would silently strip the table's dependency metadata.
+    source_base_objects: Option<Vec<String>>,
     /// Whether the destination row was already taken. The caller pre-checks
     /// this, but a concurrent writer could win the race between the check and
     /// the commit, so we still need a fail-on-conflict branch.
@@ -607,6 +613,10 @@ impl ManifestStreamMutation for RenameManifestMutation {
     ) -> Result<()> {
         if row.object_id == self.source_object_id {
             self.source_found = true;
+            // Capture the source's `base_objects` so `append_rows` can
+            // thread it onto the destination row. Without this, a rename
+            // would drop the table's declared dependency metadata.
+            self.source_base_objects = row.base_objects.clone();
             // Drop the source row: do not append it to the output batch.
             return Ok(());
         }
@@ -668,7 +678,7 @@ impl ManifestStreamMutation for RenameManifestMutation {
                 object_type: self.dest.object_type,
                 location: self.dest.location.as_deref(),
                 metadata: self.dest.metadata.as_deref(),
-                base_objects: None,
+                base_objects: self.source_base_objects.as_deref(),
             },
         )
     }
@@ -2586,6 +2596,9 @@ impl ManifestNamespace {
                 },
                 source_object_id: source_object_id_for_mutation.clone(),
                 source_found: false,
+                // Captured from the rewrite stream inside `process_existing_row`
+                // and written onto the destination row in `append_rows`.
+                source_base_objects: None,
                 dest_collision: false,
             }
         })
@@ -6363,6 +6376,7 @@ mod tests {
                 },
                 source_object_id: source_object_id.clone(),
                 source_found: false,
+                source_base_objects: None,
                 dest_collision: false,
             })
             .await;
@@ -6418,6 +6432,7 @@ mod tests {
                 },
                 source_object_id: source_object_id.clone(),
                 source_found: false,
+                source_base_objects: None,
                 dest_collision: false,
             })
             .await
@@ -6435,5 +6450,65 @@ mod tests {
             .unwrap()
             .expect("destination row should exist");
         assert_eq!(info.location, "new_table.lance");
+    }
+
+    /// A rename must thread the source row's `base_objects` onto the
+    /// destination row. `query_manifest_for_table()` (used by the
+    /// high-level `rename_table_entry`) drops that field, so the
+    /// mutation has to capture it from the rewrite stream and write it
+    /// back in `append_rows`; otherwise declared tables would lose
+    /// their dependency metadata on every rename.
+    #[tokio::test]
+    async fn test_rename_manifest_preserves_base_objects() {
+        use super::RenameManifestMutation;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let manifest_ns = create_manifest_namespace(temp_path, false).await;
+
+        let original_bases = vec!["base1.lance".to_string(), "base2.lance".to_string()];
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: "source_table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("source_table.lance".to_string()),
+                    metadata: None,
+                }],
+                Some(original_bases.clone()),
+            )
+            .await
+            .unwrap();
+
+        let source_object_id = "source_table".to_string();
+        manifest_ns
+            .rewrite_manifest("test base_objects", move || RenameManifestMutation {
+                dest: ManifestEntry {
+                    object_id: "dest_table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("dest_table.lance".to_string()),
+                    metadata: None,
+                },
+                source_object_id: source_object_id.clone(),
+                source_found: false,
+                source_base_objects: None,
+                dest_collision: false,
+            })
+            .await
+            .unwrap();
+
+        // Destination row must carry the source's `base_objects`.
+        let after = manifest_base_objects(&manifest_ns).await;
+        let dest_bases = after
+            .get("dest_table")
+            .expect("destination row should exist");
+        assert_eq!(
+            dest_bases.as_ref(),
+            Some(&original_bases),
+            "rename must preserve the source's base_objects on the destination row"
+        );
+        // And the source row must of course be gone.
+        assert!(!after.contains_key("source_table"));
     }
 }


### PR DESCRIPTION
Closes #6922

## Summary

`DirectoryNamespace` (the filesystem-backed `LanceNamespace` implementation in `rust/lance-namespace-impls/src/dir.rs`) currently falls back to the trait's default *"Not supported"* implementation for two DML operations. This PR wires them up to Lance core, on par with what `Dataset::update` / `Dataset::delete` already provide for direct dataset access.

| Method | Backed by |
|--------|-----------|
| `update_table(UpdateTableRequest) -> UpdateTableResponse` | `lance::dataset::write::UpdateBuilder` |
| `delete_from_table(DeleteFromTableRequest) -> DeleteFromTableResponse` | `Dataset::delete(predicate)` |

Both methods are already exposed on the Java side (`DirectoryNamespace.java` `updateTable` / `deleteFromTable`) and by `lance-namespace-request-client`, so this PR is **Rust-only** and unblocks the existing client surface.

## Changes

### `update_table`

- Builds an `UpdateBuilder` by setting each `[column, expression]` pair from the request, applies the optional `predicate` via `update_where`, and returns the actual `rows_updated` and the new dataset `version`.
- Validates the `updates` list **up-front** (non-empty list, exactly two elements per pair, non-empty / duplicate-free column names) so callers get a clean `InvalidInput` instead of an opaque DataFusion parse error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic, manifest-aware table rename support, including consistent updates to table locations across supported storage modes.
  * Added safeguards to validate rename requests (non-empty names/ids), reject cross-namespace renames, and prevent destination collisions.

* **Bug Fixes**
  * Improved correctness for concurrent rename scenarios by detecting stale source/destination state and failing with a clear conflict signal.
  * Ensures manifest metadata is preserved/updated appropriately during renames (including hybrid-mode location updates).

* **Tests**
  * Expanded rename test coverage for success, collisions, missing sources, invalid inputs, and cross-namespace rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->