### PR TITLE
perf(index): reduce HNSW build distance overhead

### DIFF
--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -183,11 +183,7 @@ impl VectorStore for FlatFloatStorage {
     }
 
     fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
-        Self::DistanceCalculator::new(
-            self.vectors.as_ref(),
-            self.vectors.value(id as usize),
-            self.distance_type,
-        )
+        Self::DistanceCalculator::new_from_id(self.vectors.as_ref(), id, self.distance_type)
     }
 }
 
@@ -349,20 +345,31 @@ impl VectorStore for FlatBinStorage {
     }
 
     fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
-        Self::DistanceCalculator::new_binary(
-            self.vectors.as_ref(),
-            self.vectors.value(id as usize),
-            self.distance_type,
-        )
+        Self::DistanceCalculator::new_binary_from_id(self.vectors.as_ref(), id, self.distance_type)
     }
 }
 
 pub struct FlatDistanceCal<'a, T: ArrowPrimitiveType> {
     vectors: &'a [T::Native],
-    query: Vec<T::Native>,
+    query: QueryVector<'a, T>,
     dimension: usize,
     #[allow(clippy::type_complexity)]
     distance_fn: fn(&[T::Native], &[T::Native]) -> f32,
+}
+
+enum QueryVector<'a, T: ArrowPrimitiveType> {
+    Borrowed(&'a [T::Native]),
+    Owned(Vec<T::Native>),
+}
+
+impl<'a, T: ArrowPrimitiveType> QueryVector<'a, T> {
+    #[inline]
+    fn as_slice(&self) -> &[T::Native] {
+        match self {
+            Self::Borrowed(query) => query,
+            Self::Owned(query) => query,
+        }
+    }
 }
 
 impl<'a, T> FlatDistanceCal<'a, T>
