### PR TITLE
feat: add index segment_seq metadata

### DIFF
--- a/docs/src/format/index/index.md
+++ b/docs/src/format/index/index.md
@@ -96,13 +96,15 @@ Index segments are created and updated through a transactional process:
    directory, where `{UUID}` is a newly generated unique identifier.
 
 2. **Prepare the metadata**: Create an `IndexMetadata` message with:
-   - `uuid`: The newly generated UUID
-   - `name`: The index name (must match existing segments if adding to an existing index)
-   - `fields`: The column(s) being indexed
-   - `fragment_bitmap`: The set of fragment IDs covered by this segment
-   - `index_details`: Index-specific configuration and parameters
-   - `version`: The format version of this index type
-   - See the full protobuf definition in [table.proto](https://github.com/lance-format/lance/blob/main/protos/table.proto).
+    - `uuid`: The newly generated UUID
+    - `name`: The index name (must match existing segments if adding to an existing index)
+    - `fields`: The column(s) being indexed
+    - `fragment_bitmap`: The set of fragment IDs covered by this segment
+    - `index_details`: Index-specific configuration and parameters
+    - `version`: The format version of this index type
+    - `segment_seq`: The sequence assigned when the physical segment is committed, scoped to the
+      index name
+    - See the full protobuf definition in [table.proto](https://github.com/lance-format/lance/blob/main/protos/table.proto).
 
 3. **Commit the transaction**: Write a new manifest that includes the new index segment
    in its `IndexSection`. This is done atomically using the same transaction mechanism
@@ -151,6 +153,10 @@ The `IndexMetadata` message contains important information about the index segme
 - `fragment_bitmap`: the set of fragment IDs covered by this index segment.
 - `index_details`: a protobuf `Any` message that contains index-specific details, such as index type,
   parameters, and storage format. This allows different index types to store their own metadata.
+- `segment_seq`: the monotonically increasing sequence number assigned when the physical segment is
+  committed. The sequence is scoped to the index name and starts at 1 for each index name. Missing
+  means the segment was written before `segment_seq` existed or the metadata has not reached the
+  commit layer yet.
 
 <details>
   <summary>Full protobuf definitions</summary>

--- a/docs/src/format/index/index.md
+++ b/docs/src/format/index/index.md
@@ -168,10 +168,9 @@ for that name is currently present:
   the same `segment_seq`. The value is preserved even when all physical segments for that index name
   are removed.
 
-Writers set `FLAG_INDEX_SEGMENT_SEQ` when physical segment metadata contains `segment_seq` and
-`FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER` when logical high-water metadata is present. Readers do not need
-either flag to scan data, but writers must preserve both metadata forms once the corresponding writer
-flag appears.
+Writers set `FLAG_INDEX_SEGMENT_SEQ` when physical segment metadata contains `segment_seq` or
+logical high-water metadata is present. Readers do not need the flag to scan data, but writers must
+preserve both metadata forms once the writer flag appears.
 
 <details>
   <summary>Full protobuf definitions</summary>

--- a/docs/src/format/index/index.md
+++ b/docs/src/format/index/index.md
@@ -137,7 +137,8 @@ When loading an index:
 
 1. Get the offset to the index section from the `index_section` field in the [manifest](../table/index.md#manifest).
 2. Read the index section from the manifest file. This is a protobuf message of type `IndexSection`, which
-   contains a list of `IndexMetadata` messages, each describing an index segment.
+   contains a list of `IndexMetadata` messages, each describing an index segment, and a list of
+   `LogicalIndexMetadata` messages, each describing persistent metadata for one index name.
 3. Read the index files from the `_indices/{UUID}` directory under the dataset directory,
    where `{UUID}` is the UUID of the index segment.
 
@@ -154,17 +155,33 @@ The `IndexMetadata` message contains important information about the index segme
 - `index_details`: a protobuf `Any` message that contains index-specific details, such as index type,
   parameters, and storage format. This allows different index types to store their own metadata.
 - `segment_seq`: the monotonically increasing sequence number assigned when the physical segment is
-  committed. The sequence is scoped to the index name and starts at 1 for each index name. Missing
-  means the segment was written before `segment_seq` existed or the metadata has not reached the
-  commit layer yet.
+  committed. The sequence is scoped to the index name; the first assigned value for each index name
+  is 1. Missing means the segment was written before `segment_seq` existed or the metadata has not
+  reached the commit layer yet.
+
+The `LogicalIndexMetadata` message stores metadata for an index name even when no physical segment
+for that name is currently present:
+
+- `index_name`: the logical index name.
+- `max_segment_seq`: the highest `segment_seq` that has been assigned for this index name. Writers use
+  this as the high-water mark so deleting the latest segment does not allow a later segment to reuse
+  the same `segment_seq`. The value is preserved even when all physical segments for that index name
+  are removed.
+
+Writers set `FLAG_INDEX_SEGMENT_SEQ` when physical segment metadata contains `segment_seq` and
+`FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER` when logical high-water metadata is present. Readers do not need
+either flag to scan data, but writers must preserve both metadata forms once the corresponding writer
+flag appears.
 
 <details>
   <summary>Full protobuf definitions</summary>
 
-There are both part of the `table.proto` file in the Lance source code.
+These are part of the `table.proto` file in the Lance source code.
 
 ```protobuf
 %%% proto.message.IndexSection %%%
+
+%%% proto.message.LogicalIndexMetadata %%%
 
 %%% proto.message.IndexMetadata %%%
 ```

--- a/docs/src/format/table/versioning.md
+++ b/docs/src/format/table/versioning.md
@@ -28,7 +28,9 @@ they should return an "unsupported" error on any read or write operation.
 | 4        | `FLAG_USE_V2_FORMAT_DEPRECATED` | No              | No              | Files are written with the new v2 format. This flag is deprecated and no longer used.                       |
 | 8        | `FLAG_TABLE_CONFIG`             | No              | Yes             | Table config is present in the manifest.                                                                    |
 | 16       | `FLAG_BASE_PATHS`               | Yes             | Yes             | Dataset uses multiple base paths (for shallow clones or multi-base datasets).                               |
+| 32       | `FLAG_DISABLE_TRANSACTION_FILE` | No              | Yes             | Transaction files under `_transactions/` are disabled.                                                       |
+| 64       | `FLAG_INDEX_SEGMENT_SEQ`        | No              | Yes             | Index segment metadata uses name-scoped `segment_seq`; writers must preserve monotonic assignment.           |
 
 </div>
 
-Flags with bit values 32 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.
+Flags with bit values 128 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.

--- a/docs/src/format/table/versioning.md
+++ b/docs/src/format/table/versioning.md
@@ -21,16 +21,17 @@ they should return an "unsupported" error on any read or write operation.
 
 <div class="feature-flags-table" markdown="1">
 
-| Flag Bit | Flag Name                       | Reader Required | Writer Required | Description                                                                                                 |
-|----------|---------------------------------|-----------------|-----------------|-------------------------------------------------------------------------------------------------------------|
-| 1        | `FLAG_DELETION_FILES`           | Yes             | Yes             | Fragments may contain deletion files, which record the tombstones of soft-deleted rows.                     |
-| 2        | `FLAG_STABLE_ROW_IDS`           | Yes             | Yes             | Row IDs are stable for both moves and updates. Fragments contain an index mapping row IDs to row addresses. |
-| 4        | `FLAG_USE_V2_FORMAT_DEPRECATED` | No              | No              | Files are written with the new v2 format. This flag is deprecated and no longer used.                       |
-| 8        | `FLAG_TABLE_CONFIG`             | No              | Yes             | Table config is present in the manifest.                                                                    |
-| 16       | `FLAG_BASE_PATHS`               | Yes             | Yes             | Dataset uses multiple base paths (for shallow clones or multi-base datasets).                               |
-| 32       | `FLAG_DISABLE_TRANSACTION_FILE` | No              | Yes             | Transaction files under `_transactions/` are disabled.                                                       |
-| 64       | `FLAG_INDEX_SEGMENT_SEQ`        | No              | Yes             | Index segment metadata uses name-scoped `segment_seq`; writers must preserve monotonic assignment.           |
+| Flag Bit | Flag Name                               | Reader Required | Writer Required | Description                                                                                                 |
+|----------|-----------------------------------------|-----------------|-----------------|-------------------------------------------------------------------------------------------------------------|
+| 1        | `FLAG_DELETION_FILES`                   | Yes             | Yes             | Fragments may contain deletion files, which record the tombstones of soft-deleted rows.                     |
+| 2        | `FLAG_STABLE_ROW_IDS`                   | Yes             | Yes             | Row IDs are stable for both moves and updates. Fragments contain an index mapping row IDs to row addresses. |
+| 4        | `FLAG_USE_V2_FORMAT_DEPRECATED`         | No              | No              | Files are written with the new v2 format. This flag is deprecated and no longer used.                       |
+| 8        | `FLAG_TABLE_CONFIG`                     | No              | Yes             | Table config is present in the manifest.                                                                    |
+| 16       | `FLAG_BASE_PATHS`                       | Yes             | Yes             | Dataset uses multiple base paths (for shallow clones or multi-base datasets).                               |
+| 32       | `FLAG_DISABLE_TRANSACTION_FILE`         | No              | Yes             | Transaction files under `_transactions/` are disabled.                                                       |
+| 64       | `FLAG_INDEX_SEGMENT_SEQ`                | No              | Yes             | Index metadata uses name-scoped `segment_seq`; writers must preserve physical segment assignments.          |
+| 128      | `FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER`     | No              | Yes             | Index sections store logical high-water marks; writers must preserve monotonic `segment_seq` assignment.    |
 
 </div>
 
-Flags with bit values 128 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.
+Flags with bit values 256 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.

--- a/docs/src/format/table/versioning.md
+++ b/docs/src/format/table/versioning.md
@@ -21,17 +21,16 @@ they should return an "unsupported" error on any read or write operation.
 
 <div class="feature-flags-table" markdown="1">
 
-| Flag Bit | Flag Name                               | Reader Required | Writer Required | Description                                                                                                 |
-|----------|-----------------------------------------|-----------------|-----------------|-------------------------------------------------------------------------------------------------------------|
-| 1        | `FLAG_DELETION_FILES`                   | Yes             | Yes             | Fragments may contain deletion files, which record the tombstones of soft-deleted rows.                     |
-| 2        | `FLAG_STABLE_ROW_IDS`                   | Yes             | Yes             | Row IDs are stable for both moves and updates. Fragments contain an index mapping row IDs to row addresses. |
-| 4        | `FLAG_USE_V2_FORMAT_DEPRECATED`         | No              | No              | Files are written with the new v2 format. This flag is deprecated and no longer used.                       |
-| 8        | `FLAG_TABLE_CONFIG`                     | No              | Yes             | Table config is present in the manifest.                                                                    |
-| 16       | `FLAG_BASE_PATHS`                       | Yes             | Yes             | Dataset uses multiple base paths (for shallow clones or multi-base datasets).                               |
-| 32       | `FLAG_DISABLE_TRANSACTION_FILE`         | No              | Yes             | Transaction files under `_transactions/` are disabled.                                                       |
-| 64       | `FLAG_INDEX_SEGMENT_SEQ`                | No              | Yes             | Index metadata uses name-scoped `segment_seq`; writers must preserve physical segment assignments.          |
-| 128      | `FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER`     | No              | Yes             | Index sections store logical high-water marks; writers must preserve monotonic `segment_seq` assignment.    |
+| Flag Bit | Flag Name                       | Reader Required | Writer Required | Description                                                                                                 |
+|----------|---------------------------------|-----------------|-----------------|-------------------------------------------------------------------------------------------------------------|
+| 1        | `FLAG_DELETION_FILES`           | Yes             | Yes             | Fragments may contain deletion files, which record the tombstones of soft-deleted rows.                     |
+| 2        | `FLAG_STABLE_ROW_IDS`           | Yes             | Yes             | Row IDs are stable for both moves and updates. Fragments contain an index mapping row IDs to row addresses. |
+| 4        | `FLAG_USE_V2_FORMAT_DEPRECATED` | No              | No              | Files are written with the new v2 format. This flag is deprecated and no longer used.                       |
+| 8        | `FLAG_TABLE_CONFIG`             | No              | Yes             | Table config is present in the manifest.                                                                    |
+| 16       | `FLAG_BASE_PATHS`               | Yes             | Yes             | Dataset uses multiple base paths (for shallow clones or multi-base datasets).                               |
+| 32       | `FLAG_DISABLE_TRANSACTION_FILE` | No              | Yes             | Transaction files under `_transactions/` are disabled.                                                       |
+| 64       | `FLAG_INDEX_SEGMENT_SEQ`        | No              | Yes             | Index metadata uses name-scoped `segment_seq` and logical high-water marks; writers must preserve monotonic assignment. |
 
 </div>
 
-Flags with bit values 256 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.
+Flags with bit values 128 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3910,6 +3910,7 @@ dependencies = [
  "itertools 0.13.0",
  "lance-arrow",
  "libc",
+ "libm",
  "log",
  "moka",
  "num_cpus",
@@ -3925,6 +3926,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "twox-hash",
  "url",
 ]
 
@@ -4104,7 +4106,6 @@ dependencies = [
  "lance-select",
  "lance-table",
  "lance-tokenizer",
- "libm",
  "libsais-rs",
  "log",
  "ndarray",
@@ -4124,7 +4125,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "twox-hash",
  "uuid",
 ]
 

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1205,23 +1205,6 @@ fn index_metadata_to_segment(metadata: &IndexMetadata) -> Result<IndexSegment> {
     ))
 }
 
-fn index_segment_to_metadata(template: &SegmentTemplate, segment: IndexSegment) -> IndexMetadata {
-    let (uuid, fragment_bitmap, index_details, index_version) = segment.into_parts();
-    IndexMetadata {
-        uuid,
-        fields: template.fields.clone(),
-        name: template.name.clone(),
-        dataset_version: template.dataset_version,
-        fragment_bitmap: Some(fragment_bitmap),
-        index_details: Some(index_details),
-        index_version,
-        created_at: Some(Utc::now()),
-        base_id: None,
-        files: None,
-        segment_seq: None,
-    }
-}
-
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_org_lance_Dataset_nativeOptimizeIndices(
     mut env: JNIEnv,

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1205,6 +1205,23 @@ fn index_metadata_to_segment(metadata: &IndexMetadata) -> Result<IndexSegment> {
     ))
 }
 
+fn index_segment_to_metadata(template: &SegmentTemplate, segment: IndexSegment) -> IndexMetadata {
+    let (uuid, fragment_bitmap, index_details, index_version) = segment.into_parts();
+    IndexMetadata {
+        uuid,
+        fields: template.fields.clone(),
+        name: template.name.clone(),
+        dataset_version: template.dataset_version,
+        fragment_bitmap: Some(fragment_bitmap),
+        index_details: Some(index_details),
+        index_version,
+        created_at: Some(Utc::now()),
+        base_id: None,
+        files: None,
+        segment_seq: None,
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_org_lance_Dataset_nativeOptimizeIndices(
     mut env: JNIEnv,

--- a/java/lance-jni/src/index.rs
+++ b/java/lance-jni/src/index.rs
@@ -124,6 +124,11 @@ impl IntoJava for &IndexMetadata {
         } else {
             JObject::null()
         };
+        let segment_seq = if let Some(seq) = self.segment_seq {
+            env.new_object("java/lang/Long", "(J)V", &[JValue::Long(seq as i64)])?
+        } else {
+            JObject::null()
+        };
 
         // Determine index type from index_details type_url
         let index_type = determine_index_type(env, &self.index_details)?;
@@ -131,7 +136,7 @@ impl IntoJava for &IndexMetadata {
         // Create Index object
         Ok(env.new_object(
             "org/lance/index/Index",
-            "(Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;JLjava/util/List;[BILjava/time/Instant;Ljava/lang/Integer;Lorg/lance/index/IndexType;)V",
+            "(Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;JLjava/util/List;[BILjava/time/Instant;Ljava/lang/Integer;Lorg/lance/index/IndexType;Ljava/lang/Long;)V",
             &[
                 JValue::Object(&uuid),
                 JValue::Object(&fields),
@@ -143,6 +148,7 @@ impl IntoJava for &IndexMetadata {
                 JValue::Object(&created_at),
                 JValue::Object(&base_id),
                 JValue::Object(&index_type),
+                JValue::Object(&segment_seq),
             ],
         )?)
     }

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -203,6 +203,7 @@ impl FromJObjectWithEnv<IndexMetadata> for JObject<'_> {
                 Ok(DateTime::from_timestamp(seconds, nanos).unwrap())
             })?;
         let base_id = env.get_optional_u32_from_method(self, "baseId")?;
+        let segment_seq = env.get_optional_u64_from_method(self, "segmentSeq")?;
 
         Ok(IndexMetadata {
             uuid,
@@ -215,6 +216,7 @@ impl FromJObjectWithEnv<IndexMetadata> for JObject<'_> {
             created_at,
             base_id,
             files: None,
+            segment_seq,
         })
     }
 }

