### PR TITLE
ci: replace publish-crates action with native cargo publish

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -11,11 +11,6 @@ on:
         description: "Tag to publish (e.g., v1.0.0)"
         required: true
         type: string
-      skip_check_repo:
-        description: "Skip checking if packages have been modified (useful for backfilling missed releases)"
-        required: false
-        type: boolean
-        default: false
 
 env:
   # This env var is used by Swatinem/rust-cache@v2 for the cache
@@ -90,14 +85,19 @@ jobs:
       # Wait until https://github.com/rust-lang/crates-io-auth-action/issues/51 fixed
       # - uses: rust-lang/crates-io-auth-action@v1
       #   id: auth
-      - uses: albertlockett/publish-crates@85f0989f1298bc3889830b5fc28122c7586efeec # v2.2
+      # lance-arrow-stats and lance-arrow-scalar are versioned with Arrow
+      # (currently 58.0.0) and released on Arrow's cadence, not Lance's, so
+      # they are excluded from the per-release publish. Bump and publish them
+      # explicitly when their source changes.
+      - name: Publish crates
         if: steps.check_version.outputs.skip != 'true'
-        with:
-          # registry-token: ${{ steps.auth.outputs.token }}
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          args: "--all-features"
-          path: .
-          check-repo: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_check_repo != true }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --workspace \
+            --exclude lance-arrow-stats \
+            --exclude lance-arrow-scalar \
+            --all-features
   report-failure:
     name: Report Workflow Failure
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switch the release publish step from `albertlockett/publish-crates` to `cargo publish --workspace`, which was stabilized in Rust 1.90 and supports `--exclude` natively.

Exclude `lance-arrow-stats` and `lance-arrow-scalar` from the per-release publish since they are versioned to track Arrow's major (currently 58.0.0) and released on Arrow's cadence, not Lance's. The previous action aborted the entire run whenever either crate's source changed without a version bump, which is what blocked the v7.0.0 Rust publish (#6732 removed a stale `half` dep from `arrow-stats` after `58.0.0` was published).

The `skip_check_repo` workflow_dispatch input is removed since it only configured the previous action.

Followup: bump `lance-arrow-stats` to `58.0.1` so its crates.io source matches the workspace tree again, then drop the corresponding `--exclude` from this workflow.

Fixes #6971

## Test plan
- [ ] Dispatch `cargo-publish.yml` with `tag: v7.0.0` once this lands; verify all non-excluded workspace crates publish to crates.io