### PR TITLE
docs: correct alter_columns nullable docstring

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2271,9 +2271,9 @@ class LanceDataset(pa.dataset.Dataset):
                 not changed.
             - "nullable": bool, optional
                 Whether the column should be nullable. If not specified, the column
-                nullability is not changed. Only non-nullable columns can be changed
-                to nullable. Currently, you cannot change a nullable column to
-                non-nullable.
+                nullability is not changed. A non-nullable column can always be made
+                nullable. A nullable column can be made non-nullable only if it
+                contains no NULL values; otherwise an error is raised.
             - "data_type": pyarrow.DataType, optional
                 The new data type to cast the column to. If not specified, the column
                 data type is not changed.


### PR DESCRIPTION
## Summary

The `LanceDataset.alter_columns` docstring states that a nullable column **cannot** be made non-nullable:

> Only non-nullable columns can be changed to nullable. Currently, you cannot change a nullable column to non-nullable.

This is out of date. Support for changing a nullable column to non-nullable was added in #5589 (`validate_no_nulls_before_making_non_nullable` in `rust/lance/src/dataset/schema_evolution.rs`), and the Python binding already plumbs `nullable` through (`python/src/dataset.rs`). The only requirement is that the column contains no NULL values, otherwise an error is raised.

This PR updates the docstring to describe the actual behavior in both directions.

## Changes

- Reword the `"nullable"` parameter docs for `alter_columns` to reflect that a nullable column can be made non-nullable when it has no NULL values.

## Notes

Docs-only change; no functional change and no test impact. Lint was deferred to CI for this docstring-only edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)