### PR TITLE
feat: delegate cuvs builds to external backend

### DIFF
--- a/python/python/lance/cuvs.py
+++ b/python/python/lance/cuvs.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+from __future__ import annotations
+
+import os
+import tempfile
+from importlib import import_module
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def is_cuvs_accelerator(accelerator: object) -> bool:
+    return isinstance(accelerator, str) and accelerator.lower() == "cuvs"
+
+
+def _dataset_storage_options(dataset) -> Optional[dict[str, str]]:
+    latest_storage_options = getattr(dataset, "latest_storage_options", None)
+    if callable(latest_storage_options):
+        storage_options = latest_storage_options()
+        if storage_options is not None:
+            return storage_options
+    return getattr(dataset, "_storage_options", None)
+
+
+def _require_lance_cuvs():
+    try:
+        backend = import_module("lance_cuvs")
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "accelerator='cuvs' requires the optional 'pylance-cuvs' loader "
+            "package and a matching backend package such as "
+            "'pylance-cuvs-cu12'."
+        ) from exc
+    missing = [
+        attr
+        for attr in ("train_ivf_pq", "build_ivf_pq_artifact")
+        if not hasattr(backend, attr)
+    ]
+    if missing:
+        raise ImportError(
+            "The installed 'pylance-cuvs' package is incompatible with this "
+            f"Lance build; missing backend APIs: {', '.join(missing)}"
+        )
+    return backend
+
+
+def build_vector_index_on_cuvs(
+    dataset,
+    column: str,
+    metric_type: str,
+    accelerator: str,
+    num_partitions: int,
+    num_sub_vectors: int,
+    dst_dataset_uri: str | Path | None = None,
+    storage_options: Optional[dict[str, str]] = None,
+    *,
+    sample_rate: int = 256,
+    max_iters: int = 50,
+    num_bits: int = 8,
+    batch_size: int = 1024 * 128,
+    filter_nan: bool = True,
+):
+    if not is_cuvs_accelerator(accelerator):
+        raise ValueError("build_vector_index_on_cuvs requires accelerator='cuvs'")
+
+    backend = _require_lance_cuvs()
+    if storage_options is None:
+        storage_options = _dataset_storage_options(dataset)
+    artifact_uri = (
+        os.fspath(dst_dataset_uri)
+        if dst_dataset_uri is not None
+        else tempfile.mkdtemp(prefix="lance-cuvs-artifact-")
+    )
+    training = backend.train_ivf_pq(
+        dataset.uri,
+        column,
+        metric_type=metric_type,
+        num_partitions=num_partitions,
+        num_sub_vectors=num_sub_vectors,
+        sample_rate=sample_rate,
+        max_iters=max_iters,
+        num_bits=num_bits,
+        filter_nan=filter_nan,
+        storage_options=storage_options,
+    )
+    artifact = backend.build_ivf_pq_artifact(
+        dataset.uri,
+        column,
+        training=training,
+        artifact_uri=artifact_uri,
+        batch_size=batch_size,
+        filter_nan=filter_nan,
+        storage_options=storage_options,
+    )
+    return (
+        artifact.artifact_uri,
+        artifact.files,
+        training.ivf_centroids(),
+        training.pq_codebook(),
+    )
+
+
+def prepare_global_ivf_pq_on_cuvs(
+    dataset,
+    column: str,
+    num_partitions: int,
+    num_sub_vectors: int,
+    *,
+    distance_type: str = "l2",
+    accelerator: str = "cuvs",
+    sample_rate: int = 256,
+    max_iters: int = 50,
+    num_bits: int = 8,
+    filter_nan: bool = True,
+    storage_options: Optional[dict[str, str]] = None,
+):
+    if not is_cuvs_accelerator(accelerator):
+        raise ValueError("prepare_global_ivf_pq_on_cuvs requires accelerator='cuvs'")
+
+    backend = _require_lance_cuvs()
+    if storage_options is None:
+        storage_options = _dataset_storage_options(dataset)
+    training = backend.train_ivf_pq(
+        dataset.uri,
+        column,
+        metric_type=distance_type,
+        num_partitions=num_partitions,
+        num_sub_vectors=num_sub_vectors,
+        sample_rate=sample_rate,
+        max_iters=max_iters,
+        num_bits=num_bits,
+        filter_nan=filter_nan,
+        storage_options=storage_options,
+    )
+    return {
+        "ivf_centroids": training.ivf_centroids(),
+        "pq_codebook": training.pq_codebook(),
+    }

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -40,6 +40,7 @@ from pyarrow import RecordBatch, Schema
 from lance.log import LOGGER
 
 from .blob import BlobFile
