### PR TITLE
feat(python): expose external blob mode and outside-base option for fragments

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6938,9 +6938,10 @@ def write_dataset(
           Lance-managed storage using the normal inline / packed / dedicated
           thresholds.
     allow_external_blob_outside_bases: bool, default False
-        If False, external blob URIs must map to the dataset root or a registered
-        base path. If True, external blob URIs outside registered bases are allowed.
-        This option only applies when ``external_blob_mode="reference"``.
+        If False, external blob URIs must map to a registered non-dataset-root
+        base path. If True, external blob URIs outside registered bases are
+        allowed. Only valid when ``external_blob_mode="reference"``. Setting
+        this to True with ``"ingest"`` mode raises an error.
     blob_pack_file_size_threshold: optional, int, default None
         Maximum size in bytes for blob v2 pack (.blob) sidecar files. When a pack
         file reaches this size, a new one is started. If not set, defaults to 1 GiB.

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -1012,6 +1012,8 @@ if TYPE_CHECKING:
         target_bases: Optional[List[str]] = None,
         initial_bases: Optional[List["DatasetBasePath"]] = None,
         base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+        external_blob_mode: Literal["reference", "ingest"] = "reference",
+        allow_external_blob_outside_bases: bool = False,
         namespace_client: Optional[LanceNamespace] = None,
         table_id: Optional[List[str]] = None,
     ) -> Transaction: ...
@@ -1035,6 +1037,8 @@ if TYPE_CHECKING:
         target_bases: Optional[List[str]] = None,
         initial_bases: Optional[List["DatasetBasePath"]] = None,
         base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+        external_blob_mode: Literal["reference", "ingest"] = "reference",
+        allow_external_blob_outside_bases: bool = False,
         namespace_client: Optional[LanceNamespace] = None,
         table_id: Optional[List[str]] = None,
     ) -> List[FragmentMetadata]: ...
@@ -1058,6 +1062,8 @@ def write_fragments(
     target_bases: Optional[List[str]] = None,
     initial_bases: Optional[List["DatasetBasePath"]] = None,
     base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+    external_blob_mode: Literal["reference", "ingest"] = "reference",
+    allow_external_blob_outside_bases: bool = False,
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
 ) -> List[FragmentMetadata] | Transaction:
