### PR TITLE
feat(mem_wal): prefilters for LSM search and a Scanner-aligned LsmScanner

### DIFF
--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
@@ -11,6 +11,7 @@ use datafusion::common::{ScalarValue, ToDFSchema};
 use datafusion::physical_plan::limit::GlobalLimitExec;
 use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use datafusion::prelude::{Expr, SessionContext};
+use datafusion_physical_expr::PhysicalExprRef;
 use futures::TryStreamExt;
 use lance_core::{Error, ROW_ID, Result};
 use lance_datafusion::expr::safe_coerce_scalar;
@@ -905,31 +906,53 @@ impl MemTableScanner {
     /// hasn't reached this writer yet (cold-start, or rows written between an
     /// index commit and the next memtable rotation), KNN must still produce
     /// correct, distance-bearing results so the LSM-level merge stays sound.
+    /// Compile the optional logical `filter` into a physical predicate against
+    /// the memtable schema. Shared by the vector and FTS search arms; mirrors the
+    /// compilation in [`Self::plan_full_scan`] (`optimize_expr` before
+    /// `create_physical_expr` for literal type coercion).
+    fn filter_predicate(&self) -> Result<Option<PhysicalExprRef>> {
+        let Some(ref filter) = self.filter else {
+            return Ok(None);
+        };
+        let planner = Planner::new(self.schema.clone());
+        let optimized = planner.optimize_expr(filter.clone())?;
+        Ok(Some(planner.create_physical_expr(&optimized)?))
+    }
+
     async fn plan_vector_search(&self, query: &VectorQuery) -> Result<Arc<dyn ExecutionPlan>> {
         let max_visible = self.max_visible_batch_position;
         let projection_indices = self.compute_projection_indices()?;
         let base_schema = self.base_output_schema();
+        let filter_predicate = self.filter_predicate()?;
 
-        let exec: Arc<dyn ExecutionPlan> = if self.has_vector_index(&query.column) {
-            Arc::new(VectorIndexExec::new(
-                self.batch_store.clone(),
-                self.indexes.clone(),
-                query.clone(),
-                max_visible,
-                projection_indices,
-                base_schema,
-                self.with_row_id,
-            )?)
-        } else {
-            Arc::new(MemTableBruteForceVectorExec::new(
-                self.batch_store.clone(),
-                query.clone(),
-                max_visible,
-                projection_indices,
-                base_schema,
-                self.with_row_id,
-            )?)
-        };
+        // With a prefilter we use brute force (which masks rows before the
+        // top-k cut) rather than the HNSW arm, whose graph traversal cannot
+        // honor an arbitrary predicate. Memtables are bounded, so an exact
+        // filtered brute-force scan is cheap.
+        let exec: Arc<dyn ExecutionPlan> =
+            if filter_predicate.is_none() && self.has_vector_index(&query.column) {
+                Arc::new(VectorIndexExec::new(
+                    self.batch_store.clone(),
+                    self.indexes.clone(),
+                    query.clone(),
+                    max_visible,
+                    projection_indices,
+                    base_schema,
+                    self.with_row_id,
+                )?)
+            } else {
+                Arc::new(
+                    MemTableBruteForceVectorExec::new(
+                        self.batch_store.clone(),
+                        query.clone(),
+                        max_visible,
+                        projection_indices,
+                        base_schema,
+                        self.with_row_id,
+                    )?
+                    .with_filter(filter_predicate),
+                )
+            };
         self.apply_post_index_ops(exec).await
     }
 
@@ -944,6 +967,7 @@ impl MemTableScanner {
 
         let max_visible = self.max_visible_batch_position;
         let projection_indices = self.compute_projection_indices()?;
+        let filter_predicate = self.filter_predicate()?;
 
         let index_exec = FtsIndexExec::new(
             self.batch_store.clone(),
@@ -953,7 +977,8 @@ impl MemTableScanner {
             projection_indices,
             self.base_output_schema(),
             self.with_row_id,
-        )?;
+        )?
+        .with_filter(filter_predicate);
         self.apply_post_index_ops(Arc::new(index_exec)).await
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/brute_force_vector.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/brute_force_vector.rs
@@ -15,7 +15,7 @@ use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use arrow_array::{Array, Float32Array, RecordBatch, UInt64Array, cast::AsArray};
+use arrow_array::{Array, BooleanArray, Float32Array, RecordBatch, UInt64Array, cast::AsArray};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use datafusion::common::stats::Precision;
 use datafusion::error::Result as DataFusionResult;
@@ -27,7 +27,7 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     SendableRecordBatchStream, Statistics,
 };
-use datafusion_physical_expr::EquivalenceProperties;
+use datafusion_physical_expr::{EquivalenceProperties, PhysicalExprRef};
 use futures::stream::{self, StreamExt};
 use lance_core::{Error, Result};
 use lance_linalg::distance::DistanceType;
@@ -53,6 +53,10 @@ pub struct MemTableBruteForceVectorExec {
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     with_row_id: bool,
+    /// Optional prefilter predicate, compiled against the memtable schema.
+    /// Applied per row before the top-k cut so the KNN only ranks matching
+    /// rows (true prefilter, not a lossy post-filter on the top-k).
+    filter: Option<PhysicalExprRef>,
 }
 
 impl Debug for MemTableBruteForceVectorExec {
@@ -108,7 +112,39 @@ impl MemTableBruteForceVectorExec {
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
             with_row_id,
+            filter: None,
         })
+    }
+
+    /// Attach an optional prefilter predicate (compiled against the memtable
+    /// schema). Rows that fail the predicate are excluded before the top-k cut.
+    pub fn with_filter(mut self, filter: Option<PhysicalExprRef>) -> Self {
+        self.filter = filter;
+        self
+    }
+
+    /// Evaluate the prefilter predicate against a memtable batch, returning a
+    /// keep-mask (`true` = retain). `Ok(None)` when no filter is configured.
+    fn filter_mask(&self, batch: &RecordBatch) -> Result<Option<BooleanArray>> {
+        let Some(ref predicate) = self.filter else {
+            return Ok(None);
+        };
+        let values = predicate
+            .evaluate(batch)
+            .and_then(|v| v.into_array(batch.num_rows()))
+            .map_err(|e| {
+                Error::invalid_input(format!("vector prefilter evaluation failed: {}", e))
+            })?;
+        let mask = values
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .ok_or_else(|| {
+                Error::invalid_input(
+                    "vector prefilter predicate did not evaluate to boolean".to_string(),
+                )
+            })?
+            .clone();
+        Ok(Some(mask))
     }
 
     /// Last row position visible under `max_visible_batch_position`, or `None`
