### PR TITLE
fix(fts): reset TokenSet next_id and total_length after remap

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -3091,6 +3091,44 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_merge_from_after_remap_does_not_panic() {
+        // `first` is the merge accumulator. Give it three tokens, then remap away the
+        // middle one, mirroring filter_old_data dropping a token whose postings emptied.
+        let mut first = InnerBuilder::new(0, false, TokenSetFormat::default());
+        for token in ["a", "b", "c"] {
+            first.tokens.add(token.to_owned());
+        }
+        first
+            .posting_lists
+            .resize_with(first.tokens.len(), || PostingListBuilder::new(false));
+        let first_doc = first.docs.append(10, 1);
+        first.posting_lists[0].add(first_doc, PositionRecorder::Count(1)); // "a"
+        first.posting_lists[2].add(first_doc, PositionRecorder::Count(1)); // "c"
+
+        // Remove token "b" (id 1) and compact its (empty) posting list to match.
+        first.tokens.remap(&[1]);
+        first.posting_lists.remove(1);
+        assert_eq!(first.tokens.len(), first.posting_lists.len());
+
+        // `second` contributes a brand-new token absent from `first`. Before the fix,
+        // get_or_add returned the stale next_id, indexing past posting_lists.
+        let mut second = InnerBuilder::new(1, false, TokenSetFormat::default());
+        let zeta = second.tokens.add("zeta".to_owned());
+        second
+            .posting_lists
+            .resize_with(second.tokens.len(), || PostingListBuilder::new(false));
+        let second_doc = second.docs.append(20, 1);
+        second.posting_lists[zeta as usize].add(second_doc, PositionRecorder::Count(1));
+
+        first.merge_from(second).unwrap();
+
+        assert_eq!(first.tokens.len(), 3);
+        assert_eq!(first.posting_lists.len(), 3);
+        let zeta_id = first.tokens.get("zeta").expect("zeta should be merged in");
+        assert!((zeta_id as usize) < first.posting_lists.len());
+    }
+
     #[tokio::test]
     async fn test_update_index_returns_worker_error_when_workers_exit_during_dispatch() {
         let num_batches = (*LANCE_FTS_NUM_SHARDS * 2 + 1) as u64;

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1638,17 +1638,26 @@ impl TokenSet {
             }
         };
 
+        let mut retained_length = 0;
         map.retain(
-            |_, token_id| match removed_token_ids.binary_search(token_id) {
+            |token, token_id| match removed_token_ids.binary_search(token_id) {
                 Ok(_) => false,
                 Err(index) => {
                     *token_id -= index as u32;
+                    retained_length += token.len();
                     true
                 }
             },
         );
 
         self.tokens = TokenMap::HashMap(map);
+
+        // The retain above compacts the surviving token ids into a dense `[0, len)`
+        // range, so `next_id` (handed to the next new token) must follow them down.
+        // `total_length` likewise must drop the removed tokens' bytes; it is persisted
+        // and feeds memory accounting, so a stale value drifts across remap/merge cycles.
+        self.next_id = self.tokens.len() as u32;
+        self.total_length = retained_length;
     }
 
     pub fn next_id(&self) -> u32 {


### PR DESCRIPTION
During an FTS index build, merge_existing_segments() can panic with something like "index out of bounds: the len is 936 but the index is 1077". This happens when there has been an update/delete on the table that causes some token to be evicted from the posting lists. Fixed by updating the associated bookkeeping