### PR TITLE
fix: handle nested JSON conversion recursively

### DIFF
--- a/python/python/tests/test_json.py
+++ b/python/python/tests/test_json.py
@@ -8,6 +8,7 @@ from typing import Union
 
 import lance
 import pyarrow as pa
+import pytest
 
 
 def check_json_type(ds: Union[lance.LanceDataset, pa.Table], col_name: str):
@@ -17,6 +18,16 @@ def check_json_type(ds: Union[lance.LanceDataset, pa.Table], col_name: str):
     schema = ds.schema
     field = schema.field(col_name)
     assert field.type == pa.json_()
+
+
+def check_nested_json_type(ds: Union[lance.LanceDataset, pa.Table]):
+    media_field = ds.schema.field("media")
+    extra_field = media_field.type.value_type.field("extra")
+    assert extra_field.type == pa.json_()
+
+
+def nested_extra_value(table: pa.Table):
+    return table.to_pylist()[0]["media"][0]["extra"]
 
 
 def test_json_basic_write_read():
@@ -65,6 +76,71 @@ def test_json_basic_write_read():
         # Verify data
         assert result_table.num_rows == 5
         assert result_table.column("id").to_pylist() == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.parametrize("version", ["2.1", "2.2", "2.3"])
+def test_nested_json_large_binary_cast_roundtrip(tmp_path: Path, version: str):
+    storage_schema = pa.schema(
+        [
+            pa.field(
+                "media",
+                pa.list_(
+                    pa.struct(
+                        [
+                            pa.field("uri", pa.utf8(), nullable=False),
+                            pa.field("extra", pa.large_binary()),
+                        ]
+                    )
+                ),
+            )
+        ]
+    )
+    extension_schema = pa.schema(
+        [
+            pa.field(
+                "media",
+                pa.list_(
+                    pa.struct(
+                        [
+                            pa.field("uri", pa.utf8(), nullable=False),
+                            pa.field("extra", pa.json_()),
+                        ]
+                    )
+                ),
+            )
+        ]
+    )
+    table = pa.Table.from_pylist(
+        [
+            {
+                "media": [
+                    {
+                        "uri": "s3://bucket/a.mp4",
+                        "extra": b'{"codec": "h264"}',
+                    }
+                ]
+            }
+        ],
+        schema=storage_schema,
+    ).cast(extension_schema)
+
+    dataset_path = tmp_path / f"nested_json_{version.replace('.', '_')}.lance"
+    lance.write_dataset(table, dataset_path, data_storage_version=version)
+    dataset = lance.dataset(dataset_path)
+
+    check_nested_json_type(dataset)
+
+    scanned = dataset.to_table()
+    check_nested_json_type(scanned)
+    assert json.loads(nested_extra_value(scanned)) == {"codec": "h264"}
+
+    taken = dataset.take([0])
+    check_nested_json_type(taken)
+    assert json.loads(nested_extra_value(taken)) == {"codec": "h264"}
+
+    empty = dataset.take([])
+    assert empty.num_rows == 0
+    check_nested_json_type(empty)
 
 
 def test_json_with_other_types():

--- a/rust/lance-arrow/src/json.rs
+++ b/rust/lance-arrow/src/json.rs
@@ -6,9 +6,13 @@
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use arrow_array::builder::LargeBinaryBuilder;
-use arrow_array::{Array, ArrayRef, LargeBinaryArray, LargeStringArray, RecordBatch, StringArray};
-use arrow_schema::{ArrowError, DataType, Field as ArrowField, Schema};
+use arrow_array::builder::{LargeBinaryBuilder, StringBuilder};
+use arrow_array::cast::AsArray;
+use arrow_array::{
+    Array, ArrayRef, FixedSizeListArray, LargeBinaryArray, LargeListArray, LargeStringArray,
+    ListArray, MapArray, RecordBatch, StringArray, StructArray,
+};
+use arrow_schema::{ArrowError, DataType, Field as ArrowField, Fields, Schema};
 
 use crate::ARROW_EXT_NAME_KEY;
 
@@ -51,6 +55,22 @@ pub fn has_json_fields(field: &ArrowField) -> bool {
             has_json_fields(f)
         }
         DataType::Map(f, _) => has_json_fields(f),
+        _ => false,
+    }
+}
+
+/// Check if a field or any of its descendants is an Arrow JSON field
+pub fn has_arrow_json_fields(field: &ArrowField) -> bool {
+    if is_arrow_json_field(field) {
+        return true;
+    }
+
+    match field.data_type() {
+        DataType::Struct(fields) => fields.iter().any(|f| has_arrow_json_fields(f)),
+        DataType::List(f) | DataType::LargeList(f) | DataType::FixedSizeList(f, _) => {
+            has_arrow_json_fields(f)
+        }
+        DataType::Map(f, _) => has_arrow_json_fields(f),
         _ => false,
     }
 }