@@ -207,10 +243,19 @@ impl MemTableBruteForceVectorExec {
                 ))
             })?;
 
+            // Prefilter: drop rows that fail the predicate before they reach the
+            // top-k heap (a NULL predicate result excludes the row, matching SQL).
+            let filter_mask = self.filter_mask(&stored_batch.data)?;
+
             for row in 0..n {
                 let pos = current_row + row as u64;
                 if pos > max_visible_row {
                     break;
+                }
+                if let Some(ref mask) = filter_mask
+                    && (!mask.is_valid(row) || !mask.value(row))
+                {
+                    continue;
                 }
                 if distances.is_null(row) {
                     continue;

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
@@ -7,7 +7,7 @@ use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use arrow_array::{Float32Array, RecordBatch, UInt32Array, UInt64Array};
+use arrow_array::{BooleanArray, Float32Array, RecordBatch, UInt32Array, UInt64Array};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use datafusion::common::stats::Precision;
 use datafusion::error::Result as DataFusionResult;
@@ -19,7 +19,7 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     SendableRecordBatchStream, Statistics,
 };
-use datafusion_physical_expr::EquivalenceProperties;
+use datafusion_physical_expr::{EquivalenceProperties, PhysicalExprRef};
 use futures::stream::{self, StreamExt};
 use lance_core::{Error, Result};
 
@@ -54,6 +54,10 @@ pub struct FtsIndexExec {
     max_visible_row: Option<u64>,
     /// Whether to include _rowid column (row position) in output.
     with_row_id: bool,
+    /// Optional prefilter predicate, compiled against the memtable schema.
+    /// Applied to the materialized full-schema hits before projection so the
+    /// FTS arm only returns rows matching the predicate.
+    filter: Option<PhysicalExprRef>,
 }
 
 impl Debug for FtsIndexExec {
@@ -162,7 +166,15 @@ impl FtsIndexExec {
             batch_ranges,
             max_visible_row,
             with_row_id,
+            filter: None,
         })
+    }
+
+    /// Attach an optional prefilter predicate (compiled against the memtable
+    /// schema). Hits that fail the predicate are dropped before projection.
+    pub fn with_filter(mut self, filter: Option<PhysicalExprRef>) -> Self {
+        self.filter = filter;
+        self
     }
 
     /// Find batch for a row position using binary search. O(log n).
@@ -296,6 +308,51 @@ impl FtsIndexExec {
                 let concatenated = arrow_select::concat::concat(&refs)?;
                 final_columns.push(concatenated);
             }
