### PR TITLE
perf(pq): wrap l2_targets in Arc to eliminate per-partition clones

### DIFF
--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -60,10 +60,9 @@ impl DeepSizeOf for ProductQuantizer {
             + self.num_bits.deep_size_of_children(_context)
             + self.dimension.deep_size_of_children(_context)
             + self.distance_type.deep_size_of_children(_context)
-            + self
-                .l2_targets
-                .as_ref()
-                .map_or(0, |v| (**v).iter().map(|t| t.size_bytes()).sum())
+            // deep_size_of_children on the Arc de-duplicates shared allocations
+            // via the context, so partitions sharing one l2_targets are counted once.
+            + self.l2_targets.deep_size_of_children(_context)
     }
 }
 

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -49,7 +49,8 @@ pub struct ProductQuantizer {
     /// Pre-transposed L2 targets per sub-vector for fast f32 L2 batch computation.
     /// Only populated when codebook is f32 and distance_type is L2
     /// (Cosine is converted to L2 before construction, so it benefits too).
-    l2_targets: Option<Vec<L2Prepared>>,
+    /// Wrapped in Arc so all clones (one per cached IVF partition) share one copy.
+    l2_targets: Option<Arc<Vec<L2Prepared>>>,
 }
 
 impl DeepSizeOf for ProductQuantizer {
@@ -62,7 +63,7 @@ impl DeepSizeOf for ProductQuantizer {
             + self
                 .l2_targets
                 .as_ref()
-                .map_or(0, |v| v.iter().map(|t| t.size_bytes()).sum())
+                .map_or(0, |v| (**v).iter().map(|t| t.size_bytes()).sum())
     }
 }
 
@@ -74,7 +75,7 @@ impl ProductQuantizer {
         num_sub_vectors: usize,
         num_bits: u32,
         dimension: usize,
-    ) -> Option<Vec<L2Prepared>> {
+    ) -> Option<Arc<Vec<L2Prepared>>> {
         if codebook.value_type() != DataType::Float32 || distance_type != DistanceType::L2 {
             return None;
         }
@@ -86,14 +87,14 @@ impl ProductQuantizer {
         let num_centroids = 2_usize.pow(num_bits);
         let block_size = sub_dim * num_centroids;
 
-        let targets = (0..num_sub_vectors)
+        let targets: Vec<L2Prepared> = (0..num_sub_vectors)
             .map(|sub_idx| {
                 let block_start = sub_idx * block_size;
                 let block = &values[block_start..block_start + block_size];
                 L2Prepared::new(block, sub_dim)
             })
             .collect();
-        Some(targets)
+        Some(Arc::new(targets))
     }
 
     pub fn new(
@@ -361,7 +362,7 @@ impl ProductQuantizer {
             DataType::Float32 => {
                 if let Some(targets) = &self.l2_targets {
                     let query = key.as_primitive::<datatypes::Float32Type>().values();
-                    Ok(build_distance_table_l2_prepared(targets, query))
+                    Ok(build_distance_table_l2_prepared(targets.as_slice(), query))
                 } else {
                     Ok(self
                         .build_l2_distance_table_impl::<datatypes::Float32Type>(key.as_primitive()))

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -15,6 +15,7 @@ use arrow_array::{
     types::{Float16Type, Float32Type, Float64Type, Int8Type},
 };
 use arrow_schema::DataType;
+use deepsize::DeepSizeOf;
 use half::{bf16, f16};
 use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
 use lance_core::assume_eq;
@@ -331,7 +332,7 @@ fn accumulate_l2_dimension(q: f32, row: &[f32], result: &mut [f32]) {
 /// sub-vector codebooks (e.g. 256 centroids × 16 dims = 16 KB).
 /// For large target sets the SoA layout causes L1 thrashing and
 /// [`l2_distance_batch`] with its AoS per-target locality is faster.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DeepSizeOf)]
 pub struct L2Prepared {
     transposed: Vec<f32>,
     dimension: usize,


### PR DESCRIPTION
ProductQuantizer stores `l2_targets: Option<Vec<L2Prepared>>` — a pre-transposed SoA copy of the PQ codebook (~768 KB for a 768-dim, 48 sub-vector, 256-centroid index).  Every call to `PQIndex::load()` (one per cached IVF partition) clones the entire ProductQuantizer, deep-copying this Vec.  The data is logically identical across all partitions (derived from the same global codebook) but was physically duplicated N times.

With 8000 partitions fully warmed, this wastes ~6 GB (768 KB × 8000).  We measured this empirically: lance 4.0.1 used 2.9× more memory per cached partition than lance 0.39 (1894 KB vs 443 KB), with the excess tracing directly to l2_targets.

Fix: change the field type to `Option<Arc<Vec<L2Prepared>>>`. Cloning a ProductQuantizer now bumps a reference count instead of copying megabytes; all partitions share one allocation.

Changes (5 lines in one file):
- Field type: Option<Vec<L2Prepared>> → Option<Arc<Vec<L2Prepared>>>
- build_l2_targets return type updated to match
- Construction: wrap collected Vec with Arc::new
- DeepSizeOf: deref Arc before iterating (**v).iter()
- build_l2_distance_table: targets.as_slice() to pass &[L2Prepared]