### PR TITLE
fix: compile AVX-512 dist table for target CPU

### DIFF
--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -16,7 +16,9 @@ fn main() -> Result<(), String> {
     }
 
     // Let clippy know about our custom cfg attribute
-    println!("cargo::rustc-check-cfg=cfg(kernel_support, values(\"avx512\"))");
+    println!(
+        "cargo::rustc-check-cfg=cfg(kernel_support, values(\"avx512_f16\", \"avx512_bf16\", \"avx512_dist_table\"))"
+    );
 
     println!("cargo:rerun-if-changed=src/simd/f16.c");
     println!("cargo:rerun-if-changed=src/simd/bf16.c");
@@ -58,10 +60,10 @@ fn main() -> Result<(), String> {
                 "cargo:warning=Skipping build of AVX-512 fp16 kernels. Error: {}",
                 err
             );
-        } else {
+        } else if cfg!(feature = "fp16kernels") {
             // We create a special cfg so that we can detect we have in fact
             // generated the AVX512 version of the f16 kernels.
-            println!("cargo:rustc-cfg=kernel_support=\"avx512\"");
+            println!("cargo:rustc-cfg=kernel_support=\"avx512_f16\"");
         };
         // Build AVX-512 bf16 kernels (sapphirerapids has native vdpbf16ps)
         if let Err(err) =
@@ -71,16 +73,16 @@ fn main() -> Result<(), String> {
                 "cargo:warning=Skipping build of AVX-512 bf16 kernels. Error: {}",
                 err
             );
-        } else {
-            println!("cargo:rustc-cfg=kernel_support=\"avx512\"");
+        } else if cfg!(feature = "fp16kernels") {
+            println!("cargo:rustc-cfg=kernel_support=\"avx512_bf16\"");
         };
