### PR TITLE
ci: add A-* area auto-labeler and label migration script

### DIFF
--- a/.github/labeler-area.yml
+++ b/.github/labeler-area.yml
@@ -1,0 +1,62 @@
+# Area labels (A-*) applied by actions/labeler@v5 based on changed paths.
+# See .github/workflows/labeler.yml. Title/body conventional-commit labels are
+# handled separately by srvaroa/labeler via .github/labeler.yml.
+#
+# A PR may carry multiple A-* labels (e.g. a Java + namespace change gets both).
+
+A-java:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "java/**"
+          - "rust/lance-jni/**"
+
+A-namespace:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "rust/lance-namespace*/**"
+
+A-index:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "rust/lance-index/**"
+          - "rust/lance-linalg/**"
+          - "rust/lance-tokenizer/**"
+
+A-encoding:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "rust/lance-encoding/**"
+          - "rust/lance-io/**"
+          - "rust/lance-file/**"
+          - "protos/**"
+
+# Excludes python lockfiles so a pure dependency bump is tagged A-deps only.
+# Note: a PR that touches both python code and python/uv.lock|Cargo.lock will
+# not get A-python, since the exclusion applies across all changed files.
+A-python:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file:
+              - "python/**"
+          - all-globs-to-all-files:
+              - "!python/uv.lock"
+              - "!python/Cargo.lock"
+
+A-docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
+
+A-ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+
+A-deps:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/Cargo.lock"
+          - "**/uv.lock"
+          - "deny.toml"
+          - "**/pyproject.toml"

--- a/.github/labeler-area.yml
+++ b/.github/labeler-area.yml
@@ -30,23 +30,18 @@ A-encoding:
           - "rust/lance-file/**"
           - "protos/**"
 
-# Excludes python lockfiles so a pure dependency bump is tagged A-deps only.
-# Note: a PR that touches both python code and python/uv.lock|Cargo.lock will
-# not get A-python, since the exclusion applies across all changed files.
+# Lockfiles are intentionally not excluded: a pure dependency bump gets both
+# A-python and A-deps. Over-labeling beats dropping the area signal on PRs that
+# touch python code alongside a lockfile.
 A-python:
-  - all:
-      - changed-files:
-          - any-glob-to-any-file:
-              - "python/**"
-          - all-globs-to-all-files:
-              - "!python/uv.lock"
-              - "!python/Cargo.lock"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "python/**"
 
 A-docs:
   - changed-files:
       - any-glob-to-any-file:
           - "docs/**"
-          - "**/*.md"
 
 A-ci:
   - changed-files:

--- a/.github/labeler-area.yml
+++ b/.github/labeler-area.yml
@@ -29,8 +29,8 @@ A-encoding:
           - "rust/lance-io/**"
           - "rust/lance-file/**"
 
-# On-disk format: the proto definitions and the format spec docs. A change here
-# also gets A-docs when it touches docs/src/format/**, which is intended.
+# On-disk format: the proto definitions and the format spec docs. Format docs
+# are excluded from A-docs (see below) so format changes get A-format only.
 A-format:
   - changed-files:
       - any-glob-to-any-file:
@@ -45,10 +45,16 @@ A-python:
       - any-glob-to-any-file:
           - "python/**"
 
+# Format spec docs (docs/src/format/**) are excluded so they get A-format only.
+# Caveat: a PR that touches both format docs and other docs in the same change
+# won't get A-docs, since the exclusion applies across all changed files.
 A-docs:
-  - changed-files:
-      - any-glob-to-any-file:
-          - "docs/**"
+  - all:
+      - changed-files:
+          - any-glob-to-any-file:
+              - "docs/**"
+          - all-globs-to-all-files:
+              - "!docs/src/format/**"
 
 A-ci:
   - changed-files:

--- a/.github/labeler-area.yml
+++ b/.github/labeler-area.yml
@@ -28,7 +28,14 @@ A-encoding:
           - "rust/lance-encoding/**"
           - "rust/lance-io/**"
           - "rust/lance-file/**"
