### PR TITLE
ci: update compat namespace pin for 7.2 beta

### DIFF
--- a/python/python/tests/compat/test_venv_manager.py
+++ b/python/python/tests/compat/test_venv_manager.py
@@ -13,6 +13,7 @@ from .venv_manager import _lance_namespace_dependency
         ("4.0.0b1", "lance-namespace<0.7"),
         ("6.0.0b5", "lance-namespace>=0.7.2,<0.8"),
         ("6.0.0", "lance-namespace>=0.7.2,<0.8"),
+        ("7.2.0b5", "lance-namespace>=0.8.0,<0.9"),
     ],
 )
 def test_lance_namespace_dependency(version: str, expected: str):

--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -20,9 +20,12 @@ from packaging.version import Version
 
 NAMESPACE_0_6_DEPENDENCY = "lance-namespace<0.7"
 NAMESPACE_0_7_DEPENDENCY = "lance-namespace>=0.7.2,<0.8"
+NAMESPACE_0_8_DEPENDENCY = "lance-namespace>=0.8.0,<0.9"
 
 
 def _lance_namespace_dependency(pylance_version: str) -> str:
+    if Version(pylance_version) >= Version("7.2.0b5"):
+        return NAMESPACE_0_8_DEPENDENCY
     if Version(pylance_version) >= Version("6.0.0b0"):
         return NAMESPACE_0_7_DEPENDENCY
     return NAMESPACE_0_6_DEPENDENCY


### PR DESCRIPTION
Updates compatibility test venv dependency selection so pylance 7.2 beta installs lance-namespace 0.8.x, matching the package metadata.

Failing UT that this PR addresses: https://github.com/lance-format/lance/actions/runs/26821158183/job/79080227881