### PR TITLE
fix(test): tolerate boundary-tie in IVF distance_range assertions

### DIFF
--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -4318,17 +4318,41 @@ mod tests {
         // don't verify the number of results and row ids for hamming distance,
         // because there are many vectors with the same distance
         if dist_type != DistanceType::Hamming {
-            assert_eq!(left_res.num_rows(), part_idx);
-            assert_eq!(right_res.num_rows(), k - part_idx);
+            // Tolerate a single tied pair at the partition boundary. When
+            // dists[part_idx - 1] == part_dist, the strict-less left filter
+            // excludes both tied vectors and the inclusive right filter
+            // includes both, shifting one row from left to right and dropping
+            // row_ids[k - 1] off right_res's limit. Observed for Dot distance
+            // on ARM where SIMD FMA yields tied float32 dot products that x86
+            // does not. The distance-value assertions below still cover
+            // partition correctness in both cases.
+            let boundary_tie = part_idx > 0 && dists[part_idx - 1] == part_dist;
             let left_row_ids = left_res[ROW_ID].as_primitive::<UInt64Type>().values();
             let right_row_ids = right_res[ROW_ID].as_primitive::<UInt64Type>().values();
-            row_ids.iter().enumerate().for_each(|(i, id)| {
-                if i < part_idx {
-                    assert_eq!(left_row_ids[i], *id,);
-                } else {
-                    assert_eq!(right_row_ids[i - part_idx], *id,);
+            if boundary_tie {
+                assert_eq!(left_res.num_rows(), part_idx - 1);
+                for i in 0..(part_idx - 1) {
+                    assert_eq!(left_row_ids[i], row_ids[i]);
                 }
-            });
+                assert_eq!(right_res.num_rows(), k - part_idx);
+                // right_row_ids[0..2] are the two tied vectors in tiebreaker
+                // order; their identity is not pinned. right_row_ids[i] for
+                // i >= 2 aligns with row_ids[part_idx + i - 1] because the
+                // tie shifts one vector from left to right.
+                for i in 2..(k - part_idx) {
+                    assert_eq!(right_row_ids[i], row_ids[part_idx + i - 1]);
+                }
+            } else {
+                assert_eq!(left_res.num_rows(), part_idx);
+                assert_eq!(right_res.num_rows(), k - part_idx);
+                row_ids.iter().enumerate().for_each(|(i, id)| {
+                    if i < part_idx {
+                        assert_eq!(left_row_ids[i], *id,);
+                    } else {
+                        assert_eq!(right_row_ids[i - part_idx], *id,);
+                    }
+                });
+            }
         }
         let left_dists = left_res[DIST_COL].as_primitive::<Float32Type>().values();
         let right_dists = right_res[DIST_COL].as_primitive::<Float32Type>().values();


### PR DESCRIPTION
## Problem

`test_build_ivf_pq::case_3` (`DistanceType::Dot`) fails on linux-arm with:

```
assertion `left == right` failed
  left: 4
  right: 5
at rust/lance/src/index/vector/ivf/v2.rs:4321
```

The test partitions top-k results around `part_dist = dists[part_idx]` using:
- left filter: strict `d < part_dist`, limit `part_idx`
- right filter: inclusive `d >= part_dist`, limit `k - part_idx`

It then asserts `left_res.num_rows() == part_idx` and that the row-id ordering matches the original top-k.

## Root cause

When `dists[part_idx - 1] == dists[part_idx]`, two vectors tie at the partition boundary:
- the strict-less left filter excludes both tied vectors → `left_res` has `part_idx - 1` rows
- the inclusive right filter includes both tied vectors → one row shifts from left to right, and the trailing original row drops off `right_res`'s limit
- the original row-id ordering of the tied vectors is determined by an internal tiebreaker, so the row-id assertions can fail even when the count matches

The failure is deterministic per architecture but architecture-dependent because **ARM NEON uses fused multiply-add (FMA) for SIMD dot products** by default, while x86 (without `-mfma`) does separate mul+add. FMA produces a single rounding for `a*b + c`; separate ops produce two. For Dot distance specifically — which has fewer transformations than L2 or Cosine — this ULP-level difference is enough to make two distances tie on ARM that don't tie on x86. Random vectors generated from `StdRng::seed_from_u64([13; 32])` happen to hit such a tie at the partition boundary on ARM.

## Fix

Detect the tie explicitly (`dists[part_idx - 1] == part_dist`) and weaken the count and row-id assertions for the affected positions only. The unconditional distance-value assertions immediately below (`left_dists < part_dist`, `right_dists >= part_dist`) still verify partition correctness in both branches.

## Related

Similar test relaxations on this code area:
- #6620 — relaxed recall assertion for HNSW-based indexes
- #6953 — increased nprobes for deterministic recall in `test_query_delta_indices`

## Test plan

- [x] `cargo test -p lance --lib --release test_build_ivf_pq` passes locally on x86 macOS (exercises the no-tie branch, all 12 cases including case_3)
- [ ] CI: linux-arm should now pass on `test_build_ivf_pq::case_3` (the failing case from PR #6985)