### PR TITLE
perf(search): reuse IVF_RQ query scratch

### DIFF
--- a/rust/lance-index/src/vector/bq/rotation.rs
+++ b/rust/lance-index/src/vector/bq/rotation.rs
@@ -145,6 +145,7 @@ pub fn random_fast_rotation_signs(dim: usize) -> Vec<u8> {
     signs
 }
 
+#[inline]
 pub fn apply_fast_rotation<T: AsPrimitive<f32>>(input: &[T], output: &mut [f32], signs: &[u8]) {
     // Fast random rotation pipeline, aligned with RaBitQ-Library's FhtKacRotator:
     // - power-of-two dims: repeat [random signs -> FWHT -> scale] for 4 rounds
@@ -152,8 +153,6 @@ pub fn apply_fast_rotation<T: AsPrimitive<f32>>(input: &[T], output: &mut [f32],
     //
     // This keeps the fast path matrix-free: no dense orthogonal matrix materialization.
     let dim = output.len();
-    let bytes_per_round = sign_bytes_per_round(dim);
-    debug_assert_eq!(signs.len(), FAST_ROTATION_ROUNDS * bytes_per_round);
     let input_len = input.len().min(dim);
     output[..input_len]
         .iter_mut()
@@ -163,6 +162,14 @@ pub fn apply_fast_rotation<T: AsPrimitive<f32>>(input: &[T], output: &mut [f32],
         output[input_len..].fill(0.0);
     }
 
+    apply_fast_rotation_in_place(output, signs);
+}
+
+#[inline]
+pub fn apply_fast_rotation_in_place(output: &mut [f32], signs: &[u8]) {
+    let dim = output.len();
+    let bytes_per_round = sign_bytes_per_round(dim);
+    debug_assert_eq!(signs.len(), FAST_ROTATION_ROUNDS * bytes_per_round);
     if dim == 0 {
         return;
     }

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::borrow::Cow;
 use std::collections::HashMap;
+use std::ops::Sub;
 use std::sync::Arc;
 
 use arrow::array::AsArray;
@@ -18,8 +20,16 @@ use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray, RecordBatch
 use lance_core::{Error, ROW_ID, Result};
 use lance_file::previous::reader::FileReader as PreviousFileReader;
 use lance_linalg::distance::{DistanceType, Dot};
-use lance_linalg::simd::dist_table::{BATCH_SIZE, PERM0, PERM0_INVERSE};
-use lance_linalg::simd::{self};
+use lance_linalg::simd::{
+    self,
+    dist_table::{BATCH_SIZE, PERM0, PERM0_INVERSE},
+};
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+))]
+use lance_linalg::simd::{SIMD, f32::f32x16};
 use lance_table::utils::LanceIteratorExtension;
 use num_traits::AsPrimitive;
 use prost::Message;
@@ -28,11 +38,11 @@ use serde::{Deserialize, Serialize};
 use crate::frag_reuse::FragReuseIndex;
 use crate::pb;
 use crate::vector::bq::RQRotationType;
-use crate::vector::bq::rotation::apply_fast_rotation;
+use crate::vector::bq::rotation::{apply_fast_rotation, apply_fast_rotation_in_place};
 use crate::vector::bq::transform::{ADD_FACTORS_COLUMN, SCALE_FACTORS_COLUMN};
 use crate::vector::pq::storage::transpose;
 use crate::vector::quantizer::{QuantizerMetadata, QuantizerStorage};
-use crate::vector::storage::{DistCalculator, VectorStore};
+use crate::vector::storage::{DistCalculator, QueryResidual, VectorStore};
 
 pub const RABIT_METADATA_KEY: &str = "lance:rabit";
 pub const RABIT_CODE_COLUMN: &str = "_rabit_codes";
