### PR TITLE
docs: fix broken pre-release install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pip install pylance
 To install a preview release:
 
 ```shell
-pip install --pre --extra-index-url https://pypi.fury.io/lance-format/pylance
+pip install --pre --extra-index-url https://pypi.fury.io/lance-format pylance
 ```
 
 > [!TIP]

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -22,17 +22,17 @@ For the latest features and bug fixes, you can install the preview version:
 === "pip"
 
     ```bash
-    pip install --pre --extra-index-url https://pypi.fury.io/lance-format/ pylance
+    pip install --pre --extra-index-url https://pypi.fury.io/lance-format pylance
     ```
 
 === "uv"
 
     ```bash
     uv venv
-    uv pip install --prerelease allow --index https://pypi.fury.io/lance-format/ pylance
+    uv pip install --prerelease allow --index https://pypi.fury.io/lance-format pylance
 
     # To add to pyproject.toml, just do:
-    uv add --prerelease allow --index https://pypi.fury.io/lance-format/ pylance
+    uv add --prerelease allow --index https://pypi.fury.io/lance-format pylance
     ```
 
 !!! note


### PR DESCRIPTION
Remove redundant trailing slashes and update pylance pre-release pip install command in README.md