### PR TITLE
fix: specify roaring's patch version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ rand_distr = { version = "0.5.1" }
 rand_xoshiro = "0.7.0"
 rangemap = { version = "1.0" }
 rayon = "1.10"
-roaring = "0.11"
+roaring = "0.11.4"
 rstest = "0.23.0"
 serde = { version = "^1" }
 serde_json = { version = "1" }

--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -48,7 +48,7 @@ log = "0.4"
 env_logger = "0.11.7"
 uuid = { version = "1.17.0", features = ["v4"] }
 prost = "0.14.1"
-roaring = "0.11"
+roaring = "0.11.4"
 prost-types = "0.14.1"
 chrono = "0.4.41"
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -62,7 +62,7 @@ pyo3 = { version = "0.28", features = [
 pythonize = "0.28"
 tokio = { version = "1.48", features = ["rt-multi-thread"] }
 uuid = "1.3.0"
-roaring = "0.11"
+roaring = "0.11.4"
 serde_json = "1"
 serde = "1.0.197"
 serde_yaml = "0.9.34"


### PR DESCRIPTION
Commit https://github.com/lance-format/lance/commit/43c37805866d3d7523c090c1a35528ea7c48bc8b adds these code which requires that `RoaringBitmap` should implement `Eq`. But `roaring` didn't implement it until version 0.11.4 https://github.com/RoaringBitmap/roaring-rs/pull/341.
```rust
#[derive(Debug, Clone, PartialEq, Eq, Default)]
pub struct UpdatedFragmentOffsets(pub HashMap<u64, RoaringBitmap>);
```