### PR TITLE
perf(index): cache wand head posting doc id

### DIFF
--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -446,25 +446,27 @@ struct HeadPosting {
     // Iterators that are already positioned on or after the next candidate doc.
     // The heap is ordered by smallest doc id so the top element determines
     // the next target doc to consider.
+    doc_id: u64,
     posting: Box<PostingIterator>,
 }
 
 impl HeadPosting {
     fn new(posting: Box<PostingIterator>) -> Self {
-        Self { posting }
+        let doc_id = posting
+            .doc()
+            .map(|doc| doc.doc_id())
+            .unwrap_or(TERMINATED_DOC_ID);
+        Self { doc_id, posting }
     }
 
     fn doc_id(&self) -> u64 {
-        self.posting
-            .doc()
-            .map(|doc| doc.doc_id())
-            .unwrap_or(TERMINATED_DOC_ID)
+        self.doc_id
     }
 }
 
 impl PartialEq for HeadPosting {
     fn eq(&self, other: &Self) -> bool {
-        self.doc_id() == other.doc_id()
+        self.doc_id == other.doc_id
             && self.posting.approximate_upper_bound().to_bits()
                 == other.posting.approximate_upper_bound().to_bits()
             && self.posting.token_id == other.posting.token_id
@@ -483,8 +485,8 @@ impl PartialOrd for HeadPosting {
 impl Ord for HeadPosting {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         other
-            .doc_id()
-            .cmp(&self.doc_id())
+            .doc_id
+            .cmp(&self.doc_id)
             .then_with(|| {
                 self.posting
                     .approximate_upper_bound()
@@ -900,7 +902,6 @@ impl<'a, S: Scorer> Wand<'a, S> {
 
         Ok(None)
     }
-
     fn next_and_candidate(&mut self) -> Option<DocInfo> {
         if self.lead.len() < self.num_terms {
             return None;


### PR DESCRIPTION
## Performance Improvement

### What is the performance issue or bottleneck?

FTS WAND query execution keeps `HeadPosting` values in a `BinaryHeap`. Heap comparisons repeatedly asked the wrapped `PostingIterator` for its current doc id, even though a posting's current doc id is stable while it is inside the heap.

### How does this PR improve performance?

This caches the current doc id in `HeadPosting` when it is created. When a posting is popped and advanced, it is wrapped in a new `HeadPosting`, so the cached value is refreshed at the same ownership boundary that already controls heap membership.

### Benchmark / measurement results

The benchmark used long FTS queries with 10/20/30/40/50 words.

- Single-thread query workload: avg latency improved by 5.6%, p95 latency improved by 2.9%, QPS improved by 5.9%.
- 8-thread query workload: avg latency improved by 19.3%, p95 latency improved by 24.0%, QPS improved by 24.1%.

## Validation

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/lance-e7d5-pr-target cargo test -p lance-index scalar::inverted::wand::tests::`
- `CARGO_TARGET_DIR=/tmp/lance-e7d5-pr-target cargo clippy --all --tests --benches -- -D warnings`