-        if let Err(err) = build_dist_table_with_flags("avx512", &["-march=native"]) {
+        if let Err(err) = build_dist_table_with_flags("avx512", &["-march=sapphirerapids"]) {
             println!(
                 "cargo:warning=Skipping build of AVX-512 dist_table. Error: {}",
                 err
             );
         } else {
-            println!("cargo:rustc-cfg=kernel_support=\"avx512\"");
+            println!("cargo:rustc-cfg=kernel_support=\"avx512_dist_table\"");
         };
         // Build a version with AVX
         // While GCC doesn't have support for _Float16 until GCC 12, clang

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -82,7 +82,7 @@ mod bf16_kernel {
         #[cfg(target_arch = "aarch64")]
         pub fn cosine_bf16_neon(x: *const bf16, x_norm: f32, y: *const bf16, dimension: u32)
         -> f32;
-        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512_bf16", target_arch = "x86_64"))]
         pub fn cosine_bf16_avx512(
             x: *const bf16,
             x_norm: f32,
@@ -109,7 +109,7 @@ impl Cosine for bf16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_support = "avx512",
+                kernel_support = "avx512_bf16",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512FP16 => unsafe {
@@ -141,7 +141,7 @@ mod kernel {
     unsafe extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn cosine_f16_neon(x: *const f16, x_norm: f32, y: *const f16, dimension: u32) -> f32;
-        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512_f16", target_arch = "x86_64"))]
         pub fn cosine_f16_avx512(x: *const f16, x_norm: f32, y: *const f16, dimension: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn cosine_f16_avx2(x: *const f16, x_norm: f32, y: *const f16, dimension: u32) -> f32;
@@ -161,7 +161,7 @@ impl Cosine for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_support = "avx512",
+                kernel_support = "avx512_f16",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512FP16 => unsafe {

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -122,7 +122,7 @@ mod bf16_kernel {
     unsafe extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn dot_bf16_neon(ptr1: *const bf16, ptr2: *const bf16, len: u32) -> f32;
-        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512_bf16", target_arch = "x86_64"))]
         pub fn dot_bf16_avx512(ptr1: *const bf16, ptr2: *const bf16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn dot_bf16_avx2(ptr1: *const bf16, ptr2: *const bf16, len: u32) -> f32;
@@ -143,7 +143,7 @@ impl Dot for bf16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_support = "avx512",
+                kernel_support = "avx512_bf16",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512FP16 => unsafe {
@@ -175,7 +175,7 @@ mod kernel {
     unsafe extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn dot_f16_neon(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
-        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512_f16", target_arch = "x86_64"))]
         pub fn dot_f16_avx512(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn dot_f16_avx2(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
@@ -196,7 +196,7 @@ impl Dot for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_support = "avx512",
+                kernel_support = "avx512_f16",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512FP16 => unsafe {

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -152,7 +152,7 @@ mod bf16_kernel {
     unsafe extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn l2_bf16_neon(ptr1: *const bf16, ptr2: *const bf16, len: u32) -> f32;
-        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512_bf16", target_arch = "x86_64"))]
         pub fn l2_bf16_avx512(ptr1: *const bf16, ptr2: *const bf16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn l2_bf16_avx2(ptr1: *const bf16, ptr2: *const bf16, len: u32) -> f32;
@@ -173,7 +173,7 @@ impl L2 for bf16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_support = "avx512",
+                kernel_support = "avx512_bf16",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512FP16 => unsafe {
@@ -205,7 +205,7 @@ mod kernel {
     unsafe extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn l2_f16_neon(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
-        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512_f16", target_arch = "x86_64"))]
         pub fn l2_f16_avx512(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn l2_f16_avx2(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
@@ -226,7 +226,7 @@ impl L2 for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_support = "avx512",
+                kernel_support = "avx512_f16",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512FP16 => unsafe {

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -29,7 +29,7 @@ mod kernel {
     unsafe extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn norm_l2_f16_neon(ptr: *const f16, len: u32) -> f32;
-        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512_f16", target_arch = "x86_64"))]
         pub fn norm_l2_f16_avx512(ptr: *const f16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn norm_l2_f16_avx2(ptr: *const f16, len: u32) -> f32;
@@ -57,7 +57,7 @@ impl Normalize for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_support = "avx512",
+                kernel_support = "avx512_f16",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512FP16 => unsafe {
@@ -87,7 +87,7 @@ mod bf16_kernel {
     unsafe extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn norm_l2_bf16_neon(ptr: *const bf16, len: u32) -> f32;
-        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512_bf16", target_arch = "x86_64"))]
         pub fn norm_l2_bf16_avx512(ptr: *const bf16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn norm_l2_bf16_avx2(ptr: *const bf16, len: u32) -> f32;
@@ -108,7 +108,7 @@ impl Normalize for bf16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_support = "avx512",
+                kernel_support = "avx512_bf16",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512FP16 => unsafe {

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -37,18 +37,22 @@ pub fn sum_4bit_dist_table(
     debug_assert!(n.is_multiple_of(BATCH_SIZE));
 
     match *SIMD_SUPPORT {
-        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
-        SimdSupport::Avx512 | SimdSupport::Avx512FP16 => unsafe {
+        #[cfg(all(kernel_support = "avx512_dist_table", target_arch = "x86_64"))]
+        SimdSupport::Avx512 | SimdSupport::Avx512FP16
+            if std::arch::is_x86_feature_detected!("avx512bw") =>
+        {
             for i in (0..n).step_by(BATCH_SIZE) {
                 let codes = &codes[i * code_len..(i + BATCH_SIZE) * code_len];
-                sum_4bit_dist_table_32bytes_batch_avx512(
-                    codes.as_ptr(),
-                    codes.len(),
-                    dist_table.as_ptr(),
-                    dists[i..i + BATCH_SIZE].as_mut_ptr(),
-                )
+                unsafe {
+                    sum_4bit_dist_table_32bytes_batch_avx512(
+                        codes.as_ptr(),
+                        codes.len(),
+                        dist_table.as_ptr(),
+                        dists[i..i + BATCH_SIZE].as_mut_ptr(),
+                    )
+                }
             }
-        },
+        }
         #[cfg(target_arch = "x86_64")]
         SimdSupport::Avx2 => unsafe {
             for i in (0..n).step_by(BATCH_SIZE) {
@@ -253,7 +257,7 @@ unsafe fn sum_dist_table_32bytes_batch_neon(codes: &[u8], dist_table: &[u8], dis
 // We implement the AVX512 version in C because AVX512 is not stable yet in Rust,
 // implement it in Rust once we upgrade rust to 1.89.0.
 unsafe extern "C" {
-    #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
+    #[cfg(all(kernel_support = "avx512_dist_table", target_arch = "x86_64"))]
     pub fn sum_4bit_dist_table_32bytes_batch_avx512(
         codes: *const u8,
         code_length: usize,


### PR DESCRIPTION
Fixes #7098.

`dist_table.c` was compiled with `-march=native`, so non-AVX512 build hosts could skip the AVX512 object while other AVX512 kernel cfgs still enabled Rust references. This compiles the dist-table kernel for an explicit AVX512 target and splits the build cfgs per generated kernel family, so Rust only references C symbols that were actually built.

The dist-table AVX512 dispatch now also requires `avx512bw` before using BW intrinsics.
