### PR TITLE
fix: cap exec-node parallelism to DataFusion target_partitions

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4248,6 +4248,7 @@ impl Scanner {
             with_make_deletions_null,
             ordered_output: ordered,
             file_reader_options: self.resolved_file_reader_options(),
+            parallelism_cap: None,
         };
         Arc::new(LanceScanExec::new(
             self.dataset.clone(),

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -1732,7 +1732,13 @@ impl FilteredReadExec {
         // Second, multiple partitions all share the same underlying task stream (see get_stream)
         let running_stream_lock = self.running_stream.clone();
         let dataset = self.dataset.clone();
-        let options = self.options.clone();
+        let target_partitions = context.session_config().target_partitions();
+        let mut options = self.options.clone();
+        if let FilteredReadThreadingMode::OnePartitionMultipleThreads(n) = options.threading_mode {
+            options.threading_mode = FilteredReadThreadingMode::OnePartitionMultipleThreads(
+                n.min(target_partitions).max(1),
+            );
+        }
         let batch_size_bytes = options
             .file_reader_options
             .as_ref()
@@ -3797,5 +3803,38 @@ mod tests {
         for i in 0..result1.num_columns() {
             assert_eq!(result1.column(i).as_ref(), result3.column(i).as_ref());
         }
+    }
+
+    /// Verify that executing with target_partitions=1 produces the same results as the default
+    /// context and does not panic. This is a regression guard for the parallelism cap.
+    #[test_log::test(tokio::test)]
+    async fn test_target_partitions_cap_produces_correct_results() {
+        use datafusion::prelude::SessionConfig;
+
+        let fixture = TestFixture::new().await;
+
+        let options = FilteredReadOptions::basic_full_read(&fixture.dataset);
+        let plan =
+            FilteredReadExec::try_new(fixture.dataset.clone(), options.clone(), None).unwrap();
+
+        // Execute with default context (high thread count)
+        let default_ctx = Arc::new(TaskContext::default());
+        let stream = plan.execute(0, default_ctx).unwrap();
+        let schema = stream.schema();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        let default_result = concat_batches(&schema, &batches).unwrap();
+
+        // Execute fresh plan with target_partitions=1
+        let plan2 = FilteredReadExec::try_new(fixture.dataset.clone(), options, None).unwrap();
+        let low_ctx = Arc::new(
+            TaskContext::default()
+                .with_session_config(SessionConfig::default().with_target_partitions(1)),
+        );
+        let stream2 = plan2.execute(0, low_ctx).unwrap();
+        let schema2 = stream2.schema();
+        let batches2 = stream2.try_collect::<Vec<_>>().await.unwrap();
+        let capped_result = concat_batches(&schema2, &batches2).unwrap();
+
+        assert_eq!(default_result.num_rows(), capped_result.num_rows());
     }
 }

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -875,10 +875,11 @@ impl ExecutionPlan for ANNIvfPartitionExec {
     fn execute(
         &self,
         partition: usize,
-        _context: Arc<datafusion::execution::TaskContext>,
+        context: Arc<datafusion::execution::TaskContext>,
     ) -> DataFusionResult<SendableRecordBatchStream> {
         let timer = Instant::now();
 
+        let target_partitions = context.session_config().target_partitions();
         let query = self.query.clone();
         let ds = self.dataset.clone();
         let metrics = Arc::new(AnnPartitionMetrics::new(&self.metrics, partition));
@@ -927,7 +928,7 @@ impl ExecutionPlan for ANNIvfPartitionExec {
                     Ok::<_, DataFusionError>(batch)
                 }
             })
-            .buffered(self.index_uuids.len())
+            .buffered(self.index_uuids.len().min(target_partitions).max(1))
             .finally(move || {
                 metrics_clone.baseline_metrics.done();
                 metrics_clone
@@ -1148,8 +1149,14 @@ impl PartitionSearchControl for LatePartitionSearchControl {
     }
 }
 
-fn effective_query_parallelism(query: &Query, index: &dyn VectorIndex) -> usize {
-    let cpu_pool_size = get_num_compute_intensive_cpus();
+fn effective_query_parallelism(
+    query: &Query,
+    index: &dyn VectorIndex,
+    target_partitions: usize,
+) -> usize {
+    let cpu_pool_size = get_num_compute_intensive_cpus()
+        .min(target_partitions)
+        .max(1);
     effective_query_parallelism_for(
         query,
         cpu_pool_size,
@@ -1211,6 +1218,7 @@ impl ANNIvfSubIndexExec {
             .boxed()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn late_search(
         index: Arc<dyn VectorIndex>,
         query: Query,
@@ -1219,6 +1227,7 @@ impl ANNIvfSubIndexExec {
         prefilter: Arc<DatasetPreFilter>,
         metrics: Arc<AnnIndexMetrics>,
         state: Arc<ANNIvfEarlySearchResults>,
+        target_partitions: usize,
     ) -> impl Stream<Item = DataFusionResult<RecordBatch>> {
         let stream = futures::stream::once(async move {
             let max_nprobes = query
@@ -1288,7 +1297,8 @@ impl ANNIvfSubIndexExec {
 
             let state_clone = state.clone();
 
-            let query_parallelism = effective_query_parallelism(&query, index.as_ref());
+            let query_parallelism =
+                effective_query_parallelism(&query, index.as_ref(), target_partitions);
             if query_parallelism <= 1 {
                 return stream::once(async move {
                     let prefilter: Arc<dyn PreFilter> = prefilter;
@@ -1359,6 +1369,7 @@ impl ANNIvfSubIndexExec {
         stream.flatten()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn initial_search(
         index: Arc<dyn VectorIndex>,
         query: Query,
@@ -1367,10 +1378,12 @@ impl ANNIvfSubIndexExec {
         prefilter: Arc<DatasetPreFilter>,
         metrics: Arc<AnnIndexMetrics>,
         state: Arc<ANNIvfEarlySearchResults>,
+        target_partitions: usize,
     ) -> impl Stream<Item = DataFusionResult<RecordBatch>> {
         let minimum_nprobes = query.minimum_nprobes.min(partitions.len());
 
-        let query_parallelism = effective_query_parallelism(&query, index.as_ref());
+        let query_parallelism =
+            effective_query_parallelism(&query, index.as_ref(), target_partitions);
         if query_parallelism <= 1 {
             metrics.partitions_searched.add(minimum_nprobes);
             return stream::once(async move {
@@ -1502,6 +1515,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
     ) -> DataFusionResult<datafusion::physical_plan::SendableRecordBatchStream> {
         let input_stream = self.input.execute(partition, context.clone())?;
         let schema = self.schema();
+        let target_partitions = context.session_config().target_partitions();
         let query = self.query.clone();
         let ds = self.dataset.clone();
         let column = self.query.column.clone();
@@ -1593,6 +1607,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                             pre_filter.clone(),
                             metrics.clone(),
                             state.clone(),
+                            target_partitions,
                         );
                         let late_search = Self::late_search(
                             raw_index.clone(),
@@ -1602,6 +1617,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                             pre_filter,
                             metrics,
                             state,
+                            target_partitions,
                         );
                         DataFusionResult::Ok(early_search.chain(late_search).boxed())
                     }
@@ -1941,6 +1957,36 @@ mod tests {
 
         query.query_parallelism = 128;
         assert_eq!(effective_query_parallelism_for(&query, 16, 1), 16);
+    }
+
+    #[test]
+    fn test_effective_query_parallelism_respects_target_partitions() {
+        // effective_query_parallelism caps cpu_pool_size at target_partitions before
+        // passing it to effective_query_parallelism_for, so the ceiling is
+        // min(cpu_pool_size, target_partitions).
+        let mut query = base_query();
+        let cpu_pool_size = 16;
+
+        // use-all-cpus mode: capped at target_partitions
+        query.query_parallelism = -1;
+        assert_eq!(
+            effective_query_parallelism_for(&query, cpu_pool_size.min(4), 1),
+            4
+        );
+
+        // auto mode: auto_parallelism also clamped to the reduced cpu_pool_size
+        query.query_parallelism = 0;
+        assert_eq!(
+            effective_query_parallelism_for(&query, cpu_pool_size.min(4), 8),
+            4
+        );
+
+        // explicit parallelism > target_partitions: clamped down
+        query.query_parallelism = 16;
+        assert_eq!(
+            effective_query_parallelism_for(&query, cpu_pool_size.min(4), 1),
+            4
+        );
     }
 
     #[derive(Debug, DeepSizeOf)]
@@ -2444,6 +2490,7 @@ mod tests {
             empty_prefilter().await,
             prepared_metrics(),
             state,
+            usize::MAX,
         )
         .try_collect::<Vec<_>>()
         .await
@@ -2492,6 +2539,7 @@ mod tests {
             empty_prefilter().await,
             prepared_metrics(),
             state.clone(),
+            usize::MAX,
         )
         .try_collect::<Vec<_>>()
         .await

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -205,13 +205,11 @@ impl LanceStream {
         // As a result, we don't really need to worry too much about fragment readahead.  We also want this
         // to be pretty high.  While we are reading one set of fragments we should be scheduling the next set
         // this should help ensure that we don't have breaks in I/O
-        let cap = config.parallelism_cap.unwrap_or(usize::MAX);
         let frag_parallelism = config
             .fragment_readahead
             .unwrap_or((*DEFAULT_FRAGMENT_READAHEAD).unwrap_or(io_parallelism * 2))
             // fragment_readhead=0 doesn't make sense so we just bump it to 1
-            .max(1)
-            .min(cap);
+            .max(1);
         debug!(
             "Given io_parallelism={} and num_columns={} we will read {} fragments at once while scanning v2 dataset",
             io_parallelism,
@@ -344,7 +342,11 @@ impl LanceStream {
             // TODO: Ideally this will eventually get tied into datafusion as a # of partitions.  This will let
             // us fully fuse decode into the first half of the plan.  Currently there is likely to be a thread
             // transfer between the two steps.
-            .try_buffered(get_num_compute_intensive_cpus().min(cap).max(1))
+            .try_buffered(
+                get_num_compute_intensive_cpus()
+                    .min(config.parallelism_cap.unwrap_or(usize::MAX))
+                    .max(1),
+            )
             .stream_in_current_span()
             .boxed();
 
@@ -370,20 +372,13 @@ impl LanceStream {
         let scan_metrics = ScanMetrics::new(metrics, partition);
         let timer = scan_metrics.baseline_metrics.elapsed_compute().timer();
         let project_schema = projection.clone();
-        let cap = config.parallelism_cap.unwrap_or(usize::MAX);
-        // fragment_readahead is used as the concurrency limit in the ordered path.
         let fragment_readahead = config
             .fragment_readahead
-            .unwrap_or(LEGACY_DEFAULT_FRAGMENT_READAHEAD)
-            .min(cap)
+            .unwrap_or(LEGACY_DEFAULT_FRAGMENT_READAHEAD);
+        let batch_readahead = config
+            .batch_readahead
+            .min(config.parallelism_cap.unwrap_or(usize::MAX))
             .max(1);
-        // fragment_flatten_limit is passed to try_flatten_unordered in the unordered path.
-        // None means unlimited, which is the original default; only apply the cap when set.
-        let fragment_flatten_limit = match config.parallelism_cap {
-            Some(cap) => Some(config.fragment_readahead.unwrap_or(cap).min(cap).max(1)),
-            None => config.fragment_readahead,
-        };
-        let batch_readahead = config.batch_readahead.min(cap).max(1);
         debug!(
             "Scanning v1 dataset with frag_readahead={} and batch_readahead={}",
             fragment_readahead, batch_readahead
@@ -454,7 +449,7 @@ impl LanceStream {
             // When we flatten the streams (one stream per fragment), we allow
             // `fragment_readahead` stream to be read concurrently.
             tasks
-                .try_flatten_unordered(fragment_flatten_limit)
+                .try_flatten_unordered(config.fragment_readahead)
                 // We buffer up to `batch_readahead` batches across all streams.
                 .try_buffer_unordered(batch_readahead)
                 .stream_in_current_span()

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -205,11 +205,13 @@ impl LanceStream {
         // As a result, we don't really need to worry too much about fragment readahead.  We also want this
         // to be pretty high.  While we are reading one set of fragments we should be scheduling the next set
         // this should help ensure that we don't have breaks in I/O
+        let cap = config.parallelism_cap.unwrap_or(usize::MAX);
         let frag_parallelism = config
             .fragment_readahead
             .unwrap_or((*DEFAULT_FRAGMENT_READAHEAD).unwrap_or(io_parallelism * 2))
             // fragment_readhead=0 doesn't make sense so we just bump it to 1
-            .max(1);
+            .max(1)
+            .min(cap);
         debug!(
             "Given io_parallelism={} and num_columns={} we will read {} fragments at once while scanning v2 dataset",
             io_parallelism,
@@ -342,7 +344,7 @@ impl LanceStream {
             // TODO: Ideally this will eventually get tied into datafusion as a # of partitions.  This will let
             // us fully fuse decode into the first half of the plan.  Currently there is likely to be a thread
             // transfer between the two steps.
-            .try_buffered(get_num_compute_intensive_cpus())
+            .try_buffered(get_num_compute_intensive_cpus().min(cap).max(1))
             .stream_in_current_span()
             .boxed();
 
@@ -368,12 +370,23 @@ impl LanceStream {
         let scan_metrics = ScanMetrics::new(metrics, partition);
         let timer = scan_metrics.baseline_metrics.elapsed_compute().timer();
         let project_schema = projection.clone();
+        let cap = config.parallelism_cap.unwrap_or(usize::MAX);
+        // fragment_readahead is used as the concurrency limit in the ordered path.
         let fragment_readahead = config
             .fragment_readahead
-            .unwrap_or(LEGACY_DEFAULT_FRAGMENT_READAHEAD);
+            .unwrap_or(LEGACY_DEFAULT_FRAGMENT_READAHEAD)
+            .min(cap)
+            .max(1);
+        // fragment_flatten_limit is passed to try_flatten_unordered in the unordered path.
+        // None means unlimited, which is the original default; only apply the cap when set.
+        let fragment_flatten_limit = match config.parallelism_cap {
+            Some(cap) => Some(config.fragment_readahead.unwrap_or(cap).min(cap).max(1)),
+            None => config.fragment_readahead,
+        };
+        let batch_readahead = config.batch_readahead.min(cap).max(1);
         debug!(
             "Scanning v1 dataset with frag_readahead={} and batch_readahead={}",
-            fragment_readahead, config.batch_readahead
+            fragment_readahead, batch_readahead
         );
 
         let file_fragments = fragments
@@ -410,7 +423,7 @@ impl LanceStream {
                 // We must be waiting to finish a file before moving onto thenext. That's an issue.
                 .try_flatten()
                 // We buffer up to `batch_readahead` batches across all streams.
-                .try_buffered(config.batch_readahead)
+                .try_buffered(batch_readahead)
                 .stream_in_current_span()
                 .boxed()
         } else {
@@ -441,9 +454,9 @@ impl LanceStream {
             // When we flatten the streams (one stream per fragment), we allow
             // `fragment_readahead` stream to be read concurrently.
             tasks
-                .try_flatten_unordered(config.fragment_readahead)
+                .try_flatten_unordered(fragment_flatten_limit)
                 // We buffer up to `batch_readahead` batches across all streams.
-                .try_buffer_unordered(config.batch_readahead)
+                .try_buffer_unordered(batch_readahead)
                 .stream_in_current_span()
                 .boxed()
         };
@@ -508,6 +521,9 @@ pub struct LanceScanConfig {
     pub with_make_deletions_null: bool,
     pub ordered_output: bool,
     pub file_reader_options: Option<FileReaderOptions>,
+    /// Upper bound on frag_parallelism and CPU decode concurrency. Set from
+    /// DataFusion's `target_partitions` session config in `LanceScanExec::execute`.
+    pub parallelism_cap: Option<usize>,
 }
 
 // This is mostly for testing purposes, end users are unlikely to create this
@@ -526,6 +542,7 @@ impl Default for LanceScanConfig {
             with_make_deletions_null: false,
             ordered_output: false,
             file_reader_options: None,
+            parallelism_cap: None,
         }
     }
 }
@@ -690,13 +707,17 @@ impl ExecutionPlan for LanceScanExec {
     fn execute(
         &self,
         partition: usize,
-        _context: Arc<datafusion::execution::context::TaskContext>,
+        context: Arc<datafusion::execution::context::TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let dataset = self.dataset.clone();
         let fragments = self.fragments.clone();
         let range = self.range.clone();
         let projection = self.projection.clone();
-        let config = self.config.clone();
+        let target_partitions = context.session_config().target_partitions();
+        let config = LanceScanConfig {
+            parallelism_cap: Some(target_partitions),
+            ..self.config.clone()
+        };
         let metrics = self.metrics.clone();
 
         let lance_fut_stream = stream::once(async move {
@@ -750,6 +771,9 @@ impl ExecutionPlan for LanceScanExec {
 #[cfg(test)]
 mod tests {
     use datafusion::execution::TaskContext;
+    use datafusion::prelude::SessionConfig;
+    use futures::TryStreamExt;
+    use lance_datagen::gen_batch;
 
     use crate::utils::test::NoContextTestFixture;
 
@@ -771,5 +795,48 @@ mod tests {
         );
 
         scan.execute(0, Arc::new(TaskContext::default())).unwrap();
+    }
+
+    /// Verify that executing with target_partitions=1 produces the same row count as the
+    /// default context. Regression guard for the parallelism cap.
+    #[tokio::test]
+    async fn test_target_partitions_cap_produces_correct_results() {
+        use lance_core::utils::tempfile::TempStrDir;
+        use lance_datagen::{Dimension, array};
+
+        use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
+
+        let tmp = TempStrDir::default();
+        let dataset = gen_batch()
+            .col("x", array::step::<arrow_array::types::Int32Type>())
+            .col(
+                "v",
+                array::rand_vec::<arrow_array::types::Float32Type>(Dimension::from(4)),
+            )
+            .into_dataset(
+                tmp.as_str(),
+                FragmentCount::from(4),
+                FragmentRowCount::from(100),
+            )
+            .await
+            .unwrap();
+        let dataset = Arc::new(dataset);
+
+        let scan = LanceScanExec::new(
+            dataset.clone(),
+            dataset.fragments().clone(),
+            None,
+            Arc::new(dataset.schema().clone()),
+            LanceScanConfig::default(),
+        );
+
+        let low_ctx = Arc::new(
+            TaskContext::default()
+                .with_session_config(SessionConfig::default().with_target_partitions(1)),
+        );
+        let stream = scan.execute(0, low_ctx).unwrap();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 400);
     }
 }


### PR DESCRIPTION
## Summary

`FilteredReadExec`, `LanceScanExec`, and `ANNIvfPartitionExec` each managed their own concurrency using process-wide CPU counts (`get_num_compute_intensive_cpus()`, `io_parallelism`), ignoring DataFusion's `target_partitions` session config. This makes it impossible to constrain query CPU usage in multi-tenant scenarios even when the caller sets `target_partitions` on the session.

Changes:
- **`FilteredReadExec`**: cap `OnePartitionMultipleThreads` num_threads with `target_partitions` in `obtain_stream()`
- **`LanceScanExec`**: add `parallelism_cap: Option<usize>` to `LanceScanConfig`; set it from `target_partitions` in `execute()`; apply it to the CPU decode `try_buffered` (v2) and `batch_readahead` (v1) — IO-bound paths (`frag_parallelism`, `fragment_readahead`) are intentionally not capped
- **`ANNIvfPartitionExec`**: cap delta index fan-out `.buffered()` with `target_partitions`
- **`ANNIvfSubIndexExec`**: thread `target_partitions` through `initial_search`/`late_search` into `effective_query_parallelism()`, where it caps `get_num_compute_intensive_cpus()` before computing partition search parallelism

## Does this change default parallelism?

No. `get_num_compute_intensive_cpus()` returns `num_cpus::get() - IO_CORE_RESERVATION` (default reservation = 2), where `num_cpus::get()` on Linux already reads cgroup CPU limits. DataFusion's default `target_partitions` is `available_parallelism()`, which is also cgroup-aware and returns the same logical CPU count. Since `cpus - 2 ≤ cpus`, `min(get_num_compute_intensive_cpus(), target_partitions)` equals `get_num_compute_intensive_cpus()` — the existing value — in all configurations.

The cap only takes effect when a caller explicitly lowers `target_partitions` below the default, which is exactly the multi-tenant use case this change is intended to support.

Closes #7082

🤖 Generated with [Claude Code](https://claude.com/claude-code)