### PR TITLE
fix(index): invalidate stale index cache entries after index replacement

### DIFF
--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -113,6 +113,9 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
     /// Remove all entries whose prefix starts with the given string.
     async fn invalidate_prefix(&self, prefix: &str);
 
+    /// Remove only the entry identified by `key`, if present.
+    async fn invalidate_entry(&self, key: &InternalCacheKey);
+
     /// Remove all entries.
     async fn clear(&self);
 

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -233,6 +233,18 @@ impl LanceCache {
         self.cache.invalidate_prefix(&full_prefix).await;
     }
 
+    /// Invalidate one typed entry.
+    pub async fn invalidate_with_key<K: CacheKey>(&self, cache_key: &K) {
+        let key = build_key(&self.prefix, &cache_key.key(), K::type_name());
+        self.cache.invalidate_entry(&key).await;
+    }
+
+    /// Invalidate one unsized-typed entry.
+    pub async fn invalidate_unsized_with_key<K: UnsizedCacheKey>(&self, cache_key: &K) {
+        let key = build_key(&self.prefix, &cache_key.key(), K::type_name());
+        self.cache.invalidate_entry(&key).await;
+    }
+
     pub async fn size(&self) -> usize {
         self.cache.num_entries().await
     }
@@ -804,6 +816,9 @@ mod tests {
             async fn invalidate_prefix(&self, prefix: &str) {
                 self.map.lock().await.retain(|k, _| !k.starts_with(prefix));
             }
+            async fn invalidate_entry(&self, key: &InternalCacheKey) {
+                self.map.lock().await.remove(key);
+            }
             async fn clear(&self) {
                 self.map.lock().await.clear();
             }
@@ -833,6 +848,174 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_with_key_removes_only_target() {
+        let cache = LanceCache::with_capacity(10_000);
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("a"), Arc::new(vec![1]))
+            .await;
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("b"), Arc::new(vec![2]))
+            .await;
+        // Same key, different type: should survive.
+        cache
+            .insert_with_key(&TestKey::<Vec<u8>>::new("a"), Arc::new(vec![3u8]))
+            .await;
+        assert_eq!(cache.size().await, 3);
+
+        cache
+            .invalidate_with_key(&TestKey::<Vec<i32>>::new("a"))
+            .await;
+
+        assert!(
+            cache
+                .get_with_key(&TestKey::<Vec<i32>>::new("a"))
+                .await
+                .is_none()
+        );
+        assert!(
+            cache
+                .get_with_key(&TestKey::<Vec<i32>>::new("b"))
+                .await
+                .is_some(),
+            "sibling key at same prefix must survive",
+        );
+        assert!(
+            cache
+                .get_with_key(&TestKey::<Vec<u8>>::new("a"))
+                .await
+                .is_some(),
+            "sibling type_name at same key must survive",
+        );
+        assert_eq!(cache.size().await, 2);
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_with_key_respects_prefix_scope() {
+        let base = LanceCache::with_capacity(10_000);
+        let ns_a = base.with_key_prefix("a");
+        let ns_b = base.with_key_prefix("b");
+
+        base.insert_with_key(&TestKey::<Vec<i32>>::new("k"), Arc::new(vec![1]))
+            .await;
+        ns_a.insert_with_key(&TestKey::<Vec<i32>>::new("k"), Arc::new(vec![2]))
+            .await;
+        ns_b.insert_with_key(&TestKey::<Vec<i32>>::new("k"), Arc::new(vec![3]))
+            .await;
+        assert_eq!(base.size().await, 3);
+
+        ns_a.invalidate_with_key(&TestKey::<Vec<i32>>::new("k"))
+            .await;
+
+        assert!(
+            ns_a.get_with_key(&TestKey::<Vec<i32>>::new("k"))
+                .await
+                .is_none()
+        );
+        assert!(
+            ns_b.get_with_key(&TestKey::<Vec<i32>>::new("k"))
+                .await
+                .is_some(),
+            "sibling sub-prefix must not be invalidated",
+        );
+        assert!(
+            base.get_with_key(&TestKey::<Vec<i32>>::new("k"))
+                .await
+                .is_some(),
+            "parent-prefix entry must not be invalidated",
+        );
+        assert_eq!(base.size().await, 2);
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_with_key_keeps_nested_prefix_subcache() {
+        // Parent-key invalidation must not clear child prefixes.
+        let base = LanceCache::with_capacity(10_000);
+        let nested = base.with_key_prefix("ns");
+
+        base.insert_with_key(&TestKey::<Vec<i32>>::new("k"), Arc::new(vec![1]))
+            .await;
+        nested
+            .insert_with_key(&TestKey::<Vec<i32>>::new("k"), Arc::new(vec![2]))
+            .await;
+        assert_eq!(base.size().await, 2);
+
+        base.invalidate_with_key(&TestKey::<Vec<i32>>::new("k"))
+            .await;
+
+        assert!(
+            base.get_with_key(&TestKey::<Vec<i32>>::new("k"))
+                .await
+                .is_none()
+        );
+        assert!(
+            nested
+                .get_with_key(&TestKey::<Vec<i32>>::new("k"))
+                .await
+                .is_some(),
+            "nested subcache entry must survive parent-scope invalidation",
+        );
+        assert_eq!(base.size().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_with_key_missing_is_noop() {
+        let cache = LanceCache::with_capacity(10_000);
+        cache
+            .insert_with_key(&TestKey::<Vec<i32>>::new("present"), Arc::new(vec![1]))
+            .await;
+
+        cache
+            .invalidate_with_key(&TestKey::<Vec<i32>>::new("absent"))
+            .await;
+
+        assert!(
+            cache
+                .get_with_key(&TestKey::<Vec<i32>>::new("present"))
+                .await
+                .is_some()
+        );
+        assert_eq!(cache.size().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_unsized_with_key_removes_only_target() {
+        #[derive(Debug, DeepSizeOf)]
+        struct MyType(i32);
+
+        trait MyTrait: DeepSizeOf + Send + Sync + std::any::Any {}
+        impl MyTrait for MyType {}
+
+        let cache = LanceCache::with_capacity(10_000);
+        let a: Arc<dyn MyTrait> = Arc::new(MyType(1));
+        let b: Arc<dyn MyTrait> = Arc::new(MyType(2));
+        cache
+            .insert_unsized_with_key(&TestUnsizedKey::<dyn MyTrait>::new("a"), a)
+            .await;
+        cache
+            .insert_unsized_with_key(&TestUnsizedKey::<dyn MyTrait>::new("b"), b)
+            .await;
+        assert_eq!(cache.size().await, 2);
+
+        cache
+            .invalidate_unsized_with_key(&TestUnsizedKey::<dyn MyTrait>::new("a"))
+            .await;
+
+        assert!(
+            cache
+                .get_unsized_with_key(&TestUnsizedKey::<dyn MyTrait>::new("a"))
+                .await
+                .is_none()
+        );
+        assert!(
+            cache
+                .get_unsized_with_key(&TestUnsizedKey::<dyn MyTrait>::new("b"))
+                .await
+                .is_some()
+        );
+        assert_eq!(cache.size().await, 1);
     }
 
     #[tokio::test]

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -118,6 +118,10 @@ impl CacheBackend for MokaCacheBackend {
             .expect("Cache configured correctly");
     }
 
+    async fn invalidate_entry(&self, key: &InternalCacheKey) {
+        self.cache.invalidate(key).await;
+    }
+
     async fn clear(&self) {
         self.cache.invalidate_all();
         self.cache.run_pending_tasks().await;

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2054,6 +2054,11 @@ mod fts_serializing_backend {
             self.passthrough.invalidate_prefix(prefix).await;
         }
 
+        async fn invalidate_entry(&self, key: &InternalCacheKey) {
+            self.serialized.lock().await.remove(key);
+            self.passthrough.invalidate_entry(key).await;
+        }
+
         async fn clear(&self) {
             self.serialized.lock().await.clear();
             self.passthrough.clear().await;

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::FutureExt;
 use itertools::Itertools;
-use lance_core::cache::CacheKey;
+use lance_core::cache::{CacheKey, LanceCache};
 use lance_core::datatypes::Field;
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_core::utils::address::RowAddress;
@@ -381,6 +381,41 @@ impl CacheKey for MemWalCacheKey<'_> {
 
     fn type_name() -> &'static str {
         "MemWalIndex"
+    }
+}
+
+/// Drop root and partition cache entries for removed index UUIDs.
+///
+/// Clears both bare `uuid` and active `uuid-fri_uuid` key shapes.
+pub(crate) async fn invalidate_removed_index_caches(
+    cache: &LanceCache,
+    removed_indices: &[IndexMetadata],
+    current_fri_uuid: Option<&Uuid>,
+) {
+    for removed in removed_indices {
+        let uuid_str = removed.uuid.to_string();
+
+        // Bare-UUID entries from caches created without FRI.
+        cache
+            .invalidate_with_key(&LegacyVectorIndexCacheKey::new(&uuid_str, None))
+            .await;
+        cache
+            .invalidate_with_key(&IvfIndexStateCacheKey::new(&uuid_str, None))
+            .await;
+        cache.invalidate_prefix(&format!("{}/", uuid_str)).await;
+
+        // Active FRI namespace.
+        if let Some(fri_uuid) = current_fri_uuid {
+            cache
+                .invalidate_with_key(&LegacyVectorIndexCacheKey::new(&uuid_str, Some(fri_uuid)))
+                .await;
+            cache
+                .invalidate_with_key(&IvfIndexStateCacheKey::new(&uuid_str, Some(fri_uuid)))
+                .await;
+            cache
+                .invalidate_prefix(&format!("{}-{}/", uuid_str, fri_uuid))
+                .await;
+        }
     }
 }
 
@@ -4092,6 +4127,113 @@ mod tests {
         for id in ids.values() {
             assert!(seen.insert(*id), "Duplicate id found: {}", id);
         }
+    }
+
+    #[tokio::test]
+    async fn test_optimize_indices_invalidates_removed_index_cache() {
+        // Prewarm an IVF-PQ index, then retrain it so the old UUID is retired.
+        let nrows = 256;
+        let dimensions = 16;
+        let column_name = "vector";
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                column_name,
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    dimensions,
+                ),
+                false,
+            ),
+        ]));
+
+        let float_arr = generate_random_array(nrows * dimensions as usize);
+        let vectors =
+            arrow_array::FixedSizeListArray::try_new_from_values(float_arr, dimensions).unwrap();
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(arrow_array::Int32Array::from_iter_values(0..nrows as i32)),
+                Arc::new(vectors),
+            ],
+        )
+        .unwrap();
+
+        let reader =
+            RecordBatchIterator::new(vec![record_batch].into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(reader, "memory://", None).await.unwrap();
+
+        let params = VectorIndexParams::ivf_pq(2, 8, 2, MetricType::L2, 2);
+        dataset
+            .create_index(&[column_name], IndexType::Vector, None, &params, true)
+            .await
+            .unwrap();
+
+        let indices = dataset.load_indices().await.unwrap();
+        let old_meta = indices
+            .iter()
+            .find(|idx| idx.fields == [dataset.schema().field(column_name).unwrap().id])
+            .expect("vector index should be present");
+        let old_uuid = old_meta.uuid;
+        let old_uuid_str = old_uuid.to_string();
+        let index_name = old_meta.name.clone();
+
+        // Prewarm fills the root state and partition sub-cache.
+        dataset.prewarm_index(&index_name).await.unwrap();
+
+        // Guard against a vacuous test.
+        assert!(
+            dataset
+                .index_cache
+                .get_with_key(&IvfIndexStateCacheKey::new(&old_uuid_str, None))
+                .await
+                .is_some(),
+            "IvfIndexState entry for the freshly opened index should be cached",
+        );
+
+        // Retrain replaces the index UUID.
+        dataset
+            .optimize_indices(&OptimizeOptions::retrain())
+            .await
+            .unwrap();
+
+        let new_indices = dataset.load_indices().await.unwrap();
+        let new_uuid = new_indices
+            .iter()
+            .find(|idx| idx.fields == old_meta.fields)
+            .expect("vector index should be present after optimize")
+            .uuid;
+        assert_ne!(new_uuid, old_uuid, "retrain must produce a new UUID");
+
+        // Old root entries must be gone.
+        assert!(
+            dataset
+                .index_cache
+                .get_with_key(&IvfIndexStateCacheKey::new(&old_uuid_str, None))
+                .await
+                .is_none(),
+            "stale IvfIndexState root entry must be invalidated",
+        );
+        assert!(
+            dataset
+                .index_cache
+                .get_with_key(&LegacyVectorIndexCacheKey::new(&old_uuid_str, None))
+                .await
+                .is_none(),
+            "stale LegacyVectorIndex root entry must be invalidated",
+        );
+
+        // Prefix invalidation should now be a no-op.
+        let size_before = dataset.index_cache.size().await;
+        dataset
+            .index_cache
+            .invalidate_prefix(&format!("{}/", old_uuid_str))
+            .await;
+        let size_after = dataset.index_cache.size().await;
+        assert_eq!(
+            size_before, size_after,
+            "no cache entries should remain under the removed index's UUID prefix",
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -5762,6 +5762,11 @@ mod tests {
             self.passthrough.invalidate_prefix(prefix).await;
         }
 
+        async fn invalidate_entry(&self, key: &lance_core::cache::InternalCacheKey) {
+            self.serialized.lock().await.remove(key);
+            self.passthrough.invalidate_entry(key).await;
+        }
+
         async fn clear(&self) {
             self.serialized.lock().await.clear();
             self.passthrough.clear().await;

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -50,6 +50,7 @@ use crate::dataset::{
 };
 use crate::index::DatasetIndexExt;
 use crate::index::DatasetIndexInternalExt;
+use crate::index::invalidate_removed_index_caches;
 use crate::index::vector::details::infer_missing_vector_details;
 use crate::io::deletion::read_dataset_deletion_file;
 use crate::session::Session;
@@ -58,6 +59,7 @@ use crate::session::index_caches::IndexMetadataKey;
 use futures::future::Either;
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
 use lance_core::{Error, Result};
+use lance_index::frag_reuse::FRAG_REUSE_INDEX_NAME;
 use lance_index::is_system_index;
 use lance_io::object_store::ObjectStoreRegistry;
 use log;
@@ -1071,6 +1073,12 @@ pub(crate) async fn commit_transaction(
                     .metadata_cache
                     .insert_with_key(&manifest_key, Arc::new(manifest.clone()))
                     .await;
+                // Keep the active FRI UUID for `uuid-fri_uuid` cache keys.
+                let new_fri_uuid = indices
+                    .iter()
+                    .find(|idx| idx.name == FRAG_REUSE_INDEX_NAME)
+                    .map(|idx| idx.uuid);
+
                 if !indices.is_empty() {
                     let key = IndexMetadataKey {
                         version: target_version,
@@ -1079,6 +1087,20 @@ pub(crate) async fn commit_transaction(
                         .index_cache
                         .insert_with_key(&key, Arc::new(indices))
                         .await;
+                }
+
+                // The rebased transaction has the indices actually retired.
+                if let Operation::CreateIndex {
+                    removed_indices, ..
+                } = &transaction.operation
+                    && !removed_indices.is_empty()
+                {
+                    invalidate_removed_index_caches(
+                        &dataset.index_cache,
+                        removed_indices,
+                        new_fri_uuid.as_ref(),
+                    )
+                    .await;
                 }
 
                 if !commit_config.skip_auto_cleanup {


### PR DESCRIPTION
## What

`CreateIndex` commits can retire existing index metadata, for example when `optimize_indices(...retrain...)` replaces an IVF index with a new UUID. If the old index had been prewarmed, the session index cache could still hold root entries and IVF partition entries for the removed UUID.

A later read in the same session could then observe stale cached index state that no longer matches the manifest. This clears cache entries for removed index UUIDs after the commit succeeds.

## Changes

- Add exact-key invalidation to `LanceCache` via `invalidate_with_key` and `invalidate_unsized_with_key`.
- Extend `CacheBackend` with `invalidate_entry` and implement it for the Moka backend and existing serializing test backends.
- On successful `Operation::CreateIndex` commits, invalidate cache entries for each removed index:
  - legacy vector index root entry
  - IVF state root entry
  - IVF partition sub-cache under `uuid/`
  - corresponding `uuid-fri_uuid/` entries when a fragment-reuse index is active
- Use the rebased transaction’s `removed_indices`, so conflict resolution invalidates the indices actually retired by the committed manifest.

## Notes

- Exact-key invalidation is needed because root index cache entries are keyed by UUID, while partition entries live under a cache prefix. Prefix invalidation alone cannot remove one root entry without risking unrelated cache entries.
- Invalidation happens only after the manifest write succeeds.
- This does not change index metadata, params, protos, or Python / Java APIs.

## Tests

- Cache unit tests for exact-key invalidation, sibling key/type preservation, prefix scoping, nested sub-cache preservation, missing-key no-op behavior, and unsized cache keys.
- An index integration test that prewarms an IVF-PQ index, retrains it through `optimize_indices`, and verifies the removed index UUID no longer has cached root or partition entries.
