### PR TITLE
feat(java): add missing scanner and merge insert params to align with Python/Rust

### DIFF
--- a/java/lance-jni/src/async_scanner.rs
+++ b/java/lance-jni/src/async_scanner.rs
@@ -193,6 +193,9 @@ pub extern "system" fn Java_org_lance_ipc_AsyncScanner_createAsyncScanner<'local
     use_scalar_index: jboolean,
     fast_search: jboolean,
     substrait_aggregate_obj: JObject<'local>,
+    include_deleted_rows: jboolean,
+    strict_batch_size: jboolean,
+    disable_scoring_autoprojection: jboolean,
 ) -> JObject<'local> {
     crate::ok_or_throw!(
         env,
@@ -216,6 +219,9 @@ pub extern "system" fn Java_org_lance_ipc_AsyncScanner_createAsyncScanner<'local
             use_scalar_index,
             fast_search,
             substrait_aggregate_obj,
+            include_deleted_rows,
+            strict_batch_size,
+            disable_scoring_autoprojection,
         )
     )
 }
@@ -241,6 +247,9 @@ fn inner_create_async_scanner<'local>(
     use_scalar_index: jboolean,
     fast_search: jboolean,
     substrait_aggregate_obj: JObject<'local>,
+    include_deleted_rows: jboolean,
+    strict_batch_size: jboolean,
+    disable_scoring_autoprojection: jboolean,
 ) -> Result<JObject<'local>> {
     let dataset_guard =
         unsafe { env.get_rust_field::<_, _, BlockingDataset>(jdataset, NATIVE_DATASET) }?;
@@ -265,6 +274,9 @@ fn inner_create_async_scanner<'local>(
         use_scalar_index,
         fast_search,
         substrait_aggregate_obj,
+        include_deleted_rows,
+        strict_batch_size,
+        disable_scoring_autoprojection,
     };
 
     let scanner = build_scanner_with_options(env, &dataset, options)?;

--- a/java/lance-jni/src/blocking_scanner.rs
+++ b/java/lance-jni/src/blocking_scanner.rs
@@ -247,6 +247,9 @@ pub(crate) struct ScannerOptions<'a> {
     pub use_scalar_index: jboolean,
     pub fast_search: jboolean,
     pub substrait_aggregate_obj: JObject<'a>,
+    pub include_deleted_rows: jboolean,
+    pub strict_batch_size: jboolean,
+    pub disable_scoring_autoprojection: jboolean,
 }
 
 /// Build a scanner with options applied - shared by blocking and async scanners
@@ -394,6 +397,16 @@ pub(crate) fn build_scanner_with_options<'a>(
         scanner.aggregate(AggregateExpr::substrait(substrait_aggregate))?;
     }
 
+    if options.include_deleted_rows == JNI_TRUE {
+        scanner.include_deleted_rows();
+    }
+
+    scanner.strict_batch_size(options.strict_batch_size == JNI_TRUE);
+
+    if options.disable_scoring_autoprojection == JNI_TRUE {
+        scanner.disable_scoring_autoprojection();
+    }
+
     Ok(scanner)
 }
 
@@ -423,6 +436,9 @@ pub extern "system" fn Java_org_lance_ipc_LanceScanner_createScanner<'local>(
     fast_search: jboolean,             // boolean
     substrait_aggregate_obj: JObject<'local>, // Optional<ByteBuffer>
     collect_stats: jboolean,           // boolean
+    include_deleted_rows: jboolean,    // boolean
+    strict_batch_size: jboolean,       // boolean
+    disable_scoring_autoprojection: jboolean, // boolean
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -447,6 +463,9 @@ pub extern "system" fn Java_org_lance_ipc_LanceScanner_createScanner<'local>(
             fast_search,
             substrait_aggregate_obj,
             collect_stats,
+            include_deleted_rows,
+            strict_batch_size,
+            disable_scoring_autoprojection,
         )
     )
 }
@@ -473,6 +492,9 @@ fn inner_create_scanner<'local>(
     fast_search: jboolean,
     substrait_aggregate_obj: JObject<'local>,
     collect_stats: jboolean,
+    include_deleted_rows: jboolean,
+    strict_batch_size: jboolean,
+    disable_scoring_autoprojection: jboolean,
 ) -> Result<JObject<'local>> {
     let dataset_guard =
         unsafe { env.get_rust_field::<_, _, BlockingDataset>(jdataset, NATIVE_DATASET) }?;