@@ -1142,6 +1148,18 @@ def write_fragments(
         top-level ``storage_options`` is used as a fallback. If ``dataset_uri``
         is a LanceDataset and this is omitted, the dataset's base store params
         are inherited.
+    external_blob_mode: {"reference", "ingest"}, default "reference"
+        How external blob URIs are handled on write.
+
+        - ``"reference"`` stores the URI as an external blob reference.
+        - ``"ingest"`` reads the external bytes during write and stores them in
+          Lance-managed storage using the normal inline / packed / dedicated
+          thresholds.
+    allow_external_blob_outside_bases: bool, default False
+        If False, external blob URIs must map to a registered non-dataset-root
+        base path. If True, external blob URIs outside registered bases are
+        allowed. Only valid when ``external_blob_mode="reference"``. Setting
+        this to True with ``"ingest"`` mode raises an error.
     namespace_client : optional, LanceNamespace
         A namespace client for automatic credential refresh. When provided with
         `table_id`, a storage options provider will be created automatically to
@@ -1219,6 +1237,8 @@ def write_fragments(
         target_bases=target_bases,
         initial_bases=initial_bases,
         base_store_params=base_store_params,
+        external_blob_mode=external_blob_mode,
+        allow_external_blob_outside_bases=allow_external_blob_outside_bases,
     )
 
 

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -20,6 +20,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Optional,
     Self,
     Sequence,
@@ -563,6 +564,8 @@ def _write_fragments(
     target_bases: Optional[List[str]] = None,
     initial_bases: Optional[List[Any]] = None,
     base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+    external_blob_mode: Literal["reference", "ingest"] = "reference",
+    allow_external_blob_outside_bases: bool = False,
 ): ...
 def _write_fragments_transaction(
     dataset_uri: str | Path | _Dataset,
@@ -580,6 +583,8 @@ def _write_fragments_transaction(
     target_bases: Optional[List[str]] = None,
     initial_bases: Optional[List[Any]] = None,
     base_store_params: Optional[Dict[str, Dict[str, str]]] = None,
+    external_blob_mode: Literal["reference", "ingest"] = "reference",
+    allow_external_blob_outside_bases: bool = False,
 ) -> Transaction: ...
 def _json_to_schema(schema_json: str) -> pa.Schema: ...
 def _schema_to_json(schema: pa.Schema) -> str: ...

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 from lance import Blob, BlobColumn, BlobFile, DatasetBasePath
+from lance.fragment import write_fragments
 
 lance_dataset_module = importlib.import_module("lance.dataset")
 
@@ -27,6 +28,21 @@ def _blob_row_addresses(dataset):
         .column("_rowaddr")
         .to_pylist()
     )
+
+
+def _commit_blob_fragments(dataset_uri, schema, fragments, initial_bases=None):
+    operation = lance.LanceOperation.Overwrite(
+        schema,
+        fragments,
+        initial_bases=initial_bases,
+    )
+    return lance.LanceDataset.commit(dataset_uri, operation)
+
+
+def _external_blob_table(blob_path, payload=b"hello"):
+    blob_path.parent.mkdir(parents=True, exist_ok=True)
+    blob_path.write_bytes(payload)
+    return pa.table({"blob": lance.blob_array([blob_path.as_uri()])})
 
 
 def _out_of_order_blob_selection(dataset_with_blobs, selection_kind):
@@ -586,6 +602,155 @@ def test_blob_extension_write_external_ingest_rejects_reference_only_options(tmp
         lance.write_dataset(
             table,
             tmp_path / "test_ds_v2_external_ingest_invalid",
+            data_storage_version="2.2",
+            external_blob_mode="ingest",
+            allow_external_blob_outside_bases=True,
+        )
+
+
+def test_blob_extension_write_fragments_external_denied_by_default(tmp_path):
+    blob_path = tmp_path / "external_blob.bin"
+
+    table = _external_blob_table(blob_path)
+    with pytest.raises(OSError, match="outside registered external bases"):
+        write_fragments(
+            table,
+            tmp_path / "test_fragments_v2_external_denied",
+            data_storage_version="2.2",
+            external_blob_mode="reference",
+        )
+
+
+def test_blob_extension_write_fragments_external_outside_base_allowed(tmp_path):
+    blob_path = tmp_path / "external_blob.bin"
+    dataset_uri = tmp_path / "test_fragments_v2_external_allowed"
+
+    table = _external_blob_table(blob_path)
+    fragments = write_fragments(
+        table,
+        dataset_uri,
+        data_storage_version="2.2",
+        external_blob_mode="reference",
+        allow_external_blob_outside_bases=True,
+    )
+    ds = _commit_blob_fragments(dataset_uri, table.schema, fragments)
+
+    blob = ds.take_blobs("blob", indices=[0])[0]
+    assert blob.size() == 5
+    with blob as f:
+        assert f.read() == b"hello"
+
+
+def test_blob_extension_write_fragments_transaction_external_outside_base_allowed(
+    tmp_path,
+):
+    blob_path = tmp_path / "external_blob.bin"
+    dataset_uri = tmp_path / "test_fragments_transaction_v2_external_allowed"
+
+    table = _external_blob_table(blob_path)
+    transaction = write_fragments(
+        table,
+        dataset_uri,
+        mode="create",
+        return_transaction=True,
+        data_storage_version="2.2",
+        external_blob_mode="reference",
+        allow_external_blob_outside_bases=True,
+    )
+    ds = lance.LanceDataset.commit(dataset_uri, transaction)
+
+    blob = ds.take_blobs("blob", indices=[0])[0]
+    assert blob.size() == 5
+    with blob as f:
+        assert f.read() == b"hello"
+
+
+def test_blob_extension_write_fragments_external_registered_base(tmp_path):
+    external_base = tmp_path / "external_base"
+    blob_path = external_base / "external_blob.bin"
+    dataset_uri = tmp_path / "test_fragments_v2_external_registered_base"
+
+    table = _external_blob_table(blob_path)
+    initial_bases = [DatasetBasePath(external_base.as_uri(), name="external", id=1)]
+    fragments = write_fragments(
+        table,
+        dataset_uri,
+        mode="create",
+        data_storage_version="2.2",
+        external_blob_mode="reference",
+        initial_bases=initial_bases,
+    )
+    ds = _commit_blob_fragments(
+        dataset_uri,
+        table.schema,
+        fragments,
+        initial_bases=initial_bases,
+    )
+
+    blob = ds.take_blobs("blob", indices=[0])[0]
+    assert blob.size() == 5
+    with blob as f:
+        assert f.read() == b"hello"
+
+
+def test_blob_extension_write_fragments_external_ingest(tmp_path):
+    blob_path = tmp_path / "external_blob.bin"
+    dataset_uri = tmp_path / "test_fragments_v2_external_ingest"
+
+    table = _external_blob_table(blob_path)
+    fragments = write_fragments(
+        table,
+        dataset_uri,
+        data_storage_version="2.2",
+        external_blob_mode="ingest",
+    )
+    ds = _commit_blob_fragments(dataset_uri, table.schema, fragments)
+
+    blob_path.unlink()
+
+    blob = ds.take_blobs("blob", indices=[0])[0]
+    assert blob.size() == 5
+    with blob as f:
+        assert f.read() == b"hello"
+
+
+def test_blob_extension_write_fragments_transaction_external_ingest(tmp_path):
+    blob_path = tmp_path / "external_blob.bin"
+    dataset_uri = tmp_path / "test_fragments_transaction_v2_external_ingest"
+
+    table = _external_blob_table(blob_path)
+    transaction = write_fragments(
+        table,
+        dataset_uri,
+        mode="create",
+        return_transaction=True,
+        data_storage_version="2.2",
+        external_blob_mode="ingest",
+    )
+    ds = lance.LanceDataset.commit(dataset_uri, transaction)
+
+    blob_path.unlink()
+
+    blob = ds.take_blobs("blob", indices=[0])[0]
+    assert blob.size() == 5
+    with blob as f:
+        assert f.read() == b"hello"
+
+
+def test_blob_extension_write_fragments_external_ingest_rejects_reference_only_options(
+    tmp_path,
+):
+    blob_path = tmp_path / "external_blob.bin"
+    message = (
+        "allow_external_blob_outside_bases only applies when "
+        'external_blob_mode="reference"'
+    )
+
+    table = _external_blob_table(blob_path)
+    with pytest.raises(OSError, match=message):
+        write_fragments(
+            table,
+            tmp_path / "test_fragments_v2_external_ingest_invalid",
             data_storage_version="2.2",
             external_blob_mode="ingest",
             allow_external_blob_outside_bases=True,


### PR DESCRIPTION
## Summary

Expose `external_blob_mode` and `allow_external_blob_outside_bases` on `lance.fragment.write_fragments`.

This brings the low-level fragment write API in line with `lance.write_dataset`, allowing distributed/manual fragment writers to control how BlobV2 external URIs are handled:

- `external_blob_mode="reference"` keeps external blob URI references.
- `external_blob_mode="ingest"` reads external blob bytes during fragment write and stores them in Lance-managed storage.
- `allow_external_blob_outside_bases=True` allows reference-mode writes to persist absolute external URIs outside registered base paths.

The native Python stub was also updated so the exposed kwargs are reflected in type declarations.

## Testing

Added BlobV2 fragment-write coverage for:

- Default reference-mode behavior rejecting external URIs outside registered base paths.
- Reference-mode writes allowing outside-base external URIs when `allow_external_blob_outside_bases=True`.
- Ingest-mode fragment writes copying external URI bytes into Lance-managed storage, verified by deleting the source file before reading the blob back.
- The `return_transaction=True` fragment-write path with `external_blob_mode="ingest"`.
- Invalid configuration rejection for `external_blob_mode="ingest"` combined with `allow_external_blob_outside_bases=True`.