@@ -61,6 +71,91 @@ pub struct RabitQuantizationMetadata {
 fn default_rotation_type_compat() -> RQRotationType {
     // Older metadata does not have this field and always used dense matrices.
     RQRotationType::Matrix
+}
+
+impl RabitQuantizationMetadata {
+    fn code_dim(&self) -> usize {
+        if self.code_dim > 0 {
+            self.code_dim as usize
+        } else {
+            self.rotate_mat
+                .as_ref()
+                .map(|rotate_mat| rotate_mat.len())
+                .unwrap_or_default()
+        }
+    }
+
+    fn rotate_vector_with_residual_into(
+        &self,
+        vector: &dyn Array,
+        residual_centroid: Option<&dyn Array>,
+        output: &mut [f32],
+    ) {
+        debug_assert_eq!(output.len(), self.code_dim());
+        match self.rotation_type {
+            RQRotationType::Matrix => {
+                let rotate_mat = self
+                    .rotate_mat
+                    .as_ref()
+                    .expect("RabitQ dense rotation metadata not loaded");
+
+                match rotate_mat.value_type() {
+                    DataType::Float16 => {
+                        RabitQuantizationStorage::rotate_query_vector_dense_into::<Float16Type>(
+                            rotate_mat,
+                            vector,
+                            residual_centroid,
+                            output,
+                        )
+                    }
+                    DataType::Float32 => {
+                        RabitQuantizationStorage::rotate_query_vector_dense_into::<Float32Type>(
+                            rotate_mat,
+                            vector,
+                            residual_centroid,
+                            output,
+                        )
+                    }
+                    DataType::Float64 => {
+                        RabitQuantizationStorage::rotate_query_vector_dense_into::<Float64Type>(
+                            rotate_mat,
+                            vector,
+                            residual_centroid,
+                            output,
+                        )
+                    }
+                    dt => unimplemented!("RabitQ does not support data type: {}", dt),
+                }
+            }
+            RQRotationType::Fast => {
+                let signs = self
+                    .fast_rotation_signs
+                    .as_ref()
+                    .expect("RabitQ fast rotation metadata not loaded");
+                match vector.data_type() {
+                    DataType::Float16 => RabitQuantizationStorage::rotate_query_vector_fast_into::<
+                        Float16Type,
+                    >(
+                        signs, vector, residual_centroid, output
+                    ),
+                    DataType::Float32 => {
+                        RabitQuantizationStorage::rotate_query_vector_fast_f32_into(
+                            signs,
+                            vector,
+                            residual_centroid,
+                            output,
+                        )
+                    }
+                    DataType::Float64 => RabitQuantizationStorage::rotate_query_vector_fast_into::<
+                        Float64Type,
+                    >(
+                        signs, vector, residual_centroid, output
+                    ),
+                    dt => unimplemented!("RabitQ does not support data type: {}", dt),
+                }
+            }
+        }
+    }
 }
 
 impl DeepSizeOf for RabitQuantizationMetadata {
@@ -157,15 +252,69 @@ impl DeepSizeOf for RabitQuantizationStorage {
 }
 
 impl RabitQuantizationStorage {
-    fn rotate_query_vector_dense<T: ArrowFloatType>(
+    fn code_dim(&self) -> usize {
+        self.metadata.code_dim()
+    }
+
+    fn query_factor(&self, dist_q_c: f32) -> f32 {
+        match self.distance_type {
+            DistanceType::L2 => dist_q_c,
+            DistanceType::Cosine | DistanceType::Dot => dist_q_c - 1.0,
+            _ => unimplemented!(
+                "RabitQ does not support distance type: {}",
+                self.distance_type
+            ),
+        }
+    }
+
+    fn distance_calculator_from_parts<'a>(
+        &'a self,
+        dim: usize,
+        dist_q_c: f32,
+        dist_table: Cow<'a, [f32]>,
+        sum_q: f32,
+    ) -> RabitDistCalculator<'a> {
+        RabitDistCalculator::new(
+            dim,
+            self.metadata.num_bits,
+            dist_table,
+            sum_q,
+            self.codes.values().as_primitive::<UInt8Type>().values(),
+            self.add_factors.values(),
+            self.scale_factors.values(),
+            self.query_factor(dist_q_c),
+        )
+    }
+
+    fn rotate_query_vector(&self, code_dim: usize, qr: &dyn Array) -> Vec<f32> {
+        let mut output = vec![0.0f32; code_dim];
+        self.rotate_query_vector_into(code_dim, qr, None, &mut output);
+        output
+    }
+
+    fn rotate_query_vector_into(
+        &self,
+        code_dim: usize,
+        qr: &dyn Array,
+        residual_centroid: Option<&dyn Array>,
+        output: &mut [f32],
+    ) {
+        debug_assert_eq!(output.len(), code_dim);
+        self.metadata
+            .rotate_vector_with_residual_into(qr, residual_centroid, output);
+    }
+
+    fn rotate_query_vector_dense_into<T: ArrowFloatType>(
         rotate_mat: &FixedSizeListArray,
         qr: &dyn Array,
-    ) -> Vec<f32>
-    where
-        T::Native: Dot,
+        residual_centroid: Option<&dyn Array>,
+        output: &mut [f32],
+    ) where
+        T::Native: AsPrimitive<f32> + Dot + Sub<Output = T::Native>,
     {
         let d = qr.len();
         let code_dim = rotate_mat.len();
+        debug_assert_eq!(output.len(), code_dim);
         let rotate_mat = rotate_mat
             .values()
             .as_any()
@@ -179,19 +328,38 @@ impl RabitQuantizationStorage {
             .unwrap()
             .as_slice();
 
-        rotate_mat
-            .chunks_exact(code_dim)
-            .map(|chunk| lance_linalg::distance::dot(&chunk[..d], qr))
-            .collect()
+        if let Some(residual_centroid) = residual_centroid {
+            let residual_centroid = residual_centroid
+                .as_any()
+                .downcast_ref::<T::ArrayType>()
+                .unwrap()
+                .as_slice();
+            debug_assert_eq!(residual_centroid.len(), d);
+            for (chunk, out) in rotate_mat.chunks_exact(code_dim).zip(output.iter_mut()) {
+                let mut sum = 0.0;
+                for idx in 0..d {
+                    let residual = qr[idx] - residual_centroid[idx];
+                    sum += chunk[idx].as_() * residual.as_();
+                }
+                *out = sum;
+            }
+        } else {
+            rotate_mat
+                .chunks_exact(code_dim)
+                .zip(output.iter_mut())
+                .for_each(|(chunk, out)| {
+                    *out = lance_linalg::distance::dot(&chunk[..d], qr);
+                });
+        }
     }
 
-    fn rotate_query_vector_fast<T: ArrowFloatType>(
-        code_dim: usize,
+    fn rotate_query_vector_fast_into<T: ArrowFloatType>(
         signs: &[u8],
         qr: &dyn Array,
-    ) -> Vec<f32>
-    where
-        T::Native: AsPrimitive<f32>,
+        residual_centroid: Option<&dyn Array>,
+        output: &mut [f32],
+    ) where
+        T::Native: AsPrimitive<f32> + Sub<Output = T::Native>,
     {
         let qr = qr
             .as_any()
@@ -199,9 +367,85 @@ impl RabitQuantizationStorage {
             .unwrap()
             .as_slice();
 
-        let mut output = vec![0.0f32; code_dim];
-        apply_fast_rotation(qr, &mut output, signs);
-        output
+        if let Some(residual_centroid) = residual_centroid {
+            let residual_centroid = residual_centroid
+                .as_any()
+                .downcast_ref::<T::ArrayType>()
+                .unwrap()
+                .as_slice();
+            let input_len = qr.len().min(output.len());
+            debug_assert!(residual_centroid.len() >= input_len);
+            for idx in 0..input_len {
+                output[idx] = (qr[idx] - residual_centroid[idx]).as_();
+            }
+            if input_len < output.len() {
+                output[input_len..].fill(0.0);
+            }
+            apply_fast_rotation_in_place(output, signs);
+        } else {
+            apply_fast_rotation(qr, output, signs);
+        }
+    }
+
+    fn rotate_query_vector_fast_f32_into(
+        signs: &[u8],
+        qr: &dyn Array,
+        residual_centroid: Option<&dyn Array>,
+        output: &mut [f32],
+    ) {
+        let qr = qr.as_any().downcast_ref::<Float32Array>().unwrap().values();
+
+        if let Some(residual_centroid) = residual_centroid {
+            let residual_centroid = residual_centroid
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .unwrap()
+                .values();
+            copy_subtract_f32(qr, residual_centroid, output);
+            apply_fast_rotation_in_place(output, signs);
+        } else {
+            apply_fast_rotation(qr, output, signs);
+        }
+    }
+}
+
+#[inline]
+fn copy_subtract_f32(lhs: &[f32], rhs: &[f32], output: &mut [f32]) {
+    let input_len = lhs.len().min(output.len());
+    debug_assert!(rhs.len() >= input_len);
+
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "loongarch64"
+    ))]
+    let simd_len = input_len / f32x16::LANES * f32x16::LANES;
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "loongarch64"
+    )))]
+    let simd_len = 0;
+
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "loongarch64"
+    ))]
+    for idx in (0..simd_len).step_by(f32x16::LANES) {
+        let lhs = f32x16::from(&lhs[idx..]);
+        let rhs = f32x16::from(&rhs[idx..]);
+        let result = lhs - rhs;
+        unsafe {
+            result.store_unaligned(output.as_mut_ptr().add(idx));
+        }
+    }
+
+    for idx in simd_len..input_len {
+        output[idx] = lhs[idx] - rhs[idx];
+    }
+    if input_len < output.len() {
+        output[input_len..].fill(0.0);
     }
 }
 
@@ -215,7 +459,7 @@ pub struct RabitDistCalculator<'a> {
     // this is a flattened 2D array of size d/4 * 16,
     // we split the query codes into d/4 chunks, each chunk is with 4 elements,
     // then dist_table[i][j] is the distance between the i-th query code and the code j
-    dist_table: Vec<f32>,
+    dist_table: Cow<'a, [f32]>,
     add_factors: &'a [f32],
     scale_factors: &'a [f32],
     query_factor: f32,
@@ -229,7 +473,7 @@ impl<'a> RabitDistCalculator<'a> {
     pub fn new(
         dim: usize,
         num_bits: u8,
-        dist_table: Vec<f32>,
+        dist_table: Cow<'a, [f32]>,
         sum_q: f32,
         codes: &'a [u8],
         add_factors: &'a [f32],
@@ -264,10 +508,21 @@ where
     // so there are dim/4 segments, and the number of codes is 16 (2^{SEGMENT_LENGTH}),
     // so we have dim/4 * 16 = dim * 4 elements in the dist_table
     let mut dist_table = vec![0.0; qc.len() * 4];
+    build_dist_table_direct_into::<T>(qc, &mut dist_table);
+    dist_table
+}
+
+fn build_dist_table_direct_into<T: ArrowFloatType>(qc: &[T::Native], dist_table: &mut [f32])
+where
+    T::Native: AsPrimitive<f32>,
+{
+    debug_assert_eq!(dist_table.len(), qc.len() * 4);
     qc.chunks_exact(SEGMENT_LENGTH)
         .zip(dist_table.chunks_exact_mut(SEGMENT_NUM_CODES))
-        .for_each(|(sub_vec, dist_table)| build_dist_table_for_subvec::<T>(sub_vec, dist_table));
-    dist_table
+        .for_each(|(sub_vec, dist_table)| {
+            dist_table[0] = 0.0;
+            build_dist_table_for_subvec::<T>(sub_vec, dist_table);
+        });
 }
 
 #[inline(always)]
@@ -302,19 +557,23 @@ fn quantize_dist_table_into(dist_table: &[f32], quantized_dist_table: &mut Vec<u
         .minmax_by(|a, b| a.total_cmp(b))
         .into_option()
         .unwrap();
-    quantized_dist_table.clear();
-    quantized_dist_table.resize(dist_table.len(), 0);
     // this happens if the query is all zeros
     if qmin == qmax {
+        quantized_dist_table.clear();
+        quantized_dist_table.resize(dist_table.len(), 0);
         return (qmin, qmax);
     }
     let factor = 255.0 / (qmax - qmin);
-    quantized_dist_table
-        .iter_mut()
-        .zip(dist_table.iter())
-        .for_each(|(quantized, &d)| {
-            *quantized = ((d - qmin) * factor).round() as u8;
-        });
+    quantized_dist_table.clear();
+    quantized_dist_table.reserve(dist_table.len());
+    let spare = quantized_dist_table.spare_capacity_mut();
+    for (quantized, &d) in spare[..dist_table.len()].iter_mut().zip(dist_table.iter()) {
+        quantized.write(((d - qmin) * factor).round() as u8);
+    }
+    // SAFETY: every element in the reserved range was initialized in the loop above.
+    unsafe {
+        quantized_dist_table.set_len(dist_table.len());
+    }
 
     (qmin, qmax)
 }
@@ -348,6 +607,7 @@ impl DistCalculator for RabitDistCalculator<'_> {
     }
 
     #[inline(always)]