+from .cuvs import is_cuvs_accelerator
 from .dependencies import (
     _check_for_numpy,
     _check_for_torch,
@@ -3132,12 +3133,14 @@ class LanceDataset(pa.dataset.Dataset):
 
         # Handle timing for various parts of accelerated builds
         timers = {}
+        use_cuvs = is_cuvs_accelerator(accelerator)
         if accelerator is not None and index_type != "IVF_PQ":
             LOGGER.warning(
                 "Index type %s does not support GPU acceleration; falling back to CPU",
                 index_type,
             )
             accelerator = None
+            use_cuvs = False
 
         # IMPORTANT: Distributed indexing is CPU-only. Enforce single-node when
         # accelerator or torch-related paths are detected.
@@ -3181,57 +3184,89 @@ class LanceDataset(pa.dataset.Dataset):
                 index_uuid = None
 
         if accelerator is not None:
-            from .vector import (
-                one_pass_assign_ivf_pq_on_accelerator,
-                one_pass_train_ivf_pq_on_accelerator,
-            )
-
-            LOGGER.info("Doing one-pass ivfpq accelerated computations")
             if num_partitions is None:
                 num_rows = self.count_rows()
                 num_partitions = _target_partition_size_to_num_partitions(
                     num_rows, target_partition_size
                 )
-            timers["ivf+pq_train:start"] = time.time()
-            (
-                ivf_centroids,
-                ivf_kmeans,
-                pq_codebook,
-                pq_kmeans_list,
-            ) = one_pass_train_ivf_pq_on_accelerator(
-                self,
-                column[0],
-                num_partitions,
-                metric,
-                accelerator,
-                num_sub_vectors=num_sub_vectors,
-                batch_size=20480,
-                filter_nan=filter_nan,
-            )
-            timers["ivf+pq_train:end"] = time.time()
-            ivfpq_train_time = timers["ivf+pq_train:end"] - timers["ivf+pq_train:start"]
-            LOGGER.info("ivf+pq training time: %ss", ivfpq_train_time)
-            timers["ivf+pq_assign:start"] = time.time()
-            shuffle_output_dir, shuffle_buffers = one_pass_assign_ivf_pq_on_accelerator(
-                self,
-                column[0],
-                metric,
-                accelerator,
-                ivf_kmeans,
-                pq_kmeans_list,
-                batch_size=20480,
-                filter_nan=filter_nan,
-            )
-            timers["ivf+pq_assign:end"] = time.time()
-            ivfpq_assign_time = (
-                timers["ivf+pq_assign:end"] - timers["ivf+pq_assign:start"]
-            )
-            LOGGER.info("ivf+pq transform time: %ss", ivfpq_assign_time)
+            if use_cuvs:
+                from .cuvs import build_vector_index_on_cuvs
 
-            kwargs["precomputed_shuffle_buffers"] = shuffle_buffers
-            kwargs["precomputed_shuffle_buffers_path"] = os.path.join(
-                shuffle_output_dir, "data"
-            )
+                LOGGER.info("Doing cuVS vector backend build")
+                timers["ivf+pq_build:start"] = time.time()
+                artifact_root, _, ivf_centroids, pq_codebook = (
+                    build_vector_index_on_cuvs(
+                        self,
+                        column[0],
+                        metric,
+                        accelerator,
+                        num_partitions,
+                        num_sub_vectors,
+                        storage_options=storage_options,
+                        sample_rate=kwargs.get("sample_rate", 256),
+                        max_iters=kwargs.get("max_iters", 50),
+                        num_bits=kwargs.get("num_bits", 8),
+                        batch_size=1024 * 128,
+                        filter_nan=filter_nan,
+                    )
+                )
+                kwargs["precomputed_partition_artifact_uri"] = artifact_root
+                timers["ivf+pq_build:end"] = time.time()
+                ivfpq_build_time = (
+                    timers["ivf+pq_build:end"] - timers["ivf+pq_build:start"]
+                )
+                LOGGER.info("cuVS ivf+pq build time: %ss", ivfpq_build_time)
+            else:
+                from .vector import (
+                    one_pass_assign_ivf_pq_on_accelerator,
+                    one_pass_train_ivf_pq_on_accelerator,
+                )
+
+                LOGGER.info("Doing one-pass ivfpq accelerated computations")
+                timers["ivf+pq_train:start"] = time.time()
+                (
+                    ivf_centroids,
+                    ivf_kmeans,
+                    pq_codebook,
+                    pq_kmeans_list,
+                ) = one_pass_train_ivf_pq_on_accelerator(
+                    self,
+                    column[0],
+                    num_partitions,
+                    metric,
+                    accelerator,
+                    num_sub_vectors=num_sub_vectors,
+                    batch_size=20480,
+                    filter_nan=filter_nan,
+                )
+                timers["ivf+pq_train:end"] = time.time()
+                ivfpq_train_time = (
+                    timers["ivf+pq_train:end"] - timers["ivf+pq_train:start"]
+                )
+                LOGGER.info("ivf+pq training time: %ss", ivfpq_train_time)
+                timers["ivf+pq_assign:start"] = time.time()
+                shuffle_output_dir, shuffle_buffers = (
+                    one_pass_assign_ivf_pq_on_accelerator(
+                        self,
+                        column[0],
+                        metric,
+                        accelerator,
+                        ivf_kmeans,
+                        pq_kmeans_list,
+                        batch_size=20480,
+                        filter_nan=filter_nan,
+                    )
+                )
+                timers["ivf+pq_assign:end"] = time.time()
+                ivfpq_assign_time = (
+                    timers["ivf+pq_assign:end"] - timers["ivf+pq_assign:start"]
+                )
+                LOGGER.info("ivf+pq transform time: %ss", ivfpq_assign_time)
+
+                kwargs["precomputed_shuffle_buffers"] = shuffle_buffers
+                kwargs["precomputed_shuffle_buffers_path"] = os.path.join(
+                    shuffle_output_dir, "data"
+                )
         if index_type.startswith("IVF"):
             if (ivf_centroids is not None) and (ivf_centroids_file is not None):
                 raise ValueError(
@@ -3471,7 +3506,12 @@ class LanceDataset(pa.dataset.Dataset):
             The number of sub-vectors for PQ (Product Quantization).
         accelerator : str or ``torch.Device``, optional
             If set, use an accelerator to speed up the training process.
-            Accepted accelerator: "cuda" (Nvidia GPU) and "mps" (Apple Silicon GPU).
+            Accepted accelerator:
+
+            - "cuda" (Nvidia GPU)
+            - "mps" (Apple Silicon GPU)
+            - "cuvs" for the optional `pylance-cuvs` backend
+
             If not set, use the CPU.
         index_cache_size : int, optional
             The size of the index cache in number of entries. Default value is 256.
@@ -3541,10 +3581,11 @@ class LanceDataset(pa.dataset.Dataset):
             - index_file_version
                 The version of the index file. Default is "V3".
             - precomputed_partition_artifact_uri
-                An advanced input produced by an external backend. When set,
-                Lance skips its own partition assignment and consumes the
-                precomputed partition-local artifact during finalization.
-                Requires `ivf_centroids` and `pq_codebook`.
+                An advanced input produced by an external backend such as
+                `pylance-cuvs`. When set, Lance skips its own partition
+                assignment and consumes the precomputed partition-local artifact
+                during finalization. Requires `ivf_centroids` and
+                `pq_codebook`.
 
         Optional parameters for `IVF_RQ`:
 
@@ -3588,8 +3629,9 @@ class LanceDataset(pa.dataset.Dataset):
         Experimental Accelerator (GPU) support:
 
         - *accelerate*: use GPU to train IVF partitions.
-            Only supports CUDA (Nvidia) or MPS (Apple) currently.
-            Requires PyTorch being installed.
+            Supports CUDA (Nvidia) and MPS (Apple) via the built-in torch path.
+            `accelerator="cuvs"` delegates IVF_PQ build preparation to the
+            optional `pylance-cuvs` backend.
 
         .. code-block:: python
 

--- a/python/python/lance/indices/builder.py
+++ b/python/python/lance/indices/builder.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Optional, Union
 import numpy as np
 import pyarrow as pa
 
+from lance.cuvs import is_cuvs_accelerator, prepare_global_ivf_pq_on_cuvs
 from lance.indices.ivf import IvfModel
 from lance.indices.pq import PqModel
 
@@ -115,6 +116,11 @@ class IndicesBuilder:
         self._verify_ivf_sample_rate(sample_rate, num_partitions, num_rows)
         distance_type = self._normalize_distance_type(distance_type)
         self._verify_ivf_params(num_partitions)
+        if is_cuvs_accelerator(accelerator):
+            raise NotImplementedError(
+                "IndicesBuilder.train_ivf does not support accelerator='cuvs'; "
+                "use prepare_global_ivf_pq instead"
+            )
 
         if accelerator is None:
             from lance.lance import indices
@@ -250,6 +256,26 @@ class IndicesBuilder:
         `IndicesBuilder.train_pq` (indices.train_pq_model). No public method
         names elsewhere are changed.
         """
+        if is_cuvs_accelerator(accelerator):
+            if fragment_ids is not None:
+                raise NotImplementedError(
+                    "fragment_ids is not supported with accelerator='cuvs'"
+                )
+            num_rows = self._count_rows()
+            num_partitions = self._determine_num_partitions(num_partitions, num_rows)
+            num_subvectors = self._normalize_pq_params(num_subvectors, self.dimension)
+            return prepare_global_ivf_pq_on_cuvs(
+                self.dataset,
+                self.column[0],
+                num_partitions,
+                num_subvectors,
+                distance_type=distance_type,
+                accelerator=accelerator,
+                sample_rate=sample_rate,
+                max_iters=max_iters,
+                storage_options=self.dataset.latest_storage_options(),
+            )
+
         # Global IVF training
         ivf_model = self.train_ivf(
             num_partitions,

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Optional
 
 import lance
+import lance.cuvs as lance_cuvs
 import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -562,6 +563,16 @@ def test_create_index_unsupported_accelerator(tmp_path):
             accelerator="cuda:abc",
         )
 
+    with pytest.raises(ValueError):
+        dataset.create_index(
+            "vector",
+            index_type="IVF_PQ",
+            num_partitions=4,
+            num_sub_vectors=16,
+            accelerator="cuvs:0",
+        )
+
+
 def test_create_index_accelerator_fallback(tmp_path, caplog):
     tbl = create_table()
     dataset = lance.write_dataset(tbl, tmp_path)
@@ -580,6 +591,189 @@ def test_create_index_accelerator_fallback(tmp_path, caplog):
         "does not support GPU acceleration; falling back to CPU" in record.message
         for record in caplog.records
     )
+
+
+def test_create_index_requires_pylance_cuvs_backend(tmp_path, monkeypatch):
+    tbl = create_table()
+    dataset = lance.write_dataset(tbl, tmp_path)
+    original_import_module = lance_cuvs.import_module
+
+    def _raise_missing(name):
+        if name == "lance_cuvs":
+            raise ModuleNotFoundError("No module named 'lance_cuvs'")
+        return original_import_module(name)
+
+    monkeypatch.setattr(lance_cuvs, "import_module", _raise_missing)
+    with pytest.raises(
+        ModuleNotFoundError,
+        match="requires the optional 'pylance-cuvs' loader package",
+    ):
+        dataset.create_index(
+            "vector",
+            index_type="IVF_PQ",
+            num_partitions=4,
+            num_sub_vectors=16,
+            accelerator="cuvs",
+        )
+
+
+class _FakeCuvsTraining:
+    def __init__(self, ivf_centroids, pq_codebook):
+        self._ivf_centroids = ivf_centroids
+        self._pq_codebook = pq_codebook
+
+    def ivf_centroids(self):
+        return self._ivf_centroids
+
+    def pq_codebook(self):
+        return self._pq_codebook
+
+
+class _FakeCuvsArtifact:
+    def __init__(self, artifact_uri, files):
+        self.artifact_uri = artifact_uri
+        self.files = files
+
+
+def _make_fake_cuvs_training(num_partitions: int = 4, dimension: int = 128):
+    centroids = pa.FixedSizeListArray.from_arrays(
+        pa.array(np.arange(num_partitions * dimension, dtype=np.float32)),
+        dimension,
+    )
+    codebook = pa.FixedSizeListArray.from_arrays(
+        pa.array(np.arange(16 * 256 * 8, dtype=np.float32)),
+        8,
+    )
+    return _FakeCuvsTraining(centroids, codebook)
+
+
+def test_build_vector_index_on_cuvs_delegates_to_external_backend(
+    tmp_path, monkeypatch
+):
+    ds = _make_sample_dataset_base(tmp_path, "prepare_ivf_pq_cuvs_ds", 512, 128)
+    calls = {}
+    training = _make_fake_cuvs_training()
+
+    class _FakeBackend:
+        def train_ivf_pq(self, dataset_uri, column, **kwargs):
+            calls["train"] = {
+                "dataset_uri": dataset_uri,
+                "column": column,
+                **kwargs,
+            }
+            return training
+
+        def build_ivf_pq_artifact(self, dataset_uri, column, **kwargs):
+            calls["build"] = {
+                "dataset_uri": dataset_uri,
+                "column": column,
+                **kwargs,
+            }
+            return _FakeCuvsArtifact(
+                artifact_uri=str(tmp_path / "artifact"),
+                files=[str(tmp_path / "artifact" / "data.lance")],
+            )
+
+    monkeypatch.setattr(lance_cuvs, "_require_lance_cuvs", lambda: _FakeBackend())
+
+    artifact_uri, files, ivf_centroids, pq_codebook = (
+        lance_cuvs.build_vector_index_on_cuvs(
+            ds,
+            "vector",
+            "l2",
+            "cuvs",
+            4,
+            16,
+            dst_dataset_uri=tmp_path / "artifact_root",
+            storage_options={"region": "us-east-1"},
+            sample_rate=7,
+            max_iters=20,
+            num_bits=4,
+            batch_size=4096,
+            filter_nan=False,
+        )
+    )
+
+    assert calls["train"] == {
+        "dataset_uri": ds.uri,
+        "column": "vector",
+        "metric_type": "l2",
+        "num_partitions": 4,
+        "num_sub_vectors": 16,
+        "sample_rate": 7,
+        "max_iters": 20,
+        "num_bits": 4,
+        "filter_nan": False,
+        "storage_options": {"region": "us-east-1"},
+    }
+    assert calls["build"]["dataset_uri"] == ds.uri
+    assert calls["build"]["column"] == "vector"
+    assert calls["build"]["training"] is training
+    assert calls["build"]["artifact_uri"] == str(tmp_path / "artifact_root")
+    assert calls["build"]["batch_size"] == 4096
+    assert calls["build"]["filter_nan"] is False
+    assert calls["build"]["storage_options"] == {"region": "us-east-1"}
+    assert artifact_uri == str(tmp_path / "artifact")
+    assert files == [str(tmp_path / "artifact" / "data.lance")]
+    assert ivf_centroids.equals(training.ivf_centroids())
+    assert pq_codebook.equals(training.pq_codebook())
+
+
+def test_prepare_global_ivf_pq_delegates_to_external_cuvs_backend(
+    tmp_path, monkeypatch
+):
+    ds = _make_sample_dataset_base(tmp_path, "prepare_ivf_pq_cuvs_ds", 512, 128)
+    builder = IndicesBuilder(ds, "vector")
+    ds._storage_options = {"region": "us-east-1"}
+    training = _make_fake_cuvs_training()
+    calls = {}
+
+    class _FakeBackend:
+        def train_ivf_pq(self, dataset_uri, column, **kwargs):
+            calls["train"] = {
+                "dataset_uri": dataset_uri,
+                "column": column,
+                **kwargs,
+            }
+            return training
+
+    monkeypatch.setattr(lance_cuvs, "_require_lance_cuvs", lambda: _FakeBackend())
+
+    prepared = builder.prepare_global_ivf_pq(
+        num_partitions=4,
+        num_subvectors=16,
+        distance_type="l2",
+        accelerator="cuvs",
+        sample_rate=7,
+        max_iters=20,
+    )
+
+    assert calls["train"] == {
+        "dataset_uri": ds.uri,
+        "column": "vector",
+        "metric_type": "l2",
+        "num_partitions": 4,
+        "num_sub_vectors": 16,
+        "sample_rate": 7,
+        "max_iters": 20,
+        "num_bits": 8,
+        "filter_nan": True,
+        "storage_options": {"region": "us-east-1"},
+    }
+    assert prepared["ivf_centroids"].equals(training.ivf_centroids())
+    assert prepared["pq_codebook"].equals(training.pq_codebook())
+
+
+def test_require_lance_cuvs_rejects_incompatible_backend(monkeypatch):
+    class _IncompleteBackend:
+        def train_ivf_pq(self, *args, **kwargs):
+            raise AssertionError("should not be called")
+
+    monkeypatch.setattr(lance_cuvs, "import_module", lambda name: _IncompleteBackend())
+    with pytest.raises(
+        ImportError, match="missing backend APIs: build_ivf_pq_artifact"
+    ):
+        lance_cuvs._require_lance_cuvs()
 
 
 def test_create_index_rejects_missing_precomputed_partition_artifact(tmp_path):


### PR DESCRIPTION
This PR is split out from #6463 and is stacked on the partition artifact input boundary from that PR.

It wires `accelerator="cuvs"` to the optional `pylance-cuvs` loader/backend package, so cuVS can produce a partition artifact and Lance can consume it during IVF-PQ finalization. It also covers the delegation paths for `create_index` and `IndicesBuilder.prepare_global_ivf_pq`.
