### PR TITLE
chore(deps): upgrade bench and test dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,7 +147,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -149,7 +158,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1482,7 +1491,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1706,26 +1715,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "futures",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "tokio",
@@ -1734,12 +1741,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2846,7 +2853,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2998,7 +3005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4188,7 +4195,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4196,15 +4203,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -4505,7 +4503,6 @@ dependencies = [
  "parquet",
  "permutation",
  "pin-project",
- "pprof",
  "pretty_assertions",
  "prost",
  "prost-build",
@@ -4675,7 +4672,7 @@ dependencies = [
  "futures",
  "half",
  "hex",
- "pprof",
+ "lance-testing",
  "rand 0.9.4",
  "rand_distr",
  "rand_xoshiro",
@@ -4707,10 +4704,10 @@ dependencies = [
  "lance-bitpacking",
  "lance-core",
  "lance-datagen",
+ "lance-testing",
  "log",
  "lz4",
  "num-traits",
- "pprof",
  "proptest",
  "prost",
  "prost-build",
@@ -4776,11 +4773,11 @@ dependencies = [
  "lance-datagen",
  "lance-encoding",
  "lance-io",
+ "lance-testing",
  "libc",
  "log",
  "num-traits",
  "object_store",
- "pprof",
  "pretty_assertions",
  "proptest",
  "prost",
@@ -4864,7 +4861,6 @@ dependencies = [
  "ndarray",
  "num-traits",
  "object_store",
- "pprof",
  "prost",
  "prost-build",
  "prost-types",
@@ -4913,6 +4909,7 @@ dependencies = [
  "lance-arrow",
  "lance-core",
  "lance-namespace",
+ "lance-testing",
  "log",
  "mock_instant",
  "mockall",
@@ -4922,7 +4919,6 @@ dependencies = [
  "opendal",
  "path_abs",
  "pin-project",
- "pprof",
  "prost",
  "rand 0.9.4",
  "rstest",
@@ -4951,7 +4947,6 @@ dependencies = [
  "lance-core",
  "lance-testing",
  "num-traits",
- "pprof",
  "proptest",
  "rand 0.9.4",
 ]
@@ -5083,9 +5078,9 @@ dependencies = [
  "lance-file",
  "lance-io",
  "lance-select",
+ "lance-testing",
  "log",
  "object_store",
- "pprof",
  "pretty_assertions",
  "proptest",
  "prost",
@@ -5121,8 +5116,10 @@ version = "8.0.0-beta.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",
+ "criterion",
  "lance-arrow",
  "num-traits",
+ "pprof",
  "rand 0.9.4",
 ]
 
@@ -5543,9 +5540,9 @@ checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "mockall"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
 dependencies = [
  "cfg-if 1.0.4",
  "downcast",
@@ -5557,9 +5554,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
 dependencies = [
  "cfg-if 1.0.4",
  "proc-macro2",
@@ -5718,7 +5715,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6309,6 +6306,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6676,14 +6683,13 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afad4d4df7b31280028245f152d5a575083e2abb822d05736f5e47653e77689f"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
 dependencies = [
  "aligned-vec",
  "backtrace",
  "cfg-if 1.0.4",
- "criterion",
  "findshlibs",
  "inferno",
  "libc",
@@ -6694,7 +6700,7 @@ dependencies = [
  "spin 0.10.0",
  "symbolic-demangle",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6966,7 +6972,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7609,21 +7615,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if 1.0.4",
  "glob",
@@ -7688,7 +7693,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7747,7 +7752,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8292,7 +8297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8630,7 +8635,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9661,7 +9666,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ chrono = { version = "0.4.41", default-features = false, features = [
     "now",
     "serde",
 ] }
-criterion = { version = "0.5", features = [
+criterion = { version = "0.8.2", features = [
     "async",
     "async_tokio",
     "html_reports",
@@ -159,7 +159,7 @@ jieba-rs = { version = "0.10.0", default-features = false }
 jsonb = { version = "0.5.3", default-features = false, features = ["databend"] }
 libm = "0.2.15"
 log = "0.4"
-mockall = { version = "0.13.1" }
+mockall = { version = "0.14.0" }
 mock_instant = { version = "0.6.0" }
 moka = { version = "0.12", features = ["future", "sync"] }
 ndarray = { version = "0.16.1", features = ["matrixmultiply-threading"] }
@@ -169,7 +169,7 @@ opendal = { version = "0.57" }
 object_store_opendal = { version = "0.57" }
 pin-project = "1.0"
 path_abs = "0.5"
-pprof = { version = "0.14.0", features = ["flamegraph", "criterion"] }
+pprof = { version = "0.15.0", features = ["flamegraph"] }
 proptest = "1.3.1"
 prost = "0.14.1"
 prost-build = "0.14.1"
@@ -180,7 +180,7 @@ rand_xoshiro = "0.7.0"
 rangemap = { version = "1.0" }
 rayon = "1.10"
 roaring = "0.11.4"
-rstest = "0.23.0"
+rstest = "0.26.1"
 serde = { version = "^1" }
 serde_json = { version = "1" }
 semver = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -125,6 +125,7 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     #{ allow = ["Zlib"], crate = "adler32" },
+    { allow = ["CDDL-1.0"], crate = "inferno" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/rust/lance-datagen/Cargo.toml
+++ b/rust/lance-datagen/Cargo.toml
@@ -25,9 +25,7 @@ random_word = { version = "0.5", features = ["en"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-pprof = { workspace = true }
+lance-testing.workspace = true
 
 [lib]
 bench = false

--- a/rust/lance-datagen/benches/array_gen.rs
+++ b/rust/lance-datagen/benches/array_gen.rs
@@ -12,7 +12,7 @@ use lance_datagen::{
     generator::ArrayGenerator,
 };
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 const NUM_BATCHES: u32 = 100;
 const KB_PER_BATCH: u64 = 128;

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -48,6 +48,7 @@ rand.workspace = true
 rstest.workspace = true
 test-log.workspace = true
 criterion = { workspace = true }
+lance-testing.workspace = true
 rand_xoshiro = { workspace = true }
 proptest.workspace = true
 serial_test.workspace = true
@@ -55,9 +56,6 @@ serial_test.workspace = true
 [build-dependencies]
 prost-build.workspace = true
 protobuf-src = { version = "2.1", optional = true }
-
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-pprof = { workspace = true }
 
 [features]
 default = ["lz4", "zstd", "bitpacking"]

--- a/rust/lance-encoding/benches/buffer.rs
+++ b/rust/lance-encoding/benches/buffer.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use lance_encoding::buffer::LanceBuffer;
 
 const NUM_VALUES: &[usize] = &[1024 * 1024, 32 * 1024, 8 * 1024];

--- a/rust/lance-encoding/benches/buffer.rs
+++ b/rust/lance-encoding/benches/buffer.rs
@@ -63,7 +63,7 @@ fn bench_zip(c: &mut Criterion) {
 criterion_group!(
     name=benches;
     config = Criterion::default().significance_level(0.1).sample_size(10)
-        .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+        .with_profiler(lance_testing::pprof::PProfProfiler::new(100, lance_testing::pprof::Output::Flamegraph(None)));
     targets = bench_zip);
 
 // Non-linux version does not support pprof.

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -567,7 +567,7 @@ fn bench_decode_compressed_parallel(c: &mut Criterion) {
 criterion_group!(
     name=benches;
     config = Criterion::default().significance_level(0.1).sample_size(10)
-        .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+        .with_profiler(lance_testing::pprof::PProfProfiler::new(100, lance_testing::pprof::Output::Flamegraph(None)));
     targets = bench_decode, bench_decode_fsl, bench_decode_str_with_dict_encoding, bench_decode_packed_struct,
                 bench_decode_str_with_fixed_size_binary_encoding, bench_decode_compressed,
                 bench_decode_compressed_parallel);

--- a/rust/lance-encoding/benches/encoder.rs
+++ b/rust/lance-encoding/benches/encoder.rs
@@ -166,7 +166,7 @@ fn bench_encode_structural_pages(c: &mut Criterion) {
 criterion_group!(
     name=benches;
     config = Criterion::default().significance_level(0.1).sample_size(10)
-        .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+        .with_profiler(lance_testing::pprof::PProfProfiler::new(100, lance_testing::pprof::Output::Flamegraph(None)));
     targets = bench_encode_compressed, bench_encode_structural_pages);
 
 #[cfg(not(target_os = "linux"))]

--- a/rust/lance-file/Cargo.toml
+++ b/rust/lance-file/Cargo.toml
@@ -39,6 +39,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 lance-datagen.workspace = true
+lance-testing.workspace = true
 criterion.workspace = true
 rstest.workspace = true
 proptest.workspace = true
@@ -49,9 +50,6 @@ libc.workspace = true
 [build-dependencies]
 prost-build.workspace = true
 protobuf-src = { version = "2.1", optional = true }
-
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-pprof = { workspace = true }
 
 [features]
 protoc = ["dep:protobuf-src"]

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -465,7 +465,7 @@ fn bench_random_access(c: &mut Criterion) {
 criterion_group!(
     name=benches;
     config = Criterion::default().significance_level(0.1).sample_size(10)
-        .with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+        .with_profiler(lance_testing::pprof::PProfProfiler::new(100, lance_testing::pprof::Output::Flamegraph(None)));
     targets = bench_reader, bench_random_access);
 
 // Non-linux version does not support pprof.

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -4,7 +4,9 @@ use std::sync::{Arc, Mutex};
 
 use arrow_array::{UInt32Array, cast::AsArray, types::Int32Type};
 use arrow_schema::DataType;
-use criterion::{BatchSize, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use futures::{FutureExt, StreamExt};
 use lance_core::utils::{tempfile::TempDir, tokio::get_num_compute_intensive_cpus};
 use lance_datagen::ArrayGeneratorExt;

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -99,9 +99,6 @@ tokenizer-jieba = ["dep:jieba-rs", "lance-tokenizer/tokenizer-jieba"]
 prost-build.workspace = true
 protobuf-src = { version = "2.1", optional = true }
 
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-pprof.workspace = true
-
 [package.metadata.docs.rs]
 # docs.rs uses an older version of Ubuntu that does not have the necessary protoc version
 features = ["protoc"]

--- a/rust/lance-index/benches/4bitpq_dist_table.rs
+++ b/rust/lance-index/benches/4bitpq_dist_table.rs
@@ -7,7 +7,9 @@ use std::iter::repeat_n;
 
 use arrow_array::types::{Float16Type, Float32Type, Float64Type};
 use arrow_array::{FixedSizeListArray, UInt8Array};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
 use lance_index::vector::pq::ProductQuantizer;
 use lance_index::vector::pq::distance::{build_distance_table_dot, build_distance_table_l2};

--- a/rust/lance-index/benches/4bitpq_dist_table.rs
+++ b/rust/lance-index/benches/4bitpq_dist_table.rs
@@ -16,7 +16,7 @@ use lance_testing::datagen::generate_random_array_with_seed;
 use rand::{Rng, SeedableRng, prelude::StdRng};
 
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 const PQ: usize = 96;
 const DIM: usize = 1536;

--- a/rust/lance-index/benches/bitmap.rs
+++ b/rust/lance-index/benches/bitmap.rs
@@ -18,7 +18,9 @@ use std::{
 };
 
 use common::{LOW_CARDINALITY_COUNT, TOTAL_ROWS};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use datafusion_common::ScalarValue;
 use lance_core::cache::LanceCache;
 use lance_index::metrics::NoOpMetricsCollector;

--- a/rust/lance-index/benches/bitmap.rs
+++ b/rust/lance-index/benches/bitmap.rs
@@ -27,9 +27,9 @@ use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::registry::ScalarIndexPlugin;
 use lance_index::scalar::{SargableQuery, ScalarIndex, bitmap::BitmapIndexPlugin};
 use lance_io::object_store::ObjectStore;
-use object_store::path::Path;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
+use object_store::path::Path;
 
 // Lazy static runtime - only created once
 static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();

--- a/rust/lance-index/benches/btree.rs
+++ b/rust/lance-index/benches/btree.rs
@@ -20,7 +20,9 @@ use std::{
 };
 
 use common::{LOW_CARDINALITY_COUNT, TOTAL_ROWS};
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use datafusion_common::ScalarValue;
 use lance_core::cache::LanceCache;
 use lance_index::metrics::NoOpMetricsCollector;

--- a/rust/lance-index/benches/btree.rs
+++ b/rust/lance-index/benches/btree.rs
@@ -30,9 +30,9 @@ use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::registry::ScalarIndexPlugin;
 use lance_index::scalar::{SargableQuery, ScalarIndex};
 use lance_io::object_store::ObjectStore;
-use object_store::path::Path;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
+use object_store::path::Path;
 
 /// Selectivity level for range queries
 #[derive(Clone, Copy, Debug)]

--- a/rust/lance-index/benches/compute_partition.rs
+++ b/rust/lance-index/benches/compute_partition.rs
@@ -9,7 +9,7 @@ use lance_index::vector::kmeans::{KMeansAlgoFloat, compute_partitions};
 use lance_linalg::distance::MetricType;
 use lance_testing::datagen::generate_random_array_with_seed;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 fn bench_compute_partitions(c: &mut Criterion) {
     const K: usize = 1024 * 4;

--- a/rust/lance-index/benches/find_partitions.rs
+++ b/rust/lance-index/benches/find_partitions.rs
@@ -7,7 +7,7 @@ use lance_arrow::FixedSizeListArrayExt;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 use lance_index::vector::ivf::IvfTransformer;
 use lance_linalg::distance::DistanceType;

--- a/rust/lance-index/benches/geo.rs
+++ b/rust/lance-index/benches/geo.rs
@@ -17,9 +17,9 @@ use lance_index::scalar::registry::ScalarIndexPlugin;
 use lance_index::scalar::rtree::{BoundingBox, RTreeIndex, RTreeIndexPlugin, RTreeTrainingRequest};
 use lance_index::scalar::{GeoQuery, RelationQuery, ScalarIndex};
 use lance_io::object_store::ObjectStore;
-use object_store::path::Path;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
+use object_store::path::Path;
 use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;

--- a/rust/lance-index/benches/geo.rs
+++ b/rust/lance-index/benches/geo.rs
@@ -3,7 +3,9 @@
 
 use arrow_array::{RecordBatch, UInt64Array};
 use arrow_schema::{DataType, Field};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion_common::ScalarValue;
 use geo_types::coord;

--- a/rust/lance-index/benches/hnsw.rs
+++ b/rust/lance-index/benches/hnsw.rs
@@ -13,7 +13,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use lance_arrow::FixedSizeListArrayExt;
 use lance_index::vector::v3::subindex::IvfSubIndex;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 use rayon::ThreadPoolBuilder;
 
 use lance_core::ROW_ID_FIELD;

--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -8,7 +8,9 @@
 use std::{sync::Arc, time::Duration};
 
 use arrow_array::{LargeStringArray, RecordBatch, UInt64Array};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::stream;
 use itertools::Itertools;

--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -23,9 +23,9 @@ use lance_index::{
     metrics::NoOpMetricsCollector, scalar::inverted::tokenizer::InvertedIndexParams,
 };
 use lance_io::object_store::ObjectStore;
-use object_store::path::Path;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
+use object_store::path::Path;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rand_distr::Zipf;
 

--- a/rust/lance-index/benches/kmeans.rs
+++ b/rust/lance-index/benches/kmeans.rs
@@ -9,7 +9,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use lance_arrow::FixedSizeListArrayExt;
 use lance_index::vector::utils::SimpleIndex;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 use lance_index::vector::kmeans::{
     KMeans, KMeansAlgo, KMeansAlgoFloat, KMeansParams, compute_partitions_arrow_array,

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -18,9 +18,9 @@ use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::ngram::{NGramIndexBuilder, NGramIndexBuilderOptions, NGramIndexPlugin};
 use lance_index::scalar::{TextQuery, registry::ScalarIndexPlugin};
 use lance_io::object_store::ObjectStore;
-use object_store::path::Path;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
+use object_store::path::Path;
 
 fn bench_ngram(c: &mut Criterion) {
     const TOTAL: usize = 1_000_000;

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -5,7 +5,9 @@ use std::{sync::Arc, time::Duration};
 
 use arrow::array::AsArray;
 use arrow_array::{RecordBatch, UInt64Array};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::stream;
 use itertools::Itertools;

--- a/rust/lance-index/benches/pq_dist_table.rs
+++ b/rust/lance-index/benches/pq_dist_table.rs
@@ -7,7 +7,9 @@ use std::iter::repeat_n;
 
 use arrow_array::types::{Float16Type, Float32Type, Float64Type};
 use arrow_array::{FixedSizeListArray, UInt8Array};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
 use lance_index::vector::pq::ProductQuantizer;
 use lance_index::vector::pq::distance::*;

--- a/rust/lance-index/benches/pq_dist_table.rs
+++ b/rust/lance-index/benches/pq_dist_table.rs
@@ -16,7 +16,7 @@ use lance_testing::datagen::generate_random_array_with_seed;
 use rand::{Rng, SeedableRng, prelude::StdRng};
 
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 const DIM: usize = 128;
 const PQ: usize = DIM / 8;

--- a/rust/lance-index/benches/residual_transform.rs
+++ b/rust/lance-index/benches/residual_transform.rs
@@ -6,7 +6,9 @@ use std::time::Duration;
 
 use arrow_array::{FixedSizeListArray, RecordBatch, UInt32Array, types::Float32Type};
 use arrow_schema::{DataType, Field, Schema};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use lance_arrow::FixedSizeListArrayExt;
 use lance_index::vector::residual::ResidualTransform;
 use lance_index::vector::transform::Transformer;

--- a/rust/lance-index/benches/rq.rs
+++ b/rust/lance-index/benches/rq.rs
@@ -8,7 +8,9 @@ use std::time::Duration;
 use arrow::datatypes::UInt64Type;
 use arrow_array::types::Float32Type;
 use arrow_schema::DataType;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use lance_arrow::fixed_size_list_type;
 use lance_core::ROW_ID;
 use lance_datagen::array::rand_type;

--- a/rust/lance-index/benches/sq.rs
+++ b/rust/lance-index/benches/sq.rs
@@ -17,7 +17,7 @@ use lance_index::vector::{
 use lance_linalg::distance::DistanceType;
 use lance_testing::datagen::generate_random_array;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 use rand::prelude::*;
 
 fn create_full_batch(range: Range<u64>, dim: usize) -> RecordBatch {

--- a/rust/lance-index/benches/zonemap.rs
+++ b/rust/lance-index/benches/zonemap.rs
@@ -18,9 +18,9 @@ use lance_index::scalar::zonemap::{
 };
 use lance_index::scalar::{SargableQuery, registry::ScalarIndexPlugin};
 use lance_io::object_store::ObjectStore;
-use object_store::path::Path;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
+use object_store::path::Path;
 
 fn bench_zonemap(c: &mut Criterion) {
     const TOTAL: usize = 1_000_000;

--- a/rust/lance-index/benches/zonemap.rs
+++ b/rust/lance-index/benches/zonemap.rs
@@ -3,7 +3,9 @@
 use std::{sync::Arc, time::Duration};
 
 use arrow_array::{Int32Array, RecordBatch, UInt64Array};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::scalar::ScalarValue;
 use futures::stream;

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -54,14 +54,12 @@ io-uring = { workspace = true }
 
 [dev-dependencies]
 criterion.workspace = true
+lance-testing.workspace = true
 test-log.workspace = true
 mockall.workspace = true
 rstest.workspace = true
 mock_instant.workspace = true
 tracing-mock = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-pprof.workspace = true
 
 [[bench]]
 name = "scheduler"

--- a/rust/lance-io/benches/scheduler.rs
+++ b/rust/lance-io/benches/scheduler.rs
@@ -16,7 +16,7 @@ use tokio::{runtime::Runtime, sync::mpsc, task::JoinHandle};
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 #[derive(Clone, Copy, Debug)]
 struct FullReadParams {

--- a/rust/lance-linalg/Cargo.toml
+++ b/rust/lance-linalg/Cargo.toml
@@ -35,9 +35,6 @@ cc = "1.0.83"
 # you need Clang 11 or later.)
 fp16kernels = []
 
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-pprof = { workspace = true }
-
 [[bench]]
 name = "l2"
 harness = false

--- a/rust/lance-linalg/benches/argmin.rs
+++ b/rust/lance-linalg/benches/argmin.rs
@@ -10,7 +10,7 @@ use lance_linalg::kernels::argmin_opt;
 use lance_testing::datagen::generate_random_array_with_seed;
 
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 #[inline]
 fn argmin_arrow(x: &Float32Array) -> u32 {

--- a/rust/lance-linalg/benches/cosine.rs
+++ b/rust/lance-linalg/benches/cosine.rs
@@ -12,7 +12,7 @@ use lance_linalg::distance::cosine_u8::{cosine_u8, cosine_u8_scalar};
 use num_traits::Float;
 
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 use lance_testing::datagen::generate_random_array_with_seed;
 

--- a/rust/lance-linalg/benches/cosine.rs
+++ b/rust/lance-linalg/benches/cosine.rs
@@ -5,7 +5,9 @@ use arrow_array::{
     Float32Array,
     types::{Float16Type, Float32Type, Float64Type},
 };
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use lance_arrow::{ArrowFloatType, FloatArray, bfloat16::BFloat16Type};
 use lance_linalg::distance::cosine::{Cosine, cosine_distance_batch};
 use lance_linalg::distance::cosine_u8::{cosine_u8, cosine_u8_scalar};

--- a/rust/lance-linalg/benches/dist_table.rs
+++ b/rust/lance-linalg/benches/dist_table.rs
@@ -8,7 +8,9 @@
 
 use std::iter::repeat_with;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use lance_linalg::simd::dist_table::{BATCH_SIZE, sum_4bit_dist_table, sum_4bit_dist_table_scalar};
 use rand::Rng;
 

--- a/rust/lance-linalg/benches/dot.rs
+++ b/rust/lance-linalg/benches/dot.rs
@@ -8,7 +8,9 @@ use arrow_array::{
     Float32Array,
     types::{Float16Type, Float32Type, Float64Type},
 };
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use half::bf16;
 use lance_arrow::{ArrowFloatType, FloatArray};
 use num_traits::Float;

--- a/rust/lance-linalg/benches/dot.rs
+++ b/rust/lance-linalg/benches/dot.rs
@@ -14,7 +14,7 @@ use lance_arrow::{ArrowFloatType, FloatArray};
 use num_traits::Float;
 
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 use lance_linalg::distance::dot::{Dot, dot, dot_distance};
 use lance_testing::datagen::generate_random_array_with_seed;

--- a/rust/lance-linalg/benches/hamming.rs
+++ b/rust/lance-linalg/benches/hamming.rs
@@ -3,7 +3,9 @@
 
 use std::iter::repeat_with;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use lance_linalg::distance::hamming::{hamming, hamming_scalar};
 use rand::Rng;
 

--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -12,7 +12,7 @@ use num_traits::{AsPrimitive, Float};
 use rand::Rng;
 
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 use lance_arrow::{ArrowFloatType, FloatArray};
 use lance_linalg::distance::l2_u8::l2_u8;

--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -7,7 +7,9 @@ use arrow_array::{
     Float32Array,
     types::{Float16Type, Float32Type, Float64Type},
 };
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use num_traits::{AsPrimitive, Float};
 use rand::Rng;
 

--- a/rust/lance-linalg/benches/norm_l2.rs
+++ b/rust/lance-linalg/benches/norm_l2.rs
@@ -7,7 +7,9 @@ use arrow_array::{
     Float16Array, Float32Array, Float64Array,
     types::{Float16Type, Float32Type, Float64Type},
 };
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use half::{bf16, f16};
 use num_traits::Float;
 use rand::Rng;

--- a/rust/lance-linalg/benches/norm_l2.rs
+++ b/rust/lance-linalg/benches/norm_l2.rs
@@ -17,7 +17,7 @@ use lance_linalg::distance::{norm_l2, norm_l2_f64_simd, norm_l2_impl};
 use lance_testing::datagen::generate_random_array_with_seed;
 
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 const DIMENSION: usize = 1024;
 const TOTAL: usize = 1024 * 1024; // 1M vectors

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -48,14 +48,12 @@ uuid.workspace = true
 
 [dev-dependencies]
 lance-datagen.workspace = true
+lance-testing.workspace = true
 arrow-schema.workspace = true
 criterion.workspace = true
 pretty_assertions.workspace = true
 proptest.workspace = true
 rstest.workspace = true
-
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-pprof = { workspace = true }
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-table/benches/manifest_intern.rs
+++ b/rust/lance-table/benches/manifest_intern.rs
@@ -253,7 +253,7 @@ fn bench_memory(c: &mut Criterion) {
 #[cfg(target_os = "linux")]
 criterion_group!(
     name = benches;
-    config = Criterion::default().with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+    config = Criterion::default().with_profiler(lance_testing::pprof::PProfProfiler::new(100, lance_testing::pprof::Output::Flamegraph(None)));
     targets = bench_deserialization, bench_memory
 );
 #[cfg(not(target_os = "linux"))]

--- a/rust/lance-table/benches/row_id_index.rs
+++ b/rust/lance-table/benches/row_id_index.rs
@@ -311,7 +311,7 @@ fn bench_apply_row_id(c: &mut Criterion) {
 #[cfg(target_os = "linux")]
 criterion_group!(
     name = benches;
-    config=Criterion::default().with_profiler(pprof::criterion::PProfProfiler::new(100, pprof::criterion::Output::Flamegraph(None)));
+    config=Criterion::default().with_profiler(lance_testing::pprof::PProfProfiler::new(100, lance_testing::pprof::Output::Flamegraph(None)));
     targets=bench_creation, bench_get_single, bench_apply_row_id);
 #[cfg(not(target_os = "linux"))]
 criterion_group!(

--- a/rust/lance-testing/Cargo.toml
+++ b/rust/lance-testing/Cargo.toml
@@ -17,6 +17,8 @@ rand = { workspace = true }
 num-traits = { workspace = true }
 lance-arrow = { workspace = true }
 criterion = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
 pprof = { workspace = true }
 
 [lints]

--- a/rust/lance-testing/Cargo.toml
+++ b/rust/lance-testing/Cargo.toml
@@ -16,6 +16,8 @@ arrow-schema = { workspace = true }
 rand = { workspace = true }
 num-traits = { workspace = true }
 lance-arrow = { workspace = true }
+criterion = { workspace = true }
+pprof = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/lance-testing/src/lib.rs
+++ b/rust/lance-testing/src/lib.rs
@@ -2,5 +2,6 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 pub mod datagen;
+#[cfg(target_os = "linux")]
 pub mod pprof;
 pub mod progress;

--- a/rust/lance-testing/src/lib.rs
+++ b/rust/lance-testing/src/lib.rs
@@ -2,4 +2,5 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 pub mod datagen;
+pub mod pprof;
 pub mod progress;

--- a/rust/lance-testing/src/pprof.rs
+++ b/rust/lance-testing/src/pprof.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{fs::File, os::raw::c_int, path::Path};
+
+use ::pprof::{ProfilerGuard, flamegraph::Options as FlamegraphOptions};
+use criterion::profiler::Profiler;
+
+#[allow(clippy::large_enum_variant)]
+pub enum Output<'a> {
+    Flamegraph(Option<FlamegraphOptions<'a>>),
+}
+
+pub struct PProfProfiler<'a, 'b> {
+    frequency: c_int,
+    output: Output<'b>,
+    active_profiler: Option<ProfilerGuard<'a>>,
+}
+
+impl<'a, 'b> PProfProfiler<'a, 'b> {
+    pub fn new(frequency: c_int, output: Output<'b>) -> Self {
+        Self {
+            frequency,
+            output,
+            active_profiler: None,
+        }
+    }
+}
+
+impl<'a, 'b> Profiler for PProfProfiler<'a, 'b> {
+    fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
+        self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
+    }
+
+    fn stop_profiling(&mut self, _benchmark_id: &str, benchmark_dir: &Path) {
+        std::fs::create_dir_all(benchmark_dir).unwrap();
+
+        let Output::Flamegraph(options) = &mut self.output;
+
+        let output_path = benchmark_dir.join("flamegraph.svg");
+        let output_file = File::create(&output_path).unwrap_or_else(|_| {
+            panic!("File system error while creating {}", output_path.display())
+        });
+
+        if let Some(profiler) = self.active_profiler.take() {
+            let default_options = &mut FlamegraphOptions::default();
+            let options = options.as_mut().unwrap_or(default_options);
+
+            profiler
+                .report()
+                .build()
+                .unwrap()
+                .flamegraph_with_options(output_file, options)
+                .expect("Error while writing flamegraph");
+        }
+    }
+}

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -104,7 +104,6 @@ prost-build.workspace = true
 protobuf-src = { version = "2.1", optional = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-pprof.workspace = true
 # Need this so we can prevent dynamic linking in binaries (see cli feature)
 lzma-sys = { version = "0.1" }
 

--- a/rust/lance/benches/distributed_vector_build.rs
+++ b/rust/lance/benches/distributed_vector_build.rs
@@ -10,7 +10,7 @@ use arrow_array::{cast::AsArray, types::Float32Type};
 use arrow_schema::{DataType, Field, FieldRef, Schema as ArrowSchema};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 use serde::Serialize;
 use uuid::Uuid;
 

--- a/rust/lance/benches/fts_search.rs
+++ b/rust/lance/benches/fts_search.rs
@@ -22,7 +22,7 @@ use lance_index::{
     scalar::{FullTextSearchQuery, inverted::tokenizer::InvertedIndexParams},
 };
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 use tempfile::TempDir;
 
 const WIKIPEDIA_DATASET_ENV_VAR: &str = "LANCE_WIKIPEDIA_DATASET_PATH";

--- a/rust/lance/benches/ivf_pq.rs
+++ b/rust/lance/benches/ivf_pq.rs
@@ -20,7 +20,7 @@ use lance_index::IndexType;
 use lance_linalg::distance::MetricType;
 use lance_testing::datagen::generate_random_array;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 async fn create_dataset(path: &std::path::Path, dim: usize, mode: WriteMode) {
     let schema = Arc::new(Schema::new(vec![Field::new(

--- a/rust/lance/benches/mem_wal/read/memtable_read.rs
+++ b/rust/lance/benches/mem_wal/read/memtable_read.rs
@@ -46,7 +46,7 @@ use lance_index::vector::ivf::IvfBuildParams;
 use lance_index::vector::pq::builder::PQBuildParams;
 use lance_linalg::distance::{DistanceType, MetricType};
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 use rand::Rng;
 use uuid::Uuid;
 

--- a/rust/lance/benches/mem_wal/write/mem_wal_write.rs
+++ b/rust/lance/benches/mem_wal/write/mem_wal_write.rs
@@ -70,7 +70,7 @@ use lance_index::vector::ivf::IvfBuildParams;
 use lance_index::vector::pq::PQBuildParams;
 use lance_linalg::distance::DistanceType;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 use uuid::Uuid;
 
 /// Default number of rows per batch.

--- a/rust/lance/benches/merge_insert.rs
+++ b/rust/lance/benches/merge_insert.rs
@@ -29,7 +29,7 @@ use lance_core::utils::tempfile::TempStrDir;
 use lance_index::IndexType;
 use lance_index::scalar::ScalarIndexParams;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 // Many small fragments to amplify the slow path: each indexed fragment with
 // a deletion file produces one RoaringBitmap::full() allocation per

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -24,7 +24,7 @@ use lance_index::scalar::{
 use lance_index::{metrics::NoOpMetricsCollector, scalar::btree::BTreeIndexPlugin};
 use lance_select::RowSetOps;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 
 struct BenchmarkFixture {
     _datadir: TempStrDir,

--- a/rust/lance/benches/scan.rs
+++ b/rust/lance/benches/scan.rs
@@ -23,7 +23,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use futures::stream::TryStreamExt;
 use lance_arrow::FixedSizeListArrayExt;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 use std::sync::Arc;
 
 use lance::dataset::{Dataset, WriteMode, WriteParams};

--- a/rust/lance/benches/streaming_ivf_training.rs
+++ b/rust/lance/benches/streaming_ivf_training.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator};
 use arrow_schema::{DataType, Field, FieldRef, Schema};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use lance::Dataset;
 use lance::dataset::WriteParams;

--- a/rust/lance/benches/take.rs
+++ b/rust/lance/benches/take.rs
@@ -20,9 +20,9 @@ use lance_file::version::LanceFileVersion;
 use lance_io::ReadBatchParams;
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::utils::CachedFileSize;
-use object_store::path::Path;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
+use object_store::path::Path;
 use rand::Rng;
 use std::sync::Arc;
 #[cfg(target_os = "linux")]

--- a/rust/lance/benches/take_blob.rs
+++ b/rust/lance/benches/take_blob.rs
@@ -15,7 +15,7 @@ use lance_encoding::decoder::DecoderConfig;
 use lance_file::reader::FileReaderOptions;
 use lance_file::version::LanceFileVersion;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 

--- a/rust/lance/benches/take_blob.rs
+++ b/rust/lance/benches/take_blob.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 
 use arrow_array::{LargeBinaryArray, RecordBatch, RecordBatchIterator, UInt64Array};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use lance::blob::{BlobArrayBuilder, blob_field};
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::{Dataset, ProjectionRequest, ReadParams, WriteParams};

--- a/rust/lance/benches/vector_index.rs
+++ b/rust/lance/benches/vector_index.rs
@@ -11,7 +11,7 @@ use arrow_schema::{DataType, Field, FieldRef, Schema as ArrowSchema};
 use criterion::{Criterion, criterion_group, criterion_main};
 use futures::TryStreamExt;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
 use rand::Rng;
 
 use lance::dataset::{Dataset, WriteMode, WriteParams, builder::DatasetBuilder};

--- a/rust/lance/benches/vector_throughput.rs
+++ b/rust/lance/benches/vector_throughput.rs
@@ -13,9 +13,9 @@ use arrow_schema::{DataType, Field, FieldRef, Schema as ArrowSchema};
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use futures::{StreamExt, TryStreamExt};
 use lance_file::version::LanceFileVersion;
-use log::info;
 #[cfg(target_os = "linux")]
-use pprof::criterion::{Output, PProfProfiler};
+use lance_testing::pprof::{Output, PProfProfiler};
+use log::info;
 use rand::Rng;
 
 use lance::dataset::{Dataset, WriteMode, WriteParams};


### PR DESCRIPTION
Upgrade bench and test dependencies to reduce stale tooling in the workspace.

This updates Criterion, pprof, rstest, and mockall, and moves the pprof Criterion profiler bridge into lance-testing so the workspace no longer depends on pprof's Criterion 0.5 adapter.