@@ -376,7 +383,20 @@ where
         let dimension = vectors.value_length() as usize;
         Self {
             vectors: flat_array.values(),
-            query: query.as_primitive::<T>().values().to_vec(),
+            query: QueryVector::Owned(query.as_primitive::<T>().values().to_vec()),
+            dimension,
+            distance_fn: distance_type.func(),
+        }
+    }
+
+    fn new_from_id(vectors: &'a FixedSizeListArray, id: u32, distance_type: DistanceType) -> Self {
+        let flat_array = vectors.values().as_primitive::<T>();
+        let dimension = vectors.value_length() as usize;
+        let vectors = flat_array.values();
+        let id = id as usize;
+        Self {
+            vectors,
+            query: QueryVector::Borrowed(&vectors[dimension * id..dimension * (id + 1)]),
             dimension,
             distance_fn: distance_type.func(),
         }
@@ -395,7 +415,24 @@ impl<'a> FlatDistanceCal<'a, UInt8Type> {
         let dimension = vectors.value_length() as usize;
         Self {
             vectors: flat_array.values(),
-            query: query.as_primitive::<UInt8Type>().values().to_vec(),
+            query: QueryVector::Owned(query.as_primitive::<UInt8Type>().values().to_vec()),
+            dimension,
+            distance_fn: hamming,
+        }
+    }
+
+    fn new_binary_from_id(
+        vectors: &'a FixedSizeListArray,
+        id: u32,
+        _distance_type: DistanceType,
+    ) -> Self {
+        let flat_array = vectors.values().as_primitive::<UInt8Type>();
+        let dimension = vectors.value_length() as usize;
+        let vectors = flat_array.values();
+        let id = id as usize;
+        Self {
+            vectors,
+            query: QueryVector::Borrowed(&vectors[dimension * id..dimension * (id + 1)]),
             dimension,
             distance_fn: hamming,
         }
@@ -412,12 +449,13 @@ impl<T: ArrowPrimitiveType> FlatDistanceCal<'_, T> {
 impl<T: ArrowPrimitiveType> DistCalculator for FlatDistanceCal<'_, T> {
     #[inline]
     fn distance(&self, id: u32) -> f32 {
+        let query = self.query.as_slice();
         let vector = self.get_vector(id);
-        (self.distance_fn)(&self.query, vector)
+        (self.distance_fn)(query, vector)
     }
 
     fn distance_all(&self, _k_hint: usize) -> Vec<f32> {
-        let query = &self.query;
+        let query = self.query.as_slice();
         self.vectors
             .chunks_exact(self.dimension)
             .map(|vector| (self.distance_fn)(query, vector))
@@ -453,6 +491,27 @@ impl<'a> FlatFloatDistanceCalc<'a> {
             DataType::Float64 => Self::Float64(FlatDistanceCal::<Float64Type>::new(
                 vectors,
                 query,
+                distance_type,
+            )),
+            dt => panic!("flat float storage does not support data type {dt}"),
+        }
+    }
+
+    fn new_from_id(vectors: &'a FixedSizeListArray, id: u32, distance_type: DistanceType) -> Self {
+        match vectors.value_type() {
+            DataType::Float16 => Self::Float16(FlatDistanceCal::<Float16Type>::new_from_id(
+                vectors,
+                id,
+                distance_type,
+            )),
+            DataType::Float32 => Self::Float32(FlatDistanceCal::<Float32Type>::new_from_id(
+                vectors,
+                id,
+                distance_type,
+            )),
+            DataType::Float64 => Self::Float64(FlatDistanceCal::<Float64Type>::new_from_id(
+                vectors,
+                id,
                 distance_type,
             )),
             dt => panic!("flat float storage does not support data type {dt}"),

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use super::index::FlatMetadata;
 use crate::frag_reuse::FragReuseIndex;
@@ -351,25 +351,10 @@ impl VectorStore for FlatBinStorage {
 
 pub struct FlatDistanceCal<'a, T: ArrowPrimitiveType> {
     vectors: &'a [T::Native],
-    query: QueryVector<'a, T>,
+    query: Cow<'a, [T::Native]>,
     dimension: usize,
     #[allow(clippy::type_complexity)]
     distance_fn: fn(&[T::Native], &[T::Native]) -> f32,
-}
-
-enum QueryVector<'a, T: ArrowPrimitiveType> {
-    Borrowed(&'a [T::Native]),
-    Owned(Vec<T::Native>),
-}
-
-impl<'a, T: ArrowPrimitiveType> QueryVector<'a, T> {
-    #[inline]
-    fn as_slice(&self) -> &[T::Native] {
-        match self {
-            Self::Borrowed(query) => query,
-            Self::Owned(query) => query,
-        }
-    }
 }
 
 impl<'a, T> FlatDistanceCal<'a, T>
@@ -383,7 +368,7 @@ where
         let dimension = vectors.value_length() as usize;
         Self {
             vectors: flat_array.values(),
-            query: QueryVector::Owned(query.as_primitive::<T>().values().to_vec()),
+            query: Cow::Owned(query.as_primitive::<T>().values().to_vec()),
             dimension,
             distance_fn: distance_type.func(),
         }
@@ -396,7 +381,7 @@ where
         let id = id as usize;
         Self {
             vectors,
-            query: QueryVector::Borrowed(&vectors[dimension * id..dimension * (id + 1)]),
+            query: Cow::Borrowed(&vectors[dimension * id..dimension * (id + 1)]),
             dimension,
             distance_fn: distance_type.func(),
         }
@@ -415,7 +400,7 @@ impl<'a> FlatDistanceCal<'a, UInt8Type> {
         let dimension = vectors.value_length() as usize;
         Self {
             vectors: flat_array.values(),
-            query: QueryVector::Owned(query.as_primitive::<UInt8Type>().values().to_vec()),
+            query: Cow::Owned(query.as_primitive::<UInt8Type>().values().to_vec()),
             dimension,
             distance_fn: hamming,
         }
@@ -432,7 +417,7 @@ impl<'a> FlatDistanceCal<'a, UInt8Type> {
         let id = id as usize;
         Self {
             vectors,
-            query: QueryVector::Borrowed(&vectors[dimension * id..dimension * (id + 1)]),
+            query: Cow::Borrowed(&vectors[dimension * id..dimension * (id + 1)]),
             dimension,
             distance_fn: hamming,
         }
@@ -449,13 +434,13 @@ impl<T: ArrowPrimitiveType> FlatDistanceCal<'_, T> {
 impl<T: ArrowPrimitiveType> DistCalculator for FlatDistanceCal<'_, T> {
     #[inline]
     fn distance(&self, id: u32) -> f32 {
-        let query = self.query.as_slice();
+        let query = self.query.as_ref();
         let vector = self.get_vector(id);
         (self.distance_fn)(query, vector)
     }
 
     fn distance_all(&self, _k_hint: usize) -> Vec<f32> {
-        let query = self.query.as_slice();
+        let query = self.query.as_ref();
         self.vectors
             .chunks_exact(self.dimension)
             .map(|vector| (self.distance_fn)(query, vector))

--- a/rust/lance-index/src/vector/hnsw.rs
+++ b/rust/lance-index/src/vector/hnsw.rs
@@ -69,7 +69,19 @@ pub(crate) fn select_neighbors_heuristic(
     if candidates.len() <= k {
         return candidates.iter().cloned().collect_vec();
     }
-    let mut candidates = candidates.to_vec();
+
+    select_neighbors_heuristic_owned(storage, candidates.to_vec(), k)
+}
+
+pub(crate) fn select_neighbors_heuristic_owned(
+    storage: &impl VectorStore,
+    mut candidates: Vec<OrderedNode>,
+    k: usize,
+) -> Vec<OrderedNode> {
+    if candidates.len() <= k {
+        return candidates;
+    }
+
     candidates.sort_unstable();
 
     let mut results: Vec<OrderedNode> = Vec::with_capacity(k);

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -28,7 +28,9 @@ use rand::{Rng, SeedableRng, rngs::SmallRng};
 use serde::{Deserialize, Serialize};
 
 use super::super::graph::beam_search;
-use super::{HNSW_TYPE, HnswMetadata, VECTOR_ID_COL, VECTOR_ID_FIELD, select_neighbors_heuristic};
+use super::{
+    HNSW_TYPE, HnswMetadata, VECTOR_ID_COL, VECTOR_ID_FIELD, select_neighbors_heuristic_owned,
+};
 use crate::metrics::MetricsCollector;
 use crate::prefilter::PreFilter;
 use crate::vector::flat::storage::{FlatBinStorage, FlatFloatStorage};
@@ -565,26 +567,23 @@ impl HnswBuilder {
             }
         }
         for (level, pruned_neighbors) in pruned_neighbors_per_level.iter().enumerate() {
-            let _: Vec<_> = pruned_neighbors
-                .iter()
-                .map(|unpruned_edge| {
-                    let level = level as u16;
-                    let m_max = match level {
-                        0 => self.params.m * 2,
-                        _ => self.params.m,
-                    };
-                    if unpruned_edge.dist
-                        < nodes[unpruned_edge.id as usize]
-                            .read()
-                            .unwrap()
-                            .cutoff(level, m_max)
-                    {
-                        let mut chosen_node = nodes[unpruned_edge.id as usize].write().unwrap();
-                        chosen_node.add_neighbor(node, unpruned_edge.dist, level);
-                        self.prune(storage, &mut chosen_node, level);
-                    }
-                })
-                .collect();
+            for unpruned_edge in pruned_neighbors {
+                let level = level as u16;
+                let m_max = match level {
+                    0 => self.params.m * 2,
+                    _ => self.params.m,
+                };
+                if unpruned_edge.dist
+                    < nodes[unpruned_edge.id as usize]
+                        .read()
+                        .unwrap()
+                        .cutoff(level, m_max)
+                {
+                    let mut chosen_node = nodes[unpruned_edge.id as usize].write().unwrap();
+                    chosen_node.add_neighbor(node, unpruned_edge.dist, level);
+                    self.prune(storage, &mut chosen_node, level);
+                }
+            }
         }
     }
 
@@ -621,13 +620,13 @@ impl HnswBuilder {
         };
 
         let neighbors_ranked = &mut builder_node.level_neighbors_ranked[level as usize];
-        let level_neighbors = neighbors_ranked.clone();
-        if level_neighbors.len() <= m_max {
+        if neighbors_ranked.len() <= m_max {
             builder_node.update_from_ranked_neighbors(level);
             return;
         }
 
-        *neighbors_ranked = select_neighbors_heuristic(storage, &level_neighbors, m_max);
+        let level_neighbors = std::mem::take(neighbors_ranked);
+        *neighbors_ranked = select_neighbors_heuristic_owned(storage, level_neighbors, m_max);
         builder_node.update_from_ranked_neighbors(level);
     }
 }

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -5,7 +5,11 @@
 //!
 //! Used as storage backend for Graph based algorithms.
 
-use std::{cmp::min, collections::HashMap, sync::Arc};
+use std::{
+    cmp::min,
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+};
 
 use arrow::datatypes::{self, UInt8Type};
 use arrow_array::{Array, ArrayRef, ArrowPrimitiveType, PrimitiveArray};
@@ -24,7 +28,7 @@ use lance_file::previous::{
     reader::FileReader as PreviousFileReader, writer::FileWriter as PreviousFileWriter,
 };
 use lance_io::{object_store::ObjectStore, utils::read_message};
-use lance_linalg::distance::{DistanceType, Dot, L2};
+use lance_linalg::distance::{Cosine, DistanceType, Dot, L2};
 use lance_table::utils::LanceIteratorExtension;
 use lance_table::{format::SelfDescribingFileReader, io::manifest::ManifestDescribing};
 use object_store::path::Path;
@@ -158,6 +162,7 @@ pub struct ProductQuantizationStorage {
     // For easy access
     pq_code: Arc<UInt8Array>,
     row_ids: Arc<UInt64Array>,
+    pairwise_distance_table: Arc<OnceLock<Vec<f32>>>,
 }
 
 impl DeepSizeOf for ProductQuantizationStorage {
@@ -168,6 +173,11 @@ impl DeepSizeOf for ProductQuantizationStorage {
                 .codebook
                 .as_ref()
                 .map(|codebook| codebook.get_array_memory_size())
+                .unwrap_or(0)
+            + self
+                .pairwise_distance_table
+                .get()
+                .map(|table| table.deep_size_of_children(_context))
                 .unwrap_or(0)
     }
 }
@@ -302,6 +312,7 @@ impl ProductQuantizationStorage {
             batch,
             pq_code,
             row_ids,
+            pairwise_distance_table: Arc::new(OnceLock::new()),
         })
     }
 
@@ -403,6 +414,47 @@ impl ProductQuantizationStorage {
         ids.iter()
             .map(|&id| self.row_ids.value(id as usize))
             .collect()
+    }
+
+    fn pairwise_distance_table(&self) -> &[f32] {
+        self.pairwise_distance_table
+            .get_or_init(|| {
+                let codebook = self.metadata.codebook.as_ref().unwrap();
+                match codebook.value_type() {
+                    DataType::Float16 => build_pairwise_distance_table(
+                        codebook
+                            .values()
+                            .as_primitive::<datatypes::Float16Type>()
+                            .values(),
+                        self.metadata.nbits,
+                        self.metadata.num_sub_vectors,
+                        self.metadata.dimension,
+                        self.distance_type,
+                    ),
+                    DataType::Float32 => build_pairwise_distance_table(
+                        codebook
+                            .values()
+                            .as_primitive::<datatypes::Float32Type>()
+                            .values(),
+                        self.metadata.nbits,
+                        self.metadata.num_sub_vectors,
+                        self.metadata.dimension,
+                        self.distance_type,
+                    ),
+                    DataType::Float64 => build_pairwise_distance_table(
+                        codebook
+                            .values()
+                            .as_primitive::<datatypes::Float64Type>()
+                            .values(),
+                        self.metadata.nbits,
+                        self.metadata.num_sub_vectors,
+                        self.metadata.dimension,
+                        self.distance_type,
+                    ),
+                    _ => unimplemented!("Unsupported data type: {:?}", codebook.value_type()),
+                }
+            })
+            .as_slice()
     }
 
     /// Write the PQ storage as a Lance partition to disk,
@@ -546,6 +598,7 @@ impl QuantizerStorage for ProductQuantizationStorage {
             batch,
             pq_code: Arc::new(transposed_codes),
             row_ids: new_row_ids,
+            pairwise_distance_table: self.pairwise_distance_table.clone(),
         })
     }
 
@@ -673,73 +726,14 @@ impl VectorStore for ProductQuantizationStorage {
             self.metadata.num_sub_vectors,
             id,
         );
-        let codebook = self.metadata.codebook.as_ref().unwrap();
-        match codebook.value_type() {
-            DataType::Float16 => {
-                let codebook = codebook
-                    .values()
-                    .as_primitive::<datatypes::Float16Type>()
-                    .values();
-                let query = get_centroids(
-                    codebook,
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.metadata.dimension,
-                    codes,
-                );
-                PQDistCalculator::new(
-                    codebook,
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.pq_code.clone(),
-                    &query,
-                    self.distance_type,
-                )
-            }
-            DataType::Float32 => {
-                let codebook = codebook
-                    .values()
-                    .as_primitive::<datatypes::Float32Type>()
-                    .values();
-                let query = get_centroids(
-                    codebook,
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.metadata.dimension,
-                    codes,
-                );
-                PQDistCalculator::new(
-                    codebook,
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.pq_code.clone(),
-                    &query,
-                    self.distance_type,
-                )
-            }
-            DataType::Float64 => {
-                let codebook = codebook
-                    .values()
-                    .as_primitive::<datatypes::Float64Type>()
-                    .values();
-                let query = get_centroids(
-                    codebook,
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.metadata.dimension,
-                    codes,
-                );
-                PQDistCalculator::new(
-                    codebook,
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.pq_code.clone(),
-                    &query,
-                    self.distance_type,
-                )
-            }
-            _ => unimplemented!("Unsupported data type: {:?}", codebook.value_type()),
-        }
+        PQDistCalculator::new_from_codes(
+            self.pairwise_distance_table(),
+            self.metadata.nbits,
+            self.metadata.num_sub_vectors,
+            self.pq_code.clone(),
+            codes,
+            self.distance_type,
+        )
     }
 
     fn dist_between(&self, u: u32, v: u32) -> f32 {
@@ -758,80 +752,14 @@ impl VectorStore for ProductQuantizationStorage {
             self.metadata.num_sub_vectors,
             v,
         );
-        let codebook = self.metadata.codebook.as_ref().unwrap();
-
-        match codebook.value_type() {
-            DataType::Float16 => {
-                let qu = get_centroids(
-                    codebook
-                        .values()
-                        .as_primitive::<datatypes::Float16Type>()
-                        .values(),
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.metadata.dimension,
-                    u_codes,
-                );
-                let qv = get_centroids(
-                    codebook
-                        .values()
-                        .as_primitive::<datatypes::Float16Type>()
-                        .values(),
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.metadata.dimension,
-                    v_codes,
-                );
-                self.distance_type.func()(&qu, &qv)
-            }
-            DataType::Float32 => {
-                let qu = get_centroids(
-                    codebook
-                        .values()
-                        .as_primitive::<datatypes::Float32Type>()
-                        .values(),
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.metadata.dimension,
-                    u_codes,
-                );
-                let qv = get_centroids(
-                    codebook
-                        .values()
-                        .as_primitive::<datatypes::Float32Type>()
-                        .values(),
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.metadata.dimension,
-                    v_codes,
-                );
-                self.distance_type.func()(&qu, &qv)
-            }
-            DataType::Float64 => {
-                let qu = get_centroids(
-                    codebook
-                        .values()
-                        .as_primitive::<datatypes::Float64Type>()
-                        .values(),
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.metadata.dimension,
-                    u_codes,
-                );
-                let qv = get_centroids(
-                    codebook
-                        .values()
-                        .as_primitive::<datatypes::Float64Type>()
-                        .values(),
-                    self.metadata.nbits,
-                    self.metadata.num_sub_vectors,
-                    self.metadata.dimension,
-                    v_codes,
-                );
-                self.distance_type.func()(&qu, &qv)
-            }
-            _ => unimplemented!("Unsupported data type: {:?}", codebook.value_type()),
-        }
+        pq_code_distance(
+            self.pairwise_distance_table(),
+            self.metadata.nbits,
+            self.metadata.num_sub_vectors,
+            u_codes,
+            v_codes,
+            self.distance_type,
+        )
     }
 
     fn prefers_candidate(&self, candidate: &OrderedNode, selected: &[OrderedNode]) -> bool {
@@ -868,6 +796,29 @@ impl PQDistCalculator {
             }
             _ => unimplemented!("DistanceType is not supported: {:?}", distance_type),
         };
