### PR TITLE
fix(namespace): tolerate reqwest client model additions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5024,9 +5024,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eefb02ded2c3d4b6b60669bb74822d9fa628e144fc748c79ee31f13f566e87b"
+checksum = "7a09733325812e046cb217d548afc4864dedb59545389d45cd498b3d8ecb0d20"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ lance-linalg = { version = "=8.0.0-beta.3", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=8.0.0-beta.3", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=8.0.0-beta.3", path = "./rust/lance-namespace-impls" }
 lance-namespace-datafusion = { version = "=7.0.0-beta.9", path = "./rust/lance-namespace-datafusion" }
-lance-namespace-reqwest-client = "0.8.0"
+lance-namespace-reqwest-client = "0.8.2"
 lance-select = { version = "=8.0.0-beta.3", path = "./rust/lance-select" }
 lance-tokenizer = { version = "=8.0.0-beta.3", path = "./rust/lance-tokenizer" }
 lance-table = { version = "=8.0.0-beta.3", path = "./rust/lance-table" }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4549,9 +4549,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eefb02ded2c3d4b6b60669bb74822d9fa628e144fc748c79ee31f13f566e87b"
+checksum = "7a09733325812e046cb217d548afc4864dedb59545389d45cd498b3d8ecb0d20"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/rust/lance-index/src/vector/utils.rs
+++ b/rust/lance-index/src/vector/utils.rs
@@ -305,12 +305,13 @@ mod tests {
     )) as ArrayRef, 42.0f32)]
     #[case::f32(Arc::new(Float32Array::from(
         (0..100).flat_map(|i| std::iter::repeat_n(i as f32, 16)).collect::<Vec<_>>(),
-    )) as ArrayRef, 42.1f32)]
+    )) as ArrayRef, 42.0f32)]
     fn test_simple_index_nearest_centroid(#[case] centroids: ArrayRef, #[case] query_val: f32) {
         let index = build_index(centroids, 16);
         let query: ArrayRef = Arc::new(Float32Array::from(vec![query_val; 16]));
-        let (id, _) = index.search(query).unwrap();
+        let (id, dist) = index.search(query).unwrap();
         assert_eq!(id, 42);
+        assert_eq!(dist, 0.0);
     }
 
     #[test]

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -4170,6 +4170,7 @@ impl LanceNamespace for DirectoryNamespace {
 
         Ok(GetTableTagVersionResponse {
             version: version as i64,
+            ..Default::default()
         })
     }
 

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -4168,10 +4168,7 @@ impl LanceNamespace for DirectoryNamespace {
             .await
             .map_err(|e| Self::map_tag_error(e, &request.tag, &table_uri))?;
 
-        Ok(GetTableTagVersionResponse {
-            version: version as i64,
-            ..Default::default()
-        })
+        Ok(GetTableTagVersionResponse::new(version as i64))
     }
 
     async fn create_table_tag(

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -3095,13 +3095,7 @@ mod tests {
                     "context_test_ns".to_string(),
                     "test_table".to_string(),
                 ]),
-                with_table_uri: None,
-                load_detailed_metadata: None,
-                check_declared: None,
-                vend_credentials: None,
-                version: None,
-                identity: None,
-                context: None,
+                ..Default::default()
             };
             let result = namespace.describe_table(describe_req).await;
             assert!(result.is_ok(), "Failed to describe table: {:?}", result);


### PR DESCRIPTION
The no-lock Rust workflow can resolve `lance-namespace-reqwest-client` 0.8.2, whose generated models added optional `branch` fields.

This PR makes the namespace implementations initialize those request/response models with defaults so patch-level generated model additions do not break no-lock builds.

Context: `build-no-lock` failed on #7120 while compiling `lance-namespace-impls`, independent of that PR's BM25 test-only diff.
