### PR TITLE
feat!: return write summaries from file writers

### DIFF
--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -347,8 +347,10 @@ impl LanceFileWriter {
     }
 
     pub fn finish(&self) -> PyResult<u64> {
-        rt().block_on(None, async { self.inner.lock().await.finish().await.map(|s| s.num_rows) })?
-            .infer_error()
+        rt().block_on(None, async {
+            self.inner.lock().await.finish().await.map(|s| s.num_rows)
+        })?
+        .infer_error()
     }
 
     pub fn add_global_buffer(&self, bytes: Vec<u8>) -> PyResult<u32> {

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -347,7 +347,7 @@ impl LanceFileWriter {
     }
 
     pub fn finish(&self) -> PyResult<u64> {
-        rt().block_on(None, async { self.inner.lock().await.finish().await })?
+        rt().block_on(None, async { self.inner.lock().await.finish().await.map(|s| s.num_rows) })?
             .infer_error()
     }
 

--- a/rust/lance-file/src/writer.rs
+++ b/rust/lance-file/src/writer.rs
@@ -49,6 +49,15 @@ const PAD_BUFFER: [u8; PAGE_BUFFER_ALIGNMENT] = [72; PAGE_BUFFER_ALIGNMENT];
 const MAX_PAGE_BYTES: usize = 32 * 1024 * 1024;
 const ENV_LANCE_FILE_WRITER_MAX_PAGE_BYTES: &str = "LANCE_FILE_WRITER_MAX_PAGE_BYTES";
 
+/// Summary of a completed Lance file write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileWriteSummary {
+    /// The number of rows written to the file.
+    pub num_rows: u64,
+    /// The final size of the file in bytes.
+    pub size_bytes: u64,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct FileWriterOptions {
     /// How many bytes to use for buffering column data
@@ -303,7 +312,7 @@ impl FileWriter {
         for batch in batches {
             writer.write_batch(&batch).await?;
         }
-        Ok(writer.finish().await? as usize)
+        Ok(writer.finish().await?.num_rows as usize)
     }
 
     async fn do_write_buffer(writer: &mut (impl AsyncWrite + Unpin), buf: &[u8]) -> Result<()> {
@@ -755,8 +764,8 @@ impl FileWriter {
     /// will write the file metadata and the footer.  It will not return until all
     /// data has been flushed and the file has been closed.
     ///
-    /// Returns the total number of rows written
-    pub async fn finish(&mut self) -> Result<u64> {
+    /// Returns a summary of the completed file write.
+    pub async fn finish(&mut self) -> Result<FileWriteSummary> {
         // 1. flush any remaining data and write out those pages
         let mut external_buffers =
             OutOfLineBuffers::new(self.tell().await?, PAGE_BUFFER_ALIGNMENT as u64);
@@ -812,9 +821,12 @@ impl FileWriter {
         self.writer.write_all(MAGIC).await?;
 
         // 7. close the writer
-        Writer::shutdown(self.writer.as_mut()).await?;
+        let write_result = Writer::shutdown(self.writer.as_mut()).await?;
 
-        Ok(self.rows_written)
+        Ok(FileWriteSummary {
+            num_rows: self.rows_written,
+            size_bytes: write_result.size as u64,
+        })
     }
 
     pub async fn abort(&mut self) {
@@ -1581,8 +1593,12 @@ mod tests {
         .unwrap();
 
         writer.write_batch(&batch).await.unwrap();
-        let num_rows = writer.finish().await.unwrap();
-        assert_eq!(num_rows, 2);
+        let write_summary = writer.finish().await.unwrap();
+        assert_eq!(write_summary.num_rows, 2);
+        assert_eq!(
+            write_summary.size_bytes,
+            fs.object_store.size(&path).await.unwrap()
+        );
 
         // Read back with split configuration
         let file_scheduler = fs

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -52,6 +52,13 @@ use lance_datafusion::udf::CONTAINS_TOKENS_UDF;
 
 pub const LANCE_SCALAR_INDEX: &str = "__lance_scalar_index";
 
+/// Summary of a completed index file write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexWriteSummary {
+    /// The final size of the index file in bytes.
+    pub size_bytes: u64,
+}
+
 /// Builtin index types supported by the Lance library
 ///
 /// This is primarily for convenience to avoid a bunch of string
@@ -182,9 +189,12 @@ pub trait IndexWriter: Send {
         ))
     }
     /// Finishes writing the file and closes the file
-    async fn finish(&mut self) -> Result<()>;
+    async fn finish(&mut self) -> Result<IndexWriteSummary>;
     /// Finishes writing the file and closes the file with additional metadata
-    async fn finish_with_metadata(&mut self, metadata: HashMap<String, String>) -> Result<()>;
+    async fn finish_with_metadata(
+        &mut self,
+        metadata: HashMap<String, String>,
+    ) -> Result<IndexWriteSummary>;
 }
 
 /// Trait for reading an index (or parts of an index) from storage

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -2055,7 +2055,7 @@ mod tests {
     use super::*;
     use crate::metrics::NoOpMetricsCollector;
     use crate::progress::IndexBuildProgress;
-    use crate::scalar::{IndexFile, IndexReader, IndexWriter, ScalarIndex};
+    use crate::scalar::{IndexFile, IndexReader, IndexWriteSummary, IndexWriter, ScalarIndex};
     use arrow_array::{RecordBatch, StringArray, UInt64Array};
     use arrow_schema::{DataType, Field, Schema};
     use async_trait::async_trait;
@@ -2242,12 +2242,15 @@ mod tests {
             Ok(1)
         }
 
-        async fn finish(&mut self) -> Result<()> {
-            Ok(())
+        async fn finish(&mut self) -> Result<IndexWriteSummary> {
+            Ok(IndexWriteSummary { size_bytes: 0 })
         }
 
-        async fn finish_with_metadata(&mut self, _metadata: HashMap<String, String>) -> Result<()> {
-            Ok(())
+        async fn finish_with_metadata(
+            &mut self,
+            _metadata: HashMap<String, String>,
+        ) -> Result<IndexWriteSummary> {
+            Ok(IndexWriteSummary { size_bytes: 0 })
         }
     }
 

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -3,7 +3,7 @@
 
 //! Utilities for serializing and deserializing scalar indices in the lance format
 
-use super::{IndexReader, IndexStore, IndexWriter};
+use super::{IndexReader, IndexStore, IndexWriteSummary, IndexWriter};
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
 use async_trait::async_trait;
@@ -109,14 +109,21 @@ impl<M: PreviousManifestProvider + Send + Sync> IndexWriter for PreviousFileWrit
         Ok(offset as u64)
     }
 
-    async fn finish(&mut self) -> Result<()> {
-        Self::finish(self).await.map(|_| ())
+    async fn finish(&mut self) -> Result<IndexWriteSummary> {
+        Self::finish(self).await?;
+        Ok(IndexWriteSummary {
+            size_bytes: self.tell().await? as u64,
+        })
     }
 
-    async fn finish_with_metadata(&mut self, metadata: HashMap<String, String>) -> Result<()> {
-        Self::finish_with_metadata(self, &metadata)
-            .await
-            .map(|_| ())
+    async fn finish_with_metadata(
+        &mut self,
+        metadata: HashMap<String, String>,
+    ) -> Result<IndexWriteSummary> {
+        Self::finish_with_metadata(self, &metadata).await?;
+        Ok(IndexWriteSummary {
+            size_bytes: self.tell().await? as u64,
+        })
     }
 }
 
@@ -132,15 +139,24 @@ impl IndexWriter for current_writer::FileWriter {
         Self::add_global_buffer(self, data).await
     }
 
-    async fn finish(&mut self) -> Result<()> {
-        Self::finish(self).await.map(|_| ())
+    async fn finish(&mut self) -> Result<IndexWriteSummary> {
+        let summary = Self::finish(self).await?;
+        Ok(IndexWriteSummary {
+            size_bytes: summary.size_bytes,
+        })
     }
 
-    async fn finish_with_metadata(&mut self, metadata: HashMap<String, String>) -> Result<()> {
+    async fn finish_with_metadata(
+        &mut self,
+        metadata: HashMap<String, String>,
+    ) -> Result<IndexWriteSummary> {
         metadata.into_iter().for_each(|(k, v)| {
             self.add_schema_metadata(k, v);
         });
-        Self::finish(self).await.map(|_| ())
+        let summary = Self::finish(self).await?;
+        Ok(IndexWriteSummary {
+            size_bytes: summary.size_bytes,
+        })
     }
 }
 
@@ -479,7 +495,11 @@ mod tests {
             .unwrap();
         let expected = bytes::Bytes::from_static(b"scalar-global-buffer");
         let buffer_idx = writer.add_global_buffer(expected.clone()).await.unwrap();
-        writer.finish().await.unwrap();
+        let write_summary = writer.finish().await.unwrap();
+        let files = index_store.list_files_with_sizes().await.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "global-buffer.lance");
+        assert_eq!(write_summary.size_bytes, files[0].size_bytes);
 
         let reader = index_store
             .open_index_file("global-buffer.lance")

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -1079,7 +1079,8 @@ impl NGramIndexBuilder {
             }
         }
 
-        writer.finish().await
+        writer.finish().await?;
+        Ok(())
     }
 
     async fn merge_spill_files(
@@ -1221,7 +1222,8 @@ impl NGramIndexBuilder {
             offset += batch_size;
         }
 
-        writer.finish().await
+        writer.finish().await?;
+        Ok(())
     }
 }
 

--- a/rust/lance-index/src/scalar/rtree.rs
+++ b/rust/lance-index/src/scalar/rtree.rs
@@ -885,7 +885,8 @@ impl RTreeIndexPlugin {
         )?;
 
         writer.write_record_batch(batch).await?;
-        writer.finish().await
+        writer.finish().await?;
+        Ok(())
     }
 
     async fn train_rtree_index(

--- a/rust/lance/src/dataset/fragment/write.rs
+++ b/rust/lance/src/dataset/fragment/write.rs
@@ -12,6 +12,7 @@ use lance_file::previous::writer::FileWriter as PreviousFileWriter;
 use lance_file::version::LanceFileVersion;
 use lance_file::writer::FileWriterOptions;
 use lance_io::object_store::ObjectStore;
+use lance_io::utils::CachedFileSize;
 use lance_table::format::{DataFile, Fragment};
 use lance_table::io::manifest::ManifestDescribing;
 use std::borrow::Cow;
@@ -165,7 +166,8 @@ impl<'a> FragmentCreateBuilder<'a> {
             writer.write_batches(batch_chunk.iter()).await?;
         }
 
-        fragment.physical_rows = Some(writer.finish().await? as usize);
+        let write_summary = writer.finish().await?;
+        fragment.physical_rows = Some(write_summary.num_rows as usize);
 
         if matches!(fragment.physical_rows, Some(0)) {
             return Err(Error::invalid_input("Input data was empty."));
@@ -186,6 +188,7 @@ impl<'a> FragmentCreateBuilder<'a> {
 
         fragment.files[0].fields = field_ids;
         fragment.files[0].column_indices = column_indices;
+        fragment.files[0].file_size_bytes = CachedFileSize::new(write_summary.size_bytes);
 
         progress.complete(&fragment).await?;
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -1051,9 +1051,10 @@ where
         Ok(self.writer.tell().await? as u64)
     }
     async fn finish(&mut self) -> Result<(u32, DataFile)> {
+        let num_rows = self.writer.finish().await? as u32;
         let size_bytes = self.writer.tell().await?;
         Ok((
-            self.writer.finish().await? as u32,
+            num_rows,
             DataFile::new_legacy(
                 self.path.clone(),
                 self.writer.schema(),
@@ -1106,17 +1107,17 @@ impl GenericWriter for V2WriterAdapter {
             .map(|(_, column_index)| *column_index as i32)
             .collect::<Vec<_>>();
         let (major, minor) = self.writer.version().to_numbers();
-        let num_rows = self.writer.finish().await? as u32;
+        let write_summary = self.writer.finish().await?;
         let data_file = DataFile::new(
             std::mem::take(&mut self.path),
             field_ids,
             column_indices,
             major,
             minor,
-            NonZero::new(self.writer.tell().await?),
+            NonZero::new(write_summary.size_bytes),
             self.base_id,
         );
-        Ok((num_rows, data_file))
+        Ok((write_summary.num_rows as u32, data_file))
     }
 }
 


### PR DESCRIPTION
FileWriter and IndexWriter now return write summaries from finish so callers can access the final object size without issuing an extra size lookup. This lets dataset fragment metadata and index writer callers propagate file sizes directly from the completed write path while keeping Python's existing LanceFileWriter.finish row-count behavior.
