### PR TITLE
fix(lance-index): keep TokenSet::next_id consistent after remap

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -3088,6 +3088,70 @@ mod tests {
         Ok(())
     }
 
+    // Regression test for an FTS optimize panic seen in production:
+    //   panicked at scalar/inverted/builder.rs ...
+    //   index out of bounds: the len is N but the index is N+k
+    //
+    // The setup is a target builder whose token set was previously shrunk by
+    // an `InnerBuilder::remap` (i.e. some posting lists became empty after
+    // row deletes during compaction). Before the accompanying fix,
+    // `TokenSet::remap` shifted the surviving ids down but left `next_id`
+    // unchanged, so a later `get_or_add` for an unseen token returned an id
+    // past `tokens.len()`. `merge_from` then sized `posting_lists` to
+    // `tokens.len()` and indexed it with that stale id.
+    #[tokio::test]
+    async fn merge_from_tolerates_remapped_target_token_set() -> Result<()> {
+        let mut target = InnerBuilder::new(0, false, TokenSetFormat::default());
+        // Seed with two tokens, each appearing in exactly one doc so that
+        // deleting that doc empties the corresponding posting list.
+        let alpha = target.tokens.add("alpha".to_owned());
+        let beta = target.tokens.add("beta".to_owned());
+        target
+            .posting_lists
+            .resize_with(target.tokens.len(), || PostingListBuilder::new(false));
+        let alpha_doc = target.docs.append(10, 1);
+        let beta_doc = target.docs.append(11, 1);
+        target.posting_lists[alpha as usize].add(alpha_doc, PositionRecorder::Count(1));
+        target.posting_lists[beta as usize].add(beta_doc, PositionRecorder::Count(1));
+
+        // Simulate compaction removing the beta row. InnerBuilder::remap
+        // empties beta's posting list, drops it, and calls
+        // TokenSet::remap which (without the fix) leaves next_id stale.
+        let mut mapping = HashMap::new();
+        mapping.insert(11_u64, None);
+        target.remap(&mapping).await?;
+
+        assert_eq!(target.tokens.len(), 1);
+        assert_eq!(target.tokens.next_id(), 1);
+        assert_eq!(target.posting_lists.len(), 1);
+
+        // A delta partition introducing a brand new token. With the fix,
+        // get_or_add hands back id 1 (== current tokens.len()), merge_from
+        // grows posting_lists to length 2, and the merge succeeds.
+        let mut delta = InnerBuilder::new(1, false, TokenSetFormat::default());
+        let gamma = delta.tokens.add("gamma".to_owned());
+        delta
+            .posting_lists
+            .resize_with(delta.tokens.len(), || PostingListBuilder::new(false));
+        let delta_doc = delta.docs.append(20, 1);
+        delta.posting_lists[gamma as usize].add(delta_doc, PositionRecorder::Count(1));
+
+        target.merge_from(delta)?;
+
+        assert_eq!(target.docs.len(), 2);
+        assert_eq!(target.tokens.len(), 2);
+        assert_eq!(target.posting_lists.len(), 2);
+        assert_eq!(
+            target.posting_lists[target.tokens.get("alpha").unwrap() as usize].len(),
+            1
+        );
+        assert_eq!(
+            target.posting_lists[target.tokens.get("gamma").unwrap() as usize].len(),
+            1
+        );
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_update_index_returns_worker_error_when_workers_exit_during_dispatch() {
         let num_batches = (*LANCE_FTS_NUM_SHARDS * 2 + 1) as u64;

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1648,6 +1648,13 @@ impl TokenSet {
             },
         );
 
+        // Surviving token ids were shifted down to close the gaps left by the
+        // removed ids, so `next_id` must shrink by the same amount or future
+        // `get_or_add` calls will hand out ids past `tokens.len()`. That breaks
+        // `InnerBuilder::merge_from`, which sizes `posting_lists` to
+        // `tokens.len()` and then indexes it with `get_or_add`'s return.
+        self.next_id -= removed_token_ids.len() as u32;
+
         self.tokens = TokenMap::HashMap(map);
     }
 


### PR DESCRIPTION
## Summary

`TokenSet::remap` shifts surviving token ids down to close the gaps left by removed ids, but it never decrements `next_id`. So after a remap (called from `InnerBuilder::remap` during compaction, when row deletes empty out a posting list) the invariant that `next_id == tokens.len()` is broken: `next_id` stays at its pre-remap high water mark.

The next time `InnerBuilder::merge_from` absorbs a partition that introduces a token unseen by the target, it does

```rust
self.posting_lists.resize_with(self.tokens.len(), ...);  // sized to N
// ...
let new_token_id = self.tokens.get_or_add(token);        // returns stale next_id, N+k
let merged_posting = &mut self.posting_lists[new_token_id as usize];  // panics
```

`get_or_add` returns `next_id` for new tokens, which is now greater than `tokens.len()`, so the index access panics:

```
panicked at lance-index/src/scalar/inverted/builder.rs:856:57:
index out of bounds: the len is 703894 but the index is 708550
```

We've been seeing this hit 9 tables during `optimize_indices` on the FTS `content` column.

## Fix

One line: decrement `next_id` by `removed_token_ids.len()` at the end of `TokenSet::remap` to restore the invariant. The values are guaranteed to be in range — \`next_id >= tokens.len() + removed_token_ids.len()\` going in (every surviving and removed token consumed an id), so the subtraction can't underflow.

## Test

Added `merge_from_tolerates_remapped_target_token_set` in `inverted/builder` that:
1. Builds a target with two tokens, each in its own document.
2. Runs `InnerBuilder::remap` to delete one row — this empties one posting list, drops it, and calls `TokenSet::remap`. Without the fix, \`next_id\` is now stale.
3. Calls `merge_from` with a delta partition containing a brand-new token.
4. Without the fix, step 3 panics with the OOB above. With the fix, the merge succeeds and the assertion confirms both surviving and newly-introduced tokens are present.

`cargo test -p lance-index --lib scalar::inverted` — 133 passed, 0 failed.

## Notes

- The bug predates v6.0.0 — same code in 6.x and 7.x. Suggesting `critical-fix` label since it's a crash during background optimize that requires a downgrade or manual intervention to recover from.
- I haven't dug into whether `TokenSet` is ever serialized with `next_id` and read back; if it is, existing on-disk indices may carry the stale value forward. Happy to extend the fix to clamp on load if maintainers think that's worth doing — let me know.