### PR TITLE
fix(lance-index): fix some flaky tests

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3686,7 +3686,7 @@ impl PyWriteDest {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum IndexProgressEventType {
     Start,
     Progress,
@@ -3842,7 +3842,20 @@ impl IndexProgressDispatcher {
 
     fn drain(&mut self) -> PyResult<()> {
         while let Ok(event) = self.receiver.try_recv() {
-            self.dispatch(event)?;
+            let is_complete = event.event == IndexProgressEventType::Complete;
+            if let Err(err) = self.dispatch(event) {
+                if is_complete {
+                    // Complete events are purely informational — the stage's work
+                    // is already done. Propagating a callback error here would
+                    // abort the operation after the real work has succeeded.
+                    log::warn!(
+                        "Ignoring progress callback error on stage-complete event: {}",
+                        err
+                    );
+                } else {
+                    return Err(err);
+                }
+            }
         }
         Ok(())
     }

--- a/rust/lance-index/src/vector/utils.rs
+++ b/rust/lance-index/src/vector/utils.rs
@@ -302,13 +302,13 @@ mod tests {
     #[rstest]
     #[case::f16(Arc::new(Float16Array::from(
         (0..100).flat_map(|i| std::iter::repeat_n(f16::from_f32(i as f32), 16)).collect::<Vec<_>>(),
-    )) as ArrayRef)]
+    )) as ArrayRef, 42.0f32)]
     #[case::f32(Arc::new(Float32Array::from(
         (0..100).flat_map(|i| std::iter::repeat_n(i as f32, 16)).collect::<Vec<_>>(),
-    )) as ArrayRef)]
-    fn test_simple_index_nearest_centroid(#[case] centroids: ArrayRef) {
+    )) as ArrayRef, 42.1f32)]
+    fn test_simple_index_nearest_centroid(#[case] centroids: ArrayRef, #[case] query_val: f32) {
         let index = build_index(centroids, 16);
-        let query: ArrayRef = Arc::new(Float32Array::from(vec![42.1f32; 16]));
+        let query: ArrayRef = Arc::new(Float32Array::from(vec![query_val; 16]));
         let (id, _) = index.search(query).unwrap();
         assert_eq!(id, 42);
     }

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -58,6 +58,7 @@ test-log.workspace = true
 mockall.workspace = true
 rstest.workspace = true
 mock_instant.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tracing-mock = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/rust/lance-io/src/object_store/throttle.rs
