### PR TITLE
refactor(index): scaffold ivfrq split code layout

### DIFF
--- a/docs/src/format/index/vector/index.md
+++ b/docs/src/format/index/vector/index.md
@@ -249,6 +249,7 @@ For **RabitQ (RQ)**:
 | --------------------- | ---- | ---------------------------------------------------- |
 | `rotate_mat_position` | u32  | Position of the rotation matrix in the global buffer |
 | `num_bits`            | u8   | Number of bits per dimension (currently always 1)    |
+| `code_dim`            | u32  | Rotated vector dimension for the 1-bit binary code   |
 | `packed`              | bool | Whether codes are packed for optimized computation   |
 
 #### Lance File Global Buffer
@@ -272,7 +273,10 @@ to rotate vectors before binary quantization:
 %%% proto.message.Tensor %%%
 ```
 
-The rotation matrix has shape `[code_dim, code_dim]` where `code_dim = dimension * num_bits`.
+The rotation matrix has shape `[code_dim, code_dim]` where `code_dim` is the rotated vector
+dimension. Current IVF_RQ stores the 1-bit binary code in `_rabit_codes`; future multi-bit support
+will store the remaining `num_bits - 1` ex-code bits separately instead of widening this binary
+code path.
 
 ## Appendices
 

--- a/docs/src/guide/performance.md
+++ b/docs/src/guide/performance.md
@@ -414,11 +414,11 @@ exact size depends on the quantizer:
 100M * (768 + 8) = ~72.3 GiB
 ```
 
-**RQ (RaBitQ):** Vectors are quantized to binary codes with a configurable number of bits per
-dimension. Each row also stores per-row scale and offset factors (4 bytes each) used for distance correction. Each
-row requires `dimension * num_bits / 8 + 16` bytes (8 bytes for the row ID plus 8 bytes for the factors). For
-example, 100M rows with 768 dimensions and 1 bit per dimension:
+**RQ (RaBitQ):** Vectors are currently quantized to 1-bit binary codes. Each row also stores per-row
+scale and offset factors (4 bytes each) used for distance correction. Each row requires
+`dimension / 8 + 16` bytes (8 bytes for the row ID plus 8 bytes for the factors). For example, 100M
+rows with 768 dimensions and 1 bit per dimension:
 
 ```
-100M * (768 * 1 / 8 + 16) = ~10.8 GiB
+100M * (768 / 8 + 16) = ~10.8 GiB
 ```

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1058,6 +1058,18 @@ def test_create_ivf_rq_skip_transpose():
     assert stats["indices"][0]["sub_index"]["packed"] is False
 
 