+    #[allow(clippy::uninit_vec)]
     fn distance_all_with_scratch(
         &self,
         _: usize,
@@ -363,15 +623,17 @@ impl DistCalculator for RabitDistCalculator<'_> {
             return;
         }
 
-        dists.clear();
-        dists.resize(n, 0.0);
         let (qmin, qmax) = quantize_dist_table_into(&self.dist_table, quantized_dists_table);
-        quantized_dists.clear();
-        quantized_dists.resize(n, 0);
-
         let remainder = n % BATCH_SIZE;
+        let simd_len = n - remainder;
+        quantized_dists.clear();
+        quantized_dists.reserve(simd_len);
+        // SAFETY: sum_4bit_dist_table overwrites each element in the SIMD batch range.
+        unsafe {
+            quantized_dists.set_len(simd_len);
+        }
         simd::dist_table::sum_4bit_dist_table(
-            n - remainder,
+            simd_len,
             code_len,
             self.codes,
             quantized_dists_table,
@@ -381,30 +643,30 @@ impl DistCalculator for RabitDistCalculator<'_> {
         let range = (qmax - qmin) / 255.0;
         let num_tables = quantized_dists_table.len() / 16;
         let sum_min = num_tables as f32 * qmin;
-        dists
+        dists.clear();
+        dists.reserve(n);
+        // SAFETY: the SIMD section below writes [0, simd_len), and the
+        // remainder section writes [simd_len, n).
+        unsafe {
+            dists.set_len(n);
+        }
+        let (simd_dists, remainder_dists) = dists.split_at_mut(simd_len);
+        simd_dists
             .iter_mut()
-            .take(n - remainder)
-            .zip(quantized_dists.iter().take(n - remainder))
-            .for_each(|(dist, q_dist)| {
-                *dist = (*q_dist as f32) * range + sum_min;
-            });
-
-        dists
-            .iter_mut()
+            .zip(quantized_dists.iter())
             .enumerate()
-            .take(n - remainder)
-            .for_each(|(id, dist)| {
-                let dist_vq_qr = (2.0 * *dist - self.sum_q) / self.sqrt_d;
+            .for_each(|(id, (dist, q_dist))| {
+                let dist_vq = (*q_dist as f32) * range + sum_min;
+                let dist_vq_qr = (2.0 * dist_vq - self.sum_q) / self.sqrt_d;
                 *dist =
                     dist_vq_qr * self.scale_factors[id] + self.add_factors[id] + self.query_factor;
             });
 
-        dists
+        remainder_dists
             .iter_mut()
             .enumerate()
-            .skip(n - remainder)
             .for_each(|(id, dist)| {
-                *dist = self.distance(id as u32);
+                *dist = self.distance((simd_len + id) as u32);
             });
     }
 }
@@ -447,79 +709,51 @@ impl VectorStore for RabitQuantizationStorage {
     // qr = (q-c)
     #[inline(never)]
     fn dist_calculator(&self, qr: Arc<dyn Array>, dist_q_c: f32) -> Self::DistanceCalculator<'_> {
-        let codes = self.codes.values().as_primitive::<UInt8Type>().values();
-        let code_dim = if self.metadata.code_dim > 0 {
-            self.metadata.code_dim as usize
-        } else {
-            self.metadata
-                .rotate_mat
-                .as_ref()
-                .map(|rotate_mat| rotate_mat.len())
-                .unwrap_or_default()
-        };
-
-        let rotated_qr = match self.metadata.rotation_type {
-            RQRotationType::Matrix => {
-                let rotate_mat = self
-                    .metadata
-                    .rotate_mat
-                    .as_ref()
-                    .expect("RabitQ dense rotation metadata not loaded");
-
-                match rotate_mat.value_type() {
-                    DataType::Float16 => {
-                        Self::rotate_query_vector_dense::<Float16Type>(rotate_mat, &qr)
-                    }
-                    DataType::Float32 => {
-                        Self::rotate_query_vector_dense::<Float32Type>(rotate_mat, &qr)
-                    }
-                    DataType::Float64 => {
-                        Self::rotate_query_vector_dense::<Float64Type>(rotate_mat, &qr)
-                    }
-                    dt => unimplemented!("RabitQ does not support data type: {}", dt),
-                }
-            }
-            RQRotationType::Fast => {
-                let signs = self
-                    .metadata
-                    .fast_rotation_signs
-                    .as_ref()
-                    .expect("RabitQ fast rotation metadata not loaded");
-                match qr.data_type() {
-                    DataType::Float16 => {
-                        Self::rotate_query_vector_fast::<Float16Type>(code_dim, signs, &qr)
-                    }
-                    DataType::Float32 => {
-                        Self::rotate_query_vector_fast::<Float32Type>(code_dim, signs, &qr)
-                    }
-                    DataType::Float64 => {
-                        Self::rotate_query_vector_fast::<Float64Type>(code_dim, signs, &qr)
-                    }
-                    dt => unimplemented!("RabitQ does not support data type: {}", dt),
-                }
-            }
-        };
-
+        let code_dim = self.code_dim();
+        let rotated_qr = self.rotate_query_vector(code_dim, &qr);
         let dist_table = build_dist_table_direct::<Float32Type>(&rotated_qr);
         let sum_q = rotated_qr.into_iter().sum();
 
-        let q_factor = match self.distance_type {
-            DistanceType::L2 => dist_q_c,
-            DistanceType::Cosine | DistanceType::Dot => dist_q_c - 1.0,
-            _ => unimplemented!(
-                "RabitQ does not support distance type: {}",
-                self.distance_type
-            ),
+        self.distance_calculator_from_parts(qr.len(), dist_q_c, Cow::Owned(dist_table), sum_q)
+    }
+
+    // qr = (q-c)
+    #[inline(never)]
+    fn dist_calculator_with_scratch<'a>(
+        &'a self,
+        qr: Arc<dyn Array>,
+        dist_q_c: f32,
+        residual: Option<QueryResidual<'_>>,
+        f32_scratch: &'a mut Vec<f32>,
+    ) -> Self::DistanceCalculator<'a> {
+        let code_dim = self.code_dim();
+        let dist_table_len = code_dim * 4;
+        f32_scratch.resize(code_dim + dist_table_len, 0.0);
+
+        let sum_q = {
+            let (rotated_qr, dist_table) = f32_scratch.split_at_mut(code_dim);
+            match residual {
+                Some(QueryResidual::Centroid(residual_centroid)) => {
+                    self.rotate_query_vector_into(
+                        code_dim,
+                        &qr,
+                        Some(residual_centroid),
+                        rotated_qr,
+                    );
+                }
+                None => {
+                    self.rotate_query_vector_into(code_dim, &qr, None, rotated_qr);
+                }
+            }
+            build_dist_table_direct_into::<Float32Type>(rotated_qr, dist_table);
+            rotated_qr.iter().copied().sum()
         };
-        RabitDistCalculator::new(
+
+        self.distance_calculator_from_parts(
             qr.len(),
-            self.metadata.num_bits,
-            dist_table,
+            dist_q_c,
+            Cow::Borrowed(&f32_scratch[code_dim..code_dim + dist_table_len]),
             sum_q,
-            codes,
-            self.add_factors.values(),
-            self.scale_factors.values(),
-            q_factor,
         )
     }
 
@@ -895,7 +1129,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    use arrow_array::{ArrayRef, Float32Array, UInt64Array};
+    use arrow_array::{ArrayRef, Float32Array, Float64Array, UInt64Array};
     use lance_core::ROW_ID;
     use lance_linalg::distance::DistanceType;
 
@@ -925,6 +1159,118 @@ mod tests {
         let mut dist_table = vec![0.0; SEGMENT_NUM_CODES];
         build_dist_table_for_subvec::<Float32Type>(&sub_vec, &mut dist_table);
         assert_eq!(dist_table, expected);
+    }
+
+    #[test]
+    fn test_dist_calculator_with_scratch_matches_owned_and_reuses_buffer() {
+        let code_dim = 64;
+        let original_codes = make_test_codes(50, code_dim);
+        let metadata = make_test_metadata(original_codes.value_length() as usize * 8);
+        let storage = RabitQuantizationStorage::try_from_batch(
+            make_test_batch(original_codes),
+            &metadata,
+            DistanceType::L2,
+            None,
+        )
+        .unwrap();
+        let query = Arc::new(Float32Array::from_iter_values(
+            (0..code_dim).map(|idx| idx as f32 / code_dim as f32),
+        )) as ArrayRef;
+
+        let expected = storage.dist_calculator(query.clone(), 0.25).distance_all(0);
+        let expected_scratch_len = code_dim as usize + code_dim as usize * 4;
+        let mut scratch = Vec::with_capacity(expected_scratch_len);
+        let initial_ptr = scratch.as_ptr();
+        {
+            let calc =
+                storage.dist_calculator_with_scratch(query.clone(), 0.25, None, &mut scratch);
+            assert_eq!(calc.distance_all(0), expected);
+        }
+        assert_eq!(scratch.len(), expected_scratch_len);
+        assert_eq!(scratch.as_ptr(), initial_ptr);
+
+        scratch.fill(f32::NAN);
+        {
+            let calc = storage.dist_calculator_with_scratch(query, 0.25, None, &mut scratch);
+            assert_eq!(calc.distance_all(0), expected);
+        }
+        assert_eq!(scratch.as_ptr(), initial_ptr);
+    }
+
+    #[test]
+    fn test_dist_calculator_with_scratch_applies_residual_centroid_without_residual_array() {
+        let code_dim = 64usize;
+        let original_codes = make_test_codes(50, code_dim as i32);
+        let metadata = make_test_metadata(original_codes.value_length() as usize * 8);
+        let storage = RabitQuantizationStorage::try_from_batch(
+            make_test_batch(original_codes),
+            &metadata,
+            DistanceType::L2,
+            None,
+        )
+        .unwrap();
+        let query_values = (0..code_dim)
+            .map(|idx| idx as f32 / code_dim as f32)
+            .collect::<Vec<_>>();
+        let centroid_values = (0..code_dim)
+            .map(|idx| (idx % 7) as f32 / code_dim as f32)
+            .collect::<Vec<_>>();
+        let residual_values = query_values
+            .iter()
+            .zip(centroid_values.iter())
+            .map(|(query, centroid)| query - centroid)
+            .collect::<Vec<_>>();
+        let query = Arc::new(Float32Array::from(query_values)) as ArrayRef;
+        let centroid = Arc::new(Float32Array::from(centroid_values)) as ArrayRef;
+        let residual = Arc::new(Float32Array::from(residual_values)) as ArrayRef;
+
+        let expected = storage.dist_calculator(residual, 0.25).distance_all(0);
+        let mut scratch = Vec::new();
+        let calc = storage.dist_calculator_with_scratch(
+            query.clone(),
+            0.25,
+            Some(QueryResidual::Centroid(centroid.as_ref())),
+            &mut scratch,
+        );
+
+        assert_eq!(calc.distance_all(0), expected);
+    }
+
+    #[test]
+    fn test_dist_calculator_with_scratch_applies_float64_residual_before_f32_cast() {
+        let code_dim = 64usize;
+        let original_codes = make_test_codes(50, code_dim as i32);
+        let metadata = make_test_metadata(original_codes.value_length() as usize * 8);
+        let storage = RabitQuantizationStorage::try_from_batch(
+            make_test_batch(original_codes),
+            &metadata,
+            DistanceType::L2,
+            None,
+        )
+        .unwrap();
+        let query_values = (0..code_dim)
+            .map(|idx| 1.0 + idx as f64 * 1.0e-9)
+            .collect::<Vec<_>>();
+        let centroid_values = vec![1.0; code_dim];
+        let residual_values = query_values
+            .iter()
+            .zip(centroid_values.iter())
+            .map(|(query, centroid)| query - centroid)
+            .collect::<Vec<_>>();
+        let query = Arc::new(Float64Array::from(query_values)) as ArrayRef;
+        let centroid = Arc::new(Float64Array::from(centroid_values)) as ArrayRef;
+        let residual = Arc::new(Float64Array::from(residual_values)) as ArrayRef;
+
+        let expected = storage.dist_calculator(residual, 0.25).distance_all(0);
+        let mut scratch = Vec::new();
+        let calc = storage.dist_calculator_with_scratch(
+            query,
+            0.25,
+            Some(QueryResidual::Centroid(centroid.as_ref())),
+            &mut scratch,
+        );
+
+        assert_eq!(calc.distance_all(0), expected);
     }
 
     #[test]

--- a/rust/lance-index/src/vector/flat/index.rs
+++ b/rust/lance-index/src/vector/flat/index.rs
@@ -23,7 +23,7 @@ use crate::{
         DIST_COL, Query,
         graph::{OrderedFloat, OrderedNode},
         quantizer::{Quantization, QuantizationType, Quantizer, QuantizerMetadata},
-        storage::{DistCalculator, VectorStore},
+        storage::{DistCalculator, QueryResidual, QueryScratch, VectorStore},
         v3::subindex::IvfSubIndex,
     },
 };