+        }
+
+        // Prefilter: evaluate the predicate against the full-schema hits and drop
+        // non-matching rows before scoring/projection (a NULL result excludes the
+        // row, matching SQL). The active FTS arm has no internal top-k, so this is
+        // an exact prefilter, not a lossy post-filter.
+        let (mut final_columns, all_scores, all_row_positions) =
+            if let Some(ref predicate) = self.filter {
+                let Some(first) = self.batch_store.get(0) else {
+                    return Ok(vec![]);
+                };
+                let data_batch = RecordBatch::try_new(first.data.schema(), final_columns)?;
+                let mask = predicate
+                    .evaluate(&data_batch)?
+                    .into_array(data_batch.num_rows())?;
+                let mask = mask
+                    .as_any()
+                    .downcast_ref::<BooleanArray>()
+                    .ok_or_else(|| {
+                        datafusion::error::DataFusionError::Internal(
+                            "FTS prefilter predicate did not evaluate to boolean".to_string(),
+                        )
+                    })?;
+                let filtered_columns = data_batch
+                    .columns()
+                    .iter()
+                    .map(|c| arrow_select::filter::filter(c.as_ref(), mask))
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                let filtered_scores: Vec<f32> = all_scores
+                    .iter()
+                    .zip(mask.iter())
+                    .filter_map(|(s, keep)| keep.unwrap_or(false).then_some(*s))
+                    .collect();
+                let filtered_positions: Vec<u64> = all_row_positions
+                    .iter()
+                    .zip(mask.iter())
+                    .filter_map(|(p, keep)| keep.unwrap_or(false).then_some(*p))
+                    .collect();
+                (filtered_columns, filtered_scores, filtered_positions)
+            } else {
+                (final_columns, all_scores, all_row_positions)
+            };
+
+        if all_scores.is_empty() {
+            return Ok(vec![]);
         }
 
         // Add score column

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -398,7 +398,8 @@ impl LsmScanner {
         let collector = self.build_collector();
         let base_schema = self.schema();
         let mut planner =
-            super::LsmFtsSearchPlanner::new(collector, self.pk_columns.clone(), base_schema);
+            super::LsmFtsSearchPlanner::new(collector, self.pk_columns.clone(), base_schema)
+                .with_filter(self.filter.clone());
         if let Some(session) = &self.session {
             planner = planner.with_session(session.clone());
         }

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -7,8 +7,11 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
-use arrow_array::RecordBatch;
-use arrow_schema::SchemaRef;
+use arrow_array::builder::{FixedSizeListBuilder, Float32Builder};
+use arrow_array::cast::AsArray;
+use arrow_array::types::Float32Type;
+use arrow_array::{Array, FixedSizeListArray, RecordBatch};
+use arrow_schema::{DataType, SchemaRef};
 use datafusion::common::ScalarValue;
 use datafusion::common::ToDFSchema;
 use datafusion::logical_expr::Operator;
@@ -17,6 +20,8 @@ use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use datafusion::prelude::{Expr, SessionContext};
 use futures::TryStreamExt;
 use lance_core::{Error, Result, is_system_column};
+use lance_index::scalar::FullTextSearchQuery;
+use lance_linalg::distance::DistanceType;
 use uuid::Uuid;
 
 use super::collector::{InMemoryMemTableRef, InMemoryMemTables, LsmDataSourceCollector};
@@ -26,6 +31,29 @@ use super::planner::LsmScanPlanner;
 use super::point_lookup::LsmPointLookupPlanner;
 use crate::dataset::Dataset;
 use crate::session::Session;
+
+/// Default top-k for an FTS query when no `limit` is set, mirroring the scanner's
+/// vector default so the FTS arm bounds its per-source fetch.
+const DEFAULT_FTS_K: usize = 10;
+
+/// Vector (KNN) search state, set by [`LsmScanner::nearest`] and friends. Mirrors
+/// the subset of `lance::dataset::scanner::Query` the LSM vector planner honors.
+#[derive(Debug, Clone)]
+struct LsmVectorQuery {
+    /// Vector column to search.
+    column: String,
+    /// Flat query vector (one vector; validated against the column dim in `create_plan`).
+    key: Arc<dyn Array>,
+    /// Number of nearest neighbors to fetch per source before the global merge.
+    k: usize,
+    /// Number of IVF partitions to probe on the base arm.
+    nprobes: usize,
+    /// Re-rank base candidates with exact distances when set (refine factor is
+    /// treated as a boolean; the LSM merge needs exact base distances).
+    refine: bool,
+    /// Distance metric; `None` defaults to L2 (matching the unindexed memtable arm).
+    metric_type: Option<DistanceType>,
+}
 
 /// If `filter` is a point-lookup shape on `pk_col` — `pk = lit` (either
 /// operand order) or `pk IN (lit, …)` — return the literal key values. Any
@@ -72,6 +100,38 @@ enum BaseSource {
     PathOnly(String),
 }
 
+/// The fixed-size-list dimension of `column` in `schema`. Errors if the column
+/// is missing or is not a fixed-size-list vector column.
+fn vector_dim(schema: &arrow_schema::Schema, column: &str) -> Result<i32> {
+    let field = schema
+        .field_with_name(column)
+        .map_err(|_| Error::invalid_input(format!("vector column '{}' not found", column)))?;
+    match field.data_type() {
+        DataType::FixedSizeList(_, dim) => Ok(*dim),
+        other => Err(Error::invalid_input(format!(
+            "column '{}' is not a fixed-size-list vector (got {:?})",
+            column, other
+        ))),
+    }
+}
+
+/// Wrap a flat `Float32` query vector into a single-row `FixedSizeListArray` of
+/// `dim`, as the vector planner expects. A pre-built single-row FSL passes
+/// through unchanged.
+fn key_to_fsl(key: &dyn Array, dim: i32) -> Result<FixedSizeListArray> {
+    if let Some(fsl) = key.as_any().downcast_ref::<FixedSizeListArray>() {
+        return Ok(fsl.clone());
+    }
+    let values = key
+        .as_primitive_opt::<Float32Type>()
+        .ok_or_else(|| Error::invalid_input("query vector must be Float32".to_string()))?;
+    let mut builder =
+        FixedSizeListBuilder::with_capacity(Float32Builder::with_capacity(dim as usize), dim, 1);
+    builder.values().append_slice(values.values());
+    builder.append(true);
+    Ok(builder.finish())
+}
+
 /// Scanner for LSM tree data spanning base table, flushed MemTables, and active MemTable.
 ///
 /// This scanner provides a unified interface for querying data across multiple
@@ -87,12 +147,18 @@ enum BaseSource {
 ///
 /// ```ignore
 /// let scanner = LsmScanner::new(base_table, shard_snapshots, vec!["pk".to_string()])
-///     .project(&["id", "name"])
+///     .project(&["id", "name"])?
 ///     .filter("id > 10")?
-///     .limit(100, None);
+///     .limit(Some(100), None)?;
 ///
 /// let results = scanner.try_into_batch().await?;
 /// ```
+///
+/// The query-building methods mirror [`lance::dataset::scanner::Scanner`]:
+/// [`Self::nearest`] (+ [`Self::nprobes`] / [`Self::refine`] /
+/// [`Self::distance_metric`]) for vector search and [`Self::full_text_search`]
+/// for FTS are state setters, and [`Self::create_plan`] dispatches to the right
+/// planner — so an LSM read reads like a normal scan.
 pub struct LsmScanner {
     // Data sources
     base: BaseSource,
@@ -110,6 +176,10 @@ pub struct LsmScanner {
     filter: Option<Expr>,
     limit: Option<usize>,
     offset: Option<usize>,
+    /// Vector (KNN) search; when set, `create_plan` routes to the vector planner.
+    nearest: Option<LsmVectorQuery>,
+    /// Full-text search; when set, `create_plan` routes to the FTS planner.
+    full_text_query: Option<FullTextSearchQuery>,
 
     // Internal columns
     with_row_address: bool,
@@ -155,6 +225,8 @@ impl LsmScanner {
             filter: None,
             limit: None,
             offset: None,
+            nearest: None,
+            full_text_query: None,
             with_row_address: false,
             with_memtable_gen: false,
             pk_columns,
@@ -193,6 +265,8 @@ impl LsmScanner {
             filter: None,
             limit: None,
             offset: None,
+            nearest: None,
+            full_text_query: None,
             with_row_address: false,
             with_memtable_gen: false,
             pk_columns,
@@ -257,9 +331,9 @@ impl LsmScanner {
     ///
     /// If not called, all columns from the base schema are included.
     /// Primary key columns are always included for deduplication.
-    pub fn project(mut self, columns: &[&str]) -> Self {
-        self.projection = Some(columns.iter().map(|s| s.to_string()).collect());
-        self
+    pub fn project<T: AsRef<str>>(mut self, columns: &[T]) -> Result<Self> {
+        self.projection = Some(columns.iter().map(|s| s.as_ref().to_string()).collect());
+        Ok(self)
     }
 
     /// Set filter expression using SQL-like syntax.
@@ -286,10 +360,79 @@ impl LsmScanner {
         self
     }
 
-    /// Limit the number of results.
-    pub fn limit(mut self, limit: usize, offset: Option<usize>) -> Self {
-        self.limit = Some(limit);
-        self.offset = offset;
+    /// Limit the number of results, with an optional offset. Matches
+    /// [`lance::dataset::scanner::Scanner::limit`]: both bounds are `Option<i64>`
+    /// and must be non-negative.
+    pub fn limit(mut self, limit: Option<i64>, offset: Option<i64>) -> Result<Self> {
+        if let Some(limit) = limit {
+            if limit < 0 {
+                return Err(Error::invalid_input(
+                    "limit must be non-negative".to_string(),
+                ));
+            }
+            self.limit = Some(limit as usize);
+        }
+        if let Some(offset) = offset {
+            if offset < 0 {
+                return Err(Error::invalid_input(
+                    "offset must be non-negative".to_string(),
+                ));
+            }
+            self.offset = Some(offset as usize);
+        }
+        Ok(self)
+    }
+
+    /// Find the `k` nearest neighbors of `key` in `column`. Routes `create_plan`
+    /// through the LSM vector planner (base ∪ flushed ∪ in-memory). Mirrors
+    /// [`lance::dataset::scanner::Scanner::nearest`]; the LSM path supports a
+    /// single query vector. Tune with [`Self::nprobes`], [`Self::refine`], and
+    /// [`Self::distance_metric`].
+    pub fn nearest(mut self, column: &str, key: &dyn Array, k: usize) -> Result<Self> {
+        if k == 0 {
+            return Err(Error::invalid_input("k must be positive".to_string()));
+        }
+        if key.is_empty() {
+            return Err(Error::invalid_input(
+                "query vector must have non-zero length".to_string(),
+            ));
+        }
+        self.nearest = Some(LsmVectorQuery {
+            column: column.to_string(),
+            key: key.slice(0, key.len()),
+            k,
+            nprobes: 1,
+            refine: false,
+            metric_type: None,
+        });
+        Ok(self)
+    }
+
+    /// Number of IVF partitions to probe on the base arm (default 1). No-op
+    /// unless [`Self::nearest`] was called.
+    pub fn nprobes(mut self, nprobes: usize) -> Self {
+        if let Some(q) = self.nearest.as_mut() {
+            q.nprobes = nprobes;
+        }
+        self
+    }
+
+    /// Re-rank base-table candidates with exact distances so they are directly
+    /// comparable to the exact memtable distances in the cross-source merge.
+    /// The factor is treated as a boolean today. No-op unless `nearest` was set.
+    pub fn refine(mut self, refine_factor: u32) -> Self {
+        if let Some(q) = self.nearest.as_mut() {
+            q.refine = refine_factor > 0;
+        }
+        self
+    }
+
+    /// Distance metric for the vector search. Defaults to L2. No-op unless
+    /// [`Self::nearest`] was called.
+    pub fn distance_metric(mut self, metric: DistanceType) -> Self {
+        if let Some(q) = self.nearest.as_mut() {
+            q.metric_type = Some(metric);
+        }
         self
     }
 
@@ -329,6 +472,111 @@ impl LsmScanner {
 
     /// Create the execution plan.
     pub async fn create_plan(&self) -> Result<Arc<dyn ExecutionPlan>> {
+        // Dispatch by builder state, mirroring `Scanner::create_plan` and
+        // `MemTableScanner::create_plan`: vector search, then full-text search,
+        // then the (point-lookup or union) plain scan.
+        if self.nearest.is_some() {
+            return self.plan_vector().await;
+        }
+        if self.full_text_query.is_some() {
+            return self.plan_fts().await;
+        }
+        self.plan_scan().await
+    }
+
+    /// Apply the builder's `limit`/`offset` on top of a search plan. The plain
+    /// scan applies them inside the planner; the vector/FTS arms wrap here.
+    fn apply_limit_offset(&self, plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        let skip = self.offset.unwrap_or(0);
+        if skip == 0 && self.limit.is_none() {
+            return plan;
+        }
+        Arc::new(GlobalLimitExec::new(plan, skip, self.limit))
+    }
+
+    /// Vector (KNN) search across base ∪ flushed ∪ in-memory, via the LSM vector
+    /// planner. Honors the builder filter as a prefilter.
+    async fn plan_vector(&self) -> Result<Arc<dyn ExecutionPlan>> {
+        let nearest = self
+            .nearest
+            .as_ref()
+            .expect("plan_vector requires a nearest query");
+        let base_schema = self.schema();
+        let dim = vector_dim(base_schema.as_ref(), &nearest.column)?;
+        let query_fsl = key_to_fsl(nearest.key.as_ref(), dim)?;
+        let distance_type = nearest.metric_type.unwrap_or(DistanceType::L2);
+
+        let collector = self.build_collector();
+        let mut planner = super::LsmVectorSearchPlanner::new(
+            collector,
+            self.pk_columns.clone(),
+            base_schema,
+            nearest.column.clone(),
+            distance_type,
+        )
+        .with_filter(self.filter.clone());
+        if let BaseSource::Table(dataset) = &self.base {
+            planner = planner.with_dataset(dataset.clone());
+        }
+        if let Some(session) = &self.session {
+            planner = planner.with_session(session.clone());
+        }
+        if let Some(cache) = &self.flushed_cache {
+            planner = planner.with_flushed_cache(cache.clone());
+        }
+        let plan = planner
+            .plan_search(
+                &query_fsl,
+                nearest.k,
+                nearest.nprobes,
+                self.projection.as_deref(),
+                nearest.refine,
+                1.0,
+            )
+            .await?;
+        Ok(self.apply_limit_offset(plan))
+    }
+
+    /// Full-text search across base ∪ flushed ∪ in-memory, via the LSM FTS
+    /// planner. The column comes from the query; `k` from `limit` (+ `offset`).
+    async fn plan_fts(&self) -> Result<Arc<dyn ExecutionPlan>> {
+        let query = self
+            .full_text_query
+            .as_ref()
+            .expect("plan_fts requires a full-text query");
+        let columns: Vec<String> = query.columns().into_iter().collect();
+        if columns.len() > 1 {
+            return Err(Error::invalid_input(
+                "LSM full-text search supports a single column".to_string(),
+            ));
+        }
+        let column = columns.into_iter().next().ok_or_else(|| {
+            Error::invalid_input(
+                "full_text_search requires a column; set it with `FullTextSearchQuery::with_column`"
+                    .to_string(),
+            )
+        })?;
+        let k = self.limit.unwrap_or(DEFAULT_FTS_K) + self.offset.unwrap_or(0);
+
+        let collector = self.build_collector();
+        let base_schema = self.schema();
+        let mut planner =
+            super::LsmFtsSearchPlanner::new(collector, self.pk_columns.clone(), base_schema)
+                .with_filter(self.filter.clone());
+        if let Some(session) = &self.session {
+            planner = planner.with_session(session.clone());
+        }
+        if let Some(cache) = &self.flushed_cache {
+            planner = planner.with_flushed_cache(cache.clone());
+        }
+        let plan = planner
+            .plan_search(&column, query.clone(), k, self.projection.as_deref())
+            .await?;
+        Ok(self.apply_limit_offset(plan))
+    }
+
+    /// Plain (filter / projection / limit) scan over base ∪ flushed ∪ in-memory.
+    async fn plan_scan(&self) -> Result<Arc<dyn ExecutionPlan>> {
         let collector = self.build_collector();
         let base_schema = self.schema();
 
@@ -383,32 +631,16 @@ impl LsmScanner {
             .await
     }
 
-    /// Build a local-scoring FTS plan spanning base + flushed + active sources.
-    ///
-    /// Routes through [`super::LsmFtsSearchPlanner`]. Output schema is
-    /// `projection ∪ pk_columns + _score`; per-source local BM25 `_score`
-    /// is merged DESC and capped at `k`. `column` must be FTS-indexed on
-    /// the queried sources.
-    pub async fn full_text_search(
-        &self,
-        column: &str,
-        query: lance_index::scalar::FullTextSearchQuery,
-        k: usize,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        let collector = self.build_collector();
-        let base_schema = self.schema();
-        let mut planner =
-            super::LsmFtsSearchPlanner::new(collector, self.pk_columns.clone(), base_schema)
-                .with_filter(self.filter.clone());
-        if let Some(session) = &self.session {
-            planner = planner.with_session(session.clone());
-        }
-        if let Some(cache) = &self.flushed_cache {
-            planner = planner.with_flushed_cache(cache.clone());
-        }
-        planner
-            .plan_search(column, query, k, self.projection.as_deref())
-            .await
+    /// Find rows matching a full-text query. Routes `create_plan` through the
+    /// LSM FTS planner (base ∪ flushed ∪ in-memory), local-scored by BM25 and
+    /// merged by `_score` DESC. Mirrors
+    /// [`lance::dataset::scanner::Scanner::full_text_search`]: the searched
+    /// column(s) come from the query (set via `FullTextSearchQuery::with_column`);
+    /// the top-k comes from [`Self::limit`]. The LSM path supports a single
+    /// FTS-indexed column.
+    pub fn full_text_search(mut self, query: FullTextSearchQuery) -> Result<Self> {
+        self.full_text_query = Some(query);
+        Ok(self)
     }
 
     /// Execute the scan and return a stream of record batches.
@@ -617,6 +849,212 @@ mod tests {
         // pk=1 (active), pk=4 (absent), pk=3 (frozen).
         let result = scanner.contains_pks(&id_batch(&[1, 4, 3])).await.unwrap();
         assert_eq!(result, vec![true, false, true]);
+    }
+
+    fn pk_schema(extra: arrow_schema::Field) -> SchemaRef {
+        use arrow_schema::{DataType, Field, Schema};
+        let mut id_meta = HashMap::new();
+        id_meta.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false).with_metadata(id_meta),
+            extra,
+        ]))
+    }
+
+    /// `LsmScanner::nearest(..).create_plan()` must route through the vector
+    /// planner (exercising the Scanner-aligned facade, `key_to_fsl`, and
+    /// `vector_dim`) and surface the in-memory match.
+    #[tokio::test]
+    async fn nearest_dispatches_through_facade() {
+        use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+        use crate::dataset::{Dataset, WriteParams};
+        use arrow_array::builder::{FixedSizeListBuilder, Float32Builder};
+        use arrow_array::{Float32Array, Int32Array, RecordBatchIterator};
+        use arrow_schema::{DataType, Field};
+
+        let schema = pk_schema(Field::new(
+            "vector",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
+            false,
+        ));
+        let make_batch = |ids: &[i32]| -> RecordBatch {
+            let mut vb = FixedSizeListBuilder::new(Float32Builder::new(), 4);
+            for id in ids {
+                let base = *id as f32 * 0.1;
+                for d in 0..4 {
+                    vb.values().append_value(base + d as f32 * 0.1);
+                }
+                vb.append(true);
+            }
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(ids.to_vec())),
+                    Arc::new(vb.finish()),
+                ],
+            )
+            .unwrap()
+        };
+
+        // Far, unindexed base rows contribute nothing under fast_search.
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let reader = RecordBatchIterator::new(vec![Ok(make_batch(&[100, 200]))], schema.clone());
+        let base = Arc::new(
+            Dataset::write(reader, &uri, Some(WriteParams::default()))
+                .await
+                .unwrap(),
+        );
+
+        let store = Arc::new(BatchStore::with_capacity(16));
+        let mut index = IndexStore::new();
+        index.add_hnsw(
+            "vec_hnsw".to_string(),
+            1,
+            "vector".to_string(),
+            DistanceType::L2,
+            64,
+            8,
+        );
+        let batch = make_batch(&[1, 2, 3]);
+        store.append(batch.clone()).unwrap();
+        index
+            .insert_with_batch_position(&batch, 0, Some(0))
+            .unwrap();
+
+        let scanner = LsmScanner::new(base, vec![], vec!["id".to_string()])
+            .with_in_memory_memtables(
+                Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store: store,
+                        index_store: Arc::new(index),
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            )
+            // A flat query vector (closest to id=1); the facade wraps it into an FSL.
+            .nearest(
+                "vector",
+                &Float32Array::from(vec![0.1f32, 0.2, 0.3, 0.4]),
+                3,
+            )
+            .unwrap();
+
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|b| {
+                b.column_by_name("id")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(
+            ids.first().copied(),
+            Some(1),
+            "nearest neighbor via the facade should be id=1; got {ids:?}"
+        );
+    }
+
+    /// `LsmScanner::full_text_search(query).create_plan()` must route through the
+    /// FTS planner and surface a memtable-only match.
+    #[tokio::test]
+    async fn full_text_search_dispatches_through_facade() {
+        use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+        use crate::dataset::{Dataset, WriteParams};
+        use crate::index::DatasetIndexExt;
+        use arrow_array::{Int32Array, RecordBatchIterator, StringArray};
+        use arrow_schema::{DataType, Field};
+        use lance_index::IndexType;
+        use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+
+        let schema = pk_schema(Field::new("text", DataType::Utf8, true));
+        let make_batch = |ids: &[i32], texts: &[&str]| {
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(ids.to_vec())),
+                    Arc::new(StringArray::from(texts.to_vec())),
+                ],
+            )
+            .unwrap()
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let reader =
+            RecordBatchIterator::new(vec![Ok(make_batch(&[1], &["alpha"]))], schema.clone());
+        let mut base = Dataset::write(reader, &uri, Some(WriteParams::default()))
+            .await
+            .unwrap();
+        base.create_index(
+            &["text"],
+            IndexType::Inverted,
+            Some("text_fts".to_string()),
+            &InvertedIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+        let base = Arc::new(Dataset::open(&uri).await.unwrap());
+
+        let store = Arc::new(BatchStore::with_capacity(16));
+        let mut index = IndexStore::new();
+        index.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let batch = make_batch(&[99], &["zebra"]);
+        store.append(batch.clone()).unwrap();
+        index
+            .insert_with_batch_position(&batch, 0, Some(0))
+            .unwrap();
+
+        let scanner = LsmScanner::new(base, vec![], vec!["id".to_string()])
+            .with_in_memory_memtables(
+                Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store: store,
+                        index_store: Arc::new(index),
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            )
+            .full_text_search(
+                FullTextSearchQuery::new("zebra".to_string())
+                    .with_column("text".to_string())
+                    .unwrap(),
+            )
+            .unwrap();
+
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(
+            rows, 1,
+            "facade FTS should surface the memtable 'zebra' row"
+        );
     }
 
     /// One active memtable with a maintained BTree on `id`, all rows visible.

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -44,6 +44,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::union::UnionExec;
+use datafusion::prelude::Expr;
 use lance_core::{Error, ROW_ID, Result, is_system_column};
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::inverted::query::FtsQuery as IndexFtsQuery;
@@ -79,6 +80,10 @@ pub struct LsmFtsSearchPlanner {
     flushed_cache: Option<Arc<FlushedMemTableCache>>,
     /// Over-fetch multiple for blocked sources (clamped to `>= 1.0`).
     overfetch_factor: f64,
+    /// Optional prefilter predicate applied to every source arm so FTS hits
+    /// failing the predicate are dropped. Base/flushed arms use the dataset
+    /// scanner's native filter; memtable arms filter the materialized hits.
+    filter: Option<Expr>,
 }
 
 impl LsmFtsSearchPlanner {
@@ -95,7 +100,16 @@ impl LsmFtsSearchPlanner {
             session: None,
             flushed_cache: None,
             overfetch_factor: DEFAULT_OVERFETCH_FACTOR,
+            filter: None,
         }
+    }
+
+    /// Attach an optional prefilter predicate. Every source arm restricts its
+    /// FTS hits to rows matching the predicate, matching a normal filtered
+    /// full-text scan over base ∪ flushed ∪ in-memory data.
+    pub fn with_filter(mut self, filter: Option<Expr>) -> Self {
+        self.filter = filter;
+        self
     }
 
     /// Set the over-fetch multiple for blocked sources so they still yield `k`
@@ -270,6 +284,9 @@ impl LsmFtsSearchPlanner {
                 let mut scanner = dataset.scan();
                 let cols = self.fts_scanner_projection(projection);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                if let Some(ref filter) = self.filter {
+                    scanner.filter_expr(filter.clone());
+                }
                 let bound_query = query
                     .clone()
                     .with_column(column.to_string())?
@@ -284,6 +301,9 @@ impl LsmFtsSearchPlanner {
                 let mut scanner = dataset.scan();
                 let cols = self.fts_scanner_projection(projection);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                if let Some(ref filter) = self.filter {
+                    scanner.filter_expr(filter.clone());
+                }
                 let bound_query = query
                     .clone()
                     .with_column(column.to_string())?
@@ -301,6 +321,11 @@ impl LsmFtsSearchPlanner {
                     MemTableScanner::new(batch_store.clone(), index_store.clone(), schema.clone());
                 let cols = self.fts_scanner_projection(projection);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+                if let Some(ref filter) = self.filter {
+                    // Honored inside `plan_fts_search`: the materialized hits are
+                    // masked by the predicate before projection.
+                    scanner.filter_expr(filter.clone());
+                }
                 // Emit `_rowid` (row position) so the planner can collapse
                 // duplicate-PK appends via WithinSourceDedupExec before the union.
                 if emit_row_id {
@@ -550,6 +575,100 @@ mod tests {
         }
         assert!(ids.contains(&1), "missing base hit id=1; got ids={ids:?}");
         assert!(ids.contains(&3), "missing active hit id=3; got ids={ids:?}");
+    }
+
+    /// A prefilter on a full-text search must drop hits failing the predicate
+    /// from both the base arm (native scanner filter) and the active memtable
+    /// arm (materialized-hit mask), even though they match the query text.
+    #[tokio::test]
+    async fn prefilter_drops_nonmatching_hits_across_base_and_active() {
+        use crate::index::DatasetIndexExt;
+        use datafusion::prelude::{col, lit};
+        use lance_index::IndexType;
+        use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+
+        let schema = fts_schema();
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Base rows 1 and 2 both contain "lance".
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let mut base_ds = write_dataset(
+            &base_uri,
+            vec![make_batch(&schema, &[1, 2], &["lance one", "lance two"])],
+        )
+        .await;
+        base_ds
+            .create_index(
+                &["text"],
+                IndexType::Inverted,
+                Some("text_fts".to_string()),
+                &InvertedIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+        let base_ds = Arc::new(Dataset::open(&base_uri).await.unwrap());
+
+        // Active memtable rows 0 and 3 both contain "lance".
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let active_batch = make_batch(&schema, &[0, 3], &["lance zero", "lance three"]);
+        batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, 0, Some(0))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+
+        let collector = LsmDataSourceCollector::new(base_ds, vec![]).with_in_memory_memtables(
+            uuid::Uuid::new_v4(),
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store: indexes,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
+            },
+        );
+
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema)
+            // `id >= 2` keeps base id=2 and active id=3; drops base id=1 and active id=0.
+            .with_filter(Some(col("id").gt_eq(lit(2i32))));
+        let plan = planner
+            .plan_search(
+                "text",
+                FullTextSearchQuery::new("lance".to_string()),
+                10,
+                None,
+            )
+            .await
+            .expect("planner should produce a filtered base+active plan");
+
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+
+        let mut ids: Vec<i32> = Vec::new();
+        for b in &batches {
+            let col = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                ids.push(col.value(i));
+            }
+        }
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec![2, 3],
+            "prefilter must keep only id>=2 across base (id=2) and active (id=3), \
+             dropping base id=1 and active id=0; got {ids:?}"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -801,8 +801,9 @@ mod integration_tests {
             setup_multi_level_lsm().await;
 
         // Create scanner with projection (only id column)
-        let mut scanner =
-            LsmScanner::new(base_dataset, shard_snapshots, pk_columns).project(&["id"]);
+        let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns)
+            .project(&["id"])
+            .unwrap();
         if let Some((shard_id, memtable)) = active_memtable {
             scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
@@ -832,7 +833,9 @@ mod integration_tests {
             setup_multi_level_lsm().await;
 
         // Create scanner with limit
-        let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns).limit(3, None);
+        let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns)
+            .limit(Some(3), None)
+            .unwrap();
         if let Some((shard_id, memtable)) = active_memtable {
             scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
@@ -1603,13 +1606,9 @@ mod integration_tests {
         let (base_dataset, shard_snapshots, active_memtable, pk_columns, _temp_path) =
             setup_multi_level_lsm().await;
 
-        let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns).project(&[
-            "id",
-            "_rowoffset",
-            "name",
-            "_rowaddr",
-            "_rowid",
-        ]);
+        let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns)
+            .project(&["id", "_rowoffset", "name", "_rowaddr", "_rowid"])
+            .unwrap();
         if let Some((shard_id, memtable)) = active_memtable {
             scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
@@ -1699,7 +1698,8 @@ mod integration_tests {
             setup_multi_level_lsm().await;
 
         let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns)
-            .project(&["id", "_rowid", "name"]);
+            .project(&["id", "_rowid", "name"])
+            .unwrap();
         if let Some((shard_id, memtable)) = active_memtable {
             scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
@@ -1762,7 +1762,8 @@ mod integration_tests {
 
         let scanner =
             LsmScanner::without_base_table(schema, base_uri, vec![], vec!["id".to_string()])
-                .project(&["id", "_rowaddr", "name", "_rowid"]);
+                .project(&["id", "_rowaddr", "name", "_rowid"])
+                .unwrap();
         let plan = scanner.create_plan().await.unwrap();
 
         let names: Vec<String> = plan

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -18,6 +18,7 @@ use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::union::UnionExec;
+use datafusion::prelude::Expr;
 use lance_core::Result;
 use lance_core::datatypes::OnMissing;
 use tracing::instrument;
@@ -93,6 +94,11 @@ pub struct LsmVectorSearchPlanner {
     session: Option<Arc<Session>>,
     /// Cache of opened flushed-generation datasets.
     flushed_cache: Option<Arc<FlushedMemTableCache>>,
+    /// Optional prefilter predicate applied to every source arm before its KNN
+    /// search, so rows failing the predicate never enter the top-k. Base and
+    /// flushed arms use the dataset scanner's native prefilter; memtable arms
+    /// route to a filtered brute-force scan.
+    filter: Option<Expr>,
 }
 
 impl LsmVectorSearchPlanner {
@@ -121,7 +127,16 @@ impl LsmVectorSearchPlanner {
             dataset: None,
             session: None,
             flushed_cache: None,
+            filter: None,
         }
+    }
+
+    /// Attach an optional prefilter predicate. Every source arm restricts its
+    /// KNN to rows matching the predicate (true prefilter), so results match a
+    /// normal filtered vector scan over base ∪ flushed ∪ in-memory data.
+    pub fn with_filter(mut self, filter: Option<Expr>) -> Self {
+        self.filter = filter;
+        self
     }
 
     /// Thread a session into flushed-generation opens so the first open
@@ -384,6 +399,11 @@ impl LsmVectorSearchPlanner {
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                if let Some(ref filter) = self.filter {
+                    // Native scanner prefilter: the ANN runs over rows matching
+                    // the predicate, so the top-k holds only matching rows.
+                    scanner.filter_expr(filter.clone());
+                }
                 // Only the base produces a meaningful `_rowid`. `_rowaddr`
                 // can't be combined with `fast_search()` — the IVF index
                 // doesn't preserve it and `TakeExec` refuses to insert it
@@ -412,6 +432,9 @@ impl LsmVectorSearchPlanner {
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                if let Some(ref filter) = self.filter {
+                    scanner.filter_expr(filter.clone());
+                }
                 // No `with_row_id/address`: per-source IDs would collide with base.
                 let query_arr = single_query_array(query_vector);
                 scanner.nearest(&self.vector_column, query_arr.as_ref(), k)?;
@@ -435,6 +458,11 @@ impl LsmVectorSearchPlanner {
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+                if let Some(ref filter) = self.filter {
+                    // Routed to filtered brute-force (see `plan_vector_search`):
+                    // the predicate masks rows before the memtable top-k cut.
+                    scanner.filter_expr(filter.clone());
+                }
                 // Expose `_rowid` (BatchStore row offset, monotonic with
                 // insert order) so [`WithinSourceDedupExec`] can collapse
                 // duplicate-PK rows to the newest insert. The value is
@@ -738,6 +766,105 @@ mod tests {
             dist_col.value(0).abs() < 1e-3,
             "expected near-zero distance for self-match, got {}",
             dist_col.value(0)
+        );
+    }
+
+    /// A prefilter on a vector search must restrict the KNN to rows matching the
+    /// predicate, even though the nearest (and second-nearest) rows fail it. The
+    /// active memtable has an HNSW index, but a filtered search routes to the
+    /// brute-force arm, which masks rows before the top-k cut.
+    #[tokio::test]
+    async fn test_vector_search_prefilter_restricts_to_matching_rows() {
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
+        use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+        use datafusion::prelude::{SessionContext, col, lit};
+        use futures::TryStreamExt;
+
+        let schema = create_vector_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
+        // Base rows are far from the query and unindexed, so `fast_search`
+        // contributes nothing; the test isolates the memtable prefilter.
+        let base_dataset = Arc::new(
+            create_dataset(&base_uri, vec![create_test_batch(&schema, &[100, 200])]).await,
+        );
+
+        // Active memtable with ids 0..=3 (id=1 is the exact match, id=0 ties id=2).
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut index_store = IndexStore::new();
+        index_store.add_hnsw(
+            "vector_hnsw".to_string(),
+            1,
+            "vector".to_string(),
+            lance_linalg::distance::DistanceType::L2,
+            64,
+            8,
+        );
+        let batch = create_test_batch(&schema, &[0, 1, 2, 3]);
+        batch_store.append(batch.clone()).unwrap();
+        index_store
+            .insert_with_batch_position(&batch, 0, Some(0))
+            .unwrap();
+        let index_store = Arc::new(index_store);
+
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_in_memory_memtables(
+            uuid::Uuid::new_v4(),
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
+            },
+        );
+
+        let planner = LsmVectorSearchPlanner::new(
+            collector,
+            vec!["id".to_string()],
+            schema,
+            "vector".to_string(),
+            lance_linalg::distance::DistanceType::L2,
+        )
+        // `id >= 2` excludes the two nearest rows (id=1 exact, id=0 tie).
+        .with_filter(Some(col("id").gt_eq(lit(2i32))));
+
+        let query = create_query_vector();
+        let plan = planner
+            .plan_search(&query, 10, 1, None, false, 1.0)
+            .await
+            .expect("planner should produce a filtered plan");
+
+        let ctx = SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+
+        let mut ids: Vec<i32> = Vec::new();
+        for b in &batches {
+            let col = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                ids.push(col.value(i));
+            }
+        }
+
+        // Only id=2 and id=3 satisfy `id >= 2`; the nearer id=0/id=1 are excluded.
+        assert_eq!(
+            ids.first().copied(),
+            Some(2),
+            "nearest matching row is id=2"
+        );
+        let mut sorted = ids.clone();
+        sorted.sort();
+        assert_eq!(
+            sorted,
+            vec![2, 3],
+            "prefilter must drop id=0 and id=1 (nearer but failing `id >= 2`)"
         );
     }
 


### PR DESCRIPTION
Two related changes to the MemWAL LSM read path.

## 1. Prefilters for LSM vector and full-text search

The LSM vector and FTS planners ignored a user `WHERE` predicate, so a filtered LSM search silently returned rows the same query without the filter would exclude (only the plain LSM scan honored filters).

Both planners now take a prefilter via `with_filter(Option<Expr>)`, applied per source:

- Base / flushed arms reuse the dataset scanner's native prefilter.
- Active / frozen memtable arms apply the predicate before the per-source top-k: the brute-force vector exec masks rows in `compute_topk` (a filtered vector search routes to brute force rather than HNSW), and the FTS exec masks the materialized full-schema hits before projection.

True prefilter, not a lossy post-filter on the per-source top-k.

## 2. Scanner-aligned `LsmScanner` interface

`LsmScanner` now mirrors `lance::dataset::scanner::Scanner` so an LSM read reads like a normal scan: `nearest()` and `full_text_search()` are state setters and `create_plan()` dispatches to the vector / FTS / point-lookup / plain planner.

- Add `nearest`, `nprobes`, `refine`, `distance_metric` — vector search folds the `LsmVectorSearchPlanner` behind the builder and honors the builder filter.
- `full_text_search(FullTextSearchQuery)` is now a setter (column from the query, `k` from `limit`) instead of returning a plan.
- Align `project` (`<T: AsRef<str>>` + `Result`) and `limit` (`Option<i64>, Option<i64>` + `Result`) with `Scanner`.

Knobs the LSM planner cannot yet honor (`ef`, `distance_range`, `maximum_nprobes`, `with_row_id`) are intentionally not exposed rather than silently ignored.

New tests cover the filtered memtable vector path, a filtered FTS query spanning the base and active-memtable arms, and the `nearest()` / `full_text_search()` facade dispatch.

## Follow-up

A LanceDB change will pass the query filter to the planner, adopt the aligned `LsmScanner` (shrinking its hand-rolled LSM read path), and drop its temporary `NotSupported` rejection of filtered LSM vector / FTS reads.