@@ -497,6 +519,9 @@ fn inner_create_scanner<'local>(
         use_scalar_index,
         fast_search,
         substrait_aggregate_obj,
+        include_deleted_rows,
+        strict_batch_size,
+        disable_scoring_autoprojection,
     };
 
     let scanner = build_scanner_with_options(env, &dataset, options)?;

--- a/java/lance-jni/src/merge_insert.rs
+++ b/java/lance-jni/src/merge_insert.rs
@@ -51,6 +51,7 @@ fn inner_merge_insert<'local>(
     let conflict_retries = extract_conflict_retries(env, &jparam)?;
     let retry_timeout_ms = extract_retry_timeout_ms(env, &jparam)?;
     let skip_auto_cleanup = extract_skip_auto_cleanup(env, &jparam)?;
+    let use_index = extract_use_index(env, &jparam)?;
     let marked_generations = extract_marked_generations(env, &jparam)?;
 
     let (new_ds, merge_stats) = unsafe {
@@ -69,6 +70,7 @@ fn inner_merge_insert<'local>(
             .conflict_retries(conflict_retries)
             .retry_timeout(Duration::from_millis(retry_timeout_ms as u64))
             .skip_auto_cleanup(skip_auto_cleanup)
+            .use_index(use_index)
             .mark_generations_as_merged(marked_generations)
             .try_build()?;
 
@@ -232,6 +234,13 @@ fn extract_skip_auto_cleanup<'local>(env: &mut JNIEnv<'local>, jparam: &JObject)
         .call_method(jparam, "skipAutoCleanup", "()Z", &[])?
         .z()?;
     Ok(skip_auto_cleanup)
+}
+
+fn extract_use_index<'local>(env: &mut JNIEnv<'local>, jparam: &JObject) -> Result<bool> {
+    let use_index = env
+        .call_method(jparam, "useIndex", "()Z", &[])?
+        .z()?;
+    Ok(use_index)
 }
 
 fn extract_marked_generations<'local>(

--- a/java/lance-jni/src/merge_insert.rs
+++ b/java/lance-jni/src/merge_insert.rs
@@ -237,9 +237,7 @@ fn extract_skip_auto_cleanup<'local>(env: &mut JNIEnv<'local>, jparam: &JObject)
 }
 
 fn extract_use_index<'local>(env: &mut JNIEnv<'local>, jparam: &JObject) -> Result<bool> {
-    let use_index = env
-        .call_method(jparam, "useIndex", "()Z", &[])?
-        .z()?;
+    let use_index = env.call_method(jparam, "useIndex", "()Z", &[])?.z()?;
     Ok(use_index)
 }
 

--- a/java/src/main/java/org/lance/ipc/AsyncScanner.java
+++ b/java/src/main/java/org/lance/ipc/AsyncScanner.java
@@ -80,7 +80,10 @@ public class AsyncScanner implements AutoCloseable {
             options.getColumnOrderings(),
             options.isUseScalarIndex(),
             options.isFastSearch(),
-            options.getSubstraitAggregate());
+            options.getSubstraitAggregate(),
+            options.isIncludeDeletedRows(),
+            options.isStrictBatchSize(),
+            options.isDisableScoringAutoprojection());
     scanner.allocator = allocator;
     return scanner;
   }