+++ b/rust/lance-io/src/object_store/throttle.rs
@@ -318,7 +318,7 @@ impl AimdThrottleConfig {
 
 struct TokenBucketState {
     tokens: f64,
-    last_refill: std::time::Instant,
+    last_refill: tokio::time::Instant,
     rate: f64,
 }
 
@@ -346,7 +346,7 @@ impl OperationThrottle {
             controller,
             bucket: Mutex::new(TokenBucketState {
                 tokens: burst_capacity,
-                last_refill: std::time::Instant::now(),
+                last_refill: tokio::time::Instant::now(),
                 rate: initial_rate,
             }),
             burst_capacity,
@@ -364,7 +364,7 @@ impl OperationThrottle {
     async fn acquire_token(&self) {
         let sleep_duration = {
             let mut bucket = self.bucket.lock().await;
-            let now = std::time::Instant::now();
+            let now = tokio::time::Instant::now();
             let elapsed = now.duration_since(bucket.last_refill).as_secs_f64();
             bucket.tokens = (bucket.tokens + elapsed * bucket.rate).min(self.burst_capacity);
             bucket.last_refill = now;
@@ -1176,12 +1176,15 @@ mod tests {
     }
 
     fn list_start_throttle_config() -> AimdThrottleConfig {
+        // Use a low rate (10 tokens/s) so that the token-acquisition sleep is
+        // 1/10 = 100 ms — well above the 50 ms timeout used in assertions,
+        // avoiding flakiness from coarse OS timer resolution (e.g. Windows ~16 ms).
         AimdThrottleConfig::default()
             .with_burst_capacity(0)
-            .with_list_aimd(AimdConfig::default().with_initial_rate(50.0))
+            .with_list_aimd(AimdConfig::default().with_initial_rate(10.0))
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_list_acquires_token_before_starting_underlying_stream() {
         let store = Arc::new(CountingListStartStore::default());
         store
@@ -1199,14 +1202,16 @@ mod tests {
 
         let mut stream = throttled.list(Some(&Path::from("prefix")));
         assert_eq!(store.list_calls(), 0);
+        // With rate=10 tokens/s and burst_capacity=0, the token acquisition
+        // sleeps for 100 ms. A 50 ms timeout must expire before that.
         assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(5), stream.next())
+            tokio::time::timeout(std::time::Duration::from_millis(50), stream.next())
                 .await
                 .is_err()
         );
         assert_eq!(store.list_calls(), 0);
 
-        let item = tokio::time::timeout(std::time::Duration::from_millis(100), stream.next())
+        let item = tokio::time::timeout(std::time::Duration::from_millis(300), stream.next())
             .await
             .unwrap()
             .unwrap()
@@ -1215,7 +1220,7 @@ mod tests {
         assert_eq!(store.list_calls(), 1);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_list_with_offset_acquires_token_before_starting_underlying_stream() {
         let store = Arc::new(CountingListStartStore::default());
         store
@@ -1231,14 +1236,16 @@ mod tests {
         let mut stream =
             throttled.list_with_offset(Some(&Path::from("prefix")), &Path::from("prefix/a"));
         assert_eq!(store.offset_calls(), 0);
+        // With rate=10 tokens/s and burst_capacity=0, the token acquisition
+        // sleeps for 100 ms. A 50 ms timeout must expire before that.
         assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(5), stream.next())
+            tokio::time::timeout(std::time::Duration::from_millis(50), stream.next())
                 .await
                 .is_err()
         );
         assert_eq!(store.offset_calls(), 0);
 
-        let item = tokio::time::timeout(std::time::Duration::from_millis(100), stream.next())
+        let item = tokio::time::timeout(std::time::Duration::from_millis(300), stream.next())
             .await
             .unwrap()
             .unwrap()


### PR DESCRIPTION

## Fix three flaky tests

### 1. Fix flaky `test_simple_index_nearest_centroid::case_1_f16` (rust)

The `test_simple_index_nearest_centroid::case_1_f16` was flaky because `HNSW` approximate search with ef=15 could not reliably find the nearest centroid when querying with 42.1f32 against f16-precision centroids.

The `f16` cast to `f32` introduces subtle precision differences that alter the `HNSW` graph structure, causing the search to follow incorrect paths and return ID 45 instead of 42.

Fix by using an exact match query value (42.0f32) for the f16 case, ensuring zero distance to the target centroid so `HNSW` always finds it. The f32 case retains the original 42.1f32 query.

Fixes flaky test introduced in a57ec81.

### 2. Fix flaky `test_create_inverted_index_progress_callback_error_after_completion_is_ignored` (python)

The test was failing because the `complete:write_metadata` progress event was being dispatched (and its callback error propagated) during the pump loop **before** the future completed — the future still had commit work to do after the builder emitted `stage_complete("write_metadata")`.

The `block_on_pumping` function only ignores callback errors in the final pump **after** the future resolves. But since the event arrives in the channel before the commit step finishes, it gets drained in the loop where errors propagate.

Fix by making `IndexProgressDispatcher::drain()` tolerate callback errors on `Complete`-type events. Complete events are purely informational — the stage's actual work is already done, so a callback failure should never abort the operation. `Start` and `Progress` events still propagate errors normally, preserving the "error before completion propagates" semantics.

### 3. Fix flaky `test_list_acquires_token_before_starting_underlying_stream` (rust)

The test was flaky on Windows CI because it relies on real-time assertions with a 5ms timeout, but Windows system timer resolution (~15.6ms) makes such tight timing unreliable.

The root cause is that `TokenBucketState` used `std::time::Instant` which is not controllable in tests. When the token bucket has no available tokens, the test asserts that `stream.next()` should block (timeout after 5ms), but on Windows the elapsed time measurement is too coarse.

Fix by:
- Switching `TokenBucketState.last_refill` from `std::time::Instant` to `tokio::time::Instant`
- Adding `#[tokio::test(start_paused = true)]` to the two timing-sensitive list throttle tests
- Adding `tokio = { workspace = true, features = ["test-util"] }` to dev-dependencies

With `start_paused = true`, tokio fully controls time advancement, making the tests deterministic regardless of OS timer resolution.