+def test_create_ivf_rq_rejects_unsupported_num_bits():
+    ds = lance.write_dataset(create_table(), "memory://")
+
+    with pytest.raises(NotImplementedError, match="only num_bits=1 is supported"):
+        ds.create_index(
+            "vector",
+            index_type="IVF_RQ",
+            num_partitions=4,
+            num_bits=2,
+        )
+
+
 def test_create_ivf_rq_requires_dim_divisible_by_8():
     vectors = np.zeros((1000, 30), dtype=np.float32).tolist()
     tbl = pa.Table.from_pydict(

--- a/rust/lance-index/src/vector/bq.rs
+++ b/rust/lance-index/src/vector/bq.rs
@@ -21,6 +21,10 @@ pub mod rotation;
 pub mod storage;
 pub mod transform;
 
+pub const RABIT_MIN_NUM_BITS: u8 = 1;
+pub const RABIT_MAX_NUM_BITS: u8 = 8;
+pub const RABIT_BINARY_NUM_BITS: u8 = 1;
+
 #[derive(Clone, Default)]
 pub struct BinaryQuantization {}
 
@@ -106,6 +110,46 @@ pub struct RQBuildParams {
     pub rotation_type: RQRotationType,
 }
 
+pub fn validate_rq_num_bits(num_bits: u8) -> Result<()> {
+    if !(RABIT_MIN_NUM_BITS..=RABIT_MAX_NUM_BITS).contains(&num_bits) {
+        return Err(Error::invalid_input(format!(
+            "IVF_RQ num_bits must be in {}..={}, got {}",
+            RABIT_MIN_NUM_BITS, RABIT_MAX_NUM_BITS, num_bits
+        )));
+    }
+    Ok(())
+}
+
+pub fn validate_supported_rq_num_bits(num_bits: u8) -> Result<()> {
+    validate_rq_num_bits(num_bits)?;
+    if num_bits != RABIT_BINARY_NUM_BITS {
+        return Err(Error::not_supported(format!(
+            "IVF_RQ num_bits={} is not supported yet; only num_bits=1 is supported",
+            num_bits
+        )));
+    }
+    Ok(())
+}
+
+pub fn rabit_ex_bits(num_bits: u8) -> Result<u8> {
+    validate_rq_num_bits(num_bits)?;
+    Ok(num_bits - RABIT_BINARY_NUM_BITS)
+}
+
+pub fn rabit_binary_code_bytes(rotated_dim: usize) -> usize {
+    rotated_dim.div_ceil(u8::BITS as usize)
+}
+
+pub fn rabit_ex_code_bytes(rotated_dim: usize, ex_bits: u8) -> Result<usize> {
+    let total_bits = rotated_dim.checked_mul(ex_bits as usize).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "IVF_RQ ex-code byte size overflow: rotated_dim={}, ex_bits={}",
+            rotated_dim, ex_bits
+        ))
+    })?;
+    Ok(total_bits.div_ceil(u8::BITS as usize))
+}
+
 impl RQBuildParams {
     pub fn new(num_bits: u8) -> Self {
         Self {
@@ -185,5 +229,45 @@ mod tests {
             RQRotationType::Matrix
         );
         assert!("invalid".parse::<RQRotationType>().is_err());
+    }
+
+    #[test]
+    fn test_rabit_num_bits_validation() {
+        validate_rq_num_bits(1).unwrap();
+        validate_rq_num_bits(8).unwrap();
+
+        let err = validate_rq_num_bits(0).unwrap_err();
+        assert!(
+            err.to_string().contains("IVF_RQ num_bits must be in"),
+            "{}",
+            err
+        );
+
+        let err = validate_rq_num_bits(9).unwrap_err();
+        assert!(
+            err.to_string().contains("IVF_RQ num_bits must be in"),
+            "{}",
+            err
+        );
+
+        let err = validate_supported_rq_num_bits(2).unwrap_err();
+        assert!(
+            err.to_string().contains("only num_bits=1 is supported"),
+            "{}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_rabit_split_code_byte_sizing() {
+        assert_eq!(rabit_ex_bits(1).unwrap(), 0);
+        assert_eq!(rabit_ex_bits(8).unwrap(), 7);
+
+        assert_eq!(rabit_binary_code_bytes(128), 16);
+        assert_eq!(rabit_binary_code_bytes(129), 17);
+
+        assert_eq!(rabit_ex_code_bytes(128, 0).unwrap(), 0);
+        assert_eq!(rabit_ex_code_bytes(128, 3).unwrap(), 48);
+        assert_eq!(rabit_ex_code_bytes(129, 3).unwrap(), 49);
     }
 }

--- a/rust/lance-index/src/vector/bq/builder.rs
+++ b/rust/lance-index/src/vector/bq/builder.rs
@@ -18,11 +18,13 @@ use rayon::prelude::*;
 
 use crate::vector::bq::storage::{
     RABIT_CODE_COLUMN, RABIT_METADATA_KEY, RabitQuantizationMetadata, RabitQuantizationStorage,
+    rabit_binary_code_field,
 };
 use crate::vector::bq::transform::{ADD_FACTORS_FIELD, SCALE_FACTORS_FIELD};
 use crate::vector::bq::{
-    RQBuildParams, RQRotationType,
+    RQBuildParams, RQRotationType, rabit_binary_code_bytes,
     rotation::{apply_fast_rotation, random_fast_rotation_signs},
+    validate_supported_rq_num_bits,
 };
 use crate::vector::quantizer::{Quantization, Quantizer, QuantizerBuildParams};
 
@@ -75,7 +77,8 @@ impl RabitQuantizer {
         dim: i32,
         rotation_type: RQRotationType,
     ) -> Self {
-        let code_dim = (dim * num_bits as i32) as usize;
+        debug_assert!(dim >= 0, "RabitQ dimension should be non-negative");
+        let code_dim = dim as usize;
         let metadata = match rotation_type {
             RQRotationType::Matrix => {
                 // we don't need to calculate the inverse of P, just take generated Q as P^{-1}
@@ -186,7 +189,7 @@ impl RabitQuantizer {
     }
 
     pub fn dim(&self) -> usize {
-        self.code_dim() / self.metadata.num_bits as usize
+        self.code_dim()
     }
 
     // compute the dot product of v_q * v_r
@@ -264,7 +267,7 @@ impl RabitQuantizer {
             .unwrap()
             .as_slice();
         let code_dim = self.code_dim();
-        let code_bytes = code_dim / u8::BITS as usize;
+        let code_bytes = rabit_binary_code_bytes(code_dim);
 
         match self.rotation_type() {
             RQRotationType::Matrix => {
@@ -280,7 +283,7 @@ impl RabitQuantizer {
                 debug_assert_eq!(codes.len(), n * code_bytes);
                 Ok(Arc::new(FixedSizeListArray::try_new_from_values(
                     codes,
-                    code_bytes as i32, // num_bits -> num_bytes
+                    code_bytes as i32,
                 )?))
             }
             RQRotationType::Fast => {
@@ -317,6 +320,8 @@ impl Quantization for RabitQuantizer {
         _: lance_linalg::distance::DistanceType,
         params: &Self::BuildParams,
     ) -> Result<Self> {
+        validate_supported_rq_num_bits(params.num_bits)?;
+
         let dim = data.as_fixed_size_list().value_length() as usize;
         if !dim.is_multiple_of(u8::BITS as usize) {
             return Err(Error::invalid_input(
@@ -408,20 +413,14 @@ impl Quantization for RabitQuantizer {
         metadata: &Self::Metadata,
         _: lance_linalg::distance::DistanceType,
     ) -> Result<Quantizer> {
+        validate_supported_rq_num_bits(metadata.num_bits)?;
         Ok(Quantizer::Rabit(Self {
             metadata: metadata.clone(),
         }))
     }
 
     fn field(&self) -> Field {
-        Field::new(
-            RABIT_CODE_COLUMN,
-            DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::UInt8, true)),
-                self.code_dim() as i32 / u8::BITS as i32, // num_bits -> num_bytes
-            ),
-            true,
-        )
+        rabit_binary_code_field(self.code_dim())
     }
 
     fn extra_fields(&self) -> Vec<Field> {
@@ -561,11 +560,23 @@ mod tests {
         let fast_q = RabitQuantizer::new_with_rotation::<Float32Type>(1, 128, RQRotationType::Fast);
         assert_eq!(fast_q.rotation_type(), RQRotationType::Fast);
         assert_eq!(fast_q.dim(), 128);
+        assert_eq!(fast_q.code_dim(), 128);
 
         let matrix_q =
             RabitQuantizer::new_with_rotation::<Float32Type>(1, 128, RQRotationType::Matrix);
         assert_eq!(matrix_q.rotation_type(), RQRotationType::Matrix);
         assert_eq!(matrix_q.dim(), 128);
+        assert_eq!(matrix_q.code_dim(), 128);
+    }
+
+    #[test]
+    fn test_rabit_quantizer_field_uses_binary_code_size() {
+        let q = RabitQuantizer::new_with_rotation::<Float32Type>(1, 128, RQRotationType::Fast);
+        let field = q.field();
+        let DataType::FixedSizeList(_, code_bytes) = field.data_type() else {
+            panic!("RabitQ code field should be FixedSizeList");
+        };
+        assert_eq!(*code_bytes, 16);
     }
 
     #[test]
@@ -578,6 +589,36 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("vector dimension must be divisible by 8 for IVF_RQ"),
+            "{}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_rabit_quantizer_rejects_unsupported_num_bits() {
+        let vectors = Float32Array::from(vec![0.0f32; 4 * 32]);
+        let fsl = FixedSizeListArray::try_new_from_values(vectors, 32).unwrap();
+
+        let err =
+            RabitQuantizer::build(&fsl, DistanceType::L2, &RQBuildParams::new(0)).unwrap_err();
+        assert!(
+            err.to_string().contains("IVF_RQ num_bits must be in"),
+            "{}",
+            err
+        );
+
+        let err =
+            RabitQuantizer::build(&fsl, DistanceType::L2, &RQBuildParams::new(2)).unwrap_err();
+        assert!(
+            err.to_string().contains("only num_bits=1 is supported"),
+            "{}",
+            err
+        );
+
+        let err =
+            RabitQuantizer::build(&fsl, DistanceType::L2, &RQBuildParams::new(9)).unwrap_err();
+        assert!(
+            err.to_string().contains("IVF_RQ num_bits must be in"),
             "{}",
             err
         );

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -11,7 +11,7 @@ use arrow::datatypes::{Float16Type, Float32Type, Float64Type, UInt8Type, UInt64T
 use arrow_array::{
     Array, FixedSizeListArray, Float32Array, RecordBatch, UInt8Array, UInt32Array, UInt64Array,
 };
-use arrow_schema::{DataType, SchemaRef};
+use arrow_schema::{DataType, Field, SchemaRef};
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use deepsize::DeepSizeOf;
@@ -37,17 +37,47 @@ use serde::{Deserialize, Serialize};
 
 use crate::frag_reuse::FragReuseIndex;
 use crate::pb;
-use crate::vector::bq::RQRotationType;
 use crate::vector::bq::rotation::{apply_fast_rotation, apply_fast_rotation_in_place};
 use crate::vector::bq::transform::{ADD_FACTORS_COLUMN, SCALE_FACTORS_COLUMN};
+use crate::vector::bq::{
+    RQRotationType, rabit_binary_code_bytes, rabit_ex_bits, rabit_ex_code_bytes,
+    validate_supported_rq_num_bits,
+};
 use crate::vector::pq::storage::transpose;
 use crate::vector::quantizer::{QuantizerMetadata, QuantizerStorage};
 use crate::vector::storage::{DistCalculator, QueryResidual, VectorStore};
 
 pub const RABIT_METADATA_KEY: &str = "lance:rabit";
 pub const RABIT_CODE_COLUMN: &str = "_rabit_codes";
+pub const RABIT_EX_CODE_COLUMN: &str = "_rabit_ex_codes";
 pub const SEGMENT_LENGTH: usize = 4;
 pub const SEGMENT_NUM_CODES: usize = 1 << SEGMENT_LENGTH;
+
+pub fn rabit_binary_code_field(rotated_dim: usize) -> Field {
+    Field::new(
+        RABIT_CODE_COLUMN,
+        DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::UInt8, true)),
+            rabit_binary_code_bytes(rotated_dim) as i32,
+        ),
+        true,
+    )
+}
+
+pub fn rabit_ex_code_field(rotated_dim: usize, num_bits: u8) -> Result<Option<Field>> {
+    let ex_bits = rabit_ex_bits(num_bits)?;
+    if ex_bits == 0 {
+        return Ok(None);
+    }
+    Ok(Some(Field::new(
+        RABIT_EX_CODE_COLUMN,
+        DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::UInt8, true)),
+            rabit_ex_code_bytes(rotated_dim, ex_bits)? as i32,
+        ),
+        true,
+    )))
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RabitQuantizationMetadata {
@@ -68,6 +98,23 @@ pub struct RabitQuantizationMetadata {
     pub packed: bool,
 }
 
+impl RabitQuantizationMetadata {
+    pub fn rotated_dim(&self) -> usize {
+        if self.code_dim > 0 {
+            self.code_dim as usize
+        } else {
+            self.rotate_mat
+                .as_ref()
+                .map(|rotate_mat| rotate_mat.len())
+                .unwrap_or(0)
+        }
+    }
+
+    pub fn binary_code_bytes(&self) -> usize {
+        rabit_binary_code_bytes(self.rotated_dim())
+    }
+}
+
 fn default_rotation_type_compat() -> RQRotationType {
     // Older metadata does not have this field and always used dense matrices.
     RQRotationType::Matrix
@@ -75,14 +122,7 @@ fn default_rotation_type_compat() -> RQRotationType {
 
 impl RabitQuantizationMetadata {
     fn code_dim(&self) -> usize {
-        if self.code_dim > 0 {
-            self.code_dim as usize
-        } else {
-            self.rotate_mat
-                .as_ref()
-                .map(|rotate_mat| rotate_mat.len())
-                .unwrap_or_default()
-        }
+        self.rotated_dim()
     }
 
     fn rotate_vector_with_residual_into(
@@ -451,10 +491,7 @@ fn copy_subtract_f32(lhs: &[f32], rhs: &[f32], output: &mut [f32]) {
 
 pub struct RabitDistCalculator<'a> {
     dim: usize,
-    // num_bits is the number of bits per dimension,
-    // it's always 1 for now
-    num_bits: u8,
-    // n * d * num_bits / 8 bytes
+    // n * d / 8 binary-code bytes
     codes: &'a [u8],
     // this is a flattened 2D array of size d/4 * 16,
     // we split the query codes into d/4 chunks, each chunk is with 4 elements,
@@ -482,7 +519,6 @@ impl<'a> RabitDistCalculator<'a> {
     ) -> Self {
         Self {
             dim,
-            num_bits,
             codes,
             dist_table,
             add_factors,
@@ -582,7 +618,7 @@ impl DistCalculator for RabitDistCalculator<'_> {
     #[inline(always)]
     fn distance(&self, id: u32) -> f32 {
         let id = id as usize;
-        let code_len = self.dim * (self.num_bits as usize) / u8::BITS as usize;
+        let code_len = rabit_binary_code_bytes(self.dim);
         let num_vectors = self.codes.len() / code_len;
         let dist =
             compute_single_rq_distance(self.codes, id, num_vectors, code_len, &self.dist_table);
@@ -615,7 +651,7 @@ impl DistCalculator for RabitDistCalculator<'_> {
         quantized_dists: &mut Vec<u16>,
         quantized_dists_table: &mut Vec<u8>,
     ) {
-        let code_len = self.dim * (self.num_bits as usize) / u8::BITS as usize;
+        let code_len = rabit_binary_code_bytes(self.dim);
         let n = self.codes.len() / code_len;
         if n == 0 {
             dists.clear();
@@ -714,7 +750,7 @@ impl VectorStore for RabitQuantizationStorage {
         let dist_table = build_dist_table_direct::<Float32Type>(&rotated_qr);
         let sum_q = rotated_qr.into_iter().sum();
 
-        self.distance_calculator_from_parts(qr.len(), dist_q_c, Cow::Owned(dist_table), sum_q)
+        self.distance_calculator_from_parts(code_dim, dist_q_c, Cow::Owned(dist_table), sum_q)
     }
 
     // qr = (q-c)
@@ -750,7 +786,7 @@ impl VectorStore for RabitQuantizationStorage {
         };
 
         self.distance_calculator_from_parts(
-            qr.len(),
+            code_dim,
             dist_q_c,
             Cow::Borrowed(&f32_scratch[code_dim..code_dim + dist_table_len]),
             sum_q,
@@ -923,8 +959,19 @@ impl QuantizerStorage for RabitQuantizationStorage {
         distance_type: DistanceType,
         _fri: Option<Arc<FragReuseIndex>>,
     ) -> Result<Self> {
+        validate_supported_rq_num_bits(metadata.num_bits)?;
         let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().clone();
         let codes = batch[RABIT_CODE_COLUMN].as_fixed_size_list().clone();
+        let expected_code_bytes = metadata.binary_code_bytes();
+        if expected_code_bytes > 0 && codes.value_length() as usize != expected_code_bytes {
+            return Err(Error::invalid_input(format!(
+                "RabitQ code byte width mismatch: column {} has {} bytes, metadata rotated_dim={} requires {} bytes",
+                RABIT_CODE_COLUMN,
+                codes.value_length(),
+                metadata.rotated_dim(),
+                expected_code_bytes
+            )));
+        }
         let add_factors = batch[ADD_FACTORS_COLUMN]
             .as_primitive::<Float32Type>()
             .clone();
@@ -1312,6 +1359,23 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_rabit_split_code_fields() {
+        let bin_field = rabit_binary_code_field(128);
+        let DataType::FixedSizeList(_, bin_code_bytes) = bin_field.data_type() else {
+            panic!("binary code field should be FixedSizeList");
+        };
+        assert_eq!(*bin_code_bytes, 16);
+
+        assert!(rabit_ex_code_field(128, 1).unwrap().is_none());
+        let ex_field = rabit_ex_code_field(128, 4).unwrap().unwrap();
+        assert_eq!(ex_field.name(), RABIT_EX_CODE_COLUMN);
+        let DataType::FixedSizeList(_, ex_code_bytes) = ex_field.data_type() else {
+            panic!("ex-code field should be FixedSizeList");
+        };
+        assert_eq!(*ex_code_bytes, 48);
+    }
+
     fn make_test_codes(num_vectors: usize, code_dim: i32) -> FixedSizeListArray {
         let quantizer =
             RabitQuantizer::new_with_rotation::<Float32Type>(1, code_dim, RQRotationType::Fast);
@@ -1383,6 +1447,26 @@ mod tests {
         let stored_codes = stored_batch[RABIT_CODE_COLUMN].as_fixed_size_list();
         let expected_codes = pack_codes(&original_codes);
         assert_codes_eq(stored_codes, &expected_codes);
+    }
+
+    #[test]
+    fn test_try_from_batch_rejects_unsupported_rq_num_bits() {
+        let original_codes = make_test_codes(50, 64);
+        let mut metadata = make_test_metadata(original_codes.value_length() as usize * 8);
+        metadata.num_bits = 2;
+
+        let err = RabitQuantizationStorage::try_from_batch(
+            make_test_batch(original_codes),
+            &metadata,
+            DistanceType::L2,
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("only num_bits=1 is supported"),
+            "{}",
+            err
+        );
     }
 
     #[test]

--- a/rust/lance-index/src/vector/bq/transform.rs
+++ b/rust/lance-index/src/vector/bq/transform.rs
@@ -23,12 +23,24 @@ use crate::vector::{CENTROID_DIST_COLUMN, PART_ID_COLUMN};
 pub const ADD_FACTORS_COLUMN: &str = "__add_factors";
 // the inner product of quantized vector and the centroid vector.
 pub const SCALE_FACTORS_COLUMN: &str = "__scale_factors";
+pub const EX_ADD_FACTORS_COLUMN: &str = "__add_factors_ex";
+pub const EX_SCALE_FACTORS_COLUMN: &str = "__scale_factors_ex";
 
 pub static ADD_FACTORS_FIELD: LazyLock<arrow_schema::Field> = LazyLock::new(|| {
     arrow_schema::Field::new(ADD_FACTORS_COLUMN, arrow_schema::DataType::Float32, true)
 });
 pub static SCALE_FACTORS_FIELD: LazyLock<arrow_schema::Field> = LazyLock::new(|| {
     arrow_schema::Field::new(SCALE_FACTORS_COLUMN, arrow_schema::DataType::Float32, true)
+});
+pub static EX_ADD_FACTORS_FIELD: LazyLock<arrow_schema::Field> = LazyLock::new(|| {
+    arrow_schema::Field::new(EX_ADD_FACTORS_COLUMN, arrow_schema::DataType::Float32, true)
+});
+pub static EX_SCALE_FACTORS_FIELD: LazyLock<arrow_schema::Field> = LazyLock::new(|| {
+    arrow_schema::Field::new(
+        EX_SCALE_FACTORS_COLUMN,
+        arrow_schema::DataType::Float32,
+        true,
+    )
 });
 
 pub struct RQTransformer {

--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -21,8 +21,10 @@ use crate::IndexMetadata as IndexMetaSchema;
 use crate::pb;
 use crate::vector::bq::storage::{
     RABIT_CODE_COLUMN, RABIT_METADATA_KEY, RabitQuantizationMetadata, pack_codes,
+    rabit_binary_code_field,
 };
 use crate::vector::bq::transform::{ADD_FACTORS_FIELD, SCALE_FACTORS_FIELD};
+use crate::vector::bq::validate_supported_rq_num_bits;
 use crate::vector::flat::index::FlatMetadata;
 use crate::vector::ivf::storage::{IVF_METADATA_KEY, IvfModel as IvfStorageModel};
 use crate::vector::pq::storage::{PQ_METADATA_KEY, ProductQuantizationMetadata, transpose};
@@ -297,17 +299,9 @@ pub async fn init_writer_for_rq(
     rq_meta: &RabitQuantizationMetadata,
     format_version: LanceFileVersion,
 ) -> Result<FileWriter> {
-    let num_bytes = (rq_meta.code_dim as usize).div_ceil(u8::BITS as usize);
     let arrow_schema = ArrowSchema::new(vec![
         (*ROW_ID_FIELD).clone(),
-        Field::new(
-            RABIT_CODE_COLUMN,
-            DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::UInt8, true)),
-                num_bytes as i32,
-            ),
-            true,
-        ),
+        rabit_binary_code_field(rq_meta.rotated_dim()),
         ADD_FACTORS_FIELD.clone(),
         SCALE_FACTORS_FIELD.clone(),
     ]);
@@ -988,12 +982,14 @@ pub async fn merge_partial_vector_auxiliary_files(
                     let rotate_mat_bytes = reader.read_global_buffer(buf_idx).await?;
                     rq_meta_parsed.parse_buffer(rotate_mat_bytes)?;
                 }
+                validate_supported_rq_num_bits(rq_meta_parsed.num_bits)?;
 
-                let d0 = (rq_meta_parsed.code_dim as usize)
-                    .checked_div(rq_meta_parsed.num_bits as usize)
-                    .ok_or_else(|| {
-                        Error::index("Invalid RQ metadata: num_bits is zero".to_string())
-                    })?;
+                let d0 = rq_meta_parsed.rotated_dim();
+                if d0 == 0 {
+                    return Err(Error::index(
+                        "Invalid RQ metadata: rotated dimension is zero".to_string(),
+                    ));
+                }
                 dim.get_or_insert(d0);
                 if let Some(dprev) = dim
                     && dprev != d0
@@ -2367,6 +2363,7 @@ mod tests {
         assert!(merged_rq_meta.packed);
 
         let mut total_rows = 0usize;
+        let mut checked_code_width = false;
         let mut stream = reader
             .read_stream(
                 lance_io::ReadBatchParams::RangeFull,
@@ -2377,8 +2374,19 @@ mod tests {
             .await
             .unwrap();
         while let Some(batch) = stream.next().await {
-            total_rows += batch.unwrap().num_rows();
+            let batch = batch.unwrap();
+            if !checked_code_width {
+                let schema = batch.schema();
+                let code_field = schema.field_with_name(RABIT_CODE_COLUMN).unwrap();
+                let DataType::FixedSizeList(_, code_bytes) = code_field.data_type() else {
+                    panic!("RQ code field should be FixedSizeList");
+                };
+                assert_eq!(*code_bytes, rq_meta.binary_code_bytes() as i32);
+                checked_code_width = true;
+            }
+            total_rows += batch.num_rows();
         }
+        assert!(checked_code_width);
         let expected_total: usize = expected_lengths.iter().map(|v| *v as usize).sum();
         assert_eq!(total_rows, expected_total);
     }


### PR DESCRIPTION
## Feature

What is the new feature?

This PR prepares IVF_RQ/RabitQ storage and metadata for future split-code multi-bit support while keeping the existing `num_bits=1` behavior enabled as the only supported mode.

Why do we need this feature?

Future IVF_RQ `num_bits > 1` support needs the current 1-bit binary code path to remain dimension-sized while extra code bits are stored separately. This separates those concepts before adding multi-bit search or boosting.

How does it work?

- Clarifies RabitQ `code_dim` as the rotated vector dimension and sizes `_rabit_codes` from the 1-bit binary code width.
- Adds shared `num_bits` validation and helper APIs for `ex_bits`, binary code bytes, and future ex-code bytes.
- Adds future ex-code field/metadata scaffolding and storage validation while continuing to reject `num_bits > 1` at creation/load.
- Updates distributed RQ merge, docs, and tests to preserve the current binary layout.

## Compatibility

Existing IVF_RQ metadata with missing `code_dim` still falls back to the current rotation/code layout, and the current `num_bits=1` storage/search path remains unchanged.

## Validation

- `cargo fmt --all`
- `cargo test -p lance-index vector::bq --lib`
- `cargo test -p lance-index vector::distributed::index_merger::tests::test_merge_ivf_rq_success --lib`
- `cargo clippy --all --tests --benches -- -D warnings`
- `uv run pytest python/tests/test_vector_index.py::test_create_ivf_rq_index python/tests/test_vector_index.py::test_create_ivf_rq_skip_transpose python/tests/test_vector_index.py::test_create_ivf_rq_rejects_unsupported_num_bits`
- `git diff --check`
- pre-commit during commit: `ruff`, `ruff-format`, `fmt`, `typos`

Validation note: `uv run make lint` passes `ruff format --check --diff python` and `ruff check python`, then fails in `pyright` on existing optional `TYPE_CHECKING` imports in `python/lance/dependencies.py` for `tensorflow` and `torch` in this local macOS environment. This PR only changes Python test coverage, not that module.