@@ -103,7 +106,10 @@ public class AsyncScanner implements AutoCloseable {
       Optional<List<ColumnOrdering>> columnOrderings,
       boolean useScalarIndex,
       boolean fastSearch,
-      Optional<ByteBuffer> substraitAggregate);
+      Optional<ByteBuffer> substraitAggregate,
+      boolean includeDeletedRows,
+      boolean strictBatchSize,
+      boolean disableScoringAutoprojection);
 
   /**
    * Asynchronously scan batches and return a CompletableFuture.

--- a/java/src/main/java/org/lance/ipc/LanceScanner.java
+++ b/java/src/main/java/org/lance/ipc/LanceScanner.java
@@ -77,7 +77,10 @@ public class LanceScanner implements org.apache.arrow.dataset.scanner.Scanner {
             options.isUseScalarIndex(),
             options.isFastSearch(),
             options.getSubstraitAggregate(),
-            options.isCollectStats());
+            options.isCollectStats(),
+            options.isIncludeDeletedRows(),
+            options.isStrictBatchSize(),
+            options.isDisableScoringAutoprojection());
     scanner.allocator = allocator;
     scanner.dataset = dataset;
     scanner.options = options;
@@ -103,7 +106,10 @@ public class LanceScanner implements org.apache.arrow.dataset.scanner.Scanner {
       boolean useScalarIndex,
       boolean fastSearch,
       Optional<ByteBuffer> substraitAggregate,
-      boolean collectStats);
+      boolean collectStats,
+      boolean includeDeletedRows,
+      boolean strictBatchSize,
+      boolean disableScoringAutoprojection);
 
   /**
    * Closes this scanner and releases any system resources associated with it. If the scanner is

--- a/java/src/main/java/org/lance/ipc/ScanOptions.java
+++ b/java/src/main/java/org/lance/ipc/ScanOptions.java
@@ -40,6 +40,9 @@ public class ScanOptions {
   private final Optional<ByteBuffer> substraitAggregate;
   private final boolean collectStats;
   private final boolean fastSearch;
+  private final boolean includeDeletedRows;
+  private final boolean strictBatchSize;
+  private final boolean disableScoringAutoprojection;
 
   public ScanOptions(
       Optional<List<Integer>> fragmentIds,
@@ -77,6 +80,9 @@ public class ScanOptions {
         useScalarIndex,
         substraitAggregate,
         collectStats,
+        false,
+        false,
+        false,
         false);
   }
 
@@ -121,7 +127,10 @@ public class ScanOptions {
       boolean useScalarIndex,
       Optional<ByteBuffer> substraitAggregate,
       boolean collectStats,
-      boolean fastSearch) {
+      boolean fastSearch,
+      boolean includeDeletedRows,
+      boolean strictBatchSize,
+      boolean disableScoringAutoprojection) {
     Preconditions.checkArgument(
         !(filter.isPresent() && substraitFilter.isPresent()),
         "cannot set both substrait filter and string filter");
@@ -143,6 +152,9 @@ public class ScanOptions {
     this.substraitAggregate = substraitAggregate;
     this.collectStats = collectStats;
     this.fastSearch = fastSearch;
+    this.includeDeletedRows = includeDeletedRows;
+    this.strictBatchSize = strictBatchSize;
+    this.disableScoringAutoprojection = disableScoringAutoprojection;
   }
 
   /**
@@ -297,6 +309,33 @@ public class ScanOptions {
     return collectStats;
   }
 
+  /**
+   * Get whether to include deleted rows in scan results.
+   *
+   * @return true if deleted rows should be included, false otherwise.
+   */
+  public boolean isIncludeDeletedRows() {
+    return includeDeletedRows;
+  }
+
+  /**
+   * Get whether to enforce strict batch sizing.
+   *
+   * @return true if batch sizes must be strictly enforced, false otherwise.
+   */
+  public boolean isStrictBatchSize() {
+    return strictBatchSize;
+  }
+
+  /**
+   * Get whether to disable scoring autoprojection.
+   *
+   * @return true if scoring column autoprojection is disabled, false otherwise.
+   */
+  public boolean isDisableScoringAutoprojection() {
+    return disableScoringAutoprojection;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -322,6 +361,9 @@ public class ScanOptions {
             "substraitAggregate",
             substraitAggregate.map(buf -> "ByteBuffer[" + buf.remaining() + " bytes]").orElse(null))
         .add("collectStats", collectStats)
+        .add("includeDeletedRows", includeDeletedRows)
+        .add("strictBatchSize", strictBatchSize)
+        .add("disableScoringAutoprojection", disableScoringAutoprojection)
         .toString();
   }
 
