### PR TITLE
chore: add dependabot config for weekly patch-level lockfile bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    versioning-strategy: lockfile-only
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+
+  - package-ecosystem: "cargo"
+    directory: "/python"
+    versioning-strategy: lockfile-only
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+
+  - package-ecosystem: "cargo"
+    directory: "/java/lance-jni"
+    versioning-strategy: lockfile-only
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+
+  - package-ecosystem: "uv"
+    directory: "/python"
+    versioning-strategy: lockfile-only
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+


### PR DESCRIPTION
Adds Dependabot configuration to automatically open PRs for patch-level dependency updates every Wednesday. Uses `lockfile-only` mode for Cargo and uv so only the lockfiles are touched — no manifest version specs are modified.

Covers:
- `Cargo.lock` at `/`, `/python`, `/java/lance-jni`
- `python/uv.lock`

Maven is excluded since it has no lockfile concept (version specs live directly in `pom.xml`).