### PR TITLE
feat: support update by _row_id for python and java

### DIFF
--- a/java/lance-jni/src/lib.rs
+++ b/java/lance-jni/src/lib.rs
@@ -62,6 +62,7 @@ mod storage_options;
 mod task_tracker;
 pub mod traits;
 mod transaction;
+mod update;
 pub mod utils;
 mod vector_trainer;
 

--- a/java/lance-jni/src/update.rs
+++ b/java/lance-jni/src/update.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use crate::blocking_dataset::{BlockingDataset, NATIVE_DATASET};
+use crate::error::Result;
+use crate::traits::IntoJava;
+use crate::utils::to_rust_map;
+use crate::{JNIEnvExt, RT};
+use jni::JNIEnv;
+use jni::objects::{JMap, JObject, JValueGen};
+use lance::dataset::UpdateBuilder;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeUpdate<'a>(
+    mut env: JNIEnv<'a>,
+    jdataset: JObject, // Dataset object
+    jparam: JObject,   // UpdateParams object
+) -> JObject<'a> {
+    ok_or_throw!(env, inner_update(&mut env, jdataset, jparam))
+}
+
+fn inner_update<'local>(
+    env: &mut JNIEnv<'local>,
+    jdataset: JObject,
+    jparam: JObject,
+) -> Result<JObject<'local>> {
+    let updates = extract_updates(env, &jparam)?;
+    let where_clause = extract_where(env, &jparam)?;
+    let conflict_retries = extract_conflict_retries(env, &jparam)?;
+    let retry_timeout_ms = extract_retry_timeout_ms(env, &jparam)?;
+
+    let update_result = unsafe {
+        let dataset = env.get_rust_field::<_, _, BlockingDataset>(jdataset, NATIVE_DATASET)?;
+
+        let mut builder = UpdateBuilder::new(Arc::new(dataset.clone().inner))
+            .conflict_retries(conflict_retries)
+            .retry_timeout(Duration::from_millis(retry_timeout_ms));
+
+        if let Some(predicate) = where_clause {
+            builder = builder.update_where(&predicate)?;
+        }
+
+        for (column, expr) in &updates {
+            builder = builder.set(column, expr)?;
+        }
+
+        let job = builder.build()?;
+        RT.block_on(job.execute())?
+    };
+
+    let new_ds = Arc::try_unwrap(update_result.new_dataset).unwrap();
+
+    UpdateResultJava {
+        dataset: BlockingDataset { inner: new_ds },
+        rows_updated: update_result.rows_updated,
+    }
+    .into_java(env)
+}
+
+fn extract_updates<'local>(
+    env: &mut JNIEnv<'local>,
+    jparam: &JObject,
+) -> Result<std::collections::HashMap<String, String>> {
+    let updates_obj: JObject = env
+        .call_method(jparam, "updates", "()Ljava/util/Map;", &[])?
+        .l()?;
+    let jmap = JMap::from_env(env, &updates_obj)?;
+    to_rust_map(env, &jmap)
+}
+
+fn extract_where<'local>(env: &mut JNIEnv<'local>, jparam: &JObject) -> Result<Option<String>> {
+    let where_opt = env
+        .call_method(jparam, "whereClause", "()Ljava/util/Optional;", &[])?
+        .l()?;
+    env.get_string_opt(&where_opt)
+}
+
+fn extract_conflict_retries<'local>(env: &mut JNIEnv<'local>, jparam: &JObject) -> Result<u32> {
+    let retries = env
+        .call_method(jparam, "conflictRetries", "()I", &[])?
+        .i()? as u32;
+    Ok(retries)
+}
+
+fn extract_retry_timeout_ms<'local>(env: &mut JNIEnv<'local>, jparam: &JObject) -> Result<u64> {
+    let timeout_ms = env.call_method(jparam, "retryTimeoutMs", "()J", &[])?.j()? as u64;
+    Ok(timeout_ms)
+}
+
+const UPDATE_RESULT_CLASS: &str = "org/lance/update/UpdateResult";
+const UPDATE_RESULT_CONSTRUCTOR_SIG: &str = "(Lorg/lance/Dataset;J)V";
+
+struct UpdateResultJava {
+    dataset: BlockingDataset,
+    rows_updated: u64,
+}
+
+impl IntoJava for UpdateResultJava {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        let jdataset = self.dataset.into_java(env)?;
+        Ok(env.new_object(
+            UPDATE_RESULT_CLASS,
+            UPDATE_RESULT_CONSTRUCTOR_SIG,
+            &[
+                JValueGen::Object(&jdataset),
+                JValueGen::Long(self.rows_updated as i64),
+            ],
+        )?)
+    }
+}

--- a/java/lance-jni/src/update.rs
+++ b/java/lance-jni/src/update.rs
@@ -31,26 +31,33 @@ fn inner_update<'local>(
     let conflict_retries = extract_conflict_retries(env, &jparam)?;
     let retry_timeout_ms = extract_retry_timeout_ms(env, &jparam)?;
 