@@ -345,6 +387,9 @@ public class ScanOptions {
     private boolean fastSearch = false;
     private Optional<ByteBuffer> substraitAggregate = Optional.empty();
     private boolean collectStats = false;
+    private boolean includeDeletedRows = false;
+    private boolean strictBatchSize = false;
+    private boolean disableScoringAutoprojection = false;
 
     public Builder() {}
 
@@ -372,6 +417,9 @@ public class ScanOptions {
       this.fastSearch = options.isFastSearch();
       this.substraitAggregate = options.getSubstraitAggregate();
       this.collectStats = options.isCollectStats();
+      this.includeDeletedRows = options.isIncludeDeletedRows();
+      this.strictBatchSize = options.isStrictBatchSize();
+      this.disableScoringAutoprojection = options.isDisableScoringAutoprojection();
     }
 
     /**
@@ -578,6 +626,39 @@ public class ScanOptions {
     }
 
     /**
+     * Set whether to include deleted rows in scan results. Default is false.
+     *
+     * @param includeDeletedRows whether to include deleted rows
+     * @return Builder instance for method chaining.
+     */
+    public Builder includeDeletedRows(boolean includeDeletedRows) {
+      this.includeDeletedRows = includeDeletedRows;
+      return this;
+    }
+
+    /**
+     * Set whether to enforce strict batch sizing. Default is false.
+     *
+     * @param strictBatchSize whether to enforce strict batch sizing
+     * @return Builder instance for method chaining.
+     */
+    public Builder strictBatchSize(boolean strictBatchSize) {
+      this.strictBatchSize = strictBatchSize;
+      return this;
+    }
+
+    /**
+     * Set whether to disable scoring column autoprojection. Default is false.
+     *
+     * @param disableScoringAutoprojection whether to disable autoprojection
+     * @return Builder instance for method chaining.
+     */
+    public Builder disableScoringAutoprojection(boolean disableScoringAutoprojection) {
+      this.disableScoringAutoprojection = disableScoringAutoprojection;
+      return this;
+    }
+
+    /**
      * Build the LanceScanOptions instance.
      *
      * @return LanceScanOptions instance with the specified parameters.
@@ -601,7 +682,10 @@ public class ScanOptions {
           useScalarIndex,
           substraitAggregate,
           collectStats,
-          fastSearch);
+          fastSearch,
+          includeDeletedRows,
+          strictBatchSize,
+          disableScoringAutoprojection);
     }
   }
 }

--- a/java/src/main/java/org/lance/merge/MergeInsertParams.java
+++ b/java/src/main/java/org/lance/merge/MergeInsertParams.java
@@ -38,6 +38,7 @@ public class MergeInsertParams {
   private int conflictRetries = 10;
   private long retryTimeoutMs = 30 * 1000;
   private boolean skipAutoCleanup = false;
+  private boolean useIndex = true;
   private List<MergedGeneration> markedGenerations = Collections.emptyList();
 
   public MergeInsertParams(List<String> on) {
@@ -228,6 +229,22 @@ public class MergeInsertParams {
   }
 
   /**
+   * Controls whether to use indices for the merge operation.
+   *
+   * <p>When set to false, forces a full table scan even if an index exists on the join key. This
+   * can be useful for benchmarking or when the optimizer chooses a suboptimal path.
+   *
+   * <p>Default is true (use index if available).
+   *
+   * @param useIndex Whether to use indices for the merge join
+   * @return This MergeInsertParams instance
+   */
+  public MergeInsertParams withUseIndex(boolean useIndex) {
+    this.useIndex = useIndex;
+    return this;
+  }
+
+  /**
    * Mark MemWAL generations as merged into the base table.
    *
    * <p>Use this when the merge insert incorporates data from MemWAL flushed generations. It updates
@@ -298,6 +315,10 @@ public class MergeInsertParams {
     return skipAutoCleanup;
   }
 
+  public boolean useIndex() {
+    return useIndex;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -315,6 +336,7 @@ public class MergeInsertParams {
         .add("conflictRetries", conflictRetries)
         .add("retryTimeoutMs", retryTimeoutMs)
         .add("skipAutoCleanup", skipAutoCleanup)
+        .add("useIndex", useIndex)
         .toString();
   }
 

--- a/java/src/test/java/org/lance/AsyncScannerTest.java
+++ b/java/src/test/java/org/lance/AsyncScannerTest.java
@@ -192,6 +192,75 @@ public class AsyncScannerTest {
     return rowCount;
   }
 
+  @Test
+  void testIncludeDeletedRowsAsync(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("async_scanner_include_deleted_rows").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+      try (Dataset dataset = testDataset.write(1, 10)) {
+        assertEquals(10, dataset.countRows());
+
+        // Delete half the rows
+        dataset.delete("id >= 5");
+        assertEquals(5, dataset.countRows());
+
+        // Async scan without includeDeletedRows — should only see live rows
+        ScanOptions defaultOptions = new ScanOptions.Builder().batchSize(20L).build();
+        try (AsyncScanner scanner = AsyncScanner.create(dataset, defaultOptions, allocator)) {
+          ArrowReader reader = scanner.scanBatchesAsync().get(10, TimeUnit.SECONDS);
+          assertEquals(5, countRows(reader), "default async scan: should exclude deleted rows");
+          reader.close();
+        }
+
+        // Async scan with includeDeletedRows=true — should see all rows
+        ScanOptions includeDeletedOptions =
+            new ScanOptions.Builder()
+                .batchSize(20L)
+                .withRowId(true) // required by includeDeletedRows
+                .includeDeletedRows(true)
+                .build();
+        try (AsyncScanner scanner =
+            AsyncScanner.create(dataset, includeDeletedOptions, allocator)) {
+          ArrowReader reader = scanner.scanBatchesAsync().get(10, TimeUnit.SECONDS);
+          assertEquals(
+              10, countRows(reader), "includeDeletedRows async: should include deleted rows");
+          reader.close();
+        }
+      }
+    }
+  }
+
+  @Test
+  void testStrictBatchSizeAsync(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("async_scanner_strict_batch_size").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+      try (Dataset dataset = testDataset.write(1, 25)) {
+        int batchSize = 10;
+
+        ScanOptions strictOptions =
+            new ScanOptions.Builder().batchSize(batchSize).strictBatchSize(true).build();
+
+        try (AsyncScanner scanner = AsyncScanner.create(dataset, strictOptions, allocator)) {
+          ArrowReader reader = scanner.scanBatchesAsync().get(10, TimeUnit.SECONDS);
+          int totalRows = 0;
+          while (reader.loadNextBatch()) {
+            int rows = reader.getVectorSchemaRoot().getRowCount();
+            assertTrue(
+                rows <= batchSize, "strict async: batch " + rows + " should be <= " + batchSize);
+            totalRows += rows;
+          }
+          assertEquals(25, totalRows, "strictBatchSize async: should read all rows");
+          reader.close();
+        }
+      }
+    }
+  }
+
   /**
    * Example 3: Multiple concurrent async scans.
    *

--- a/java/src/test/java/org/lance/MergeInsertTest.java
+++ b/java/src/test/java/org/lance/MergeInsertTest.java
@@ -275,6 +275,29 @@ public class MergeInsertTest {
     return stream;
   }
 
+  @Test
+  public void testMergeInsertWithoutIndex() throws Exception {
+    // Verify that merge insert with useIndex=false still completes and
+    // produces results consistent with the default (useIndex=true).
+
+    try (VectorSchemaRoot source = buildSource(testDataset.getSchema(), allocator)) {
+      try (ArrowArrayStream sourceStream = convertToStream(source, allocator)) {
+        MergeInsertResult result =
+            dataset.mergeInsert(
+                new MergeInsertParams(Collections.singletonList("id"))
+                    .withMatchedUpdateAll()
+                    .withNotMatched(MergeInsertParams.WhenNotMatched.InsertAll)
+                    .withUseIndex(false),
+                sourceStream);
+
+        Assertions.assertEquals(
+            "{0=Source 0, 1=Source 1, 2=Source 2, 3=Person 3, 4=Person 4, 7=Source 7, 8=Source 8, 9=Source 9}",
+            readAll(result.dataset()).toString(),
+            "merge insert with useIndex=false should produce correct upsert results");
+      }
+    }
+  }
+
   private TreeMap<Integer, String> readAll(Dataset dataset) throws Exception {
     try (ArrowReader reader = dataset.newScan().scanBatches()) {
       TreeMap<Integer, String> map = new TreeMap<>();

--- a/java/src/test/java/org/lance/ScannerTest.java
+++ b/java/src/test/java/org/lance/ScannerTest.java
@@ -697,6 +697,120 @@ public class ScannerTest {
     }
   }
 
+  @Test
+  void testIncludeDeletedRows(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("include_deleted_rows").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+      try (Dataset dataset = testDataset.write(1, 10)) {
+        assertEquals(10, dataset.countRows());
+
+        // Delete rows where id >= 5
+        dataset.delete("id >= 5");
+        assertEquals(5, dataset.countRows());
+
+        // Default scan should exclude deleted rows
+        try (LanceScanner scanner =
+            dataset.newScan(new ScanOptions.Builder().batchSize(20).build())) {
+          assertEquals(5, scanner.countRows(), "default scan: should exclude deleted rows");
+        }
+
+        // includeDeletedRows=true should surface deleted rows
+        // NOTE: includeDeletedRows requires withRowId=true
+        try (LanceScanner scanner =
+            dataset.newScan(
+                new ScanOptions.Builder()
+                    .batchSize(20)
+                    .withRowId(true)
+                    .includeDeletedRows(true)
+                    .build())) {
+          assertEquals(10, scanner.countRows(), "includeDeletedRows: should include deleted rows");
+        }
+      }
+    }
+  }
+
+  @Test
+  void testStrictBatchSize(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("strict_batch_size").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+      try (Dataset dataset = testDataset.write(1, 25)) {
+        int batchSize = 10;
+
+        // With strictBatchSize=true, no batch should exceed batchSize
+        try (Scanner scanner =
+            dataset.newScan(
+                new ScanOptions.Builder().batchSize(batchSize).strictBatchSize(true).build())) {
+          try (ArrowReader reader = scanner.scanBatches()) {
+            int totalRows = 0;
+            while (reader.loadNextBatch()) {
+              int rows = reader.getVectorSchemaRoot().getRowCount();
+              assertTrue(rows <= batchSize, "strict: batch " + rows + " should be <= " + batchSize);
+              totalRows += rows;
+            }
+            assertEquals(25, totalRows);
+          }
+        }
+
+        // strictBatchSize=false (default) — batch size may vary
+        try (Scanner scanner =
+            dataset.newScan(new ScanOptions.Builder().batchSize(batchSize).build())) {
+          try (ArrowReader reader = scanner.scanBatches()) {
+            int totalRows = 0;
+            while (reader.loadNextBatch()) {
+              totalRows += reader.getVectorSchemaRoot().getRowCount();
+            }
+            assertEquals(25, totalRows);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  void testDisableScoringAutoprojection(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("disable_scoring_autoprojection").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      testDataset.createEmptyDataset().close();
+      try (Dataset dataset = testDataset.write(1, 10)) {
+        // Smoke test: verify the option is accepted and scan still works
+        ScanOptions options =
+            new ScanOptions.Builder().batchSize(20).disableScoringAutoprojection(true).build();
+
+        try (LanceScanner scanner = dataset.newScan(options)) {
+          assertEquals(
+              10,
+              scanner.countRows(),
+              "scan with disableScoringAutoprojection should return all rows");
+        }
+
+        // Also verify it doesn't break when combined with other options
+        ScanOptions combinedOptions =
+            new ScanOptions.Builder()
+                .batchSize(20)
+                .filter("id < 5")
+                .disableScoringAutoprojection(true)
+                .includeDeletedRows(false)
+                .strictBatchSize(false)
+                .build();
+
+        try (LanceScanner scanner = dataset.newScan(combinedOptions)) {
+          assertEquals(
+              5,
+              scanner.countRows(),
+              "scan with disableScoringAutoprojection + filter should work");
+        }
+      }
+    }
+  }
+
   private void validScanResult(Dataset dataset, int fragmentId, int rowCount) throws Exception {
     try (Scanner scanner =
         dataset.newScan(


### PR DESCRIPTION
## feat(java): add missing scanner and merge insert params to align with Python/Rust

### Summary

Add 4 parameters to the Java SDK that already exist in the Rust core and Python bindings but were absent in Java.

### Changes

| Param | Type | API | Rust method |
|-------|------|-----|-------------|
| includeDeletedRows | boolean | ScanOptions | Scanner::include_deleted_rows() |
| strictBatchSize | boolean | ScanOptions | Scanner::strict_batch_size() |
| disableScoringAutoprojection | boolean | ScanOptions | Scanner::disable_scoring_autoprojection() |
| useIndex | boolean | MergeInsertParams | MergeInsertBuilder::use_index() |

### Files Changed

- `java/lance-jni/src/async_scanner.rs`
- `java/lance-jni/src/blocking_scanner.rs`
- `java/lance-jni/src/merge_insert.rs`
- `java/src/main/java/org/lance/ipc/AsyncScanner.java`
- `java/src/main/java/org/lance/ipc/LanceScanner.java`
- `java/src/main/java/org/lance/ipc/ScanOptions.java`
- `java/src/main/java/org/lance/merge/MergeInsertParams.java`
- `java/src/test/java/org/lance/AsyncScannerTest.java`
- `java/src/test/java/org/lance/MergeInsertTest.java`
- `java/src/test/java/org/lance/ScannerTest.java`

**+376 insertions, -6 deletions**
