### PR TITLE
fix: preserve zero-length buffers in binary copy compaction

### DIFF
--- a/rust/lance/src/dataset/optimize/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/binary_copy.rs
@@ -362,10 +362,12 @@ pub async fn rewrite_files_binary_copy(
                         // Therefore `page_index - batch_pages + local_idx` yields the exact
                         // source page we are currently materializing, allowing us to access
                         // its metadata (encoding, row count, buffers) for the new page entry.
-                        let page =
-                            &src_column_info.page_infos[page_index - batch_pages + local_idx];
+                        let page_idx = page_index - batch_pages + local_idx;
+                        let page = &src_column_info.page_infos[page_idx];
                         let mut new_offsets = Vec::with_capacity(*buffer_count);
-                        for (_, size) in page.buffer_offsets_and_sizes.iter() {
+                        for (buffer_idx, (_, size)) in
+                            page.buffer_offsets_and_sizes.iter().enumerate()
+                        {
                             let writer = current_writer.as_mut().unwrap().as_mut();
                             current_pos =
                                 apply_alignment_padding(writer, current_pos, version).await?;
@@ -374,9 +376,10 @@ pub async fn rewrite_files_binary_copy(
                                 new_offsets.push((start, 0));
                             } else {
                                 let bytes = bytes_iter.next().ok_or_else(|| {
-                                    Error::execution(
-                                        "binary copy: missing page buffer bytes while rewriting data file",
-                                    )
+                                    Error::execution(format!(
+                                        "binary copy: missing page buffer bytes while rewriting data file \
+                                         (column {col_idx}, page {page_idx}, buffer {buffer_idx}, expected size {size})",
+                                    ))
                                 })?;
                                 writer.write_all(&bytes).await?;
                                 current_pos += bytes.len() as u64;
@@ -428,7 +431,9 @@ pub async fn rewrite_files_binary_copy(
                         file_scheduler.submit_request(ranges, 0).await?
                     };
                     let mut bytes_iter = bytes_vec.into_iter();
-                    for (_, size) in src_column_info.buffer_offsets_and_sizes.iter() {
+                    for (buffer_idx, (_, size)) in
+                        src_column_info.buffer_offsets_and_sizes.iter().enumerate()
+                    {
                         let writer = current_writer.as_mut().unwrap().as_mut();
                         current_pos = apply_alignment_padding(writer, current_pos, version).await?;
                         let start = current_pos;
@@ -436,9 +441,10 @@ pub async fn rewrite_files_binary_copy(
                             col_buffers[col_idx].push((start, 0));
                         } else {
                             let bytes = bytes_iter.next().ok_or_else(|| {
-                                Error::execution(
-                                    "binary copy: missing column buffer bytes while rewriting data file",
-                                )
+                                Error::execution(format!(
+                                    "binary copy: missing column buffer bytes while rewriting data file \
+                                     (column {col_idx}, buffer {buffer_idx}, expected size {size})",
+                                ))
                             })?;
                             writer.write_all(&bytes).await?;
                             current_pos += bytes.len() as u64;

--- a/rust/lance/src/dataset/optimize/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/binary_copy.rs
@@ -337,7 +337,9 @@ pub async fn rewrite_files_binary_copy(
                         }
                         batch_counts.push(current_page.buffer_offsets_and_sizes.len());
                         for (offset, size) in current_page.buffer_offsets_and_sizes.iter() {
-                            batch_ranges.push((*offset)..(*offset + *size));
+                            if *size > 0 {
+                                batch_ranges.push((*offset)..(*offset + *size));
+                            }
                         }
                         batch_bytes += page_bytes;
                         batch_pages += 1;
@@ -363,12 +365,19 @@ pub async fn rewrite_files_binary_copy(
                         let page =
                             &src_column_info.page_infos[page_index - batch_pages + local_idx];
                         let mut new_offsets = Vec::with_capacity(*buffer_count);
-                        for _ in 0..*buffer_count {
-                            if let Some(bytes) = bytes_iter.next() {
-                                let writer = current_writer.as_mut().unwrap().as_mut();
-                                current_pos =
-                                    apply_alignment_padding(writer, current_pos, version).await?;
-                                let start = current_pos;
+                        for (_, size) in page.buffer_offsets_and_sizes.iter() {
+                            let writer = current_writer.as_mut().unwrap().as_mut();
+                            current_pos =
+                                apply_alignment_padding(writer, current_pos, version).await?;
+                            let start = current_pos;
+                            if *size == 0 {
+                                new_offsets.push((start, 0));
+                            } else {
+                                let bytes = bytes_iter.next().ok_or_else(|| {
+                                    Error::execution(
+                                        "binary copy: missing page buffer bytes while rewriting data file",
+                                    )
+                                })?;
                                 writer.write_all(&bytes).await?;
                                 current_pos += bytes.len() as u64;
                                 new_offsets.push((start, bytes.len() as u64));
@@ -410,16 +419,31 @@ pub async fn rewrite_files_binary_copy(
                     let ranges: Vec<Range<u64>> = src_column_info
                         .buffer_offsets_and_sizes
                         .iter()
+                        .filter(|(_, size)| *size > 0)
                         .map(|(offset, size)| (*offset)..(*offset + *size))
                         .collect();
-                    let bytes_vec = file_scheduler.submit_request(ranges, 0).await?;
-                    for bytes in bytes_vec.into_iter() {
+                    let bytes_vec = if ranges.is_empty() {
+                        Vec::new()
+                    } else {
+                        file_scheduler.submit_request(ranges, 0).await?
+                    };
+                    let mut bytes_iter = bytes_vec.into_iter();
+                    for (_, size) in src_column_info.buffer_offsets_and_sizes.iter() {
                         let writer = current_writer.as_mut().unwrap().as_mut();
                         current_pos = apply_alignment_padding(writer, current_pos, version).await?;
                         let start = current_pos;
-                        writer.write_all(&bytes).await?;
-                        current_pos += bytes.len() as u64;
-                        col_buffers[col_idx].push((start, bytes.len() as u64));
+                        if *size == 0 {
+                            col_buffers[col_idx].push((start, 0));
+                        } else {
+                            let bytes = bytes_iter.next().ok_or_else(|| {
+                                Error::execution(
+                                    "binary copy: missing column buffer bytes while rewriting data file",
+                                )
+                            })?;
+                            writer.write_all(&bytes).await?;
+                            current_pos += bytes.len() as u64;
+                            col_buffers[col_idx].push((start, bytes.len() as u64));
+                        }
                     }
                 }
             } // finished all columns in the current source file

--- a/rust/lance/src/dataset/optimize/tests/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/tests/binary_copy.rs
@@ -77,12 +77,19 @@ async fn do_test_binary_copy_empty_string_scalar_index(version: LanceFileVersion
     .await
     .unwrap();
 
+    let before = dataset.scan().try_into_batch().await.unwrap();
+
     let options = CompactionOptions {
         target_rows_per_fragment: 100_000,
         compaction_mode: Some(CompactionMode::ForceBinaryCopy),
         ..Default::default()
     };
     compact_files(&mut dataset, options, None).await.unwrap();
+
+    // Scanning the compacted data must round-trip the zero-length buffers
+    // untouched; a corrupted offsets table would surface as mismatched data here.
+    let after = dataset.scan().try_into_batch().await.unwrap();
+    assert_eq!(before, after);
 
     dataset
         .create_index(
@@ -94,6 +101,16 @@ async fn do_test_binary_copy_empty_string_scalar_index(version: LanceFileVersion
         )
         .await
         .unwrap();
+
+    // The scalar index over the empty strings must also return the full set.
+    let indexed = dataset
+        .scan()
+        .filter("text = ''")
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(indexed.num_rows(), 4_000);
 }
 
 #[tokio::test]

--- a/rust/lance/src/dataset/optimize/tests/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/tests/binary_copy.rs
@@ -46,6 +46,57 @@ async fn do_test_binary_copy_merge_small_files(version: LanceFileVersion) {
 }
 
 #[tokio::test]
+async fn test_binary_copy_empty_string_scalar_index() {
+    for version in LanceFileVersion::iter_non_legacy() {
+        do_test_binary_copy_empty_string_scalar_index(version).await;
+    }
+}
+
+async fn do_test_binary_copy_empty_string_scalar_index(version: LanceFileVersion) {
+    use arrow_array::StringArray;
+
+    let test_dir = TempStrDir::default();
+    let schema = Arc::new(Schema::new(vec![Field::new("text", DataType::Utf8, false)]));
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(StringArray::from_iter_values(
+            std::iter::repeat_n("", 4_000),
+        ))],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(data)], schema);
+    let mut dataset = Dataset::write(
+        reader,
+        &test_dir,
+        Some(WriteParams {
+            max_rows_per_file: 1_000,
+            data_storage_version: Some(version),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let options = CompactionOptions {
+        target_rows_per_fragment: 100_000,
+        compaction_mode: Some(CompactionMode::ForceBinaryCopy),
+        ..Default::default()
+    };
+    compact_files(&mut dataset, options, None).await.unwrap();
+
+    dataset
+        .create_index(
+            &["text"],
+            IndexType::Scalar,
+            Some("text_idx".into()),
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
 async fn test_binary_copy_with_defer_remap() {
     for version in LanceFileVersion::iter_non_legacy() {
         do_test_binary_copy_with_defer_remap(version).await;


### PR DESCRIPTION
closes: https://github.com/lance-format/lance/issues/6991