### PR TITLE
docs: add new maintainers and update affiliations

### DIFF
--- a/docs/src/community/maintainers.md
+++ b/docs/src/community/maintainers.md
@@ -59,14 +59,19 @@ Maintainers with GitHub write access are additionally encouraged to:
 | Nathan Ma              | majin1102            | ByteDance         | ✓                   | Apache Amoro (incubating) PPMC Member           |
 | ChanChan Mao           | ccmao1130            | LanceDB           |                     |                                                 |
 | Lu Qiu                 | LuQQiu               | LanceDB           | ✓                   | Alluxio PMC Member                              |
+| Dan Rammer             | hamersaw             | LanceDB           | ✓                   |                                                 |
 | Rong Rong              | walterddr            | Google DeepMind   |                     | Apache Pinot PMC Member, Apache Flink Committer |
 | Nat Roth               | nrothGIT             | Meta AI           |                     |                                                 |
 | Kevin Shaffer-Morrison | kevinshaffermorrison | AWS               |                     |                                                 |
 | Noah Shpak             | noahshpak            | Thinking Machines |                     |                                                 |
+| Chunxu Tang            | ChunxuTang           | Google            |                     | PrestoDB Committer                              |
 | Ankit Vij              | ankitvij-db          | Databricks        |                     |                                                 |
-| Beinan Wang            | beinan               | Uber              |                     | Alluxio PMC Member, Presto TSC Member           |
+| Beinan Wang            | beinan               | Microsoft AI      |                     | Alluxio PMC Member, Presto TSC Member           |
 | Jiacheng Yang          | jiachengdb           | Google AI         |                     |                                                 |
-| Jinglun                | wojiaodoubao         | Bytedance         |                     | Apache Hadoop Committer                         |
+| Yang Jie               | LuciferYang          | Baidu Inc.        |                     |                                                 |
+| Jianjian Xie           | jja725               | Uber              |                     |                                                 |
+| Zhang Yue              | zhangyue19921010     | ByteDance         |                     |                                                 |
+| Jinglun                | wojiaodoubao         | ByteDance         |                     | Apache Hadoop Committer                         |
 
 ## Becoming a Maintainer
 


### PR DESCRIPTION
Updates the maintainer roster in `docs/src/community/maintainers.md` following recently passed maintainer votes.

**New maintainers:**

| Name | GitHub Handle | Affiliation | Write Access |
|------|--------------|-------------|--------------|
| Dan Rammer | hamersaw | LanceDB | ✓ |
| Chunxu Tang | ChunxuTang | Google | |
| Yang Jie | LuciferYang | Baidu Inc. | |
| Jianjian Xie | jja725 | Uber | |
| Zhang Yue | zhangyue19921010 | ByteDance | |

**Affiliation update:**
- Beinan Wang: Uber → Microsoft AI

**Consistency fix:**
- Standardized Jinglun's affiliation spelling from "Bytedance" to "ByteDance" to match the other ByteDance entries.

New entries are inserted in the roster's existing surname-alphabetical order (single-word names kept at the end).