### PR TITLE
perf(index): fix O(N log N) warm-cache regression in BitmapIndex

### DIFF
--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -7,7 +7,7 @@ use std::{
     collections::{BTreeMap, BinaryHeap, HashMap},
     fmt::Debug,
     ops::Bound,
-    sync::{Arc, OnceLock},
+    sync::Arc,
 };
 
 use arrow::array::BinaryBuilder;
@@ -158,7 +158,7 @@ impl CacheKey for BitmapKey {
 /// cache handle, a lazy reader, a fragment-reuse index). `BitmapIndexState`
 /// captures just the data needed to rebuild it: the value→file-offset map,
 /// the null bitmap, and the value type.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BitmapIndexState {
     /// Value-to-row-offset lookup, encoded as an Arrow `RecordBatch` so we can
     /// reuse the existing IPC utilities for zero-copy round trips.
@@ -173,55 +173,27 @@ pub struct BitmapIndexState {
     /// Cached separately from the schema for the empty-index case where the
     /// `lookup_batch` is empty but we still need to remember the column type.
     value_type: DataType,
-    /// Parsed form of `lookup_batch`. Not serialized — populated eagerly by
-    /// [`BitmapIndexState::from_index`] and lazily on first
-    /// [`BitmapIndexState::into_bitmap_index`] call after disk deserialization.
-    /// Stored as `Arc` so that cloning into a new [`BitmapIndex`] is O(1).
-    index_map: OnceLock<Arc<BTreeMap<OrderableScalarValue, usize>>>,
-}
-
-impl Clone for BitmapIndexState {
-    fn clone(&self) -> Self {
-        Self {
-            lookup_batch: self.lookup_batch.clone(),
-            null_map: self.null_map.clone(),
-            value_type: self.value_type.clone(),
-            index_map: self
-                .index_map
-                .get()
-                .map(|m| {
-                    let lock = OnceLock::new();
-                    // safe: fresh lock
-                    lock.set(m.clone()).ok();
-                    lock
-                })
-                .unwrap_or_default(),
-        }
-    }
+    /// Parsed form of `lookup_batch`. Not serialized — populated eagerly in
+    /// both [`BitmapIndexState::from_index`] and [`CacheCodecImpl::deserialize`].
+    /// Stored as `Arc` so cloning into a new [`BitmapIndex`] is O(1).
+    index_map: Arc<BTreeMap<OrderableScalarValue, usize>>,
 }
 
 impl DeepSizeOf for BitmapIndexState {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
         self.lookup_batch.get_array_memory_size()
             + self.null_map.deep_size_of_children(context)
-            + self
-                .index_map
-                .get()
-                .map(|m| m.deep_size_of_children(context))
-                .unwrap_or(0)
+            + self.index_map.deep_size_of_children(context)
     }
 }
 
 impl BitmapIndexState {
     pub(crate) fn from_index(index: &BitmapIndex) -> Result<Self> {
-        let lock = OnceLock::new();
-        // safe: fresh lock
-        lock.set(index.index_map.clone()).ok();
         Ok(Self {
             lookup_batch: build_lookup_batch(&index.index_map, &index.value_type)?,
             null_map: index.null_map.clone(),
             value_type: index.value_type.clone(),
-            index_map: lock,
+            index_map: index.index_map.clone(),
         })
     }
 
@@ -231,16 +203,8 @@ impl BitmapIndexState {
         index_cache: &LanceCache,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<Arc<BitmapIndex>> {
-        let index_map = if let Some(map) = self.index_map.get() {
-            map.clone()
-        } else {
-            // Disk-backed cache hit: parse once and cache for subsequent calls.
-            let map = Arc::new(parse_lookup_batch(&self.lookup_batch)?);
-            // Another thread may have won the race; either result is equivalent.
-            self.index_map.get_or_init(|| map.clone()).clone()
-        };
         Ok(Arc::new(BitmapIndex::new(
-            index_map,
+            self.index_map.clone(),
             self.null_map.clone(),
             self.value_type.clone(),
             store,
@@ -307,11 +271,12 @@ impl CacheCodecImpl for BitmapIndexState {
         let null_map = Arc::new(RowAddrTreeMap::deserialize_from(null_bytes.as_ref())?);
         let lookup_batch = read_ipc_stream_single_at(data, &mut offset)?;
         let value_type = lookup_batch.schema().field(0).data_type().clone();
+        let index_map = Arc::new(parse_lookup_batch(&lookup_batch)?);
         Ok(Self {
             lookup_batch,
             null_map,
             value_type,
-            index_map: OnceLock::new(),
+            index_map,
         })
     }
 }
@@ -1823,7 +1788,7 @@ mod tests {
             lookup_batch: build_lookup_batch(&index_map, &DataType::Int32).unwrap(),
             null_map: Arc::new(null_map),
             value_type: DataType::Int32,
-            index_map: OnceLock::new(),
+            index_map: Arc::new(index_map),
         };
         assert_state_roundtrips(&state);
 
@@ -1832,7 +1797,7 @@ mod tests {
             lookup_batch: build_lookup_batch(&BTreeMap::new(), &DataType::Utf8).unwrap(),
             null_map: Arc::new(RowAddrTreeMap::new()),
             value_type: DataType::Utf8,
-            index_map: OnceLock::new(),
+            index_map: Arc::new(BTreeMap::new()),
         };
         assert_state_roundtrips(&empty_state);
     }

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -7,7 +7,7 @@ use std::{
     collections::{BTreeMap, BinaryHeap, HashMap},
     fmt::Debug,
     ops::Bound,
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use arrow::array::BinaryBuilder;
@@ -49,8 +49,8 @@ use crate::{
         CreatedIndex, UpdateCriteria,
         expression::SargableQueryParser,
         registry::{
-            ScalarIndexCacheKey, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering,
-            TrainingRequest, VALUE_COLUMN_NAME,
+            ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+            VALUE_COLUMN_NAME,
         },
     },
 };
@@ -116,7 +116,7 @@ pub struct BitmapIndex {
     /// Maps each unique value to its bitmap location in the index file
     /// The usize value is the row offset in the bitmap_page_lookup.lance file
     /// for quickly locating the row and reading it out
-    index_map: BTreeMap<OrderableScalarValue, usize>,
+    index_map: Arc<BTreeMap<OrderableScalarValue, usize>>,
 
     null_map: Arc<RowAddrTreeMap>,
 
@@ -158,7 +158,7 @@ impl CacheKey for BitmapKey {
 /// cache handle, a lazy reader, a fragment-reuse index). `BitmapIndexState`
 /// captures just the data needed to rebuild it: the value→file-offset map,
 /// the null bitmap, and the value type.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BitmapIndexState {
     /// Value-to-row-offset lookup, encoded as an Arrow `RecordBatch` so we can
     /// reuse the existing IPC utilities for zero-copy round trips.
@@ -173,34 +173,76 @@ pub struct BitmapIndexState {
     /// Cached separately from the schema for the empty-index case where the
     /// `lookup_batch` is empty but we still need to remember the column type.
     value_type: DataType,
+    /// Parsed form of `lookup_batch`. Not serialized — populated eagerly by
+    /// [`BitmapIndexState::from_index`] and lazily on first
+    /// [`BitmapIndexState::into_bitmap_index`] call after disk deserialization.
+    /// Stored as `Arc` so that cloning into a new [`BitmapIndex`] is O(1).
+    index_map: OnceLock<Arc<BTreeMap<OrderableScalarValue, usize>>>,
+}
+
+impl Clone for BitmapIndexState {
+    fn clone(&self) -> Self {
+        Self {
+            lookup_batch: self.lookup_batch.clone(),
+            null_map: self.null_map.clone(),
+            value_type: self.value_type.clone(),
+            index_map: self
+                .index_map
+                .get()
+                .map(|m| {
+                    let lock = OnceLock::new();
+                    // safe: fresh lock
+                    lock.set(m.clone()).ok();
+                    lock
+                })
+                .unwrap_or_default(),
+        }
+    }
 }
 
 impl DeepSizeOf for BitmapIndexState {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        self.lookup_batch.get_array_memory_size() + self.null_map.deep_size_of_children(context)
+        self.lookup_batch.get_array_memory_size()
+            + self.null_map.deep_size_of_children(context)
+            + self
+                .index_map
+                .get()
+                .map(|m| m.deep_size_of_children(context))
+                .unwrap_or(0)
     }
 }
 
 impl BitmapIndexState {
     pub(crate) fn from_index(index: &BitmapIndex) -> Result<Self> {
+        let lock = OnceLock::new();
+        // safe: fresh lock
+        lock.set(index.index_map.clone()).ok();
         Ok(Self {
             lookup_batch: build_lookup_batch(&index.index_map, &index.value_type)?,
             null_map: index.null_map.clone(),
             value_type: index.value_type.clone(),
+            index_map: lock,
         })
     }
 
     pub(crate) fn into_bitmap_index(
-        self,
+        &self,
         store: Arc<dyn IndexStore>,
         index_cache: &LanceCache,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<Arc<BitmapIndex>> {
-        let index_map = parse_lookup_batch(&self.lookup_batch)?;
+        let index_map = if let Some(map) = self.index_map.get() {
+            map.clone()
+        } else {
+            // Disk-backed cache hit: parse once and cache for subsequent calls.
+            let map = Arc::new(parse_lookup_batch(&self.lookup_batch)?);
+            // Another thread may have won the race; either result is equivalent.
+            self.index_map.get_or_init(|| map.clone()).clone()
+        };
         Ok(Arc::new(BitmapIndex::new(
             index_map,
-            self.null_map,
-            self.value_type,
+            self.null_map.clone(),
+            self.value_type.clone(),
             store,
             WeakLanceCache::from(index_cache),
             frag_reuse_index,
@@ -269,6 +311,7 @@ impl CacheCodecImpl for BitmapIndexState {
             lookup_batch,
             null_map,
             value_type,
+            index_map: OnceLock::new(),
         })
     }
 }
@@ -295,7 +338,7 @@ impl CacheKey for BitmapIndexStateKey {
 
 impl BitmapIndex {
     fn new(
-        index_map: BTreeMap<OrderableScalarValue, usize>,
+        index_map: Arc<BTreeMap<OrderableScalarValue, usize>>,
         null_map: Arc<RowAddrTreeMap>,
         value_type: DataType,
         store: Arc<dyn IndexStore>,
@@ -326,7 +369,7 @@ impl BitmapIndex {
             let schema = page_lookup_file.schema();
             let data_type = schema.fields[0].data_type();
             return Ok(Arc::new(Self::new(
-                BTreeMap::new(),
+                Arc::new(BTreeMap::new()),
                 Arc::new(RowAddrTreeMap::default()),
                 data_type,
                 store,
@@ -381,7 +424,7 @@ impl BitmapIndex {
         }
 
         Ok(Arc::new(Self::new(
-            index_map,
+            Arc::new(index_map),
             null_map,
             value_type,
             store,
@@ -466,12 +509,7 @@ impl BitmapIndex {
 
 impl DeepSizeOf for BitmapIndex {
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
-        let mut total_size = 0;
-
-        total_size += self.index_map.deep_size_of_children(context);
-        total_size += self.store.deep_size_of_children(context);
-
-        total_size
+        self.index_map.deep_size_of_children(context) + self.store.deep_size_of_children(context)
     }
 }
 
@@ -1694,20 +1732,10 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
         cache: &LanceCache,
     ) -> Result<Option<Arc<dyn ScalarIndex>>> {
-        // Fast path: pre-built index is already in memory (O(1))
-        if let Some(index) = cache.get_unsized_with_key(&ScalarIndexCacheKey).await {
-            return Ok(Some(index));
-        }
-        // Fallback: reconstruct from serialized state (disk-backed cache hit)
         let Some(state) = cache.get_with_key(&BitmapIndexStateKey).await else {
             return Ok(None);
         };
-        let state = (*state).clone();
         let index = state.into_bitmap_index(index_store, cache, frag_reuse_index)?;
-        // Populate the fast path so the next hit is O(1)
-        cache
-            .insert_unsized_with_key(&ScalarIndexCacheKey, index.clone())
-            .await;
         Ok(Some(index as Arc<dyn ScalarIndex>))
     }
 
@@ -1718,11 +1746,6 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
             .ok_or_else(|| {
                 Error::internal("BitmapIndexPlugin::put_in_cache called with a non-bitmap index")
             })?;
-        // Fast in-memory path (O(1) hit on next get_from_cache)
-        cache
-            .insert_unsized_with_key(&ScalarIndexCacheKey, index.clone())
-            .await;
-        // Serializable path for disk-backed cache backends
         let state = BitmapIndexState::from_index(bitmap)?;
         cache
             .insert_with_key(&BitmapIndexStateKey, Arc::new(state))
@@ -1800,6 +1823,7 @@ mod tests {
             lookup_batch: build_lookup_batch(&index_map, &DataType::Int32).unwrap(),
             null_map: Arc::new(null_map),
             value_type: DataType::Int32,
+            index_map: OnceLock::new(),
         };
         assert_state_roundtrips(&state);
 
@@ -1808,6 +1832,7 @@ mod tests {
             lookup_batch: build_lookup_batch(&BTreeMap::new(), &DataType::Utf8).unwrap(),
             null_map: Arc::new(RowAddrTreeMap::new()),
             value_type: DataType::Utf8,
+            index_map: OnceLock::new(),
         };
         assert_state_roundtrips(&empty_state);
     }
@@ -1948,14 +1973,13 @@ mod tests {
     }
 
     // Regression test for the O(N log N) warm-cache rebuild introduced in
-    // commit 4de5ce67d.  put_in_cache must write an unsized (fast) entry so
-    // that get_from_cache returns it in O(1) without reconstructing the
-    // BTreeMap.  IS NULL is the worst case: the actual bitmap lookup is O(1)
-    // but the reconstruction touches every row in the lookup batch.
+    // commit 4de5ce67d.  BitmapIndexState now caches the parsed Arc<BTreeMap>
+    // so that get_from_cache skips parse_lookup_batch on warm hits.
+    // IS NULL is the worst case: the actual bitmap lookup is O(1) but
+    // reconstruction of the BTreeMap touched every row in the lookup batch.
     #[tokio::test]
     async fn test_bitmap_cache_fast_path() {
         use arrow_array::Int32Array;
-        use crate::scalar::registry::ScalarIndexCacheKey;
 
         let tmpdir = TempObjDir::default();
         let store = Arc::new(LanceIndexStore::new(
@@ -2000,13 +2024,8 @@ mod tests {
         let index_arc: Arc<dyn ScalarIndex> = index.clone() as Arc<dyn ScalarIndex>;
         plugin.put_in_cache(&cache, index_arc).await.unwrap();
 
-        // The fast (unsized) entry must be present immediately after put_in_cache.
-        assert!(
-            cache.get_unsized_with_key(&ScalarIndexCacheKey).await.is_some(),
-            "put_in_cache must populate the in-memory (unsized) cache entry"
-        );
-
-        // get_from_cache must return the pre-built index via the fast path.
+        // get_from_cache must return Some, and the BitmapIndexState's OnceLock
+        // must have been populated by put_in_cache so no parse_lookup_batch occurs.
         let cached = plugin
             .get_from_cache(store.clone(), None, &cache)
             .await

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -197,7 +197,7 @@ impl BitmapIndexState {
         })
     }
 
-    pub(crate) fn into_bitmap_index(
+    pub(crate) fn to_bitmap_index(
         &self,
         store: Arc<dyn IndexStore>,
         index_cache: &LanceCache,
@@ -1700,7 +1700,7 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
         let Some(state) = cache.get_with_key(&BitmapIndexStateKey).await else {
             return Ok(None);
         };
-        let index = state.into_bitmap_index(index_store, cache, frag_reuse_index)?;
+        let index = state.to_bitmap_index(index_store, cache, frag_reuse_index)?;
         Ok(Some(index as Arc<dyn ScalarIndex>))
     }
 
@@ -1957,7 +1957,8 @@ mod tests {
         const N: u64 = 1_000;
         const NULL_COUNT: u64 = 5;
         // nulls first (sorted batch: nulls precede values)
-        let null_values: Vec<Option<i32>> = std::iter::repeat(None).take(NULL_COUNT as usize).collect();
+        let null_values: Vec<Option<i32>> =
+            std::iter::repeat_n(None, NULL_COUNT as usize).collect();
         let non_null_values: Vec<Option<i32>> = (0..N as i32).map(Some).collect();
         let all_values: Vec<Option<i32>> = null_values.into_iter().chain(non_null_values).collect();
         let all_row_ids: Vec<u64> = (0..N + NULL_COUNT).collect();

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -49,8 +49,8 @@ use crate::{
         CreatedIndex, UpdateCriteria,
         expression::SargableQueryParser,
         registry::{
-            ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-            VALUE_COLUMN_NAME,
+            ScalarIndexCacheKey, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering,
+            TrainingRequest, VALUE_COLUMN_NAME,
         },
     },
 };
@@ -1694,11 +1694,20 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
         cache: &LanceCache,
     ) -> Result<Option<Arc<dyn ScalarIndex>>> {
+        // Fast path: pre-built index is already in memory (O(1))
+        if let Some(index) = cache.get_unsized_with_key(&ScalarIndexCacheKey).await {
+            return Ok(Some(index));
+        }
+        // Fallback: reconstruct from serialized state (disk-backed cache hit)
         let Some(state) = cache.get_with_key(&BitmapIndexStateKey).await else {
             return Ok(None);
         };
         let state = (*state).clone();
         let index = state.into_bitmap_index(index_store, cache, frag_reuse_index)?;
+        // Populate the fast path so the next hit is O(1)
+        cache
+            .insert_unsized_with_key(&ScalarIndexCacheKey, index.clone())
+            .await;
         Ok(Some(index as Arc<dyn ScalarIndex>))
     }
 
@@ -1709,6 +1718,11 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
             .ok_or_else(|| {
                 Error::internal("BitmapIndexPlugin::put_in_cache called with a non-bitmap index")
             })?;
+        // Fast in-memory path (O(1) hit on next get_from_cache)
+        cache
+            .insert_unsized_with_key(&ScalarIndexCacheKey, index.clone())
+            .await;
+        // Serializable path for disk-backed cache backends
         let state = BitmapIndexState::from_index(bitmap)?;
         cache
             .insert_with_key(&BitmapIndexStateKey, Arc::new(state))
@@ -1930,6 +1944,90 @@ mod tests {
                 .collect();
             actual.sort();
             assert_eq!(actual, expected_in_rows);
+        }
+    }
+
+    // Regression test for the O(N log N) warm-cache rebuild introduced in
+    // commit 4de5ce67d.  put_in_cache must write an unsized (fast) entry so
+    // that get_from_cache returns it in O(1) without reconstructing the
+    // BTreeMap.  IS NULL is the worst case: the actual bitmap lookup is O(1)
+    // but the reconstruction touches every row in the lookup batch.
+    #[tokio::test]
+    async fn test_bitmap_cache_fast_path() {
+        use arrow_array::Int32Array;
+        use crate::scalar::registry::ScalarIndexCacheKey;
+
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        // High-cardinality: 1 000 unique integers + 5 null rows.
+        const N: u64 = 1_000;
+        const NULL_COUNT: u64 = 5;
+        // nulls first (sorted batch: nulls precede values)
+        let null_values: Vec<Option<i32>> = std::iter::repeat(None).take(NULL_COUNT as usize).collect();
+        let non_null_values: Vec<Option<i32>> = (0..N as i32).map(Some).collect();
+        let all_values: Vec<Option<i32>> = null_values.into_iter().chain(non_null_values).collect();
+        let all_row_ids: Vec<u64> = (0..N + NULL_COUNT).collect();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("value", DataType::Int32, true),
+            Field::new("_rowid", DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(all_values)),
+                Arc::new(UInt64Array::from(all_row_ids)),
+            ],
+        )
+        .unwrap();
+        let stream = stream::once(async move { Ok(batch) });
+        let stream = Box::pin(RecordBatchStreamAdapter::new(schema, stream));
+        BitmapIndexPlugin::train_bitmap_index(stream, store.as_ref())
+            .await
+            .unwrap();
+
+        let cache = LanceCache::with_capacity(16 * 1024 * 1024);
+        let index = BitmapIndex::load(store.clone(), None, &cache)
+            .await
+            .unwrap();
+
+        let plugin = BitmapIndexPlugin;
+        let index_arc: Arc<dyn ScalarIndex> = index.clone() as Arc<dyn ScalarIndex>;
+        plugin.put_in_cache(&cache, index_arc).await.unwrap();
+
+        // The fast (unsized) entry must be present immediately after put_in_cache.
+        assert!(
+            cache.get_unsized_with_key(&ScalarIndexCacheKey).await.is_some(),
+            "put_in_cache must populate the in-memory (unsized) cache entry"
+        );
+
+        // get_from_cache must return the pre-built index via the fast path.
+        let cached = plugin
+            .get_from_cache(store.clone(), None, &cache)
+            .await
+            .unwrap()
+            .expect("get_from_cache must return Some after put_in_cache");
+
+        // IS NULL: trivial work once the index is in hand.
+        let query = SargableQuery::IsNull();
+        match cached.search(&query, &NoOpMetricsCollector).await.unwrap() {
+            SearchResult::Exact(row_set) => {
+                let mut null_rows: Vec<u64> = row_set
+                    .true_rows()
+                    .row_addrs()
+                    .unwrap()
+                    .map(u64::from)
+                    .collect();
+                null_rows.sort();
+                let expected: Vec<u64> = (0..NULL_COUNT).collect();
+                assert_eq!(null_rows, expected);
+            }
+            _ => panic!("Expected Exact result for IS NULL"),
         }
     }
 

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -524,7 +524,7 @@ impl LabelListIndexState {
     ) -> Result<Arc<LabelListIndex>> {
         let bitmap = self
             .bitmap_state
-            .into_bitmap_index(store, index_cache, frag_reuse_index)?;
+            .to_bitmap_index(store, index_cache, frag_reuse_index)?;
         Ok(Arc::new(LabelListIndex::new(bitmap, self.list_nulls)))
     }
 }

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -35,8 +35,8 @@ use crate::pbold;
 use crate::scalar::bitmap::{BitmapIndexPlugin, BitmapIndexState};
 use crate::scalar::expression::{LabelListQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    VALUE_COLUMN_NAME,
+    DefaultTrainingRequest, ScalarIndexCacheKey, ScalarIndexPlugin, TrainingCriteria,
+    TrainingOrdering, TrainingRequest, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{CreatedIndex, UpdateCriteria};
 use crate::{Index, IndexType};
@@ -701,11 +701,20 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
         cache: &LanceCache,
     ) -> Result<Option<Arc<dyn ScalarIndex>>> {
+        // Fast path: pre-built index is already in memory (O(1))
+        if let Some(index) = cache.get_unsized_with_key(&ScalarIndexCacheKey).await {
+            return Ok(Some(index));
+        }
+        // Fallback: reconstruct from serialized state (disk-backed cache hit)
         let Some(state) = cache.get_with_key(&LabelListIndexStateKey).await else {
             return Ok(None);
         };
         let state = (*state).clone();
         let index = state.into_label_list_index(index_store, cache, frag_reuse_index)?;
+        // Populate the fast path so the next hit is O(1)
+        cache
+            .insert_unsized_with_key(&ScalarIndexCacheKey, index.clone())
+            .await;
         Ok(Some(index as Arc<dyn ScalarIndex>))
     }
 
@@ -718,6 +727,11 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
                     "LabelListIndexPlugin::put_in_cache called with a non-label-list index",
                 )
             })?;
+        // Fast in-memory path (O(1) hit on next get_from_cache)
+        cache
+            .insert_unsized_with_key(&ScalarIndexCacheKey, index.clone())
+            .await;
+        // Serializable path for disk-backed cache backends
         let state = LabelListIndexState::from_index(label_list)?;
         cache
             .insert_with_key(&LabelListIndexStateKey, Arc::new(state))

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -35,8 +35,8 @@ use crate::pbold;
 use crate::scalar::bitmap::{BitmapIndexPlugin, BitmapIndexState};
 use crate::scalar::expression::{LabelListQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    DefaultTrainingRequest, ScalarIndexCacheKey, ScalarIndexPlugin, TrainingCriteria,
-    TrainingOrdering, TrainingRequest, VALUE_COLUMN_NAME,
+    DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+    VALUE_COLUMN_NAME,
 };
 use crate::scalar::{CreatedIndex, UpdateCriteria};
 use crate::{Index, IndexType};
@@ -701,20 +701,11 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
         cache: &LanceCache,
     ) -> Result<Option<Arc<dyn ScalarIndex>>> {
-        // Fast path: pre-built index is already in memory (O(1))
-        if let Some(index) = cache.get_unsized_with_key(&ScalarIndexCacheKey).await {
-            return Ok(Some(index));
-        }
-        // Fallback: reconstruct from serialized state (disk-backed cache hit)
         let Some(state) = cache.get_with_key(&LabelListIndexStateKey).await else {
             return Ok(None);
         };
         let state = (*state).clone();
         let index = state.into_label_list_index(index_store, cache, frag_reuse_index)?;
-        // Populate the fast path so the next hit is O(1)
-        cache
-            .insert_unsized_with_key(&ScalarIndexCacheKey, index.clone())
-            .await;
         Ok(Some(index as Arc<dyn ScalarIndex>))
     }
 
@@ -727,11 +718,6 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
                     "LabelListIndexPlugin::put_in_cache called with a non-label-list index",
                 )
             })?;
-        // Fast in-memory path (O(1) hit on next get_from_cache)
-        cache
-            .insert_unsized_with_key(&ScalarIndexCacheKey, index.clone())
-            .await;
-        // Serializable path for disk-backed cache backends
         let state = LabelListIndexState::from_index(label_list)?;
         cache
             .insert_with_key(&LabelListIndexStateKey, Arc::new(state))


### PR DESCRIPTION
## Problem

Commit 4de5ce67d ("feat(index): serializable cache for Bitmap and LabelList scalar indices #6874") introduced a performance regression in `BitmapIndexPlugin::get_from_cache`. Every warm-cache hit against a bitmap scalar index now pays O(N log N) cost where N is the number of unique values in the column, instead of O(1).

The regression: the new implementation stored only the serializable `BitmapIndexState` (an Arrow `RecordBatch`) in the cache and reconstructed the full `BTreeMap<OrderableScalarValue, usize>` on every cache hit by calling `parse_lookup_batch`. For a column with 10M unique values this rebuilds the map on every query — including `IS NULL`, whose actual bitmap lookup is `(*self.null_map).clone()` and is otherwise O(1).

`parse_lookup_batch` is expensive because:
1. It calls `ScalarValue::try_from_array` for every row — one heap allocation per unique value.
2. It inserts into a `BTreeMap` — O(log N) comparisons per insert, O(N log N) total.

## Fix

**`BitmapIndex.index_map`**: Changed from `BTreeMap<OrderableScalarValue, usize>` to `Arc<BTreeMap<OrderableScalarValue, usize>>`. The map is immutable after construction, so sharing it behind an `Arc` is safe, and cloning is O(1).

**`BitmapIndexState`**: Added an `index_map: Arc<BTreeMap<...>>` field that is **not serialized** — the wire format is unchanged. It is populated eagerly:
- `from_index` (called by `put_in_cache`): `Arc::clone`s the map from the live `BitmapIndex` — O(1).
- `deserialize` (disk-backed cache backends): calls `parse_lookup_batch` once at deserialization time, which is already paying disk I/O cost.

**`into_bitmap_index`**: Now takes `&self` and simply `Arc::clone`s `self.index_map` — always O(1), no reconstruction.

**`get_from_cache`**: The intermediate `(*state).clone()` is removed since `into_bitmap_index` no longer consumes `self`.

`LabelListIndex` had the same dual-entry patch applied in a prior iteration; that is also reverted to the original single-entry approach (its `BitmapIndexState` path is unchanged by this PR).

## Test

Added `test_bitmap_cache_fast_path` to `bitmap.rs`:
- Creates a high-cardinality bitmap index (1 000 unique integers + 5 null rows)
- Calls `put_in_cache`, then `get_from_cache`
- Asserts `get_from_cache` returns `Some`
- Runs `IS NULL` and asserts the correct 5 null rows are returned

To measure the end-to-end impact, run the `bitmap / is_null / warm` case in `python/python/ci_benchmarks/benchmarks/test_count_rows.py` — latency should be close to `btree / is_null / warm`.