@@ -292,21 +312,249 @@ fn get_json_path(
 /// Convert an Arrow JSON field to Lance JSON field (with JSONB storage)
 pub fn arrow_json_to_lance_json(field: &ArrowField) -> ArrowField {
     if is_arrow_json_field(field) {
-        // Convert Arrow JSON (Utf8/LargeUtf8) to Lance JSON (LargeBinary)
-        // Preserve all metadata from the original field
-        let mut new_field =
-            ArrowField::new(field.name(), DataType::LargeBinary, field.is_nullable());
-
-        // Copy all metadata from the original field
-        let mut metadata = field.metadata().clone();
-        // Add/override the extension metadata for Lance JSON
-        metadata.insert(ARROW_EXT_NAME_KEY.to_string(), JSON_EXT_NAME.to_string());
-
-        new_field = new_field.with_metadata(metadata);
-        new_field
-    } else {
-        field.clone()
+        return field_with_extension(field, DataType::LargeBinary, JSON_EXT_NAME);
     }
+
+    let data_type = match field.data_type() {
+        DataType::Struct(fields) => {
+            let fields = fields
+                .iter()
+                .map(|field| Arc::new(arrow_json_to_lance_json(field)))
+                .collect::<Vec<_>>();
+            DataType::Struct(Fields::from(fields))
+        }
+        DataType::List(item) => DataType::List(Arc::new(arrow_json_to_lance_json(item))),
+        DataType::LargeList(item) => DataType::LargeList(Arc::new(arrow_json_to_lance_json(item))),
+        DataType::FixedSizeList(item, size) => {
+            DataType::FixedSizeList(Arc::new(arrow_json_to_lance_json(item)), *size)
+        }
+        DataType::Map(entries, keys_sorted) => {
+            DataType::Map(Arc::new(arrow_json_to_lance_json(entries)), *keys_sorted)
+        }
+        _ => return field.clone(),
+    };
+
+    field_with_data_type(field, data_type)
+}
+
+/// Convert a Lance JSON field to Arrow JSON field.
+pub fn lance_json_to_arrow_json(field: &ArrowField) -> ArrowField {
+    if is_json_field(field) {
+        return field_with_extension(field, DataType::Utf8, ARROW_JSON_EXT_NAME);
+    }
+
+    let data_type = match field.data_type() {
+        DataType::Struct(fields) => {
+            let fields = fields
+                .iter()
+                .map(|field| Arc::new(lance_json_to_arrow_json(field)))
+                .collect::<Vec<_>>();
+            DataType::Struct(Fields::from(fields))
+        }
+        DataType::List(item) => DataType::List(Arc::new(lance_json_to_arrow_json(item))),
+        DataType::LargeList(item) => DataType::LargeList(Arc::new(lance_json_to_arrow_json(item))),
+        DataType::FixedSizeList(item, size) => {
+            DataType::FixedSizeList(Arc::new(lance_json_to_arrow_json(item)), *size)
+        }
+        DataType::Map(entries, keys_sorted) => {
+            DataType::Map(Arc::new(lance_json_to_arrow_json(entries)), *keys_sorted)
+        }
+        _ => return field.clone(),
+    };
+
+    field_with_data_type(field, data_type)
+}
+
+fn field_with_data_type(field: &ArrowField, data_type: DataType) -> ArrowField {
+    ArrowField::new(field.name(), data_type, field.is_nullable())
+        .with_metadata(field.metadata().clone())
+}
+
+fn field_with_extension(
+    field: &ArrowField,
+    data_type: DataType,
+    extension_name: &str,
+) -> ArrowField {
+    let mut metadata = field.metadata().clone();
+    metadata.insert(ARROW_EXT_NAME_KEY.to_string(), extension_name.to_string());
+    ArrowField::new(field.name(), data_type, field.is_nullable()).with_metadata(metadata)
+}
+
+fn convert_json_array<F>(
+    field: &ArrowField,
+    array: &ArrayRef,
+    convert_leaf: &F,
+) -> Result<(ArrowField, ArrayRef, bool), ArrowError>
+where
+    F: Fn(&ArrowField, &ArrayRef) -> Result<Option<(ArrowField, ArrayRef)>, ArrowError>,
+{
+    if let Some((field, array)) = convert_leaf(field, array)? {
+        return Ok((field, array, true));
+    }
+
+    match field.data_type() {
+        DataType::Struct(fields) => {
+            let struct_array = array.as_struct();
+            let mut new_fields = Vec::with_capacity(fields.len());
+            let mut new_columns = Vec::with_capacity(fields.len());
+            let mut changed = false;
+
+            for (field, column) in fields.iter().zip(struct_array.columns()) {
+                let (new_field, new_column, field_changed) =
+                    convert_json_array(field, column, convert_leaf)?;
+                changed |= field_changed;
+                new_fields.push(Arc::new(new_field));
+                new_columns.push(new_column);
+            }
+
+            if changed {
+                let fields = Fields::from(new_fields);
+                let new_field = field_with_data_type(field, DataType::Struct(fields.clone()));
+                let new_array =
+                    StructArray::new(fields, new_columns, struct_array.nulls().cloned());
+                Ok((new_field, Arc::new(new_array) as ArrayRef, true))
+            } else {
+                Ok((field.clone(), array.clone(), false))
+            }
+        }
+        DataType::List(item) => {
+            let list_array: &ListArray = array.as_list();
+            let (new_item, new_values, changed) =
+                convert_json_array(item, list_array.values(), convert_leaf)?;
+            if changed {
+                let new_field =
+                    field_with_data_type(field, DataType::List(Arc::new(new_item.clone())));
+                let new_array = ListArray::new(
+                    Arc::new(new_item),
+                    list_array.offsets().clone(),
+                    new_values,
+                    list_array.nulls().cloned(),
+                );
+                Ok((new_field, Arc::new(new_array) as ArrayRef, true))
+            } else {
+                Ok((field.clone(), array.clone(), false))
+            }
+        }
+        DataType::LargeList(item) => {
+            let list_array: &LargeListArray = array.as_list();
+            let (new_item, new_values, changed) =
+                convert_json_array(item, list_array.values(), convert_leaf)?;
+            if changed {
+                let new_field =
+                    field_with_data_type(field, DataType::LargeList(Arc::new(new_item.clone())));
+                let new_array = LargeListArray::new(
+                    Arc::new(new_item),
+                    list_array.offsets().clone(),
+                    new_values,
+                    list_array.nulls().cloned(),
+                );
+                Ok((new_field, Arc::new(new_array) as ArrayRef, true))
+            } else {
+                Ok((field.clone(), array.clone(), false))
+            }
+        }
+        DataType::FixedSizeList(item, size) => {
+            let list_array: &FixedSizeListArray = array.as_fixed_size_list();
+            let (new_item, new_values, changed) =
+                convert_json_array(item, list_array.values(), convert_leaf)?;
+            if changed {
+                let new_field = field_with_data_type(
+                    field,
+                    DataType::FixedSizeList(Arc::new(new_item.clone()), *size),
+                );
+                let new_array = FixedSizeListArray::try_new_with_length(
+                    Arc::new(new_item),
+                    *size,
+                    new_values,
+                    list_array.nulls().cloned(),
+                    list_array.len(),
+                )?;
+                Ok((new_field, Arc::new(new_array) as ArrayRef, true))
+            } else {
+                Ok((field.clone(), array.clone(), false))
+            }
+        }
+        DataType::Map(entries, keys_sorted) => {
+            let map_array = array
+                .as_any()
+                .downcast_ref::<MapArray>()
+                .expect("DataType::Map array must be MapArray");
+            let entries_array = Arc::new(map_array.entries().clone()) as ArrayRef;
+            let (new_entries, new_entries_array, changed) =
+                convert_json_array(entries, &entries_array, convert_leaf)?;
+            if changed {
+                let entries_struct = new_entries_array
+                    .as_any()
+                    .downcast_ref::<StructArray>()
+                    .expect("Map entries must be StructArray")
+                    .clone();
+                let new_field = field_with_data_type(
+                    field,
+                    DataType::Map(Arc::new(new_entries.clone()), *keys_sorted),
+                );
+                let new_array = MapArray::new(
+                    Arc::new(new_entries),
+                    map_array.offsets().clone(),
+                    entries_struct,
+                    map_array.nulls().cloned(),
+                    *keys_sorted,
+                );
+                Ok((new_field, Arc::new(new_array) as ArrayRef, true))
+            } else {
+                Ok((field.clone(), array.clone(), false))
+            }
+        }
+        _ => Ok((field.clone(), array.clone(), false)),
+    }
+}
+
+fn convert_arrow_json_array(
+    field: &ArrowField,
+    array: &ArrayRef,
+) -> Result<(ArrowField, ArrayRef, bool), ArrowError> {
+    convert_json_array(field, array, &|field, array| {
+        if is_arrow_json_field(field) {
+            let json_array = JsonArray::try_from(array.clone())?;
+            Ok(Some((
+                arrow_json_to_lance_json(field),
+                Arc::new(json_array.into_inner()) as ArrayRef,
+            )))
+        } else {
+            Ok(None)
+        }
+    })
+}
+
+fn convert_lance_json_array(
+    field: &ArrowField,
+    array: &ArrayRef,
+) -> Result<(ArrowField, ArrayRef, bool), ArrowError> {
+    convert_json_array(field, array, &|field, array| {
+        if is_json_field(field) {
+            let binary_array = array
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .expect("Lance JSON field must be LargeBinaryArray");
+            let mut builder = StringBuilder::new();
+
+            for i in 0..binary_array.len() {
+                if binary_array.is_null(i) {
+                    builder.append_null();
+                } else {
+                    let jsonb_bytes = binary_array.value(i);
+                    let json_str = decode_json(jsonb_bytes);
+                    builder.append_value(&json_str);
+                }
+            }
+
+            Ok(Some((
+                lance_json_to_arrow_json(field),
+                Arc::new(builder.finish()) as ArrayRef,
+            )))
+        } else {
+            Ok(None)
+        }
+    })
 }
 
 /// Convert a RecordBatch with Lance JSON columns (JSONB) back to Arrow JSON format (strings)
@@ -320,50 +568,11 @@ pub fn convert_lance_json_to_arrow(
 
     for (i, field) in schema.fields().iter().enumerate() {
         let column = batch.column(i);
+        let (new_field, new_column, changed) = convert_lance_json_array(field, column)?;
 
-        if is_json_field(field) {
-            needs_conversion = true;
-
-            // Convert the field back to Arrow JSON (Utf8)
-            let mut new_field = ArrowField::new(field.name(), DataType::Utf8, field.is_nullable());
-            let mut metadata = field.metadata().clone();
-            // Change from lance.json to arrow.json
-            metadata.insert(
-                ARROW_EXT_NAME_KEY.to_string(),
-                ARROW_JSON_EXT_NAME.to_string(),
-            );
-            new_field.set_metadata(metadata);
-            new_fields.push(new_field);
-
-            // Convert the data from JSONB to JSON strings
-            if batch.num_rows() == 0 {
-                // For empty batches, create an empty String array
-                let empty_strings = arrow_array::builder::StringBuilder::new().finish();
-                new_columns.push(Arc::new(empty_strings) as ArrayRef);
-            } else {
-                // Convert JSONB back to JSON strings
-                // Downcast is guaranteed to succeed since is_json_field verified the type
-                let binary_array = column
-                    .as_any()
-                    .downcast_ref::<LargeBinaryArray>()
-                    .expect("Lance JSON field must be LargeBinaryArray");
-
-                let mut builder = arrow_array::builder::StringBuilder::new();
-                for i in 0..binary_array.len() {
-                    if binary_array.is_null(i) {
-                        builder.append_null();
-                    } else {
-                        let jsonb_bytes = binary_array.value(i);
-                        let json_str = decode_json(jsonb_bytes);
-                        builder.append_value(&json_str);
-                    }
-                }
-                new_columns.push(Arc::new(builder.finish()) as ArrayRef);
-            }
-        } else {
-            new_fields.push(field.as_ref().clone());
-            new_columns.push(column.clone());
-        }
+        needs_conversion |= changed;
+        new_fields.push(new_field);
+        new_columns.push(new_column);
     }
 
     if needs_conversion {
@@ -389,40 +598,11 @@ pub fn convert_json_columns(
 
     for (i, field) in schema.fields().iter().enumerate() {
         let column = batch.column(i);
+        let (new_field, new_column, changed) = convert_arrow_json_array(field, column)?;
 
-        if is_arrow_json_field(field) {
-            needs_conversion = true;
-
-            // Convert the field metadata
-            new_fields.push(arrow_json_to_lance_json(field));
-
-            // Convert the data from JSON strings to JSONB
-            if batch.num_rows() == 0 {
-                // For empty batches, create an empty LargeBinary array
-                let empty_binary = LargeBinaryBuilder::new().finish();
-                new_columns.push(Arc::new(empty_binary) as ArrayRef);
-            } else {
-                // Convert non-empty data
-                // is_arrow_json_field guarantees type is Utf8 or LargeUtf8
-                let json_array =
-                    if let Some(string_array) = column.as_any().downcast_ref::<StringArray>() {
-                        JsonArray::try_from(string_array)?
-                    } else {
-                        let large_string_array = column
-                            .as_any()
-                            .downcast_ref::<LargeStringArray>()
-                            .expect("Arrow JSON field must be Utf8 or LargeUtf8");
-                        JsonArray::try_from(large_string_array)?
-                    };
-
-                let binary_array = json_array.into_inner();
-
-                new_columns.push(Arc::new(binary_array) as ArrayRef);
-            }
-        } else {
-            new_fields.push(field.as_ref().clone());
-            new_columns.push(column.clone());
-        }
+        needs_conversion |= changed;
+        new_fields.push(new_field);
+        new_columns.push(new_column);
     }
 
     if needs_conversion {
@@ -544,6 +724,128 @@ mod tests {
             let decoded = decode_json(jsonb_bytes);
             assert!(decoded.contains("name"));
         }
+    }
+
+    #[test]
+    fn test_convert_nested_json_columns() {
+        use arrow_buffer::{OffsetBuffer, ScalarBuffer};
+
+        let uri_field = Arc::new(ArrowField::new("uri", DataType::Utf8, false));
+        let mut metadata = std::collections::HashMap::new();
+        metadata.insert(
+            ARROW_EXT_NAME_KEY.to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
+        let extra_field =
+            Arc::new(ArrowField::new("extra", DataType::Utf8, true).with_metadata(metadata));
+        let item_fields = Fields::from(vec![uri_field, extra_field]);
+
+        let values = StructArray::new(
+            item_fields.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![Some("a.jpg"), Some("b.jpg")])) as ArrayRef,
+                Arc::new(StringArray::from(vec![
+                    Some(r#"{"codec":"h264"}"#),
+                    None::<&str>,
+                ])) as ArrayRef,
+            ],
+            None,
+        );
+        let item = Arc::new(ArrowField::new("item", DataType::Struct(item_fields), true));
+        let media = ListArray::new(
+            item,
+            OffsetBuffer::new(ScalarBuffer::from(vec![0, 1, 2])),
+            Arc::new(values),
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![ArrowField::new(
+            "media",
+            media.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(media) as ArrayRef]).unwrap();
+
+        assert!(has_arrow_json_fields(batch.schema().field(0)));
+
+        let converted = convert_json_columns(&batch).unwrap();
+        let converted_schema = converted.schema();
+        let DataType::List(item) = converted_schema.field(0).data_type() else {
+            panic!("expected list field");
+        };
+        let DataType::Struct(fields) = item.data_type() else {
+            panic!("expected struct item");
+        };
+        assert!(is_json_field(&fields[1]));
+
+        let list_array: &ListArray = converted.column(0).as_list();
+        let values = list_array.values().as_struct();
+        let extra = values
+            .column(1)
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .unwrap();
+        assert!(decode_json(extra.value(0)).contains("h264"));
+        assert!(extra.is_null(1));
+
+        let logical = convert_lance_json_to_arrow(&converted).unwrap();
+        let logical_schema = logical.schema();
+        let DataType::List(item) = logical_schema.field(0).data_type() else {
+            panic!("expected list field");
+        };
+        let DataType::Struct(fields) = item.data_type() else {
+            panic!("expected struct item");
+        };
+        assert!(is_arrow_json_field(&fields[1]));
+
+        let list_array: &ListArray = logical.column(0).as_list();
+        let values = list_array.values().as_struct();
+        let extra = values
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(extra.value(0).contains("h264"));
+        assert!(extra.is_null(1));
+    }
+
+    #[test]
+    fn test_convert_fixed_size_list_zero_json_preserves_length() {
+        let mut metadata = std::collections::HashMap::new();
+        metadata.insert(
+            ARROW_EXT_NAME_KEY.to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
+        let item = Arc::new(ArrowField::new("item", DataType::Utf8, true).with_metadata(metadata));
+        let values = Arc::new(StringArray::from(Vec::<Option<&str>>::new())) as ArrayRef;
+        let lists = FixedSizeListArray::try_new_with_length(item, 0, values, None, 3).unwrap();
+        let schema = Arc::new(Schema::new(vec![ArrowField::new(
+            "lists",
+            lists.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(lists) as ArrayRef]).unwrap();
+
+        let converted = convert_json_columns(&batch).unwrap();
+        assert_eq!(converted.num_rows(), 3);
+        assert_eq!(converted.column(0).len(), 3);
+
+        let converted_schema = converted.schema();
+        let DataType::FixedSizeList(item, size) = converted_schema.field(0).data_type() else {
+            panic!("expected fixed size list field");
+        };
+        assert_eq!(*size, 0);
+        assert!(is_json_field(item));
+
+        let logical = convert_lance_json_to_arrow(&converted).unwrap();
+        assert_eq!(logical.num_rows(), 3);
+        assert_eq!(logical.column(0).len(), 3);
+
+        let logical_schema = logical.schema();
+        let DataType::FixedSizeList(item, size) = logical_schema.field(0).data_type() else {
+            panic!("expected fixed size list field");
+        };
+        assert_eq!(*size, 0);
+        assert!(is_arrow_json_field(item));
     }
 
     #[test]

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -18,6 +18,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_expr::Expr;
 use futures::{Future, Stream, StreamExt, TryStreamExt};
 use lance_arrow::RecordBatchExt;
+use lance_arrow::json::convert_lance_json_to_arrow;
 use lance_core::datatypes::Schema;
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::deletion::OffsetMapper;
@@ -107,7 +108,7 @@ pub async fn take(
 ) -> Result<RecordBatch> {
     let projection = projection.into_projection_plan(Arc::new(dataset.clone()))?;
     if offsets.is_empty() {
-        return Ok(RecordBatch::new_empty(Arc::new(
+        return to_logical_json_batch(RecordBatch::new_empty(Arc::new(
             projection.output_schema()?,
         )));
     }
@@ -169,9 +170,11 @@ async fn do_take_rows(
             let row_addr_col = Arc::new(UInt64Array::from(Vec::<u64>::new()));
             let row_addr_field =
                 ArrowField::new(ROW_ADDR, arrow::datatypes::DataType::UInt64, false);
-            return Ok(empty_batch.try_with_column(row_addr_field, row_addr_col)?);
+            return to_logical_json_batch(
+                empty_batch.try_with_column(row_addr_field, row_addr_col)?,
+            );
         }
-        return Ok(empty_batch);
+        return to_logical_json_batch(empty_batch);
     }
 
     let row_addr_stats = check_row_addrs(&row_addrs);
@@ -388,12 +391,12 @@ async fn do_take_rows(
         }
     }
 
-    Ok(projection.project_batch(batch).await?)
+    to_logical_json_batch(projection.project_batch(batch).await?)
 }
 
 async fn take_rows(builder: TakeBuilder) -> Result<RecordBatch> {
     if builder.is_empty() {
-        return Ok(RecordBatch::new_empty(Arc::new(
+        return to_logical_json_batch(RecordBatch::new_empty(Arc::new(
             builder.projection.output_schema()?,
         )));
     }
@@ -401,6 +404,10 @@ async fn take_rows(builder: TakeBuilder) -> Result<RecordBatch> {
     let projection = builder.projection.clone();
 
     do_take_rows(builder, projection).await
+}
+
+fn to_logical_json_batch(batch: RecordBatch) -> Result<RecordBatch> {
+    Ok(convert_lance_json_to_arrow(&batch)?)
 }
 
 /// Get a stream of batches based on iterator of ranges of row numbers.
@@ -582,8 +589,13 @@ fn take_struct_array(array: &StructArray, indices: &UInt64Array) -> Result<Struc
 
 #[cfg(test)]
 mod test {
-    use arrow_array::{Int32Array, LargeBinaryArray, RecordBatchIterator, StringArray};
-    use arrow_schema::{DataType, Schema as ArrowSchema};
+    use arrow_array::{
+        Int32Array, LargeBinaryArray, ListArray, RecordBatchIterator, StringArray, StructArray,
+    };
+    use arrow_buffer::{OffsetBuffer, ScalarBuffer};
+    use arrow_schema::{DataType, Fields, Schema as ArrowSchema};
+    use lance_arrow::ARROW_EXT_NAME_KEY;
+    use lance_arrow::json::{ARROW_JSON_EXT_NAME, is_arrow_json_field};
     use lance_core::{ROW_ADDR_FIELD, ROW_ID_FIELD};
     use lance_file::version::LanceFileVersion;
     use pretty_assertions::assert_eq;
@@ -614,6 +626,72 @@ mod test {
             ],
         )
         .unwrap()
+    }
+
+    fn nested_arrow_json_batch() -> RecordBatch {
+        let uri_field = Arc::new(ArrowField::new("uri", DataType::Utf8, false));
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            ARROW_EXT_NAME_KEY.to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
+        let extra_field =
+            Arc::new(ArrowField::new("extra", DataType::Utf8, true).with_metadata(metadata));
+        let item_fields = Fields::from(vec![uri_field, extra_field]);
+        let values = StructArray::new(
+            item_fields.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![Some("a.jpg"), Some("b.jpg")])) as ArrayRef,
+                Arc::new(StringArray::from(vec![
+                    Some(r#"{"codec":"h264"}"#),
+                    None::<&str>,
+                ])) as ArrayRef,
+            ],
+            None,
+        );
+        let item = Arc::new(ArrowField::new("item", DataType::Struct(item_fields), true));
+        let media = ListArray::new(
+            item,
+            OffsetBuffer::new(ScalarBuffer::from(vec![0, 1, 2])),
+            Arc::new(values),
+            None,
+        );
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "media",
+            media.data_type().clone(),
+            true,
+        )]));
+
+        RecordBatch::try_new(schema, vec![Arc::new(media) as ArrayRef]).unwrap()
+    }
+
+    fn assert_nested_arrow_json_schema(batch: &RecordBatch) {
+        let schema = batch.schema();
+        let DataType::List(item) = schema.field(0).data_type() else {
+            panic!("expected list field");
+        };
+        let DataType::Struct(fields) = item.data_type() else {
+            panic!("expected struct item");
+        };
+        assert!(is_arrow_json_field(&fields[1]));
+    }
+
+    fn assert_first_nested_json_value(batch: &RecordBatch) {
+        let media: &ListArray = batch.column(0).as_list();
+        let values = media.values().as_struct();
+        let uri = values
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let extra = values
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+
+        assert_eq!(uri.value(0), "a.jpg");
+        assert!(extra.value(0).contains("h264"));
     }
 
     #[rstest]
@@ -670,6 +748,41 @@ mod test {
             .unwrap(),
             values
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_take_nested_arrow_json_returns_logical_schema(
+        #[values(LanceFileVersion::V2_1, LanceFileVersion::V2_2, LanceFileVersion::V2_3)]
+        data_storage_version: LanceFileVersion,
+    ) {
+        let data = nested_arrow_json_batch();
+        let write_params = WriteParams {
+            data_storage_version: Some(data_storage_version),
+            enable_stable_row_ids: false,
+            ..Default::default()
+        };
+        let batches = RecordBatchIterator::new([Ok(data.clone())], data.schema());
+        let dataset = Dataset::write(batches, "memory://", Some(write_params))
+            .await
+            .unwrap();
+        let projection = Schema::try_from(data.schema().as_ref()).unwrap();
+
+        let values = dataset.take(&[0], projection.clone()).await.unwrap();
+        assert_nested_arrow_json_schema(&values);
+        assert_first_nested_json_value(&values);
+
+        let empty = dataset.take(&[], projection.clone()).await.unwrap();
+        assert_eq!(empty.num_rows(), 0);
+        assert_nested_arrow_json_schema(&empty);
+
+        let values = dataset.take_rows(&[0], projection.clone()).await.unwrap();
+        assert_nested_arrow_json_schema(&values);
+        assert_first_nested_json_value(&values);
+
+        let empty = dataset.take_rows(&[], projection).await.unwrap();
+        assert_eq!(empty.num_rows(), 0);
+        assert_nested_arrow_json_schema(&empty);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/tests/dataset_scanner.rs
+++ b/rust/lance/src/dataset/tests/dataset_scanner.rs
@@ -6,15 +6,17 @@ use std::sync::Arc;
 use std::vec;
 
 use crate::index::vector::VectorIndexParams;
-use lance_arrow::FixedSizeListArrayExt;
-use lance_arrow::json::{JsonArray, is_arrow_json_field, json_field};
+use lance_arrow::json::{ARROW_JSON_EXT_NAME, JsonArray, is_arrow_json_field, json_field};
+use lance_arrow::{ARROW_EXT_NAME_KEY, FixedSizeListArrayExt};
 
 use crate::index::DatasetIndexExt;
 use arrow::compute::concat_batches;
 use arrow_array::UInt64Array;
-use arrow_array::{Array, FixedSizeListArray};
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, FixedSizeListArray, ListArray, StructArray};
 use arrow_array::{Float32Array, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
-use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef};
+use arrow_buffer::{OffsetBuffer, ScalarBuffer};
+use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema, SchemaRef};
 use futures::TryStreamExt;
 use lance_arrow::SchemaExt;
 use lance_core::cache::LanceCache;
@@ -358,6 +360,80 @@ async fn test_scan_limit_offset_preserves_json_extension_metadata() {
         batch_with_offset.schema().field_with_name("meta").unwrap()
     ));
     assert_eq!(batch_no_offset.schema(), batch_with_offset.schema());
+}
+
+#[tokio::test]
+async fn test_scan_nested_arrow_json_extension_v2() {
+    let mut json_metadata = HashMap::new();
+    json_metadata.insert(
+        ARROW_EXT_NAME_KEY.to_string(),
+        ARROW_JSON_EXT_NAME.to_string(),
+    );
+    let item_fields = Fields::from(vec![
+        Arc::new(ArrowField::new("uri", DataType::Utf8, false)),
+        Arc::new(ArrowField::new("extra", DataType::Utf8, true).with_metadata(json_metadata)),
+    ]);
+    let item = Arc::new(ArrowField::new(
+        "item",
+        DataType::Struct(item_fields.clone()),
+        true,
+    ));
+    let media_field = ArrowField::new("media", DataType::List(item.clone()), true);
+    let schema = Arc::new(ArrowSchema::new(vec![media_field]));
+
+    for version in [
+        LanceFileVersion::V2_1,
+        LanceFileVersion::V2_2,
+        LanceFileVersion::V2_3,
+    ] {
+        let values = StructArray::new(
+            item_fields.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![Some("a.jpg"), Some("b.jpg")])) as Arc<dyn Array>,
+                Arc::new(StringArray::from(vec![
+                    Some(r#"{"codec":"h264"}"#),
+                    None::<&str>,
+                ])) as Arc<dyn Array>,
+            ],
+            None,
+        );
+        let media = ListArray::new(
+            item.clone(),
+            OffsetBuffer::new(ScalarBuffer::from(vec![0, 1, 2])),
+            Arc::new(values),
+            None,
+        );
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(media)]).unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema.clone());
+        let write_params = WriteParams {
+            data_storage_version: Some(version),
+            ..WriteParams::default()
+        };
+        let uri = format!("memory://{}", Uuid::new_v4());
+        let dataset = Dataset::write(reader, &uri, Some(write_params))
+            .await
+            .unwrap();
+
+        let batch = dataset.scan().try_into_batch().await.unwrap();
+        let batch_schema = batch.schema();
+        let DataType::List(item) = batch_schema.field(0).data_type() else {
+            panic!("expected media list field");
+        };
+        let DataType::Struct(fields) = item.data_type() else {
+            panic!("expected media item struct");
+        };
+        assert!(is_arrow_json_field(&fields[1]));
+
+        let media: &ListArray = batch.column(0).as_list();
+        let items = media.values().as_struct();
+        let extra = items
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(extra.value(0).contains("h264"));
+        assert!(extra.is_null(1));
+    }
 }
 
 #[tokio::test]

