### PR TITLE
perf(fts): defer DocSet load until wand actually needs it

### DIFF
--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -221,6 +221,23 @@ pub trait IndexReader: Send + Sync {
         range: std::ops::Range<usize>,
         projection: Option<&[&str]>,
     ) -> Result<RecordBatch>;
+    /// Read multiple ranges and concatenate into a single batch.
+    /// Default impl runs `read_range`s in parallel via `try_join_all`.
+    async fn read_ranges(
+        &self,
+        ranges: &[std::ops::Range<usize>],
+        projection: Option<&[&str]>,
+    ) -> Result<RecordBatch> {
+        if ranges.is_empty() {
+            return self.read_range(0..0, projection).await;
+        }
+        let futures = ranges
+            .iter()
+            .map(|r| self.read_range(r.clone(), projection));
+        let batches = futures::future::try_join_all(futures).await?;
+        let schema = batches[0].schema();
+        Ok(arrow_select::concat::concat_batches(&schema, &batches)?)
+    }
     /// Read a range of rows as a stream of record batches.
     ///
     /// This allows the caller to process rows incrementally without loading the

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -7,6 +7,7 @@ mod encoding;
 mod index;
 mod iter;
 pub mod json;
+mod lazy_docset;
 pub mod parser;
 pub mod query;
 mod scorer;

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1341,6 +1341,10 @@ impl InvertedPartition {
     }
 
     #[instrument(level = "debug", skip_all)]