--- a/java/src/main/java/org/lance/index/Index.java
+++ b/java/src/main/java/org/lance/index/Index.java
@@ -37,6 +37,7 @@ public class Index {
   private final Instant createdAt;
   private final Integer baseId;
   private final IndexType indexType;
+  private final Long segmentSeq;
 
   private Index(
       UUID uuid,
@@ -48,7 +49,8 @@ public class Index {
       int indexVersion,
       Instant createdAt,
       Integer baseId,
-      IndexType indexType) {
+      IndexType indexType,
+      Long segmentSeq) {
     this.uuid = uuid;
     this.fields = fields;
     this.name = name;
@@ -59,6 +61,7 @@ public class Index {
     this.createdAt = createdAt;
     this.baseId = baseId;
     this.indexType = indexType;
+    this.segmentSeq = segmentSeq;
   }
 
   public UUID uuid() {
@@ -131,6 +134,15 @@ public class Index {
     return indexType;
   }
 
+  /**
+   * Dataset-wide monotonically increasing sequence for this physical index segment.
+   *
+   * @return the segment sequence, if present
+   */
+  public Optional<Long> segmentSeq() {
+    return Optional.ofNullable(segmentSeq);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -145,7 +157,8 @@ public class Index {
         && Arrays.equals(indexDetails, index.indexDetails)
         && Objects.equals(createdAt, index.createdAt)
         && Objects.equals(baseId, index.baseId)
-        && indexType == index.indexType;
+        && indexType == index.indexType
+        && Objects.equals(segmentSeq, index.segmentSeq);
   }
 
   @Override
@@ -160,7 +173,8 @@ public class Index {
             createdAt,
             baseId,
             fragments,
-            indexType);
+            indexType,
+            segmentSeq);
     result = 31 * result + Arrays.hashCode(indexDetails);
     return result;
   }
@@ -176,6 +190,7 @@ public class Index {
         .add("indexType", indexType)
         .add("createdAt", createdAt)
         .add("baseId", baseId)
+        .add("segmentSeq", segmentSeq)
         .toString();
   }
 
@@ -200,6 +215,7 @@ public class Index {
     private Instant createdAt;
     private Integer baseId;
     private IndexType indexType;
+    private Long segmentSeq;
 
     private Builder() {}
 
@@ -253,6 +269,11 @@ public class Index {
       return this;
     }
 
+    public Builder segmentSeq(Long segmentSeq) {
+      this.segmentSeq = segmentSeq;
+      return this;
+    }
+
     public Index build() {
       return new Index(
           uuid,
@@ -264,7 +285,8 @@ public class Index {
           indexVersion,
           createdAt,
           baseId,
-          indexType);
+          indexType,
+          segmentSeq);
     }
   }
 }

--- a/java/src/test/java/org/lance/index/VectorIndexTest.java
+++ b/java/src/test/java/org/lance/index/VectorIndexTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -100,6 +101,12 @@ public class VectorIndexTest {
                 TestVectorDataset.vectorColumnName,
                 List.of(firstSegment, secondSegment));
         assertEquals(2, committed.size());
+        assertEquals(
+            List.of(1L, 2L),
+            committed.stream()
+                .map(index -> index.segmentSeq().orElseThrow())
+                .sorted()
+                .collect(Collectors.toList()));
         assertTrue(dataset.listIndexes().contains(TestVectorDataset.indexName));
       }
     }

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -113,6 +113,8 @@ message Manifest {
   // * 2: row ids are stable and stored as part of the fragment metadata.
   // * 4: use v2 format (deprecated)
   // * 8: table config is present
+  // * 16: dataset uses multiple base paths
+  // * 32: transaction files are disabled
   uint64 reader_feature_flags = 9;
 
   // Feature flags for writers.
@@ -123,6 +125,9 @@ message Manifest {
   //
   // The flag identities are the same as for reader_feature_flags, but the values of
   // reader_feature_flags and writer_feature_flags are not required to be identical.
+  //
+  // Writer-only flags:
+  // * 64: index segments use segment_seq
   uint64 writer_feature_flags = 10;
 
   // The highest fragment ID that has been used so far.
@@ -286,6 +291,14 @@ message IndexMetadata {
   // of index sizes without extra IO.
   // If this is empty, the index files sizes are unknown.
   repeated IndexFile files = 10;
+
+  // Monotonically increasing sequence number for this index segment, scoped to
+  // the index name.
+  //
+  // Starts at 1 for each index name. Missing means the segment was written
+  // before this feature or is uncommitted metadata that has not reached the
+  // commit layer yet.
+  optional uint64 segment_seq = 11;
 }
 
 // Metadata about a single file within an index segment.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -309,9 +309,19 @@ message IndexFile {
   uint64 size_bytes = 2;
 }
 
+// Metadata about one logical index name.
+message LogicalIndexMetadata {
+  // Logical index name.
+  string index_name = 1;
+
+  // Highest segment_seq that has ever been assigned for this logical index.
+  optional uint64 max_segment_seq = 2;
+}
+
 // Index Section, containing a list of index metadata for one dataset version.
 message IndexSection {
   repeated IndexMetadata indices = 1;
+  repeated LogicalIndexMetadata logical_indexes = 2;
 }
 
 // A DataFragment is a set of files which represent the different columns of the same

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5370,6 +5370,7 @@ class Index:
     base_id: Optional[int] = None
     files: Optional[List["IndexFile"]] = None
     index_details: Optional[Tuple[str, bytes]] = None
+    segment_seq: Optional[int] = None
 
 
 class IndexInformation(TypedDict):

--- a/python/python/lance/lance/indices/__init__.pyi
+++ b/python/python/lance/lance/indices/__init__.pyi
@@ -73,6 +73,7 @@ class IndexSegmentDescription:
     created_at: Optional[datetime]
     size_bytes: Optional[int]
     base_id: Optional[int]
+    segment_seq: Optional[int]
 
     def __repr__(self) -> str: ...
 

--- a/python/python/tests/compat/compat_decorator.py
+++ b/python/python/tests/compat/compat_decorator.py
@@ -157,6 +157,10 @@ class UpgradeDowngradeTest:
         """Return True to skip the current-write -> old-read downgrade test."""
         return False
 
+    def expected_write_error_after_current_write(self, version: str) -> Optional[str]:
+        """Return expected error text when old writers cannot write current data."""
+        return None
+
     def current_env(self, method_name: str) -> Dict[str, str]:
         """Return environment overrides for methods executed in the current runtime."""
         return {}
@@ -334,7 +338,7 @@ def test_func({sig_params}):
     # Old version: verify can read
     venv = venv_factory.get_venv(version)
     venv.execute_method(obj, "check_read", obj.compat_env(version, "check_read"))
-    venv.execute_method(obj, "check_write", obj.compat_env(version, "check_write"))
+    _check_write_after_current_write(obj, venv, version)
 '''
     else:  # upgrade_downgrade
         func_body = f'''
@@ -353,10 +357,26 @@ def test_func({sig_params}):
         obj.check_write()
     # Old version: verify can still read
     venv.execute_method(obj, "check_read", obj.compat_env(version, "check_read"))
-    venv.execute_method(obj, "check_write", obj.compat_env(version, "check_write"))
+    _check_write_after_current_write(obj, venv, version)
 '''
 
     # Execute to create the function
-    namespace = {"cls": cls, "_temporary_env": _temporary_env, "pytest": pytest}
+    namespace = {
+        "cls": cls,
+        "_temporary_env": _temporary_env,
+        "_check_write_after_current_write": _check_write_after_current_write,
+        "pytest": pytest,
+    }
     exec(func_body, namespace)
     return namespace["test_func"]
+
+
+def _check_write_after_current_write(obj, venv, version: str):
+    expected = obj.expected_write_error_after_current_write(version)
+    if expected is None:
+        venv.execute_method(obj, "check_write", obj.compat_env(version, "check_write"))
+        return
+
+    with pytest.raises(RuntimeError) as exc:
+        venv.execute_method(obj, "check_write", obj.compat_env(version, "check_write"))
+    assert expected in str(exc.value)

--- a/python/python/tests/compat/test_scalar_indices.py
+++ b/python/python/tests/compat/test_scalar_indices.py
@@ -5,8 +5,9 @@
 Scalar index compatibility tests for Lance.
 
 Tests that scalar indices (BTREE, BITMAP, LABEL_LIST, NGRAM, ZONEMAP,
-BLOOMFILTER, JSON, FTS) created with one version of Lance can be read
-and written by other versions.
+BLOOMFILTER, JSON, FTS) created with one version of Lance can be read by
+other versions. Older writers are expected to reject current index metadata
+once writer-only compatibility flags are set.
 """
 
 import shutil
@@ -22,8 +23,13 @@ from .compat_decorator import (
 from .util import safe_data_storage_version
 
 
+class ScalarIndexForwardCompatTest(UpgradeDowngradeTest):
+    def expected_write_error_after_current_write(self, version: str) -> str:
+        return "This dataset cannot be written by this version of Lance"
+
+
 @compat_test(min_version="0.30.0")
-class BTreeIndex(UpgradeDowngradeTest):
+class BTreeIndex(ScalarIndexForwardCompatTest):
     """Test BTREE scalar index compatibility (introduced in 0.20.0).
 
     Started fully working in 0.30.0 with various fixes.
@@ -79,7 +85,7 @@ class BTreeIndex(UpgradeDowngradeTest):
 
 
 @compat_test(min_version="0.22.0")
-class BitmapLabelListIndex(UpgradeDowngradeTest):
+class BitmapLabelListIndex(ScalarIndexForwardCompatTest):
     """Test BITMAP and LABEL_LIST scalar index compatibility (introduced in 0.20.0).
 
     Started fully working in 0.22.0 with fixes to LABEL_LIST index.
@@ -137,7 +143,7 @@ class BitmapLabelListIndex(UpgradeDowngradeTest):
 
 
 @compat_test(min_version="0.36.0")
-class NgramIndex(UpgradeDowngradeTest):
+class NgramIndex(ScalarIndexForwardCompatTest):
     """Test NGRAM index compatibility (introduced in 0.36.0)."""
 
     def __init__(self, path: Path):
@@ -186,7 +192,7 @@ class NgramIndex(UpgradeDowngradeTest):
 
 
 @compat_test(min_version="0.36.0")
-class ZonemapBloomfilterIndex(UpgradeDowngradeTest):
+class ZonemapBloomfilterIndex(ScalarIndexForwardCompatTest):
     """Test ZONEMAP and BLOOMFILTER index compatibility (introduced in 0.36.0)."""
 
     def __init__(self, path: Path):
@@ -241,7 +247,7 @@ class ZonemapBloomfilterIndex(UpgradeDowngradeTest):
 
 
 @compat_test(min_version="0.36.0")
-class JsonIndex(UpgradeDowngradeTest):
+class JsonIndex(ScalarIndexForwardCompatTest):
     """Test JSON index compatibility (introduced in 0.36.0)."""
 
     def __init__(self, path: Path):
@@ -297,7 +303,7 @@ class JsonIndex(UpgradeDowngradeTest):
 
 
 @compat_test(min_version="0.36.0")
-class FtsIndex(UpgradeDowngradeTest):
+class FtsIndex(ScalarIndexForwardCompatTest):
     """Test FTS (full-text search) index compatibility (introduced in 0.36.0)."""
 
     def __init__(self, path: Path):

--- a/python/python/tests/compat/test_vector_indices.py
+++ b/python/python/tests/compat/test_vector_indices.py
@@ -5,7 +5,8 @@
 Vector index compatibility tests for Lance.
 
 Tests that vector indices (IVF_PQ, etc.) created with one version of Lance
-can be read and written by other versions.
+can be read by other versions. Older writers are expected to reject current
+index metadata once writer-only compatibility flags are set.
 """
 
 import os
@@ -24,8 +25,13 @@ from .compat_decorator import (
 from .util import safe_data_storage_version
 
 
+class VectorIndexForwardCompatTest(UpgradeDowngradeTest):
+    def expected_write_error_after_current_write(self, version: str) -> str:
+        return "This dataset cannot be written by this version of Lance"
+
+
 @compat_test(min_version="0.29.1.beta2")
-class PqVectorIndex(UpgradeDowngradeTest):
+class PqVectorIndex(VectorIndexForwardCompatTest):
     """Test PQ (Product Quantization) vector index compatibility."""
 
     def __init__(self, path: Path):
@@ -101,7 +107,7 @@ class PqVectorIndex(UpgradeDowngradeTest):
 
 
 @compat_test(min_version="0.39.0")
-class HnswPqVectorIndex(UpgradeDowngradeTest):
+class HnswPqVectorIndex(VectorIndexForwardCompatTest):
     """Test IVF_HNSW_PQ vector index compatibility.
 
     Note: Only tests versions >= 0.39.0 because earlier versions don't support
@@ -182,7 +188,7 @@ class HnswPqVectorIndex(UpgradeDowngradeTest):
 
 
 @compat_test(min_version="0.39.0")
-class HnswSqVectorIndex(UpgradeDowngradeTest):
+class HnswSqVectorIndex(VectorIndexForwardCompatTest):
     """Test IVF_HNSW_SQ vector index compatibility.
 
     Note: Only tests versions >= 0.39.0 because earlier versions don't support
@@ -263,7 +269,7 @@ class HnswSqVectorIndex(UpgradeDowngradeTest):
 
 
 @compat_test(min_version="4.0.0-beta.8")
-class IvfRqVectorIndex(UpgradeDowngradeTest):
+class IvfRqVectorIndex(VectorIndexForwardCompatTest):
     """Test IVF_RQ vector index compatibility. V2 was introduced in v4.0.0-beta.8"""
 
     def __init__(self, path: Path):

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -3100,6 +3100,9 @@ def test_commit_existing_index_segments_accepts_uncommitted_vector_segments(tmp_
 
     assert len(segments) == 2
     ds = ds.commit_existing_index_segments("vector_idx", "vector", segments)
+    desc = next(desc for desc in ds.describe_indices() if desc.name == "vector_idx")
+    segment_seqs = sorted(segment.segment_seq for segment in desc.segments)
+    assert segment_seqs == [1, 2]
 
     q = np.random.rand(128).astype(np.float32)
     results = ds.to_table(nearest={"column": "vector", "q": q, "k": 5})

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -542,6 +542,7 @@ async fn do_load_shuffled_vectors(
         created_at: Some(Utc::now()),
         base_id: None,
         files: Some(files),
+        segment_seq: None,
     };
     let segment = IndexSegment::new(
         metadata.uuid,
@@ -637,6 +638,8 @@ pub struct PyIndexSegmentDescription {
     /// The id of the dataset base path that stores this segment
     /// (None when the segment is stored in the dataset's default base path)
     pub base_id: Option<i64>,
+    /// Monotonically increasing sequence for this segment within its index name
+    pub segment_seq: Option<u64>,
 }
 
 impl PyIndexSegmentDescription {
@@ -656,19 +659,21 @@ impl PyIndexSegmentDescription {
             created_at: segment.created_at,
             size_bytes,
             base_id: segment.base_id.map(|id| id as i64),
+            segment_seq: segment.segment_seq,
         }
     }
 
     pub fn __repr__(&self) -> String {
         format!(
-            "IndexSegmentDescription(uuid={}, dataset_version_at_last_update={}, fragment_ids={:?}, index_version={}, created_at={:?}, size_bytes={:?}, base_id={:?})",
+            "IndexSegmentDescription(uuid={}, dataset_version_at_last_update={}, fragment_ids={:?}, index_version={}, created_at={:?}, size_bytes={:?}, base_id={:?}, segment_seq={:?})",
             self.uuid,
             self.dataset_version_at_last_update,
             self.fragment_ids,
             self.index_version,
             self.created_at,
             self.size_bytes,
-            self.base_id
+            self.base_id,
+            self.segment_seq
         )
     }
 }

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -86,6 +86,10 @@ impl FromPyObject<'_, '_> for PyLance<IndexMetadata> {
             .getattr("files")?
             .extract::<Option<Vec<PyLance<IndexFile>>>>()?
             .map(|v| v.into_iter().map(|f| f.0).collect());
+        let segment_seq = match ob.getattr("segment_seq") {
+            Ok(segment_seq) => segment_seq.extract()?,
+            Err(_) => None,
+        };
         let index_details = match ob.getattr("index_details") {
             Ok(details) => details
                 .extract::<Option<(String, Vec<u8>)>>()?
@@ -104,6 +108,7 @@ impl FromPyObject<'_, '_> for PyLance<IndexMetadata> {
             created_at,
             base_id,
             files,
+            segment_seq,
         }))
     }
 }
@@ -146,6 +151,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&IndexMetadata> {
             .index_details
             .as_ref()
             .map(|details| (details.type_url.clone(), details.value.clone()));
+        let segment_seq = self.0.segment_seq;
 
         let cls = namespace
             .getattr("Index")
@@ -161,6 +167,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&IndexMetadata> {
             base_id,
             files,
             index_details,
+            segment_seq,
         ))
     }
 }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -20,10 +20,12 @@ pub const FLAG_TABLE_CONFIG: u64 = 8;
 pub const FLAG_BASE_PATHS: u64 = 16;
 /// Disable writing transaction file under _transaction/, this flag is set when we only want to write inline transaction in manifest
 pub const FLAG_DISABLE_TRANSACTION_FILE: u64 = 32;
-/// Index segment metadata uses segment_seq and writers must preserve monotonic assignment.
+/// Index metadata uses segment_seq.
 pub const FLAG_INDEX_SEGMENT_SEQ: u64 = 64;
+/// Index section stores logical high-water marks for segment_seq assignment.
+pub const FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER: u64 = 128;
 /// The first bit that is unknown as a feature flag
-pub const FLAG_UNKNOWN: u64 = 128;
+pub const FLAG_UNKNOWN: u64 = 256;
 
 /// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
 pub fn apply_feature_flags(
@@ -106,6 +108,7 @@ mod tests {
         assert!(can_read_dataset(super::FLAG_BASE_PATHS));
         assert!(can_read_dataset(super::FLAG_DISABLE_TRANSACTION_FILE));
         assert!(can_read_dataset(super::FLAG_INDEX_SEGMENT_SEQ));
+        assert!(can_read_dataset(super::FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER));
         assert!(can_read_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_STABLE_ROW_IDS
@@ -124,6 +127,7 @@ mod tests {
         assert!(can_write_dataset(super::FLAG_BASE_PATHS));
         assert!(can_write_dataset(super::FLAG_DISABLE_TRANSACTION_FILE));
         assert!(can_write_dataset(super::FLAG_INDEX_SEGMENT_SEQ));
+        assert!(can_write_dataset(super::FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER));
         assert!(can_write_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_STABLE_ROW_IDS
@@ -132,6 +136,7 @@ mod tests {
                 | super::FLAG_BASE_PATHS
                 | super::FLAG_DISABLE_TRANSACTION_FILE
                 | super::FLAG_INDEX_SEGMENT_SEQ
+                | super::FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER
         ));
         assert!(!can_write_dataset(super::FLAG_UNKNOWN));
     }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -20,12 +20,10 @@ pub const FLAG_TABLE_CONFIG: u64 = 8;
 pub const FLAG_BASE_PATHS: u64 = 16;
 /// Disable writing transaction file under _transaction/, this flag is set when we only want to write inline transaction in manifest
 pub const FLAG_DISABLE_TRANSACTION_FILE: u64 = 32;
-/// Index metadata uses segment_seq.
+/// Index metadata uses segment_seq and logical high-water marks.
 pub const FLAG_INDEX_SEGMENT_SEQ: u64 = 64;
-/// Index section stores logical high-water marks for segment_seq assignment.
-pub const FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER: u64 = 128;
 /// The first bit that is unknown as a feature flag
-pub const FLAG_UNKNOWN: u64 = 256;
+pub const FLAG_UNKNOWN: u64 = 128;
 
 /// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
 pub fn apply_feature_flags(
@@ -108,7 +106,6 @@ mod tests {
         assert!(can_read_dataset(super::FLAG_BASE_PATHS));
         assert!(can_read_dataset(super::FLAG_DISABLE_TRANSACTION_FILE));
         assert!(can_read_dataset(super::FLAG_INDEX_SEGMENT_SEQ));
-        assert!(can_read_dataset(super::FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER));
         assert!(can_read_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_STABLE_ROW_IDS
@@ -127,7 +124,6 @@ mod tests {
         assert!(can_write_dataset(super::FLAG_BASE_PATHS));
         assert!(can_write_dataset(super::FLAG_DISABLE_TRANSACTION_FILE));
         assert!(can_write_dataset(super::FLAG_INDEX_SEGMENT_SEQ));
-        assert!(can_write_dataset(super::FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER));
         assert!(can_write_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_STABLE_ROW_IDS
@@ -136,7 +132,6 @@ mod tests {
                 | super::FLAG_BASE_PATHS
                 | super::FLAG_DISABLE_TRANSACTION_FILE
                 | super::FLAG_INDEX_SEGMENT_SEQ
-                | super::FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER
         ));
         assert!(!can_write_dataset(super::FLAG_UNKNOWN));
     }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -20,8 +20,10 @@ pub const FLAG_TABLE_CONFIG: u64 = 8;
 pub const FLAG_BASE_PATHS: u64 = 16;
 /// Disable writing transaction file under _transaction/, this flag is set when we only want to write inline transaction in manifest
 pub const FLAG_DISABLE_TRANSACTION_FILE: u64 = 32;
+/// Index segment metadata uses segment_seq and writers must preserve monotonic assignment.
+pub const FLAG_INDEX_SEGMENT_SEQ: u64 = 64;
 /// The first bit that is unknown as a feature flag
-pub const FLAG_UNKNOWN: u64 = 64;
+pub const FLAG_UNKNOWN: u64 = 128;
 
 /// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
 pub fn apply_feature_flags(
@@ -103,6 +105,7 @@ mod tests {
         assert!(can_read_dataset(super::FLAG_TABLE_CONFIG));
         assert!(can_read_dataset(super::FLAG_BASE_PATHS));
         assert!(can_read_dataset(super::FLAG_DISABLE_TRANSACTION_FILE));
+        assert!(can_read_dataset(super::FLAG_INDEX_SEGMENT_SEQ));
         assert!(can_read_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_STABLE_ROW_IDS
@@ -120,12 +123,15 @@ mod tests {
         assert!(can_write_dataset(super::FLAG_TABLE_CONFIG));
         assert!(can_write_dataset(super::FLAG_BASE_PATHS));
         assert!(can_write_dataset(super::FLAG_DISABLE_TRANSACTION_FILE));
+        assert!(can_write_dataset(super::FLAG_INDEX_SEGMENT_SEQ));
         assert!(can_write_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_STABLE_ROW_IDS
                 | super::FLAG_USE_V2_FORMAT_DEPRECATED
                 | super::FLAG_TABLE_CONFIG
                 | super::FLAG_BASE_PATHS
+                | super::FLAG_DISABLE_TRANSACTION_FILE
+                | super::FLAG_INDEX_SEGMENT_SEQ
         ));
         assert!(!can_write_dataset(super::FLAG_UNKNOWN));
     }

--- a/rust/lance-table/src/format.rs
+++ b/rust/lance-table/src/format.rs
@@ -13,7 +13,10 @@ pub use crate::rowids::version::{
     RowDatasetVersionMeta, RowDatasetVersionRun, RowDatasetVersionSequence,
 };
 pub use fragment::*;
-pub use index::{IndexFile, IndexMetadata, index_metadata_codec, list_index_files_with_sizes};
+pub use index::{
+    IndexFile, IndexMetadata, IndexSection, LogicalIndexMetadata, index_metadata_codec,
+    list_index_files_with_sizes,
+};
 
 pub use manifest::{
     BasePath, DETACHED_VERSION_MASK, DataStorageFormat, Manifest, SelfDescribingFileReader,

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -76,6 +76,12 @@ pub struct IndexMetadata {
     /// This is None if the file sizes are unknown. This happens for indices created
     /// before this field was added.
     pub files: Option<Vec<IndexFile>>,
+
+    /// Monotonically increasing sequence for this physical segment within its index name.
+    ///
+    /// This is None for legacy segments and uncommitted segment metadata. The commit
+    /// layer assigns it before a segment is written to a manifest.
+    pub segment_seq: Option<u64>,
 }
 
 impl IndexMetadata {
@@ -132,6 +138,7 @@ impl DeepSizeOf for IndexMetadata {
                 .map(|fragment_bitmap| fragment_bitmap.serialized_size())
                 .unwrap_or(0)
             + self.files.deep_size_of_children(context)
+            + self.segment_seq.deep_size_of_children(context)
     }
 }
 
@@ -178,6 +185,7 @@ impl TryFrom<pb::IndexMetadata> for IndexMetadata {
             }),
             base_id: proto.base_id,
             files,
+            segment_seq: proto.segment_seq,
         })
     }
 }
@@ -222,6 +230,7 @@ impl From<&IndexMetadata> for pb::IndexMetadata {
             created_at: idx.created_at.map(|dt| dt.timestamp_millis() as u64),
             base_id: idx.base_id,
             files,
+            segment_seq: idx.segment_seq,
         }
     }
 }
@@ -319,6 +328,7 @@ mod tests {
                     path: "index.idx".to_string(),
                     size_bytes: 1024,
                 }]),
+                segment_seq: Some(1),
             },
             IndexMetadata {
                 uuid: Uuid::new_v4(),
@@ -331,6 +341,7 @@ mod tests {
                 created_at: None,
                 base_id: Some(7),
                 files: None,
+                segment_seq: None,
             },
         ];
 

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -26,6 +26,45 @@ pub struct IndexFile {
     pub size_bytes: u64,
 }
 
+/// Metadata about one logical index name.
+#[derive(Debug, Clone, PartialEq, Eq, DeepSizeOf)]
+pub struct LogicalIndexMetadata {
+    /// Logical index name.
+    pub index_name: String,
+
+    /// Highest segment_seq assigned for this logical index.
+    pub max_segment_seq: Option<u64>,
+}
+
+/// Index section metadata.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct IndexSection {
+    /// Physical index segments.
+    pub indices: Vec<IndexMetadata>,
+
+    /// Logical index metadata, including per-index high-water marks.
+    pub logical_indexes: Vec<LogicalIndexMetadata>,
+}
+
+impl IndexSection {
+    pub fn new(indices: Vec<IndexMetadata>) -> Self {
+        Self {
+            indices,
+            logical_indexes: Vec::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_empty() && self.logical_indexes.is_empty()
+    }
+}
+
+impl From<Vec<IndexMetadata>> for IndexSection {
+    fn from(indices: Vec<IndexMetadata>) -> Self {
+        Self::new(indices)
+    }
+}
+
 /// Index metadata
 #[derive(Debug, Clone, PartialEq)]
 pub struct IndexMetadata {
@@ -235,10 +274,64 @@ impl From<&IndexMetadata> for pb::IndexMetadata {
     }
 }
 
+impl From<&LogicalIndexMetadata> for pb::LogicalIndexMetadata {
+    fn from(metadata: &LogicalIndexMetadata) -> Self {
+        Self {
+            index_name: metadata.index_name.clone(),
+            max_segment_seq: metadata.max_segment_seq,
+        }
+    }
+}
+
+impl From<pb::LogicalIndexMetadata> for LogicalIndexMetadata {
+    fn from(proto: pb::LogicalIndexMetadata) -> Self {
+        Self {
+            index_name: proto.index_name,
+            max_segment_seq: proto.max_segment_seq,
+        }
+    }
+}
+
+impl From<&IndexSection> for pb::IndexSection {
+    fn from(section: &IndexSection) -> Self {
+        Self {
+            indices: section
+                .indices
+                .iter()
+                .map(pb::IndexMetadata::from)
+                .collect(),
+            logical_indexes: section
+                .logical_indexes
+                .iter()
+                .map(pb::LogicalIndexMetadata::from)
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<pb::IndexSection> for IndexSection {
+    type Error = Error;
+
+    fn try_from(proto: pb::IndexSection) -> Result<Self> {
+        Ok(Self {
+            indices: proto
+                .indices
+                .into_iter()
+                .map(IndexMetadata::try_from)
+                .collect::<Result<Vec<_>>>()?,
+            logical_indexes: proto
+                .logical_indexes
+                .into_iter()
+                .map(LogicalIndexMetadata::from)
+                .collect(),
+        })
+    }
+}
+
 /// Returns a [`CacheCodec`](lance_core::cache::CacheCodec) for `Vec<IndexMetadata>`.
 ///
-/// Uses `pb::IndexSection` (which wraps `repeated IndexMetadata`) as the wire
-/// format, reusing the existing `TryFrom`/`From` conversions.
+/// Uses `pb::IndexSection` as the wire format, but only caches the physical
+/// `IndexMetadata` entries.
 ///
 /// Uses [`CacheCodec::new`](lance_core::cache::CacheCodec::new) because the
 /// orphan rule prevents `impl CacheCodecImpl for Vec<IndexMetadata>`.
@@ -254,6 +347,7 @@ fn serialize_index_metadata(
         .expect("index_metadata_codec: wrong type (this is a bug in the cache layer)");
     let section = pb::IndexSection {
         indices: vec.iter().map(pb::IndexMetadata::from).collect(),
+        logical_indexes: Vec::new(),
     };
     writer.write_all(&section.encode_to_vec())?;
     Ok(())
@@ -374,6 +468,38 @@ mod tests {
             assert_eq!(orig.index_version, rec.index_version);
             assert_eq!(orig.base_id, rec.base_id);
             assert_eq!(orig.files, rec.files);
+            assert_eq!(orig.segment_seq, rec.segment_seq);
         }
+    }
+
+    #[test]
+    fn test_index_section_roundtrip_preserves_logical_metadata() {
+        use prost::Message;
+
+        let section = IndexSection {
+            indices: vec![IndexMetadata {
+                uuid: Uuid::new_v4(),
+                name: "my_index".to_string(),
+                fields: vec![0],
+                dataset_version: 42,
+                fragment_bitmap: Some(RoaringBitmap::from_iter([1, 2, 3])),
+                index_details: None,
+                index_version: 1,
+                created_at: None,
+                base_id: None,
+                files: None,
+                segment_seq: Some(7),
+            }],
+            logical_indexes: vec![LogicalIndexMetadata {
+                index_name: "my_index".to_string(),
+                max_segment_seq: Some(9),
+            }],
+        };
+
+        let encoded = pb::IndexSection::from(&section).encode_to_vec();
+        let decoded = pb::IndexSection::decode(encoded.as_slice()).unwrap();
+        let decoded = IndexSection::try_from(decoded).unwrap();
+
+        assert_eq!(section, decoded);
     }
 }

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -53,7 +53,7 @@ use lance_core::{Error, Result};
 use lance_io::object_store::{ObjectStore, ObjectStoreExt, ObjectStoreParams};
 use lance_io::traits::{WriteExt, Writer};
 
-use crate::format::{IndexMetadata, Manifest, Transaction, is_detached_version};
+use crate::format::{IndexSection, Manifest, Transaction, is_detached_version};
 use lance_core::utils::tracing::{AUDIT_MODE_CREATE, AUDIT_TYPE_MANIFEST, TRACE_FILE_AUDIT};
 #[cfg(feature = "dynamodb")]
 use {
@@ -202,7 +202,7 @@ pub async fn migrate_scheme_to_v2(object_store: &ObjectStore, dataset_base: &Pat
 pub type ManifestWriter = for<'a> fn(
     object_store: &'a ObjectStore,
     manifest: &'a mut Manifest,
-    indices: Option<Vec<IndexMetadata>>,
+    index_section: Option<IndexSection>,
     path: &'a Path,
     transaction: Option<Transaction>,
 ) -> BoxFuture<'a, Result<WriteResult>>;
@@ -213,13 +213,13 @@ pub type ManifestWriter = for<'a> fn(
 pub fn write_manifest_file_to_path<'a>(
     object_store: &'a ObjectStore,
     manifest: &'a mut Manifest,
-    indices: Option<Vec<IndexMetadata>>,
+    index_section: Option<IndexSection>,
     path: &'a Path,
     transaction: Option<Transaction>,
 ) -> BoxFuture<'a, Result<WriteResult>> {
     Box::pin(async move {
         let mut object_writer = ObjectWriter::new(object_store, path).await?;
-        let pos = write_manifest(&mut object_writer, manifest, indices, transaction).await?;
+        let pos = write_manifest(&mut object_writer, manifest, index_section, transaction).await?;
         object_writer
             .write_magics(pos, MAJOR_VERSION, MINOR_VERSION, MAGIC)
             .await?;
@@ -922,7 +922,7 @@ pub trait CommitHandler: Debug + Send + Sync {
     async fn commit(
         &self,
         manifest: &mut Manifest,
-        indices: Option<Vec<IndexMetadata>>,
+        index_section: Option<IndexSection>,
         base_path: &Path,
         object_store: &ObjectStore,
         manifest_writer: ManifestWriter,
@@ -1184,7 +1184,7 @@ impl CommitHandler for UnsafeCommitHandler {
     async fn commit(
         &self,
         manifest: &mut Manifest,
-        indices: Option<Vec<IndexMetadata>>,
+        index_section: Option<IndexSection>,
         base_path: &Path,
         object_store: &ObjectStore,
         manifest_writer: ManifestWriter,
@@ -1201,8 +1201,14 @@ impl CommitHandler for UnsafeCommitHandler {
         }
 
         let version_path = naming_scheme.manifest_path(base_path, manifest.version);
-        let res =
-            manifest_writer(object_store, manifest, indices, &version_path, transaction).await?;
+        let res = manifest_writer(
+            object_store,
+            manifest,
+            index_section,
+            &version_path,
+            transaction,
+        )
+        .await?;
 
         write_version_hint(object_store, base_path, manifest.version).await;
 
@@ -1311,7 +1317,7 @@ where
     async fn commit(
         &self,
         manifest: &mut Manifest,
-        indices: Option<Vec<IndexMetadata>>,
+        index_section: Option<IndexSection>,
         base_path: &Path,
         object_store: &ObjectStore,
         manifest_writer: ManifestWriter,
@@ -1343,7 +1349,7 @@ where
                 return Err(CommitError::OtherError(e.into()));
             }
         }
-        let res = manifest_writer(object_store, manifest, indices, &path, transaction).await;
+        let res = manifest_writer(object_store, manifest, index_section, &path, transaction).await;
 
         // Release the lock
         lease.release(res.is_ok()).await?;
@@ -1370,7 +1376,7 @@ where
     async fn commit(
         &self,
         manifest: &mut Manifest,
-        indices: Option<Vec<IndexMetadata>>,
+        index_section: Option<IndexSection>,
         base_path: &Path,
         object_store: &ObjectStore,
         manifest_writer: ManifestWriter,
@@ -1380,7 +1386,7 @@ where
         self.as_ref()
             .commit(
                 manifest,
-                indices,
+                index_section,
                 base_path,
                 object_store,
                 manifest_writer,
@@ -1401,7 +1407,7 @@ impl CommitHandler for RenameCommitHandler {
     async fn commit(
         &self,
         manifest: &mut Manifest,
-        indices: Option<Vec<IndexMetadata>>,
+        index_section: Option<IndexSection>,
         base_path: &Path,
         object_store: &ObjectStore,
         manifest_writer: ManifestWriter,
@@ -1414,7 +1420,14 @@ impl CommitHandler for RenameCommitHandler {
         let path = naming_scheme.manifest_path(base_path, manifest.version);
         let tmp_path = make_staging_manifest_path(&path)?;
 
-        let res = manifest_writer(object_store, manifest, indices, &tmp_path, transaction).await?;
+        let res = manifest_writer(
+            object_store,
+            manifest,
+            index_section,
+            &tmp_path,
+            transaction,
+        )
+        .await?;
 
         match object_store
             .inner
@@ -1460,7 +1473,7 @@ impl CommitHandler for ConditionalPutCommitHandler {
     async fn commit(
         &self,
         manifest: &mut Manifest,
-        indices: Option<Vec<IndexMetadata>>,
+        index_section: Option<IndexSection>,
         base_path: &Path,
         object_store: &ObjectStore,
         manifest_writer: ManifestWriter,
@@ -1474,7 +1487,7 @@ impl CommitHandler for ConditionalPutCommitHandler {
         manifest_writer(
             &memory_store,
             manifest,
-            indices,
+            index_section,
             &dummy_path.into(),
             transaction,
         )

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -2055,7 +2055,7 @@ mod tests {
     fn succeeding_manifest_writer<'a>(
         _object_store: &'a ObjectStore,
         _manifest: &'a mut Manifest,
-        _indices: Option<Vec<IndexMetadata>>,
+        _index_section: Option<IndexSection>,
         _path: &'a Path,
         _transaction: Option<Transaction>,
     ) -> BoxFuture<'a, Result<WriteResult>> {
@@ -2066,7 +2066,7 @@ mod tests {
     fn hanging_manifest_writer<'a>(
         _object_store: &'a ObjectStore,
         _manifest: &'a mut Manifest,
-        _indices: Option<Vec<IndexMetadata>>,
+        _index_section: Option<IndexSection>,
         _path: &'a Path,
         _transaction: Option<Transaction>,
     ) -> BoxFuture<'a, Result<WriteResult>> {

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -23,7 +23,7 @@ use super::{
     MANIFEST_EXTENSION, ManifestLocation, ManifestNamingScheme, current_manifest_path,
     default_resolve_version, make_staging_manifest_path, write_version_hint,
 };
-use crate::format::{IndexMetadata, Manifest, Transaction};
+use crate::format::{IndexSection, Manifest, Transaction};
 use crate::io::commit::{CommitError, CommitHandler};
 
 /// External manifest store
@@ -459,7 +459,7 @@ impl CommitHandler for ExternalManifestCommitHandler {
     async fn commit(
         &self,
         manifest: &mut Manifest,
-        indices: Option<Vec<IndexMetadata>>,
+        index_section: Option<IndexSection>,
         base_path: &Path,
         object_store: &ObjectStore,
         manifest_writer: super::ManifestWriter,
@@ -472,8 +472,14 @@ impl CommitHandler for ExternalManifestCommitHandler {
         // step 1: Write the manifest we want to commit to object store with a temporary name
         let path = naming_scheme.manifest_path(base_path, manifest.version);
         let staging_path = make_staging_manifest_path(&path)?;
-        let write_res =
-            manifest_writer(object_store, manifest, indices, &staging_path, transaction).await?;
+        let write_res = manifest_writer(
+            object_store,
+            manifest,
+            index_section,
+            &staging_path,
+            transaction,
+        )
+        .await?;
 
         // step 2 & 3: Put the manifest to external store
         let result = self

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -23,7 +23,9 @@ use lance_io::{
     utils::read_message,
 };
 
-use crate::format::{DataStorageFormat, IndexMetadata, MAGIC, Manifest, Transaction, pb};
+use crate::format::{
+    DataStorageFormat, IndexMetadata, IndexSection, MAGIC, Manifest, Transaction, pb,
+};
 
 use super::commit::ManifestLocation;
 
@@ -114,6 +116,19 @@ pub async fn read_manifest_indexes(
     location: &ManifestLocation,
     manifest: &Manifest,
 ) -> Result<Vec<IndexMetadata>> {
+    Ok(
+        read_manifest_index_section(object_store, location, manifest)
+            .await?
+            .indices,
+    )
+}
+
+#[instrument(level = "debug", skip(object_store, manifest))]
+pub async fn read_manifest_index_section(
+    object_store: &ObjectStore,
+    location: &ManifestLocation,
+    manifest: &Manifest,
+) -> Result<IndexSection> {
     if let Some(pos) = manifest.index_section.as_ref() {
         let reader = if let Some(size) = location.size {
             object_store
@@ -123,29 +138,21 @@ pub async fn read_manifest_indexes(
             object_store.open(&location.path).await?
         };
         let section: pb::IndexSection = read_message(reader.as_ref(), *pos).await?;
-
-        let indices = section
-            .indices
-            .into_iter()
-            .map(IndexMetadata::try_from)
-            .collect::<Result<Vec<_>>>()?;
-        Ok(indices)
+        IndexSection::try_from(section)
     } else {
-        Ok(vec![])
+        Ok(IndexSection::default())
     }
 }
 
 async fn do_write_manifest(
     writer: &mut dyn Writer,
     manifest: &mut Manifest,
-    indices: Option<Vec<IndexMetadata>>,
+    index_section: Option<IndexSection>,
     mut transaction: Option<Transaction>,
 ) -> Result<usize> {
     // Write indices if presented.
-    if let Some(indices) = indices.as_ref() {
-        let section = pb::IndexSection {
-            indices: indices.iter().map(|i| i.into()).collect(),
-        };
+    if let Some(index_section) = index_section.as_ref() {
+        let section = pb::IndexSection::from(index_section);
         let pos = writer.write_protobuf(&section).await?;
         manifest.index_section = Some(pos);
     }
@@ -165,7 +172,7 @@ async fn do_write_manifest(
 pub async fn write_manifest(
     writer: &mut dyn Writer,
     manifest: &mut Manifest,
-    indices: Option<Vec<IndexMetadata>>,
+    index_section: Option<IndexSection>,
     transaction: Option<Transaction>,
 ) -> Result<usize> {
     // Write dictionary values.
@@ -209,7 +216,7 @@ pub async fn write_manifest(
         }
     }
 
-    do_write_manifest(writer, manifest, indices, transaction).await
+    do_write_manifest(writer, manifest, index_section, transaction).await
 }
 
 /// Implementation of ManifestProvider that describes a Lance file by writing

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -123,10 +123,7 @@ pub use lance_core::ROW_ID;
 use lance_core::box_error;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_namespace::models::{DeclareTableRequest, DescribeTableRequest};
-use lance_table::feature_flags::{
-    FLAG_INDEX_SEGMENT_SEQ, FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER, apply_feature_flags,
-    can_read_dataset,
-};
+use lance_table::feature_flags::{FLAG_INDEX_SEGMENT_SEQ, apply_feature_flags, can_read_dataset};
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
 pub use schema_evolution::{
     BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
@@ -3362,21 +3359,14 @@ pub(crate) async fn write_manifest_file(
             use_stable_row_ids,
             config.disable_transaction_file,
         )?;
-        if let Some(index_section) = index_section.as_ref() {
-            if index_section
-                .indices
-                .iter()
-                .any(|idx| idx.segment_seq.is_some())
-            {
-                manifest.writer_feature_flags |= FLAG_INDEX_SEGMENT_SEQ;
-            }
-            if index_section
-                .logical_indexes
-                .iter()
-                .any(|idx| idx.max_segment_seq.is_some())
-            {
-                manifest.writer_feature_flags |= FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER;
-            }
+        if index_section.as_ref().is_some_and(|section| {
+            section.indices.iter().any(|idx| idx.segment_seq.is_some())
+                || section
+                    .logical_indexes
+                    .iter()
+                    .any(|idx| idx.max_segment_seq.is_some())
+        }) {
+            manifest.writer_feature_flags |= FLAG_INDEX_SEGMENT_SEQ;
         }
     }
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -43,7 +43,8 @@ use lance_io::utils::{
 };
 use lance_namespace::LanceNamespace;
 use lance_table::format::{
-    DataFile, DataStorageFormat, DeletionFile, Fragment, IndexMetadata, Manifest, RowIdMeta, pb,
+    DataFile, DataStorageFormat, DeletionFile, Fragment, IndexMetadata, IndexSection, Manifest,
+    RowIdMeta, pb,
 };
 use lance_table::io::commit::{
     CommitConfig, CommitError, CommitHandler, CommitLock, ManifestLocation, ManifestNamingScheme,
@@ -122,7 +123,10 @@ pub use lance_core::ROW_ID;
 use lance_core::box_error;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_namespace::models::{DeclareTableRequest, DescribeTableRequest};
-use lance_table::feature_flags::{FLAG_INDEX_SEGMENT_SEQ, apply_feature_flags, can_read_dataset};
+use lance_table::feature_flags::{
+    FLAG_INDEX_SEGMENT_SEQ, FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER, apply_feature_flags,
+    can_read_dataset,
+};
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
 pub use schema_evolution::{
     BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
@@ -657,12 +661,10 @@ impl Dataset {
             let message_len =
                 LittleEndian::read_u32(&last_block[offset_in_block..offset_in_block + 4]) as usize;
             let message_data = &last_block[offset_in_block + 4..offset_in_block + 4 + message_len];
-            let section = lance_table::format::pb::IndexSection::decode(message_data)?;
-            let mut indices: Vec<IndexMetadata> = section
-                .indices
-                .into_iter()
-                .map(IndexMetadata::try_from)
-                .collect::<Result<Vec<_>>>()?;
+            let section = IndexSection::try_from(lance_table::format::pb::IndexSection::decode(
+                message_data,
+            )?)?;
+            let mut indices = section.indices;
             retain_supported_indices(&mut indices);
             let ds_index_cache = session.index_cache.for_dataset(uri);
             let metadata_key = crate::session::index_caches::IndexMetadataKey {
@@ -3345,7 +3347,7 @@ pub(crate) async fn write_manifest_file(
     commit_handler: &dyn CommitHandler,
     base_path: &Path,
     manifest: &mut Manifest,
-    indices: Option<Vec<IndexMetadata>>,
+    index_section: Option<IndexSection>,
     config: &ManifestWriteConfig,
     naming_scheme: ManifestNamingScheme,
     mut transaction: Option<&Transaction>,
@@ -3360,11 +3362,21 @@ pub(crate) async fn write_manifest_file(
             use_stable_row_ids,
             config.disable_transaction_file,
         )?;
-        if indices
-            .as_ref()
-            .is_some_and(|indices| indices.iter().any(|idx| idx.segment_seq.is_some()))
-        {
-            manifest.writer_feature_flags |= FLAG_INDEX_SEGMENT_SEQ;
+        if let Some(index_section) = index_section.as_ref() {
+            if index_section
+                .indices
+                .iter()
+                .any(|idx| idx.segment_seq.is_some())
+            {
+                manifest.writer_feature_flags |= FLAG_INDEX_SEGMENT_SEQ;
+            }
+            if index_section
+                .logical_indexes
+                .iter()
+                .any(|idx| idx.max_segment_seq.is_some())
+            {
+                manifest.writer_feature_flags |= FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER;
+            }
         }
     }
 
@@ -3375,7 +3387,7 @@ pub(crate) async fn write_manifest_file(
     commit_handler
         .commit(
             manifest,
-            indices,
+            index_section,
             base_path,
             object_store,
             write_manifest_file_to_path,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -122,7 +122,7 @@ pub use lance_core::ROW_ID;
 use lance_core::box_error;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_namespace::models::{DeclareTableRequest, DescribeTableRequest};
-use lance_table::feature_flags::{apply_feature_flags, can_read_dataset};
+use lance_table::feature_flags::{FLAG_INDEX_SEGMENT_SEQ, apply_feature_flags, can_read_dataset};
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
 pub use schema_evolution::{
     BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
@@ -3330,6 +3330,12 @@ impl ManifestWriteConfig {
     pub fn disable_transaction_file(&self) -> bool {
         self.disable_transaction_file
     }
+
+    #[cfg(test)]
+    pub(crate) fn with_auto_set_feature_flags(mut self, auto_set_feature_flags: bool) -> Self {
+        self.auto_set_feature_flags = auto_set_feature_flags;
+        self
+    }
 }
 
 /// Commit a manifest file and create a copy at the latest manifest path.
@@ -3354,6 +3360,12 @@ pub(crate) async fn write_manifest_file(
             use_stable_row_ids,
             config.disable_transaction_file,
         )?;
+        if indices
+            .as_ref()
+            .is_some_and(|indices| indices.iter().any(|idx| idx.segment_seq.is_some()))
+        {
+            manifest.writer_feature_flags |= FLAG_INDEX_SEGMENT_SEQ;
+        }
     }
 
     manifest.set_timestamp(timestamp_to_nanos(config.timestamp));

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1605,6 +1605,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         }
     }
 

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1601,7 +1601,7 @@ mod tests {
             dataset_version: dataset.version().version,
             fragment_bitmap: Some(fragment_bitmap.into_iter().collect()),
             index_details: None,
-            index_version: IndexType::Vector.version(),
+            index_version: 0,
             created_at: None,
             base_id: None,
             files: None,

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -15,7 +15,7 @@ use lance_index::IndexType;
 use lance_index::mem_wal::{FlushedGeneration, ShardManifest};
 use lance_index::scalar::{IndexStore, ScalarIndexParams};
 use lance_io::object_store::ObjectStore;
-use lance_table::format::IndexMetadata;
+use lance_table::format::{IndexMetadata, IndexSection};
 use lance_table::io::commit::write_manifest_file_to_path;
 use lance_table::io::deletion::write_deletion_file;
 use log::info;
@@ -320,7 +320,7 @@ impl MemTableFlusher {
         write_manifest_file_to_path(
             &self.object_store,
             &mut manifest,
-            indexes,
+            indexes.map(IndexSection::new),
             &manifest_path,
             None,
         )

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -631,6 +631,7 @@ impl MemTableFlusher {
                 created_at: None,
                 base_id: None,
                 files: None,
+                segment_seq: None,
             };
             created_indexes.push(index_meta);
 
@@ -927,6 +928,7 @@ impl MemTableFlusher {
             created_at: Some(chrono::Utc::now()),
             index_version: 1,
             files: None,
+            segment_seq: None,
         };
 
         Ok(index_meta)

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -286,6 +286,11 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                     created_at: curr_index_meta.created_at,
                     base_id: None,
                     files: curr_index_meta.files.clone(),
+                    segment_seq: if new_id == curr_index_meta.uuid {
+                        curr_index_meta.segment_seq
+                    } else {
+                        None
+                    },
                 },
                 RemapResult::Remapped(remapped_index) => IndexMetadata {
                     uuid: remapped_index.new_id,
@@ -298,6 +303,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                     created_at: curr_index_meta.created_at,
                     base_id: None,
                     files: remapped_index.files,
+                    segment_seq: None,
                 },
             };
 

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -2052,7 +2052,7 @@ impl lance_table::io::commit::CommitHandler for ErroringCommitHandler {
     async fn commit(
         &self,
         _manifest: &mut lance_table::format::Manifest,
-        _indices: Option<Vec<lance_table::format::IndexMetadata>>,
+        _index_section: Option<lance_table::format::IndexSection>,
         _base_path: &Path,
         _object_store: &ObjectStore,
         _manifest_writer: lance_table::io::commit::ManifestWriter,

--- a/rust/lance/src/dataset/tests/dataset_transactions.rs
+++ b/rust/lance/src/dataset/tests/dataset_transactions.rs
@@ -369,7 +369,7 @@ async fn test_inline_transaction() {
         if indices.is_empty() {
             None
         } else {
-            Some(indices.clone())
+            Some(lance_table::format::IndexSection::new(indices.clone()))
         },
         &ManifestWriteConfig::default(),
         ds.manifest_location.naming_scheme,

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -24,7 +24,7 @@ use lance_core::datatypes::{
 };
 use lance_core::{Error, Result, datatypes::Schema};
 use lance_file::{datatypes::Fields, version::LanceFileVersion};
-use lance_index::mem_wal::MergedGeneration;
+use lance_index::mem_wal::{MEM_WAL_INDEX_NAME, MergedGeneration};
 use lance_index::{frag_reuse::FRAG_REUSE_INDEX_NAME, is_system_index};
 use lance_io::object_store::ObjectStore;
 use lance_table::feature_flags::{FLAG_STABLE_ROW_IDS, apply_feature_flags};
@@ -1582,6 +1582,96 @@ pub fn translate_config_updates(
     }
 }
 
+fn assign_index_segment_seqs(
+    indices: &mut [IndexMetadata],
+    new_index_uuids: &HashSet<Uuid>,
+    sequence_baseline_indices: &[IndexMetadata],
+) {
+    let has_new_indices = !new_index_uuids.is_empty();
+    let mut next_seq_by_name = HashMap::<String, u64>::new();
+    for index in sequence_baseline_indices {
+        if let Some(segment_seq) = index.segment_seq {
+            let next_seq = next_seq_by_name.entry(index.name.clone()).or_insert(1);
+            *next_seq = (*next_seq).max(segment_seq + 1);
+        }
+    }
+    let mut segment_seq_by_uuid = HashMap::new();
+
+    for index in sequence_baseline_indices {
+        if let Some(segment_seq) = index.segment_seq {
+            segment_seq_by_uuid.insert(index.uuid, segment_seq);
+        } else if has_new_indices {
+            let next_seq = next_seq_by_name.entry(index.name.clone()).or_insert(1);
+            segment_seq_by_uuid.insert(index.uuid, *next_seq);
+            *next_seq += 1;
+        }
+    }
+
+    for index in indices
+        .iter_mut()
+        .filter(|idx| !new_index_uuids.contains(&idx.uuid) && idx.segment_seq.is_none())
+    {
+        if let Some(segment_seq) = segment_seq_by_uuid.get(&index.uuid) {
+            index.segment_seq = Some(*segment_seq);
+        } else if has_new_indices {
+            let next_seq = next_seq_by_name.entry(index.name.clone()).or_insert(1);
+            index.segment_seq = Some(*next_seq);
+            *next_seq += 1;
+        }
+    }
+
+    for index in indices
+        .iter_mut()
+        .filter(|idx| new_index_uuids.contains(&idx.uuid))
+    {
+        let next_seq = next_seq_by_name.entry(index.name.clone()).or_insert(1);
+        index.segment_seq = Some(*next_seq);
+        *next_seq += 1;
+    }
+}
+
+pub(crate) fn assign_index_segment_seqs_for_new_indices(
+    current_indices: &[IndexMetadata],
+    removed_indices: &[IndexMetadata],
+    new_indices: &mut [IndexMetadata],
+) {
+    if new_indices.is_empty() {
+        return;
+    }
+
+    let removed_uuids = removed_indices
+        .iter()
+        .map(|idx| idx.uuid)
+        .collect::<HashSet<_>>();
+    let all_new_uuids = new_indices
+        .iter()
+        .map(|idx| idx.uuid)
+        .collect::<HashSet<_>>();
+    let new_uuids = new_indices
+        .iter()
+        .map(|idx| idx.uuid)
+        .filter(|uuid| !removed_uuids.contains(uuid))
+        .collect::<HashSet<_>>();
+    let mut final_indices = current_indices
+        .iter()
+        .filter(|idx| !removed_uuids.contains(&idx.uuid) && !all_new_uuids.contains(&idx.uuid))
+        .cloned()
+        .collect::<Vec<_>>();
+    final_indices.extend(new_indices.iter().cloned());
+
+    assign_index_segment_seqs(&mut final_indices, &new_uuids, current_indices);
+
+    let assigned = final_indices
+        .into_iter()
+        .filter(|idx| all_new_uuids.contains(&idx.uuid))
+        .map(|idx| (idx.uuid, idx.segment_seq))
+        .collect::<HashMap<_, _>>();
+
+    for index in new_indices {
+        index.segment_seq = assigned.get(&index.uuid).copied().flatten();
+    }
+}
+
 /// Helper function to translate old-style schema metadata to new UpdateMap format
 pub fn translate_schema_metadata_updates(
     schema_metadata: &std::collections::HashMap<String, String>,
@@ -1834,6 +1924,8 @@ impl Transaction {
         };
         let mut final_fragments = Vec::new();
         let mut final_indices = current_indices;
+        let segment_seq_baseline_indices = final_indices.clone();
+        let mut new_index_uuids_for_segment_seq = HashSet::new();
 
         let mut next_row_id = {
             // Only use row ids if the feature flag is set already or
@@ -2031,11 +2123,23 @@ impl Transaction {
                 Self::retain_relevant_indices(&mut final_indices, &schema, &final_fragments);
 
                 if !merged_generations.is_empty() {
+                    let old_mem_wal_id = final_indices
+                        .iter()
+                        .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+                        .map(|idx| idx.uuid);
                     update_mem_wal_index_merged_generations(
                         &mut final_indices,
                         current_manifest.map_or(1, |m| m.version + 1),
                         merged_generations.clone(),
                     )?;
+                    if let Some(new_mem_wal_id) = final_indices
+                        .iter()
+                        .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+                        .map(|idx| idx.uuid)
+                        && Some(new_mem_wal_id) != old_mem_wal_id
+                    {
+                        new_index_uuids_for_segment_seq.insert(new_mem_wal_id);
+                    }
                 }
             }
             Operation::Overwrite { fragments, .. } => {
@@ -2081,10 +2185,17 @@ impl Transaction {
                     }
                 } else {
                     Self::handle_rewrite_indices(&mut final_indices, rewritten_indices, groups)?;
+                    new_index_uuids_for_segment_seq.extend(
+                        rewritten_indices
+                            .iter()
+                            .filter(|idx| idx.new_id != idx.old_id)
+                            .map(|idx| idx.new_id),
+                    );
                 }
 
                 if let Some(frag_reuse_index) = frag_reuse_index {
                     final_indices.retain(|idx| idx.name != frag_reuse_index.name);
+                    new_index_uuids_for_segment_seq.insert(frag_reuse_index.uuid);
                     final_indices.push(frag_reuse_index.clone());
                 }
             }
@@ -2101,6 +2212,11 @@ impl Transaction {
                     .iter()
                     .map(|new_index| new_index.uuid)
                     .collect::<HashSet<_>>();
+                let new_uuids_to_assign = new_uuids
+                    .difference(&removed_uuids)
+                    .copied()
+                    .collect::<HashSet<_>>();
+                new_index_uuids_for_segment_seq.extend(new_uuids_to_assign);
                 final_indices.retain(|existing_index| {
                     !removed_uuids.contains(&existing_index.uuid)
                         && !new_uuids.contains(&existing_index.uuid)
@@ -2301,11 +2417,23 @@ impl Transaction {
                 );
             }
             Operation::UpdateMemWalState { merged_generations } => {
+                let old_mem_wal_id = final_indices
+                    .iter()
+                    .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+                    .map(|idx| idx.uuid);
                 update_mem_wal_index_merged_generations(
                     &mut final_indices,
                     current_manifest.map_or(1, |m| m.version + 1),
                     merged_generations.clone(),
                 )?;
+                if let Some(new_mem_wal_id) = final_indices
+                    .iter()
+                    .find(|idx| idx.name == MEM_WAL_INDEX_NAME)
+                    .map(|idx| idx.uuid)
+                    && Some(new_mem_wal_id) != old_mem_wal_id
+                {
+                    new_index_uuids_for_segment_seq.insert(new_mem_wal_id);
+                }
             }
             Operation::UpdateBases { .. } => {
                 // UpdateBases operation doesn't modify fragments or indices
@@ -2313,6 +2441,12 @@ impl Transaction {
                 final_fragments.extend(maybe_existing_fragments?.clone());
             }
         };
+
+        assign_index_segment_seqs(
+            &mut final_indices,
+            &new_index_uuids_for_segment_seq,
+            &segment_seq_baseline_indices,
+        );
 
         // If a fragment was reserved then it may not belong at the end of the fragments list.
         final_fragments.sort_by_key(|frag| frag.id);
@@ -2808,6 +2942,9 @@ impl Transaction {
                 groups,
             )?);
             index.uuid = rewritten_index.new_id;
+            if rewritten_index.new_id != rewritten_index.old_id {
+                index.segment_seq = None;
+            }
             // Update file sizes to match the new index files. When not available
             // (e.g., from older writers), clear the old file sizes to avoid
             // using stale sizes from the pre-remap index.
@@ -3872,6 +4009,7 @@ mod tests {
             created_at: Some(Utc::now()),
             base_id: None,
             files: None,
+            segment_seq: None,
         }
     }
 
@@ -4379,6 +4517,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         }
     }
 
@@ -4401,6 +4540,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         }
     }
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -31,13 +31,11 @@ use lance_table::feature_flags::{FLAG_STABLE_ROW_IDS, apply_feature_flags};
 use lance_table::rowids::read_row_ids;
 use lance_table::{
     format::{
-        BasePath, DataFile, DataStorageFormat, Fragment, IndexFile, IndexMetadata, Manifest,
-        RowDatasetVersionMeta, RowDatasetVersionRun, RowDatasetVersionSequence, RowIdMeta, pb,
+        BasePath, DataFile, DataStorageFormat, Fragment, IndexFile, IndexMetadata, IndexSection,
+        LogicalIndexMetadata, Manifest, RowDatasetVersionMeta, RowDatasetVersionRun,
+        RowDatasetVersionSequence, RowIdMeta, pb,
     },
-    io::{
-        commit::CommitHandler,
-        manifest::{read_manifest, read_manifest_indexes},
-    },
+    io::{commit::CommitHandler, manifest::read_manifest},
     rowids::{RowIdSequence, segment::U64Segment, version::build_version_meta, write_row_ids},
 };
 use object_store::path::Path;
@@ -1586,9 +1584,18 @@ fn assign_index_segment_seqs(
     indices: &mut [IndexMetadata],
     new_index_uuids: &HashSet<Uuid>,
     sequence_baseline_indices: &[IndexMetadata],
+    logical_indexes: &mut Vec<LogicalIndexMetadata>,
 ) {
     let has_new_indices = !new_index_uuids.is_empty();
     let mut next_seq_by_name = HashMap::<String, u64>::new();
+    for logical_index in logical_indexes.iter() {
+        if let Some(max_segment_seq) = logical_index.max_segment_seq {
+            let next_seq = next_seq_by_name
+                .entry(logical_index.index_name.clone())
+                .or_insert(1);
+            *next_seq = (*next_seq).max(max_segment_seq + 1);
+        }
+    }
     for index in sequence_baseline_indices {
         if let Some(segment_seq) = index.segment_seq {
             let next_seq = next_seq_by_name.entry(index.name.clone()).or_insert(1);
@@ -1628,10 +1635,109 @@ fn assign_index_segment_seqs(
         index.segment_seq = Some(*next_seq);
         *next_seq += 1;
     }
+
+    let mut max_segment_seq_by_name = HashMap::<String, u64>::new();
+    for index in sequence_baseline_indices {
+        if let Some(segment_seq) = segment_seq_by_uuid
+            .get(&index.uuid)
+            .copied()
+            .or(index.segment_seq)
+        {
+            let max_segment_seq = max_segment_seq_by_name
+                .entry(index.name.clone())
+                .or_insert(segment_seq);
+            *max_segment_seq = (*max_segment_seq).max(segment_seq);
+        }
+    }
+    for index in indices.iter() {
+        if let Some(segment_seq) = index.segment_seq {
+            let max_segment_seq = max_segment_seq_by_name
+                .entry(index.name.clone())
+                .or_insert(segment_seq);
+            *max_segment_seq = (*max_segment_seq).max(segment_seq);
+        }
+    }
+    for logical_index in logical_indexes.iter() {
+        if let Some(max_segment_seq) = logical_index.max_segment_seq {
+            let max_entry = max_segment_seq_by_name
+                .entry(logical_index.index_name.clone())
+                .or_insert(max_segment_seq);
+            *max_entry = (*max_entry).max(max_segment_seq);
+        }
+    }
+
+    logical_indexes
+        .retain(|logical_index| max_segment_seq_by_name.contains_key(&logical_index.index_name));
+    let mut existing_names = logical_indexes
+        .iter()
+        .map(|logical_index| logical_index.index_name.clone())
+        .collect::<HashSet<_>>();
+    for logical_index in logical_indexes.iter_mut() {
+        logical_index.max_segment_seq = max_segment_seq_by_name
+            .get(&logical_index.index_name)
+            .copied();
+    }
+    for (index_name, max_segment_seq) in max_segment_seq_by_name {
+        if existing_names.insert(index_name.clone()) {
+            logical_indexes.push(LogicalIndexMetadata {
+                index_name,
+                max_segment_seq: Some(max_segment_seq),
+            });
+        }
+    }
+    logical_indexes.sort_by(|left, right| left.index_name.cmp(&right.index_name));
+}
+
+fn merge_logical_index_high_water_marks(
+    index_section: &mut IndexSection,
+    current_index_section: &IndexSection,
+) {
+    let mut max_segment_seq_by_name = HashMap::<String, u64>::new();
+    for logical_index in index_section
+        .logical_indexes
+        .iter()
+        .chain(current_index_section.logical_indexes.iter())
+    {
+        if let Some(max_segment_seq) = logical_index.max_segment_seq {
+            let max_entry = max_segment_seq_by_name
+                .entry(logical_index.index_name.clone())
+                .or_insert(max_segment_seq);
+            *max_entry = (*max_entry).max(max_segment_seq);
+        }
+    }
+    for index in index_section
+        .indices
+        .iter()
+        .chain(current_index_section.indices.iter())
+    {
+        if let Some(segment_seq) = index.segment_seq {
+            let max_entry = max_segment_seq_by_name
+                .entry(index.name.clone())
+                .or_insert(segment_seq);
+            *max_entry = (*max_entry).max(segment_seq);
+        }
+    }
+
+    index_section.logical_indexes = max_segment_seq_by_name
+        .into_iter()
+        .map(|(index_name, max_segment_seq)| LogicalIndexMetadata {
+            index_name,
+            max_segment_seq: Some(max_segment_seq),
+        })
+        .collect();
+    index_section
+        .logical_indexes
+        .sort_by(|left, right| left.index_name.cmp(&right.index_name));
+}
+
+pub(crate) struct CurrentManifestMetadata<'a> {
+    pub manifest: &'a Manifest,
+    pub index_section: &'a IndexSection,
 }
 
 pub(crate) fn assign_index_segment_seqs_for_new_indices(
     current_indices: &[IndexMetadata],
+    logical_indexes: &[LogicalIndexMetadata],
     removed_indices: &[IndexMetadata],
     new_indices: &mut [IndexMetadata],
 ) {
@@ -1659,7 +1765,13 @@ pub(crate) fn assign_index_segment_seqs_for_new_indices(
         .collect::<Vec<_>>();
     final_indices.extend(new_indices.iter().cloned());
 
-    assign_index_segment_seqs(&mut final_indices, &new_uuids, current_indices);
+    let mut logical_indexes = logical_indexes.to_vec();
+    assign_index_segment_seqs(
+        &mut final_indices,
+        &new_uuids,
+        current_indices,
+        &mut logical_indexes,
+    );
 
     let assigned = final_indices
         .into_iter()
@@ -1832,24 +1944,31 @@ impl Transaction {
         version: u64,
         config: &ManifestWriteConfig,
         tx_path: &str,
-        current_manifest: &Manifest,
-    ) -> Result<(Manifest, Vec<IndexMetadata>)> {
+        current: CurrentManifestMetadata<'_>,
+    ) -> Result<(Manifest, IndexSection)> {
         let location = commit_handler
             .resolve_version_location(base_path, version, &object_store.inner)
             .await?;
         let mut manifest = read_manifest(object_store, &location.path, location.size).await?;
         manifest.set_timestamp(timestamp_to_nanos(config.timestamp));
         manifest.transaction_file = Some(tx_path.to_string());
-        let indices = read_manifest_indexes(object_store, &location, &manifest).await?;
+        let mut index_section = lance_table::io::manifest::read_manifest_index_section(
+            object_store,
+            &location,
+            &manifest,
+        )
+        .await?;
+        merge_logical_index_high_water_marks(&mut index_section, current.index_section);
         manifest.max_fragment_id = manifest
             .max_fragment_id
-            .max(current_manifest.max_fragment_id);
-        Ok((manifest, indices))
+            .max(current.manifest.max_fragment_id);
+        Ok((manifest, index_section))
     }
 
     /// Create a new manifest from the current manifest and the transaction.
     ///
     /// `current_manifest` should only be None if the dataset does not yet exist.
+    #[cfg(test)]
     pub(crate) fn build_manifest(
         &self,
         current_manifest: Option<&Manifest>,
@@ -1857,6 +1976,23 @@ impl Transaction {
         transaction_file_path: &str,
         config: &ManifestWriteConfig,
     ) -> Result<(Manifest, Vec<IndexMetadata>)> {
+        let (manifest, index_section) = self.build_manifest_with_index_section(
+            current_manifest,
+            IndexSection::new(current_indices),
+            transaction_file_path,
+            config,
+        )?;
+        Ok((manifest, index_section.indices))
+    }
+
+    /// Create a new manifest and index section from the current manifest and transaction.
+    pub(crate) fn build_manifest_with_index_section(
+        &self,
+        current_manifest: Option<&Manifest>,
+        current_index_section: IndexSection,
+        transaction_file_path: &str,
+        config: &ManifestWriteConfig,
+    ) -> Result<(Manifest, IndexSection)> {
         if config.use_stable_row_ids
             && current_manifest
                 .map(|m| !m.uses_stable_row_ids())
@@ -1923,8 +2059,12 @@ impl Transaction {
                 .unwrap_or(0)
         };
         let mut final_fragments = Vec::new();
+        let IndexSection {
+            indices: current_indices,
+            logical_indexes: mut final_logical_indexes,
+        } = current_index_section;
         let mut final_indices = current_indices;
-        let segment_seq_baseline_indices = final_indices.clone();
+        let mut segment_seq_baseline_indices = final_indices.clone();
         let mut new_index_uuids_for_segment_seq = HashSet::new();
 
         let mut next_row_id = {
@@ -2158,6 +2298,8 @@ impl Transaction {
                 }
                 final_fragments.extend(new_fragments);
                 final_indices = Vec::new();
+                final_logical_indexes.clear();
+                segment_seq_baseline_indices.clear();
             }
             Operation::Rewrite {
                 groups,
@@ -2446,6 +2588,7 @@ impl Transaction {
             &mut final_indices,
             &new_index_uuids_for_segment_seq,
             &segment_seq_baseline_indices,
+            &mut final_logical_indexes,
         );
 
         // If a fragment was reserved then it may not belong at the end of the fragments list.
@@ -2687,7 +2830,13 @@ impl Transaction {
             manifest.next_row_id = next_row_id;
         }
 
-        Ok((manifest, final_indices))
+        Ok((
+            manifest,
+            IndexSection {
+                indices: final_indices,
+                logical_indexes: final_logical_indexes,
+            },
+        ))
     }
 
     fn register_pure_rewrite_rows_update_frags_in_indices(

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -178,6 +178,7 @@ pub(crate) async fn build_index_metadata_from_segments(
                 created_at: Some(chrono::Utc::now()),
                 base_id: None,
                 files: None,
+                segment_seq: None,
             };
             crate::index::scalar::inverted::finalize_segment_files_if_needed(dataset, &metadata)
                 .await?;
@@ -4496,6 +4497,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         };
 
         let desc = IndexDescriptionImpl::try_new(vec![metadata], &dataset)
@@ -4536,6 +4538,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         };
 
         let desc = IndexDescriptionImpl::try_new(vec![metadata], &dataset)

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -2584,7 +2584,7 @@ mod tests {
     };
     use lance_io::{assert_io_eq, assert_io_lt};
     use lance_linalg::distance::{DistanceType, MetricType};
-    use lance_table::feature_flags::FLAG_INDEX_SEGMENT_SEQ;
+    use lance_table::feature_flags::{FLAG_INDEX_SEGMENT_SEQ, FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER};
     use lance_testing::datagen::generate_random_array;
     use object_store::ObjectStoreExt;
     use rstest::rstest;
@@ -6585,6 +6585,10 @@ mod tests {
             dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
             0
         );
+        assert_ne!(
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
+            0
+        );
 
         let replacement = write_vector_segment_metadata(
             &dataset,
@@ -6821,7 +6825,8 @@ mod tests {
 
         let mut legacy_manifest = dataset.manifest.as_ref().clone();
         legacy_manifest.version += 1;
-        legacy_manifest.writer_feature_flags &= !FLAG_INDEX_SEGMENT_SEQ;
+        legacy_manifest.writer_feature_flags &=
+            !(FLAG_INDEX_SEGMENT_SEQ | FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER);
         legacy_manifest.transaction_section = None;
         legacy_manifest.transaction_file = None;
         let mut legacy_indices = dataset.load_indices().await.unwrap().as_ref().clone();
@@ -6833,7 +6838,7 @@ mod tests {
             dataset.commit_handler.as_ref(),
             &dataset.base,
             &mut legacy_manifest,
-            Some(legacy_indices),
+            Some(lance_table::format::IndexSection::new(legacy_indices)),
             &ManifestWriteConfig::default().with_auto_set_feature_flags(false),
             dataset.manifest_location.naming_scheme,
             None,
@@ -6879,6 +6884,434 @@ mod tests {
         assert_eq!(segment_seq_by_uuid.get(&replacement.uuid), Some(&Some(3)));
         assert_ne!(
             dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
+            0
+        );
+        assert_ne!(
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remove_last_legacy_index_segment_clears_index_section() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let segment = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"segment",
+        )
+        .await;
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&segment)],
+            )
+            .await
+            .unwrap();
+
+        let mut legacy_manifest = dataset.manifest.as_ref().clone();
+        legacy_manifest.version += 1;
+        legacy_manifest.writer_feature_flags &=
+            !(FLAG_INDEX_SEGMENT_SEQ | FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER);
+        legacy_manifest.transaction_section = None;
+        legacy_manifest.transaction_file = None;
+        let mut legacy_indices = dataset.load_indices().await.unwrap().as_ref().clone();
+        for index in &mut legacy_indices {
+            index.segment_seq = None;
+        }
+        write_manifest_file(
+            dataset.object_store.as_ref(),
+            dataset.commit_handler.as_ref(),
+            &dataset.base,
+            &mut legacy_manifest,
+            Some(lance_table::format::IndexSection::new(legacy_indices)),
+            &ManifestWriteConfig::default().with_auto_set_feature_flags(false),
+            dataset.manifest_location.naming_scheme,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut dataset = Dataset::open(test_uri).await.unwrap();
+        let legacy_index = dataset.load_indices_by_name("vector_idx").await.unwrap()[0].clone();
+        assert_eq!(legacy_index.segment_seq, None);
+
+        let transaction = Transaction::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![],
+                removed_indices: vec![legacy_index],
+            },
+            None,
+        );
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+
+        assert!(
+            dataset
+                .load_indices_by_name("vector_idx")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let index_section = lance_table::io::manifest::read_manifest_index_section(
+            dataset.object_store.as_ref(),
+            &dataset.manifest_location,
+            &dataset.manifest,
+        )
+        .await
+        .unwrap();
+        assert!(index_section.is_empty());
+        assert_eq!(
+            dataset.manifest.writer_feature_flags
+                & (FLAG_INDEX_SEGMENT_SEQ | FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_preserves_sequence_after_last_segment_removed() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let segment = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"segment",
+        )
+        .await;
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&segment)],
+            )
+            .await
+            .unwrap();
+
+        let original = dataset.load_indices_by_name("vector_idx").await.unwrap()[0].clone();
+        assert_eq!(original.segment_seq, Some(1));
+
+        let transaction = Transaction::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![],
+                removed_indices: vec![original],
+            },
+            None,
+        );
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+        assert!(
+            dataset
+                .load_indices_by_name("vector_idx")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let index_section = lance_table::io::manifest::read_manifest_index_section(
+            dataset.object_store.as_ref(),
+            &dataset.manifest_location,
+            &dataset.manifest,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            index_section
+                .logical_indexes
+                .iter()
+                .find(|idx| idx.index_name == "vector_idx")
+                .and_then(|idx| idx.max_segment_seq),
+            Some(1)
+        );
+        assert_ne!(
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
+            0
+        );
+
+        let replacement = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"replacement",
+        )
+        .await;
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&replacement)],
+            )
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        assert_eq!(committed[0].segment_seq, Some(2));
+    }
+
+    #[tokio::test]
+    async fn test_restore_preserves_index_segment_sequence_high_water() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let first = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"first",
+        )
+        .await;
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&first)],
+            )
+            .await
+            .unwrap();
+        let version_with_first = dataset.manifest.version;
+        assert_eq!(
+            dataset.load_indices_by_name("vector_idx").await.unwrap()[0].segment_seq,
+            Some(1)
+        );
+
+        let second = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"second",
+        )
+        .await;
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&second)],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            dataset.load_indices_by_name("vector_idx").await.unwrap()[0].segment_seq,
+            Some(2)
+        );
+
+        let mut restored = dataset.checkout_version(version_with_first).await.unwrap();
+        restored.restore().await.unwrap();
+
+        let index_section = lance_table::io::manifest::read_manifest_index_section(
+            restored.object_store.as_ref(),
+            &restored.manifest_location,
+            &restored.manifest,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            index_section
+                .logical_indexes
+                .iter()
+                .find(|idx| idx.index_name == "vector_idx")
+                .and_then(|idx| idx.max_segment_seq),
+            Some(2)
+        );
+        assert_ne!(
+            restored.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
+            0
+        );
+        assert_eq!(
+            restored.load_indices_by_name("vector_idx").await.unwrap()[0].segment_seq,
+            Some(1)
+        );
+
+        let third = write_vector_segment_metadata(
+            &restored,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"third",
+        )
+        .await;
+        restored
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&third)],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            restored.load_indices_by_name("vector_idx").await.unwrap()[0].segment_seq,
+            Some(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_overwrite_clears_index_segment_sequence_high_water() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let segment = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"segment",
+        )
+        .await;
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&segment)],
+            )
+            .await
+            .unwrap();
+
+        let overwrite_reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+        let overwritten = Dataset::write(
+            overwrite_reader,
+            test_uri,
+            Some(WriteParams {
+                mode: WriteMode::Overwrite,
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert!(overwritten.load_indices().await.unwrap().is_empty());
+        let index_section = lance_table::io::manifest::read_manifest_index_section(
+            overwritten.object_store.as_ref(),
+            &overwritten.manifest_location,
+            &overwritten.manifest,
+        )
+        .await
+        .unwrap();
+        assert!(index_section.is_empty());
+        assert_eq!(
+            overwritten.manifest.writer_feature_flags
+                & (FLAG_INDEX_SEGMENT_SEQ | FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER),
             0
         );
     }
@@ -6952,6 +7385,10 @@ mod tests {
         assert_eq!(refreshed[0].segment_seq, Some(1));
         assert_ne!(
             dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
+            0
+        );
+        assert_ne!(
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
             0
         );
     }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -6688,6 +6688,21 @@ mod tests {
             .collect::<HashMap<_, _>>();
         assert_eq!(segment_seq_by_uuid.get(&seg0.uuid), Some(&Some(1)));
         assert_eq!(segment_seq_by_uuid.get(&seg1.uuid), Some(&Some(2)));
+        let index_section = lance_table::io::manifest::read_manifest_index_section(
+            dataset.object_store.as_ref(),
+            &dataset.manifest_location,
+            &dataset.manifest,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            index_section
+                .logical_indexes
+                .iter()
+                .find(|idx| idx.index_name == "vector_idx")
+                .and_then(|idx| idx.max_segment_seq),
+            Some(2)
+        );
     }
 
     #[tokio::test]
@@ -6877,6 +6892,21 @@ mod tests {
         assert_eq!(segment_seq_by_uuid.get(&seg0.uuid), Some(&Some(1)));
         assert!(!segment_seq_by_uuid.contains_key(&seg1.uuid));
         assert_eq!(segment_seq_by_uuid.get(&replacement.uuid), Some(&Some(3)));
+        let index_section = lance_table::io::manifest::read_manifest_index_section(
+            dataset.object_store.as_ref(),
+            &dataset.manifest_location,
+            &dataset.manifest,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            index_section
+                .logical_indexes
+                .iter()
+                .find(|idx| idx.index_name == "vector_idx")
+                .and_then(|idx| idx.max_segment_seq),
+            Some(3)
+        );
         assert_ne!(
             dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
             0

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -2584,7 +2584,7 @@ mod tests {
     };
     use lance_io::{assert_io_eq, assert_io_lt};
     use lance_linalg::distance::{DistanceType, MetricType};
-    use lance_table::feature_flags::{FLAG_INDEX_SEGMENT_SEQ, FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER};
+    use lance_table::feature_flags::FLAG_INDEX_SEGMENT_SEQ;
     use lance_testing::datagen::generate_random_array;
     use object_store::ObjectStoreExt;
     use rstest::rstest;
@@ -6585,10 +6585,6 @@ mod tests {
             dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
             0
         );
-        assert_ne!(
-            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
-            0
-        );
 
         let replacement = write_vector_segment_metadata(
             &dataset,
@@ -6825,8 +6821,7 @@ mod tests {
 
         let mut legacy_manifest = dataset.manifest.as_ref().clone();
         legacy_manifest.version += 1;
-        legacy_manifest.writer_feature_flags &=
-            !(FLAG_INDEX_SEGMENT_SEQ | FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER);
+        legacy_manifest.writer_feature_flags &= !FLAG_INDEX_SEGMENT_SEQ;
         legacy_manifest.transaction_section = None;
         legacy_manifest.transaction_file = None;
         let mut legacy_indices = dataset.load_indices().await.unwrap().as_ref().clone();
@@ -6886,10 +6881,6 @@ mod tests {
             dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
             0
         );
-        assert_ne!(
-            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
-            0
-        );
     }
 
     #[tokio::test]
@@ -6940,8 +6931,7 @@ mod tests {
 
         let mut legacy_manifest = dataset.manifest.as_ref().clone();
         legacy_manifest.version += 1;
-        legacy_manifest.writer_feature_flags &=
-            !(FLAG_INDEX_SEGMENT_SEQ | FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER);
+        legacy_manifest.writer_feature_flags &= !FLAG_INDEX_SEGMENT_SEQ;
         legacy_manifest.transaction_section = None;
         legacy_manifest.transaction_file = None;
         let mut legacy_indices = dataset.load_indices().await.unwrap().as_ref().clone();
@@ -6994,8 +6984,7 @@ mod tests {
         .unwrap();
         assert!(index_section.is_empty());
         assert_eq!(
-            dataset.manifest.writer_feature_flags
-                & (FLAG_INDEX_SEGMENT_SEQ | FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER),
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
             0
         );
     }
@@ -7085,7 +7074,7 @@ mod tests {
             Some(1)
         );
         assert_ne!(
-            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
             0
         );
 
@@ -7203,7 +7192,7 @@ mod tests {
             Some(2)
         );
         assert_ne!(
-            restored.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
+            restored.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
             0
         );
         assert_eq!(
@@ -7310,8 +7299,7 @@ mod tests {
         .unwrap();
         assert!(index_section.is_empty());
         assert_eq!(
-            overwritten.manifest.writer_feature_flags
-                & (FLAG_INDEX_SEGMENT_SEQ | FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER),
+            overwritten.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
             0
         );
     }
@@ -7385,10 +7373,6 @@ mod tests {
         assert_eq!(refreshed[0].segment_seq, Some(1));
         assert_ne!(
             dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
-            0
-        );
-        assert_ne!(
-            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ_HIGH_WATER,
             0
         );
     }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -6518,6 +6518,10 @@ mod tests {
         )
         .await
         .unwrap();
+        assert_eq!(
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
+            0
+        );
 
         let field_id = dataset.schema().field("vector").unwrap().id;
         let seg0 = write_vector_segment_metadata(

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -195,6 +195,7 @@ pub(crate) async fn build_index_metadata_from_segments(
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: Some(files),
+            segment_seq: None,
         });
     }
 
@@ -1377,6 +1378,7 @@ impl DatasetIndexExt for Dataset {
                 created_at: Some(chrono::Utc::now()),
                 base_id: None, // New merged index file locates in the cloned dataset.
                 files: res.files,
+                segment_seq: None,
             };
             removed_indices.extend(res.removed_indices.iter().map(|&idx| idx.clone()));
             new_indices.push(new_idx);
@@ -2553,7 +2555,7 @@ mod tests {
     use super::*;
     use crate::dataset::builder::DatasetBuilder;
     use crate::dataset::optimize::{CompactionOptions, compact_files};
-    use crate::dataset::{WriteMode, WriteParams};
+    use crate::dataset::{ManifestWriteConfig, WriteMode, WriteParams, write_manifest_file};
     use crate::index::vector::VectorIndexParams;
     use crate::session::Session;
     use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount, copy_test_data_to_tmp};
@@ -2582,6 +2584,7 @@ mod tests {
     };
     use lance_io::{assert_io_eq, assert_io_lt};
     use lance_linalg::distance::{DistanceType, MetricType};
+    use lance_table::feature_flags::FLAG_INDEX_SEGMENT_SEQ;
     use lance_testing::datagen::generate_random_array;
     use object_store::ObjectStoreExt;
     use rstest::rstest;
@@ -2619,6 +2622,7 @@ mod tests {
                 path: INDEX_FILE_NAME.to_string(),
                 size_bytes: payload.len() as u64,
             }]),
+            segment_seq: None,
         }
     }
 
@@ -6571,6 +6575,385 @@ mod tests {
                 .all(|idx| idx.files.as_ref().is_some_and(|files| !files.is_empty())),
             "committed segment metadata should capture on-disk file info"
         );
+        let mut segment_seqs = committed
+            .iter()
+            .map(|idx| idx.segment_seq)
+            .collect::<Vec<_>>();
+        segment_seqs.sort();
+        assert_eq!(segment_seqs, vec![Some(1), Some(2)]);
+        assert_ne!(
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
+            0
+        );
+
+        let replacement = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [1_u32],
+            b"replacement",
+        )
+        .await;
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&replacement)],
+            )
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        let segment_seq_by_uuid = committed
+            .iter()
+            .map(|idx| (idx.uuid, idx.segment_seq))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(segment_seq_by_uuid.get(&seg0.uuid), Some(&Some(1)));
+        assert!(!segment_seq_by_uuid.contains_key(&seg1.uuid));
+        assert_eq!(segment_seq_by_uuid.get(&replacement.uuid), Some(&Some(3)));
+    }
+
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_rebase_assigns_next_segment_seq() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(20), BatchCount::from(2));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        let mut stale_dataset = dataset.clone();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let seg0 = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"seg0",
+        )
+        .await;
+        let seg1 = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [1_u32],
+            b"seg1",
+        )
+        .await;
+
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg0)],
+            )
+            .await
+            .unwrap();
+
+        stale_dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg1)],
+            )
+            .await
+            .unwrap();
+
+        let dataset = Dataset::open(test_uri).await.unwrap();
+        let committed = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        let segment_seq_by_uuid = committed
+            .iter()
+            .map(|idx| (idx.uuid, idx.segment_seq))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(segment_seq_by_uuid.get(&seg0.uuid), Some(&Some(1)));
+        assert_eq!(segment_seq_by_uuid.get(&seg1.uuid), Some(&Some(2)));
+    }
+
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_sequence_is_scoped_to_index_name() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(20), BatchCount::from(2));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let seg0 = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"seg0",
+        )
+        .await;
+        let other_seg0 = write_vector_segment_metadata(
+            &dataset,
+            "other_vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"other-seg0",
+        )
+        .await;
+
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg0)],
+            )
+            .await
+            .unwrap();
+        dataset
+            .commit_existing_index_segments(
+                "other_vector_idx",
+                "vector",
+                vec![segment_from_metadata(&other_seg0)],
+            )
+            .await
+            .unwrap();
+
+        let vector_idx = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        let other_vector_idx = dataset
+            .load_indices_by_name("other_vector_idx")
+            .await
+            .unwrap();
+        assert_eq!(vector_idx[0].segment_seq, Some(1));
+        assert_eq!(other_vector_idx[0].segment_seq, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_commit_existing_index_segments_backfills_legacy_segment_seq() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(20), BatchCount::from(2));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let seg0 = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"seg0",
+        )
+        .await;
+        let seg1 = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [1_u32],
+            b"seg1",
+        )
+        .await;
+
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&seg0), segment_from_metadata(&seg1)],
+            )
+            .await
+            .unwrap();
+
+        let mut legacy_manifest = dataset.manifest.as_ref().clone();
+        legacy_manifest.version += 1;
+        legacy_manifest.writer_feature_flags &= !FLAG_INDEX_SEGMENT_SEQ;
+        legacy_manifest.transaction_section = None;
+        legacy_manifest.transaction_file = None;
+        let mut legacy_indices = dataset.load_indices().await.unwrap().as_ref().clone();
+        for index in &mut legacy_indices {
+            index.segment_seq = None;
+        }
+        write_manifest_file(
+            dataset.object_store.as_ref(),
+            dataset.commit_handler.as_ref(),
+            &dataset.base,
+            &mut legacy_manifest,
+            Some(legacy_indices),
+            &ManifestWriteConfig::default().with_auto_set_feature_flags(false),
+            dataset.manifest_location.naming_scheme,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut dataset = Dataset::open(test_uri).await.unwrap();
+        assert!(
+            dataset
+                .load_indices_by_name("vector_idx")
+                .await
+                .unwrap()
+                .iter()
+                .all(|idx| idx.segment_seq.is_none())
+        );
+
+        let replacement = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [1_u32],
+            b"replacement",
+        )
+        .await;
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&replacement)],
+            )
+            .await
+            .unwrap();
+
+        let committed = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        let segment_seq_by_uuid = committed
+            .iter()
+            .map(|idx| (idx.uuid, idx.segment_seq))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(segment_seq_by_uuid.get(&seg0.uuid), Some(&Some(1)));
+        assert!(!segment_seq_by_uuid.contains_key(&seg1.uuid));
+        assert_eq!(segment_seq_by_uuid.get(&replacement.uuid), Some(&Some(3)));
+        assert_ne!(
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_index_metadata_refresh_preserves_segment_seq() {
+        use lance_datagen::{BatchCount, RowCount, array};
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "vector",
+                array::rand_vec::<arrow_array::types::Float32Type>(8.into()),
+            )
+            .into_reader_rows(RowCount::from(10), BatchCount::from(1));
+
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 10,
+                max_rows_per_group: 10,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let field_id = dataset.schema().field("vector").unwrap().id;
+        let segment = write_vector_segment_metadata(
+            &dataset,
+            "vector_idx",
+            field_id,
+            Uuid::new_v4(),
+            [0_u32],
+            b"segment",
+        )
+        .await;
+
+        dataset
+            .commit_existing_index_segments(
+                "vector_idx",
+                "vector",
+                vec![segment_from_metadata(&segment)],
+            )
+            .await
+            .unwrap();
+
+        let original = dataset.load_indices_by_name("vector_idx").await.unwrap()[0].clone();
+        assert_eq!(original.segment_seq, Some(1));
+
+        let mut refreshed = original.clone();
+        refreshed.segment_seq = None;
+        let transaction = Transaction::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![refreshed],
+                removed_indices: vec![original],
+            },
+            None,
+        );
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+
+        let refreshed = dataset.load_indices_by_name("vector_idx").await.unwrap();
+        assert_eq!(refreshed[0].segment_seq, Some(1));
+        assert_ne!(
+            dataset.manifest.writer_feature_flags & FLAG_INDEX_SEGMENT_SEQ,
+            0
+        );
     }
 
     #[tokio::test]
@@ -6730,6 +7113,7 @@ mod tests {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: seg0.files.clone(),
+            segment_seq: None,
         };
 
         let err = dataset

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -490,6 +490,7 @@ impl<'a> CreateIndexBuilder<'a> {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: created_index.files,
+            segment_seq: None,
         })
     }
 

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -174,5 +174,6 @@ pub(crate) async fn build_frag_reuse_index_metadata(
         base_id: None,
         // Fragment reuse index is inline (no files)
         files: None,
+        segment_seq: None,
     })
 }

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -113,6 +113,7 @@ pub(crate) fn new_mem_wal_index_meta(
         base_id: None,
         // Memory WAL index is inline (no files)
         files: None,
+        segment_seq: None,
     })
 }
 

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -713,6 +713,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         }
     }
 

--- a/rust/lance/src/index/scalar/btree.rs
+++ b/rust/lance/src/index/scalar/btree.rs
@@ -189,5 +189,6 @@ pub(crate) async fn merge_segments(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: created_index.files,
+        segment_seq: None,
     })
 }

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -138,6 +138,7 @@ pub(crate) async fn merge_segments(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: created_index.files,
+        segment_seq: None,
         ..segments[0].clone()
     })
 }

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -1825,6 +1825,7 @@ pub async fn initialize_vector_index(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: Some(files),
+        segment_seq: None,
     };
 
     let transaction = Transaction::new(

--- a/rust/lance/src/index/vector/details.rs
+++ b/rust/lance/src/index/vector/details.rs
@@ -926,6 +926,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         };
 
         let metric = metric_type_from_index_metadata(&index);
@@ -948,6 +949,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         };
 
         let metric = metric_type_from_index_metadata(&index);
@@ -968,6 +970,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         };
 
         let metric = metric_type_from_index_metadata(&index);
@@ -1009,6 +1012,7 @@ mod tests {
                 created_at: None,
                 base_id: None,
                 files: None,
+                segment_seq: None,
             };
 
             let metric = metric_type_from_index_metadata(&index);

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -4671,6 +4671,7 @@ mod tests {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: None,
+            segment_seq: None,
         };
 
         // We need to commit this index to the dataset so that it can be found
@@ -4710,6 +4711,7 @@ mod tests {
             created_at: None, // Test index, not setting timestamp
             base_id: None,
             files: None,
+            segment_seq: None,
         };
 
         let prefilter = Arc::new(DatasetPreFilter::new(dataset.clone(), &[index_meta], None));
@@ -4770,6 +4772,7 @@ mod tests {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: None,
+            segment_seq: None,
         };
 
         // We need to commit this new index to the dataset so it can be found

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -30,6 +30,7 @@ use lance_file::version::LanceFileVersion;
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_io::utils::CachedFileSize;
 use lance_select::RowAddrTreeMap;
+use lance_table::feature_flags::can_write_dataset;
 use lance_table::format::{
     DETACHED_VERSION_MASK, DataStorageFormat, DeletionFile, Fragment, IndexMetadata, Manifest,
     WriterVersion, is_detached_version, list_index_files_with_sizes, pb,
@@ -784,6 +785,15 @@ pub(crate) async fn do_commit_detached_transaction(
     write_config: &ManifestWriteConfig,
     commit_config: &CommitConfig,
 ) -> Result<(Manifest, ManifestLocation)> {
+    if !can_write_dataset(dataset.manifest.writer_feature_flags) {
+        let message = format!(
+            "This dataset cannot be written by this version of Lance. \
+             Please upgrade Lance to write to this dataset.\n Flags: {}",
+            dataset.manifest.writer_feature_flags
+        );
+        return Err(Error::not_supported_source(message.into()));
+    }
+
     // We don't strictly need a transaction file but we go ahead and create one for
     // record-keeping if nothing else.
     let transaction_file = if !write_config.disable_transaction_file() {
@@ -924,6 +934,15 @@ pub(crate) async fn commit_transaction(
 ) -> Result<(Manifest, ManifestLocation)> {
     // Note: object_store has been configured with WriteParams, but dataset.object_store.as_ref()
     // has not necessarily. So for anything involving writing, use `object_store`.
+    if !can_write_dataset(dataset.manifest.writer_feature_flags) {
+        let message = format!(
+            "This dataset cannot be written by this version of Lance. \
+             Please upgrade Lance to write to this dataset.\n Flags: {}",
+            dataset.manifest.writer_feature_flags
+        );
+        return Err(Error::not_supported_source(message.into()));
+    }
+
     let read_version = transaction.read_version;
     let mut target_version = read_version + 1;
     let original_dataset = dataset.clone();

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -32,25 +32,28 @@ use lance_io::utils::CachedFileSize;
 use lance_select::RowAddrTreeMap;
 use lance_table::feature_flags::can_write_dataset;
 use lance_table::format::{
-    DETACHED_VERSION_MASK, DataStorageFormat, DeletionFile, Fragment, IndexMetadata, Manifest,
-    WriterVersion, is_detached_version, list_index_files_with_sizes, pb,
+    DETACHED_VERSION_MASK, DataStorageFormat, DeletionFile, Fragment, IndexMetadata, IndexSection,
+    Manifest, WriterVersion, is_detached_version, list_index_files_with_sizes, pb,
 };
 use lance_table::io::commit::{
     CommitConfig, CommitError, CommitHandler, ManifestLocation, ManifestNamingScheme,
 };
+use lance_table::io::manifest::read_manifest_index_section;
 use rand::{Rng, rng};
 
 use super::ObjectStore;
 use crate::Dataset;
 use crate::dataset::cleanup::auto_cleanup_hook;
 use crate::dataset::fragment::FileFragment;
-use crate::dataset::transaction::{Operation, Transaction};
+use crate::dataset::transaction::{CurrentManifestMetadata, Operation, Transaction};
 use crate::dataset::{
     ManifestWriteConfig, NewTransactionResult, TRANSACTIONS_DIR, load_new_transactions,
     write_manifest_file,
 };
+#[cfg(test)]
 use crate::index::DatasetIndexExt;
 use crate::index::DatasetIndexInternalExt;
+use crate::index::retain_supported_indices;
 use crate::index::vector::details::infer_missing_vector_details;
 use crate::io::deletion::read_dataset_deletion_file;
 use crate::session::Session;
@@ -155,7 +158,7 @@ async fn do_commit_new_dataset(
         String::new()
     };
 
-    let (mut manifest, indices) = if let Operation::Clone {
+    let (mut manifest, index_section) = if let Operation::Clone {
         is_shallow,
         ref_name,
         ref_version,
@@ -192,23 +195,19 @@ async fn do_commit_new_dataset(
                 transaction_file.clone(),
             );
 
-            let updated_indices = if let Some(index_section_pos) = source_manifest.index_section {
-                let reader = object_store.open(&source_manifest_location.path).await?;
-                let section: pb::IndexSection =
-                    lance_io::utils::read_message(reader.as_ref(), index_section_pos).await?;
-                section
-                    .indices
-                    .into_iter()
-                    .map(|index_pb| {
-                        let mut index = IndexMetadata::try_from(index_pb)?;
-                        index.base_id = Some(new_base_id);
-                        Ok(index)
-                    })
-                    .collect::<Result<Vec<_>>>()?
-            } else {
-                vec![]
-            };
-            (new_manifest, updated_indices)
+            let mut updated_index_section =
+                if let Some(index_section_pos) = source_manifest.index_section {
+                    let reader = object_store.open(&source_manifest_location.path).await?;
+                    let section: pb::IndexSection =
+                        lance_io::utils::read_message(reader.as_ref(), index_section_pos).await?;
+                    IndexSection::try_from(section)?
+                } else {
+                    IndexSection::default()
+                };
+            for index in &mut updated_index_section.indices {
+                index.base_id = Some(new_base_id);
+            }
+            (new_manifest, updated_index_section)
         } else {
             // Deep clone: build a manifest that references local files (no external bases)
             let mut new_manifest = source_manifest.clone();
@@ -228,27 +227,25 @@ async fn do_commit_new_dataset(
             new_manifest.fragments = Arc::new(new_frags);
 
             // Indices: keep metadata but normalize base to local
-            let mut updated_indices = Vec::new();
+            let mut updated_index_section = IndexSection::default();
             if let Some(index_section_pos) = source_manifest.index_section {
                 let reader = object_store.open(&source_manifest_location.path).await?;
                 let section: pb::IndexSection =
                     lance_io::utils::read_message(reader.as_ref(), index_section_pos).await?;
-                updated_indices = section
-                    .indices
-                    .into_iter()
-                    .map(|index_pb| {
-                        let mut index = IndexMetadata::try_from(index_pb)?;
-                        index.base_id = None;
-                        Ok(index)
-                    })
-                    .collect::<Result<Vec<_>>>()?;
+                updated_index_section = IndexSection::try_from(section)?;
+                for index in &mut updated_index_section.indices {
+                    index.base_id = None;
+                }
             }
-            (new_manifest, updated_indices)
+            (new_manifest, updated_index_section)
         }
     } else {
-        let (manifest, indices) =
-            transaction.build_manifest(None, vec![], &transaction_file, write_config)?;
-        (manifest, indices)
+        transaction.build_manifest_with_index_section(
+            None,
+            IndexSection::default(),
+            &transaction_file,
+            write_config,
+        )?
     };
 
     let result = write_manifest_file(
@@ -256,10 +253,10 @@ async fn do_commit_new_dataset(
         commit_handler,
         base_path,
         &mut manifest,
-        if indices.is_empty() {
+        if index_section.is_empty() {
             None
         } else {
-            Some(indices.clone())
+            Some(index_section.clone())
         },
         write_config,
         manifest_naming_scheme,
@@ -743,6 +740,31 @@ async fn migrate_indices(dataset: &Dataset, indices: &mut [IndexMetadata]) -> Re
     Ok(())
 }
 
+async fn load_index_section_for_commit(dataset: &Dataset) -> Result<IndexSection> {
+    let mut index_section = read_manifest_index_section(
+        dataset.object_store.as_ref(),
+        &dataset.manifest_location,
+        &dataset.manifest,
+    )
+    .await?;
+    retain_supported_indices(&mut index_section.indices);
+    infer_missing_vector_details(dataset, &mut index_section.indices).await;
+    Ok(index_section)
+}
+
+fn index_section_for_write(
+    index_section: &IndexSection,
+    current_manifest: Option<&Manifest>,
+) -> Option<IndexSection> {
+    if !index_section.is_empty()
+        || current_manifest.is_some_and(|manifest| manifest.index_section.is_some())
+    {
+        Some(index_section.clone())
+    } else {
+        None
+    }
+}
+
 pub(crate) struct BadFragmentBitmapError {
     pub bad_indices: Vec<(String, Vec<u32>)>,
 }
@@ -808,8 +830,9 @@ pub(crate) async fn do_commit_detached_transaction(
         // Pick a random u64 with the highest bit set to indicate it is detached
         let random_version = rng().random::<u64>() | DETACHED_VERSION_MASK;
 
-        let (mut manifest, mut indices) = match transaction.operation {
+        let (mut manifest, mut index_section) = match transaction.operation {
             Operation::Restore { version } => {
+                let current_index_section = load_index_section_for_commit(dataset).await?;
                 Transaction::restore_old_manifest(
                     object_store,
                     commit_handler,
@@ -817,13 +840,16 @@ pub(crate) async fn do_commit_detached_transaction(
                     version,
                     write_config,
                     &transaction_file,
-                    &dataset.manifest,
+                    CurrentManifestMetadata {
+                        manifest: dataset.manifest.as_ref(),
+                        index_section: &current_index_section,
+                    },
                 )
                 .await?
             }
-            _ => transaction.build_manifest(
+            _ => transaction.build_manifest_with_index_section(
                 Some(dataset.manifest.as_ref()),
-                dataset.load_indices().await?.as_ref().clone(),
+                load_index_section_for_commit(dataset).await?,
                 &transaction_file,
                 write_config,
             )?,
@@ -838,7 +864,7 @@ pub(crate) async fn do_commit_detached_transaction(
         fix_schema(&mut manifest)?;
         check_storage_version(&mut manifest)?;
         check_column_indices(&manifest)?;
-        migrate_indices(dataset, &mut indices).await?;
+        migrate_indices(dataset, &mut index_section.indices).await?;
 
         // Try to commit the manifest
         let result = write_manifest_file(
@@ -846,11 +872,7 @@ pub(crate) async fn do_commit_detached_transaction(
             commit_handler,
             &dataset.base,
             &mut manifest,
-            if indices.is_empty() {
-                None
-            } else {
-                Some(indices.clone())
-            },
+            index_section_for_write(&index_section, Some(dataset.manifest.as_ref())),
             write_config,
             ManifestNamingScheme::V2,
             Some(transaction),
@@ -1015,8 +1037,9 @@ pub(crate) async fn commit_transaction(
             ));
         }
         // Build an up-to-date manifest from the transaction and current manifest
-        let (mut manifest, mut indices) = match transaction.operation {
+        let (mut manifest, mut index_section) = match transaction.operation {
             Operation::Restore { version } => {
+                let current_index_section = load_index_section_for_commit(&dataset).await?;
                 Transaction::restore_old_manifest(
                     object_store,
                     commit_handler,
@@ -1024,13 +1047,16 @@ pub(crate) async fn commit_transaction(
                     version,
                     write_config,
                     transaction_file,
-                    &dataset.manifest,
+                    CurrentManifestMetadata {
+                        manifest: dataset.manifest.as_ref(),
+                        index_section: &current_index_section,
+                    },
                 )
                 .await?
             }
-            _ => transaction.build_manifest(
+            _ => transaction.build_manifest_with_index_section(
                 Some(dataset.manifest.as_ref()),
-                dataset.load_indices().await?.as_ref().clone(),
+                load_index_section_for_commit(&dataset).await?,
                 transaction_file,
                 write_config,
             )?,
@@ -1052,7 +1078,7 @@ pub(crate) async fn commit_transaction(
         check_storage_version(&mut manifest)?;
         check_column_indices(&manifest)?;
 
-        migrate_indices(&dataset, &mut indices).await?;
+        migrate_indices(&dataset, &mut index_section.indices).await?;
 
         // Try to commit the manifest
         let result = write_manifest_file(
@@ -1060,11 +1086,7 @@ pub(crate) async fn commit_transaction(
             commit_handler,
             &dataset.base,
             &mut manifest,
-            if indices.is_empty() {
-                None
-            } else {
-                Some(indices.clone())
-            },
+            index_section_for_write(&index_section, Some(dataset.manifest.as_ref())),
             write_config,
             manifest_naming_scheme,
             Some(&transaction),
@@ -1090,13 +1112,13 @@ pub(crate) async fn commit_transaction(
                     .metadata_cache
                     .insert_with_key(&manifest_key, Arc::new(manifest.clone()))
                     .await;
-                if !indices.is_empty() {
+                if !index_section.indices.is_empty() {
                     let key = IndexMetadataKey {
                         version: target_version,
                     };
                     dataset
                         .index_cache
-                        .insert_with_key(&key, Arc::new(indices))
+                        .insert_with_key(&key, Arc::new(index_section.indices))
                         .await;
                 }
 
@@ -1792,7 +1814,7 @@ mod tests {
         async fn commit(
             &self,
             _manifest: &mut Manifest,
-            _indices: Option<Vec<IndexMetadata>>,
+            _index_section: Option<IndexSection>,
             _base_path: &Path,
             _object_store: &ObjectStore,
             _manifest_writer: ManifestWriter,

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -754,11 +754,9 @@ async fn load_index_section_for_commit(dataset: &Dataset) -> Result<IndexSection
 
 fn index_section_for_write(
     index_section: &IndexSection,
-    current_manifest: Option<&Manifest>,
+    _current_manifest: Option<&Manifest>,
 ) -> Option<IndexSection> {
-    if !index_section.is_empty()
-        || current_manifest.is_some_and(|manifest| manifest.index_section.is_some())
-    {
+    if !index_section.is_empty() {
         Some(index_section.clone())
     } else {
         None

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1605,8 +1605,15 @@ impl<'a> TransactionRebase<'a> {
             }
 
             let current_indices = dataset.load_indices().await?;
+            let current_index_section = lance_table::io::manifest::read_manifest_index_section(
+                dataset.object_store.as_ref(),
+                &dataset.manifest_location,
+                &dataset.manifest,
+            )
+            .await?;
             assign_index_segment_seqs_for_new_indices(
                 current_indices.as_ref(),
+                &current_index_section.logical_indexes,
                 removed_indices,
                 new_indices,
             );

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -7,7 +7,7 @@ use crate::index::mem_wal::{load_mem_wal_index_details, new_mem_wal_index_meta};
 use crate::io::deletion::read_dataset_deletion_file;
 use crate::{
     Dataset,
-    dataset::transaction::{Operation, Transaction},
+    dataset::transaction::{Operation, Transaction, assign_index_segment_seqs_for_new_indices},
 };
 use futures::{StreamExt, TryStreamExt};
 use lance_core::{Error, Result, utils::deletion::DeletionVector};
@@ -35,6 +35,26 @@ pub struct TransactionRebase<'a> {
     /// Merged generations from conflicting UpdateMemWalState transactions.
     /// Used when rebasing CreateIndex of MemWalIndex.
     conflicting_mem_wal_merged_gens: Vec<MergedGeneration>,
+}
+
+fn create_index_segments_are_rebasable(
+    new_index: &IndexMetadata,
+    created_index: &IndexMetadata,
+) -> bool {
+    if new_index.fields != created_index.fields {
+        return false;
+    }
+
+    if new_index.index_details.as_deref() != created_index.index_details.as_deref() {
+        return false;
+    }
+
+    match (&new_index.fragment_bitmap, &created_index.fragment_bitmap) {
+        (Some(new_fragments), Some(created_fragments)) => {
+            new_fragments.is_disjoint(created_fragments)
+        }
+        _ => false,
+    }
 }
 
 impl<'a> TransactionRebase<'a> {
@@ -522,7 +542,10 @@ impl<'a> TransactionRebase<'a> {
                         .any(|new_index| {
                             created_indices
                                 .iter()
-                                .any(|created_index| created_index.name == new_index.name)
+                                .filter(|created_index| created_index.name == new_index.name)
+                                .any(|created_index| {
+                                    !create_index_segments_are_rebasable(new_index, created_index)
+                                })
                         });
 
                     if (self_has_frag_reuse && other_has_frag_reuse)
@@ -1581,6 +1604,13 @@ impl<'a> TransactionRebase<'a> {
                 }
             }
 
+            let current_indices = dataset.load_indices().await?;
+            assign_index_segment_seqs_for_new_indices(
+                current_indices.as_ref(),
+                removed_indices,
+                new_indices,
+            );
+
             Ok(self.transaction)
         } else {
             Err(wrong_operation_err(&self.transaction.operation))
@@ -2216,6 +2246,7 @@ mod tests {
             created_at: None, // Test index, not setting timestamp
             base_id: None,
             files: None,
+            segment_seq: None,
         };
         let fragment0 = Fragment::new(0);
         let fragment1 = Fragment::new(1);
@@ -2706,6 +2737,48 @@ mod tests {
     }
 
     #[test]
+    fn test_create_index_segments_require_matching_details() {
+        let details = Arc::new(prost_types::Any {
+            type_url: "type.googleapis.com/lance.test.IndexDetails".to_string(),
+            value: vec![1],
+        });
+        let index0 = IndexMetadata {
+            uuid: uuid::Uuid::new_v4(),
+            name: "test".to_string(),
+            fields: vec![0],
+            dataset_version: 1,
+            fragment_bitmap: Some([0].into_iter().collect()),
+            index_details: Some(details.clone()),
+            index_version: 0,
+            created_at: None,
+            base_id: None,
+            files: None,
+            segment_seq: None,
+        };
+        let same_details = IndexMetadata {
+            uuid: uuid::Uuid::new_v4(),
+            fragment_bitmap: Some([1].into_iter().collect()),
+            index_details: Some(details),
+            ..index0.clone()
+        };
+        let different_details = IndexMetadata {
+            uuid: uuid::Uuid::new_v4(),
+            fragment_bitmap: Some([2].into_iter().collect()),
+            index_details: Some(Arc::new(prost_types::Any {
+                type_url: "type.googleapis.com/lance.test.IndexDetails".to_string(),
+                value: vec![2],
+            })),
+            ..index0.clone()
+        };
+
+        assert!(create_index_segments_are_rebasable(&index0, &same_details));
+        assert!(!create_index_segments_are_rebasable(
+            &index0,
+            &different_details
+        ));
+    }
+
+    #[test]
     fn test_create_index_conflicts_only_on_same_name() {
         let index0 = IndexMetadata {
             uuid: uuid::Uuid::new_v4(),
@@ -2718,6 +2791,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         };
         let index1 = IndexMetadata {
             uuid: uuid::Uuid::new_v4(),
@@ -2784,6 +2858,7 @@ mod tests {
                         created_at: None,
                         base_id: None,
                         files: None,
+                        segment_seq: None,
                     }],
                     removed_indices: vec![],
                 },

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -2387,6 +2387,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            segment_seq: None,
         };
         let prefilter = Arc::new(DatasetPreFilter::new(dataset, &[index], None));
         prefilter.wait_for_ready().await.unwrap();


### PR DESCRIPTION
Adds optional, name-scoped `segment_seq` metadata to index segments and assigns it in the commit/rebase layer. The change stores `LogicalIndexMetadata.max_segment_seq` in the manifest index section so sequence numbers are not reused after the highest physical segment for an index name is removed.

This backfills legacy segments on the next segment commit, uses the single writer feature flag `FLAG_INDEX_SEGMENT_SEQ` for both physical `segment_seq` and logical high-water metadata, and preserves existing Rust/Python/Java describe/build call patterns by assigning sequence numbers at commit time.

Discussion: https://github.com/lance-format/lance/discussions/7044