### PR TITLE
fix(storage): retry throttled fts metadata listing

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -1695,7 +1695,7 @@ async fn list_metadata_files(object_store: &ObjectStore, index_dir: &Path) -> Re
                     part_metadata_files.push(file_name.to_string());
                 }
             }
-            Err(_) => continue,
+            Err(err) => return Err(err),
         }
     }
 
@@ -1955,12 +1955,21 @@ mod tests {
     use arrow_array::{RecordBatch, StringArray, UInt64Array};
     use arrow_schema::{DataType, Field, Schema};
     use async_trait::async_trait;
+    use bytes::Bytes;
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-    use futures::stream;
+    use futures::stream::{self, BoxStream};
     use lance_core::ROW_ID;
     use lance_core::cache::LanceCache;
     use lance_core::utils::tempfile::TempDir;
+    use object_store::memory::InMemory;
+    use object_store::{
+        CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+        ObjectStore as OSObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+        Result as OSResult,
+    };
     use std::any::Any;
+    use std::fmt::{Display, Formatter};
+    use std::ops::Range;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::time::Duration;
 
@@ -1972,6 +1981,121 @@ mod tests {
         let docs = Arc::new(StringArray::from(vec![Some(doc)]));
         let row_ids = Arc::new(UInt64Array::from(vec![row_id]));
         RecordBatch::try_new(schema, vec![docs, row_ids]).unwrap()
+    }
+
+    struct FailingListObjectStore {
+        inner: InMemory,
+    }
+
+    impl Default for FailingListObjectStore {
+        fn default() -> Self {
+            Self {
+                inner: InMemory::new(),
+            }
+        }
+    }
+
+    impl Display for FailingListObjectStore {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FailingListObjectStore")
+        }
+    }
+
+    impl Debug for FailingListObjectStore {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("FailingListObjectStore").finish()
+        }
+    }
+
+    #[async_trait]
+    impl OSObjectStore for FailingListObjectStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            bytes: PutPayload,
+            opts: PutOptions,
+        ) -> OSResult<PutResult> {
+            self.inner.put_opts(location, bytes, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> OSResult<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(&self, _prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            stream::iter(vec![Err(object_store::Error::Generic {
+                store: "failing-list",
+                source: "boom listing metadata".into(),
+            })])
+            .boxed()
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&Path>,
+            offset: &Path,
+        ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            self.inner.list_with_offset(prefix, offset)
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
+            self.inner.copy_opts(from, to, opts).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_metadata_files_propagates_list_error() -> Result<()> {
+        let mut object_store = ObjectStore::memory();
+        object_store.inner = Arc::new(FailingListObjectStore::default());
+
+        let err = list_metadata_files(&object_store, &Path::from("index"))
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("boom listing metadata"),
+            "expected original list error, got: {err}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_list_metadata_files_empty_directory_returns_no_files_error() -> Result<()> {
+        let object_store = ObjectStore::memory();
+
+        let err = list_metadata_files(&object_store, &Path::from("empty-index"))
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("No partition metadata files found"),
+            "expected empty-directory error, got: {err}"
+        );
+        Ok(())
     }
 
     #[derive(Debug, Default, Clone)]

--- a/rust/lance-io/src/object_store/list_retry.rs
+++ b/rust/lance-io/src/object_store/list_retry.rs
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{sync::Arc, task::Poll};
+use std::{future::Future, pin::Pin, sync::Arc, task::Poll, time::Duration};
 
 use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 use object_store::{ObjectMeta, ObjectStore, path::Path};
+use rand::Rng;
+use tokio::time::Sleep;
+
+const DEFAULT_BASE_RETRY_DELAY: Duration = Duration::from_millis(100);
+const DEFAULT_MAX_RETRY_DELAY: Duration = Duration::from_secs(5);
 
 /// A stream that does outer retries on list operations.
 ///
@@ -18,6 +23,9 @@ pub struct ListRetryStream {
     last_successful_key: Option<Path>,
     max_retries: usize,
     current_retries: usize,
+    retry_sleep: Option<Pin<Box<Sleep>>>,
+    base_retry_delay: Duration,
+    max_retry_delay: Duration,
 }
 
 impl ListRetryStream {
@@ -34,6 +42,31 @@ impl ListRetryStream {
             last_successful_key: None,
             max_retries,
             current_retries: 0,
+            retry_sleep: None,
+            base_retry_delay: DEFAULT_BASE_RETRY_DELAY,
+            max_retry_delay: DEFAULT_MAX_RETRY_DELAY,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_backoff(
+        object_store: Arc<dyn ObjectStore>,
+        prefix: Option<Path>,
+        max_retries: usize,
+        base_retry_delay: Duration,
+        max_retry_delay: Duration,
+    ) -> Self {
+        let current_stream = object_store.list(prefix.as_ref());
+        Self {
+            object_store,
+            current_stream,
+            prefix,
+            last_successful_key: None,
+            max_retries,
+            current_retries: 0,
+            retry_sleep: None,
+            base_retry_delay,
+            max_retry_delay,
         }
     }
 
@@ -46,6 +79,29 @@ impl ListRetryStream {
                 | object_store::Error::NotImplemented { .. }
         )
     }
+
+    fn retry_delay(&self) -> Duration {
+        let exponent = self.current_retries.saturating_sub(1).min(16) as u32;
+        let base_ms = self.base_retry_delay.as_millis().max(1);
+        let max_ms = self.max_retry_delay.as_millis().max(base_ms);
+        let cap_ms = base_ms.saturating_mul(1_u128 << exponent).min(max_ms);
+        let min_ms = (cap_ms / 2).max(1);
+        let delay_ms = if cap_ms > min_ms {
+            rand::rng().random_range(min_ms..=cap_ms)
+        } else {
+            cap_ms
+        };
+        Duration::from_millis(delay_ms.min(u64::MAX as u128) as u64)
+    }
+
+    fn recreate_stream(&mut self) {
+        self.current_stream = if let Some(offset) = self.last_successful_key.clone() {
+            self.object_store
+                .list_with_offset(self.prefix.as_ref(), &offset)
+        } else {
+            self.object_store.list(self.prefix.as_ref())
+        };
+    }
 }
 
 impl Stream for ListRetryStream {
@@ -57,6 +113,16 @@ impl Stream for ListRetryStream {
     ) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         loop {
+            if let Some(sleep) = this.retry_sleep.as_mut() {
+                match sleep.as_mut().poll(cx) {
+                    Poll::Ready(()) => {
+                        this.retry_sleep = None;
+                        this.recreate_stream();
+                    }
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+
             match this.current_stream.poll_next_unpin(cx) {
                 Poll::Ready(Some(Ok(meta))) => {
                     this.last_successful_key = Some(meta.location.clone());
@@ -69,14 +135,7 @@ impl Stream for ListRetryStream {
                 Poll::Ready(Some(Err(error))) if Self::is_retryable(&error) => {
                     if this.current_retries < this.max_retries {
                         this.current_retries += 1;
-
-                        this.current_stream = if let Some(offset) = this.last_successful_key.clone()
-                        {
-                            this.object_store
-                                .list_with_offset(this.prefix.as_ref(), &offset)
-                        } else {
-                            this.object_store.list(this.prefix.as_ref())
-                        };
+                        this.retry_sleep = Some(Box::pin(tokio::time::sleep(this.retry_delay())));
 
                         continue;
                     } else {
@@ -97,6 +156,21 @@ impl Stream for ListRetryStream {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::fmt::{Debug, Display, Formatter};
+    use std::ops::Range;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
+
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use futures::stream;
+    use object_store::memory::InMemory;
+    use object_store::{
+        CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, PutMultipartOptions,
+        PutOptions, PutPayload, PutResult, Result as OSResult,
+    };
 
     fn assert_send<T: Send>() {}
 
@@ -104,5 +178,226 @@ mod tests {
     fn test_list_retry_stream_send() {
         // Ensure that ListRetryStream is Send
         assert_send::<ListRetryStream>();
+    }
+
+    fn object_meta(path: &str) -> ObjectMeta {
+        ObjectMeta {
+            location: Path::from(path),
+            last_modified: chrono::Utc::now(),
+            size: 1,
+            e_tag: None,
+            version: None,
+        }
+    }
+
+    fn retryable_error() -> object_store::Error {
+        object_store::Error::Generic {
+            store: "scripted",
+            source: "retryable list error".into(),
+        }
+    }
+
+    fn not_found_error() -> object_store::Error {
+        object_store::Error::NotFound {
+            path: "missing".to_string(),
+            source: "missing".into(),
+        }
+    }
+
+    struct ScriptedListStore {
+        inner: InMemory,
+        list_streams: Mutex<VecDeque<Vec<OSResult<ObjectMeta>>>>,
+        offset_streams: Mutex<VecDeque<Vec<OSResult<ObjectMeta>>>>,
+        list_calls: AtomicUsize,
+        offset_calls: AtomicUsize,
+        last_offset: Mutex<Option<Path>>,
+    }
+
+    impl ScriptedListStore {
+        fn new(
+            list_streams: Vec<Vec<OSResult<ObjectMeta>>>,
+            offset_streams: Vec<Vec<OSResult<ObjectMeta>>>,
+        ) -> Self {
+            Self {
+                inner: InMemory::new(),
+                list_streams: Mutex::new(list_streams.into()),
+                offset_streams: Mutex::new(offset_streams.into()),
+                list_calls: AtomicUsize::new(0),
+                offset_calls: AtomicUsize::new(0),
+                last_offset: Mutex::new(None),
+            }
+        }
+
+        fn list_calls(&self) -> usize {
+            self.list_calls.load(Ordering::SeqCst)
+        }
+
+        fn offset_calls(&self) -> usize {
+            self.offset_calls.load(Ordering::SeqCst)
+        }
+
+        fn last_offset(&self) -> Option<Path> {
+            self.last_offset.lock().unwrap().clone()
+        }
+    }
+
+    impl Display for ScriptedListStore {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ScriptedListStore")
+        }
+    }
+
+    impl Debug for ScriptedListStore {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ScriptedListStore").finish()
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for ScriptedListStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            bytes: PutPayload,
+            opts: PutOptions,
+        ) -> OSResult<PutResult> {
+            self.inner.put_opts(location, bytes, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> OSResult<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(&self, _prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            self.list_calls.fetch_add(1, Ordering::SeqCst);
+            let results = self
+                .list_streams
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_default();
+            stream::iter(results).boxed()
+        }
+
+        fn list_with_offset(
+            &self,
+            _prefix: Option<&Path>,
+            offset: &Path,
+        ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            self.offset_calls.fetch_add(1, Ordering::SeqCst);
+            *self.last_offset.lock().unwrap() = Some(offset.clone());
+            let results = self
+                .offset_streams
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_default();
+            stream::iter(results).boxed()
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
+            self.inner.copy_opts(from, to, opts).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_retry_stream_retries_after_backoff() {
+        let store = Arc::new(ScriptedListStore::new(
+            vec![
+                vec![Err(retryable_error())],
+                vec![Ok(object_meta("prefix/file"))],
+            ],
+            vec![],
+        ));
+        let stream = ListRetryStream::new_with_backoff(
+            store.clone(),
+            Some(Path::from("prefix")),
+            1,
+            Duration::from_millis(20),
+            Duration::from_millis(20),
+        );
+
+        let start = Instant::now();
+        let items = stream.collect::<Vec<_>>().await;
+
+        assert_eq!(items.len(), 1);
+        assert!(items[0].is_ok());
+        assert_eq!(store.list_calls(), 2);
+        assert!(
+            start.elapsed() >= Duration::from_millis(10),
+            "retry should wait before recreating the list stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_retry_stream_resumes_after_last_successful_key() {
+        let store = Arc::new(ScriptedListStore::new(
+            vec![vec![Ok(object_meta("prefix/a")), Err(retryable_error())]],
+            vec![vec![Ok(object_meta("prefix/b"))]],
+        ));
+        let stream = ListRetryStream::new_with_backoff(
+            store.clone(),
+            Some(Path::from("prefix")),
+            1,
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+        );
+
+        let items = stream.collect::<Vec<_>>().await;
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].as_ref().unwrap().location, Path::from("prefix/a"));
+        assert_eq!(items[1].as_ref().unwrap().location, Path::from("prefix/b"));
+        assert_eq!(store.list_calls(), 1);
+        assert_eq!(store.offset_calls(), 1);
+        assert_eq!(store.last_offset(), Some(Path::from("prefix/a")));
+    }
+
+    #[tokio::test]
+    async fn test_list_retry_stream_non_retryable_errors_return_immediately() {
+        let store = Arc::new(ScriptedListStore::new(
+            vec![vec![Err(not_found_error())]],
+            vec![],
+        ));
+        let stream = ListRetryStream::new_with_backoff(
+            store.clone(),
+            Some(Path::from("prefix")),
+            5,
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+        );
+
+        let items = stream.collect::<Vec<_>>().await;
+
+        assert_eq!(items.len(), 1);
+        assert!(matches!(
+            items.into_iter().next().unwrap(),
+            Err(object_store::Error::NotFound { .. })
+        ));
+        assert_eq!(store.list_calls(), 1);
+        assert_eq!(store.offset_calls(), 0);
     }
 }

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -163,13 +163,6 @@ impl ObjectStoreProvider for AwsStoreProvider {
         let throttle_config = AimdThrottleConfig::from_storage_options(params.storage_options())?;
         let inner = if throttle_config.is_disabled() {
             inner
-        } else if storage_options.client_max_retries() == 0 {
-            log::warn!(
-                "AIMD throttle disabled: the current implementation relies on the object store \
-                 client surfacing retry errors, which requires client_max_retries > 0. \
-                 No throttle or retry layer will be applied."
-            );
-            inner
         } else {
             Arc::new(AimdThrottledStore::new(inner, throttle_config)?) as Arc<dyn OSObjectStore>
         };

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -269,13 +269,6 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
         let throttle_config = AimdThrottleConfig::from_storage_options(params.storage_options())?;
         let inner = if throttle_config.is_disabled() {
             inner
-        } else if storage_options.client_max_retries() == 0 {
-            log::warn!(
-                "AIMD throttle disabled: the current implementation relies on the object store \
-                 client surfacing retry errors, which requires client_max_retries > 0. \
-                 No throttle or retry layer will be applied."
-            );
-            inner
         } else {
             Arc::new(AimdThrottledStore::new(inner, throttle_config)?) as Arc<dyn OSObjectStore>
         };

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -122,13 +122,6 @@ impl ObjectStoreProvider for GcsStoreProvider {
         let throttle_config = AimdThrottleConfig::from_storage_options(params.storage_options())?;
         let inner = if throttle_config.is_disabled() {
             inner
-        } else if storage_options.client_max_retries() == 0 {
-            log::warn!(
-                "AIMD throttle disabled: the current implementation relies on the object store \
-                 client surfacing retry errors, which requires client_max_retries > 0. \
-                 No throttle or retry layer will be applied."
-            );
-            inner
         } else {
             Arc::new(AimdThrottledStore::new(inner, throttle_config)?) as Arc<dyn OSObjectStore>
         };

--- a/rust/lance-io/src/object_store/throttle.rs
+++ b/rust/lance-io/src/object_store/throttle.rs
@@ -63,7 +63,21 @@ use tracing::{debug, warn};
 pub fn is_throttle_error(err: &object_store::Error) -> bool {
     // Only Generic errors can carry throttle responses
     if let object_store::Error::Generic { source, .. } = err {
-        source.to_string().contains("retries, max_retries")
+        let message = source.to_string();
+        let lowercase = message.to_ascii_lowercase();
+        lowercase.contains("retries, max_retries")
+            || lowercase.contains("serverbusy")
+            || lowercase.contains("server busy")
+            || lowercase.contains("egress is over the account limit")
+            || lowercase.contains("http 429")
+            || lowercase.contains("status code: 429")
+            || lowercase.contains("429 too many requests")
+            || lowercase.contains("too many requests")
+            || lowercase.contains("slowdown")
+            || lowercase.contains("please reduce your request rate")
+            || lowercase.contains("rate limit")
+            || lowercase.contains("throttling")
+            || lowercase.contains("throttled")
     } else {
         false
     }
@@ -83,7 +97,7 @@ pub struct AimdThrottleConfig {
     pub write: AimdConfig,
     /// AIMD configuration for delete operations.
     pub delete: AimdConfig,
-    /// AIMD configuration for list operations (list_with_delimiter).
+    /// AIMD configuration for list operations.
     pub list: AimdConfig,
     /// Maximum tokens that can accumulate for bursts (shared across all categories).
     pub burst_capacity: u32,
@@ -557,11 +571,11 @@ impl MultipartUpload for ThrottledMultipartUpload {
 /// - **read**: `get`, `get_opts`, `get_range`, `get_ranges`, `head`
 /// - **write**: `put`, `put_opts`, `put_multipart`, `put_multipart_opts`, `copy`, `copy_if_not_exists`, `rename`, `rename_if_not_exists`
 /// - **delete**: `delete`
-/// - **list**: `list_with_delimiter`
+/// - **list**: `list`, `list_with_offset`, `list_with_delimiter`
 ///
-/// Streaming operations (`list`, `list_with_offset`, `delete_stream`) do not acquire tokens,
-/// but observe each yielded item and feed the result back to the AIMD controller so it can
-/// adjust the rate for other operations in the same category.
+/// Streaming list operations acquire a token before starting the underlying list stream.
+/// Streaming operations also observe each yielded item and feed the result back to the
+/// AIMD controller so it can adjust the rate for other operations in the same category.
 ///
 /// This is not perfect but probably as close as we can get without moving the throttle into
 /// the object_store crate itself.
@@ -691,13 +705,19 @@ impl ObjectStore for AimdThrottledStore {
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
         let throttle = Arc::clone(&self.list);
-        self.target
-            .list(prefix)
-            .map(move |item| {
-                throttle.observe_outcome(&item);
-                item
-            })
-            .boxed()
+        let throttle_for_start = Arc::clone(&throttle);
+        let target = Arc::clone(&self.target);
+        let prefix = prefix.cloned();
+        futures::stream::once(async move {
+            throttle_for_start.acquire_token().await;
+            target.list(prefix.as_ref())
+        })
+        .flatten()
+        .map(move |item| {
+            throttle.observe_outcome(&item);
+            item
+        })
+        .boxed()
     }
 
     fn list_with_offset(
@@ -706,13 +726,20 @@ impl ObjectStore for AimdThrottledStore {
         offset: &Path,
     ) -> BoxStream<'static, OSResult<ObjectMeta>> {
         let throttle = Arc::clone(&self.list);
-        self.target
-            .list_with_offset(prefix, offset)
-            .map(move |item| {
-                throttle.observe_outcome(&item);
-                item
-            })
-            .boxed()
+        let throttle_for_start = Arc::clone(&throttle);
+        let target = Arc::clone(&self.target);
+        let prefix = prefix.cloned();
+        let offset = offset.clone();
+        futures::stream::once(async move {
+            throttle_for_start.acquire_token().await;
+            target.list_with_offset(prefix.as_ref(), &offset)
+        })
+        .flatten()
+        .map(move |item| {
+            throttle.observe_outcome(&item);
+            item
+        })
+        .boxed()
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
@@ -740,7 +767,7 @@ mod tests {
     use object_store::memory::InMemory;
     use rstest::rstest;
     use std::collections::VecDeque;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
     const THROTTLE_ERROR_RESPONSE: &str = "request failed, after 3 retries, max_retries: 3, retry_timeout: 30s - Server returned non-2xx status code: 503: x-ms-request-id: azure-request-id";
 
@@ -760,8 +787,10 @@ mod tests {
     #[case::not_found("Object not found", false)]
     #[case::permission_denied("Access denied", false)]
     #[case::timeout("Connection timed out", false)]
-    #[case::http_429_without_retries("HTTP 429 Too Many Requests", false)]
-    #[case::slowdown_without_retries("SlowDown: Please reduce your request rate", false)]
+    #[case::http_429_without_retries("HTTP 429 Too Many Requests", true)]
+    #[case::slowdown_without_retries("SlowDown: Please reduce your request rate", true)]
+    #[case::azure_server_busy("Code: ServerBusy", true)]
+    #[case::azure_egress_limit("Message: Egress is over the account limit", true)]
     fn test_is_throttle_error(#[case] msg: &str, #[case] expected: bool) {
         let err = make_generic_error(msg);
         assert_eq!(
@@ -1049,6 +1078,173 @@ mod tests {
             new_rate,
             initial_rate
         );
+    }
+
+    struct CountingListStartStore {
+        inner: InMemory,
+        list_calls: AtomicUsize,
+        offset_calls: AtomicUsize,
+    }
+
+    impl Default for CountingListStartStore {
+        fn default() -> Self {
+            Self {
+                inner: InMemory::new(),
+                list_calls: AtomicUsize::new(0),
+                offset_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl CountingListStartStore {
+        fn list_calls(&self) -> usize {
+            self.list_calls.load(Ordering::SeqCst)
+        }
+
+        fn offset_calls(&self) -> usize {
+            self.offset_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl Display for CountingListStartStore {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "CountingListStartStore")
+        }
+    }
+
+    impl Debug for CountingListStartStore {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("CountingListStartStore").finish()
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for CountingListStartStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            bytes: PutPayload,
+            opts: PutOptions,
+        ) -> OSResult<PutResult> {
+            self.inner.put_opts(location, bytes, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> OSResult<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            self.list_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.list(prefix)
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&Path>,
+            offset: &Path,
+        ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            self.offset_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.list_with_offset(prefix, offset)
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
+            self.inner.copy_opts(from, to, opts).await
+        }
+    }
+
+    fn list_start_throttle_config() -> AimdThrottleConfig {
+        AimdThrottleConfig::default()
+            .with_burst_capacity(0)
+            .with_list_aimd(AimdConfig::default().with_initial_rate(50.0))
+    }
+
+    #[tokio::test]
+    async fn test_list_acquires_token_before_starting_underlying_stream() {
+        let store = Arc::new(CountingListStartStore::default());
+        store
+            .put(
+                &Path::from("prefix/file.txt"),
+                PutPayload::from_static(b"data"),
+            )
+            .await
+            .unwrap();
+        let throttled = AimdThrottledStore::new(
+            store.clone() as Arc<dyn ObjectStore>,
+            list_start_throttle_config(),
+        )
+        .unwrap();
+
+        let mut stream = throttled.list(Some(&Path::from("prefix")));
+        assert_eq!(store.list_calls(), 0);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(5), stream.next())
+                .await
+                .is_err()
+        );
+        assert_eq!(store.list_calls(), 0);
+
+        let item = tokio::time::timeout(std::time::Duration::from_millis(100), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(item.location, Path::from("prefix/file.txt"));
+        assert_eq!(store.list_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_with_offset_acquires_token_before_starting_underlying_stream() {
+        let store = Arc::new(CountingListStartStore::default());
+        store
+            .put(&Path::from("prefix/b"), PutPayload::from_static(b"data"))
+            .await
+            .unwrap();
+        let throttled = AimdThrottledStore::new(
+            store.clone() as Arc<dyn ObjectStore>,
+            list_start_throttle_config(),
+        )
+        .unwrap();
+
+        let mut stream =
+            throttled.list_with_offset(Some(&Path::from("prefix")), &Path::from("prefix/a"));
+        assert_eq!(store.offset_calls(), 0);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(5), stream.next())
+                .await
+                .is_err()
+        );
+        assert_eq!(store.offset_calls(), 0);
+
+        let item = tokio::time::timeout(std::time::Duration::from_millis(100), stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(item.location, Path::from("prefix/b"));
+        assert_eq!(store.offset_calls(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Bug Fix

### What is the bug?
Distributed FTS indexing can encounter transient object-store list failures during partition metadata discovery, especially Azure `ServerBusy` and account egress-limit responses. These failures were not retried consistently on the Lance side, and FTS metadata listing could swallow list stream errors and later report the misleading error `No partition metadata files found`.

### What issues or incorrect behavior does the bug cause?
Transient cloud throttling can fail FTS index builds instead of backing off and resuming. When the list failure happens while discovering partition metadata, the user can lose the original service error body, request ID, or throttle reason and see an empty-directory error instead. List streams also did not feed the AIMD limiter before the underlying object-store list request started.

### How does this PR fix the problem?
- Add delayed retry with conservative jittered exponential backoff to object-store list retry streams, while preserving immediate return for non-retryable errors.
- Resume retried list streams from the last successfully yielded key.
- Acquire the AIMD list token before creating `list` and `list_with_offset` delegate streams, then continue observing yielded items and errors.
- Expand throttle classification for targeted cloud throttling messages, including Azure `ServerBusy`, account egress limits, HTTP 429, and known rate-limit phrases.
- Remove the provider-side `client_max_retries=0` AIMD-disable guard for AWS, Azure, and GCP. Users should set `lance_aimd_max_retries=0` to explicitly disable Lance AIMD throttling.
- Propagate real FTS metadata list stream errors immediately while preserving the existing no-files error for genuinely empty metadata directories.

No public Rust, Python, or Java APIs are added.

## Validation

- `cargo test -p lance-io list_retry`
- `CARGO_TARGET_DIR=/tmp/lance-fc2c-target cargo test -p lance-io throttle`
- `CARGO_TARGET_DIR=/tmp/lance-fc2c-target cargo test -p lance-index list_metadata_files`
- `CARGO_TARGET_DIR=/tmp/lance-fc2c-target cargo test -p lance merge_existing_index_segments_supports_fts_segments`
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/lance-fc2c-target cargo clippy --all --tests --benches -- -D warnings`