+        Self {
+            distance_table,
+            num_sub_vectors,
+            pq_code,
+            num_bits,
+            distance_type,
+        }
+    }
+
+    fn new_from_codes(
+        pairwise_distance_table: &[f32],
+        num_bits: u32,
+        num_sub_vectors: usize,
+        pq_code: Arc<UInt8Array>,
+        query_codes: impl Iterator<Item = u8>,
+        distance_type: DistanceType,
+    ) -> Self {
+        let distance_table = distance_table_from_codes(
+            pairwise_distance_table,
+            num_bits,
+            num_sub_vectors,
+            query_codes,
+        );
         Self {
             distance_table,
             num_sub_vectors,
@@ -962,6 +913,153 @@ impl DistCalculator for PQDistCalculator {
     }
 }
 
+fn build_pairwise_distance_table<T: L2 + Cosine + Dot>(
+    codebook: &[T],
+    num_bits: u32,
+    num_sub_vectors: usize,
+    dimension: usize,
+    distance_type: DistanceType,
+) -> Vec<f32> {
+    let num_centroids = 2_usize.pow(num_bits);
+    let sub_vector_width = dimension / num_sub_vectors;
+    let mut result = Vec::with_capacity(num_sub_vectors * num_centroids * num_centroids);
+    let distance_fn = distance_type.func();
+    for sub_vector_idx in 0..num_sub_vectors {
+        let sub_vector_offset = sub_vector_idx * num_centroids * sub_vector_width;
+        let centroids =
+            &codebook[sub_vector_offset..sub_vector_offset + num_centroids * sub_vector_width];
+        for query_centroid_idx in 0..num_centroids {
+            let query_offset = query_centroid_idx * sub_vector_width;
+            let query = &centroids[query_offset..query_offset + sub_vector_width];
+            for centroid_idx in 0..num_centroids {
+                let centroid_offset = centroid_idx * sub_vector_width;
+                let centroid = &centroids[centroid_offset..centroid_offset + sub_vector_width];
+                result.push(distance_fn(query, centroid));
+            }
+        }
+    }
+    result
+}
+
+fn distance_table_from_codes(
+    pairwise_distance_table: &[f32],
+    num_bits: u32,
+    num_sub_vectors: usize,
+    query_codes: impl Iterator<Item = u8>,
+) -> Vec<f32> {
+    let num_centroids = 2_usize.pow(num_bits);
+    let mut distance_table = Vec::with_capacity(num_sub_vectors * num_centroids);
+    if num_bits == 4 {
+        for (byte_idx, query_code) in query_codes.enumerate() {
+            let current_idx = (query_code & 0x0F) as usize;
+            let current_sub_vector_idx = 2 * byte_idx;
+            extend_pairwise_distance_row(
+                &mut distance_table,
+                pairwise_distance_table,
+                num_centroids,
+                current_sub_vector_idx,
+                current_idx,
+            );
+
+            let next_idx = (query_code >> 4) as usize;
+            let next_sub_vector_idx = current_sub_vector_idx + 1;
+            extend_pairwise_distance_row(
+                &mut distance_table,
+                pairwise_distance_table,
+                num_centroids,
+                next_sub_vector_idx,
+                next_idx,
+            );
+        }
+    } else {
+        for (sub_vector_idx, query_code) in query_codes.enumerate() {
+            extend_pairwise_distance_row(
+                &mut distance_table,
+                pairwise_distance_table,
+                num_centroids,
+                sub_vector_idx,
+                query_code as usize,
+            );
+        }
+    }
+    distance_table
+}
+
+fn extend_pairwise_distance_row(
+    distance_table: &mut Vec<f32>,
+    pairwise_distance_table: &[f32],
+    num_centroids: usize,
+    sub_vector_idx: usize,
+    query_centroid_idx: usize,
+) {
+    let start = (sub_vector_idx * num_centroids + query_centroid_idx) * num_centroids;
+    distance_table.extend_from_slice(&pairwise_distance_table[start..start + num_centroids]);
+}
+
+fn pq_code_distance(
+    pairwise_distance_table: &[f32],
+    num_bits: u32,
+    num_sub_vectors: usize,
+    lhs_codes: impl Iterator<Item = u8>,
+    rhs_codes: impl Iterator<Item = u8>,
+    distance_type: DistanceType,
+) -> f32 {
+    let num_centroids = 2_usize.pow(num_bits);
+    let dist = if num_bits == 4 {
+        lhs_codes
+            .zip(rhs_codes)
+            .enumerate()
+            .map(|(byte_idx, (lhs, rhs))| {
+                let current_sub_vector_idx = 2 * byte_idx;
+                pairwise_distance(
+                    pairwise_distance_table,
+                    num_centroids,
+                    current_sub_vector_idx,
+                    (lhs & 0x0F) as usize,
+                    (rhs & 0x0F) as usize,
+                ) + pairwise_distance(
+                    pairwise_distance_table,
+                    num_centroids,
+                    current_sub_vector_idx + 1,
+                    (lhs >> 4) as usize,
+                    (rhs >> 4) as usize,
+                )
+            })
+            .sum()
+    } else {
+        lhs_codes
+            .zip(rhs_codes)
+            .enumerate()
+            .map(|(sub_vector_idx, (lhs, rhs))| {
+                pairwise_distance(
+                    pairwise_distance_table,
+                    num_centroids,
+                    sub_vector_idx,
+                    lhs as usize,
+                    rhs as usize,
+                )
+            })
+            .sum()
+    };
+
+    if distance_type == DistanceType::Dot {
+        dist - (num_sub_vectors as f32 - 1.0)
+    } else {
+        dist
+    }
+}
+
+fn pairwise_distance(
+    pairwise_distance_table: &[f32],
+    num_centroids: usize,
+    sub_vector_idx: usize,
+    query_centroid_idx: usize,
+    centroid_idx: usize,
+) -> f32 {
+    pairwise_distance_table
+        [(sub_vector_idx * num_centroids + query_centroid_idx) * num_centroids + centroid_idx]
+}
+
 fn get_pq_code(
     pq_code: &[u8],
     num_bits: u32,
@@ -983,6 +1081,7 @@ fn get_pq_code(
         .exact_size(num_bytes)
 }
 
+#[cfg(test)]
 fn get_centroids<T: Clone>(
     codebook: &[T],
     num_bits: u32,
@@ -1011,6 +1110,7 @@ fn get_centroids<T: Clone>(
     centroids
 }
 
+#[cfg(test)]
 fn get_centroids_4bit<T: Clone>(
     codebook: &[T],
     num_sub_vectors: usize,
@@ -1147,6 +1247,50 @@ mod tests {
         let dist1 = storage.dist_between(u, v);
         let dist2 = storage.dist_between(v, u);
         assert_eq!(dist1, dist2);
+    }
+
+    #[tokio::test]
+    async fn test_dist_calculator_from_id_matches_reconstructed_distance() {
+        let mut rng = rand::rng();
+        let storage = create_pq_storage().await;
+        let u = rng.random_range(0..storage.len() as u32);
+        let v = rng.random_range(0..storage.len() as u32);
+        let codebook = storage
+            .metadata
+            .codebook
+            .as_ref()
+            .unwrap()
+            .values()
+            .as_primitive::<datatypes::Float32Type>();
+        let pq_codes = storage.pq_code.values();
+        let qu = get_centroids(
+            codebook.values(),
+            storage.metadata.nbits,
+            storage.metadata.num_sub_vectors,
+            storage.metadata.dimension,
+            get_pq_code(
+                pq_codes,
+                storage.metadata.nbits,
+                storage.metadata.num_sub_vectors,
+                u,
+            ),
+        );
+        let qv = get_centroids(
+            codebook.values(),
+            storage.metadata.nbits,
+            storage.metadata.num_sub_vectors,
+            storage.metadata.dimension,
+            get_pq_code(
+                pq_codes,
+                storage.metadata.nbits,
+                storage.metadata.num_sub_vectors,
+                v,
+            ),
+        );
+        let expected = storage.distance_type.func()(&qu, &qv);
+        let dist_calc = storage.dist_calculator_from_id(u);
+        assert!((dist_calc.distance(v) - expected).abs() < 1e-4);
+        assert!((storage.dist_between(u, v) - expected).abs() < 1e-4);
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -372,10 +372,10 @@ impl VectorStore for ScalarQuantizationStorage {
 
     fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
         let (offset, chunk) = self.chunk(id);
-        let query_sq_code = chunk.sq_code_slice(id - offset).to_vec();
+        let query_sq_code = chunk.sq_code_slice(id - offset);
         let bounds = self.quantizer.bounds();
         SQDistCalculator {
-            query_sq_code,
+            query_sq_code: SQQueryCode::Borrowed(query_sq_code),
             scale: sq_distance_scale(&bounds),
             storage: self,
         }
@@ -389,9 +389,24 @@ fn sq_distance_scale(bounds: &Range<f64>) -> f32 {
 }
 
 pub struct SQDistCalculator<'a> {
-    query_sq_code: Vec<u8>,
+    query_sq_code: SQQueryCode<'a>,
     scale: f32,
     storage: &'a ScalarQuantizationStorage,
+}
+
+enum SQQueryCode<'a> {
+    Borrowed(&'a [u8]),
+    Owned(Vec<u8>),
+}
+
+impl SQQueryCode<'_> {
+    #[inline]
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Borrowed(query) => query,
+            Self::Owned(query) => query,
+        }
+    }
 }
 
 impl<'a> SQDistCalculator<'a> {
@@ -415,7 +430,7 @@ impl<'a> SQDistCalculator<'a> {
             }
         };
         Self {
-            query_sq_code,
+            query_sq_code: SQQueryCode::Owned(query_sq_code),
             scale: sq_distance_scale(&bounds),
             storage,
         }
@@ -426,15 +441,17 @@ impl DistCalculator for SQDistCalculator<'_> {
     fn distance(&self, id: u32) -> f32 {
         let (offset, chunk) = self.storage.chunk(id);
         let sq_code = chunk.sq_code_slice(id - offset);
+        let query_sq_code = self.query_sq_code.as_slice();
         let dist = match self.storage.distance_type {
-            DistanceType::L2 | DistanceType::Cosine => l2_u8(sq_code, &self.query_sq_code) as f32,
-            DistanceType::Dot => dot_distance(sq_code, &self.query_sq_code),
+            DistanceType::L2 | DistanceType::Cosine => l2_u8(sq_code, query_sq_code) as f32,
+            DistanceType::Dot => dot_distance(sq_code, query_sq_code),
             _ => panic!("We should not reach here: sq distance can only be L2 or Dot"),
         };
         dist * self.scale
     }
 
     fn distance_all(&self, _k_hint: usize) -> Vec<f32> {
+        let query_sq_code = self.query_sq_code.as_slice();
         match self.storage.distance_type {
             DistanceType::L2 | DistanceType::Cosine => self
                 .storage
@@ -444,7 +461,7 @@ impl DistCalculator for SQDistCalculator<'_> {
                     c.sq_codes
                         .values()
                         .chunks_exact(c.dim())
-                        .map(|sq_codes| l2_u8(sq_codes, &self.query_sq_code) as f32)
+                        .map(|sq_codes| l2_u8(sq_codes, query_sq_code) as f32)
                 })
                 .map(|dist| dist * self.scale)
                 .collect(),
@@ -456,7 +473,7 @@ impl DistCalculator for SQDistCalculator<'_> {
                     c.sq_codes
                         .values()
                         .chunks_exact(c.dim())
-                        .map(|sq_codes| dot_distance(sq_codes, &self.query_sq_code))
+                        .map(|sq_codes| dot_distance(sq_codes, query_sq_code))
                 })
                 .map(|dist| dist * self.scale)
                 .collect(),


