### PR TITLE
refactor!: separate memtable row position from row ids

### DIFF
--- a/rust/lance/src/dataset/mem_wal/memtable/scanner.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner.rs
@@ -37,4 +37,5 @@ mod builder;
 mod exec;
 
 pub use builder::MemTableScanner;
+pub(crate) use exec::MEMWAL_ROW_POSITION_COLUMN;
 pub use exec::{BTreeIndexExec, FtsIndexExec, MemTableScanExec, VectorIndexExec};

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
@@ -18,8 +18,8 @@ use lance_datafusion::planner::Planner;
 use lance_linalg::distance::DistanceType;
 
 use super::exec::{
-    BTreeIndexExec, FtsIndexExec, MemTableBruteForceVectorExec, MemTableDedupScanExec,
-    MemTableScanExec, VectorIndexExec,
+    BTreeIndexExec, FtsIndexExec, MEMWAL_ROW_POSITION_COLUMN, MemTableBruteForceVectorExec,
+    MemTableDedupScanExec, MemTableScanExec, VectorIndexExec,
 };
 use crate::dataset::mem_wal::scanner::exec::validate_pk_types;
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
@@ -277,11 +277,11 @@ pub struct MemTableScanner {
     use_index: bool,
     batch_size: Option<usize>,
     /// Whether to include _rowid column in output.
-    /// In MemTable, _rowid is the row_position (global row offset).
     with_row_id: bool,
     /// Whether to include _rowaddr column in output.
-    /// Same value as _rowid but named for compatibility with LSM scanner.
     with_row_address: bool,
+    /// Whether to include the internal BatchStore row position column.
+    with_row_position: bool,
 }
 
 impl MemTableScanner {
@@ -316,13 +316,15 @@ impl MemTableScanner {
             batch_size: None,
             with_row_id: false,
             with_row_address: false,
+            with_row_position: false,
         }
     }
 
     /// Project only the specified columns.
     ///
     /// Special columns:
-    /// - `_rowid`: Returns the row position (global row offset in MemTable)
+    /// - `_rowid`: Included as nullable UInt64. Active memtable rows have no
+    ///   real Lance row id, so values are NULL.
     pub fn project(&mut self, columns: &[&str]) -> &mut Self {
         // Check if _rowid is requested in projection
         let mut filtered_columns = Vec::new();
@@ -342,7 +344,7 @@ impl MemTableScanner {
 
     /// Include the _rowid column in output.
     ///
-    /// In MemTable, _rowid is the row_position (global row offset).
+    /// Active memtable rows have no real Lance row id, so values are NULL.
     pub fn with_row_id(&mut self) -> &mut Self {
         self.with_row_id = true;
         self
@@ -350,10 +352,18 @@ impl MemTableScanner {
 
     /// Include the _rowaddr column in output.
     ///
-    /// Same value as _rowid but named for compatibility with LSM scanner.
-    /// Used when scanning MemTable as part of a unified LSM scan.
+    /// Active memtable rows have no real Lance row address, so values are NULL.
     pub fn with_row_address(&mut self) -> &mut Self {
         self.with_row_address = true;
+        self
+    }
+
+    /// Include the internal BatchStore row position column.
+    ///
+    /// This is for LSM-internal dedup / ordering only. It is not a Lance row id,
+    /// row address, or public system column.
+    pub(crate) fn with_internal_row_position(&mut self) -> &mut Self {
+        self.with_row_position = true;
         self
     }
 
@@ -700,6 +710,14 @@ impl MemTableScanner {
             fields.push(Field::new(ROW_ADDRESS_COLUMN, DataType::UInt64, true));
         }
 
+        if self.with_row_position {
+            fields.push(Field::new(
+                MEMWAL_ROW_POSITION_COLUMN,
+                DataType::UInt64,
+                true,
+            ));
+        }
+
         Arc::new(arrow_schema::Schema::new(fields))
     }
 
@@ -768,6 +786,7 @@ impl MemTableScanner {
             self.schema.clone(),
             self.with_row_id,
             self.with_row_address,
+            self.with_row_position,
             filter_predicate,
             filter_expr,
         );
@@ -830,6 +849,7 @@ impl MemTableScanner {
             pk_indices,
             self.with_row_id,
             self.with_row_address,
+            self.with_row_position,
             filter_predicate,
             filter_expr,
         )))
@@ -859,6 +879,7 @@ impl MemTableScanner {
             self.output_schema(),
             self.with_row_id,
             self.with_row_address,
+            self.with_row_position,
         )?;
         self.apply_post_index_ops(Arc::new(index_exec)).await
     }
@@ -886,6 +907,7 @@ impl MemTableScanner {
                 projection_indices,
                 base_schema,
                 self.with_row_id,
+                self.with_row_position,
             )?)
         } else {
             Arc::new(MemTableBruteForceVectorExec::new(
@@ -895,6 +917,7 @@ impl MemTableScanner {
                 projection_indices,
                 base_schema,
                 self.with_row_id,
+                self.with_row_position,
             )?)
         };
         self.apply_post_index_ops(exec).await
@@ -920,6 +943,7 @@ impl MemTableScanner {
             projection_indices,
             self.base_output_schema(),
             self.with_row_id,
+            self.with_row_position,
         )?;
         self.apply_post_index_ops(Arc::new(index_exec)).await
     }