+
+# On-disk format: the proto definitions and the format spec docs. A change here
+# also gets A-docs when it touches docs/src/format/**, which is intended.
+A-format:
+  - changed-files:
+      - any-glob-to-any-file:
           - "protos/**"
+          - "docs/src/format/**"
 
 # Lockfiles are intentionally not excluded: a pure dependency bump gets both
 # A-python and A-deps. Over-labeling beats dropping the area signal on PRs that

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,11 @@
 version: 1
 appendOnly: true
-# Labels are applied based on conventional commits standard
+# Title/body labels based on the conventional commits standard
 # https://www.conventionalcommits.org/en/v1.0.0/
 # These labels are later used in release notes. See .github/release.yml
+#
+# Path-based area labels (A-*) are handled separately by actions/labeler.
+# See .github/labeler-area.yml and .github/workflows/labeler.yml.
 labels:
 # If the PR title has an ! before the : it will be considered a breaking change
 # For example, `feat!: add new feature` will be considered a breaking change
@@ -22,9 +25,3 @@ labels:
   title: "^ci(\\(.+\\))?!?:.*"
 - label: chore
   title: "^(chore|test|build|style)(\\(.+\\))?!?:.*"
-- label: java
-  files:
-    - "java\\/.*"
-- label: python
-  files:
-    - "python\\/.*"

--- a/.github/scripts/migrate-area-labels.sh
+++ b/.github/scripts/migrate-area-labels.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# One-time migration to the A-* area-label convention (issue #6986).
+#
+# Maps the existing area-ish labels onto the A-* names used by
+# .github/labeler-area.yml. GitHub preserves a label on all existing
+# issues/PRs through a rename, so 1:1 renames are non-destructive. Merges
+# (two old labels -> one A-* label) rename the higher-traffic label in place
+# and re-tag the smaller label's items onto it before deleting it.
+#
+# Run once, manually, by a maintainer with triage rights, AFTER the auto-labeler
+# is merged (actions/labeler applies existing labels but does not create them):
+#
+#   REPO=lance-format/lance ./.github/scripts/migrate-area-labels.sh
+#
+# Idempotent-ish: re-running skips steps whose target already exists.
+#
+# Not migrated (intentional):
+#   - ci, documentation: kept as title-based conventional-commit labels that
+#     feed release notes (.github/release.yml); A-ci / A-docs are separate
+#     path-based area labels created fresh below.
+#   - rust: left as-is; A-core was dropped, so core changes stay unlabelled.
+
+set -euo pipefail
+
+REPO="${REPO:-lance-format/lance}"
+AREA_COLOR="006b75" # shared color for the A-* family
+
+label_exists() {
+  gh label list --repo "$REPO" --limit 500 --json name -q '.[].name' | grep -Fxq "$1"
+}
+
+# rename_label OLD NEW DESCRIPTION
+rename_label() {
+  local old="$1" new="$2" desc="$3"
+  if label_exists "$new"; then
+    echo "skip rename: '$new' already exists"
+    return
+  fi
+  if ! label_exists "$old"; then
+    echo "skip rename: source '$old' not found"
+    return
+  fi
+  echo "rename '$old' -> '$new'"
+  gh label edit "$old" --repo "$REPO" --name "$new" --description "$desc" --color "$AREA_COLOR"
+}
+
+# ensure_label NAME DESCRIPTION
+ensure_label() {
+  local name="$1" desc="$2"
+  if label_exists "$name"; then
+    echo "update '$name'"
+    gh label edit "$name" --repo "$REPO" --description "$desc" --color "$AREA_COLOR"
+    return
+  fi
+  echo "create '$name'"
+  gh label create "$name" --repo "$REPO" --description "$desc" --color "$AREA_COLOR"
+}
+
+# merge_label SOURCE TARGET -- re-tag SOURCE's items onto TARGET, then delete SOURCE
+merge_label() {
+  local source="$1" target="$2"
+  if ! label_exists "$source"; then
+    echo "skip merge: source '$source' not found"
+    return
+  fi
+  if ! label_exists "$target"; then
+    echo "ERROR: merge target '$target' is missing; run the rename step first" >&2
+    exit 1
+  fi
+  echo "merge '$source' -> '$target'"
+
+  local issues prs
+  issues=$(gh issue list --repo "$REPO" --label "$source" --state all --limit 1000 --json number -q '.[].number')
+  prs=$(gh pr list --repo "$REPO" --label "$source" --state all --limit 1000 --json number -q '.[].number')
+
+  if [ "$(printf '%s\n' "$issues" | grep -c .)" -ge 1000 ] || [ "$(printf '%s\n' "$prs" | grep -c .)" -ge 1000 ]; then
+    echo "ERROR: '$source' has >=1000 items; re-tag manually to avoid truncation" >&2
+    exit 1
+  fi
+
+  for n in $issues; do
+    gh issue edit "$n" --repo "$REPO" --add-label "$target" >/dev/null
+  done
+  for n in $prs; do
+    gh pr edit "$n" --repo "$REPO" --add-label "$target" >/dev/null
+  done
+
+  gh label delete "$source" --repo "$REPO" --yes
+}
+
+# --- 1:1 renames (non-destructive) ---
+rename_label java "A-java" "Java bindings + JNI"
+rename_label python "A-python" "Python bindings"
+
+# --- merges: rename the higher-traffic label, fold in the smaller one ---
+rename_label vector "A-index" "Vector index, linalg, tokenizer"
+merge_label indexes "A-index"
+
+rename_label file-storage "A-encoding" "Encoding, IO, file format"
+merge_label format "A-encoding"
+
+rename_label dependencies "A-deps" "Dependency updates"
+merge_label "python:uv" "A-deps"
+
+# --- brand-new labels (no existing source) ---
+ensure_label "A-namespace" "Namespace impls"
+ensure_label "A-docs" "Documentation"
+ensure_label "A-ci" "CI / build workflows"
+
+echo "Done. Current A-* labels:"
+gh label list --repo "$REPO" --limit 500 --json name -q '.[].name' | grep '^A-' | sort