### PR DESCRIPTION
## Performance Improvement

HNSW index construction spends a large amount of time creating distance calculators from graph node ids and pruning graph neighbors. The hot path previously copied vectors or reconstructed PQ centroids when the query was already an indexed vector, and PQ `dist_between` rebuilt full centroid vectors for both endpoints.

This PR reduces that overhead by:

- Borrowing flat and SQ query vectors directly from storage when creating `dist_calculator_from_id`.
- Reusing owned candidate buffers in HNSW neighbor pruning and avoiding an unused backlink collection.
- Lazily building and sharing a PQ centroid pairwise distance table, then deriving per-query distance rows directly from PQ codes.
- Computing PQ code-to-code distance from the shared pairwise table instead of reconstructing centroid vectors.

### Benchmarks

GCP `c4-standard-16`, `RUSTFLAGS="-C target-cpu=native" cargo bench -p lance-index --bench hnsw -- create_hnsw --sample-size 10 --warm-up-time 1 --measurement-time 5`, 100k x 128 benchmark cases.

| Benchmark | main median | PR median | Change |
| --- | ---: | ---: | ---: |
| `create_hnsw(100000x128)` | 6.7919 s | 4.1944 s | 38.2% faster |
| `create_hnsw_sq(100000x128)` | 3.5711 s | 3.5269 s | 1.2% faster |
| `create_hnsw_pq(100000x128)` | 30.129 s | 13.457 s | 55.3% faster |

The PQ pairwise table is initialized lazily and shared across remapped storage instances. Criterion warmup pays the one-time initialization cost before measurement; production first use will pay that setup once per storage instance.

### Validation

- `cargo fmt --all`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo test -p lance-index vector::hnsw::builder::tests::test_builder_write_load --lib`
- `cargo test -p lance-index vector::sq::storage::tests::test_get_chunks --lib`
- `cargo test -p lance-index vector::pq::storage::tests::test_dist_calculator_from_id_matches_reconstructed_distance --lib`
