### PR TITLE
fix(mem-wal): surface fenced flush to durability waiters instead of hanging

### DIFF
--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -43,6 +43,13 @@ pub const WRITER_EPOCH_KEY: &str = "writer_epoch";
 /// replay skips sentinels via their empty batch list).
 pub const FENCE_SENTINEL_KEY: &str = "fence_sentinel";
 
+/// True if `error` is the terminal fence emitted by `ManifestStore::check_fenced`
+/// (a successor claimed a higher epoch). Matches the message it formats, since
+/// fences surface as a plain `Error::io` rather than a typed variant.
+fn is_fence_error(error: &Error) -> bool {
+    error.to_string().contains("Writer fenced")
+}
+
 /// Watcher for batch durability using watermark-based tracking.
 ///
 /// Uses a shared watch channel that broadcasts the durable watermark.
@@ -53,22 +60,36 @@ pub struct BatchDurableWatcher {
     rx: watch::Receiver<usize>,
     /// Target batch ID to wait for.
     target_batch_position: usize,
+    /// Terminal flush failure (e.g. a fence) shared with the flusher. When
+    /// set, the watermark will never advance to the target, so `wait`
+    /// returns this error instead of blocking forever.
+    terminal_error: Arc<StdMutex<Option<String>>>,
 }
 
 impl BatchDurableWatcher {
     /// Create a new watcher for a specific batch ID.
-    pub fn new(rx: watch::Receiver<usize>, target_batch_position: usize) -> Self {
+    pub fn new(
+        rx: watch::Receiver<usize>,
+        target_batch_position: usize,
+        terminal_error: Arc<StdMutex<Option<String>>>,
+    ) -> Self {
         Self {
             rx,
             target_batch_position,
+            terminal_error,
         }
     }
 
     /// Wait until the batch is durable.
     ///
-    /// Returns Ok(()) when `durable_watermark >= target_batch_position`.
+    /// Returns Ok(()) when `durable_watermark >= target_batch_position`, or
+    /// Err if a terminal flush failure (e.g. a fence) means the watermark can
+    /// never reach the target.
     pub async fn wait(&mut self) -> Result<()> {
         loop {
+            if let Some(msg) = self.terminal_error.lock().unwrap().clone() {
+                return Err(Error::io(msg));
+            }
             let current = *self.rx.borrow();
             if current >= self.target_batch_position {
                 return Ok(());
@@ -317,6 +338,11 @@ pub struct WalFlusher {
     /// Created at construction and recreated after each flush.
     /// Used by backpressure to wait for WAL flushes.
     wal_flush_cell: std::sync::Mutex<Option<WatchableOnceCell<super::write::DurabilityResult>>>,
+    /// First terminal flush failure (a fence). Shared with every
+    /// `BatchDurableWatcher` so a fenced flush — which never advances the
+    /// watermark — wakes durability waiters with the error instead of
+    /// hanging them forever.
+    terminal_error: Arc<StdMutex<Option<String>>>,
 }
 
 impl WalFlusher {
@@ -338,6 +364,7 @@ impl WalFlusher {
             shard_id,
             flush_tx: None,
             wal_flush_cell: std::sync::Mutex::new(Some(wal_flush_cell)),
+            terminal_error: Arc::new(StdMutex::new(None)),
         }
     }
 
@@ -358,7 +385,27 @@ impl WalFlusher {
     pub fn track_batch(&self, batch_position: usize) -> BatchDurableWatcher {
         // Return a watcher that waits for this batch to become durable
         // batch_position is 0-indexed, so we wait for watermark > batch_position (i.e., >= batch_position + 1)
-        BatchDurableWatcher::new(self.durable_watermark_rx.clone(), batch_position + 1)
+        BatchDurableWatcher::new(
+            self.durable_watermark_rx.clone(),
+            batch_position + 1,
+            Arc::clone(&self.terminal_error),
+        )
+    }
+
+    /// Record a terminal flush failure (a fence) and wake every pending
+    /// durability waiter. A fence is permanent — the watermark will never
+    /// advance — so waiters must observe the error rather than block forever.
+    /// Idempotent: only the first failure is retained.
+    fn mark_terminal_failure(&self, error: &Error) {
+        {
+            let mut slot = self.terminal_error.lock().unwrap();
+            if slot.is_none() {
+                *slot = Some(error.to_string());
+            }
+        }
+        // Wake `wait`ers without advancing the watermark; each re-checks
+        // `terminal_error` and returns the error.
+        self.durable_watermark_tx.send_modify(|_| {});
     }
 
     /// Get the current durable watermark.
@@ -431,7 +478,7 @@ impl WalFlusher {
         source: &WalFlushSource,
         end_batch_position: usize,
     ) -> Result<WalFlushResult> {
-        match source {
+        let result = match source {
             WalFlushSource::BatchStore {
                 batch_store,
                 indexes,
@@ -440,7 +487,16 @@ impl WalFlusher {
                     .await
             }
             WalFlushSource::WalOnly { state } => self.flush_from_wal_only(state).await,
+        };
+        // A fence is terminal: the append will never succeed, so the
+        // durability watermark can never advance. Wake any waiter (e.g. a
+        // `durable_write` put) with the fence error instead of hanging it.
+        if let Err(e) = &result
+            && is_fence_error(e)
+        {
+            self.mark_terminal_failure(e);
         }
+        result
     }
 
     async fn flush_from_batch_store(
@@ -1698,6 +1754,64 @@ mod tests {
         // Successor's own writes land after the sentinel (position 3).
         let res = second.append(vec![batch]).await.unwrap();
         assert_eq!(res.entry_position, 3);
+    }
+
+    // Regression: a fenced WAL flush never advances the durability watermark.
+    // A `durable_write` put waits on a `BatchDurableWatcher`, so without
+    // terminal-failure propagation the watcher blocks forever (the predecessor
+    // pod's HTTP write hangs until the client times out). The flusher must
+    // surface the fence through the watcher so the caller fails fast with 410.
+    #[tokio::test]
+    async fn test_durable_watcher_aborts_on_fence_instead_of_hanging() {
+        let (store, base_path, _temp_dir) = create_local_store().await;
+        let shard_id = Uuid::new_v4();
+        let schema = create_test_schema();
+
+        // Predecessor claims epoch 1 and writes one entry (position 1), seeding
+        // its cached next position at 2. The flusher shares this appender.
+        let first = Arc::new(
+            WalAppender::open(store.clone(), base_path.clone(), shard_id, 0)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(first.writer_epoch(), 1);
+        first
+            .append(vec![create_test_batch(&schema, 1)])
+            .await
+            .unwrap();
+        let flusher = WalFlusher::new(Arc::clone(&first));
+
+        // Successor claims epoch 2 and drops a sentinel at the predecessor's
+        // next slot (position 2) — a rolling-restart pod replacement.
+        let second = WalAppender::open(store.clone(), base_path.clone(), shard_id, 0)
+            .await
+            .unwrap();
+        assert_eq!(second.writer_epoch(), 2);
+        assert_eq!(second.write_fence_sentinel().await.unwrap(), 2);
+
+        // A durable put on the predecessor: stage a batch and track it.
+        let batch_store = Arc::new(BatchStore::with_capacity(10));
+        batch_store.append(create_test_batch(&schema, 1)).unwrap();
+        let mut watcher = flusher.track_batch(0);
+
+        // Flushing collides with the sentinel and fences. Both the flush result
+        // and the watcher must report the fence — and the watcher must resolve
+        // promptly, not block on a watermark that can never advance.
+        let source = batch_store_source(&batch_store);
+        let flush_err = flusher.flush(&source, batch_store.len()).await.unwrap_err();
+        assert!(
+            is_fence_error(&flush_err),
+            "expected fence error from flush, got: {flush_err}"
+        );
+
+        let waited = tokio::time::timeout(std::time::Duration::from_secs(5), watcher.wait()).await;
+        let err = waited
+            .expect("watcher.wait() hung after a fenced flush")
+            .expect_err("watcher must surface the fence, not report success");
+        assert!(
+            is_fence_error(&err),
+            "watcher must report the fence so the HTTP layer maps 410, got: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

A `durable_write` put waits on a `BatchDurableWatcher`, which only resolves when the durability watermark reaches its target batch position. The watermark is advanced **exclusively on a successful** WAL flush (`flush_from_batch_store`).

When a flush fails terminally — a successor has claimed a higher epoch and fenced this writer — the append returns `Err` before the watermark advances, the background dispatcher logs and swallows the error (by design, so a transient flush failure doesn't deadlock puts), and the watch channel is never closed. The watcher's `wait()` therefore **loops forever**: the watermark can never reach the target and the channel never closes. The put hangs until the client times out.

This became reachable with the fence-on-claim sentinel (#7110): a fenced predecessor's next flush now collides with the sentinel and fails, where it previously false-acked into an empty slot and advanced the watermark. Surfaced downstream as a WAL server's `merge_insert` HTTP handler hanging (client `operation timed out`) after a rolling-restart pod replacement, instead of returning a terminal verdict.

## Fix

Share a terminal-error slot between `WalFlusher` and every `BatchDurableWatcher` it hands out. On a fence error, `flush` records the error and wakes all waiters (via `send_modify`, without advancing the watermark); `wait()` re-checks the slot and returns the fence error. A fence is permanent, so failing fast is correct — and the error text is preserved so callers can map it to a terminal verdict (e.g. HTTP 410).

Only fences poison the slot; transient flush failures keep the existing log-and-retry-on-next-flush behavior.

## Test

`test_durable_watcher_aborts_on_fence_instead_of_hanging`: a predecessor's durable flush collides with a successor's fence sentinel; the watcher resolves with the fence error under a timeout rather than blocking forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)