-    let update_result = unsafe {
+    // Clone the inner Dataset out of the `get_rust_field` guard and drop the
+    // guard before running the long-lived async update. Otherwise the guard
+    // would block any other JNI call on the same dataset for the entire
+    // duration of `execute()`.
+    let inner_dataset = unsafe {
         let dataset = env.get_rust_field::<_, _, BlockingDataset>(jdataset, NATIVE_DATASET)?;
-
-        let mut builder = UpdateBuilder::new(Arc::new(dataset.clone().inner))
-            .conflict_retries(conflict_retries)
-            .retry_timeout(Duration::from_millis(retry_timeout_ms));
-
-        if let Some(predicate) = where_clause {
-            builder = builder.update_where(&predicate)?;
-        }
-
-        for (column, expr) in &updates {
-            builder = builder.set(column, expr)?;
-        }
-
-        let job = builder.build()?;
-        RT.block_on(job.execute())?
+        dataset.inner.clone()
     };
 
-    let new_ds = Arc::try_unwrap(update_result.new_dataset).unwrap();
+    let mut builder = UpdateBuilder::new(Arc::new(inner_dataset))
+        .conflict_retries(conflict_retries)
+        .retry_timeout(Duration::from_millis(retry_timeout_ms));
+
+    if let Some(predicate) = where_clause {
+        builder = builder.update_where(&predicate)?;
+    }
+
+    for (column, expr) in &updates {
+        builder = builder.set(column, expr)?;
+    }
+
+    let job = builder.build()?;
+    let update_result = RT.block_on(job.execute())?;
+
+    // Avoid panicking if Lance core retains a clone of the Arc; fall back to a
+    // deep clone so the JNI boundary stays panic-free.
+    let new_ds = Arc::try_unwrap(update_result.new_dataset).unwrap_or_else(|arc| (*arc).clone());
 
     UpdateResultJava {
         dataset: BlockingDataset { inner: new_ds },

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -2041,8 +2041,9 @@ public class Dataset implements Closeable {
    * {@code _rowaddr}, and {@code _rowoffset}, allowing rows to be targeted by stable row id (e.g.
    * {@code "_rowid IN (1, 2, 3)"}).
    *
-   * <p>It is important that after update the current dataset is changed and should be closed. The
-   * new committed dataset is contained in the {@link UpdateResult}.
+   * <p>This call does not mutate the current {@code Dataset} instance: it still references the
+   * pre-update version. Callers should close this {@code Dataset} and switch to {@link
+   * UpdateResult#getDataset()}, which holds the newly committed version.
    *
    * @param params update parameters
    * @return UpdateResult containing the new committed Dataset and the number of rows updated.

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -40,6 +40,8 @@ import org.lance.operation.UpdateMap;
 import org.lance.schema.ColumnAlteration;
 import org.lance.schema.LanceSchema;
 import org.lance.schema.SqlExpressions;
+import org.lance.update.UpdateParams;
+import org.lance.update.UpdateResult;
 import org.lance.util.JsonUtils;
 
 import org.apache.arrow.c.ArrowArrayStream;
@@ -2026,6 +2028,43 @@ public class Dataset implements Closeable {
 
   private native MergeInsertResult nativeMergeInsert(
       MergeInsertParams mergeInsert, long arrowStreamMemoryAddress);
+
+  /**
+   * Update column values for rows matching an optional predicate.
+   *
+   * <p>This is similar to SQL's {@code UPDATE} statement: the entries of {@link
+   * UpdateParams#updates()} map target column names to SQL expressions evaluated for every row that
+   * satisfies {@link UpdateParams#whereClause()}. If no predicate is provided, every row is
+   * updated.
+   *
+   * <p>The predicate may reference dataset columns as well as the system columns {@code _rowid},
+   * {@code _rowaddr}, and {@code _rowoffset}, allowing rows to be targeted by stable row id (e.g.
+   * {@code "_rowid IN (1, 2, 3)"}).
+   *
+   * <p>It is important that after update the current dataset is changed and should be closed. The
+   * new committed dataset is contained in the {@link UpdateResult}.
+   *
+   * @param params update parameters
+   * @return UpdateResult containing the new committed Dataset and the number of rows updated.
+   */
+  public UpdateResult update(UpdateParams params) {
+    Preconditions.checkNotNull(params, "params must not be null");
+    try (LockManager.WriteLock writeLock = lockManager.acquireWriteLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      UpdateResult result = nativeUpdate(params);
+
+      Dataset newDataset = result.getDataset();
+      if (selfManagedAllocator) {
+        newDataset.allocator = new RootAllocator(Long.MAX_VALUE);
+      } else {
+        newDataset.allocator = allocator;
+      }
+
+      return result;
+    }
+  }
+
+  private native UpdateResult nativeUpdate(UpdateParams params);
 
   /**
    * Initialize MemWAL on this dataset.

--- a/java/src/main/java/org/lance/update/UpdateParams.java
+++ b/java/src/main/java/org/lance/update/UpdateParams.java
@@ -16,6 +16,7 @@ package org.lance.update;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -32,10 +33,16 @@ import java.util.Optional;
  * stable row id.
  */
 public class UpdateParams {
+  // Defaults are kept in sync with the Rust core defaults declared on
+  // `lance::dataset::UpdateBuilder` (`conflict_retries = 10`,
+  // `retry_timeout = 30s`). When the Rust defaults change, update both sides.
+  private static final int DEFAULT_CONFLICT_RETRIES = 10;
+  private static final long DEFAULT_RETRY_TIMEOUT_MS = 30_000L;
+
   private final Map<String, String> updates;
   private Optional<String> whereClause = Optional.empty();
-  private int conflictRetries = 10;
-  private long retryTimeoutMs = 30 * 1000;
+  private int conflictRetries = DEFAULT_CONFLICT_RETRIES;
+  private long retryTimeoutMs = DEFAULT_RETRY_TIMEOUT_MS;
 
   public UpdateParams(Map<String, String> updates) {
     Preconditions.checkNotNull(updates, "updates must not be null");
@@ -61,7 +68,7 @@ public class UpdateParams {
   /**
    * Set number of times to retry the operation if there is contention.
    *
-   * <p>Default is 10.
+   * <p>Default mirrors the Rust core default ({@value #DEFAULT_CONFLICT_RETRIES}).
    *
    * @param retries Number of times to retry the operation if there is contention.
    * @return This UpdateParams instance.
@@ -76,7 +83,8 @@ public class UpdateParams {
    * Set the timeout in milliseconds used to limit retries.
    *
    * <p>This is the maximum time to spend on the operation before giving up. At least one attempt
-   * will be made, regardless of how long it takes to complete. Default is 30000.
+   * will be made, regardless of how long it takes to complete. Default mirrors the Rust core
+   * default ({@value #DEFAULT_RETRY_TIMEOUT_MS} ms).
    *
    * @param timeoutMs Timeout in milliseconds used to limit retries.
    * @return This UpdateParams instance.
@@ -87,8 +95,9 @@ public class UpdateParams {
     return this;
   }
 
+  /** Returns an unmodifiable view of the update expressions. */
   public Map<String, String> updates() {
-    return updates;
+    return Collections.unmodifiableMap(updates);
   }
 
   public Optional<String> whereClause() {

--- a/java/src/main/java/org/lance/update/UpdateParams.java
+++ b/java/src/main/java/org/lance/update/UpdateParams.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.update;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Parameters describing an update operation.
+ *
+ * <p>An update operation is similar to SQL's {@code UPDATE} statement: each entry in {@link
+ * #updates()} maps a target column name to a SQL expression evaluated for every row that matches
+ * the optional {@link #whereClause()}.
+ *
+ * <p>The {@code where} clause accepts the dataset columns as well as the system columns {@code
+ * _rowid}, {@code _rowaddr}, and {@code _rowoffset}, which is useful for targeting specific rows by
+ * stable row id.
+ */
+public class UpdateParams {
+  private final Map<String, String> updates;
+  private Optional<String> whereClause = Optional.empty();
+  private int conflictRetries = 10;
+  private long retryTimeoutMs = 30 * 1000;
+
+  public UpdateParams(Map<String, String> updates) {
+    Preconditions.checkNotNull(updates, "updates must not be null");
+    Preconditions.checkArgument(!updates.isEmpty(), "updates must not be empty");
+    this.updates = new HashMap<>(updates);
+  }
+
+  /**
+   * Restrict the update to rows matching the given SQL predicate.
+   *
+   * <p>The predicate is evaluated against the dataset schema augmented with the system columns
+   * {@code _rowid}, {@code _rowaddr}, and {@code _rowoffset}.
+   *
+   * @param whereClause SQL predicate, e.g. {@code "id = 1"} or {@code "_rowid IN (1, 2, 3)"}.
+   * @return This UpdateParams instance.
+   */
+  public UpdateParams withWhere(String whereClause) {
+    Preconditions.checkNotNull(whereClause, "whereClause must not be null");
+    this.whereClause = Optional.of(whereClause);
+    return this;
+  }
+
+  /**
+   * Set number of times to retry the operation if there is contention.
+   *
+   * <p>Default is 10.
+   *
+   * @param retries Number of times to retry the operation if there is contention.
+   * @return This UpdateParams instance.
+   */
+  public UpdateParams withConflictRetries(int retries) {
+    Preconditions.checkArgument(retries >= 0, "retries must be non-negative");
+    this.conflictRetries = retries;
+    return this;
+  }
+
+  /**
+   * Set the timeout in milliseconds used to limit retries.
+   *
+   * <p>This is the maximum time to spend on the operation before giving up. At least one attempt
+   * will be made, regardless of how long it takes to complete. Default is 30000.
+   *
+   * @param timeoutMs Timeout in milliseconds used to limit retries.
+   * @return This UpdateParams instance.
+   */
+  public UpdateParams withRetryTimeoutMs(long timeoutMs) {
+    Preconditions.checkArgument(timeoutMs >= 0, "timeoutMs must be non-negative");
+    this.retryTimeoutMs = timeoutMs;
+    return this;
+  }
+
+  public Map<String, String> updates() {
+    return updates;
+  }
+
+  public Optional<String> whereClause() {
+    return whereClause;
+  }
+
+  public int conflictRetries() {
+    return conflictRetries;
+  }
+
+  public long retryTimeoutMs() {
+    return retryTimeoutMs;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("updates", updates)
+        .add("whereClause", whereClause.orElse(null))
+        .add("conflictRetries", conflictRetries)
+        .add("retryTimeoutMs", retryTimeoutMs)
+        .toString();
+  }
+}

--- a/java/src/main/java/org/lance/update/UpdateParams.java
+++ b/java/src/main/java/org/lance/update/UpdateParams.java
@@ -31,6 +31,12 @@ import java.util.Optional;
  * <p>The {@code where} clause accepts the dataset columns as well as the system columns {@code
  * _rowid}, {@code _rowaddr}, and {@code _rowoffset}, which is useful for targeting specific rows by
  * stable row id.
+ *
+ * <p><strong>Important:</strong> {@code _rowid} is only a <em>stable</em> identifier when the
+ * dataset was created with {@code WriteParams.Builder().withEnableStableRowIds(true)}. Without
+ * stable row ids, {@code _rowid} is a positional id that can shift across compaction, deletion, or
+ * re-insertion. Targeting rows by an unstable {@code _rowid} in {@link #withWhere(String)} can
+ * silently update the wrong rows.
  */
 public class UpdateParams {
   // Defaults are kept in sync with the Rust core defaults declared on
@@ -55,6 +61,10 @@ public class UpdateParams {
    *
    * <p>The predicate is evaluated against the dataset schema augmented with the system columns
    * {@code _rowid}, {@code _rowaddr}, and {@code _rowoffset}.
+   *
+   * <p>When matching rows by {@code _rowid}, the dataset must have been created with stable row ids
+   * enabled (see the class-level Javadoc); otherwise the predicate may silently target the wrong
+   * rows.
    *
    * @param whereClause SQL predicate, e.g. {@code "id = 1"} or {@code "_rowid IN (1, 2, 3)"}.
    * @return This UpdateParams instance.

--- a/java/src/main/java/org/lance/update/UpdateResult.java
+++ b/java/src/main/java/org/lance/update/UpdateResult.java
@@ -25,10 +25,16 @@ import com.google.common.base.MoreObjects;
 public final class UpdateResult {
   private final Dataset dataset;
   private final long numRowsUpdated;
+  // Snapshot the dataset identity at construction time so toString() stays safe to call after the
+  // caller has closed the dataset (closed datasets reject native uri()/version() calls).
+  private final String datasetUri;
+  private final long datasetVersion;
 
   public UpdateResult(Dataset dataset, long numRowsUpdated) {
     this.dataset = dataset;
     this.numRowsUpdated = numRowsUpdated;
+    this.datasetUri = dataset.uri();
+    this.datasetVersion = dataset.version();
   }
 
   /** Returns the new dataset reflecting the committed update. */
@@ -43,11 +49,10 @@ public final class UpdateResult {
 
   @Override
   public String toString() {
-    // Avoid dumping the full Dataset (which includes native handles, schema, manifest, etc.).
-    // A lightweight identifier (uri + version) is enough for diagnostics.
+    // Use the snapshot taken at construction time; the caller may have already closed `dataset`.
     return MoreObjects.toStringHelper(this)
-        .add("datasetUri", dataset.uri())
-        .add("datasetVersion", dataset.version())
+        .add("datasetUri", datasetUri)
+        .add("datasetVersion", datasetVersion)
         .add("numRowsUpdated", numRowsUpdated)
         .toString();
   }

--- a/java/src/main/java/org/lance/update/UpdateResult.java
+++ b/java/src/main/java/org/lance/update/UpdateResult.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.update;
+
+import org.lance.Dataset;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Result of {@link org.lance.Dataset#update(UpdateParams)}.
+ *
+ * <p>Contains the new {@link Dataset} produced by the commit and the number of rows affected.
+ */
+public final class UpdateResult {
+  private final Dataset dataset;
+  private final long numRowsUpdated;
+
+  public UpdateResult(Dataset dataset, long numRowsUpdated) {
+    this.dataset = dataset;
+    this.numRowsUpdated = numRowsUpdated;
+  }
+
+  /** Returns the new dataset reflecting the committed update. */
+  public Dataset getDataset() {
+    return dataset;
+  }
+
+  /** Returns the number of rows that matched the predicate and were updated. */
+  public long getNumRowsUpdated() {
+    return numRowsUpdated;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("dataset", dataset)
+        .add("numRowsUpdated", numRowsUpdated)
+        .toString();
+  }
+}

--- a/java/src/main/java/org/lance/update/UpdateResult.java
+++ b/java/src/main/java/org/lance/update/UpdateResult.java
@@ -43,8 +43,11 @@ public final class UpdateResult {
 
   @Override
   public String toString() {
+    // Avoid dumping the full Dataset (which includes native handles, schema, manifest, etc.).
+    // A lightweight identifier (uri + version) is enough for diagnostics.
     return MoreObjects.toStringHelper(this)
-        .add("dataset", dataset)
+        .add("datasetUri", dataset.uri())
+        .add("datasetVersion", dataset.version())
         .add("numRowsUpdated", numRowsUpdated)
         .toString();
   }

--- a/java/src/test/java/org/lance/UpdateTest.java
+++ b/java/src/test/java/org/lance/UpdateTest.java
@@ -15,6 +15,7 @@ package org.lance;
 
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
+import org.lance.operation.Append;
 import org.lance.update.UpdateParams;
 import org.lance.update.UpdateResult;
 
@@ -33,11 +34,15 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 public class UpdateTest {
+  private static final int ROW_COUNT = 5;
+  private static final String ROW_ID_COLUMN = "_rowid";
+
   @TempDir private Path tempDir;
   private RootAllocator allocator;
   private TestUtils.SimpleTestDataset testDataset;
@@ -48,8 +53,21 @@ public class UpdateTest {
     String datasetPath = tempDir.resolve(UUID.randomUUID().toString()).toString();
     allocator = new RootAllocator(Long.MAX_VALUE);
     testDataset = new TestUtils.SimpleTestDataset(allocator, datasetPath);
-    testDataset.createEmptyDataset().close();
-    dataset = testDataset.write(1, 5);
+
+    // Enable stable row ids so that `_rowid` is a stable u64 identifier and can be
+    // used as an update predicate (the core feature exercised by the rowid tests).
+    Dataset empty =
+        testDataset.createDatasetWithWriteParams(
+            new WriteParams.Builder().withEnableStableRowIds(true).build());
+
+    FragmentMetadata fragment = testDataset.createNewFragment(ROW_COUNT);
+    SourcedTransaction transaction =
+        new SourcedTransaction.Builder(empty)
+            .operation(Append.builder().fragments(Arrays.asList(fragment)).build())
+            .readVersion(empty.version())
+            .build();
+    dataset = transaction.commit();
+    empty.close();
   }
 
   @AfterEach
@@ -64,10 +82,10 @@ public class UpdateTest {
   public void testUpdateAllRows() {
     UpdateResult result = dataset.update(new UpdateParams(ImmutableMap.of("name", "'updated'")));
 
-    Assertions.assertEquals(5, result.getNumRowsUpdated());
+    Assertions.assertEquals(ROW_COUNT, result.getNumRowsUpdated());
     try (Dataset newDataset = result.getDataset()) {
       List<String> names = readNames(newDataset);
-      Assertions.assertEquals(5, names.size());
+      Assertions.assertEquals(ROW_COUNT, names.size());
       for (String name : names) {
         Assertions.assertEquals("updated", name);
       }
@@ -81,148 +99,75 @@ public class UpdateTest {
 
     Assertions.assertEquals(1, result.getNumRowsUpdated());
     try (Dataset newDataset = result.getDataset()) {
-      // id=2 should be 'updated'; others remain "Person <i>".
-      try (LanceScanner scanner =
-          newDataset.newScan(
-              new ScanOptions.Builder().columns(java.util.Arrays.asList("id", "name")).build())) {
-        try (ArrowReader reader = scanner.scanBatches()) {
-          int seen = 0;
-          while (reader.loadNextBatch()) {
-            VectorSchemaRoot batch = reader.getVectorSchemaRoot();
-            IntVector idVector = (IntVector) batch.getVector("id");
-            VarCharVector nameVector = (VarCharVector) batch.getVector("name");
-            for (int i = 0; i < batch.getRowCount(); i++) {
-              int id = idVector.get(i);
-              String name = new String(nameVector.get(i));
-              if (id == 2) {
-                Assertions.assertEquals("updated", name);
-              } else {
-                Assertions.assertEquals("Person " + id, name);
-              }
-              seen++;
-            }
-          }
-          Assertions.assertEquals(5, seen);
-        }
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
+      assertNamesById(
+          newDataset, id -> id == 2 ? "updated" : "Person " + id, /* expectedRows= */ ROW_COUNT);
     }
   }
 
   @Test
   public void testUpdateByRowId() throws Exception {
-    // Read the stable row id of one row and update by `_rowid`.
-    long targetRowId;
-    int targetId;
-    try (LanceScanner scanner =
-        dataset.newScan(
-            new ScanOptions.Builder()
-                .columns(java.util.Arrays.asList("id"))
-                .withRowId(true)
-                .build())) {
-      try (ArrowReader reader = scanner.scanBatches()) {
-        Assertions.assertTrue(reader.loadNextBatch());
-        VectorSchemaRoot batch = reader.getVectorSchemaRoot();
-        UInt8Vector rowIdVector = (UInt8Vector) batch.getVector("_rowid");
-        IntVector idVector = (IntVector) batch.getVector("id");
-        targetRowId = rowIdVector.get(2);
-        targetId = idVector.get(2);
-      }
-    }
+    List<long[]> sample = readRowIdsAndIds(dataset);
+    long targetRowId = sample.get(0)[2];
+    int targetId = (int) sample.get(1)[2];
 
     UpdateResult result =
         dataset.update(
             new UpdateParams(ImmutableMap.of("name", "'updated'"))
-                .withWhere("_rowid = " + targetRowId));
+                .withWhere(ROW_ID_COLUMN + " = " + targetRowId));
 
     Assertions.assertEquals(1, result.getNumRowsUpdated());
     try (Dataset newDataset = result.getDataset()) {
-      try (LanceScanner scanner =
-          newDataset.newScan(
-              new ScanOptions.Builder().columns(java.util.Arrays.asList("id", "name")).build())) {
-        try (ArrowReader reader = scanner.scanBatches()) {
-          int updated = 0;
-          while (reader.loadNextBatch()) {
-            VectorSchemaRoot batch = reader.getVectorSchemaRoot();
-            IntVector idVector = (IntVector) batch.getVector("id");
-            VarCharVector nameVector = (VarCharVector) batch.getVector("name");
-            for (int i = 0; i < batch.getRowCount(); i++) {
-              int id = idVector.get(i);
-              String name = new String(nameVector.get(i));
-              if (id == targetId) {
-                Assertions.assertEquals("updated", name);
-                updated++;
-              } else {
-                Assertions.assertEquals("Person " + id, name);
-              }
-            }
-          }
-          Assertions.assertEquals(1, updated);
-        }
-      }
+      assertNamesById(
+          newDataset,
+          id -> id == targetId ? "updated" : "Person " + id,
+          /* expectedRows= */ ROW_COUNT);
     }
   }
 
   @Test
   public void testUpdateByRowIdInList() throws Exception {
-    List<Long> targetRowIds = new ArrayList<>();
-    List<Integer> targetIds = new ArrayList<>();
-    try (LanceScanner scanner =
-        dataset.newScan(
-            new ScanOptions.Builder()
-                .columns(java.util.Arrays.asList("id"))
-                .withRowId(true)
-                .build())) {
-      try (ArrowReader reader = scanner.scanBatches()) {
-        Assertions.assertTrue(reader.loadNextBatch());
-        VectorSchemaRoot batch = reader.getVectorSchemaRoot();
-        UInt8Vector rowIdVector = (UInt8Vector) batch.getVector("_rowid");
-        IntVector idVector = (IntVector) batch.getVector("id");
-        for (int idx : new int[] {0, 2, 4}) {
-          targetRowIds.add(rowIdVector.get(idx));
-          targetIds.add(idVector.get(idx));
-        }
-      }
-    }
+    List<long[]> sample = readRowIdsAndIds(dataset);
+    long[] rowIds = sample.get(0);
+    long[] ids = sample.get(1);
+    int[] indices = new int[] {0, 2, 4};
 
     StringBuilder inList = new StringBuilder();
-    for (int i = 0; i < targetRowIds.size(); i++) {
+    List<Integer> targetIds = new ArrayList<>();
+    for (int i = 0; i < indices.length; i++) {
       if (i > 0) {
         inList.append(", ");
       }
-      inList.append(targetRowIds.get(i));
+      inList.append(rowIds[indices[i]]);
+      targetIds.add((int) ids[indices[i]]);
     }
 
     UpdateResult result =
         dataset.update(
             new UpdateParams(ImmutableMap.of("name", "'updated'"))
-                .withWhere("_rowid IN (" + inList + ")"));
+                .withWhere(ROW_ID_COLUMN + " IN (" + inList + ")"));
 
     Assertions.assertEquals(targetIds.size(), result.getNumRowsUpdated());
     try (Dataset newDataset = result.getDataset()) {
-      try (LanceScanner scanner =
-          newDataset.newScan(
-              new ScanOptions.Builder().columns(java.util.Arrays.asList("id", "name")).build())) {
-        try (ArrowReader reader = scanner.scanBatches()) {
-          int updated = 0;
-          while (reader.loadNextBatch()) {
-            VectorSchemaRoot batch = reader.getVectorSchemaRoot();
-            IntVector idVector = (IntVector) batch.getVector("id");
-            VarCharVector nameVector = (VarCharVector) batch.getVector("name");
-            for (int i = 0; i < batch.getRowCount(); i++) {
-              int id = idVector.get(i);
-              String name = new String(nameVector.get(i));
-              if (targetIds.contains(id)) {
-                Assertions.assertEquals("updated", name);
-                updated++;
-              } else {
-                Assertions.assertEquals("Person " + id, name);
-              }
-            }
-          }
-          Assertions.assertEquals(targetIds.size(), updated);
-        }
+      assertNamesById(
+          newDataset,
+          id -> targetIds.contains(id) ? "updated" : "Person " + id,
+          /* expectedRows= */ ROW_COUNT);
+    }
+  }
+
+  @Test
+  public void testUpdateWithRetryParameters() {
+    // Ensure builder-style retry knobs round-trip through the JNI layer.
+    UpdateResult result =
+        dataset.update(
+            new UpdateParams(ImmutableMap.of("name", "'retried'"))
+                .withConflictRetries(3)
+                .withRetryTimeoutMs(60_000));
+
+    Assertions.assertEquals(ROW_COUNT, result.getNumRowsUpdated());
+    try (Dataset newDataset = result.getDataset()) {
+      for (String name : readNames(newDataset)) {
+        Assertions.assertEquals("retried", name);
       }
     }
   }
@@ -233,11 +178,67 @@ public class UpdateTest {
         IllegalArgumentException.class, () -> new UpdateParams(Collections.emptyMap()));
   }
 
-  private List<String> readNames(Dataset dataset) {
+  /**
+   * Returns a 2-element list: index 0 contains the {@code _rowid} values, index 1 contains the
+   * {@code id} values. Both arrays are sized to {@link #ROW_COUNT}.
+   */
+  private List<long[]> readRowIdsAndIds(Dataset ds) throws Exception {
+    long[] rowIds = new long[ROW_COUNT];
+    long[] ids = new long[ROW_COUNT];
+    try (LanceScanner scanner =
+        ds.newScan(
+            new ScanOptions.Builder().columns(Arrays.asList("id")).withRowId(true).build())) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        int row = 0;
+        while (reader.loadNextBatch()) {
+          VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+          // Lance stable `_rowid` is an Arrow uint64; Arrow Java represents uint64 as
+          // `UInt8Vector` (the "8" refers to byte width, not bit width).
+          UInt8Vector rowIdVector = (UInt8Vector) batch.getVector(ROW_ID_COLUMN);
+          IntVector idVector = (IntVector) batch.getVector("id");
+          for (int i = 0; i < batch.getRowCount(); i++) {
+            rowIds[row] = rowIdVector.get(i);
+            ids[row] = idVector.get(i);
+            row++;
+          }
+        }
+        Assertions.assertEquals(ROW_COUNT, row);
+      }
+    }
+    return Arrays.asList(rowIds, ids);
+  }
+
+  private interface IntToString {
+    String apply(int id);
+  }
+
+  private void assertNamesById(Dataset ds, IntToString expected, int expectedRows) {
+    try (LanceScanner scanner =
+        ds.newScan(new ScanOptions.Builder().columns(Arrays.asList("id", "name")).build())) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        int seen = 0;
+        while (reader.loadNextBatch()) {
+          VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+          IntVector idVector = (IntVector) batch.getVector("id");
+          VarCharVector nameVector = (VarCharVector) batch.getVector("name");
+          for (int i = 0; i < batch.getRowCount(); i++) {
+            int id = idVector.get(i);
+            String name = new String(nameVector.get(i));
+            Assertions.assertEquals(expected.apply(id), name);
+            seen++;
+          }
+        }
+        Assertions.assertEquals(expectedRows, seen);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<String> readNames(Dataset ds) {
     List<String> names = new ArrayList<>();
     try (LanceScanner scanner =
-        dataset.newScan(
-            new ScanOptions.Builder().columns(java.util.Arrays.asList("name")).build())) {
+        ds.newScan(new ScanOptions.Builder().columns(Arrays.asList("name")).build())) {
       try (ArrowReader reader = scanner.scanBatches()) {
         while (reader.loadNextBatch()) {
           VectorSchemaRoot batch = reader.getVectorSchemaRoot();

--- a/java/src/test/java/org/lance/UpdateTest.java
+++ b/java/src/test/java/org/lance/UpdateTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+import org.lance.ipc.LanceScanner;
+import org.lance.ipc.ScanOptions;
+import org.lance.update.UpdateParams;
+import org.lance.update.UpdateResult;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.UInt8Vector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+public class UpdateTest {
+  @TempDir private Path tempDir;
+  private RootAllocator allocator;
+  private TestUtils.SimpleTestDataset testDataset;
+  private Dataset dataset;
+
+  @BeforeEach
+  public void setup() {
+    String datasetPath = tempDir.resolve(UUID.randomUUID().toString()).toString();
+    allocator = new RootAllocator(Long.MAX_VALUE);
+    testDataset = new TestUtils.SimpleTestDataset(allocator, datasetPath);
+    testDataset.createEmptyDataset().close();
+    dataset = testDataset.write(1, 5);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (dataset != null) {
+      dataset.close();
+    }
+    allocator.close();
+  }
+
+  @Test
+  public void testUpdateAllRows() {
+    UpdateResult result = dataset.update(new UpdateParams(ImmutableMap.of("name", "'updated'")));
+
+    Assertions.assertEquals(5, result.getNumRowsUpdated());
+    try (Dataset newDataset = result.getDataset()) {
+      List<String> names = readNames(newDataset);
+      Assertions.assertEquals(5, names.size());
+      for (String name : names) {
+        Assertions.assertEquals("updated", name);
+      }
+    }
+  }
+
+  @Test
+  public void testUpdateWithWhere() {
+    UpdateResult result =
+        dataset.update(new UpdateParams(ImmutableMap.of("name", "'updated'")).withWhere("id = 2"));
+
+    Assertions.assertEquals(1, result.getNumRowsUpdated());
+    try (Dataset newDataset = result.getDataset()) {
+      // id=2 should be 'updated'; others remain "Person <i>".
+      try (LanceScanner scanner =
+          newDataset.newScan(
+              new ScanOptions.Builder().columns(java.util.Arrays.asList("id", "name")).build())) {
+        try (ArrowReader reader = scanner.scanBatches()) {
+          int seen = 0;
+          while (reader.loadNextBatch()) {
+            VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+            IntVector idVector = (IntVector) batch.getVector("id");
+            VarCharVector nameVector = (VarCharVector) batch.getVector("name");
+            for (int i = 0; i < batch.getRowCount(); i++) {
+              int id = idVector.get(i);
+              String name = new String(nameVector.get(i));
+              if (id == 2) {
+                Assertions.assertEquals("updated", name);
+              } else {
+                Assertions.assertEquals("Person " + id, name);
+              }
+              seen++;
+            }
+          }
+          Assertions.assertEquals(5, seen);
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Test
+  public void testUpdateByRowId() throws Exception {
+    // Read the stable row id of one row and update by `_rowid`.
+    long targetRowId;
+    int targetId;
+    try (LanceScanner scanner =
+        dataset.newScan(
+            new ScanOptions.Builder()
+                .columns(java.util.Arrays.asList("id"))
+                .withRowId(true)
+                .build())) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        Assertions.assertTrue(reader.loadNextBatch());
+        VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+        UInt8Vector rowIdVector = (UInt8Vector) batch.getVector("_rowid");
+        IntVector idVector = (IntVector) batch.getVector("id");
+        targetRowId = rowIdVector.get(2);
+        targetId = idVector.get(2);
+      }
+    }
+
+    UpdateResult result =
+        dataset.update(
+            new UpdateParams(ImmutableMap.of("name", "'updated'"))
+                .withWhere("_rowid = " + targetRowId));
+
+    Assertions.assertEquals(1, result.getNumRowsUpdated());
+    try (Dataset newDataset = result.getDataset()) {
+      try (LanceScanner scanner =
+          newDataset.newScan(
+              new ScanOptions.Builder().columns(java.util.Arrays.asList("id", "name")).build())) {
+        try (ArrowReader reader = scanner.scanBatches()) {
+          int updated = 0;
+          while (reader.loadNextBatch()) {
+            VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+            IntVector idVector = (IntVector) batch.getVector("id");
+            VarCharVector nameVector = (VarCharVector) batch.getVector("name");
+            for (int i = 0; i < batch.getRowCount(); i++) {
+              int id = idVector.get(i);
+              String name = new String(nameVector.get(i));
+              if (id == targetId) {
+                Assertions.assertEquals("updated", name);
+                updated++;
+              } else {
+                Assertions.assertEquals("Person " + id, name);
+              }
+            }
+          }
+          Assertions.assertEquals(1, updated);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testUpdateByRowIdInList() throws Exception {
+    List<Long> targetRowIds = new ArrayList<>();
+    List<Integer> targetIds = new ArrayList<>();
+    try (LanceScanner scanner =
+        dataset.newScan(
+            new ScanOptions.Builder()
+                .columns(java.util.Arrays.asList("id"))
+                .withRowId(true)
+                .build())) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        Assertions.assertTrue(reader.loadNextBatch());
+        VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+        UInt8Vector rowIdVector = (UInt8Vector) batch.getVector("_rowid");
+        IntVector idVector = (IntVector) batch.getVector("id");
+        for (int idx : new int[] {0, 2, 4}) {
+          targetRowIds.add(rowIdVector.get(idx));
+          targetIds.add(idVector.get(idx));
+        }
+      }
+    }
+
+    StringBuilder inList = new StringBuilder();
+    for (int i = 0; i < targetRowIds.size(); i++) {
+      if (i > 0) {
+        inList.append(", ");
+      }
+      inList.append(targetRowIds.get(i));
+    }
+
+    UpdateResult result =
+        dataset.update(
+            new UpdateParams(ImmutableMap.of("name", "'updated'"))
+                .withWhere("_rowid IN (" + inList + ")"));
+
+    Assertions.assertEquals(targetIds.size(), result.getNumRowsUpdated());
+    try (Dataset newDataset = result.getDataset()) {
+      try (LanceScanner scanner =
+          newDataset.newScan(
+              new ScanOptions.Builder().columns(java.util.Arrays.asList("id", "name")).build())) {
+        try (ArrowReader reader = scanner.scanBatches()) {
+          int updated = 0;
+          while (reader.loadNextBatch()) {
+            VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+            IntVector idVector = (IntVector) batch.getVector("id");
+            VarCharVector nameVector = (VarCharVector) batch.getVector("name");
+            for (int i = 0; i < batch.getRowCount(); i++) {
+              int id = idVector.get(i);
+              String name = new String(nameVector.get(i));
+              if (targetIds.contains(id)) {
+                Assertions.assertEquals("updated", name);
+                updated++;
+              } else {
+                Assertions.assertEquals("Person " + id, name);
+              }
+            }
+          }
+          Assertions.assertEquals(targetIds.size(), updated);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testUpdateRejectsEmptyUpdates() {
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> new UpdateParams(Collections.emptyMap()));
+  }
+
+  private List<String> readNames(Dataset dataset) {
+    List<String> names = new ArrayList<>();
+    try (LanceScanner scanner =
+        dataset.newScan(
+            new ScanOptions.Builder().columns(java.util.Arrays.asList("name")).build())) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        while (reader.loadNextBatch()) {
+          VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+          VarCharVector nameVector = (VarCharVector) batch.getVector("name");
+          for (int i = 0; i < batch.getRowCount(); i++) {
+            names.add(new String(nameVector.get(i)));
+          }
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return names;
+  }
+}

--- a/java/src/test/java/org/lance/UpdateTest.java
+++ b/java/src/test/java/org/lance/UpdateTest.java
@@ -178,6 +178,32 @@ public class UpdateTest {
         IllegalArgumentException.class, () -> new UpdateParams(Collections.emptyMap()));
   }
 
+  @Test
+  public void testUpdateRejectsNegativeRetryParameters() {
+    UpdateParams params = new UpdateParams(ImmutableMap.of("name", "'x'"));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> params.withConflictRetries(-1));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> params.withRetryTimeoutMs(-1));
+  }
+
+  @Test
+  public void testUpdatePropagatesInvalidWhereClause() {
+    // Unknown column should surface as an exception from the Rust core, not a silent no-op.
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            dataset.update(
+                new UpdateParams(ImmutableMap.of("name", "'x'"))
+                    .withWhere("nonexistent_column = 1")));
+  }
+
+  @Test
+  public void testUpdatePropagatesInvalidUpdateExpression() {
+    // Malformed SQL expression should surface as an exception, not a silent no-op.
+    Assertions.assertThrows(
+        Exception.class,
+        () -> dataset.update(new UpdateParams(ImmutableMap.of("name", "this is not sql"))));
+  }
+
   /**
    * Returns a 2-element list: index 0 contains the {@code _rowid} values, index 1 contains the
    * {@code id} values. Both arrays are sized to {@link #ROW_COUNT}.

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -3121,6 +3121,75 @@ def test_update_dataset_scanner_after_stable_row_id_update(tmp_path: Path):
     assert scanner_table == actual
 
 
+def test_update_by_rowid(tmp_path: Path):
+    nrows = 30
+    table = pa.table(
+        {
+            "id": pa.array(range(nrows), pa.int64()),
+            "name": pa.array(["foo"] * nrows, pa.string()),
+        }
+    )
+    dataset = lance.write_dataset(
+        table,
+        tmp_path / "dataset",
+        max_rows_per_file=10,
+        enable_stable_row_ids=True,
+    )
+
+    orig = dataset.to_table(columns=["id"], with_row_id=True)
+    target_idx = 5
+    target_row_id = orig.column("_rowid")[target_idx].as_py()
+    target_id = orig.column("id")[target_idx].as_py()
+
+    update_dict = dataset.update(
+        updates=dict(name="'updated'"),
+        where=f"_rowid = {target_row_id}",
+    )
+    check_update_stats(update_dict, (1,))
+
+    actual = dataset.to_table().sort_by("id")
+    for row in actual.to_pylist():
+        if row["id"] == target_id:
+            assert row["name"] == "updated"
+        else:
+            assert row["name"] == "foo"
+
+
+def test_update_by_rowid_in_list(tmp_path: Path):
+    nrows = 30
+    table = pa.table(
+        {
+            "id": pa.array(range(nrows), pa.int64()),
+            "name": pa.array(["foo"] * nrows, pa.string()),
+        }
+    )
+    dataset = lance.write_dataset(
+        table,
+        tmp_path / "dataset",
+        max_rows_per_file=10,
+        enable_stable_row_ids=True,
+    )
+
+    orig = dataset.to_table(columns=["id"], with_row_id=True)
+    target_indices = [3, 7, 15]
+    target_row_ids = [orig.column("_rowid")[i].as_py() for i in target_indices]
+    target_ids = {orig.column("id")[i].as_py() for i in target_indices}
+
+    in_list = ", ".join(str(rid) for rid in target_row_ids)
+    update_dict = dataset.update(
+        updates=dict(name="'updated'"),
+        where=f"_rowid IN ({in_list})",
+    )
+    check_update_stats(update_dict, (3,))
+
+    actual = dataset.to_table().sort_by("id")
+    for row in actual.to_pylist():
+        if row["id"] in target_ids:
+            assert row["name"] == "updated"
+        else:
+            assert row["name"] == "foo"
+
+
 def test_update_dataset_all_types(tmp_path: Path):
     table = pa.table(
         {


### PR DESCRIPTION
The function of updating by `_row_id` has been supported via #6837 . This is a follow-up PR to expose the feature for Python and Java. The changes for the two upper modules are listed here:

* Python: added test cases;
* Java: supported the basic update API and also update by `_row_id` ;