@@ -1223,7 +1247,7 @@ mod tests {
         assert_eq!(output_schema.field(2).name(), "_rowid");
         assert_eq!(output_schema.field(2).data_type(), &DataType::UInt64);
 
-        // Verify data includes correct row IDs
+        // Verify data includes nullable row IDs
         let result = scanner.try_into_batch().await.unwrap();
         assert_eq!(result.num_columns(), 3);
         assert_eq!(result.schema().field(2).name(), "_rowid");
@@ -1234,9 +1258,9 @@ mod tests {
             .downcast_ref::<arrow_array::UInt64Array>()
             .unwrap();
         assert_eq!(row_ids.len(), 10);
-        // Row IDs should be 0-9 for a single batch
+        // Active memtable rows do not have stable Lance row IDs yet.
         for i in 0..10 {
-            assert_eq!(row_ids.value(i), i as u64);
+            assert!(row_ids.is_null(i));
         }
     }
 
@@ -1284,9 +1308,9 @@ mod tests {
             .downcast_ref::<arrow_array::UInt64Array>()
             .unwrap();
 
-        // Row IDs should be 0-9 across both batches
+        // Active memtable rows do not have stable Lance row IDs yet.
         for i in 0..10 {
-            assert_eq!(row_ids.value(i), i as u64);
+            assert!(row_ids.is_null(i));
         }
     }
 
@@ -1440,7 +1464,7 @@ mod tests {
         assert_eq!(output_schema.field(2).name(), "_rowaddr");
         assert_eq!(output_schema.field(2).data_type(), &DataType::UInt64);
 
-        // Verify data includes correct row addresses
+        // Verify data includes nullable row addresses
         let result = scanner.try_into_batch().await.unwrap();
         assert_eq!(result.num_columns(), 3);
         assert_eq!(result.schema().field(2).name(), "_rowaddr");
@@ -1451,9 +1475,9 @@ mod tests {
             .downcast_ref::<arrow_array::UInt64Array>()
             .unwrap();
         assert_eq!(row_addrs.len(), 10);
-        // Row addresses should be 0-9 for a single batch
+        // Active memtable rows do not have row addresses yet.
         for i in 0..10 {
-            assert_eq!(row_addrs.value(i), i as u64);
+            assert!(row_addrs.is_null(i));
         }
     }
 
@@ -1512,10 +1536,10 @@ mod tests {
             .downcast_ref::<arrow_array::UInt64Array>()
             .unwrap();
 
-        // Both should have the same values
+        // Active memtable rows do not have stable row IDs or row addresses yet.
         for i in 0..5 {
-            assert_eq!(row_ids.value(i), i as u64);
-            assert_eq!(row_addrs.value(i), i as u64);
+            assert!(row_ids.is_null(i));
+            assert!(row_addrs.is_null(i));
         }
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec.rs
@@ -17,6 +17,12 @@ mod fts;
 mod scan;
 mod vector;
 
+/// Internal active-memtable row position column.
+///
+/// This is an implementation detail used for MemWAL ordering / dedup. It is
+/// not a Lance system column and must not be exposed in canonical LSM output.
+pub const MEMWAL_ROW_POSITION_COLUMN: &str = "__memwal_row_position";
+
 pub use brute_force_vector::MemTableBruteForceVectorExec;
 pub use btree::BTreeIndexExec;
 pub use dedup_scan::MemTableDedupScanExec;

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/brute_force_vector.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/brute_force_vector.rs
@@ -53,6 +53,7 @@ pub struct MemTableBruteForceVectorExec {
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     with_row_id: bool,
+    with_row_position: bool,
 }
 
 impl Debug for MemTableBruteForceVectorExec {
@@ -80,6 +81,7 @@ impl MemTableBruteForceVectorExec {
         projection: Option<Vec<usize>>,
         base_schema: SchemaRef,
         with_row_id: bool,
+        with_row_position: bool,
     ) -> Result<Self> {
         let mut fields: Vec<Field> = base_schema
             .fields()
@@ -89,6 +91,13 @@ impl MemTableBruteForceVectorExec {
         fields.push(Field::new(DISTANCE_COLUMN, DataType::Float32, true));
         if with_row_id {
             fields.push(Field::new(lance_core::ROW_ID, DataType::UInt64, true));
+        }
+        if with_row_position {
+            fields.push(Field::new(
+                super::MEMWAL_ROW_POSITION_COLUMN,
+                DataType::UInt64,
+                true,
+            ));
         }
         let output_schema = Arc::new(Schema::new(fields));
 
@@ -108,6 +117,7 @@ impl MemTableBruteForceVectorExec {
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
             with_row_id,
+            with_row_position,
         })
     }
 
@@ -305,6 +315,12 @@ impl MemTableBruteForceVectorExec {
                 };
 
                 if self.with_row_id {
+                    let row_id_col =
+                        UInt64Array::from_iter(std::iter::repeat_n(None, rows_with_dist.len()));
+                    final_columns.push(Arc::new(row_id_col));
+                }
+
+                if self.with_row_position {
                     final_columns.push(Arc::new(UInt64Array::from(row_positions)));
                 }
 
@@ -407,6 +423,7 @@ impl ExecutionPlan for MemTableBruteForceVectorExec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dataset::mem_wal::memtable::scanner::MEMWAL_ROW_POSITION_COLUMN;
     use arrow_array::{FixedSizeListArray, Float32Array, Int32Array};
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::physical_plan::common::collect;
@@ -484,6 +501,7 @@ mod tests {
                 None,
                 schema,
                 false,
+                false,
             )
             .expect("ctor"),
         );
@@ -518,7 +536,7 @@ mod tests {
         let store = Arc::new(BatchStore::with_capacity(4));
         let query = query_for([0.5, 0.5], 10);
         let exec = Arc::new(
-            MemTableBruteForceVectorExec::new(store, query, usize::MAX, None, schema, false)
+            MemTableBruteForceVectorExec::new(store, query, usize::MAX, None, schema, false, false)
                 .expect("ctor"),
         );
         let out_schema = exec.schema();
@@ -543,7 +561,7 @@ mod tests {
         let query = query_for([0.0, 0.0], 4);
         let exec = Arc::new(
             MemTableBruteForceVectorExec::new(
-                store, query, /* max_visible_batch_position = */ 0, None, schema, false,
+                store, query, /* max_visible_batch_position = */ 0, None, schema, false, false,
             )
             .expect("ctor"),
         );
@@ -576,7 +594,7 @@ mod tests {
         query.distance_lower_bound = Some(1.0);
         query.distance_upper_bound = Some(5.0);
         let exec = Arc::new(
-            MemTableBruteForceVectorExec::new(store, query, usize::MAX, None, schema, false)
+            MemTableBruteForceVectorExec::new(store, query, usize::MAX, None, schema, false, false)
                 .expect("ctor"),
         );
         let out = execute_to_batches(exec).await;
@@ -595,7 +613,56 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn populates_row_id_when_requested() {
+    async fn populates_internal_row_position_when_requested() {
+        let schema = make_schema();
+        let batch = make_batch(
+            schema.clone(),
+            &[10, 11, 12],
+            &[[3.0, 0.0], [1.0, 0.0], [2.0, 0.0]],
+        );
+        let store = store_with_batches(vec![batch]);
+        let query = query_for([0.0, 0.0], 3);
+        let exec = Arc::new(
+            MemTableBruteForceVectorExec::new(
+                store,
+                query,
+                usize::MAX,
+                None,
+                schema,
+                /* with_row_id = */ false,
+                /* with_row_position = */ true,
+            )
+            .expect("ctor"),
+        );
+        let out_schema = exec.schema();
+        assert!(
+            out_schema
+                .field_with_name(MEMWAL_ROW_POSITION_COLUMN)
+                .is_ok()
+        );
+
+        let out = execute_to_batches(exec).await;
+        let mut pairs: Vec<(i32, u64)> = Vec::new();
+        for batch in &out {
+            let ids = batch
+                .column_by_name("id")
+                .unwrap()
+                .as_primitive::<arrow_array::types::Int32Type>();
+            let row_positions = batch
+                .column_by_name(MEMWAL_ROW_POSITION_COLUMN)
+                .unwrap()
+                .as_primitive::<arrow_array::types::UInt64Type>();
+            for i in 0..batch.num_rows() {
+                pairs.push((ids.value(i), row_positions.value(i)));
+            }
+        }
+        // Row offsets are insert-order: id=10 -> 0, id=11 -> 1, id=12 -> 2.
+        pairs.sort_by_key(|(id, _)| *id);
+        assert_eq!(pairs, vec![(10, 0), (11, 1), (12, 2)]);
+    }
+
+    #[tokio::test]
+    async fn public_row_id_is_null() {
         let schema = make_schema();
         let batch = make_batch(
             schema.clone(),
@@ -612,29 +679,17 @@ mod tests {
                 None,
                 schema,
                 /* with_row_id = */ true,
+                /* with_row_position = */ false,
             )
             .expect("ctor"),
         );
-        let out_schema = exec.schema();
-        assert!(out_schema.field_with_name(lance_core::ROW_ID).is_ok());
 
         let out = execute_to_batches(exec).await;
-        let mut pairs: Vec<(i32, u64)> = Vec::new();
         for batch in &out {
-            let ids = batch
-                .column_by_name("id")
-                .unwrap()
-                .as_primitive::<arrow_array::types::Int32Type>();
-            let rowids = batch
-                .column_by_name(lance_core::ROW_ID)
-                .unwrap()
-                .as_primitive::<arrow_array::types::UInt64Type>();
+            let rowids = batch.column_by_name(lance_core::ROW_ID).unwrap();
             for i in 0..batch.num_rows() {
-                pairs.push((ids.value(i), rowids.value(i)));
+                assert!(rowids.is_null(i));
             }
         }
-        // Row offsets are insert-order: id=10 → 0, id=11 → 1, id=12 → 2.
-        pairs.sort_by_key(|(id, _)| *id);
-        assert_eq!(pairs, vec![(10, 0), (11, 1), (12, 2)]);
     }
 }

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/btree.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/btree.rs
@@ -274,18 +274,20 @@ impl BTreeIndexExec {
                 // Add _rowid column if requested. Active memtable rows do not
                 // have real Lance row ids.
                 if self.with_row_id {
-                    let row_id_col = UInt64Array::from_iter(
-                        std::iter::repeat_n(None, rows_with_positions.len()),
-                    );
+                    let row_id_col = UInt64Array::from_iter(std::iter::repeat_n(
+                        None,
+                        rows_with_positions.len(),
+                    ));
                     final_columns.push(Arc::new(row_id_col));
                 }
 
                 // Add _rowaddr column if requested. Active memtable rows do not
                 // have real row addresses.
                 if self.with_row_address {
-                    let row_addr_col = UInt64Array::from_iter(
-                        std::iter::repeat_n(None, rows_with_positions.len()),
-                    );
+                    let row_addr_col = UInt64Array::from_iter(std::iter::repeat_n(
+                        None,
+                        rows_with_positions.len(),
+                    ));
                     final_columns.push(Arc::new(row_addr_col));
                 }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/btree.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/btree.rs
@@ -38,10 +38,12 @@ pub struct BTreeIndexExec {
     metrics: ExecutionPlanMetricsSet,
     /// Column name of the indexed field.
     column: String,
-    /// Whether to include _rowid column (row position) in output.
+    /// Whether to include _rowid column in output.
     with_row_id: bool,
-    /// Whether to include _rowaddr column (same as row position) in output.
+    /// Whether to include _rowaddr column in output.
     with_row_address: bool,
+    /// Whether to include the internal BatchStore row position column.
+    with_row_position: bool,
 }
 
 impl Debug for BTreeIndexExec {
@@ -70,8 +72,8 @@ impl BTreeIndexExec {
     /// * `max_visible_batch_position` - MVCC visibility sequence number
     /// * `projection` - Optional column indices to project
     /// * `output_schema` - Schema after projection (should include _rowid/_rowaddr if requested)
-    /// * `with_row_id` - Whether to include _rowid column (row position)
-    /// * `with_row_address` - Whether to include _rowaddr column (same as row position)
+    /// * `with_row_id` - Whether to include _rowid column
+    /// * `with_row_address` - Whether to include _rowaddr column
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         batch_store: Arc<BatchStore>,
@@ -82,6 +84,7 @@ impl BTreeIndexExec {
         output_schema: SchemaRef,
         with_row_id: bool,
         with_row_address: bool,
+        with_row_position: bool,
     ) -> Result<Self> {
         // Verify the index exists for this column
         let column = predicate.column().to_string();
@@ -111,6 +114,7 @@ impl BTreeIndexExec {
             column,
             with_row_id,
             with_row_address,
+            with_row_position,
         })
     }
 
@@ -267,13 +271,25 @@ impl BTreeIndexExec {
                         columns
                     };
 
-                // Add _rowid column if requested
+                // Add _rowid column if requested. Active memtable rows do not
+                // have real Lance row ids.
                 if self.with_row_id {
-                    final_columns.push(Arc::new(UInt64Array::from(row_positions.clone())));
+                    let row_id_col = UInt64Array::from_iter(
+                        std::iter::repeat_n(None, rows_with_positions.len()),
+                    );
+                    final_columns.push(Arc::new(row_id_col));
                 }
 
-                // Add _rowaddr column if requested (same value as row position)
+                // Add _rowaddr column if requested. Active memtable rows do not
+                // have real row addresses.
                 if self.with_row_address {
+                    let row_addr_col = UInt64Array::from_iter(
+                        std::iter::repeat_n(None, rows_with_positions.len()),
+                    );
+                    final_columns.push(Arc::new(row_addr_col));
+                }
+
+                if self.with_row_position {
                     final_columns.push(Arc::new(UInt64Array::from(row_positions)));
                 }
 
@@ -383,7 +399,7 @@ impl ExecutionPlan for BTreeIndexExec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{Int32Array, StringArray};
+    use arrow_array::{Array, Int32Array, StringArray};
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::common::ScalarValue;
     use futures::TryStreamExt;
@@ -439,6 +455,7 @@ mod tests {
             schema,
             false,
             false,
+            false,
         )
         .unwrap();
 
@@ -481,6 +498,7 @@ mod tests {
             0,
             None,
             schema,
+            false,
             false,
             false,
         )
@@ -528,6 +546,7 @@ mod tests {
             schema.clone(),
             false,
             false,
+            false,
         )
         .unwrap();
 
@@ -546,6 +565,7 @@ mod tests {
             1,
             None,
             schema,
+            false,
             false,
             false,
         )
@@ -597,6 +617,7 @@ mod tests {
             schema_with_rowid.clone(),
             true,
             false,
+            false,
         )
         .unwrap();
 
@@ -613,7 +634,8 @@ mod tests {
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total_rows, 1);
 
-        // Verify _rowid column is present and has correct value
+        // Verify _rowid column is present but not populated with the internal
+        // BatchStore row position unless explicitly requested.
         let batch = &batches[0];
         assert_eq!(batch.num_columns(), 3);
         assert_eq!(batch.schema().field(2).name(), "_rowid");
@@ -623,7 +645,7 @@ mod tests {
             .as_any()
             .downcast_ref::<UInt64Array>()
             .unwrap();
-        assert_eq!(row_ids.value(0), 5); // Row position for id=5 is 5
+        assert!(row_ids.is_null(0));
     }
 
     #[tokio::test]
@@ -661,6 +683,7 @@ mod tests {
                 schema.clone(),
                 false,
                 false,
+                false,
             )
             .unwrap(),
         );
@@ -688,6 +711,7 @@ mod tests {
                 None,
                 schema_with_rowid,
                 true,
+                false,
                 false,
             )
             .unwrap(),

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/dedup_scan.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/dedup_scan.rs
@@ -54,6 +54,7 @@ pub struct MemTableDedupScanExec {
     metrics: ExecutionPlanMetricsSet,
     with_row_id: bool,
     with_row_address: bool,
+    with_row_position: bool,
     filter_predicate: Option<PhysicalExprRef>,
     /// Original filter expression, for display only.
     filter_expr: Option<Expr>,
@@ -85,6 +86,7 @@ impl MemTableDedupScanExec {
         pk_indices: Vec<usize>,
         with_row_id: bool,
         with_row_address: bool,
+        with_row_position: bool,
         filter_predicate: Option<PhysicalExprRef>,
         filter_expr: Option<Expr>,
     ) -> Self {
@@ -105,6 +107,7 @@ impl MemTableDedupScanExec {
             metrics: ExecutionPlanMetricsSet::new(),
             with_row_id,
             with_row_address,
+            with_row_position,
             filter_predicate,
             filter_expr,
         }
@@ -195,9 +198,10 @@ impl ExecutionPlan for MemTableDedupScanExec {
         let schema = self.output_schema.clone();
         let with_row_id = self.with_row_id;
         let with_row_address = self.with_row_address;
+        let with_row_position = self.with_row_position;
         let filter_predicate = self.filter_predicate.clone();
         let pk_indices = self.pk_indices.clone();
-        let need_row_offsets = with_row_id || with_row_address;
+        let need_row_offsets = with_row_position;
 
         // Cross-batch seen-set: first time a PK hash is seen (newest-first) wins.
         let mut seen: HashSet<u64> = HashSet::new();
@@ -261,9 +265,16 @@ impl ExecutionPlan for MemTableDedupScanExec {
                 emitted.columns().to_vec()
             };
             if with_row_id {
-                columns.push(Arc::new(UInt64Array::from(filtered_offsets.clone())));
+                let row_id_col =
+                    UInt64Array::from_iter(std::iter::repeat_n(None, emitted.num_rows()));
+                columns.push(Arc::new(row_id_col));
             }
             if with_row_address {
+                let row_addr_col =
+                    UInt64Array::from_iter(std::iter::repeat_n(None, emitted.num_rows()));
+                columns.push(Arc::new(row_addr_col));
+            }
+            if with_row_position {
                 columns.push(Arc::new(UInt64Array::from(filtered_offsets)));
             }
 
@@ -304,6 +315,7 @@ impl ExecutionPlan for MemTableDedupScanExec {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dataset::mem_wal::memtable::scanner::MEMWAL_ROW_POSITION_COLUMN;
     use arrow_array::Int32Array;
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::prelude::col;
@@ -327,6 +339,7 @@ mod tests {
                 DataType::UInt64,
                 true,
             ),
+            Field::new(MEMWAL_ROW_POSITION_COLUMN, DataType::UInt64, true),
         ]))
     }
 
@@ -344,7 +357,7 @@ mod tests {
         .unwrap()
     }
 
-    /// Run the exec and collect (id -> (value, rowaddr)).
+    /// Run the exec and collect (id -> (value, internal row position)).
     async fn run(
         store: Arc<BatchStore>,
         max_visible: usize,
@@ -364,6 +377,7 @@ mod tests {
             vec![0],
             false,
             true,
+            true,
             filter_predicate,
             filter_expr,
         );
@@ -375,9 +389,14 @@ mod tests {
             let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
             let values = b.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
             let addrs = b.column(2).as_any().downcast_ref::<UInt64Array>().unwrap();
+            let positions = b.column(3).as_any().downcast_ref::<UInt64Array>().unwrap();
             for i in 0..b.num_rows() {
+                assert!(
+                    addrs.is_null(i),
+                    "public _rowaddr must not expose active memtable row position"
+                );
                 let value = (!values.is_null(i)).then(|| values.value(i));
-                let prev = out.insert(ids.value(i), (value, addrs.value(i)));
+                let prev = out.insert(ids.value(i), (value, positions.value(i)));
                 assert!(prev.is_none(), "duplicate PK {} in output", ids.value(i));
             }
         }

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
@@ -52,8 +52,10 @@ pub struct FtsIndexExec {
     batch_ranges: Vec<BatchRange>,
     /// Maximum visible row position based on max_visible_batch_position (None if nothing visible).
     max_visible_row: Option<u64>,
-    /// Whether to include _rowid column (row position) in output.
+    /// Whether to include _rowid column in output.
     with_row_id: bool,
+    /// Whether to include the internal BatchStore row position column.
+    with_row_position: bool,
 }
 
 impl Debug for FtsIndexExec {
@@ -81,7 +83,8 @@ impl FtsIndexExec {
     /// * `max_visible_batch_position` - MVCC visibility sequence number
     /// * `projection` - Optional column indices to project
     /// * `base_schema` - Schema before adding score column (and _rowid if with_row_id)
-    /// * `with_row_id` - Whether to include _rowid column (row position)
+    /// * `with_row_id` - Whether to include _rowid column
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         batch_store: Arc<BatchStore>,
         indexes: Arc<IndexStore>,
@@ -90,6 +93,7 @@ impl FtsIndexExec {
         projection: Option<Vec<usize>>,
         base_schema: SchemaRef,
         with_row_id: bool,
+        with_row_position: bool,
     ) -> Result<Self> {
         // Verify the index exists for this column
         let column = &query.column;
@@ -114,6 +118,13 @@ impl FtsIndexExec {
         fields.push(Field::new(SCORE_COLUMN, DataType::Float32, true));
         if with_row_id {
             fields.push(Field::new(lance_core::ROW_ID, DataType::UInt64, true));
+        }
+        if with_row_position {
+            fields.push(Field::new(
+                super::MEMWAL_ROW_POSITION_COLUMN,
+                DataType::UInt64,
+                true,
+            ));
         }
         let output_schema = Arc::new(Schema::new(fields));
 
@@ -162,6 +173,7 @@ impl FtsIndexExec {
             batch_ranges,
             max_visible_row,
             with_row_id,
+            with_row_position,
         })
     }
 
@@ -300,6 +312,8 @@ impl FtsIndexExec {
             }
         }
 
+        let num_rows = all_scores.len();
+
         // Add score column
         final_columns.push(Arc::new(Float32Array::from(all_scores)));
 
@@ -316,8 +330,14 @@ impl FtsIndexExec {
             final_columns
         };
 
-        // Add _rowid column if requested
+        // Add _rowid column if requested. Active memtable rows do not have
+        // real Lance row ids.
         if self.with_row_id {
+            let row_id_col = UInt64Array::from_iter(std::iter::repeat_n(None, num_rows));
+            projected_columns.push(Arc::new(row_id_col));
+        }
+
+        if self.with_row_position {
             projected_columns.push(Arc::new(UInt64Array::from(all_row_positions)));
         }
 
@@ -469,7 +489,8 @@ mod tests {
 
         let query = FtsQuery::match_query("text", "hello");
 
-        let exec = FtsIndexExec::new(batch_store, indexes, query, 0, None, schema, false).unwrap();
+        let exec =
+            FtsIndexExec::new(batch_store, indexes, query, 0, None, schema, false, false).unwrap();
 
         let ctx = Arc::new(TaskContext::default());
         let stream = exec.execute(0, ctx).unwrap();
@@ -514,6 +535,7 @@ mod tests {
             None,
             schema.clone(),
             false,
+            false,
         )
         .unwrap();
 
@@ -525,7 +547,8 @@ mod tests {
         assert_eq!(total_rows, 2); // "hello" in batch1 docs 0 and 2
 
         // Query with max_visible=1 should see both batches
-        let exec = FtsIndexExec::new(batch_store, indexes, query, 1, None, schema, false).unwrap();
+        let exec =
+            FtsIndexExec::new(batch_store, indexes, query, 1, None, schema, false, false).unwrap();
 
         let ctx = Arc::new(TaskContext::default());
         let stream = exec.execute(0, ctx).unwrap();

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/scan.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/scan.rs
@@ -43,10 +43,12 @@ pub struct MemTableScanExec {
     source_schema: SchemaRef,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
-    /// Whether to include _rowid column (row position) in output.
+    /// Whether to include _rowid column in output.
     with_row_id: bool,
-    /// Whether to include _rowaddr column (row position, same as _rowid but different name).
+    /// Whether to include _rowaddr column in output.
     with_row_address: bool,
+    /// Whether to include the internal BatchStore row position column.
+    with_row_position: bool,
     /// Optional filter predicate (physical expression).
     filter_predicate: Option<PhysicalExprRef>,
     /// Original filter expression for display purposes.
@@ -77,7 +79,7 @@ impl MemTableScanExec {
     /// * `max_visible_batch_position` - Maximum batch position visible (inclusive)
     /// * `projection` - Optional column indices to project
     /// * `output_schema` - Schema after projection (should include _rowid/_rowaddr if requested)
-    /// * `with_row_id` - Whether to include _rowid column (row position)
+    /// * `with_row_id` - Whether to include _rowid column
     pub fn new(
         batch_store: Arc<BatchStore>,
         max_visible_batch_position: usize,
@@ -93,6 +95,7 @@ impl MemTableScanExec {
             output_schema,
             with_row_id,
             false, // with_row_address
+            false, // with_row_position
             None,
             None,
         )
@@ -107,8 +110,8 @@ impl MemTableScanExec {
     /// * `projection` - Optional column indices to project
     /// * `output_schema` - Schema after projection (should include _rowid/_rowaddr if requested)
     /// * `source_schema` - Schema of source data (before projection), used for filter evaluation
-    /// * `with_row_id` - Whether to include _rowid column (row position)
-    /// * `with_row_address` - Whether to include _rowaddr column (row position, for LSM scanner)
+    /// * `with_row_id` - Whether to include _rowid column
+    /// * `with_row_address` - Whether to include _rowaddr column
     /// * `filter_predicate` - Optional physical expression for filtering
     /// * `filter_expr` - Optional logical expression for display
     #[allow(clippy::too_many_arguments)]
@@ -120,6 +123,7 @@ impl MemTableScanExec {
         source_schema: SchemaRef,
         with_row_id: bool,
         with_row_address: bool,
+        with_row_position: bool,
         filter_predicate: Option<PhysicalExprRef>,
         filter_expr: Option<Expr>,
     ) -> Self {
@@ -140,6 +144,7 @@ impl MemTableScanExec {
             metrics: ExecutionPlanMetricsSet::new(),
             with_row_id,
             with_row_address,
+            with_row_position,
             filter_predicate,
             filter_expr,
         }
@@ -233,10 +238,10 @@ impl ExecutionPlan for MemTableScanExec {
         let source_schema = self.source_schema.clone();
         let with_row_id = self.with_row_id;
         let with_row_address = self.with_row_address;
+        let with_row_position = self.with_row_position;
         let filter_predicate = self.filter_predicate.clone();
 
-        // We need row offsets if either _rowid or _rowaddr is requested
-        let need_row_offsets = with_row_id || with_row_address;
+        let need_row_offsets = with_row_position;
 
         let projected_batches: Vec<DataFusionResult<RecordBatch>> = batches_with_offsets
             .into_iter()
@@ -311,13 +316,25 @@ impl ExecutionPlan for MemTableScanExec {
                         filtered_batch.columns().to_vec()
                     };
 
-                // Add _rowid column if requested
+                // Add _rowid column if requested. Active memtable rows do not
+                // have real Lance row ids.
                 if with_row_id {
-                    columns.push(Arc::new(UInt64Array::from(filtered_row_offsets.clone())));
+                    let row_id_col = UInt64Array::from_iter(
+                        std::iter::repeat_n(None, filtered_batch.num_rows()),
+                    );
+                    columns.push(Arc::new(row_id_col));
                 }
 
-                // Add _rowaddr column if requested (same value as _rowid, different name)
+                // Add _rowaddr column if requested. Active memtable rows do not
+                // have real row addresses.
                 if with_row_address {
+                    let row_addr_col = UInt64Array::from_iter(
+                        std::iter::repeat_n(None, filtered_batch.num_rows()),
+                    );
+                    columns.push(Arc::new(row_addr_col));
+                }
+
+                if with_row_position {
                     columns.push(Arc::new(UInt64Array::from(filtered_row_offsets)));
                 }
 
@@ -365,7 +382,7 @@ impl ExecutionPlan for MemTableScanExec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{Int32Array, StringArray};
+    use arrow_array::{Array, Int32Array, StringArray};
     use arrow_schema::{DataType, Field, Schema};
     use futures::TryStreamExt;
 
@@ -521,24 +538,24 @@ mod tests {
 
         assert_eq!(batches.len(), 2);
 
-        // First batch should have row_ids 0-4
+        // Public active memtable scans cannot expose BatchStore row positions
+        // as stable Lance row IDs.
         let row_ids_1 = batches[0]
             .column(2)
             .as_any()
             .downcast_ref::<UInt64Array>()
             .unwrap();
         assert_eq!(row_ids_1.len(), 5);
-        assert_eq!(row_ids_1.value(0), 0);
-        assert_eq!(row_ids_1.value(4), 4);
+        assert!(row_ids_1.is_null(0));
+        assert!(row_ids_1.is_null(4));
 
-        // Second batch should have row_ids 5-7
         let row_ids_2 = batches[1]
             .column(2)
             .as_any()
             .downcast_ref::<UInt64Array>()
             .unwrap();
         assert_eq!(row_ids_2.len(), 3);
-        assert_eq!(row_ids_2.value(0), 5);
-        assert_eq!(row_ids_2.value(2), 7);
+        assert!(row_ids_2.is_null(0));
+        assert!(row_ids_2.is_null(2));
     }
 }

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/scan.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/scan.rs
@@ -319,18 +319,20 @@ impl ExecutionPlan for MemTableScanExec {
                 // Add _rowid column if requested. Active memtable rows do not
                 // have real Lance row ids.
                 if with_row_id {
-                    let row_id_col = UInt64Array::from_iter(
-                        std::iter::repeat_n(None, filtered_batch.num_rows()),
-                    );
+                    let row_id_col = UInt64Array::from_iter(std::iter::repeat_n(
+                        None,
+                        filtered_batch.num_rows(),
+                    ));
                     columns.push(Arc::new(row_id_col));
                 }
 
                 // Add _rowaddr column if requested. Active memtable rows do not
                 // have real row addresses.
                 if with_row_address {
-                    let row_addr_col = UInt64Array::from_iter(
-                        std::iter::repeat_n(None, filtered_batch.num_rows()),
-                    );
+                    let row_addr_col = UInt64Array::from_iter(std::iter::repeat_n(
+                        None,
+                        filtered_batch.num_rows(),
+                    ));
                     columns.push(Arc::new(row_addr_col));
                 }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/vector.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/vector.rs
@@ -40,8 +40,10 @@ pub struct VectorIndexExec {
     output_schema: SchemaRef,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
-    /// Whether to include _rowid column (row position) in output.
+    /// Whether to include _rowid column in output.
     with_row_id: bool,
+    /// Whether to include the internal BatchStore row position column.
+    with_row_position: bool,
 }
 
 impl Debug for VectorIndexExec {
@@ -79,7 +81,8 @@ impl VectorIndexExec {
     /// * `max_visible_batch_position` - MVCC visibility sequence number
     /// * `projection` - Optional column indices to project
     /// * `base_schema` - Schema after projection (will add _distance column, and _rowid if with_row_id)
-    /// * `with_row_id` - Whether to include _rowid column (row position)
+    /// * `with_row_id` - Whether to include _rowid column
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         batch_store: Arc<BatchStore>,
         indexes: Arc<IndexStore>,
@@ -88,6 +91,7 @@ impl VectorIndexExec {
         projection: Option<Vec<usize>>,
         base_schema: SchemaRef,
         with_row_id: bool,
+        with_row_position: bool,
     ) -> Result<Self> {
         let column = &query.column;
         if indexes.get_hnsw_by_column(column).is_none() {
@@ -106,6 +110,13 @@ impl VectorIndexExec {
         fields.push(Field::new(DISTANCE_COLUMN, DataType::Float32, true));
         if with_row_id {
             fields.push(Field::new(lance_core::ROW_ID, DataType::UInt64, true));
+        }
+        if with_row_position {
+            fields.push(Field::new(
+                super::MEMWAL_ROW_POSITION_COLUMN,
+                DataType::UInt64,
+                true,
+            ));
         }
         let output_schema = Arc::new(Schema::new(fields));
 
@@ -126,6 +137,7 @@ impl VectorIndexExec {
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
             with_row_id,
+            with_row_position,
         })
     }
 
@@ -262,8 +274,15 @@ impl VectorIndexExec {
                     columns
                 };
 
-                // Add _rowid column if requested
+                // Add _rowid column if requested. Active memtable rows do not
+                // have real Lance row ids.
                 if self.with_row_id {
+                    let row_id_col =
+                        UInt64Array::from_iter(std::iter::repeat_n(None, rows_with_dist.len()));
+                    final_columns.push(Arc::new(row_id_col));
+                }
+
+                if self.with_row_position {
                     final_columns.push(Arc::new(UInt64Array::from(row_positions)));
                 }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/within_source_dedup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/within_source_dedup.rs
@@ -6,10 +6,10 @@
 //!
 //! In MemWAL/LSM mode the same primary key can be written multiple times into
 //! the same memtable. The active memtable stores rows in insert order (larger
-//! `_rowaddr` = newer), while flushed memtables are reverse-written so that
-//! within a flushed file the smallest `_rowid` is the newest insert (see
-//! `memtable/flush.rs:152` and `hnsw/storage.rs:307`). Point lookup uses this
-//! node to collapse such duplicates *within a single source* so that the
+//! internal row position = newer), while flushed memtables are reverse-written
+//! so that within a flushed file the smallest `_rowid` is the newest insert
+//! (see `memtable/flush.rs:152` and `hnsw/storage.rs:307`). Point lookup uses
+//! this node to collapse such duplicates *within a single source* so that the
 //! downstream `CoalesceFirstExec` / `LIMIT` sees at most one row per primary
 //! key per source.
 
@@ -33,31 +33,29 @@ use futures::{Stream, StreamExt, ready};
 
 use super::pk::{compute_pk_hash, resolve_pk_indices};
 
-/// Among rows that share a primary key, which row-address extreme identifies
-/// the newest insert to keep. The kept row is always the freshest; only the
-/// row address (`_rowaddr`/`_rowid`) used to find it differs by source.
+/// Among rows that share a primary key, which ordering-column extreme
+/// identifies the newest insert to keep. The kept row is always the freshest;
+/// only the ordering column differs by source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DedupDirection {
-    /// Keep the row with the largest row-address value (active memtable: larger
-    /// `_rowaddr` = inserted later).
-    KeepMaxRowAddr,
-    /// Keep the row with the smallest row-address value (flushed memtable under
-    /// reverse-write: smaller `_rowid` = inserted later).
-    KeepMinRowAddr,
+    /// Keep the row with the largest ordering value.
+    KeepMax,
+    /// Keep the row with the smallest ordering value.
+    KeepMin,
 }
 
 /// Deduplicates rows from a single source by primary key, keeping the row
-/// whose `row_addr_column` value wins per [`DedupDirection`].
+/// whose `ordering_column` value wins per [`DedupDirection`].
 ///
 /// # Required columns
 ///
 /// The input must expose:
 /// - All `pk_columns`
-/// - `row_addr_column` of `UInt64` type
+/// - `ordering_column` of `UInt64` type
 ///
 /// The output schema is unchanged from the input. Callers that need to hide
-/// the row-address column from downstream consumers should compose this node
-/// with `project_to_canonical` or `null_columns`.
+/// the ordering column from downstream consumers should compose this node with
+/// `project_to_canonical` or `null_columns`.
 ///
 /// # Performance
 ///
@@ -68,7 +66,7 @@ pub enum DedupDirection {
 pub struct WithinSourceDedupExec {
     input: Arc<dyn ExecutionPlan>,
     pk_columns: Vec<String>,
-    row_addr_column: String,
+    ordering_column: String,
     direction: DedupDirection,
     schema: SchemaRef,
     properties: Arc<PlanProperties>,
@@ -78,7 +76,7 @@ impl WithinSourceDedupExec {
     pub fn new(
         input: Arc<dyn ExecutionPlan>,
         pk_columns: Vec<String>,
-        row_addr_column: impl Into<String>,
+        ordering_column: impl Into<String>,
         direction: DedupDirection,
     ) -> Self {
         let schema = input.schema();
@@ -91,7 +89,7 @@ impl WithinSourceDedupExec {
         Self {
             input,
             pk_columns,
-            row_addr_column: row_addr_column.into(),
+            ordering_column: ordering_column.into(),
             direction,
             schema,
             properties,
@@ -102,8 +100,8 @@ impl WithinSourceDedupExec {
         &self.pk_columns
     }
 
-    pub fn row_addr_column(&self) -> &str {
-        &self.row_addr_column
+    pub fn ordering_column(&self) -> &str {
+        &self.ordering_column
     }
 
     pub fn direction(&self) -> DedupDirection {
@@ -119,9 +117,9 @@ impl DisplayAs for WithinSourceDedupExec {
             | DisplayFormatType::TreeRender => {
                 write!(
                     f,
-                    "WithinSourceDedupExec: pk=[{}], row_addr={}, direction={:?}",
+                    "WithinSourceDedupExec: pk=[{}], ordering={}, direction={:?}",
                     self.pk_columns.join(", "),
-                    self.row_addr_column,
+                    self.ordering_column,
                     self.direction,
                 )
             }
@@ -162,7 +160,7 @@ impl ExecutionPlan for WithinSourceDedupExec {
         Ok(Arc::new(Self::new(
             children[0].clone(),
             self.pk_columns.clone(),
-            self.row_addr_column.clone(),
+            self.ordering_column.clone(),
             self.direction,
         )))
     }
@@ -176,7 +174,7 @@ impl ExecutionPlan for WithinSourceDedupExec {
         Ok(Box::pin(WithinSourceDedupStream {
             input: input_stream,
             pk_columns: self.pk_columns.clone(),
-            row_addr_column: self.row_addr_column.clone(),
+            ordering_column: self.ordering_column.clone(),
             direction: self.direction,
             schema: self.schema.clone(),
             winners: HashMap::new(),
@@ -189,13 +187,13 @@ impl ExecutionPlan for WithinSourceDedupExec {
 /// have to keep the source batch alive after we've picked the winner.
 struct Winner {
     batch: RecordBatch,
-    row_addr: u64,
+    ordering_value: u64,
 }
 
 struct WithinSourceDedupStream {
     input: SendableRecordBatchStream,
     pk_columns: Vec<String>,
-    row_addr_column: String,
+    ordering_column: String,
     direction: DedupDirection,
     schema: SchemaRef,
     winners: HashMap<u64, Winner>,
@@ -208,38 +206,38 @@ impl WithinSourceDedupStream {
             return Ok(());
         }
         let pk_indices = resolve_pk_indices(&batch, &self.pk_columns)?;
-        let row_addr_array = batch
-            .column_by_name(&self.row_addr_column)
+        let ordering_array = batch
+            .column_by_name(&self.ordering_column)
             .ok_or_else(|| {
                 datafusion::error::DataFusionError::Internal(format!(
-                    "Row-address column '{}' not found in batch",
-                    self.row_addr_column
+                    "Ordering column '{}' not found in batch",
+                    self.ordering_column
                 ))
             })?
             .as_any()
             .downcast_ref::<UInt64Array>()
             .ok_or_else(|| {
                 datafusion::error::DataFusionError::Internal(format!(
-                    "Row-address column '{}' is not UInt64",
-                    self.row_addr_column
+                    "Ordering column '{}' is not UInt64",
+                    self.ordering_column
                 ))
             })?;
 
         for row_idx in 0..batch.num_rows() {
-            if row_addr_array.is_null(row_idx) {
-                // A NULL row address can't be ordered against a real one. Skip
-                // rather than guess — callers should always project a real
-                // row-address column for dedup-eligible sources.
+            if ordering_array.is_null(row_idx) {
+                // A NULL ordering value can't be ordered against a real one.
+                // Skip rather than guess — callers should always project a
+                // real ordering column for dedup-eligible sources.
                 continue;
             }
-            let row_addr = row_addr_array.value(row_idx);
+            let ordering_value = ordering_array.value(row_idx);
             let pk_hash = compute_pk_hash(&batch, &pk_indices, row_idx);
 
             let take_row = match self.winners.get(&pk_hash) {
                 None => true,
                 Some(existing) => match self.direction {
-                    DedupDirection::KeepMaxRowAddr => row_addr > existing.row_addr,
-                    DedupDirection::KeepMinRowAddr => row_addr < existing.row_addr,
+                    DedupDirection::KeepMax => ordering_value > existing.ordering_value,
+                    DedupDirection::KeepMin => ordering_value < existing.ordering_value,
                 },
             };
 
@@ -249,7 +247,7 @@ impl WithinSourceDedupStream {
                     pk_hash,
                     Winner {
                         batch: single,
-                        row_addr,
+                        ordering_value,
                     },
                 );
             }
@@ -316,11 +314,11 @@ mod tests {
             Field::new("id", DataType::Int32, false),
             Field::new("name", DataType::Utf8, true),
             Field::new("_distance", DataType::Float32, true),
-            Field::new("_row_addr", DataType::UInt64, true),
+            Field::new("_ordering", DataType::UInt64, true),
         ]))
     }
 
-    fn batch(ids: &[i32], names: &[&str], distances: &[f32], row_addr: &[u64]) -> RecordBatch {
+    fn batch(ids: &[i32], names: &[&str], distances: &[f32], ordering: &[u64]) -> RecordBatch {
         let schema = create_test_schema();
         RecordBatch::try_new(
             schema,
@@ -328,7 +326,7 @@ mod tests {
                 Arc::new(Int32Array::from(ids.to_vec())),
                 Arc::new(StringArray::from(names.to_vec())),
                 Arc::new(Float32Array::from(distances.to_vec())),
-                Arc::new(UInt64Array::from(row_addr.to_vec())),
+                Arc::new(UInt64Array::from(ordering.to_vec())),
             ],
         )
         .unwrap()
@@ -338,7 +336,7 @@ mod tests {
         let schema = create_test_schema();
         let input = TestMemoryExec::try_new_exec(&[batches], schema, None).unwrap();
         let exec =
-            WithinSourceDedupExec::new(input, vec!["id".to_string()], "_row_addr", direction);
+            WithinSourceDedupExec::new(input, vec!["id".to_string()], "_ordering", direction);
         let ctx = SessionContext::new();
         let stream = exec.execute(0, ctx.task_ctx()).unwrap();
         stream.try_collect().await.unwrap()
@@ -359,15 +357,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn keep_max_picks_largest_row_addr() {
-        // Active-memtable case: same pk inserted twice; newer = larger _rowaddr.
+    async fn keep_max_picks_largest_ordering_value() {
+        // Active-memtable case: same pk inserted twice; newer = larger ordering value.
         let b1 = batch(
             &[1, 1, 2],
             &["old", "new", "two"],
             &[0.1, 0.2, 0.3],
             &[10, 99, 5],
         );
-        let out = run(vec![b1], DedupDirection::KeepMaxRowAddr).await;
+        let out = run(vec![b1], DedupDirection::KeepMax).await;
         let rows = extract(&out);
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0], (1, "new".to_string(), 99));
@@ -375,15 +373,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn keep_min_picks_smallest_row_addr() {
-        // Flushed-memtable case under reverse-write: newer = smaller _rowid.
+    async fn keep_min_picks_smallest_ordering_value() {
+        // Flushed-memtable case under reverse-write: newer = smaller ordering value.
         let b1 = batch(
             &[1, 1, 2],
             &["old", "new", "two"],
             &[0.1, 0.2, 0.3],
             &[99, 10, 5],
         );
-        let out = run(vec![b1], DedupDirection::KeepMinRowAddr).await;
+        let out = run(vec![b1], DedupDirection::KeepMin).await;
         let rows = extract(&out);
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0], (1, "new".to_string(), 10));
@@ -394,7 +392,7 @@ mod tests {
     async fn dedup_across_batches() {
         let b1 = batch(&[1, 2], &["a", "b"], &[0.1, 0.2], &[1, 1]);
         let b2 = batch(&[1, 3], &["a_new", "c"], &[0.5, 0.4], &[7, 1]);
-        let out = run(vec![b1, b2], DedupDirection::KeepMaxRowAddr).await;
+        let out = run(vec![b1, b2], DedupDirection::KeepMax).await;
         let rows = extract(&out);
         assert_eq!(rows.len(), 3);
         assert_eq!(rows[0], (1, "a_new".to_string(), 7));
@@ -404,13 +402,13 @@ mod tests {
 
     #[tokio::test]
     async fn empty_input() {
-        let out = run(vec![], DedupDirection::KeepMaxRowAddr).await;
+        let out = run(vec![], DedupDirection::KeepMax).await;
         let total: usize = out.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, 0);
     }
 
     #[tokio::test]
-    async fn null_row_addr_skipped() {
+    async fn null_ordering_value_skipped() {
         // Rows with NULL row address can't be ordered — they're dropped so they
         // don't accidentally become winners against real values.
         let schema = create_test_schema();
@@ -424,7 +422,7 @@ mod tests {
             ],
         )
         .unwrap();
-        let out = run(vec![b], DedupDirection::KeepMaxRowAddr).await;
+        let out = run(vec![b], DedupDirection::KeepMax).await;
         let rows = extract(&out);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0], (1, "real".to_string(), 5));

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -24,8 +24,8 @@ use super::exec::{
 };
 use super::flushed_cache::{FlushedMemTableCache, open_flushed_dataset};
 use super::projection::{
-    build_scanner_projection, canonical_output_schema, null_columns, project_to_canonical,
-    wants_row_address, wants_row_id,
+    build_scanner_projection, canonical_output_schema, project_to_canonical, wants_row_address,
+    wants_row_id,
 };
 use crate::session::Session;
 
@@ -273,32 +273,27 @@ impl LsmPointLookupPlanner {
                 schema,
                 ..
             } => {
-                use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
+                use crate::dataset::mem_wal::memtable::scanner::{
+                    MEMWAL_ROW_POSITION_COLUMN, MemTableScanner,
+                };
 
                 let mut scanner =
                     MemTableScanner::new(batch_store.clone(), index_store.clone(), schema.clone());
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>());
                 scanner.filter_expr(filter.clone());
-                // Expose `_rowid` (the BatchStore row offset, monotonic with
-                // insert order) so we can pick the most recently inserted
-                // duplicate below. Without this, a `FilterExec → LIMIT 1`
-                // over insert-ordered scan would return the *oldest* of
-                // multiple rows sharing the target primary key.
-                scanner.with_row_id();
+                // Expose the BatchStore row position as an internal column
+                // so we can pick the most recently inserted duplicate below.
+                scanner.with_internal_row_position();
                 let raw = scanner.create_plan().await?;
-                // Within the active memtable, larger `_rowid` = newer
+                // Within the active memtable, larger row position = newer
                 // insert. After dedup there is exactly one row per PK.
                 let deduped: Arc<dyn ExecutionPlan> = Arc::new(WithinSourceDedupExec::new(
                     raw,
                     self.pk_columns.clone(),
-                    lance_core::ROW_ID,
-                    DedupDirection::KeepMaxRowAddr,
+                    MEMWAL_ROW_POSITION_COLUMN,
+                    DedupDirection::KeepMax,
                 ));
-                // Per-source `_rowid` would collide with the base table's;
-                // NULL it before canonicalization (the value is internal to
-                // this arm). project_to_canonical drops it entirely when
-                // the user didn't request `_rowid` in the projection.
-                null_columns(deduped, &[lance_core::ROW_ID])?
+                deduped
             }
         };
         project_to_canonical(scan, &target)
@@ -658,7 +653,7 @@ mod tests {
         // memtable must return the *newest* row. The bug was that
         // `FilterExec → LIMIT 1` over an insert-ordered scan returned the
         // first (oldest) match. `WithinSourceDedupExec` collapses by PK,
-        // keeping the row with the largest `_rowid` (insert order).
+        // keeping the row with the largest internal row position.
         use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
         use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
         use futures::TryStreamExt;
@@ -674,7 +669,7 @@ mod tests {
         index_store.add_btree("id_idx".to_string(), 0, "id".to_string());
 
         // Two writes to pk=1, then an unrelated pk=2. The "new" row goes
-        // *second* so its `_rowid` is larger.
+        // *second* so its internal row position is larger.
         let b_old = create_test_batch(&schema, &[1], "old");
         let b_new = create_test_batch(&schema, &[1], "new");
         let b_other = create_test_batch(&schema, &[2], "two");
@@ -719,6 +714,15 @@ mod tests {
 
         let total: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total, 1, "expected exactly one row for pk=1");
+        assert!(
+            batches[0]
+                .schema()
+                .field_with_name(
+                    crate::dataset::mem_wal::memtable::scanner::MEMWAL_ROW_POSITION_COLUMN
+                )
+                .is_err(),
+            "internal row position column leaked into point lookup output"
+        );
         let name_col = batches[0].column_by_name("name").unwrap();
         let name_arr = name_col.as_any().downcast_ref::<StringArray>().unwrap();
         assert_eq!(

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -54,7 +54,7 @@ use crate::session::Session;
 ///       UnionExec
 ///         ProjectionExec (canonical output schema)
 ///           SortExec(_distance, fetch=k)
-///             WithinSourceDedupExec: KeepMaxRowAddr           (active)
+///             WithinSourceDedupExec: KeepMax                  (active)
 ///               KNNExec: active memtable, fetch=ceil(k*overfetch)
 ///         ProjectionExec (canonical output schema)
 ///           ProjectionExec (null_columns _rowid)
@@ -260,17 +260,17 @@ impl LsmVectorSearchPlanner {
             // Make each source independently newest-per-PK before the union:
             //  * active: the append-only HNSW returns one node per inserted
             //    version, so collapse duplicate PKs to the newest insert
-            //    (KeepMaxRowAddr on `_rowid`) and re-sort by distance. This
-            //    stays probabilistic — a fresh version evicted from the
-            //    over-fetched top-k still leaks.
+            //    (KeepMax on the internal row position) and re-sort by
+            //    distance. This stays probabilistic — a fresh version evicted
+            //    from the over-fetched top-k still leaks.
             //  * flushed/base: drop cross-gen superseded rows via the
             //    block-list (within-gen is handled by the flushed DV).
             let knn = if is_active {
                 let deduped: Arc<dyn ExecutionPlan> = Arc::new(WithinSourceDedupExec::new(
                     knn,
                     self.pk_columns.clone(),
-                    lance_core::ROW_ID,
-                    DedupDirection::KeepMaxRowAddr,
+                    crate::dataset::mem_wal::memtable::scanner::MEMWAL_ROW_POSITION_COLUMN,
+                    DedupDirection::KeepMax,
                 ));
                 sort_by_distance(deduped, k)?
             } else {
@@ -284,10 +284,10 @@ impl LsmVectorSearchPlanner {
                     None => knn,
                 }
             };
-            // Lance's `fast_search()` and the active scan both produce a
-            // per-source `_rowid` that would collide with base row ids in the
-            // canonical output, so NULL it on non-base arms. The base arm keeps
-            // its real `_rowid` to drive the post-rerank take.
+            // Lance's `fast_search()` produces per-source `_rowid` values that
+            // would collide with base row ids in the canonical output, so NULL
+            // them on non-base arms. The base arm keeps its real `_rowid` to
+            // drive the post-rerank take.
             let after_null = if is_base {
                 knn
             } else {
@@ -435,14 +435,10 @@ impl LsmVectorSearchPlanner {
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>());
-                // Expose `_rowid` (BatchStore row offset, monotonic with
-                // insert order) so [`WithinSourceDedupExec`] can collapse
-                // duplicate-PK rows to the newest insert. The value is
-                // per-source and NULL'd before reaching the canonical merge.
-                // (VectorIndexExec only plumbs `with_row_id`, not
-                // `with_row_address`, but the two yield identical values
-                // for an active memtable so either would work.)
-                scanner.with_row_id();
+                // Expose the BatchStore row position as an internal column
+                // so [`WithinSourceDedupExec`] can collapse duplicate-PK rows
+                // to the newest insert.
+                scanner.with_internal_row_position();
                 let query_arr: Arc<dyn Array> = Arc::new(query_vector.clone());
                 scanner.nearest(&self.vector_column, query_arr, k);
                 scanner.nprobes(nprobes);
@@ -1021,7 +1017,11 @@ mod tests {
 
         let out_schema = batches[0].schema();
         assert!(out_schema.field_with_name(DISTANCE_COLUMN).is_ok());
-        for internal in [super::super::exec::MEMTABLE_GEN_COLUMN, "_freshness"] {
+        for internal in [
+            super::super::exec::MEMTABLE_GEN_COLUMN,
+            crate::dataset::mem_wal::memtable::scanner::MEMWAL_ROW_POSITION_COLUMN,
+            "_freshness",
+        ] {
             assert!(
                 out_schema.field_with_name(internal).is_err(),
                 "`{}` leaked into output: {:?}",


### PR DESCRIPTION
## Summary

  Separates active MemTable internal row positions from public Lance `_rowid` / `_rowaddr` semantics.

  - Add an internal `__memwal_row_position` column for MemWAL dedup/order logic
  - Keep public active MemTable `_rowid` / `_rowaddr` outputs nullable instead of using row positions
  - Update active point lookup and vector search dedup to use the internal row position column
  - Generalize `WithinSourceDedupExec` from row-address ordering to ordering-column based dedup
  
  ## Breaking changes

  - `MemTableScanner::with_row_id()` and `MemTableScanner::with_row_address()` now return all-NULL system columns for active memtable rows instead of insertion-
  order surrogate values. Existing callers that used these columns as row positions will continue to compile but will observe NULL values instead.
  - `DedupDirection` variants were renamed. Downstream code matching on the old variant names must update to the new names.
  - `WithinSourceDedupExec::row_addr_column()` was renamed to `ordering_column()`. Callers using the old accessor must update their code.