--- a/.github/scripts/migrate-area-labels.sh
+++ b/.github/scripts/migrate-area-labels.sh
@@ -97,8 +97,8 @@ rename_label python "A-python" "Python bindings"
 rename_label vector "A-index" "Vector index, linalg, tokenizer"
 merge_label indexes "A-index"
 
-rename_label file-storage "A-encoding" "Encoding, IO, file format"
-merge_label format "A-encoding"
+rename_label file-storage "A-encoding" "Encoding, IO, file reader/writer"
+rename_label format "A-format" "On-disk format: protos and format spec docs"
 
 rename_label dependencies "A-deps" "Dependency updates"
 merge_label "python:uv" "A-deps"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,24 @@
+name: Area Labeler
+
+on:
+  # pull_request_target is required so labels can be applied to PRs from forks.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply area labels
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          configuration-path: .github/labeler-area.yml
+          # Match dotfiles/dot-folders (e.g. .github/**) for A-ci.
+          dot: true


### PR DESCRIPTION
Adds an `actions/labeler@v5` workflow that applies path-based `A-*` area labels (from #6986) so open PRs can be filtered by code area, e.g. `is:pr is:open label:A-encoding`.

Path-based labeling moves to the new labeler (`.github/labeler-area.yml`); the existing `srvaroa/labeler` keeps only the title/body conventional-commit labels that feed release notes. `.github/scripts/migrate-area-labels.sh` renames/merges the current labels onto the `A-*` names — it is **manually run by a maintainer when we merge**, not wired into CI (the labeler applies existing labels but doesn't create them).

Labels: `A-java`, `A-namespace`, `A-index`, `A-encoding`, `A-format`, `A-python`, `A-docs`, `A-ci`, `A-deps`. A PR can carry several. A few notable cases:

- `A-format` (`protos/**`, `docs/src/format/**`) tracks on-disk format changes, kept distinct from `A-encoding`; format docs are excluded from `A-docs`.
- `A-python` doesn't exclude lockfiles, so a dependency bump gets both `A-python` and `A-deps` (over-label rather than lose the area signal).
- `ci`/`documentation` are left as-is — they remain title-based release-notes labels, separate from `A-ci`/`A-docs`.

Refs #6986