+    // Deferred-DocSet adds the `docs` param (caller materializes it) on top of
+    // the cross-partition `shared_threshold`, tipping this hot-path search fn
+    // one over the limit. Bundling args isn't worth the churn here.
+    #[allow(clippy::too_many_arguments)]
     pub fn bm25_search(
         &self,
         docs: &DocSet,

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -4379,7 +4379,20 @@ impl DocSet {
         let batch = reader.read_range(0..reader.num_rows(), None).await?;
         let row_id_col = batch[ROW_ID].as_primitive::<datatypes::UInt64Type>();
         let num_tokens_col = batch[NUM_TOKEN_COL].as_primitive::<datatypes::UInt32Type>();
+        Self::from_columns(row_id_col, num_tokens_col, is_legacy, frag_reuse_index)
+    }
 
+    /// Build a `DocSet` from already-loaded `row_id` and `num_tokens`
+    /// arrow columns. Lets callers that have one column already in hand
+    /// (e.g. [`crate::scalar::inverted::lazy_docset::LazyDocSet`] after
+    /// `total_tokens_num` pre-fetched `num_tokens`) skip re-reading that
+    /// column.
+    pub fn from_columns(
+        row_id_col: &UInt64Array,
+        num_tokens_col: &arrow_array::UInt32Array,
+        is_legacy: bool,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Self> {
         // for legacy format, the row id is doc id; sorting keeps binary search viable
         if is_legacy {
             let (row_ids, num_tokens): (Vec<_>, Vec<_>) = row_id_col

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1211,11 +1211,21 @@ impl InvertedPartition {
         let tokens = TokenSet::load(token_file, token_set_format).await?;
         let invert_list_file = store.open_index_file(&posting_file_path(id)).await?;
         let inverted_list = PostingListReader::try_new(invert_list_file, index_cache).await?;
-        // Defer the per-doc row_id/num_tokens read. Construction only
-        // calls reader.num_rows() (no IO); the bulk load happens on first
-        // scoring use, and partitions that never score skip it entirely.
-        let docs_file = store.open_index_file(&doc_file_path(id)).await?;
-        let docs = Arc::new(LazyDocSet::new(docs_file, false, frag_reuse_index));
+        // Defer the per-doc row_id/num_tokens read. Construction reads only
+        // the doc count (one footer read) and then drops the reader; the bulk
+        // load happens on first scoring use, re-opening the docs file on
+        // demand, and partitions that never score skip it entirely. Storing
+        // the store + path instead of an open reader keeps a cached partition
+        // from pinning a docs-file handle for its whole lifetime.
+        let docs_path = doc_file_path(id);
+        let num_docs = store.open_index_file(&docs_path).await?.num_rows();
+        let docs = Arc::new(LazyDocSet::new(
+            store.clone(),
+            docs_path,
+            num_docs,
+            false,
+            frag_reuse_index,
+        ));
 
         Ok(Self {
             id,

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1035,6 +1035,11 @@ impl InvertedIndex {
                 part.inverted_list
                     .prewarm_posting_lists(with_position)
                     .await?;
+                // Materialize the deferred DocSet too: prewarm's contract is
+                // that subsequent queries do no IO, so the per-doc row_ids /
+                // num_tokens must be resident, not lazily faulted in at query
+                // time. `ensure_loaded` opens, reads, and drops the reader.
+                part.docs.ensure_loaded().await?;
                 Result::Ok(())
             });
         stream::iter(prewarm_futures)

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -521,18 +521,12 @@ impl InvertedIndex {
         })
     }
 
-    /// Build a single-segment [`MemBM25Scorer`] whose per-term IDF table
-    /// covers every token that the per-partition scoring loop will look
-    /// up. For fuzzy queries that means the union of Levenshtein
-    /// expansions, not just the raw query tokens — otherwise
-    /// `query_weight(expanded_token)` returns 0 and the BM25 contribution
-    /// of every expanded match is discarded.
     pub async fn bm25_base_scorer(
         &self,
         query_tokens: &Tokens,
         params: &FtsSearchParams,
     ) -> Result<MemBM25Scorer> {
-        let scorer = IndexBM25Scorer::new(self.partitions.iter().map(|part| part.as_ref()));
+        let (total_tokens, num_docs) = self.aggregate_corpus_stats().await?;
         let mut terms: Vec<String> = Vec::new();
         let mut seen = HashSet::new();
         if matches!(params.fuzziness, Some(n) if n != 0) {
@@ -555,18 +549,37 @@ impl InvertedIndex {
             let df = self.df_for_term(term).await?;
             token_docs.insert(term.clone(), df);
         }
-        Ok(MemBM25Scorer::new(
-            scorer.total_tokens(),
-            scorer.num_docs(),
-            token_docs,
-        ))
+        Ok(MemBM25Scorer::new(total_tokens, num_docs, token_docs))
     }
 
     pub async fn bm25_stats_for_terms(&self, terms: &[String]) -> Result<(u64, usize, Vec<usize>)> {
-        let scorer = IndexBM25Scorer::new(self.partitions.iter().map(|part| part.as_ref()));
+        let (total_tokens, num_docs) = self.aggregate_corpus_stats().await?;
         let token_docs =
             futures::future::try_join_all(terms.iter().map(|term| self.df_for_term(term))).await?;
-        Ok((scorer.total_tokens(), scorer.num_docs(), token_docs))
+        Ok((total_tokens, num_docs, token_docs))
+    }
+
+    /// Aggregate per-partition `total_tokens` and `num_docs` across the
+    /// index. `len` is cheap (no IO); `total_tokens_num` reads only the
+    /// num_tokens column the first time per partition and caches it on
+    /// `LazyDocSet`. Avoids materializing the full DocSet just to get
+    /// these two scalars.
+    async fn aggregate_corpus_stats(&self) -> Result<(u64, usize)> {
+        let io_parallelism = self.store.io_parallelism();
+        let num_docs: usize = self.partitions.iter().map(|p| p.docs.len()).sum();
+        let futures = self
+            .partitions
+            .iter()
+            .map(|p| {
+                let docs = p.docs.clone();
+                async move { docs.total_tokens_num().await }
+            })
+            .collect::<Vec<_>>();
+        let totals: Vec<u64> = stream::iter(futures)
+            .buffer_unordered(io_parallelism)
+            .try_collect()
+            .await?;
+        Ok((totals.into_iter().sum(), num_docs))
     }
 
     /// Sum the posting-list length for `term` across this index's partitions
@@ -671,8 +684,14 @@ impl InvertedIndex {
                         .load_posting_lists(tokens.as_ref(), params.as_ref(), metrics.as_ref())
                         .await?;
                     if postings.is_empty() {
+                        // No hits in this partition; its DocSet stays
+                        // unloaded, so we never pay the per-doc
+                        // row_id/num_tokens download for it.
                         return Result::Ok(PartitionCandidates::empty());
                     }
+                    // Wand needs the full DocSet sync. Materialize it now,
+                    // only for partitions that actually contribute hits.
+                    part.docs.ensure_loaded().await?;
                     let max_position = postings
                         .iter()
                         .map(|posting| posting.term_index() as usize)
@@ -806,7 +825,7 @@ impl InvertedIndex {
                 store,
                 tokens,
                 inverted_list,
-                docs,
+                docs: Arc::new(crate::scalar::inverted::lazy_docset::LazyDocSet::from_loaded(docs)),
                 token_set_format: TokenSetFormat::Arrow,
             })],
             deleted_fragments: RoaringBitmap::new(),
@@ -1098,7 +1117,10 @@ pub struct InvertedPartition {
     store: Arc<dyn IndexStore>,
     pub(crate) tokens: TokenSet,
     pub(crate) inverted_list: Arc<PostingListReader>,
-    pub(crate) docs: DocSet,
+    /// Per-doc row_id + num_tokens. Wrapped in [`LazyDocSet`] so partitions
+    /// that don't contribute hits to a query never pay the full-array
+    /// download. Scoring paths call `ensure_loaded` before walking wand.
+    pub(crate) docs: Arc<crate::scalar::inverted::lazy_docset::LazyDocSet>,
     token_set_format: TokenSetFormat,
 }
 
@@ -1140,8 +1162,15 @@ impl InvertedPartition {
         let tokens = TokenSet::load(token_file, token_set_format).await?;
         let invert_list_file = store.open_index_file(&posting_file_path(id)).await?;
         let inverted_list = PostingListReader::try_new(invert_list_file, index_cache).await?;
+        // Defer the per-doc row_id/num_tokens read. Construction only
+        // calls reader.num_rows() (no IO); the bulk load happens on first
+        // scoring use, and partitions that never score skip it entirely.
         let docs_file = store.open_index_file(&doc_file_path(id)).await?;
-        let docs = DocSet::load(docs_file, false, frag_reuse_index).await?;
+        let docs = Arc::new(crate::scalar::inverted::lazy_docset::LazyDocSet::new(
+            docs_file,
+            false,
+            frag_reuse_index,
+        ));
 
         Ok(Self {
             id,
@@ -1265,12 +1294,21 @@ impl InvertedPartition {
             return Ok(Vec::new());
         }
 
-        // let local_metrics = LocalMetricsCollector::default();
+        // self.docs is wrapped in LazyDocSet; callers must materialize it
+        // via `docs.ensure_loaded()` before entering wand. We unwrap here
+        // and panic if that contract was missed.
+        let docs = self
+            .docs
+            .loaded()
+            .expect(
+                "InvertedPartition::bm25_search requires docs to be materialized; \
+                 caller must `partition.docs.ensure_loaded().await` first",
+            )
+            .as_ref();
         let scorer = IndexBM25Scorer::new(std::iter::once(self));
-        let mut wand = Wand::new(operator, postings.into_iter(), &self.docs, scorer)
+        let mut wand = Wand::new(operator, postings.into_iter(), docs, scorer)
             .with_shared_threshold(shared_threshold);
         let hits = wand.search(params, mask, metrics)?;
-        // local_metrics.dump_into(metrics);
         Ok(hits)
     }
 
@@ -1282,7 +1320,10 @@ impl InvertedPartition {
             self.inverted_list.posting_tail_codec(),
         );
         builder.tokens = self.tokens.into_mutable();
-        builder.docs = self.docs;
+        // into_builder rewrites every doc, so materialize the full
+        // DocSet now and clone it out of the Arc.
+        let docs_arc = self.docs.ensure_loaded().await?;
+        builder.docs = (*docs_arc).clone();
 
         builder
             .posting_lists

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -53,6 +53,7 @@ use tracing::{info, instrument};
 
 use super::encoding::{PositionBlockBuilder, decode_group_starts};
 use super::iter::PostingListIterator;
+use super::lazy_docset::LazyDocSet;
 use super::{InvertedIndexBuilder, InvertedIndexParams, wand::*};
 use super::{
     builder::{
@@ -375,6 +376,35 @@ impl DeepSizeOf for InvertedIndex {
     }
 }
 
+/// Resolve any `Pending` candidates that wand emitted via the
+/// deferred-row_id path. After this returns, every entry in
+/// `candidates` carries a real row_id.
+async fn resolve_deferred_candidates(
+    docs: &LazyDocSet,
+    candidates: &mut [DocCandidate],
+) -> Result<()> {
+    let pending: Vec<u32> = candidates
+        .iter()
+        .filter_map(|c| match c.addr {
+            CandidateAddr::Pending(d) => Some(d),
+            CandidateAddr::RowId(_) => None,
+        })
+        .collect();
+    if pending.is_empty() {
+        return Ok(());
+    }
+    let mut iter = docs.resolve_row_ids(&pending).await?.into_iter();
+    for c in candidates {
+        if matches!(c.addr, CandidateAddr::Pending(_)) {
+            let r = iter.next().ok_or_else(|| {
+                Error::internal("resolve_row_ids returned fewer items than requested")
+            })?;
+            c.addr = CandidateAddr::RowId(r);
+        }
+    }
+    Ok(())
+}
+
 impl InvertedIndex {
     fn format_version(&self) -> InvertedListFormatVersion {
         self.partitions
@@ -521,6 +551,12 @@ impl InvertedIndex {
         })
     }
 
+    /// Build a single-segment [`MemBM25Scorer`] whose per-term IDF table
+    /// covers every token that the per-partition scoring loop will look
+    /// up. For fuzzy queries that means the union of Levenshtein
+    /// expansions, not just the raw query tokens — otherwise
+    /// `query_weight(expanded_token)` returns 0 and the BM25 contribution
+    /// of every expanded match is discarded.
     pub async fn bm25_base_scorer(
         &self,
         query_tokens: &Tokens,
@@ -689,9 +725,7 @@ impl InvertedIndex {
                         // row_id/num_tokens download for it.
                         return Result::Ok(PartitionCandidates::empty());
                     }
-                    // Wand needs the full DocSet sync. Materialize it now,
-                    // only for partitions that actually contribute hits.
-                    part.docs.ensure_loaded().await?;
+                    let docs_for_wand = part.docs.docs_for_wand(mask.as_ref()).await?;
                     let max_position = postings
                         .iter()
                         .map(|posting| posting.term_index() as usize)
@@ -705,8 +739,10 @@ impl InvertedIndex {
                     let params = params.clone();
                     let mask = mask.clone();
                     let metrics = metrics.clone();
-                    spawn_cpu(move || {
-                        let candidates = part.bm25_search(
+                    let part_for_wand = part.clone();
+                    let mut partition_result = spawn_cpu(move || {
+                        let candidates = part_for_wand.bm25_search(
+                            docs_for_wand.as_ref(),
                             params.as_ref(),
                             operator,
                             mask,
@@ -714,12 +750,15 @@ impl InvertedIndex {
                             metrics.as_ref(),
                             shared_threshold,
                         )?;
-                        Ok(PartitionCandidates {
+                        std::result::Result::<_, Error>::Ok(PartitionCandidates {
                             tokens_by_position,
                             candidates,
                         })
                     })
-                    .await
+                    .await?;
+                    resolve_deferred_candidates(&part.docs, &mut partition_result.candidates)
+                        .await?;
+                    Result::Ok(partition_result)
                 }
             })
             .collect::<Vec<_>>();
@@ -742,11 +781,21 @@ impl InvertedIndex {
                 idf_by_position.push(idf_weight);
             }
             for DocCandidate {
-                row_id,
+                addr,
                 freqs,
                 doc_length,
             } in res.candidates
             {
+                // resolve_deferred_candidates ran upstream, so every
+                // candidate carries a real row_id at this point.
+                let row_id = match addr {
+                    CandidateAddr::RowId(r) => r,
+                    CandidateAddr::Pending(_) => {
+                        return Err(Error::internal(
+                            "bm25_search post-condition: deferred candidate left unresolved",
+                        ));
+                    }
+                };
                 let mut score = 0.0;
                 for (term_index, freq) in freqs.into_iter() {
                     debug_assert!((term_index as usize) < idf_by_position.len());
@@ -825,7 +874,7 @@ impl InvertedIndex {
                 store,
                 tokens,
                 inverted_list,
-                docs: Arc::new(crate::scalar::inverted::lazy_docset::LazyDocSet::from_loaded(docs)),
+                docs: Arc::new(LazyDocSet::from_loaded(docs)),
                 token_set_format: TokenSetFormat::Arrow,
             })],
             deleted_fragments: RoaringBitmap::new(),
@@ -1117,10 +1166,10 @@ pub struct InvertedPartition {
     store: Arc<dyn IndexStore>,
     pub(crate) tokens: TokenSet,
     pub(crate) inverted_list: Arc<PostingListReader>,
-    /// Per-doc row_id + num_tokens. Wrapped in [`LazyDocSet`] so partitions
+    /// Per-doc row_id + num_tokens. Wrapped in `LazyDocSet` so partitions
     /// that don't contribute hits to a query never pay the full-array
     /// download. Scoring paths call `ensure_loaded` before walking wand.
-    pub(crate) docs: Arc<crate::scalar::inverted::lazy_docset::LazyDocSet>,
+    pub(crate) docs: Arc<LazyDocSet>,
     token_set_format: TokenSetFormat,
 }
 
@@ -1166,11 +1215,7 @@ impl InvertedPartition {
         // calls reader.num_rows() (no IO); the bulk load happens on first
         // scoring use, and partitions that never score skip it entirely.
         let docs_file = store.open_index_file(&doc_file_path(id)).await?;
-        let docs = Arc::new(crate::scalar::inverted::lazy_docset::LazyDocSet::new(
-            docs_file,
-            false,
-            frag_reuse_index,
-        ));
+        let docs = Arc::new(LazyDocSet::new(docs_file, false, frag_reuse_index));
 
         Ok(Self {
             id,
@@ -1283,6 +1328,7 @@ impl InvertedPartition {
     #[instrument(level = "debug", skip_all)]
     pub fn bm25_search(
         &self,
+        docs: &DocSet,
         params: &FtsSearchParams,
         operator: Operator,
         mask: Arc<RowAddrMask>,
@@ -1294,17 +1340,9 @@ impl InvertedPartition {
             return Ok(Vec::new());
         }
 
-        // self.docs is wrapped in LazyDocSet; callers must materialize it
-        // via `docs.ensure_loaded()` before entering wand. We unwrap here
-        // and panic if that contract was missed.
-        let docs = self
-            .docs
-            .loaded()
-            .expect(
-                "InvertedPartition::bm25_search requires docs to be materialized; \
-                 caller must `partition.docs.ensure_loaded().await` first",
-            )
-            .as_ref();
+        // Caller selects the DocSet shape via `LazyDocSet::docs_for_wand`
+        // and passes it in here; wand uses `docs.has_row_ids()` to
+        // handle the num_tokens-only case.
         let scorer = IndexBM25Scorer::new(std::iter::once(self));
         let mut wand = Wand::new(operator, postings.into_iter(), docs, scorer)
             .with_shared_threshold(shared_threshold);
@@ -4283,11 +4321,25 @@ pub struct DocSet {
 impl DocSet {
     #[inline]
     pub fn len(&self) -> usize {
-        self.row_ids.len()
+        // Use num_tokens instead of row_ids so the deferred-row_ids
+        // scoring path (which constructs a DocSet via
+        // [`Self::from_num_tokens_only`]) still reports the right doc
+        // count.
+        self.num_tokens.len()
     }
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// True iff the per-doc `row_id` array is populated. The
+    /// deferred-row_id scoring path constructs DocSets with the array
+    /// left empty so wand can skip the load; callers that need to do
+    /// row_id lookups in the inner loop must check this and fall back
+    /// to async resolution otherwise.
+    #[inline]
+    pub fn has_row_ids(&self) -> bool {
+        !self.row_ids.is_empty()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&u64, &u32)> {
@@ -4382,11 +4434,26 @@ impl DocSet {
         Self::from_columns(row_id_col, num_tokens_col, is_legacy, frag_reuse_index)
     }
 
+    /// Build a `DocSet` carrying only the per-doc `num_tokens` array;
+    /// `row_ids` and `inv` are left empty. Used by the deferred-row_id
+    /// scoring path: wand checks `has_row_ids()` to skip `row_id` /
+    /// `num_tokens_by_row_id` calls, and the per-partition caller
+    /// resolves doc_id → row_id for the surviving top-K post-wand.
+    pub fn from_num_tokens_only(num_tokens_col: &arrow_array::UInt32Array) -> Self {
+        let num_tokens = num_tokens_col.values().to_vec();
+        let total_tokens = num_tokens.iter().map(|&n| n as u64).sum();
+        Self {
+            row_ids: Vec::new(),
+            num_tokens,
+            inv: Vec::new(),
+            total_tokens,
+        }
+    }
+
     /// Build a `DocSet` from already-loaded `row_id` and `num_tokens`
     /// arrow columns. Lets callers that have one column already in hand
-    /// (e.g. [`crate::scalar::inverted::lazy_docset::LazyDocSet`] after
-    /// `total_tokens_num` pre-fetched `num_tokens`) skip re-reading that
-    /// column.
+    /// (e.g. `LazyDocSet` after `total_tokens_num` pre-fetched
+    /// `num_tokens`) skip re-reading that column.
     pub fn from_columns(
         row_id_col: &UInt64Array,
         num_tokens_col: &arrow_array::UInt32Array,

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -5945,9 +5945,13 @@ mod tests {
         }
     }
 
+    // Returns the `TempObjDir` guard so callers keep the backing store alive
+    // for the index's lifetime: the deferred DocSet re-opens the docs file on
+    // demand (it does not pin an open handle), so the files must still exist
+    // when the test exercises a scoring path.
     async fn load_counted_v2_index(
         num_tokens: usize,
-    ) -> (Arc<InvertedIndex>, Arc<PostingMetadataCounter>) {
+    ) -> (Arc<InvertedIndex>, Arc<PostingMetadataCounter>, TempObjDir) {
         let tmpdir = TempObjDir::default();
         let inner_store = Arc::new(LanceIndexStore::new(
             ObjectStore::local().into(),
@@ -5994,7 +5998,7 @@ mod tests {
         let index = InvertedIndex::load(counting_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
-        (index, counter)
+        (index, counter, tmpdir)
     }
 
     /// IO regression test for the lazy posting-metadata refactor. Builds a
@@ -6019,7 +6023,7 @@ mod tests {
     #[case::tokens_1000(1000)]
     #[tokio::test]
     async fn test_bm25_stats_for_terms_is_lazy(#[case] num_tokens: usize) {
-        let (index, counter) = load_counted_v2_index(num_tokens).await;
+        let (index, counter, _tmpdir) = load_counted_v2_index(num_tokens).await;
         assert!(
             !index.partitions[0].inverted_list.is_legacy_layout(),
             "this test only proves the lazy path for v2 indexes",
@@ -6068,7 +6072,7 @@ mod tests {
         // total token count.
         let num_tokens = 500;
         let queried_tokens: [u32; 4] = [0, 1, 2, 3];
-        let (index, counter) = load_counted_v2_index(num_tokens).await;
+        let (index, counter, _tmpdir) = load_counted_v2_index(num_tokens).await;
         let inverted_list = index.partitions[0].inverted_list.clone();
         assert!(
             !inverted_list.is_legacy_layout(),

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -4,82 +4,105 @@
 //! Deferred-load wrapper around [`DocSet`].
 //!
 //! The inverted-index `DocSet` holds the per-doc `row_id` and `num_tokens`
-//! arrays for a partition. Today every partition opens with the full set
-//! materialized — roughly 12 bytes × num_docs (~10 MiB per partition on
-//! large indexes). Across thousands of partitions and cold object storage
-//! that's tens of GiB of IO pulled before a query knows whether any
-//! particular partition even contains the term it's looking for.
+//! arrays for a partition. Eager loading on partition open pulls roughly
+//! 12 bytes × num_docs per partition; across thousands of partitions on
+//! cold object storage that's tens of GiB of IO before a query has even
+//! checked whether a partition contains the term it's looking for.
 //!
-//! [`LazyDocSet`] defers the load. Construction only stashes the reader and
-//! reads `num_rows` (no IO). The cheap, scoring-irrelevant queries the
-//! stats path needs — `len`, `total_tokens` — go through async accessors
-//! that compute on demand and cache. Wand scoring still requires the full
-//! `DocSet`, so the caller pays `ensure_loaded` only for partitions that
-//! actually contribute hits.
+//! [`LazyDocSet`] defers the load. Cheap sync getters (`len`,
+//! `total_tokens_cached`) work without IO; async getters fetch on
+//! demand and cache. Wand scoring still needs per-doc num_tokens, but
+//! only partitions that actually contribute hits pay
+//! `ensure_num_tokens_loaded`/`ensure_loaded`.
 
 use std::sync::Arc;
 
 use arrow::array::AsArray;
 use arrow::datatypes::{UInt32Type, UInt64Type};
 use arrow_array::{UInt32Array, UInt64Array};
+use lance_core::ROW_ID;
 use lance_core::Result;
 use tokio::sync::OnceCell;
-
-use lance_core::ROW_ID;
 
 use crate::frag_reuse::FragReuseIndex;
 use crate::scalar::IndexReader;
 use crate::scalar::inverted::index::{DocSet, NUM_TOKEN_COL};
+use lance_select::mask::RowAddrMask;
 
 /// Lazy view over an inverted-index partition's `DocSet`.
 ///
-/// All sync getters work without IO; async getters fetch on demand and
-/// cache. Methods that need the full per-doc arrays (`row_id`,
-/// `num_tokens`, iteration) require an explicit [`Self::ensure_loaded`]
-/// first.
-pub struct LazyDocSet {
+/// Two variants:
+/// - `Loaded`: a pre-materialized DocSet (legacy paths, tests).
+///   Sync accessors return cached values; async accessors return
+///   the same DocSet.
+/// - `Deferred`: backed by an [`IndexReader`]; columns are read and
+///   cached on first request.
+pub enum LazyDocSet {
+    Loaded(LoadedDocSet),
+    Deferred(Box<DeferredDocSet>),
+}
+
+/// Pre-materialized DocSet view -- no reader, no IO.
+pub struct LoadedDocSet {
+    docs: Arc<DocSet>,
+    num_rows: usize,
+    total_tokens: u64,
+}
+
+/// Reader-backed DocSet view that loads on demand and caches.
+pub struct DeferredDocSet {
     reader: Arc<dyn IndexReader>,
     is_legacy: bool,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
-    /// `reader.num_rows()` cached at construction. Equivalent to the eager
-    /// `DocSet::len`.
+    /// `reader.num_rows()` cached at construction.
     num_rows: usize,
-    /// `sum(num_tokens)` cached on first request, either from the
-    /// fully-loaded DocSet or from a single-column read.
+    /// `sum(num_tokens)` cached on first compute.
     total_tokens: OnceCell<u64>,
-    /// `NUM_TOKEN_COL` arrow buffer cached the first time it's read (by
-    /// either `total_tokens_num` or `ensure_loaded`). Reusing it on the
-    /// scoring path avoids re-reading the same column for hit partitions
-    /// after the stats path already pulled it.
+    /// `NUM_TOKEN_COL` arrow buffer cached on first read.
     num_tokens_col: OnceCell<Arc<UInt32Array>>,
-    /// Full DocSet, materialized lazily when scoring needs per-doc
-    /// `row_id`/`num_tokens`.
+    /// `ROW_ID` arrow buffer cached on first read.
+    row_ids_col: OnceCell<Arc<UInt64Array>>,
+    /// Full DocSet, materialized on first `ensure_loaded`.
     full: OnceCell<Arc<DocSet>>,
 }
 
 impl std::fmt::Debug for LazyDocSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LazyDocSet")
-            .field("num_rows", &self.num_rows)
-            .field("total_tokens_loaded", &self.total_tokens.initialized())
-            .field("full_loaded", &self.full.initialized())
-            .finish()
+        match self {
+            Self::Loaded(l) => f
+                .debug_struct("LazyDocSet::Loaded")
+                .field("num_rows", &l.num_rows)
+                .field("total_tokens", &l.total_tokens)
+                .finish(),
+            Self::Deferred(d) => f
+                .debug_struct("LazyDocSet::Deferred")
+                .field("num_rows", &d.num_rows)
+                .field("total_tokens_loaded", &d.total_tokens.initialized())
+                .field("full_loaded", &d.full.initialized())
+                .finish(),
+        }
     }
 }
 
 impl deepsize::DeepSizeOf for LazyDocSet {
     fn deep_size_of_children(&self, ctx: &mut deepsize::Context) -> usize {
-        // Approximate: only account for the fully-loaded DocSet and the
-        // cached num_tokens column when present.
-        self.full
-            .get()
-            .map(|d| d.deep_size_of_children(ctx))
-            .unwrap_or(0)
-            + self
-                .num_tokens_col
-                .get()
-                .map(|arr| arr.len() * std::mem::size_of::<u32>())
-                .unwrap_or(0)
+        match self {
+            Self::Loaded(l) => l.docs.deep_size_of_children(ctx),
+            Self::Deferred(d) => {
+                d.full
+                    .get()
+                    .map(|d| d.deep_size_of_children(ctx))
+                    .unwrap_or(0)
+                    + d.num_tokens_col
+                        .get()
+                        .map(|arr| arr.len() * std::mem::size_of::<u32>())
+                        .unwrap_or(0)
+                    + d.row_ids_col
+                        .get()
+                        .map(|arr| arr.len() * std::mem::size_of::<u64>())
+                        .unwrap_or(0)
+            }
+        }
     }
 }
 
@@ -90,57 +113,119 @@ impl LazyDocSet {
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Self {
         let num_rows = reader.num_rows();
-        Self {
+        Self::Deferred(Box::new(DeferredDocSet {
             reader,
             is_legacy,
             frag_reuse_index,
             num_rows,
             total_tokens: OnceCell::new(),
             num_tokens_col: OnceCell::new(),
+            row_ids_col: OnceCell::new(),
             full: OnceCell::new(),
+        }))
+    }
+
+    /// Wrap an already-materialized [`DocSet`]. Used by legacy paths
+    /// and tests that need to seed a partition without a reader.
+    pub fn from_loaded(docs: DocSet) -> Self {
+        let num_rows = docs.len();
+        let total_tokens = docs.total_tokens_num();
+        Self::Loaded(LoadedDocSet {
+            docs: Arc::new(docs),
+            num_rows,
+            total_tokens,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Loaded(l) => l.num_rows,
+            Self::Deferred(d) => d.num_rows,
         }
     }
 
-    /// Wrap an already-materialized [`DocSet`]. Useful for legacy paths and
-    /// tests that need to seed a partition without an underlying reader.
-    pub fn from_loaded(docs: DocSet) -> Self {
-        // Build a synthetic LazyDocSet whose `full` cell is pre-populated.
-        // The reader/frag-reuse fields will never be touched.
-        let num_rows = docs.len();
-        let total_tokens = docs.total_tokens_num();
-        let me = Self {
-            reader: panic_reader(),
-            is_legacy: false,
-            frag_reuse_index: None,
-            num_rows,
-            total_tokens: OnceCell::new(),
-            num_tokens_col: OnceCell::new(),
-            full: OnceCell::new(),
-        };
-        let _ = me.total_tokens.set(total_tokens);
-        let _ = me.full.set(Arc::new(docs));
-        me
+    /// Sync read of cached `total_tokens`. Returns `None` for a
+    /// `Deferred` LazyDocSet that hasn't yet had any of
+    /// `total_tokens_num` / `ensure_num_tokens_loaded` / `ensure_loaded`
+    /// run. Used by sync scoring code that has already paid for one
+    /// of those async calls.
+    pub fn total_tokens_cached(&self) -> Option<u64> {
+        match self {
+            Self::Loaded(l) => Some(l.total_tokens),
+            Self::Deferred(d) => d.total_tokens.get().copied(),
+        }
     }
 
-    /// Number of docs in the partition (cheap, no IO).
-    pub fn len(&self) -> usize {
-        self.num_rows
+    /// True if this DocSet carries a FragReuseIndex. Callers MUST
+    /// avoid the deferred-row_id path when this is set: targeted
+    /// row_id reads return raw stored ids, bypassing the per-id
+    /// `remap_row_id` filter that `DocSet::from_columns` applies.
+    pub fn has_frag_reuse_remap(&self) -> bool {
+        match self {
+            Self::Loaded(_) => false,
+            Self::Deferred(d) => d.frag_reuse_index.is_some(),
+        }
     }
 
-    /// Returns the full [`DocSet`] if it has already been loaded; otherwise
-    /// `None`. Sync; callers that need a guaranteed value should call
-    /// [`Self::ensure_loaded`] first.
-    pub fn loaded(&self) -> Option<&Arc<DocSet>> {
-        self.full.get()
-    }
-
-    /// Sum of `num_tokens` across all docs. Lazy-computed on first call:
-    /// if the full DocSet is loaded, reads from it; otherwise issues a
-    /// single-column read of `NUM_TOKEN_COL` from the docs file (about
-    /// half the bytes of a full DocSet load). Caches both the sum and
-    /// the per-row arrow buffer so a subsequent `ensure_loaded` can
-    /// reuse the buffer instead of re-reading.
+    /// Sum of `num_tokens` across all docs.
     pub async fn total_tokens_num(&self) -> Result<u64> {
+        match self {
+            Self::Loaded(l) => Ok(l.total_tokens),
+            Self::Deferred(d) => d.total_tokens_num().await,
+        }
+    }
+
+    /// Materialize the full DocSet, including row_ids.
+    pub async fn ensure_loaded(&self) -> Result<Arc<DocSet>> {
+        match self {
+            Self::Loaded(l) => Ok(l.docs.clone()),
+            Self::Deferred(d) => d.ensure_loaded().await,
+        }
+    }
+
+    /// Materialize a DocSet that carries num_tokens but no row_ids.
+    /// Used by the deferred-row_id scoring path; the per-partition
+    /// caller resolves surviving doc_ids -> row_ids post-wand via
+    /// [`Self::resolve_row_ids`]. The result is NOT cached on the
+    /// LazyDocSet -- a later `ensure_loaded` must still produce a
+    /// full DocSet.
+    pub async fn ensure_num_tokens_loaded(&self) -> Result<Arc<DocSet>> {
+        match self {
+            Self::Loaded(l) => Ok(l.docs.clone()),
+            Self::Deferred(d) => d.ensure_num_tokens_loaded().await,
+        }
+    }
+
+    /// Pick the right DocSet shape for a wand walk under `mask`:
+    /// the num_tokens-only deferred form when the mask is trivial
+    /// AND no FragReuseIndex needs to filter row_ids; otherwise the
+    /// full DocSet. Encapsulates the policy so callers don't have to
+    /// rederive the conditions for the targeted-read fast path.
+    pub async fn docs_for_wand(&self, mask: &RowAddrMask) -> Result<Arc<DocSet>> {
+        if mask.is_select_all() && !self.has_frag_reuse_remap() {
+            self.ensure_num_tokens_loaded().await
+        } else {
+            self.ensure_loaded().await
+        }
+    }
+
+    /// Resolve a batch of `doc_id`s to their `row_id`s. Used by the
+    /// deferred-row_id scoring path to map post-wand top-K candidates
+    /// without going through a full DocSet build.
+    ///
+    /// Not safe with a FragReuseIndex (see
+    /// [`Self::has_frag_reuse_remap`]): the targeted reads return
+    /// raw stored ids without applying the remap/skip.
+    pub async fn resolve_row_ids(&self, doc_ids: &[u32]) -> Result<Vec<u64>> {
+        match self {
+            Self::Loaded(l) => Ok(doc_ids.iter().map(|&d| l.docs.row_id(d)).collect()),
+            Self::Deferred(d) => d.resolve_row_ids(doc_ids).await,
+        }
+    }
+}
+
+impl DeferredDocSet {
+    async fn total_tokens_num(&self) -> Result<u64> {
         if let Some(v) = self.total_tokens.get() {
             return Ok(*v);
         }
@@ -149,98 +234,99 @@ impl LazyDocSet {
             let _ = self.total_tokens.set(v);
             return Ok(v);
         }
-        let col = self.read_num_tokens_column().await?;
+        let col = self.num_tokens_column().await?;
         let sum: u64 = col.values().iter().map(|&n| n as u64).sum();
         let _ = self.total_tokens.set(sum);
         Ok(sum)
     }
 
-    /// Internal helper: read (or return cached) `NUM_TOKEN_COL`.
-    async fn read_num_tokens_column(&self) -> Result<Arc<UInt32Array>> {
-        if let Some(arr) = self.num_tokens_col.get() {
-            return Ok(arr.clone());
-        }
-        let batch = self
-            .reader
-            .read_range(0..self.num_rows, Some(&[NUM_TOKEN_COL]))
-            .await?;
-        let arr = Arc::new(batch[NUM_TOKEN_COL].as_primitive::<UInt32Type>().clone());
-        // `set` errors if another caller raced; their value is equivalent.
-        let _ = self.num_tokens_col.set(arr.clone());
-        Ok(self.num_tokens_col.get().unwrap().clone())
+    async fn num_tokens_column(&self) -> Result<Arc<UInt32Array>> {
+        self.num_tokens_col
+            .get_or_try_init(|| async {
+                let batch = self
+                    .reader
+                    .read_range(0..self.num_rows, Some(&[NUM_TOKEN_COL]))
+                    .await?;
+                Result::Ok(Arc::new(
+                    batch[NUM_TOKEN_COL].as_primitive::<UInt32Type>().clone(),
+                ))
+            })
+            .await
+            .cloned()
     }
 
-    /// Materialize the full [`DocSet`] and cache it. If a prior
-    /// `total_tokens_num` already pulled `NUM_TOKEN_COL`, we read only
-    /// `ROW_ID` here and rebuild the DocSet from the two columns —
-    /// halving the bytes pulled for hit partitions whose stats path
-    /// already paid the num_tokens read.
-    pub async fn ensure_loaded(&self) -> Result<Arc<DocSet>> {
+    async fn row_ids_column(&self) -> Result<Arc<UInt64Array>> {
+        self.row_ids_col
+            .get_or_try_init(|| async {
+                let batch = self
+                    .reader
+                    .read_range(0..self.num_rows, Some(&[ROW_ID]))
+                    .await?;
+                Result::Ok(Arc::new(batch[ROW_ID].as_primitive::<UInt64Type>().clone()))
+            })
+            .await
+            .cloned()
+    }
+
+    async fn ensure_loaded(&self) -> Result<Arc<DocSet>> {
+        let docs = self
+            .full
+            .get_or_try_init(|| async {
+                // If the stats path already pulled NUM_TOKEN_COL,
+                // read only ROW_ID and rebuild from the two columns.
+                let docs = if self.num_tokens_col.get().is_some() {
+                    let num_tokens = self.num_tokens_column().await?;
+                    let row_ids = self.row_ids_column().await?;
+                    DocSet::from_columns(
+                        row_ids.as_ref(),
+                        num_tokens.as_ref(),
+                        self.is_legacy,
+                        self.frag_reuse_index.clone(),
+                    )?
+                } else {
+                    DocSet::load(
+                        self.reader.clone(),
+                        self.is_legacy,
+                        self.frag_reuse_index.clone(),
+                    )
+                    .await?
+                };
+                Result::Ok(Arc::new(docs))
+            })
+            .await?
+            .clone();
+        let _ = self.total_tokens.set(docs.total_tokens_num());
+        Ok(docs)
+    }
+
+    async fn ensure_num_tokens_loaded(&self) -> Result<Arc<DocSet>> {
         if let Some(full) = self.full.get() {
             return Ok(full.clone());
         }
-        let docs = if self.num_tokens_col.get().is_some() {
-            let num_tokens = self.read_num_tokens_column().await?;
-            let batch = self
-                .reader
-                .read_range(0..self.num_rows, Some(&[ROW_ID]))
-                .await?;
-            let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
-            DocSet::from_columns(
-                row_ids,
-                num_tokens.as_ref(),
-                self.is_legacy,
-                self.frag_reuse_index.clone(),
-            )?
-        } else {
-            // Cold path: nothing cached yet, fall back to the full read.
-            DocSet::load(
-                self.reader.clone(),
-                self.is_legacy,
-                self.frag_reuse_index.clone(),
-            )
-            .await?
-        };
-        let docs = Arc::new(docs);
-        let _ = self.full.set(docs.clone());
+        let num_tokens = self.num_tokens_column().await?;
+        let docs = Arc::new(DocSet::from_num_tokens_only(num_tokens.as_ref()));
         let _ = self.total_tokens.set(docs.total_tokens_num());
-        Ok(self.full.get().unwrap().clone())
+        Ok(docs)
     }
-}
 
-/// Sentinel reader used by [`LazyDocSet::from_loaded`]; the LazyDocSet's
-/// IO paths never touch it because `total_tokens` and `full` are
-/// pre-populated.
-fn panic_reader() -> Arc<dyn IndexReader> {
-    struct Panic;
-    #[async_trait::async_trait]
-    impl IndexReader for Panic {
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
+    async fn resolve_row_ids(&self, doc_ids: &[u32]) -> Result<Vec<u64>> {
+        if let Some(full) = self.full.get()
+            && full.has_row_ids()
+        {
+            return Ok(doc_ids.iter().map(|&d| full.row_id(d)).collect());
         }
-        async fn read_record_batch(
-            &self,
-            _n: u64,
-            _batch_size: u64,
-        ) -> Result<arrow_array::RecordBatch> {
-            panic!("synthetic LazyDocSet reader should never be queried")
+        if let Some(arr) = self.row_ids_col.get() {
+            return Ok(doc_ids.iter().map(|&d| arr.value(d as usize)).collect());
         }
-        async fn read_range(
-            &self,
-            _range: std::ops::Range<usize>,
-            _projection: Option<&[&str]>,
-        ) -> Result<arrow_array::RecordBatch> {
-            panic!("synthetic LazyDocSet reader should never be queried")
+        // Targeted per-doc reads -- the deferred path's whole point.
+        // Lance v2 coalesces nearby reads at the page level.
+        let mut row_ids = Vec::with_capacity(doc_ids.len());
+        for &d in doc_ids {
+            let d = d as usize;
+            let batch = self.reader.read_range(d..d + 1, Some(&[ROW_ID])).await?;
+            let arr = batch[ROW_ID].as_primitive::<UInt64Type>();
+            row_ids.push(arr.value(0));
         }
-        async fn num_batches(&self, _batch_size: u64) -> u32 {
-            0
-        }
-        fn num_rows(&self) -> usize {
-            0
-        }
-        fn schema(&self) -> &lance_core::datatypes::Schema {
-            panic!("synthetic LazyDocSet reader should never be queried")
-        }
+        Ok(row_ids)
     }
-    Arc::new(Panic)
 }

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -318,15 +318,12 @@ impl DeferredDocSet {
         if let Some(arr) = self.row_ids_col.get() {
             return Ok(doc_ids.iter().map(|&d| arr.value(d as usize)).collect());
         }
-        // Targeted per-doc reads -- the deferred path's whole point.
-        // Lance v2 coalesces nearby reads at the page level.
-        let mut row_ids = Vec::with_capacity(doc_ids.len());
-        for &d in doc_ids {
-            let d = d as usize;
-            let batch = self.reader.read_range(d..d + 1, Some(&[ROW_ID])).await?;
-            let arr = batch[ROW_ID].as_primitive::<UInt64Type>();
-            row_ids.push(arr.value(0));
-        }
-        Ok(row_ids)
+        let ranges: Vec<std::ops::Range<usize>> = doc_ids
+            .iter()
+            .map(|&d| d as usize..d as usize + 1)
+            .collect();
+        let batch = self.reader.read_ranges(&ranges, Some(&[ROW_ID])).await?;
+        let arr = batch[ROW_ID].as_primitive::<UInt64Type>();
+        Ok((0..arr.len()).map(|i| arr.value(i)).collect())
     }
 }

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Deferred-load wrapper around [`DocSet`].
+//!
+//! The inverted-index `DocSet` holds the per-doc `row_id` and `num_tokens`
+//! arrays for a partition. Today every partition opens with the full set
+//! materialized — roughly 12 bytes × num_docs (~10 MiB per partition on
+//! large indexes). Across thousands of partitions and cold object storage
+//! that's tens of GiB of IO pulled before a query knows whether any
+//! particular partition even contains the term it's looking for.
+//!
+//! [`LazyDocSet`] defers the load. Construction only stashes the reader and
+//! reads `num_rows` (no IO). The cheap, scoring-irrelevant queries the
+//! stats path needs — `len`, `total_tokens` — go through async accessors
+//! that compute on demand and cache. Wand scoring still requires the full
+//! `DocSet`, so the caller pays `ensure_loaded` only for partitions that
+//! actually contribute hits.
+
+use std::sync::Arc;
+
+use lance_core::Result;
+use tokio::sync::OnceCell;
+
+use crate::frag_reuse::FragReuseIndex;
+use crate::scalar::IndexReader;
+use crate::scalar::inverted::index::{DocSet, NUM_TOKEN_COL};
+use arrow::array::AsArray;
+use arrow::datatypes::UInt32Type;
+
+/// Lazy view over an inverted-index partition's `DocSet`.
+///
+/// All sync getters work without IO; async getters fetch on demand and
+/// cache. Methods that need the full per-doc arrays (`row_id`,
+/// `num_tokens`, iteration) require an explicit [`Self::ensure_loaded`]
+/// first.
+pub struct LazyDocSet {
+    reader: Arc<dyn IndexReader>,
+    is_legacy: bool,
+    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    /// `reader.num_rows()` cached at construction. Equivalent to the eager
+    /// `DocSet::len`.
+    num_rows: usize,
+    /// `sum(num_tokens)` cached on first request, either from the
+    /// fully-loaded DocSet or from a single-column read.
+    total_tokens: OnceCell<u64>,
+    /// Full DocSet, materialized lazily when scoring needs per-doc
+    /// `row_id`/`num_tokens`.
+    full: OnceCell<Arc<DocSet>>,
+}
+
+impl std::fmt::Debug for LazyDocSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LazyDocSet")
+            .field("num_rows", &self.num_rows)
+            .field("total_tokens_loaded", &self.total_tokens.initialized())
+            .field("full_loaded", &self.full.initialized())
+            .finish()
+    }
+}
+
+impl deepsize::DeepSizeOf for LazyDocSet {
+    fn deep_size_of_children(&self, ctx: &mut deepsize::Context) -> usize {
+        // Approximate: only account for the fully-loaded DocSet if present.
+        self.full
+            .get()
+            .map(|d| d.deep_size_of_children(ctx))
+            .unwrap_or(0)
+    }
+}
+
+impl LazyDocSet {
+    pub fn new(
+        reader: Arc<dyn IndexReader>,
+        is_legacy: bool,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Self {
+        let num_rows = reader.num_rows();
+        Self {
+            reader,
+            is_legacy,
+            frag_reuse_index,
+            num_rows,
+            total_tokens: OnceCell::new(),
+            full: OnceCell::new(),
+        }
+    }
+
+    /// Wrap an already-materialized [`DocSet`]. Useful for legacy paths and
+    /// tests that need to seed a partition without an underlying reader.
+    pub fn from_loaded(docs: DocSet) -> Self {
+        // Build a synthetic LazyDocSet whose `full` cell is pre-populated.
+        // The reader/frag-reuse fields will never be touched.
+        let num_rows = docs.len();
+        let total_tokens = docs.total_tokens_num();
+        let me = Self {
+            reader: panic_reader(),
+            is_legacy: false,
+            frag_reuse_index: None,
+            num_rows,
+            total_tokens: OnceCell::new(),
+            full: OnceCell::new(),
+        };
+        let _ = me.total_tokens.set(total_tokens);
+        let _ = me.full.set(Arc::new(docs));
+        me
+    }
+
+    /// Number of docs in the partition (cheap, no IO).
+    pub fn len(&self) -> usize {
+        self.num_rows
+    }
+
+    /// Returns the full [`DocSet`] if it has already been loaded; otherwise
+    /// `None`. Sync; callers that need a guaranteed value should call
+    /// [`Self::ensure_loaded`] first.
+    pub fn loaded(&self) -> Option<&Arc<DocSet>> {
+        self.full.get()
+    }
+
+    /// Sum of `num_tokens` across all docs. Lazy-computed on first call:
+    /// if the full DocSet is loaded, reads from it; otherwise issues a
+    /// single-column read of `NUM_TOKEN_COL` from the docs file (about
+    /// half the bytes of a full DocSet load). Result is cached.
+    pub async fn total_tokens_num(&self) -> Result<u64> {
+        if let Some(v) = self.total_tokens.get() {
+            return Ok(*v);
+        }
+        if let Some(full) = self.full.get() {
+            let v = full.total_tokens_num();
+            let _ = self.total_tokens.set(v);
+            return Ok(v);
+        }
+        // Read just the num_tokens column. Avoids pulling row_ids (the
+        // other half of the DocSet bytes).
+        let batch = self
+            .reader
+            .read_range(0..self.num_rows, Some(&[NUM_TOKEN_COL]))
+            .await?;
+        let col = batch[NUM_TOKEN_COL].as_primitive::<UInt32Type>();
+        let sum: u64 = col.values().iter().map(|&n| n as u64).sum();
+        let _ = self.total_tokens.set(sum);
+        Ok(sum)
+    }
+
+    /// Materialize the full [`DocSet`] and cache it. Cheap to call
+    /// repeatedly.
+    pub async fn ensure_loaded(&self) -> Result<Arc<DocSet>> {
+        if let Some(full) = self.full.get() {
+            return Ok(full.clone());
+        }
+        let docs = DocSet::load(
+            self.reader.clone(),
+            self.is_legacy,
+            self.frag_reuse_index.clone(),
+        )
+        .await?;
+        let docs = Arc::new(docs);
+        // Use OnceCell::set; another caller may have raced ahead, in which
+        // case we discard ours.
+        let _ = self.full.set(docs.clone());
+        // Also seed total_tokens so subsequent queries don't re-read.
+        let _ = self.total_tokens.set(docs.total_tokens_num());
+        Ok(self.full.get().unwrap().clone())
+    }
+}
+
+/// Sentinel reader used by [`LazyDocSet::from_loaded`]; the LazyDocSet's
+/// IO paths never touch it because `total_tokens` and `full` are
+/// pre-populated.
+fn panic_reader() -> Arc<dyn IndexReader> {
+    struct Panic;
+    #[async_trait::async_trait]
+    impl IndexReader for Panic {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        async fn read_record_batch(
+            &self,
+            _n: u64,
+            _batch_size: u64,
+        ) -> Result<arrow_array::RecordBatch> {
+            panic!("synthetic LazyDocSet reader should never be queried")
+        }
+        async fn read_range(
+            &self,
+            _range: std::ops::Range<usize>,
+            _projection: Option<&[&str]>,
+        ) -> Result<arrow_array::RecordBatch> {
+            panic!("synthetic LazyDocSet reader should never be queried")
+        }
+        async fn num_batches(&self, _batch_size: u64) -> u32 {
+            0
+        }
+        fn num_rows(&self) -> usize {
+            0
+        }
+        fn schema(&self) -> &lance_core::datatypes::Schema {
+            panic!("synthetic LazyDocSet reader should never be queried")
+        }
+    }
+    Arc::new(Panic)
+}

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -19,14 +19,17 @@
 
 use std::sync::Arc;
 
+use arrow::array::AsArray;
+use arrow::datatypes::{UInt32Type, UInt64Type};
+use arrow_array::{UInt32Array, UInt64Array};
 use lance_core::Result;
 use tokio::sync::OnceCell;
+
+use lance_core::ROW_ID;
 
 use crate::frag_reuse::FragReuseIndex;
 use crate::scalar::IndexReader;
 use crate::scalar::inverted::index::{DocSet, NUM_TOKEN_COL};
-use arrow::array::AsArray;
-use arrow::datatypes::UInt32Type;
 
 /// Lazy view over an inverted-index partition's `DocSet`.
 ///
@@ -44,6 +47,11 @@ pub struct LazyDocSet {
     /// `sum(num_tokens)` cached on first request, either from the
     /// fully-loaded DocSet or from a single-column read.
     total_tokens: OnceCell<u64>,
+    /// `NUM_TOKEN_COL` arrow buffer cached the first time it's read (by
+    /// either `total_tokens_num` or `ensure_loaded`). Reusing it on the
+    /// scoring path avoids re-reading the same column for hit partitions
+    /// after the stats path already pulled it.
+    num_tokens_col: OnceCell<Arc<UInt32Array>>,
     /// Full DocSet, materialized lazily when scoring needs per-doc
     /// `row_id`/`num_tokens`.
     full: OnceCell<Arc<DocSet>>,
@@ -61,11 +69,17 @@ impl std::fmt::Debug for LazyDocSet {
 
 impl deepsize::DeepSizeOf for LazyDocSet {
     fn deep_size_of_children(&self, ctx: &mut deepsize::Context) -> usize {
-        // Approximate: only account for the fully-loaded DocSet if present.
+        // Approximate: only account for the fully-loaded DocSet and the
+        // cached num_tokens column when present.
         self.full
             .get()
             .map(|d| d.deep_size_of_children(ctx))
             .unwrap_or(0)
+            + self
+                .num_tokens_col
+                .get()
+                .map(|arr| arr.len() * std::mem::size_of::<u32>())
+                .unwrap_or(0)
     }
 }
 
@@ -82,6 +96,7 @@ impl LazyDocSet {
             frag_reuse_index,
             num_rows,
             total_tokens: OnceCell::new(),
+            num_tokens_col: OnceCell::new(),
             full: OnceCell::new(),
         }
     }
@@ -99,6 +114,7 @@ impl LazyDocSet {
             frag_reuse_index: None,
             num_rows,
             total_tokens: OnceCell::new(),
+            num_tokens_col: OnceCell::new(),
             full: OnceCell::new(),
         };
         let _ = me.total_tokens.set(total_tokens);
@@ -121,7 +137,9 @@ impl LazyDocSet {
     /// Sum of `num_tokens` across all docs. Lazy-computed on first call:
     /// if the full DocSet is loaded, reads from it; otherwise issues a
     /// single-column read of `NUM_TOKEN_COL` from the docs file (about
-    /// half the bytes of a full DocSet load). Result is cached.
+    /// half the bytes of a full DocSet load). Caches both the sum and
+    /// the per-row arrow buffer so a subsequent `ensure_loaded` can
+    /// reuse the buffer instead of re-reading.
     pub async fn total_tokens_num(&self) -> Result<u64> {
         if let Some(v) = self.total_tokens.get() {
             return Ok(*v);
@@ -131,35 +149,60 @@ impl LazyDocSet {
             let _ = self.total_tokens.set(v);
             return Ok(v);
         }
-        // Read just the num_tokens column. Avoids pulling row_ids (the
-        // other half of the DocSet bytes).
-        let batch = self
-            .reader
-            .read_range(0..self.num_rows, Some(&[NUM_TOKEN_COL]))
-            .await?;
-        let col = batch[NUM_TOKEN_COL].as_primitive::<UInt32Type>();
+        let col = self.read_num_tokens_column().await?;
         let sum: u64 = col.values().iter().map(|&n| n as u64).sum();
         let _ = self.total_tokens.set(sum);
         Ok(sum)
     }
 
-    /// Materialize the full [`DocSet`] and cache it. Cheap to call
-    /// repeatedly.
+    /// Internal helper: read (or return cached) `NUM_TOKEN_COL`.
+    async fn read_num_tokens_column(&self) -> Result<Arc<UInt32Array>> {
+        if let Some(arr) = self.num_tokens_col.get() {
+            return Ok(arr.clone());
+        }
+        let batch = self
+            .reader
+            .read_range(0..self.num_rows, Some(&[NUM_TOKEN_COL]))
+            .await?;
+        let arr = Arc::new(batch[NUM_TOKEN_COL].as_primitive::<UInt32Type>().clone());
+        // `set` errors if another caller raced; their value is equivalent.
+        let _ = self.num_tokens_col.set(arr.clone());
+        Ok(self.num_tokens_col.get().unwrap().clone())
+    }
+
+    /// Materialize the full [`DocSet`] and cache it. If a prior
+    /// `total_tokens_num` already pulled `NUM_TOKEN_COL`, we read only
+    /// `ROW_ID` here and rebuild the DocSet from the two columns —
+    /// halving the bytes pulled for hit partitions whose stats path
+    /// already paid the num_tokens read.
     pub async fn ensure_loaded(&self) -> Result<Arc<DocSet>> {
         if let Some(full) = self.full.get() {
             return Ok(full.clone());
         }
-        let docs = DocSet::load(
-            self.reader.clone(),
-            self.is_legacy,
-            self.frag_reuse_index.clone(),
-        )
-        .await?;
+        let docs = if self.num_tokens_col.get().is_some() {
+            let num_tokens = self.read_num_tokens_column().await?;
+            let batch = self
+                .reader
+                .read_range(0..self.num_rows, Some(&[ROW_ID]))
+                .await?;
+            let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+            DocSet::from_columns(
+                row_ids,
+                num_tokens.as_ref(),
+                self.is_legacy,
+                self.frag_reuse_index.clone(),
+            )?
+        } else {
+            // Cold path: nothing cached yet, fall back to the full read.
+            DocSet::load(
+                self.reader.clone(),
+                self.is_legacy,
+                self.frag_reuse_index.clone(),
+            )
+            .await?
+        };
         let docs = Arc::new(docs);
-        // Use OnceCell::set; another caller may have raced ahead, in which
-        // case we discard ours.
         let _ = self.full.set(docs.clone());
-        // Also seed total_tokens so subsequent queries don't re-read.
         let _ = self.total_tokens.set(docs.total_tokens_num());
         Ok(self.full.get().unwrap().clone())
     }

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -25,8 +25,8 @@ use lance_core::Result;
 use tokio::sync::OnceCell;
 
 use crate::frag_reuse::FragReuseIndex;
-use crate::scalar::IndexReader;
 use crate::scalar::inverted::index::{DocSet, NUM_TOKEN_COL};
+use crate::scalar::{IndexReader, IndexStore};
 use lance_select::mask::RowAddrMask;
 
 /// Lazy view over an inverted-index partition's `DocSet`.
@@ -49,12 +49,22 @@ pub struct LoadedDocSet {
     total_tokens: u64,
 }
 
-/// Reader-backed DocSet view that loads on demand and caches.
+/// Store-backed DocSet view that loads on demand and caches.
+///
+/// Holds the [`IndexStore`] and docs-file path rather than an open
+/// [`IndexReader`], so a cached partition does not pin a docs-file
+/// handle for its whole lifetime. The reader is re-opened on demand
+/// inside each column accessor and dropped when that read completes;
+/// because the resulting buffers are cached in the `OnceCell`s below,
+/// a contributing partition re-opens only on a cold miss, and a
+/// partition that never scores never opens the docs file at all after
+/// construction.
 pub struct DeferredDocSet {
-    reader: Arc<dyn IndexReader>,
+    store: Arc<dyn IndexStore>,
+    docs_path: String,
     is_legacy: bool,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
-    /// `reader.num_rows()` cached at construction.
+    /// Doc count cached at construction so `len()` stays sync + IO-free.
     num_rows: usize,
     /// `sum(num_tokens)` cached on first compute.
     total_tokens: OnceCell<u64>,
@@ -108,13 +118,15 @@ impl deepsize::DeepSizeOf for LazyDocSet {
 
 impl LazyDocSet {
     pub fn new(
-        reader: Arc<dyn IndexReader>,
+        store: Arc<dyn IndexStore>,
+        docs_path: String,
+        num_rows: usize,
         is_legacy: bool,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Self {
-        let num_rows = reader.num_rows();
         Self::Deferred(Box::new(DeferredDocSet {
-            reader,
+            store,
+            docs_path,
             is_legacy,
             frag_reuse_index,
             num_rows,
@@ -225,6 +237,12 @@ impl LazyDocSet {
 }
 
 impl DeferredDocSet {
+    /// Open a fresh docs-file reader. Dropped by the caller once its read
+    /// completes, so no handle is pinned across the partition's lifetime.
+    async fn reader(&self) -> Result<Arc<dyn IndexReader>> {
+        self.store.open_index_file(&self.docs_path).await
+    }
+
     async fn total_tokens_num(&self) -> Result<u64> {
         if let Some(v) = self.total_tokens.get() {
             return Ok(*v);
@@ -243,8 +261,8 @@ impl DeferredDocSet {
     async fn num_tokens_column(&self) -> Result<Arc<UInt32Array>> {
         self.num_tokens_col
             .get_or_try_init(|| async {
-                let batch = self
-                    .reader
+                let reader = self.reader().await?;
+                let batch = reader
                     .read_range(0..self.num_rows, Some(&[NUM_TOKEN_COL]))
                     .await?;
                 Result::Ok(Arc::new(
@@ -258,10 +276,8 @@ impl DeferredDocSet {
     async fn row_ids_column(&self) -> Result<Arc<UInt64Array>> {
         self.row_ids_col
             .get_or_try_init(|| async {
-                let batch = self
-                    .reader
-                    .read_range(0..self.num_rows, Some(&[ROW_ID]))
-                    .await?;
+                let reader = self.reader().await?;
+                let batch = reader.read_range(0..self.num_rows, Some(&[ROW_ID])).await?;
                 Result::Ok(Arc::new(batch[ROW_ID].as_primitive::<UInt64Type>().clone()))
             })
             .await
@@ -285,7 +301,7 @@ impl DeferredDocSet {
                     )?
                 } else {
                     DocSet::load(
-                        self.reader.clone(),
+                        self.reader().await?,
                         self.is_legacy,
                         self.frag_reuse_index.clone(),
                     )
@@ -322,7 +338,8 @@ impl DeferredDocSet {
             .iter()
             .map(|&d| d as usize..d as usize + 1)
             .collect();
-        let batch = self.reader.read_ranges(&ranges, Some(&[ROW_ID])).await?;
+        let reader = self.reader().await?;
+        let batch = reader.read_ranges(&ranges, Some(&[ROW_ID])).await?;
         let arr = batch[ROW_ID].as_primitive::<UInt64Type>();
         Ok((0..arr.len()).map(|i| arr.value(i)).collect())
     }

--- a/rust/lance-index/src/scalar/inverted/scorer.rs
+++ b/rust/lance-index/src/scalar/inverted/scorer.rs
@@ -87,33 +87,41 @@ impl Scorer for MemBM25Scorer {
 pub struct IndexBM25Scorer<'a> {
     partitions: Vec<&'a InvertedPartition>,
     num_docs: usize,
-    total_tokens: u64,
     avg_doc_length: f32,
 }
 
 impl<'a> IndexBM25Scorer<'a> {
+    /// Sync constructor. Reads `total_tokens` directly from each partition
+    /// via `LazyDocSet::loaded()`; callers must have already materialized
+    /// the DocSets (e.g. via `ensure_loaded`). Panics with a clear message
+    /// otherwise — this is the wand-scoring path where the contract is
+    /// statically known.
     pub fn new(partitions: impl Iterator<Item = &'a InvertedPartition>) -> Self {
         let partitions = partitions.collect::<Vec<_>>();
         let num_docs = partitions.iter().map(|p| p.docs.len()).sum();
-        let total_tokens = partitions
+        let total_tokens: u64 = partitions
             .iter()
-            .map(|part| part.docs.total_tokens_num())
-            .sum::<u64>();
+            .map(|p| {
+                p.docs
+                    .loaded()
+                    .expect(
+                        "IndexBM25Scorer::new requires every partition's DocSet to be \
+                         loaded; call `partition.docs.ensure_loaded().await` first",
+                    )
+                    .total_tokens_num()
+            })
+            .sum();
         let avgdl = total_tokens as f32 / num_docs as f32;
         Self {
             partitions,
             num_docs,
-            total_tokens,
             avg_doc_length: avgdl,
         }
     }
 
+    #[allow(dead_code)]
     pub fn num_docs(&self) -> usize {
         self.num_docs
-    }
-
-    pub fn total_tokens(&self) -> u64 {
-        self.total_tokens
     }
 
     pub fn num_docs_containing_token(&self, token: &str) -> usize {

--- a/rust/lance-index/src/scalar/inverted/scorer.rs
+++ b/rust/lance-index/src/scalar/inverted/scorer.rs
@@ -91,24 +91,22 @@ pub struct IndexBM25Scorer<'a> {
 }
 
 impl<'a> IndexBM25Scorer<'a> {
-    /// Sync constructor. Reads `total_tokens` directly from each partition
-    /// via `LazyDocSet::loaded()`; callers must have already materialized
-    /// the DocSets (e.g. via `ensure_loaded`). Panics with a clear message
-    /// otherwise — this is the wand-scoring path where the contract is
-    /// statically known.
+    /// Sync constructor. Reads each partition's cached `total_tokens` via
+    /// `LazyDocSet::total_tokens_cached()`; callers must have already
+    /// populated it (via `ensure_loaded`, `ensure_num_tokens_loaded`, or
+    /// `total_tokens_num`). Panics with a clear message otherwise — this
+    /// is the wand-scoring path where the contract is statically known.
     pub fn new(partitions: impl Iterator<Item = &'a InvertedPartition>) -> Self {
         let partitions = partitions.collect::<Vec<_>>();
         let num_docs = partitions.iter().map(|p| p.docs.len()).sum();
         let total_tokens: u64 = partitions
             .iter()
             .map(|p| {
-                p.docs
-                    .loaded()
-                    .expect(
-                        "IndexBM25Scorer::new requires every partition's DocSet to be \
-                         loaded; call `partition.docs.ensure_loaded().await` first",
-                    )
-                    .total_tokens_num()
+                p.docs.total_tokens_cached().expect(
+                    "IndexBM25Scorer::new requires each partition's total_tokens to be \
+                     cached; call `ensure_loaded` / `ensure_num_tokens_loaded` / \
+                     `total_tokens_num` first",
+                )
             })
             .sum();
         let avgdl = total_tokens as f32 / num_docs as f32;
@@ -117,11 +115,6 @@ impl<'a> IndexBM25Scorer<'a> {
             num_docs,
             avg_doc_length: avgdl,
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn num_docs(&self) -> usize {
-        self.num_docs
     }
 
     pub fn num_docs_containing_token(&self, token: &str) -> usize {

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -435,9 +435,19 @@ impl PostingIterator {
     }
 }
 
+/// How wand identified a candidate: either it already had the real
+/// row_id (DocSet carried row_ids), or only the partition-local
+/// doc_id (deferred-row_id path; the caller must resolve via
+/// [`super::lazy_docset::LazyDocSet::resolve_row_ids`]).
+#[derive(Debug, Clone, Copy)]
+pub enum CandidateAddr {
+    RowId(u64),
+    Pending(u32),
+}
+
 #[derive(Debug)]
 pub struct DocCandidate {
-    pub row_id: u64,
+    pub addr: CandidateAddr,
     /// (term_index, freq)
     pub freqs: Vec<(u32, u32)>,
     pub doc_length: u32,
@@ -698,6 +708,12 @@ impl<'a, S: Scorer> Wand<'a, S> {
             _ => {}
         }
 
+        // Deferred-row_id path: when the DocSet was built without
+        // row_ids, wand emits candidates carrying just the
+        // partition-local doc_id; the outer caller resolves them to
+        // row_ids post-wand.
+        let docs_has_row_ids = self.docs.has_row_ids();
+
         let mut candidates = BinaryHeap::with_capacity(std::cmp::min(limit, BLOCK_SIZE * 10));
         let mut num_comparisons = 0;
         loop {
@@ -707,14 +723,20 @@ impl<'a, S: Scorer> Wand<'a, S> {
             };
             num_comparisons += 1;
 
+            // Either a real row_id (so we can run the mask check
+            // inline) or the doc_id widened to u64 (deferred path;
+            // the outer caller will resolve it post-wand).
             let row_id = match &doc {
                 DocInfo::Raw(doc) => {
-                    // if the doc is not located, we need to find the row id
-                    self.docs.row_id(doc.doc_id)
+                    if docs_has_row_ids {
+                        self.docs.row_id(doc.doc_id)
+                    } else {
+                        doc.doc_id as u64
+                    }
                 }
                 DocInfo::Located(doc) => doc.row_id,
             };
-            if !mask.selected(row_id) {
+            if docs_has_row_ids && !mask.selected(row_id) {
                 if self.operator == Operator::Or {
                     self.push_back_leads(doc.doc_id() + 1);
                 }
@@ -764,10 +786,21 @@ impl<'a, S: Scorer> Wand<'a, S> {
         }
         metrics.record_comparisons(num_comparisons);
 
+        // The heap entry's `row_id` slot is either a real row_id
+        // (DocSet had row_ids) or the doc_id widened to u64
+        // (deferred). Tag it accordingly so the caller can match
+        // rather than guess.
+        let to_addr = |row_id_slot: u64| {
+            if docs_has_row_ids {
+                CandidateAddr::RowId(row_id_slot)
+            } else {
+                CandidateAddr::Pending(row_id_slot as u32)
+            }
+        };
         Ok(candidates
             .into_iter()
             .map(|Reverse((doc, freqs, doc_length))| DocCandidate {
-                row_id: doc.row_id,
+                addr: to_addr(doc.row_id),
                 freqs,
                 doc_length,
             })
@@ -871,10 +904,12 @@ impl<'a, S: Scorer> Wand<'a, S> {
         }
         metrics.record_comparisons(num_comparisons);
 
+        // flat_search is driven by an explicit row_ids iterator, so
+        // every candidate already has a real row_id.
         Ok(candidates
             .into_iter()
             .map(|Reverse((doc, freqs, doc_length))| DocCandidate {
-                row_id: doc.row_id,
+                addr: CandidateAddr::RowId(doc.row_id),
                 freqs,
                 doc_length,
             })
@@ -2160,7 +2195,13 @@ mod tests {
             )
             .unwrap();
 
-        let matched = result.into_iter().map(|doc| doc.row_id).collect::<Vec<_>>();
+        let matched = result
+            .into_iter()
+            .map(|doc| match doc.addr {
+                CandidateAddr::RowId(r) => r,
+                CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
+            })
+            .collect::<Vec<_>>();
         assert_eq!(matched, vec![2]);
     }
 

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -1977,7 +1977,13 @@ mod tests {
                     &NoOpMetricsCollector,
                 )
                 .unwrap();
-            let mut row_ids = hits.iter().map(|hit| hit.row_id).collect::<Vec<_>>();
+            let mut row_ids = hits
+                .iter()
+                .map(|hit| match hit.addr {
+                    CandidateAddr::RowId(r) => r,
+                    CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
+                })
+                .collect::<Vec<_>>();
             row_ids.sort_unstable();
             (row_ids, scored.load(Ordering::Relaxed))
         };

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -239,6 +239,85 @@ impl IndexReader for current_reader::FileReader {
         Ok(batches[0].clone())
     }
 
+    async fn read_ranges(
+        &self,
+        ranges: &[std::ops::Range<usize>],
+        projection: Option<&[&str]>,
+    ) -> Result<RecordBatch> {
+        let empty_batch = || {
+            Ok(RecordBatch::new_empty(Arc::new(
+                self.schema().as_ref().into(),
+            )))
+        };
+        if ranges.is_empty() {
+            return empty_batch();
+        }
+        let projection = if let Some(projection) = projection {
+            ReaderProjection::from_column_names(
+                self.metadata().version(),
+                self.schema(),
+                projection,
+            )?
+        } else {
+            ReaderProjection::from_whole_schema(self.schema(), self.metadata().version())
+        };
+        // `DecodeBatchScheduler::schedule_ranges` requires sorted,
+        // non-overlapping ranges; sort internally and permute the
+        // result back to caller order so callers don't have to know.
+        let mut order: Vec<usize> = (0..ranges.len()).collect();
+        order.sort_by_key(|&i| ranges[i].start);
+        let already_sorted = order.iter().enumerate().all(|(i, &j)| i == j);
+        let sorted_ranges: Arc<[std::ops::Range<u64>]> = order
+            .iter()
+            .map(|&i| ranges[i].start as u64..ranges[i].end as u64)
+            .collect();
+        let total_rows: u64 = sorted_ranges.iter().map(|r| r.end - r.start).sum();
+        let batches = self
+            .read_stream_projected(
+                ReadBatchParams::Ranges(sorted_ranges),
+                (total_rows as u32).max(1),
+                16,
+                projection,
+                FilterExpression::no_filter(),
+            )
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+        let merged = match batches.len() {
+            0 => return empty_batch(),
+            1 => batches.into_iter().next().unwrap(),
+            _ => {
+                let schema = batches[0].schema();
+                arrow_select::concat::concat_batches(&schema, &batches)?
+            }
+        };
+        if already_sorted {
+            return Ok(merged);
+        }
+        let sorted_sizes: Vec<u32> = order
+            .iter()
+            .map(|&i| (ranges[i].end - ranges[i].start) as u32)
+            .collect();
+        let mut sorted_offsets = Vec::with_capacity(sorted_sizes.len());
+        let mut acc = 0u32;
+        for &s in &sorted_sizes {
+            sorted_offsets.push(acc);
+            acc += s;
+        }
+        let mut sorted_pos = vec![0usize; ranges.len()];
+        for (sp, &oi) in order.iter().enumerate() {
+            sorted_pos[oi] = sp;
+        }
+        let mut take_indices = Vec::with_capacity(total_rows as usize);
+        for &sp in &sorted_pos {
+            for k in 0..sorted_sizes[sp] {
+                take_indices.push(sorted_offsets[sp] + k);
+            }
+        }
+        let take_arr = arrow_array::UInt32Array::from(take_indices);
+        Ok(arrow_select::take::take_record_batch(&merged, &take_arr)?)
+    }
+
     async fn read_range_stream(
         &self,
         range: std::ops::Range<usize>,

--- a/rust/lance-select/src/mask.rs
+++ b/rust/lance-select/src/mask.rs
@@ -78,6 +78,13 @@ impl RowAddrMask {
         }
     }
 
+    /// True if every row_id is selected. Lets callers (e.g. the FTS wand
+    /// loop) skip per-row mask checks entirely, which in turn lets the
+    /// deferred-row_id scoring path skip loading the row_id column.
+    pub fn is_select_all(&self) -> bool {
+        matches!(self, Self::BlockList(b) if b.is_empty())
+    }
+
     /// Return the indices of the input row ids that were valid
     pub fn selected_indices<'a>(&self, row_ids: impl Iterator<Item = &'a u64> + 'a) -> Vec<u64> {
         row_ids

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1204,6 +1204,83 @@ async fn test_fts_rank() {
     assert_eq!(row_ids, &[0]);
 }
 
+#[tokio::test]
+async fn test_fts_unfiltered_after_filtered_returns_real_row_ids() {
+    // After a filtered FTS scan populates the per-partition cache,
+    // the next unfiltered scan must still return real row_ids, not
+    // partition-local doc_ids. Needs >1 fragment so the two differ
+    // (fragment N's row_ids start at N << 32).
+    let text_col = GenericStringArray::<i32>::from(vec![
+        "alpha first",
+        "alpha second",
+        "alpha third",
+        "alpha fourth",
+    ]);
+    let batch = RecordBatch::try_new(
+        arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "text",
+            text_col.data_type().to_owned(),
+            false,
+        )])
+        .into(),
+        vec![Arc::new(text_col) as ArrayRef],
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let test_uri = TempStrDir::default();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        &test_uri,
+        Some(WriteParams {
+            max_rows_per_file: 1,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    dataset
+        .create_index(
+            &["text"],
+            IndexType::Inverted,
+            None,
+            &InvertedIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let fts = |ds: &Dataset, filter: Option<&str>| {
+        let mut s = ds.scan();
+        s.with_row_id()
+            .full_text_search(FullTextSearchQuery::new("alpha".to_owned()))
+            .unwrap();
+        if let Some(f) = filter {
+            s.prefilter(true).filter(f).unwrap();
+        }
+        s
+    };
+    let sorted_row_ids = |b: &RecordBatch| {
+        let mut v: Vec<u64> = b[ROW_ID].as_primitive::<UInt64Type>().values().to_vec();
+        v.sort();
+        v
+    };
+
+    let fresh = sorted_row_ids(&fts(&dataset, None).try_into_batch().await.unwrap());
+    assert_eq!(fresh.len(), 4);
+
+    // Reopen so the baseline scan's cached LazyDocSet doesn't mask
+    // the regression -- the filtered scan needs to be the first
+    // thing that touches the DocSet.
+    let dataset = Dataset::open(test_uri.as_str()).await.unwrap();
+    fts(&dataset, Some("text LIKE 'alpha first%'"))
+        .try_into_batch()
+        .await
+        .unwrap();
+
+    let after = sorted_row_ids(&fts(&dataset, None).try_into_batch().await.unwrap());
+    assert_eq!(after, fresh);
+}
+
 async fn create_fts_dataset<
     Offset: arrow::array::OffsetSizeTrait,
     ListOffset: arrow::array::OffsetSizeTrait,

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -14,7 +14,9 @@ use crate::{Dataset, Error};
 use lance_core::ROW_ADDR;
 use lance_index::IndexType;
 use lance_index::optimize::OptimizeOptions;
+use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::ScalarIndexParams;
+use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
 use mock_instant::thread_local::MockClock;
 
 use crate::dataset::write::{InsertBuilder, WriteMode, WriteParams};
@@ -2630,4 +2632,83 @@ async fn test_sub_schema_merge_insert_binary_v2_2() {
     let binary_arr = a_col.as_any().downcast_ref::<BinaryArray>().unwrap();
     assert_eq!(binary_arr.value(0), data_a.as_slice());
     assert_eq!(binary_arr.value(1), data_b.as_slice());
+}
+
+#[tokio::test]
+async fn test_fts_unfiltered_after_compaction_returns_remapped_row_ids() {
+    // After `compact_files` with `defer_index_remap = true`, queries
+    // read the old FTS index but must apply the dataset's
+    // FragReuseIndex remap. Otherwise the deferred-row_id path
+    // returns pre-compaction row_ids that no longer exist.
+    use arrow::datatypes::UInt64Type;
+
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        ArrowField::new("text", DataType::Utf8, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![0, 1, 2, 3])),
+            Arc::new(StringArray::from(vec![
+                "alpha first",
+                "alpha second",
+                "alpha third",
+                "alpha fourth",
+            ])),
+        ],
+    )
+    .unwrap();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        "memory://test_fts_frag_reuse",
+        Some(WriteParams {
+            max_rows_per_file: 1, // 4 fragments -> 4 partitions
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    dataset
+        .create_index(
+            &["text"],
+            IndexType::Inverted,
+            None,
+            &InvertedIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+    compact_files(
+        &mut dataset,
+        CompactionOptions {
+            target_rows_per_fragment: 1000,
+            defer_index_remap: true,
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    let after = dataset
+        .scan()
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new("alpha".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(after.num_rows(), 4);
+    let returned: Vec<u64> = after[ROW_ID].as_primitive::<UInt64Type>().values().to_vec();
+    let live: std::collections::HashSet<u64> =
+        dataset.scan().with_row_id().try_into_batch().await.unwrap()[ROW_ID]
+            .as_primitive::<UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect();
+    for id in &returned {
+        assert!(live.contains(id), "stale row_id {id}");
+    }
 }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -7513,12 +7513,16 @@ mod tests {
             .unwrap();
         assert!(results.num_rows() > 0);
 
-        // Verify IOPs
+        // Verify IOPs. The deferred DocSet loads per-doc num_tokens/row_ids on
+        // first use rather than eagerly at index open, so a cold (un-prewarmed)
+        // query opens the docs file on demand — a couple more IOPs than the
+        // eager path, but constant and only on the first query (prewarm or a
+        // warm cache serve it with zero IO).
         let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_lt!(
             stats,
             read_iops,
-            15,
+            18,
             "Inverted index query should use minimal IOPs"
         );
     }


### PR DESCRIPTION
Make `InvertedPartition::load` defer the per-partition `DocSet` work
(row_id + num_tokens) until the wand walk actually needs it, instead
of materializing the entire DocSet up front.