### PR TITLE
fix(linalg): reduce cosine bench TOTAL to avoid FixedSizeBinaryArray i32 overflow

### DIFF
--- a/rust/lance-linalg/benches/cosine.rs
+++ b/rust/lance-linalg/benches/cosine.rs
@@ -40,7 +40,7 @@ where
     T::Native: Cosine,
 {
     const DIMENSION: usize = 1024;
-    const TOTAL: usize = 1024 * 1024; // 1M vectors
+    const TOTAL: usize = 512 * 1024;
 
     let type_name = std::any::type_name::<T::Native>();
     let key = generate_random_array_with_seed::<T>(DIMENSION, [0; 32]);


### PR DESCRIPTION
BFloat16Type arrays are backed by FixedSizeBinaryArray (2 bytes/element). With TOTAL=1M and DIMENSION=1024 the allocation reached 2*1024^3 bytes, exceeding Arrow's i32 offset limit of 2^31-1 and causing a panic.

Fixes #7113