--- a/rust/lance/src/dataset/utils.rs
+++ b/rust/lance/src/dataset/utils.rs
@@ -12,7 +12,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::StreamExt;
 use lance_arrow::json::{
     arrow_json_to_lance_json, convert_json_columns, convert_lance_json_to_arrow,
-    is_arrow_json_field, is_json_field,
+    has_arrow_json_fields, has_json_fields, lance_json_to_arrow_json,
 };
 use lance_core::ROW_ID;
 use lance_table::rowids::{RowIdIndex, RowIdSequence};
@@ -208,12 +208,12 @@ impl SchemaAdapter {
         self.logical_schema
             .fields()
             .iter()
-            .any(|field| is_arrow_json_field(field) || physical_field(field).is_some())
+            .any(|field| has_arrow_json_fields(field) || physical_field(field).is_some())
     }
 
     /// Determine if the physical schema includes Lance JSON fields that must be converted back.
     pub fn requires_logical_conversion(schema: &ArrowSchemaRef) -> bool {
-        schema.fields().iter().any(|field| is_json_field(field))
+        schema.fields().iter().any(|field| has_json_fields(field))
     }
 
     pub fn to_physical_batch(&self, batch: RecordBatch) -> Result<RecordBatch> {
@@ -237,7 +237,7 @@ impl SchemaAdapter {
         let arrow_schema = stream.schema();
         let mut new_fields = Vec::with_capacity(arrow_schema.fields().len());
         for field in arrow_schema.fields() {
-            if is_arrow_json_field(field) {
+            if has_arrow_json_fields(field) {
                 new_fields.push(Arc::new(arrow_json_to_lance_json(field)));
             } else if let Some(phys) = physical_field(field) {
                 new_fields.push(Arc::new(phys));
@@ -271,9 +271,6 @@ impl SchemaAdapter {
         &self,
         stream: SendableRecordBatchStream,
     ) -> SendableRecordBatchStream {
-        use lance_arrow::ARROW_EXT_NAME_KEY;
-        use lance_arrow::json::ARROW_JSON_EXT_NAME;
-
         if !Self::requires_logical_conversion(&stream.schema()) {
             return stream;
         }
@@ -281,19 +278,8 @@ impl SchemaAdapter {
         let arrow_schema = stream.schema();
         let mut new_fields = Vec::with_capacity(arrow_schema.fields().len());
         for field in arrow_schema.fields() {
-            if is_json_field(field) {
-                let mut new_field = arrow_schema::Field::new(
-                    field.name(),
-                    arrow_schema::DataType::Utf8,
-                    field.is_nullable(),
-                );
-                let mut metadata = field.metadata().clone();
-                metadata.insert(
-                    ARROW_EXT_NAME_KEY.to_string(),
-                    ARROW_JSON_EXT_NAME.to_string(),
-                );
-                new_field.set_metadata(metadata);
-                new_fields.push(new_field);
+            if has_json_fields(field) {
+                new_fields.push(lance_json_to_arrow_json(field));
             } else {
                 new_fields.push(field.as_ref().clone());
             }


### PR DESCRIPTION
Nested Arrow JSON fields were only converted at the top level, so V2.1+ writes could store nested `arrow.json` with a logical/physical schema mismatch and scans or takes could expose the wrong representation.

This recursively converts JSON extension fields across nested Arrow containers and restores logical Arrow JSON on scan/take results, including empty batches and `FixedSizeList(size=0)` edge cases.

Fixes #7015.
