### PR TITLE
perf(core): track fragment ids without scanning

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -133,6 +133,11 @@ message Manifest {
   // For a single fragment, will be zero. For no fragments, will be absent.
   optional uint32 max_fragment_id = 11;
 
+  // The next fragment ID to assign.
+  //
+  // Writers use this counter directly instead of scanning the fragment list.
+  optional uint64 next_fragment_id = 22;
+
   // Path to the transaction file, relative to `{root}/_transactions`. The file at that
   // location contains a wire-format serialized Transaction message representing the
   // transaction that created this version.

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -73,6 +73,12 @@ pub struct Manifest {
     /// None means never set, Some(0) means max ID used so far is 0
     pub max_fragment_id: Option<u32>,
 
+    /// The next fragment id to assign.
+    ///
+    /// When present, this lets writers allocate fragment ids in O(1) time
+    /// without scanning the fragment list.
+    pub next_fragment_id: Option<u64>,
+
     /// The path to the transaction file, relative to the root of the dataset
     pub transaction_file: Option<String>,
 
@@ -188,6 +194,7 @@ impl Manifest {
             reader_feature_flags: 0,
             writer_feature_flags: 0,
             max_fragment_id: None,
+            next_fragment_id: None,
             transaction_file: None,
             transaction_section: None,
             fragment_offsets,
@@ -219,6 +226,7 @@ impl Manifest {
             reader_feature_flags: 0, // These will be set on commit
             writer_feature_flags: 0, // These will be set on commit
             max_fragment_id: previous.max_fragment_id,
+            next_fragment_id: previous.next_fragment_id,
             transaction_file: None,
             transaction_section: None,
             fragment_offsets,
@@ -276,6 +284,7 @@ impl Manifest {
             reader_feature_flags: 0, // These will be set on commit
             writer_feature_flags: 0, // These will be set on commit
             max_fragment_id: self.max_fragment_id,
+            next_fragment_id: self.next_fragment_id,
             transaction_file: Some(transaction_file),
             transaction_section: None,
             fragment_offsets: self.fragment_offsets.clone(),
@@ -373,35 +382,36 @@ impl Manifest {
         }
     }
 
-    /// Check the current fragment list and update the high water mark
+    /// Update the max_fragment_id high-water mark from a known value.
+    ///
+    /// Call this with the last assigned fragment ID rather than scanning all fragments.
+    /// The high-water mark only increases; passing a value smaller than the current max
+    /// is a no-op for the max counter, while `next_fragment_id` is still kept in sync.
+    pub fn set_max_fragment_id_from(&mut self, new_max: u64) {
+        let new_max_u32: u32 = new_max.try_into().expect("fragment id exceeds u32::MAX");
+        let max_fragment_id = self
+            .max_fragment_id
+            .map(|current_max| current_max.max(new_max_u32))
+            .unwrap_or(new_max_u32);
+        self.max_fragment_id = Some(max_fragment_id);
+        self.next_fragment_id = Some(
+            u64::from(max_fragment_id)
+                .checked_add(1)
+                .expect("fragment id counter overflowed"),
+        );
+    }
+
+    /// Check the current fragment list and update the high water mark.
+    ///
+    /// Prefer [`set_max_fragment_id_from`] when the last assigned ID is already known,
+    /// as it avoids an O(n) scan of the fragment list.
     pub fn update_max_fragment_id(&mut self) {
-        // If there are no fragments, don't update max_fragment_id
         if self.fragments.is_empty() {
             return;
         }
 
-        let max_fragment_id = self
-            .fragments
-            .iter()
-            .map(|f| f.id)
-            .max()
-            .unwrap() // Safe because we checked fragments is not empty
-            .try_into()
-            .unwrap();
-
-        match self.max_fragment_id {
-            None => {
-                // First time being set
-                self.max_fragment_id = Some(max_fragment_id);
-            }
-            Some(current_max) => {
-                // Only update if the computed max is greater than current
-                // This preserves the high water mark even when fragments are deleted
-                if max_fragment_id > current_max {
-                    self.max_fragment_id = Some(max_fragment_id);
-                }
-            }
-        }
+        let max_fragment_id: u64 = self.fragments.iter().map(|f| f.id).max().unwrap();
+        self.set_max_fragment_id_from(max_fragment_id);
     }
 
     /// Return the max fragment id.
@@ -412,9 +422,29 @@ impl Manifest {
         if let Some(max_id) = self.max_fragment_id {
             // Return the stored high water mark
             Some(max_id.into())
+        } else if let Some(next_fragment_id) = self.next_fragment_id {
+            next_fragment_id.checked_sub(1)
         } else {
             // Not yet set, compute from fragment list
             self.fragments.iter().map(|f| f.id).max()
+        }
+    }
+
+    /// Return the next fragment id to assign.
+    ///
+    /// Prefer this over scanning fragments when allocating new fragment ids.
+    pub fn next_fragment_id(&self) -> u64 {
+        if let Some(next_fragment_id) = self.next_fragment_id {
+            next_fragment_id
+        } else if let Some(max_fragment_id) = self.max_fragment_id {
+            u64::from(max_fragment_id) + 1
+        } else {
+            self.fragments
+                .iter()
+                .map(|f| f.id)
+                .max()
+                .map(|id| id + 1)
+                .unwrap_or(0)
         }
     }
 
@@ -914,6 +944,7 @@ impl TryFrom<pb::Manifest> for Manifest {
             reader_feature_flags: p.reader_feature_flags,
             writer_feature_flags: p.writer_feature_flags,
             max_fragment_id: p.max_fragment_id,
+            next_fragment_id: p.next_fragment_id,
             fragments,
             transaction_file: if p.transaction_file.is_empty() {
                 None
@@ -976,6 +1007,7 @@ impl From<&Manifest> for pb::Manifest {
             reader_feature_flags: m.reader_feature_flags,
             writer_feature_flags: m.writer_feature_flags,
             max_fragment_id: m.max_fragment_id,
+            next_fragment_id: m.next_fragment_id,
             transaction_file: m.transaction_file.clone().unwrap_or_default(),
             next_row_id: m.next_row_id,
             data_format: Some(pb::manifest::DataStorageFormat {
@@ -1344,6 +1376,62 @@ mod tests {
         );
 
         assert_eq!(manifest.max_field_id(), 43);
+    }
+
+    #[test]
+    fn test_fragment_id_counters_round_trip() {
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new(
+            "a",
+            arrow_schema::DataType::Int64,
+            false,
+        )]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+        let fragments = vec![
+            Fragment::with_file_legacy(0, "path1", &schema, Some(10)),
+            Fragment::with_file_legacy(1, "path2", &schema, Some(15)),
+        ];
+        let mut manifest = Manifest::new(
+            schema,
+            Arc::new(fragments),
+            DataStorageFormat::default(),
+            HashMap::new(),
+        );
+
+        manifest.set_max_fragment_id_from(1);
+        assert_eq!(manifest.max_fragment_id(), Some(1));
+        assert_eq!(manifest.next_fragment_id(), 2);
+
+        let proto: pb::Manifest = (&manifest).into();
+        assert_eq!(proto.next_fragment_id, Some(2));
+
+        let round_trip = Manifest::try_from(proto).unwrap();
+        assert_eq!(round_trip.max_fragment_id(), Some(1));
+        assert_eq!(round_trip.next_fragment_id(), 2);
+    }
+
+    #[test]
+    fn set_max_fragment_id_from_keeps_next_fragment_id_in_sync() {
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new(
+            "a",
+            arrow_schema::DataType::Int64,
+            false,
+        )]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+        let mut manifest = Manifest::new(
+            schema,
+            Arc::new(vec![]),
+            DataStorageFormat::default(),
+            HashMap::new(),
+        );
+
+        manifest.max_fragment_id = Some(1);
+        manifest.next_fragment_id = None;
+
+        manifest.set_max_fragment_id_from(1);
+
+        assert_eq!(manifest.max_fragment_id(), Some(1));
+        assert_eq!(manifest.next_fragment_id(), 2);
+        assert_eq!(manifest.next_fragment_id, Some(2));
     }
 
     #[test]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3357,7 +3357,17 @@ pub(crate) async fn write_manifest_file(
 
     manifest.set_timestamp(timestamp_to_nanos(config.timestamp));
 
-    manifest.update_max_fragment_id();
+    // Only scan fragments when neither fragment id counter was written yet
+    // (backward compat with old manifests).
+    if manifest.max_fragment_id.is_none() {
+        match manifest.next_fragment_id {
+            Some(next_fragment_id) if next_fragment_id > 0 => {
+                manifest.set_max_fragment_id_from(next_fragment_id - 1)
+            }
+            Some(_) => {}
+            None => manifest.update_max_fragment_id(),
+        }
+    }
 
     commit_handler
         .commit(

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1383,7 +1383,14 @@ async fn load_index_fragmaps(dataset: &Dataset) -> Result<Vec<RoaringBitmap>> {
             index_fragmaps.push(fragment_bitmap.clone());
         } else {
             let dataset_at_index = dataset.checkout_version(index.dataset_version).await?;
-            let frags = 0..dataset_at_index.manifest.max_fragment_id.unwrap_or(0);
+            let next_fragment_id: u32 = dataset_at_index
+                .manifest
+                .next_fragment_id()
+                .try_into()
+                .expect(
+                    "fragment count exceeds u32::MAX; RoaringBitmap cannot represent fragment ids",
+                );
+            let frags = 0..next_fragment_id;
             index_fragmaps.push(RoaringBitmap::from_sorted_iter(frags).unwrap());
         }
     }
@@ -1444,8 +1451,11 @@ async fn reserve_fragment_ids(
     )
     .await?;
 
-    // Need +1 since max_fragment_id is inclusive in this case and ranges are exclusive
-    let new_max_exclusive = manifest.max_fragment_id.unwrap_or(0) + 1;
+    // next_fragment_id is exclusive and the bitmap range end is exclusive too.
+    let new_max_exclusive: u32 = manifest
+        .next_fragment_id()
+        .try_into()
+        .expect("fragment count exceeds u32::MAX; RoaringBitmap cannot represent fragment ids");
     let reserved_ids = (new_max_exclusive - fragments.len() as u32)..(new_max_exclusive);
 
     for (fragment, new_id) in fragments.zip(reserved_ids) {

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -1712,6 +1712,23 @@ impl Transaction {
         })
     }
 
+    fn track_max_fragment_id(max_fragment_id: &mut Option<u64>, fragment_id: u64) {
+        *max_fragment_id = Some(
+            max_fragment_id
+                .map(|current| current.max(fragment_id))
+                .unwrap_or(fragment_id),
+        );
+    }
+
+    fn track_max_fragment_ids<'a>(
+        max_fragment_id: &mut Option<u64>,
+        fragments: impl IntoIterator<Item = &'a Fragment>,
+    ) {
+        for fragment in fragments {
+            Self::track_max_fragment_id(max_fragment_id, fragment.id);
+        }
+    }
+
     fn data_storage_format_from_files(
         fragments: &[Fragment],
         user_requested: Option<LanceFileVersion>,
@@ -1751,9 +1768,19 @@ impl Transaction {
         manifest.set_timestamp(timestamp_to_nanos(config.timestamp));
         manifest.transaction_file = Some(tx_path.to_string());
         let indices = read_manifest_indexes(object_store, &location, &manifest).await?;
-        manifest.max_fragment_id = manifest
-            .max_fragment_id
-            .max(current_manifest.max_fragment_id);
+        // Ensure the high-water marks never go backwards when restoring an old
+        // version.  Both max_fragment_id and next_fragment_id must stay in sync;
+        // bumping one without the other would cause subsequent appends to reuse
+        // already-allocated fragment IDs.
+        let current_next = current_manifest.next_fragment_id();
+        let restored_next = manifest.next_fragment_id();
+        if current_next > restored_next {
+            // Current manifest has a higher water mark; advance the restored one.
+            // current_next - 1 is safe: next_fragment_id() returns 0 only when
+            // there are no fragments, but current_next > restored_next >= 0 means
+            // current_next >= 1.
+            manifest.set_max_fragment_id_from(current_next - 1);
+        }
         Ok((manifest, indices))
     }
 
@@ -1827,11 +1854,9 @@ impl Transaction {
         let mut fragment_id = if matches!(self.operation, Operation::Overwrite { .. }) {
             0
         } else {
-            current_manifest
-                .and_then(|m| m.max_fragment_id())
-                .map(|id| id + 1)
-                .unwrap_or(0)
+            current_manifest.map(|m| m.next_fragment_id()).unwrap_or(0)
         };
+        let mut max_transaction_fragment_id = None;
         let mut final_fragments = Vec::new();
         let mut final_indices = current_indices;
 
@@ -1872,6 +1897,7 @@ impl Transaction {
                 let mut new_fragments =
                     Self::fragments_with_ids(fragments.clone(), &mut fragment_id)
                         .collect::<Vec<_>>();
+                Self::track_max_fragment_ids(&mut max_transaction_fragment_id, &new_fragments);
                 if let Some(next_row_id) = &mut next_row_id {
                     Self::assign_row_ids(next_row_id, new_fragments.as_mut_slice())?;
                     // Add version metadata for all new fragments
@@ -1980,6 +2006,7 @@ impl Transaction {
                 let mut new_fragments =
                     Self::fragments_with_ids(new_fragments.clone(), &mut fragment_id)
                         .collect::<Vec<_>>();
+                Self::track_max_fragment_ids(&mut max_transaction_fragment_id, &new_fragments);
 
                 // Assign row IDs to any fragments that don't have them yet
                 // (e.g., inserted rows from merge_insert operations)
@@ -2042,6 +2069,7 @@ impl Transaction {
                 let mut new_fragments =
                     Self::fragments_with_ids(fragments.clone(), &mut fragment_id)
                         .collect::<Vec<_>>();
+                Self::track_max_fragment_ids(&mut max_transaction_fragment_id, &new_fragments);
                 if let Some(next_row_id) = &mut next_row_id {
                     Self::assign_row_ids(next_row_id, new_fragments.as_mut_slice())?;
                     // Add version metadata for all new fragments
@@ -2062,13 +2090,18 @@ impl Transaction {
             } => {
                 final_fragments.extend(maybe_existing_fragments?.clone());
                 let current_version = current_manifest.map(|m| m.version).unwrap_or_default();
-                Self::handle_rewrite_fragments(
+                if let Some(max_rewritten_fragment_id) = Self::handle_rewrite_fragments(
                     &mut final_fragments,
                     groups,
                     &mut fragment_id,
                     current_version,
                     next_row_id.as_ref(),
-                )?;
+                )? {
+                    Self::track_max_fragment_id(
+                        &mut max_transaction_fragment_id,
+                        max_rewritten_fragment_id,
+                    );
+                }
 
                 if next_row_id.is_some() {
                     // We can re-use indices, but need to rewrite the fragment bitmaps
@@ -2142,6 +2175,7 @@ impl Transaction {
                         }
                     }
                 }
+                Self::track_max_fragment_ids(&mut max_transaction_fragment_id, &merged_fragments);
                 final_fragments.extend(merged_fragments);
 
                 // Some fields that have indices may have been removed, so we should
@@ -2372,7 +2406,12 @@ impl Transaction {
         }
         manifest.set_timestamp(timestamp_to_nanos(config.timestamp));
 
-        manifest.update_max_fragment_id();
+        // Update max_fragment_id from fragment IDs supplied or produced by this transaction.
+        // This covers both locally assigned IDs and pre-reserved IDs without
+        // scanning the full active fragment list.
+        if let Some(max_transaction_fragment_id) = max_transaction_fragment_id {
+            manifest.set_max_fragment_id_from(max_transaction_fragment_id);
+        }
 
         match &self.operation {
             Operation::Overwrite {
@@ -2543,8 +2582,10 @@ impl Transaction {
             }
         }
 
-        if let Operation::ReserveFragments { num_fragments } = self.operation {
-            manifest.max_fragment_id = Some(manifest.max_fragment_id.unwrap_or(0) + num_fragments);
+        if let Operation::ReserveFragments { num_fragments } = self.operation
+            && num_fragments > 0
+        {
+            manifest.set_max_fragment_id_from(fragment_id + u64::from(num_fragments) - 1);
         }
 
         manifest.transaction_file = Some(transaction_file_path.to_string());
@@ -2822,7 +2863,8 @@ impl Transaction {
         fragment_id: &mut u64,
         version: u64,
         _next_row_id: Option<&u64>,
-    ) -> Result<()> {
+    ) -> Result<Option<u64>> {
+        let mut max_rewritten_fragment_id = None;
         for group in groups {
             // If the old fragments are contiguous, find the range
             let replace_range = {
@@ -2857,6 +2899,7 @@ impl Transaction {
 
             let new_fragments = Self::fragments_with_ids(group.new_fragments.clone(), fragment_id)
                 .collect::<Vec<_>>();
+            Self::track_max_fragment_ids(&mut max_rewritten_fragment_id, &new_fragments);
 
             // Version metadata for rewritten fragments is handled by the compaction code
             // (recalc_versions_for_rewritten_fragments) which preserves version information
@@ -2873,7 +2916,7 @@ impl Transaction {
                 final_fragments.extend(new_fragments);
             }
         }
-        Ok(())
+        Ok(max_rewritten_fragment_id)
     }
 
     /// collect the pure(the num of row IDs are equal to the physical rows) "rewrite rows" updated fragment ids
@@ -3876,6 +3919,37 @@ mod tests {
     }
 
     #[test]
+    fn reserve_fragments_backfills_legacy_fragment_counters() {
+        let schema = ArrowSchema::new(vec![ArrowField::new("id", DataType::Int32, false)]);
+        let mut manifest = Manifest::new(
+            LanceSchema::try_from(&schema).unwrap(),
+            Arc::new(vec![Fragment::new(0), Fragment::new(1), Fragment::new(2)]),
+            DataStorageFormat::new(LanceFileVersion::V2_0),
+            HashMap::new(),
+        );
+        manifest.max_fragment_id = None;
+        manifest.next_fragment_id = None;
+
+        let tx = Transaction::new(
+            manifest.version,
+            Operation::ReserveFragments { num_fragments: 2 },
+            None,
+        );
+
+        let (reserved, _) = tx
+            .build_manifest(
+                Some(&manifest),
+                vec![],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap();
+
+        assert_eq!(reserved.max_fragment_id(), Some(4));
+        assert_eq!(reserved.next_fragment_id(), 5);
+    }
+
+    #[test]
     fn test_rewrite_fragments() {
         let existing_fragments: Vec<Fragment> = (0..10).map(Fragment::new).collect();
 
@@ -3900,7 +3974,7 @@ mod tests {
         let mut fragment_id = 20;
         let version = 0;
 
-        Transaction::handle_rewrite_fragments(
+        let max_rewritten_fragment_id = Transaction::handle_rewrite_fragments(
             &mut final_fragments,
             &rewrite_groups,
             &mut fragment_id,
@@ -3910,6 +3984,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(fragment_id, 21);
+        assert_eq!(max_rewritten_fragment_id, Some(20));
 
         let expected_fragments: Vec<Fragment> = vec![
             Fragment::new(0),
@@ -3924,6 +3999,78 @@ mod tests {
         ];
 
         assert_eq!(final_fragments, expected_fragments);
+    }
+
+    #[test]
+    fn rewrite_build_manifest_advances_counter_for_preassigned_fragment_ids() {
+        let schema = ArrowSchema::new(vec![ArrowField::new("id", DataType::Int32, false)]);
+        let lance_schema = LanceSchema::try_from(&schema).unwrap();
+        let mut manifest = Manifest::new(
+            lance_schema,
+            Arc::new(vec![Fragment::new(0), Fragment::new(1), Fragment::new(2)]),
+            DataStorageFormat::new(LanceFileVersion::V2_0),
+            HashMap::new(),
+        );
+        manifest.set_max_fragment_id_from(2);
+
+        let tx = Transaction::new(
+            manifest.version,
+            Operation::Rewrite {
+                groups: vec![RewriteGroup {
+                    old_fragments: vec![Fragment::new(1), Fragment::new(2)],
+                    new_fragments: vec![Fragment::new(15), Fragment::new(16)],
+                }],
+                rewritten_indices: vec![],
+                frag_reuse_index: None,
+            },
+            None,
+        );
+
+        let (rewritten, _) = tx
+            .build_manifest(
+                Some(&manifest),
+                vec![],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap();
+
+        assert_eq!(rewritten.max_fragment_id(), Some(16));
+        assert_eq!(rewritten.next_fragment_id(), 17);
+    }
+
+    #[test]
+    fn merge_build_manifest_advances_counter_for_preassigned_fragment_ids() {
+        let schema = ArrowSchema::new(vec![ArrowField::new("id", DataType::Int32, false)]);
+        let lance_schema = LanceSchema::try_from(&schema).unwrap();
+        let mut manifest = Manifest::new(
+            lance_schema.clone(),
+            Arc::new(vec![Fragment::new(0), Fragment::new(1)]),
+            DataStorageFormat::new(LanceFileVersion::V2_0),
+            HashMap::new(),
+        );
+        manifest.set_max_fragment_id_from(1);
+
+        let tx = Transaction::new(
+            manifest.version,
+            Operation::Merge {
+                fragments: vec![Fragment::new(0), Fragment::new(1), Fragment::new(9)],
+                schema: lance_schema,
+            },
+            None,
+        );
+
+        let (merged, _) = tx
+            .build_manifest(
+                Some(&manifest),
+                vec![],
+                "txn",
+                &ManifestWriteConfig::default(),
+            )
+            .unwrap();
+
+        assert_eq!(merged.max_fragment_id(), Some(9));
+        assert_eq!(merged.next_fragment_id(), 10);
     }
 
     #[test]

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -65,7 +65,10 @@ impl DatasetPreFilter {
         let mut fragments = RoaringBitmap::new();
         let all_have_bitmaps = indices.iter().all(|idx| idx.fragment_bitmap.is_some());
         if !all_have_bitmaps {
-            fragments.insert_range(0..dataset.manifest.max_fragment_id.unwrap_or(0));
+            let next_fragment_id: u32 = dataset.manifest.next_fragment_id().try_into().expect(
+                "fragment count exceeds u32::MAX; RoaringBitmap cannot represent fragment ids",
+            );
+            fragments.insert_range(0..next_fragment_id);
         } else {
             indices.iter().for_each(|idx| {
                 fragments |= idx.fragment_bitmap.as_ref().unwrap();


### PR DESCRIPTION
## Summary

- Add a persisted `next_fragment_id` manifest/protobuf counter so writers can allocate fragment IDs in O(1).
- Use the counter in append/reserve/rewrite/merge/restore paths while preserving legacy fallback behavior for older manifests.
- Keep index fragment bitmap range calculations aligned with the exclusive next-fragment counter and add targeted regression coverage.

## Testing

- `PATH=/Users/beinan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH cargo fmt --all`
- `PATH=/Users/beinan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH cargo clippy --all --tests --benches -- -D warnings`
- `PATH=/Users/beinan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH cargo test -p lance-table fragment_id --lib`
- `PATH=/Users/beinan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH cargo test -p lance build_manifest_advances_counter_for_preassigned_fragment_ids --lib`
- `PATH=/Users/beinan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH cargo test -p lance reserve_fragments_backfills_legacy_fragment_counters --lib`