@@ -128,15 +128,50 @@ impl IvfSubIndex for FlatIndex {
         prefilter: Arc<dyn PreFilter>,
         metrics: &dyn MetricsCollector,
     ) -> Result<RecordBatch> {
+        let mut scratch = QueryScratch::new();
+        self.search_with_scratch(
+            query,
+            k,
+            params,
+            storage,
+            prefilter,
+            metrics,
+            None,
+            &mut scratch,
+        )
+    }
+
+    fn search_with_scratch(
+        &self,
+        query: ArrayRef,
+        k: usize,
+        params: Self::QueryParams,
+        storage: &impl VectorStore,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: &dyn MetricsCollector,
+        residual: Option<QueryResidual<'_>>,
+        scratch: &mut QueryScratch,
+    ) -> Result<RecordBatch> {
         let is_range_query = params.lower_bound.is_some() || params.upper_bound.is_some();
         let row_ids = storage.row_ids();
-        let dist_calc = storage.dist_calculator(query, params.dist_q_c);
+        let dist_calc = storage.dist_calculator_with_scratch(
+            query,
+            params.dist_q_c,
+            residual,
+            &mut scratch.query_f32,
+        );
         let mut res = BinaryHeap::with_capacity(k);
         metrics.record_comparisons(storage.len());
 
         match prefilter.is_empty() {
             true => {
-                let dists = dist_calc.distance_all(k);
+                dist_calc.distance_all_with_scratch(
+                    k,
+                    &mut scratch.distances,
+                    &mut scratch.u16,
+                    &mut scratch.u8,
+                );
+                let dists = scratch.distances.iter().copied();
 
                 if is_range_query {
                     let lower_bound = params.lower_bound.unwrap_or(f32::MIN).into();
@@ -210,9 +245,7 @@ impl IvfSubIndex for FlatIndex {
         res: &mut BinaryHeap<OrderedNode<u64>>,
         metrics: &dyn MetricsCollector,
     ) -> Result<()> {
-        let mut distance_scratch = Vec::new();
-        let mut u16_scratch = Vec::new();
-        let mut u8_scratch = Vec::new();
+        let mut scratch = QueryScratch::new();
         self.accumulate_topk_with_scratch(
             query,
             k,
@@ -220,9 +253,8 @@ impl IvfSubIndex for FlatIndex {
             storage,
             prefilter,
             res,
-            &mut distance_scratch,
-            &mut u16_scratch,
-            &mut u8_scratch,
+            None,
+            &mut scratch,
             metrics,
         )
     }
@@ -235,21 +267,30 @@ impl IvfSubIndex for FlatIndex {
         storage: &impl VectorStore,
         prefilter: Arc<dyn PreFilter>,
         res: &mut BinaryHeap<OrderedNode<u64>>,
-        distance_scratch: &mut Vec<f32>,
-        u16_scratch: &mut Vec<u16>,
-        u8_scratch: &mut Vec<u8>,
+        residual: Option<QueryResidual<'_>>,
+        scratch: &mut QueryScratch,
         metrics: &dyn MetricsCollector,
     ) -> Result<()> {
         let is_range_query = params.lower_bound.is_some() || params.upper_bound.is_some();
         let row_ids = storage.row_ids();
-        let dist_calc = storage.dist_calculator(query, params.dist_q_c);
+        let dist_calc = storage.dist_calculator_with_scratch(
+            query,
+            params.dist_q_c,
+            residual,
+            &mut scratch.query_f32,
+        );
         let mut max_dist = res.peek().map(|node| node.dist);
         metrics.record_comparisons(storage.len());
 
         match prefilter.is_empty() {
             true => {
-                dist_calc.distance_all_with_scratch(k, distance_scratch, u16_scratch, u8_scratch);
-                let dists = distance_scratch.iter().copied();
+                dist_calc.distance_all_with_scratch(
+                    k,
+                    &mut scratch.distances,
+                    &mut scratch.u16,
+                    &mut scratch.u8,
+                );
+                let dists = scratch.distances.iter().copied();
 
                 if is_range_query {
                     let lower_bound = params.lower_bound.unwrap_or(f32::MIN).into();

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -16,7 +16,14 @@ use lance_file::reader::FileReader;
 use lance_io::ReadBatchParams;
 use lance_linalg::distance::DistanceType;
 use prost::Message;
-use std::{any::Any, sync::Arc};
+use std::{
+    any::Any,
+    mem::size_of,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+use crossbeam_queue::ArrayQueue;
 
 use crate::frag_reuse::FragReuseIndex;
 use crate::{
@@ -52,14 +59,186 @@ pub trait DistCalculator {
         _u16_scratch: &mut Vec<u16>,
         _u8_scratch: &mut Vec<u8>,
     ) {
-        dists.clear();
-        dists.extend(self.distance_all(k_hint));
+        *dists = self.distance_all(k_hint);
     }
 
     fn prefetch(&self, _id: u32) {}
 }
 
 pub const STORAGE_METADATA_KEY: &str = "storage_metadata";
+
+#[derive(Debug)]
+pub struct QueryScratch {
+    pub distances: Vec<f32>,
+    pub query_f32: Vec<f32>,
+    pub u16: Vec<u16>,
+    pub u8: Vec<u8>,
+}
+
+impl QueryScratch {
+    pub const fn new() -> Self {
+        Self {
+            distances: Vec::new(),
+            query_f32: Vec::new(),
+            u16: Vec::new(),
+            u8: Vec::new(),
+        }
+    }
+
+    pub fn with_capacity(capacity: QueryScratchCapacity) -> Self {
+        Self {
+            distances: vec![0.0; capacity.distances],
+            query_f32: vec![0.0; capacity.query_f32],
+            u16: vec![0; capacity.u16],
+            u8: vec![0; capacity.u8],
+        }
+    }
+}
+
+impl Default for QueryScratch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeepSizeOf for QueryScratch {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        self.distances.capacity() * size_of::<f32>()
+            + self.query_f32.capacity() * size_of::<f32>()
+            + self.u16.capacity() * size_of::<u16>()
+            + self.u8.capacity() * size_of::<u8>()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct QueryScratchCapacity {
+    pub distances: usize,
+    pub query_f32: usize,
+    pub u16: usize,
+    pub u8: usize,
+}
+
+impl QueryScratchCapacity {
+    pub const fn new(distances: usize, query_f32: usize, u16: usize, u8: usize) -> Self {
+        Self {
+            distances,
+            query_f32,
+            u16,
+            u8,
+        }
+    }
+
+    fn deep_size_bytes(&self) -> usize {
+        self.distances * size_of::<f32>()
+            + self.query_f32 * size_of::<f32>()
+            + self.u16 * size_of::<u16>()
+            + self.u8 * size_of::<u8>()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum QueryResidual<'a> {
+    Centroid(&'a dyn arrow_array::Array),
+}
+
+#[derive(Debug)]
+pub struct QueryScratchPool {
+    scratches: ArrayQueue<QueryScratch>,
+    scratch_capacity: QueryScratchCapacity,
+}
+
+impl QueryScratchPool {
+    pub fn new(size: usize) -> Self {
+        Self::with_capacity(size, QueryScratchCapacity::default())
+    }
+
+    pub fn with_capacity(size: usize, capacity: QueryScratchCapacity) -> Self {
+        let size = size.max(1);
+        let scratches = ArrayQueue::new(size);
+        for _ in 0..size {
+            scratches
+                .push(QueryScratch::with_capacity(capacity))
+                .expect("query scratch pool should have spare capacity during initialization");
+        }
+        Self {
+            scratches,
+            scratch_capacity: capacity,
+        }
+    }
+
+    pub fn scratch(&self) -> QueryScratchGuard<'_> {
+        let (scratch, pooled) = if let Some(scratch) = self.scratches.pop() {
+            (scratch, true)
+        } else {
+            (QueryScratch::with_capacity(self.scratch_capacity), false)
+        };
+        QueryScratchGuard {
+            pool: self,
+            scratch: Some(scratch),
+            pooled,
+        }
+    }
+
+    pub fn with_scratch<T>(&self, f: impl FnOnce(&mut QueryScratch) -> T) -> T {
+        let mut scratch = self.scratch();
+        f(&mut scratch)
+    }
+}
+
+pub struct QueryScratchGuard<'a> {
+    pool: &'a QueryScratchPool,
+    scratch: Option<QueryScratch>,
+    pooled: bool,
+}
+
+impl Deref for QueryScratchGuard<'_> {
+    type Target = QueryScratch;
+
+    fn deref(&self) -> &Self::Target {
+        self.scratch
+            .as_ref()
+            .expect("query scratch guard should hold scratch")
+    }
+}
+
+impl DerefMut for QueryScratchGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.scratch
+            .as_mut()
+            .expect("query scratch guard should hold scratch")
+    }
+}
+
+impl Drop for QueryScratchGuard<'_> {
+    fn drop(&mut self) {
+        if !self.pooled {
+            return;
+        }
+        if let Some(scratch) = self.scratch.take() {
+            match self.pool.scratches.push(scratch) {
+                Ok(()) => {}
+                Err(_) => unreachable!("query scratch pool should not exceed its capacity"),
+            }
+        }
+    }
+}
+
+impl DeepSizeOf for QueryScratchPool {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        let mut total = self.scratches.capacity() * size_of::<QueryScratch>();
+        let mut scratches = Vec::new();
+        while let Some(scratch) = self.scratches.pop() {
+            total += scratch.deep_size_of_children(context);
+            scratches.push(scratch);
+        }
+        let checked_out = self.scratches.capacity().saturating_sub(scratches.len());
+        total += checked_out * self.scratch_capacity.deep_size_bytes();
+        for scratch in scratches {
+            let _ = self.scratches.push(scratch);
+        }
+        total
+    }
+}
 
 /// Vector Storage is the abstraction to store the vectors.
 ///
@@ -109,6 +288,18 @@ pub trait VectorStore: Send + Sync + Sized + Clone {
     /// Using dist calculator can be more efficient as it can pre-compute some
     /// values.
     fn dist_calculator(&self, query: ArrayRef, dist_q_c: f32) -> Self::DistanceCalculator<'_>;
+
+    /// Create a [DistCalculator], reusing caller-owned scratch for query-time
+    /// precomputed state when the storage supports it.
+    fn dist_calculator_with_scratch<'a>(
+        &'a self,
+        query: ArrayRef,
+        dist_q_c: f32,
+        _residual: Option<QueryResidual<'_>>,
+        _f32_scratch: &'a mut Vec<f32>,
+    ) -> Self::DistanceCalculator<'a> {
+        self.dist_calculator(query, dist_q_c)
+    }
 
     fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_>;
 
@@ -334,5 +525,111 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
             self.distance_type,
             self.frag_reuse_index.clone(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{QueryScratchCapacity, QueryScratchPool};
+    use deepsize::DeepSizeOf;
+
+    #[test]
+    fn test_query_scratch_pool_reuses_buffers() {
+        let pool = QueryScratchPool::new(1);
+        let first_ptrs = pool.with_scratch(|scratch| {
+            scratch.query_f32.clear();
+            scratch.query_f32.resize(16, 1.0);
+            scratch.distances.clear();
+            scratch.distances.resize(8, 2.0);
+            scratch.u16.clear();
+            scratch.u16.resize(4, 3);
+            scratch.u8.clear();
+            scratch.u8.resize(2, 4);
+            (
+                scratch.query_f32.as_ptr(),
+                scratch.distances.as_ptr(),
+                scratch.u16.as_ptr(),
+                scratch.u8.as_ptr(),
+            )
+        });
+
+        let second_ptrs = pool.with_scratch(|scratch| {
+            assert_eq!(scratch.query_f32.len(), 16);
+            assert!(scratch.query_f32.iter().all(|value| *value == 1.0));
+            assert_eq!(scratch.distances.len(), 8);
+            assert!(scratch.distances.iter().all(|value| *value == 2.0));
+            assert_eq!(scratch.u16.len(), 4);
+            assert!(scratch.u16.iter().all(|value| *value == 3));
+            assert_eq!(scratch.u8.len(), 2);
+            assert!(scratch.u8.iter().all(|value| *value == 4));
+            (
+                scratch.query_f32.as_ptr(),
+                scratch.distances.as_ptr(),
+                scratch.u16.as_ptr(),
+                scratch.u8.as_ptr(),
+            )
+        });
+
+        assert_eq!(first_ptrs, second_ptrs);
+    }
+
+    #[test]
+    fn test_query_scratch_pool_is_pool_owned() {
+        let first_pool = QueryScratchPool::new(1);
+        let second_pool = QueryScratchPool::new(1);
+
+        let first_ptr = first_pool.with_scratch(|scratch| {
+            scratch.query_f32.resize(16, 1.0);
+            scratch.query_f32.as_ptr()
+        });
+        let second_ptr = second_pool.with_scratch(|scratch| {
+            scratch.query_f32.resize(16, 1.0);
+            scratch.query_f32.as_ptr()
+        });
+
+        assert_ne!(first_ptr, second_ptr);
+    }
+
+    #[test]
+    fn test_query_scratch_pool_uses_temporary_scratch_when_empty() {
+        let pool = QueryScratchPool::with_capacity(1, QueryScratchCapacity::new(8, 16, 4, 2));
+        let pooled = pool.scratch();
+        assert!(pooled.pooled);
+
+        let temporary = pool.scratch();
+        assert!(!temporary.pooled);
+        assert_eq!(temporary.distances.len(), 8);
+        assert_eq!(temporary.query_f32.len(), 16);
+        assert_eq!(temporary.u16.len(), 4);
+        assert_eq!(temporary.u8.len(), 2);
+    }
+
+    #[test]
+    fn test_query_scratch_pool_deep_size_includes_buffer_capacity() {
+        let empty_size = QueryScratchPool::new(1).deep_size_of();
+        let pool = QueryScratchPool::with_capacity(1, QueryScratchCapacity::new(8, 16, 4, 2));
+
+        assert!(pool.deep_size_of() > empty_size);
+
+        let idle_size = pool.deep_size_of();
+        let _checked_out = pool.scratch();
+
+        assert_eq!(pool.deep_size_of(), idle_size);
+    }
+
+    #[test]
+    fn test_query_scratch_pool_initializes_buffer_capacity() {
+        let pool = QueryScratchPool::with_capacity(1, QueryScratchCapacity::new(8, 16, 4, 2));
+
+        pool.with_scratch(|scratch| {
+            assert_eq!(scratch.distances.len(), 8);
+            assert_eq!(scratch.distances.capacity(), 8);
+            assert_eq!(scratch.query_f32.len(), 16);
+            assert_eq!(scratch.query_f32.capacity(), 16);
+            assert_eq!(scratch.u16.len(), 4);
+            assert_eq!(scratch.u16.capacity(), 4);
+            assert_eq!(scratch.u8.len(), 2);
+            assert_eq!(scratch.u8.capacity(), 2);
+        });
     }
 }

--- a/rust/lance-index/src/vector/v3/subindex.rs
+++ b/rust/lance-index/src/vector/v3/subindex.rs
@@ -11,7 +11,7 @@ use lance_core::{Error, Result};
 
 use crate::metrics::MetricsCollector;
 use crate::vector::graph::OrderedNode;
-use crate::vector::storage::VectorStore;
+use crate::vector::storage::{QueryResidual, QueryScratch, VectorStore};
 use crate::vector::{flat, hnsw};
 use crate::{prefilter::PreFilter, vector::Query};
 /// A sub index for IVF index
@@ -47,6 +47,22 @@ pub trait IvfSubIndex: Send + Sync + Debug + DeepSizeOf {
         metrics: &dyn MetricsCollector,
     ) -> Result<RecordBatch>;
 
+    /// Search the sub-index, reusing scratch buffers owned by the caller.
+    #[allow(clippy::too_many_arguments)]
+    fn search_with_scratch(
+        &self,
+        query: ArrayRef,
+        k: usize,
+        params: Self::QueryParams,
+        storage: &impl VectorStore,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: &dyn MetricsCollector,
+        _residual: Option<QueryResidual<'_>>,
+        _scratch: &mut QueryScratch,
+    ) -> Result<RecordBatch> {
+        self.search(query, k, params, storage, prefilter, metrics)
+    }
+
     /// Return true if this sub-index can accumulate candidates into a caller-owned heap.
     fn supports_global_topk_heap() -> bool {
         false
@@ -78,9 +94,8 @@ pub trait IvfSubIndex: Send + Sync + Debug + DeepSizeOf {
         storage: &impl VectorStore,
         prefilter: Arc<dyn PreFilter>,
         heap: &mut BinaryHeap<OrderedNode<u64>>,
-        _distance_scratch: &mut Vec<f32>,
-        _u16_scratch: &mut Vec<u16>,
-        _u8_scratch: &mut Vec<u8>,
+        _residual: Option<QueryResidual<'_>>,
+        _scratch: &mut QueryScratch,
         metrics: &dyn MetricsCollector,
     ) -> Result<()> {
         self.accumulate_topk(query, k, params, storage, prefilter, heap, metrics)

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -81,6 +81,9 @@ pub fn sum_4bit_dist_table_scalar(
     dist_table: &[u8],
     dists: &mut [u16],
 ) {
+    let num_full_vectors = codes.len() / (BATCH_SIZE * code_len) * BATCH_SIZE;
+    dists[..num_full_vectors].fill(0);
+
     for (vec_block_idx, blocks) in codes.chunks_exact(BATCH_SIZE * code_len).enumerate() {
         for (sub_vec_idx, block) in blocks.chunks_exact(BATCH_SIZE).enumerate() {
             let current_dist_table = &dist_table[sub_vec_idx * 2 * 16..(sub_vec_idx * 2 + 1) * 16];
@@ -301,6 +304,23 @@ mod tests {
 
         // so the distance is 2 * (dist_table[0x6] + dist_table[0xb + 16]) = 2*(7 + 12) = 38
         assert_eq!(dists[1], 38);
+    }
+
+    #[test]
+    fn test_sum_4bit_dist_table_overwrites_output() {
+        let n = BATCH_SIZE;
+        let code_len = 16;
+        let codes = vec![0x12; n * code_len];
+        let dist_table = vec![1u8; BATCH_SIZE * code_len];
+
+        let mut expected = vec![u16::MAX; n];
+        sum_4bit_dist_table_scalar(code_len, &codes, &dist_table, &mut expected);
+
+        let mut actual = vec![u16::MAX; n];
+        sum_4bit_dist_table(n, code_len, &codes, &dist_table, &mut actual);
+
+        assert_eq!(actual, expected);
+        assert!(actual.iter().all(|dist| *dist != u16::MAX));
     }
 
     /// Test that the SIMD path (NEON on ARM, AVX2 on x86) produces identical

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -16,6 +16,7 @@ use crate::index::{PreFilter, vector::VectorIndex};
 use arrow::compute::concat_batches;
 use arrow_arith::numeric::sub;
 use arrow_array::{ArrayRef, Float32Array, RecordBatch, UInt32Array, UInt64Array};
+use arrow_schema::DataType;
 use async_trait::async_trait;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::SendableRecordBatchStream;
@@ -46,7 +47,9 @@ use lance_index::vector::quantizer::{
     QuantizationType, Quantizer, QuantizerMetadata, QuantizerStorage,
 };
 use lance_index::vector::sq::ScalarQuantizer;
-use lance_index::vector::storage::VectorStore;
+use lance_index::vector::storage::{
+    QueryResidual, QueryScratch, QueryScratchCapacity, QueryScratchPool, VectorStore,
+};
 use lance_index::vector::v3::subindex::SubIndexType;
 use lance_index::{
     INDEX_AUXILIARY_FILE_NAME, INDEX_FILE_NAME, Index, IndexType, pb,
@@ -527,6 +530,8 @@ pub struct IVFIndex<S: IvfSubIndex + 'static, Q: Quantization + 'static> {
     index_cache: WeakLanceCache,
 
     io_parallelism: usize,
+    scratch_pool: Arc<QueryScratchPool>,
+    use_residual_scratch: bool,
 
     _marker: PhantomData<(S, Q)>,
 }
@@ -539,6 +544,7 @@ impl<S: IvfSubIndex, Q: Quantization> DeepSizeOf for IVFIndex<S, Q> {
             + self.sub_index_metadata.deep_size_of_children(context)
             + self.uuid.deep_size_of_children(context)
             + self.storage.deep_size_of_children(context)
+            + self.scratch_pool.deep_size_of_children(context)
         // Skipping session since it is a weak ref
     }
 }
@@ -585,8 +591,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
 
     fn run_prepared_partition_search(
         distance_type: DistanceType,
+        use_residual_scratch: bool,
         prepared: PreparedPartitionSearch<S, Q>,
         metrics: &dyn MetricsCollector,
+        scratch: &mut QueryScratch,
     ) -> Result<RecordBatch> {
         let PreparedPartitionSearch {
             query,
@@ -596,11 +604,17 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             part_entry,
             _marker: _,
         } = prepared;
-        let query = Self::preprocess_partition_query(
-            distance_type,
+        let residual = Self::residual_for_scratch(
+            use_residual_scratch,
             partition_id,
             partition_centroid.as_ref(),
-            &query,
+        )?;
+        let query = Self::preprocess_partition_query_owned(
+            distance_type,
+            use_residual_scratch,
+            partition_id,
+            partition_centroid.as_ref(),
+            query,
         )?;
         let param = (&query).into();
         let refine_factor = query.refine_factor.unwrap_or(1) as usize;
@@ -611,19 +625,26 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             .ok_or(Error::internal(
                 "failed to downcast partition entry".to_string(),
             ))?;
-        let batch = part
-            .index
-            .search(query.key, k, param, &part.storage, pre_filter, metrics)?;
+        let batch = part.index.search_with_scratch(
+            query.key,
+            k,
+            param,
+            &part.storage,
+            pre_filter,
+            metrics,
+            residual,
+            scratch,
+        )?;
         Ok(batch)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn accumulate_prepared_partition_search(
         distance_type: DistanceType,
+        use_residual_scratch: bool,
         prepared: PreparedPartitionSearch<S, Q>,
         heap: &mut BinaryHeap<OrderedNode<u64>>,
-        distance_scratch: &mut Vec<f32>,
-        u16_scratch: &mut Vec<u16>,
-        u8_scratch: &mut Vec<u8>,
+        scratch: &mut QueryScratch,
         metrics: &dyn MetricsCollector,
     ) -> Result<()> {
         let PreparedPartitionSearch {
@@ -634,11 +655,17 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             part_entry,
             _marker: _,
         } = prepared;
-        let query = Self::preprocess_partition_query(
-            distance_type,
+        let residual = Self::residual_for_scratch(
+            use_residual_scratch,
             partition_id,
             partition_centroid.as_ref(),
-            &query,
+        )?;
+        let query = Self::preprocess_partition_query_owned(
+            distance_type,
+            use_residual_scratch,
+            partition_id,
+            partition_centroid.as_ref(),
+            query,
         )?;
         let param = (&query).into();
         let refine_factor = query.refine_factor.unwrap_or(1) as usize;
@@ -656,11 +683,25 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             &part.storage,
             pre_filter,
             heap,
-            distance_scratch,
-            u16_scratch,
-            u8_scratch,
+            residual,
+            scratch,
             metrics,
         )
+    }
+
+    fn residual_for_scratch<'a>(
+        use_residual_scratch: bool,
+        partition_id: usize,
+        partition_centroid: Option<&'a ArrayRef>,
+    ) -> Result<Option<QueryResidual<'a>>> {
+        if use_residual_scratch {
+            let partition_centroid = partition_centroid.ok_or_else(|| {
+                Error::index(format!("partition centroid {partition_id} does not exist"))
+            })?;
+            Ok(Some(QueryResidual::Centroid(partition_centroid.as_ref())))
+        } else {
+            Ok(None)
+        }
     }
 
     fn global_heap_to_batch(heap: BinaryHeap<OrderedNode<u64>>) -> Result<RecordBatch> {
@@ -676,21 +717,71 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
 
     fn preprocess_partition_query(
         distance_type: DistanceType,
+        use_residual_scratch: bool,
         partition_id: usize,
         partition_centroid: Option<&ArrayRef>,
         query: &Query,
+    ) -> Result<Query> {
+        Self::preprocess_partition_query_owned(
+            distance_type,
+            use_residual_scratch,
+            partition_id,
+            partition_centroid,
+            query.clone(),
+        )
+    }
+
+    fn preprocess_partition_query_owned(
+        distance_type: DistanceType,
+        use_residual_scratch: bool,
+        partition_id: usize,
+        partition_centroid: Option<&ArrayRef>,
+        mut query: Query,
     ) -> Result<Query> {
         if Q::use_residual(distance_type) {
             let partition_centroid = partition_centroid.ok_or_else(|| {
                 Error::index(format!("partition centroid {partition_id} does not exist"))
             })?;
+            if use_residual_scratch {
+                return Ok(query);
+            }
             let residual_key = sub(&query.key, partition_centroid)?;
-            let mut part_query = query.clone();
-            part_query.key = residual_key;
-            Ok(part_query)
-        } else {
-            Ok(query.clone())
+            query.key = residual_key;
         }
+        Ok(query)
+    }
+
+    fn query_scratch_capacity(ivf: &IvfModel) -> QueryScratchCapacity {
+        if Q::quantization_type() != QuantizationType::Rabit {
+            return QueryScratchCapacity::default();
+        }
+
+        let dim = ivf.dimension();
+        let dist_table_len = dim * 4;
+        let max_partition_len = ivf.lengths.iter().copied().max().unwrap_or_default() as usize;
+
+        QueryScratchCapacity::new(
+            max_partition_len,
+            dim + dist_table_len,
+            max_partition_len,
+            dist_table_len,
+        )
+    }
+
+    fn use_residual_scratch(ivf: &IvfModel, distance_type: DistanceType) -> bool {
+        Q::quantization_type() == QuantizationType::Rabit
+            && Q::use_residual(distance_type)
+            && ivf
+                .centroids_array()
+                .map(|centroids| centroids.value_type() == DataType::Float32)
+                .unwrap_or(false)
+    }
+
+    fn query_scratch_pool(ivf: &IvfModel) -> QueryScratchPool {
+        QueryScratchPool::with_capacity(
+            get_num_compute_intensive_cpus(),
+            Self::query_scratch_capacity(ivf),
+        )
     }
 
     /// Create a new IVF index.
@@ -796,10 +887,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             )
             .await;
 
+        let scratch_pool = Arc::new(Self::query_scratch_pool(&ivf));
+        let use_residual_scratch = Self::use_residual_scratch(&ivf, distance_type);
+
         Ok(Self {
             uri: to_local_path(&uri),
             index_path: uri.as_ref().to_string(),
             uuid,
+            scratch_pool,
+            use_residual_scratch,
             ivf,
             reader: index_reader,
             storage,
@@ -825,10 +921,14 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         index_cache: LanceCache,
         io_parallelism: usize,
     ) -> Self {
+        let scratch_pool = Arc::new(Self::query_scratch_pool(&ivf));
+        let use_residual_scratch = Self::use_residual_scratch(&ivf, distance_type);
         Self {
             uri,
             index_path,
             uuid,
+            scratch_pool,
+            use_residual_scratch,
             ivf,
             reader,
             storage,
@@ -924,6 +1024,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
     pub fn preprocess_query(&self, partition_id: usize, query: &Query) -> Result<Query> {
         Self::preprocess_partition_query(
             self.distance_type,
+            self.use_residual_scratch,
             partition_id,
             self.ivf.centroid(partition_id).as_ref(),
             query,
@@ -1107,7 +1208,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
         let part_entry = self.load_partition(partition_id, true, metrics).await?;
         pre_filter.wait_for_ready().await?;
 
+        let residual_centroid = if self.use_residual_scratch {
+            Some(self.ivf.centroid(partition_id).ok_or_else(|| {
+                Error::index(format!("partition centroid {partition_id} does not exist"))
+            })?)
+        } else {
+            None
+        };
         let query = self.preprocess_query(partition_id, query)?;
+        let scratch_pool = self.scratch_pool.clone();
         let (batch, local_metrics) = spawn_cpu(move || {
             let param = (&query).into();
             let refine_factor = query.refine_factor.unwrap_or(1) as usize;
@@ -1119,14 +1228,19 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
                 .ok_or(Error::internal(
                     "failed to downcast partition entry".to_string(),
                 ))?;
-            let batch = part.index.search(
-                query.key,
-                k,
-                param,
-                &part.storage,
-                pre_filter,
-                &local_metrics,
-            )?;
+            let residual = residual_centroid.as_deref().map(QueryResidual::Centroid);
+            let batch = scratch_pool.with_scratch(|scratch| {
+                part.index.search_with_scratch(
+                    query.key,
+                    k,
+                    param,
+                    &part.storage,
+                    pre_filter,
+                    &local_metrics,
+                    residual,
+                    scratch,
+                )
+            })?;
             Result::Ok((batch, local_metrics))
         })
         .await?;
@@ -1157,7 +1271,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
         let prepared = prepared
             .downcast::<PreparedPartitionSearch<S, Q>>()
             .map_err(|_| Error::internal("failed to downcast prepared partition search"))?;
-        Self::run_prepared_partition_search(self.distance_type, *prepared, metrics)
+        self.scratch_pool.with_scratch(|scratch| {
+            Self::run_prepared_partition_search(
+                self.distance_type,
+                self.use_residual_scratch,
+                *prepared,
+                metrics,
+                scratch,
+            )
+        })
     }
 
     fn supports_prepared_partition_search(&self) -> bool {
@@ -1229,24 +1351,25 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
                 .await?;
 
             let distance_type = self.distance_type;
+            let use_residual_scratch = self.use_residual_scratch;
             let search_metrics = metrics.clone();
+            let scratch_pool = self.scratch_pool.clone();
             let batch = spawn_cpu(move || -> DataFusionResult<RecordBatch> {
                 let mut heap = BinaryHeap::with_capacity(heap_capacity);
-                let mut distance_scratch = Vec::new();
-                let mut u16_scratch = Vec::new();
-                let mut u8_scratch = Vec::new();
-                for prepared in prepared {
-                    Self::accumulate_prepared_partition_search(
-                        distance_type,
-                        prepared,
-                        &mut heap,
-                        &mut distance_scratch,
-                        &mut u16_scratch,
-                        &mut u8_scratch,
-                        search_metrics.as_ref(),
-                    )
-                    .map_err(DataFusionError::from)?;
-                }
+                scratch_pool.with_scratch(|scratch| -> DataFusionResult<()> {
+                    for prepared in prepared {
+                        Self::accumulate_prepared_partition_search(
+                            distance_type,
+                            use_residual_scratch,
+                            prepared,
+                            &mut heap,
+                            scratch,
+                            search_metrics.as_ref(),
+                        )
+                        .map_err(DataFusionError::from)?;
+                    }
+                    Ok(())
+                })?;
                 Self::global_heap_to_batch(heap).map_err(DataFusionError::from)
             })
             .await?;
@@ -1295,50 +1418,58 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
         });
 
         let distance_type = self.distance_type;
+        let use_residual_scratch = self.use_residual_scratch;
         let search_metrics = metrics.clone();
         let batch_tx_for_search = batch_tx.clone();
         let search_control = control.clone();
+        let scratch_pool = self.scratch_pool.clone();
         tokio::spawn(async move {
             let search_result = spawn_cpu(move || -> DataFusionResult<()> {
-                while let Some(prepared) = prepared_rx.blocking_recv() {
-                    let prepared = match prepared {
-                        Ok(prepared) => prepared,
-                        Err(err) => {
-                            let _ =
-                                batch_tx_for_search.blocking_send(Err(DataFusionError::from(err)));
+                scratch_pool.with_scratch(|scratch| {
+                    while let Some(prepared) = prepared_rx.blocking_recv() {
+                        let prepared = match prepared {
+                            Ok(prepared) => prepared,
+                            Err(err) => {
+                                let _ = batch_tx_for_search
+                                    .blocking_send(Err(DataFusionError::from(err)));
+                                return Ok(());
+                            }
+                        };
+
+                        if search_control
+                            .as_ref()
+                            .is_some_and(|control| control.should_stop())
+                        {
                             return Ok(());
                         }
-                    };
 
-                    if search_control
-                        .as_ref()
-                        .is_some_and(|control| control.should_stop())
-                    {
-                        return Ok(());
-                    }
-
-                    let batch = Self::run_prepared_partition_search(
-                        distance_type,
-                        prepared,
-                        search_metrics.as_ref(),
-                    )
-                    .map_err(DataFusionError::from);
-                    match batch {
-                        Ok(batch) => {
-                            if let Some(control) = search_control.as_ref() {
-                                control.record_batch(&batch);
+                        let batch = {
+                            Self::run_prepared_partition_search(
+                                distance_type,
+                                use_residual_scratch,
+                                prepared,
+                                search_metrics.as_ref(),
+                                scratch,
+                            )
+                        }
+                        .map_err(DataFusionError::from);
+                        match batch {
+                            Ok(batch) => {
+                                if let Some(control) = search_control.as_ref() {
+                                    control.record_batch(&batch);
+                                }
+                                if batch_tx_for_search.blocking_send(Ok(batch)).is_err() {
+                                    return Ok(());
+                                }
                             }
-                            if batch_tx_for_search.blocking_send(Ok(batch)).is_err() {
+                            Err(err) => {
+                                let _ = batch_tx_for_search.blocking_send(Err(err));
                                 return Ok(());
                             }
                         }
-                        Err(err) => {
-                            let _ = batch_tx_for_search.blocking_send(Err(err));
-                            return Ok(());
-                        }
                     }
-                }
-                Ok(())
+                    Ok(())
+                })
             })
             .await;
 


### PR DESCRIPTION
## Performance Improvement

IVF_RQ query currently allocates several temporary buffers on the hot path, including rotated query vectors, distance tables, and residual query arrays. These allocations happen repeatedly during partition search and show up in latency-sensitive vector search workloads.

This PR adds runtime query scratch reuse for the IVF_RQ flat search path:

- Create a runtime `QueryScratchPool` when an `IVFIndex` is loaded or reconstructed; it is not part of serialized/cached `IvfIndexState`.
- Keep scratch lifetime tied to the loaded index, so different indexes have independent scratch pools.
- Pre-size `num_compute_intensive_cpus()` scratch entries from per-index dimensions and partition sizes.
- Use a non-blocking pool strategy: if the pool is empty, allocate a same-sized temporary scratch that is not returned to the pool.
- Avoid residual query array allocation for Float32 RQ by passing the centroid into the RQ distance calculator and rotating `q - c` into scratch directly.
- Preserve non-Float32 residual semantics by falling back to typed Arrow residual preprocessing instead of doing f32-before-subtract residual math.
- Reuse RQ rotated query, distance table, quantized table, and distance output buffers through `QueryScratch`.
- Include scratch pool capacity in `DeepSizeOf`, including checked-out scratch slots.
- Avoid clearing the RQ distance output buffer before the batch distance kernel overwrites it.

## Benchmarks

GCP VM: `yang-agent-ae1f-ivfrq-rebase-20260528` (`c4-standard-16`)

Workload: `lance_ivfrq`, `sift1m`, `num_bits=1`, `target_partition_size=4096`, `k=10`. IVF_PQ was not included.

Baseline: `main` at `5cf70b27b3ad38ecdcd1547b7af385e05f67598a`
Current PR head: `8476110dd4dd018bba05b8320ff999920a88288e`

| max_threads | query | avg latency | p99 latency | QPS |
|---:|---|---:|---:|---:|
| 1 | `nprobes=8` | 0.803 ms -> 0.772 ms (-3.80%) | 0.977 ms -> 0.893 ms (-8.59%) | 1222.64 -> 1269.49 (+3.83%) |
| 1 | `nprobes=24, refine_factor=null` | 1.040 ms -> 0.973 ms (-6.44%) | 1.199 ms -> 1.094 ms (-8.83%) | 948.73 -> 1014.18 (+6.90%) |
| 16 | `nprobes=8` | 7.014 ms -> 6.835 ms (-2.55%) | 11.411 ms -> 11.347 ms (-0.57%) | 2228.36 -> 2285.86 (+2.58%) |
| 16 | `nprobes=24, refine_factor=null` | 7.268 ms -> 7.009 ms (-3.57%) | 11.791 ms -> 11.421 ms (-3.13%) | 2140.48 -> 2217.49 (+3.60%) |

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo test -p lance-index vector::storage::tests::test_query_scratch_pool -- --nocapture`
- `cargo test -p lance-index vector::bq::storage::tests::test_dist_calculator_with_scratch -- --nocapture`
- `cargo test -p lance index::vector::ivf::v2::tests:: -- --nocapture`