### PR TITLE
feat(index): accelerate regex and infix LIKE with the ngram index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4906,6 +4906,7 @@ dependencies = [
  "rand_distr",
  "rangemap",
  "rayon",
+ "regex-syntax",
  "roaring",
  "rstest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,7 @@ rand_distr = { version = "0.5.1" }
 rand_xoshiro = "0.7.0"
 rangemap = { version = "1.0" }
 rayon = "1.10"
+regex-syntax = "0.8.10"
 roaring = "0.11.4"
 rstest = "0.26.1"
 serde = { version = "^1" }

--- a/docs/src/format/index/scalar/ngram.md
+++ b/docs/src/format/index/scalar/ngram.md
@@ -30,3 +30,9 @@ The N-gram index provides inexact results for the following query types:
 | Query Type     | Description              | Operation                                             | Result Type |
 |----------------|--------------------------|-------------------------------------------------------|-------------|
 | **contains**   | Substring search in text | Finds all trigrams in query, intersects posting lists | AtMost      |
+| **regexp_like** / **regexp_match** | Regular-expression match | Derives a necessary trigram condition from the pattern (AND of intersections, OR of unions), then rechecks the true regex | AtMost |
+| **LIKE** (infix) | Wildcard match such as `%foo%bar%` | Uses the literal segments of the pattern as a trigram condition, then rechecks the LIKE | AtMost |
+
+Patterns from which no trigram can be derived - for example `a.b`, `.*`,
+case-insensitive matches, or literal runs shorter than three characters - fall
+back to rechecking every row. This is always correct, just not accelerated.

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4472,6 +4472,7 @@ dependencies = [
  "rand_distr",
  "rangemap",
  "rayon",
+ "regex-syntax",
  "roaring",
  "serde",
  "serde_json",

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -56,6 +56,7 @@ object_store.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 rand.workspace = true
+regex-syntax.workspace = true
 roaring.workspace = true
 rayon.workspace = true
 serde_json.workspace = true

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -8,6 +8,7 @@ use arrow_array::{BooleanArray, ListArray, RecordBatch, UInt64Array};
 use arrow_schema::{Field, Schema};
 use async_trait::async_trait;
 use bytes::Bytes;
+use datafusion::functions::regex::regexplike::RegexpLikeFunc;
 use datafusion::functions::string::contains::ContainsFunc;
 use datafusion::functions_nested::array_has;
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -633,9 +634,15 @@ impl AnyQuery for LabelListQuery {
 pub enum TextQuery {
     /// Retrieve all row ids where the text contains the given string
     StringContains(String),
-    // TODO: In the future we should be able to do string-insensitive contains
-    // as well as partial matches (e.g. LIKE 'foo%') and potentially even
-    // some regular expressions
+    /// Retrieve all row ids whose text matches the given regular expression.
+    ///
+    /// The pattern is a full regular expression (as accepted by `regexp_like`).
+    /// The index returns a candidate superset that the scan rechecks, so any
+    /// pattern is sound; patterns with no usable trigram structure simply fall
+    /// back to rechecking every row.
+    Regex(String),
+    // TODO: In the future we should be able to do case-insensitive contains
+    // as well as partial matches (e.g. LIKE 'foo%').
 }
 
 impl AnyQuery for TextQuery {
@@ -654,6 +661,17 @@ impl AnyQuery for TextQuery {
                 args: vec![
                     Expr::Column(Column::new_unqualified(col)),
                     Expr::Literal(ScalarValue::Utf8(Some(substr.clone())), None),
+                ],
+            }),
+            // `regexp_like` returns Boolean directly, so the reconstructed
+            // expression can be used as-is for the recheck filter (no IsNotNull
+            // wrapper, unlike `regexp_match`). It is the semantic equivalent of
+            // the original predicate for the "does it match" question.
+            Self::Regex(pattern) => Expr::ScalarFunction(ScalarFunction {
+                func: Arc::new(RegexpLikeFunc::new().into()),
+                args: vec![
+                    Expr::Column(Column::new_unqualified(col)),
+                    Expr::Literal(ScalarValue::Utf8(Some(pattern.clone())), None),
                 ],
             }),
         }

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -781,20 +781,28 @@ impl ScalarQueryParser for LabelListQueryParser {
     }
 }
 
-/// A parser for indices that handle string contains queries
+/// A parser for indices that handle string `contains` queries, and -- when
+/// `supports_regex` is set -- `regexp_like` / `regexp_match` queries.
 #[derive(Debug, Clone)]
 pub struct TextQueryParser {
     index_name: String,
     index_type: String,
     needs_recheck: bool,
+    supports_regex: bool,
 }
 
 impl TextQueryParser {
-    pub fn new(index_name: String, index_type: String, needs_recheck: bool) -> Self {
+    pub fn new(
+        index_name: String,
+        index_type: String,
+        needs_recheck: bool,
+        supports_regex: bool,
+    ) -> Self {
         Self {
             index_name,
             index_type,
             needs_recheck,
+            supports_regex,
         }
     }
 }
@@ -837,30 +845,155 @@ impl ScalarQueryParser for TextQueryParser {
         func: &ScalarUDF,
         args: &[Expr],
     ) -> Option<IndexedExpression> {
-        if args.len() != 2 {
+        // The first argument is the indexed column; the second is the substring
+        // / pattern. `contains` takes exactly two arguments; the regex functions
+        // optionally take a third flags argument.
+        if args.len() < 2 {
             return None;
         }
-        let scalar = maybe_scalar(&args[1], data_type)?;
-        match scalar {
-            ScalarValue::Utf8(Some(scalar_str)) | ScalarValue::LargeUtf8(Some(scalar_str)) => {
-                if func.name() == "contains" {
-                    let query = TextQuery::StringContains(scalar_str);
-                    Some(IndexedExpression::index_query_with_recheck(
-                        column.to_string(),
-                        self.index_name.clone(),
-                        self.index_type.clone(),
-                        Arc::new(query),
-                        self.needs_recheck,
-                    ))
-                } else {
+        // A non-string pattern cannot be handled.
+        let (ScalarValue::Utf8(Some(pattern)) | ScalarValue::LargeUtf8(Some(pattern))) =
+            maybe_scalar(&args[1], data_type)?
+        else {
+            return None;
+        };
+
+        let query = match func.name() {
+            "contains" if args.len() == 2 => TextQuery::StringContains(pattern),
+            "regexp_like" | "regexp_match" if self.supports_regex => {
+                let pattern = match args.get(2) {
+                    Some(flags_expr) => apply_regex_flags(&pattern, flags_expr)?,
+                    None => pattern,
+                };
+                // If the pattern yields no usable trigram (e.g. `a.b`), leave it
+                // to a full scan instead of routing it to the index, which could
+                // only answer with an unsupported "recheck everything" result.
+                if !crate::scalar::ngram::regex_can_use_index(&pattern) {
+                    return None;
+                }
+                TextQuery::Regex(pattern)
+            }
+            _ => return None,
+        };
+
+        Some(IndexedExpression::index_query_with_recheck(
+            column.to_string(),
+            self.index_name.clone(),
+            self.index_type.clone(),
+            Arc::new(query),
+            self.needs_recheck,
+        ))
+    }
+
+    fn visit_like(
+        &self,
+        column: &str,
+        like: &Like,
+        pattern: &ScalarValue,
+    ) -> Option<IndexedExpression> {
+        // Infix LIKE is accelerated only by the ngram index (via its regex
+        // machinery). A plain-literal `regexp_like(col, 'foo')` is rewritten to
+        // `col LIKE '%foo%'` before it reaches the index, so this is the path
+        // that accelerates those. ILIKE is skipped because its case folding does
+        // not match the index's normalization.
+        if !self.supports_regex || like.case_insensitive {
+            return None;
+        }
+        let pattern_str = match pattern {
+            ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)) => s.as_str(),
+            _ => return None,
+        };
+        // Translate the LIKE pattern into a loose regex used only for candidate
+        // generation; the original LIKE stays as the recheck filter, so the
+        // regex only needs to be a sound superset.
+        let regex = like_to_regex(pattern_str, like.escape_char)?;
+        if !crate::scalar::ngram::regex_can_use_index(&regex) {
+            return None;
+        }
+        Some(IndexedExpression {
+            scalar_query: Some(ScalarIndexExpr::Query(ScalarIndexSearch {
+                column: column.to_string(),
+                index_name: self.index_name.clone(),
+                index_type: self.index_type.clone(),
+                query: Arc::new(TextQuery::Regex(regex)),
+                needs_recheck: self.needs_recheck,
+                fragment_bitmap: None,
+            })),
+            refine_expr: Some(Expr::Like(like.clone())),
+        })
+    }
+}
+
+/// Translate a LIKE pattern into a regular expression used purely for ngram
+/// candidate generation: `%` becomes `.*`, `_` becomes `.`, and literal
+/// characters are regex-escaped. Returns `None` when no literal run is long
+/// enough to yield a trigram (the index could not help, so a full scan is left
+/// to handle it).
+fn like_to_regex(pattern: &str, escape: Option<char>) -> Option<String> {
+    let mut regex = String::new();
+    let mut run = 0usize;
+    let mut longest_run = 0usize;
+    let mut chars = pattern.chars();
+    while let Some(c) = chars.next() {
+        let literal = if Some(c) == escape {
+            // The next character is escaped, i.e. a literal.
+            chars.next()
+        } else {
+            match c {
+                '%' => {
+                    regex.push_str(".*");
+                    run = 0;
                     None
                 }
+                '_' => {
+                    regex.push('.');
+                    run = 0;
+                    None
+                }
+                other => Some(other),
             }
-            _ => {
-                // If the scalar is not a string, we cannot handle it
-                None
+        };
+        if let Some(lit) = literal {
+            if regex_syntax::is_meta_character(lit) {
+                regex.push('\\');
+            }
+            regex.push(lit);
+            // Only runs of alphanumeric characters can produce a trigram.
+            if lit.is_alphanumeric() {
+                run += 1;
+                longest_run = longest_run.max(run);
+            } else {
+                run = 0;
             }
         }
+    }
+    (longest_run >= 3).then_some(regex)
+}
+
+/// Fold the supported `regexp_like` / `regexp_match` flags into an inline prefix
+/// on the pattern (e.g. flags `"i"` -> `"(?i)pattern"`). Returns `None` for a
+/// non-literal flags argument or an unrecognized flag, so the caller leaves the
+/// predicate to a full recheck rather than risk changing its semantics.
+fn apply_regex_flags(pattern: &str, flags_expr: &Expr) -> Option<String> {
+    let (Expr::Literal(ScalarValue::Utf8(Some(flags)), _)
+    | Expr::Literal(ScalarValue::LargeUtf8(Some(flags)), _)) = flags_expr
+    else {
+        return None;
+    };
+    let mut inline = String::new();
+    for flag in flags.chars() {
+        // Only flags expressible as an inline `(?...)` group in the regex crate
+        // (which the recheck uses) are safe to fold.
+        if ['i', 's', 'm', 'x'].contains(&flag) {
+            inline.push(flag);
+        } else {
+            return None;
+        }
+    }
+    if inline.is_empty() {
+        Some(pattern.to_string())
+    } else {
+        Some(format!("(?{inline}){pattern}"))
     }
 }
 
@@ -1813,7 +1946,18 @@ fn visit_node(
         Expr::IsFalse(expr) => Ok(visit_is_bool(expr.as_ref(), index_info, false)),
         Expr::IsTrue(expr) => Ok(visit_is_bool(expr.as_ref(), index_info, true)),
         Expr::IsNull(expr) => Ok(visit_is_null(expr.as_ref(), index_info, false)),
-        Expr::IsNotNull(expr) => Ok(visit_is_null(expr.as_ref(), index_info, true)),
+        Expr::IsNotNull(expr) => {
+            // `regexp_match(col, pat)` returns a list and is coerced to
+            // `IsNotNull(regexp_match(...))` before it reaches here. Unwrap that
+            // so the regex acceleration applies; everything else is a genuine
+            // IS NOT NULL check.
+            if let Expr::ScalarFunction(scalar_fn) = expr.as_ref()
+                && scalar_fn.func.name() == "regexp_match"
+            {
+                return Ok(visit_scalar_fn(scalar_fn, index_info));
+            }
+            Ok(visit_is_null(expr.as_ref(), index_info, true))
+        }
         Expr::Not(expr) => visit_not(expr.as_ref(), index_info, depth),
         Expr::BinaryExpr(binary_expr) => visit_binary_expr(binary_expr, index_info, depth),
         Expr::ScalarFunction(scalar_fn) => Ok(visit_scalar_fn(scalar_fn, index_info)),
@@ -2688,6 +2832,59 @@ mod tests {
         // !{l, u} = {!u, !l}. AllowList → BlockList.
         assert!(matches!(negated.lower, NullableRowAddrMask::BlockList(_)));
         assert!(matches!(negated.upper, NullableRowAddrMask::BlockList(_)));
+    }
+
+    #[test]
+    fn test_like_to_regex() {
+        // `%` -> `.*`, `_` -> `.`, with a literal run of at least three chars.
+        assert_eq!(like_to_regex("%foo%", None).as_deref(), Some(".*foo.*"));
+        assert_eq!(like_to_regex("foo%bar", None).as_deref(), Some("foo.*bar"));
+        assert_eq!(like_to_regex("foo_bar", None).as_deref(), Some("foo.bar"));
+        assert_eq!(like_to_regex("foobar", None).as_deref(), Some("foobar"));
+
+        // Regex metacharacters in the literal portion are escaped.
+        assert_eq!(
+            like_to_regex("%a.bcd%", None).as_deref(),
+            Some(".*a\\.bcd.*")
+        );
+
+        // No literal run of three alphanumeric characters -> no index help.
+        assert_eq!(like_to_regex("%ab%", None), None);
+        assert_eq!(like_to_regex("%a%b%c%", None), None);
+        assert_eq!(like_to_regex("%", None), None);
+
+        // The escape character makes the following character a literal.
+        assert_eq!(
+            like_to_regex(r"%foo\%bar%", Some('\\')).as_deref(),
+            Some(".*foo%bar.*")
+        );
+    }
+
+    #[test]
+    fn test_apply_regex_flags() {
+        fn flags(s: &str) -> Expr {
+            Expr::Literal(ScalarValue::Utf8(Some(s.to_string())), None)
+        }
+
+        // Empty flags leave the pattern untouched (no inline group emitted).
+        assert_eq!(apply_regex_flags("foo", &flags("")).as_deref(), Some("foo"));
+        // Supported flags are folded into an inline `(?...)` prefix.
+        assert_eq!(
+            apply_regex_flags("foo", &flags("i")).as_deref(),
+            Some("(?i)foo")
+        );
+        assert_eq!(
+            apply_regex_flags("foo", &flags("is")).as_deref(),
+            Some("(?is)foo")
+        );
+        // An unrecognized flag bails out so the caller leaves the predicate to a
+        // full recheck rather than risk changing its semantics.
+        assert_eq!(apply_regex_flags("foo", &flags("g")), None);
+        // A non-string (hence non-literal-flags) argument cannot be folded.
+        assert_eq!(
+            apply_regex_flags("foo", &Expr::Literal(ScalarValue::Int32(Some(1)), None)),
+            None
+        );
     }
 
     #[test]

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -1352,6 +1352,12 @@ impl ScalarIndex for FMIndexScalarIndex {
                     Default::default(),
                 )))
             }
+            // Regex queries are routed only to the ngram index (the FM-index's
+            // query parser advertises `supports_regex = false`), so this is
+            // unreachable in practice; reject it explicitly rather than silently.
+            TextQuery::Regex(_) => Err(Error::invalid_input(
+                "FMIndex does not support regular expression queries",
+            )),
         }
     }
     fn can_remap(&self) -> bool {
@@ -1645,6 +1651,9 @@ impl ScalarIndexPlugin for FMIndexPlugin {
         Some(Box::new(TextQueryParser::new(
             index_name,
             self.name().to_string(),
+            // needs_recheck: the FM-index returns exact substring matches.
+            false,
+            // supports_regex: regex acceleration is only implemented for ngram.
             false,
         )))
     }

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -5,7 +5,10 @@ use std::any::Any;
 use std::collections::BTreeMap;
 use std::iter::once;
 use std::time::Instant;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use super::lance_format::LanceIndexStore;
 use super::{
@@ -48,6 +51,9 @@ use log::info;
 use roaring::{RoaringBitmap, RoaringTreemap};
 use serde::Serialize;
 use tracing::instrument;
+
+mod ngram_regex;
+pub(crate) use ngram_regex::regex_can_use_index;
 
 const TOKENS_COL: &str = "tokens";
 const POSTING_LIST_COL: &str = "posting_list";
@@ -475,6 +481,45 @@ impl ScalarIndex for NGramIndex {
                 let list_refs = posting_lists.iter().map(|list| list.as_ref());
                 let row_ids = NGramPostingList::intersect(list_refs);
                 Ok(SearchResult::at_most(RowAddrTreeMap::from(row_ids)))
+            }
+            TextQuery::Regex(pattern) => {
+                let trigram_query = ngram_regex::regex_to_trigram_query(pattern);
+                match &trigram_query {
+                    // No usable trigram structure (e.g. `a.b`, `.*`): the index
+                    // cannot prune, so every row must be rechecked.
+                    ngram_regex::TrigramQuery::All => {
+                        Ok(SearchResult::at_least(RowAddrTreeMap::new()))
+                    }
+                    // The pattern is provably unsatisfiable.
+                    ngram_regex::TrigramQuery::None => {
+                        Ok(SearchResult::exact(RowAddrTreeMap::new()))
+                    }
+                    _ => {
+                        let mut tokens = HashSet::new();
+                        ngram_regex::collect_tokens(&trigram_query, &mut tokens);
+                        // Fetch the posting list for every trigram the condition
+                        // references; a token absent from the index contributes
+                        // an empty list, which `eval_trigram_query` handles.
+                        let present = tokens.into_iter().filter_map(|token| {
+                            self.tokens.get(&token).map(|offset| (token, *offset))
+                        });
+                        let lists = futures::stream::iter(present.map(|(token, offset)| {
+                            self.list_reader
+                                .ngram_list(offset, metrics)
+                                .map(move |result| result.map(|list| (token, list)))
+                        }))
+                        .buffer_unordered(self.io_parallelism)
+                        .try_collect::<Vec<(u32, Arc<NGramPostingList>)>>()
+                        .await?;
+                        metrics.record_comparisons(lists.len());
+                        let bitmaps: HashMap<u32, RoaringTreemap> = lists
+                            .into_iter()
+                            .map(|(token, list)| (token, list.bitmap.clone()))
+                            .collect();
+                        let row_ids = ngram_regex::eval_trigram_query(&trigram_query, &bitmaps);
+                        Ok(SearchResult::at_most(RowAddrTreeMap::from(row_ids)))
+                    }
+                }
             }
         }
     }
@@ -1279,6 +1324,9 @@ impl ScalarIndexPlugin for NGramIndexPlugin {
         Some(Box::new(TextQueryParser::new(
             index_name,
             self.name().to_string(),
+            // needs_recheck: ngram results are an inexact candidate superset.
+            true,
+            // supports_regex: the ngram index can answer regex queries.
             true,
         )))
     }
@@ -1536,6 +1584,107 @@ mod tests {
             .unwrap();
         let expected = SearchResult::at_most(RowAddrTreeMap::from_iter([8]));
         assert_eq!(expected, res);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_ngram_regex_search() {
+        // Same corpus as test_basic_ngram_index.
+        let data = StringArray::from_iter_values([
+            "cat",         // 0
+            "dog",         // 1
+            "cat dog",     // 2
+            "dog cat",     // 3
+            "elephant",    // 4
+            "mouse",       // 5
+            "rhino",       // 6
+            "giraffe",     // 7
+            "rhinos nose", // 8
+        ]);
+        let row_ids = UInt64Array::from_iter_values((0..data.len()).map(|i| i as u64));
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(VALUE_COLUMN_NAME, DataType::Utf8, false),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+        let data =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(data), Arc::new(row_ids)]).unwrap();
+        let data = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::once(std::future::ready(Ok(data))),
+        ));
+
+        let builder = NGramIndexBuilder::try_new(NGramIndexBuilderOptions::default()).unwrap();
+        let (index, _tmpdir) = do_train(builder, data).await;
+
+        async fn search(index: &NGramIndex, pattern: &str) -> SearchResult {
+            index
+                .search(
+                    &TextQuery::Regex(pattern.to_string()),
+                    &NoOpMetricsCollector,
+                )
+                .await
+                .unwrap()
+        }
+
+        // A plain literal yields the same candidates as contains("cat").
+        assert_eq!(
+            search(&index, "cat").await,
+            SearchResult::at_most(RowAddrTreeMap::from_iter([0, 2, 3]))
+        );
+
+        // Alternation -> union of each branch's rows.
+        assert_eq!(
+            search(&index, "(cat|dog)").await,
+            SearchResult::at_most(RowAddrTreeMap::from_iter([0, 1, 2, 3]))
+        );
+
+        // AND across `.*`: must contain both the `rhino` and `nose` trigrams, so
+        // row 6 ("rhino") is correctly excluded and only row 8 survives.
+        assert_eq!(
+            search(&index, "rhino.*nose").await,
+            SearchResult::at_most(RowAddrTreeMap::from_iter([8]))
+        );
+
+        // No derivable trigram -> recheck everything.
+        assert_eq!(
+            search(&index, "a.b").await,
+            SearchResult::at_least(RowAddrTreeMap::new())
+        );
+
+        // A trigram that is absent from the index -> empty candidate set.
+        assert_eq!(
+            search(&index, "zzz").await,
+            SearchResult::at_most(RowAddrTreeMap::new())
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_ngram_regex_search_nulls() {
+        // Rows: cat(0), dog(1), NULL(2), NULL(3), cat dog(4).
+        let data = simple_data_with_nulls();
+        let builder = NGramIndexBuilder::try_new(NGramIndexBuilderOptions::default()).unwrap();
+        let (index, _tmpdir) = do_train(builder, data).await;
+
+        // The NULL rows (2, 3) must never appear in the candidate set.
+        let res = index
+            .search(&TextQuery::Regex("cat".to_string()), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert_eq!(
+            res,
+            SearchResult::at_most(RowAddrTreeMap::from_iter([0, 4]))
+        );
+
+        let res = index
+            .search(
+                &TextQuery::Regex("(cat|dog)".to_string()),
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            res,
+            SearchResult::at_most(RowAddrTreeMap::from_iter([0, 1, 4]))
+        );
     }
 
     fn test_data_schema() -> Arc<Schema> {

--- a/rust/lance-index/src/scalar/ngram/ngram_regex.rs
+++ b/rust/lance-index/src/scalar/ngram/ngram_regex.rs
@@ -1,0 +1,673 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Deriving a trigram pre-filter from a regular expression.
+//!
+//! This is the query-side counterpart of the ngram index that lets us
+//! accelerate `regexp_like` / `regexp_match` predicates the same way the index
+//! already accelerates `contains`. The idea (the same one Postgres `pg_trgm`
+//! and Russ Cox's Google Code Search use) is to derive, from the regex, a
+//! boolean condition over trigram presence that is *necessary* for any string
+//! to match, evaluate it against the inverted index, and let the scan recheck
+//! the true regex on the surviving rows.
+//!
+//! The derived condition is a [`TrigramQuery`] -- an AND/OR tree of trigram
+//! tokens. `AND` maps onto posting-list intersection and `OR` onto union, which
+//! is exactly the set algebra the ngram index is built for.
+//!
+//! # Soundness
+//!
+//! The single invariant that matters is that the condition must never require a
+//! trigram that a matching string could lack -- otherwise we would drop real
+//! matches (a false negative, far worse than a false positive, which the recheck
+//! removes). Everything here is therefore a conservative *over*-approximation:
+//! when in doubt we emit [`TrigramQuery::All`] ("no constraint, recheck
+//! everything"). Concretely:
+//!
+//! * Every trigram requirement is produced by [`trigrams_of_string`], which runs
+//!   the *same* tokenizer the index was built with, so a string shorter than a
+//!   trigram (or with no alphanumeric run) contributes no requirement.
+//! * Character classes and case-insensitive folds are treated as a single
+//!   unknown character (`All`), because the index's normalization does not agree
+//!   with Unicode case folding (e.g. `(?i)c` also matches `ℂ`, which the index
+//!   does not fold to `c`). Literal runs -- the common case -- are fully used.
+//! * When the exact / prefix / suffix string sets grow past a bound we first fold
+//!   their trigrams into the running condition and only then drop the strings, so
+//!   collapsing precision never removes a necessary trigram.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+use regex_syntax::hir::{Class, Hir, HirKind};
+use roaring::RoaringTreemap;
+
+use super::{NGRAM_N, NGRAM_TOKENIZER, ngram_to_token, tokenize_visitor};
+
+/// Maximum number of strings kept in an `exact` / `prefix` / `suffix` set before
+/// it is folded into the trigram condition and dropped.
+const MAX_SET_SIZE: usize = 16;
+/// Maximum length (in characters) of a string kept in a set. Longer strings are
+/// trimmed to a sound shorter affix.
+const MAX_STRING_LEN: usize = 32;
+
+/// A boolean condition over trigram presence that is *necessary* for a regex to
+/// match. `All` means "no constraint" and `None` means "unsatisfiable"; by
+/// construction these only ever appear at the root of the tree.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TrigramQuery {
+    /// No constraint: every row is a candidate (the scan must recheck all rows).
+    All,
+    /// Unsatisfiable: no row can match.
+    None,
+    /// The given trigram token must be present.
+    Trigram(u32),
+    /// Every child condition must hold (posting-list intersection).
+    And(Vec<Self>),
+    /// At least one child condition must hold (posting-list union).
+    Or(Vec<Self>),
+}
+
+impl TrigramQuery {
+    /// Build an `AND` of conditions, applying identity (`All`), absorbing
+    /// (`None`), flattening, sorting and de-duplication so the result is
+    /// canonical and free of nested `All`/`None`.
+    fn and(items: Vec<Self>) -> Self {
+        let mut flat = Vec::with_capacity(items.len());
+        for item in items {
+            match item {
+                Self::All => {}                               // identity
+                Self::None => return Self::None,              // absorbing
+                Self::And(children) => flat.extend(children), // flatten
+                other => flat.push(other),
+            }
+        }
+        flat.sort();
+        flat.dedup();
+        match flat.len() {
+            0 => Self::All,
+            1 => flat.pop().unwrap(),
+            _ => Self::And(flat),
+        }
+    }
+
+    /// Build an `OR` of conditions, applying absorbing (`All`), identity
+    /// (`None`), flattening, sorting and de-duplication.
+    fn or(items: Vec<Self>) -> Self {
+        let mut flat = Vec::with_capacity(items.len());
+        for item in items {
+            match item {
+                Self::All => return Self::All,               // absorbing
+                Self::None => {}                             // identity
+                Self::Or(children) => flat.extend(children), // flatten
+                other => flat.push(other),
+            }
+        }
+        flat.sort();
+        flat.dedup();
+        match flat.len() {
+            0 => Self::None,
+            1 => flat.pop().unwrap(),
+            _ => Self::Or(flat),
+        }
+    }
+}
+
+/// Information about the set of strings a sub-expression can match, used to
+/// build a necessary trigram condition bottom-up. For every string `s` the
+/// sub-expression matches: `s` is in `exact` (when it is `Some`), `s` starts
+/// with some member of `prefix` and ends with some member of `suffix`, and `s`
+/// satisfies `match_q`.
+struct RegexInfo {
+    /// Whether the sub-expression can match the empty string.
+    emptyable: bool,
+    /// The complete set of strings the sub-expression matches, or `None` if that
+    /// set is unbounded / unknown.
+    exact: Option<BTreeSet<String>>,
+    /// Strings that every match must start with (empty = unknown).
+    prefix: BTreeSet<String>,
+    /// Strings that every match must end with (empty = unknown).
+    suffix: BTreeSet<String>,
+    /// A necessary trigram condition for the sub-expression.
+    match_q: TrigramQuery,
+}
+
+impl RegexInfo {
+    /// The empty string (also used for zero-width anchors): matches only `""`.
+    fn empty_string() -> Self {
+        let empty = BTreeSet::from([String::new()]);
+        Self {
+            emptyable: true,
+            exact: Some(empty.clone()),
+            prefix: empty.clone(),
+            suffix: empty,
+            match_q: TrigramQuery::All,
+        }
+    }
+
+    /// A fixed literal string.
+    fn literal(s: &str) -> Self {
+        let set = BTreeSet::from([s.to_string()]);
+        Self {
+            emptyable: s.is_empty(),
+            exact: Some(set.clone()),
+            prefix: set.clone(),
+            suffix: set,
+            match_q: trigrams_of_string(s),
+        }
+    }
+
+    /// A single unknown character (a character class we cannot pin down).
+    fn any_char() -> Self {
+        Self {
+            emptyable: false,
+            exact: None,
+            prefix: BTreeSet::new(),
+            suffix: BTreeSet::new(),
+            match_q: TrigramQuery::All,
+        }
+    }
+
+    /// Enforce the size/length bounds, folding any information about to be
+    /// discarded into `match_q` first so that precision loss never drops a
+    /// necessary trigram. Idempotent.
+    fn bound(&mut self) {
+        let oversized_exact = self.exact.as_ref().is_some_and(|exact| {
+            exact.len() > MAX_SET_SIZE || exact.iter().any(|s| s.chars().count() > MAX_STRING_LEN)
+        });
+        if oversized_exact {
+            let exact = self.exact.take().expect("checked above");
+            self.fold_into_match(&exact);
+        }
+
+        self.prefix = self
+            .prefix
+            .iter()
+            .map(|s| leading(s, MAX_STRING_LEN))
+            .collect();
+        if self.prefix.len() > MAX_SET_SIZE {
+            let prefix = std::mem::take(&mut self.prefix);
+            self.fold_into_match(&prefix);
+        }
+
+        self.suffix = self
+            .suffix
+            .iter()
+            .map(|s| trailing(s, MAX_STRING_LEN))
+            .collect();
+        if self.suffix.len() > MAX_SET_SIZE {
+            let suffix = std::mem::take(&mut self.suffix);
+            self.fold_into_match(&suffix);
+        }
+    }
+
+    /// AND the trigrams of `set` (a complete set of possible affixes/strings)
+    /// into `match_q`. Sound because the set is exhaustive for its role.
+    fn fold_into_match(&mut self, set: &BTreeSet<String>) {
+        let folded = trigrams_of_set(set.iter());
+        let current = std::mem::replace(&mut self.match_q, TrigramQuery::All);
+        self.match_q = TrigramQuery::and(vec![current, folded]);
+    }
+}
+
+/// AND together the trigrams of `s`. Reuses the index's own tokenizer so the
+/// tokens are normalized (lowercase, ASCII-folded, alphanumeric-bounded)
+/// exactly as they were stored. Returns `All` if `s` yields no trigram (too
+/// short, or no run of three alphanumeric characters).
+fn trigrams_of_string(s: &str) -> TrigramQuery {
+    let mut tokens = Vec::new();
+    tokenize_visitor(&NGRAM_TOKENIZER, s, |ngram| {
+        tokens.push(TrigramQuery::Trigram(ngram_to_token(ngram, NGRAM_N)));
+    });
+    TrigramQuery::and(tokens)
+}
+
+/// OR together the trigram conditions of each string in `set`. An empty set
+/// means "unknown" and yields `All` (no constraint); if any member yields `All`
+/// the whole OR is `All`.
+fn trigrams_of_set<'a>(set: impl IntoIterator<Item = &'a String>) -> TrigramQuery {
+    let queries: Vec<_> = set.into_iter().map(|s| trigrams_of_string(s)).collect();
+    if queries.is_empty() {
+        return TrigramQuery::All;
+    }
+    TrigramQuery::or(queries)
+}
+
+/// Concatenate every string in `a` with every string in `b`.
+fn cross_concat(a: &BTreeSet<String>, b: &BTreeSet<String>) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for x in a {
+        for y in b {
+            out.insert(format!("{x}{y}"));
+        }
+    }
+    out
+}
+
+/// The first `n` characters of `s` (a sound shorter prefix).
+fn leading(s: &str, n: usize) -> String {
+    s.chars().take(n).collect()
+}
+
+/// The last `n` characters of `s` (a sound shorter suffix).
+fn trailing(s: &str, n: usize) -> String {
+    let count = s.chars().count();
+    s.chars().skip(count.saturating_sub(n)).collect()
+}
+
+/// If `class` matches exactly one scalar value, return that character.
+fn singleton_char(class: &Class) -> Option<char> {
+    match class {
+        Class::Unicode(u) => {
+            let ranges = u.ranges();
+            match ranges {
+                [r] if r.start() == r.end() => Some(r.start()),
+                _ => None,
+            }
+        }
+        Class::Bytes(b) => {
+            let ranges = b.ranges();
+            match ranges {
+                [r] if r.start() == r.end() && r.start() < 0x80 => Some(r.start() as char),
+                _ => None,
+            }
+        }
+    }
+}
+
+/// Compute the [`RegexInfo`] for `hir` bottom-up.
+fn analyze(hir: &Hir) -> RegexInfo {
+    let mut info = match hir.kind() {
+        // Zero-width: the empty match. Anchors (^, $, \b) carry no trigram.
+        HirKind::Empty | HirKind::Look(_) => RegexInfo::empty_string(),
+        HirKind::Literal(lit) => match std::str::from_utf8(&lit.0) {
+            Ok(s) => RegexInfo::literal(s),
+            // A literal that is not valid UTF-8 cannot be reasoned about here.
+            Err(_) => RegexInfo::any_char(),
+        },
+        HirKind::Class(class) => match singleton_char(class) {
+            Some(ch) => RegexInfo::literal(ch.encode_utf8(&mut [0u8; 4])),
+            None => RegexInfo::any_char(),
+        },
+        HirKind::Repetition(rep) => {
+            let inner = analyze(&rep.sub);
+            let at_least_one = rep.min >= 1;
+            RegexInfo {
+                emptyable: !at_least_one || inner.emptyable,
+                // We do not unroll bounded repetitions, so the matched set is
+                // unbounded as far as we are concerned.
+                exact: None,
+                prefix: if at_least_one {
+                    inner.prefix.clone()
+                } else {
+                    BTreeSet::new()
+                },
+                suffix: if at_least_one {
+                    inner.suffix.clone()
+                } else {
+                    BTreeSet::new()
+                },
+                // Only a required occurrence (min >= 1) contributes; the single
+                // inner match is necessary, never multiplied.
+                match_q: if at_least_one {
+                    inner.match_q
+                } else {
+                    TrigramQuery::All
+                },
+            }
+        }
+        HirKind::Capture(cap) => analyze(&cap.sub),
+        HirKind::Concat(subs) => analyze_concat(subs),
+        HirKind::Alternation(subs) => analyze_alternation(subs),
+    };
+    info.bound();
+    info
+}
+
+fn analyze_concat(subs: &[Hir]) -> RegexInfo {
+    let mut acc = RegexInfo::empty_string();
+    for sub in subs {
+        acc = concat_info(acc, analyze(sub));
+    }
+    acc
+}
+
+/// Combine two adjacent sub-expressions. This is the subtle part: it recovers
+/// trigrams that straddle the junction via the cross product of `acc.suffix` and
+/// `next.prefix`.
+fn concat_info(acc: RegexInfo, next: RegexInfo) -> RegexInfo {
+    let emptyable = acc.emptyable && next.emptyable;
+
+    // Trigrams spanning the junction (computed from the pre-merge affixes).
+    let boundary = if acc.suffix.is_empty() || next.prefix.is_empty() {
+        TrigramQuery::All
+    } else {
+        trigrams_of_set(cross_concat(&acc.suffix, &next.prefix).iter())
+    };
+
+    // exact = acc.exact x next.exact, only while both are finite and small.
+    let exact = match (&acc.exact, &next.exact) {
+        (Some(a), Some(b)) if a.len().saturating_mul(b.len()) <= MAX_SET_SIZE => {
+            Some(cross_concat(a, b))
+        }
+        _ => None,
+    };
+
+    // A match starts with acc's full string (when known) then next's prefix,
+    // otherwise with acc's own prefix.
+    let prefix = match &acc.exact {
+        Some(a) if !next.prefix.is_empty() => cross_concat(a, &next.prefix),
+        Some(a) => a.clone(),
+        None => acc.prefix.clone(),
+    };
+
+    // Mirror image for the suffix (driven by the right side).
+    let suffix = match &next.exact {
+        Some(b) if !acc.suffix.is_empty() => cross_concat(&acc.suffix, b),
+        Some(b) => b.clone(),
+        None => next.suffix.clone(),
+    };
+
+    let match_q = TrigramQuery::and(vec![acc.match_q, next.match_q, boundary]);
+
+    let mut info = RegexInfo {
+        emptyable,
+        exact,
+        prefix,
+        suffix,
+        match_q,
+    };
+    info.bound();
+    info
+}
+
+fn analyze_alternation(subs: &[Hir]) -> RegexInfo {
+    let infos: Vec<RegexInfo> = subs.iter().map(analyze).collect();
+
+    let emptyable = infos.iter().any(|i| i.emptyable);
+
+    let exact = if infos.iter().all(|i| i.exact.is_some()) {
+        Some(
+            infos
+                .iter()
+                .flat_map(|i| i.exact.as_ref().unwrap().iter().cloned())
+                .collect(),
+        )
+    } else {
+        None
+    };
+
+    // A common prefix exists only if every branch contributes one.
+    let prefix = if infos.iter().all(|i| !i.prefix.is_empty()) {
+        infos
+            .iter()
+            .flat_map(|i| i.prefix.iter().cloned())
+            .collect()
+    } else {
+        BTreeSet::new()
+    };
+    let suffix = if infos.iter().all(|i| !i.suffix.is_empty()) {
+        infos
+            .iter()
+            .flat_map(|i| i.suffix.iter().cloned())
+            .collect()
+    } else {
+        BTreeSet::new()
+    };
+
+    let match_q = TrigramQuery::or(infos.into_iter().map(|i| i.match_q).collect());
+
+    RegexInfo {
+        emptyable,
+        exact,
+        prefix,
+        suffix,
+        match_q,
+    }
+}
+
+/// Derive a necessary trigram condition from a regular expression pattern.
+///
+/// Returns [`TrigramQuery::All`] when no useful condition can be derived (an
+/// unparsable pattern, or one with no trigram-able literal structure such as
+/// `a.b` or `.*`); callers must treat that as "recheck everything".
+pub fn regex_to_trigram_query(pattern: &str) -> TrigramQuery {
+    // An unparsable pattern cannot be accelerated; rechecking is still safe.
+    let Ok(hir) = regex_syntax::parse(pattern) else {
+        return TrigramQuery::All;
+    };
+    let info = analyze(&hir);
+
+    let mut conditions = vec![info.match_q];
+    if let Some(exact) = &info.exact {
+        if exact.is_empty() {
+            // The expression matches nothing.
+            return TrigramQuery::None;
+        }
+        conditions.push(trigrams_of_set(exact.iter()));
+    }
+    conditions.push(trigrams_of_set(info.prefix.iter()));
+    conditions.push(trigrams_of_set(info.suffix.iter()));
+    TrigramQuery::and(conditions)
+}
+
+/// Whether a regular expression yields any trigram condition the index can use
+/// to prune candidates. When it does not (e.g. `a.b`, `.*`, or a case-insensitive
+/// pattern), callers should leave the predicate to a full scan rather than route
+/// it to the index, which would otherwise have to ask the scan to recheck every
+/// row -- a path the index result type (`AtLeast`) does not support.
+pub fn regex_can_use_index(pattern: &str) -> bool {
+    regex_to_trigram_query(pattern) != TrigramQuery::All
+}
+
+/// Collect the distinct trigram tokens referenced anywhere in the tree.
+pub fn collect_tokens(query: &TrigramQuery, out: &mut HashSet<u32>) {
+    match query {
+        TrigramQuery::Trigram(token) => {
+            out.insert(*token);
+        }
+        TrigramQuery::And(items) | TrigramQuery::Or(items) => {
+            for item in items {
+                collect_tokens(item, out);
+            }
+        }
+        TrigramQuery::All | TrigramQuery::None => {}
+    }
+}
+
+/// Evaluate the tree against a map of `trigram token -> posting list`. A token
+/// missing from the map contributes an empty set (sound: a required trigram that
+/// is absent everywhere yields no rows; an absent OR branch contributes
+/// nothing). `All` / `None` are handled by the caller before evaluation.
+pub fn eval_trigram_query(
+    query: &TrigramQuery,
+    bitmaps: &HashMap<u32, RoaringTreemap>,
+) -> RoaringTreemap {
+    match query {
+        TrigramQuery::Trigram(token) => bitmaps.get(token).cloned().unwrap_or_default(),
+        TrigramQuery::And(items) => {
+            let mut iter = items.iter();
+            let mut acc = match iter.next() {
+                Some(first) => eval_trigram_query(first, bitmaps),
+                None => return RoaringTreemap::new(),
+            };
+            for item in iter {
+                if acc.is_empty() {
+                    break;
+                }
+                acc &= &eval_trigram_query(item, bitmaps);
+            }
+            acc
+        }
+        TrigramQuery::Or(items) => {
+            let mut acc = RoaringTreemap::new();
+            for item in items {
+                acc |= &eval_trigram_query(item, bitmaps);
+            }
+            acc
+        }
+        TrigramQuery::All | TrigramQuery::None => RoaringTreemap::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A single trigram condition, hashed the same way the index hashes it.
+    fn tri(trigram: &str) -> TrigramQuery {
+        TrigramQuery::Trigram(ngram_to_token(trigram, NGRAM_N))
+    }
+
+    fn q(pattern: &str) -> TrigramQuery {
+        regex_to_trigram_query(pattern)
+    }
+
+    #[test]
+    fn test_single_literal_trigram() {
+        assert_eq!(q("foo"), tri("foo"));
+    }
+
+    #[test]
+    fn test_multi_trigram_literal() {
+        assert_eq!(
+            q("foobar"),
+            TrigramQuery::and(vec![tri("foo"), tri("oob"), tri("oba"), tri("bar")])
+        );
+    }
+
+    #[test]
+    fn test_wildcard_splits_into_and() {
+        // `.*` breaks the literal run; both sides are required.
+        assert_eq!(
+            q("foo.*bar"),
+            TrigramQuery::and(vec![tri("foo"), tri("bar")])
+        );
+    }
+
+    #[test]
+    fn test_alternation_is_or() {
+        assert_eq!(
+            q("(cat|dog)"),
+            TrigramQuery::or(vec![tri("cat"), tri("dog")])
+        );
+    }
+
+    #[test]
+    fn test_anchors_are_transparent() {
+        assert_eq!(
+            q("^rhino"),
+            TrigramQuery::and(vec![tri("rhi"), tri("hin"), tri("ino")])
+        );
+        assert_eq!(q("nose$"), TrigramQuery::and(vec![tri("nos"), tri("ose")]));
+    }
+
+    #[test]
+    fn test_boundary_trigram_recovered_across_groups() {
+        // A capturing group is not merged into the adjacent literals, so this
+        // exercises the suffix x prefix cross product that recovers the `foo`
+        // trigram straddling the `(o)` group boundary in "foobar".
+        assert_eq!(
+            q("fo(o)bar"), // spellchecker:disable-line
+            TrigramQuery::and(vec![tri("foo"), tri("oob"), tri("oba"), tri("bar")])
+        );
+    }
+
+    #[test]
+    fn test_no_trigram_yields_all() {
+        // No run of three literal characters anywhere.
+        assert_eq!(q("a.b"), TrigramQuery::All);
+        assert_eq!(q(".*"), TrigramQuery::All);
+        // Every alternation branch is shorter than a trigram, so we must not
+        // require either two-character branch as a (non-existent) trigram.
+        assert_eq!(q("fo|ba"), TrigramQuery::All); // spellchecker:disable-line
+    }
+
+    #[test]
+    fn test_case_insensitive_not_accelerated() {
+        // Unicode case folding (e.g. `(?i)c` also matches U+2102) does not agree
+        // with the index's normalization, so case-insensitive patterns are left
+        // unaccelerated (correct via recheck) rather than risk a false negative.
+        assert_eq!(q("(?i)Cat"), TrigramQuery::All);
+    }
+
+    #[test]
+    fn test_unparsable_pattern_yields_all() {
+        assert_eq!(q("("), TrigramQuery::All);
+    }
+
+    #[test]
+    fn test_large_alternation_stays_bounded() {
+        // More than MAX_SET_SIZE branches: must still produce a sound OR without
+        // panicking or exploding.
+        let pattern = (0..40)
+            .map(|i| format!("aa{i:02}zz"))
+            .collect::<Vec<_>>()
+            .join("|");
+        let result = q(&pattern);
+        // Each branch shares the trigram `aa0`/`aa1`/... and `zz`-ish endings;
+        // the important property is that it is a sound non-empty condition.
+        assert_ne!(result, TrigramQuery::None);
+    }
+
+    #[test]
+    fn test_plus_requires_inner() {
+        // `(abc)+` must contain at least one `abc`.
+        assert_eq!(q("(abc)+"), tri("abc"));
+    }
+
+    #[test]
+    fn test_optional_group_is_not_required() {
+        // `(foo)?bar` -> foo optional, bar required.
+        assert_eq!(q("(foo)?bar"), tri("bar"));
+    }
+
+    #[test]
+    fn test_eval_and_or_with_missing_tokens() {
+        let foo = ngram_to_token("foo", NGRAM_N);
+        let bar = ngram_to_token("bar", NGRAM_N);
+        let mut bitmaps = HashMap::new();
+        bitmaps.insert(foo, RoaringTreemap::from_iter([1u64, 2, 3]));
+        bitmaps.insert(bar, RoaringTreemap::from_iter([2u64, 3, 4]));
+        // `baz` is absent from the index.
+
+        // AND intersects.
+        let and = TrigramQuery::and(vec![tri("foo"), tri("bar")]);
+        assert_eq!(
+            eval_trigram_query(&and, &bitmaps),
+            RoaringTreemap::from_iter([2u64, 3])
+        );
+
+        // OR unions.
+        let or = TrigramQuery::or(vec![tri("foo"), tri("bar")]);
+        assert_eq!(
+            eval_trigram_query(&or, &bitmaps),
+            RoaringTreemap::from_iter([1u64, 2, 3, 4])
+        );
+
+        // A missing token is empty: it zeroes an AND but is harmless in an OR.
+        let and_missing = TrigramQuery::and(vec![tri("foo"), tri("baz")]);
+        assert!(eval_trigram_query(&and_missing, &bitmaps).is_empty());
+        let or_missing = TrigramQuery::or(vec![tri("foo"), tri("baz")]);
+        assert_eq!(
+            eval_trigram_query(&or_missing, &bitmaps),
+            RoaringTreemap::from_iter([1u64, 2, 3])
+        );
+    }
+
+    #[test]
+    fn test_collect_tokens() {
+        let query = TrigramQuery::and(vec![
+            tri("foo"),
+            TrigramQuery::or(vec![tri("bar"), tri("baz")]),
+        ]);
+        let mut tokens = HashSet::new();
+        collect_tokens(&query, &mut tokens);
+        assert_eq!(
+            tokens,
+            HashSet::from([
+                ngram_to_token("foo", NGRAM_N),
+                ngram_to_token("bar", NGRAM_N),
+                ngram_to_token("baz", NGRAM_N),
+            ])
+        );
+    }
+}

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -176,6 +176,10 @@ name = "scalar_index"
 harness = false
 
 [[bench]]
+name = "regex_ngram"
+harness = false
+
+[[bench]]
 name = "merge_insert"
 harness = false
 

--- a/rust/lance/benches/regex_ngram.rs
+++ b/rust/lance/benches/regex_ngram.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Benchmark: regex predicate scans over an ngram-indexed string column.
+//!
+//! Each query is a `regexp_match(doc, '...')` filter against a dataset that has
+//! an NGram index on `doc`. The query set spans a selective AND pattern, an
+//! alternation, a plain literal (rewritten to an infix LIKE before it reaches
+//! the index), and a deliberately non-accelerable pattern (`a.b`, which yields
+//! no trigram) that serves as a regression guard.
+//!
+//! On `main` none of these use the index (regex falls through to a full scan +
+//! recheck); with the ngram-regex acceleration the index prunes candidates for
+//! the first three while `a.b` stays a full scan. Capture a baseline on `main`
+//! with `--save-baseline before_7130`, then compare after the change with
+//! `--baseline before_7130`.
+
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow::array::AsArray;
+use arrow_array::{RecordBatch, RecordBatchIterator, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use criterion::{Criterion, criterion_group, criterion_main};
+use futures::TryStreamExt;
+use lance::Dataset;
+use lance::index::DatasetIndexExt;
+use lance_core::utils::tempfile::TempStrDir;
+use lance_datagen::{RowCount, array};
+use lance_index::IndexType;
+use lance_index::scalar::ScalarIndexParams;
+#[cfg(target_os = "linux")]
+use lance_testing::pprof::{Output, PProfProfiler};
+
+const TOTAL: usize = 200_000;
+
+/// Build the `doc` column: random sentences with rare markers injected into a
+/// small fraction of rows so the regex queries have controlled selectivity.
+/// The markers (`zqxwvu`, `needlexyz`, `qwerasdf`) are unlikely to appear in
+/// the generated English-word sentences.
+fn build_docs() -> StringArray {
+    let mut sentence_gen = array::random_sentence(1, 30, false);
+    let base = sentence_gen
+        .generate_default(RowCount::from(TOTAL as u64))
+        .unwrap();
+    let base = base.as_string::<i32>();
+    let docs = (0..TOTAL).map(|i| {
+        let sentence = base.value(i);
+        if i % 200 == 0 {
+            // ~0.5% of rows match `zqxwvu.*needlexyz` and `zqxwvu`.
+            format!("{sentence} zqxwvu needlexyz")
+        } else if i % 211 == 0 {
+            // A second marker for the alternation query.
+            format!("{sentence} qwerasdf")
+        } else {
+            sentence.to_string()
+        }
+    });
+    StringArray::from_iter_values(docs)
+}
+
+async fn build_dataset(tempdir: &TempStrDir) -> Arc<Dataset> {
+    let schema = Arc::new(Schema::new(vec![Field::new("doc", DataType::Utf8, false)]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(build_docs())]).unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+
+    let mut dataset = Dataset::write(reader, tempdir.as_str(), None)
+        .await
+        .unwrap();
+    dataset
+        .create_index(
+            &["doc"],
+            IndexType::NGram,
+            None,
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+    Arc::new(dataset)
+}
+
+async fn scan_filter(dataset: &Dataset, filter: &str) -> usize {
+    let mut scanner = dataset.scan();
+    scanner.filter(filter).unwrap();
+    let stream = scanner.try_into_stream().await.unwrap();
+    let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+    batches.iter().map(|b| b.num_rows()).sum()
+}
+
+fn bench_regex_ngram(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let tempdir = TempStrDir::default();
+    let dataset = rt.block_on(build_dataset(&tempdir));
+
+    let queries = [
+        ("selective_and", "regexp_match(doc, 'zqxwvu.*needlexyz')"),
+        (
+            "alternation",
+            "regexp_match(doc, '(zqxwvu|qwerasdf|needlexyz)')",
+        ),
+        ("plain_literal", "regexp_match(doc, 'zqxwvu')"),
+        ("non_accelerable_a_dot_b", "regexp_match(doc, 'a.b')"),
+    ];
+
+    let mut group = c.benchmark_group("regex_ngram");
+    group
+        .sample_size(10)
+        .measurement_time(Duration::from_secs(15));
+    for (name, filter) in queries {
+        group.bench_function(name, |b| {
+            b.iter(|| black_box(rt.block_on(scan_filter(&dataset, filter))));
+        });
+    }
+    group.finish();
+}
+
+#[cfg(target_os = "linux")]
+criterion_group!(
+    name = benches;
+    config = Criterion::default()
+        .significance_level(0.1)
+        .sample_size(10)
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_regex_ngram);
+
+#[cfg(not(target_os = "linux"))]
+criterion_group!(
+    name = benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10);
+    targets = bench_regex_ngram);
+
+criterion_main!(benches);

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -8413,6 +8413,198 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_ngram_regex_index_scan() {
+        use arrow::array::AsArray;
+
+        // A small, fixed corpus written across multiple fragments so the ngram
+        // index spans fragment boundaries.
+        let values = [
+            "rhino",       // 0
+            "rhinos nose", // 1
+            "cat",         // 2
+            "dog",         // 3
+            "cat dog",     // 4
+            "elephant",    // 5
+            "catalog",     // 6
+            "scatter",     // 7
+            "rhino horn",  // 8
+            "mouse",       // 9
+            "category",    // 10
+            "dogma",       // 11
+        ];
+        let array = StringArray::from_iter_values(values);
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "s",
+            DataType::Utf8,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let write_params = WriteParams {
+            max_rows_per_file: 4, // 12 rows -> 3 fragments
+            ..Default::default()
+        };
+        let mut dataset = Dataset::write(reader, "memory://test_ngram_regex", Some(write_params))
+            .await
+            .unwrap();
+        dataset
+            .create_index(
+                &["s"],
+                IndexType::NGram,
+                None,
+                &ScalarIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+        assert!(
+            dataset.get_fragments().len() > 1,
+            "expected a multi-fragment dataset"
+        );
+
+        // Scan with `filter` and return the matched `s` values, sorted.
+        async fn matched(dataset: &Dataset, filter: &str) -> Vec<String> {
+            let mut scan = dataset.scan();
+            scan.filter(filter).unwrap();
+            let batches = scan
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let mut out = Vec::new();
+            for batch in batches {
+                let col = batch.column_by_name("s").unwrap().as_string::<i32>();
+                out.extend(col.iter().flatten().map(|s| s.to_string()));
+            }
+            out.sort();
+            out
+        }
+
+        // `regexp_like`: a plain literal substring.
+        assert_eq!(
+            matched(&dataset, "regexp_like(s, 'rhino')").await,
+            ["rhino", "rhino horn", "rhinos nose"]
+        );
+        // `regexp_match` (coerced to `IsNotNull(regexp_match(...))`) accelerates too.
+        assert_eq!(
+            matched(&dataset, "regexp_match(s, 'rhino')").await,
+            ["rhino", "rhino horn", "rhinos nose"]
+        );
+        // Anchored: recheck must drop trigram false positives -- the `cat`
+        // trigram also occurs in cat dog / catalog / scatter / category.
+        assert_eq!(matched(&dataset, "regexp_like(s, 'cat$')").await, ["cat"]);
+        // AND across `.*`: row 8 ("rhino horn") shares the rhino trigrams but
+        // lacks the nose trigrams, so only "rhinos nose" survives.
+        assert_eq!(
+            matched(&dataset, "regexp_like(s, 'rhino.*nose')").await,
+            ["rhinos nose"]
+        );
+        // Alternation.
+        assert_eq!(
+            matched(&dataset, "regexp_like(s, '(catalog|elephant)')").await,
+            ["catalog", "elephant"]
+        );
+        // A non-accelerable pattern (no trigram derivable) still returns correct
+        // results via a full recheck.
+        assert_eq!(matched(&dataset, "regexp_like(s, 'o.m')").await, ["dogma"]);
+        // A case-insensitive flag is not accelerated (the index normalization
+        // disagrees with Unicode case folding) but must still return correct
+        // results via a full recheck -- here matching despite the upper-case
+        // pattern. This exercises the three-argument `regexp_like` flags path.
+        assert_eq!(
+            matched(&dataset, "regexp_like(s, 'RHINO', 'i')").await,
+            ["rhino", "rhino horn", "rhinos nose"]
+        );
+
+        // Infix LIKE is accelerated through the same machinery (a plain-literal
+        // `regexp_like` is rewritten to LIKE before it reaches the index).
+        assert_eq!(
+            matched(&dataset, "s LIKE '%rhino%'").await,
+            ["rhino", "rhino horn", "rhinos nose"]
+        );
+        // Prefix LIKE: recheck drops "scatter", which contains the `cat` trigram
+        // but does not start with "cat".
+        assert_eq!(
+            matched(&dataset, "s LIKE 'cat%'").await,
+            ["cat", "cat dog", "catalog", "category"]
+        );
+
+        // The ngram index is actually engaged for every accelerated form.
+        for filter in [
+            "regexp_like(s, 'rhino')",
+            "regexp_match(s, 'rhino')",
+            "s LIKE '%rhino%'",
+        ] {
+            let mut scan = dataset.scan();
+            scan.filter(filter).unwrap();
+            let plan = scan.create_plan().await.unwrap();
+            let plan_str = format!(
+                "{}",
+                datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+            );
+            assert!(
+                plan_str.contains("ScalarIndexQuery") && plan_str.contains("NGram"),
+                "expected ngram index usage for `{filter}`, got plan:\n{plan_str}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ngram_regex_non_accelerable_recheck() {
+        // `a.b` yields no trigram, so the index returns "recheck everything".
+        // This must still produce ALL correct matches across fragments, not an
+        // empty set (a regression test for the AtLeast recheck path, which a
+        // single-match case would not catch).
+        let unit = ["acb", "dog", "axb", "cat", "qqq", "rhino"];
+        let values: Vec<&str> = unit.iter().copied().cycle().take(60).collect();
+        let array = StringArray::from_iter_values(values);
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "text",
+            DataType::Utf8,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let write_params = WriteParams {
+            max_rows_per_file: 20, // 60 rows -> 3 fragments
+            ..Default::default()
+        };
+        let mut dataset =
+            Dataset::write(reader, "memory://test_ngram_regex_ne", Some(write_params))
+                .await
+                .unwrap();
+        dataset
+            .create_index(
+                &["text"],
+                IndexType::NGram,
+                None,
+                &ScalarIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+
+        async fn count(dataset: &Dataset, filter: &str) -> usize {
+            let mut scan = dataset.scan();
+            scan.filter(filter).unwrap();
+            let batches = scan
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            batches.iter().map(|b| b.num_rows()).sum()
+        }
+
+        // "acb" and "axb" each appear 10 times in the 60 rows -> 20 matches.
+        assert_eq!(count(&dataset, "regexp_match(text, 'a.b')").await, 20);
+        assert_eq!(count(&dataset, "regexp_like(text, 'a.b')").await, 20);
+    }
+
+    #[tokio::test]
     async fn test_like_prefix_with_btree_index() {
         // Create dataset with string data that has various prefixes
         // Avoid LIKE special characters (%, _) in data to keep tests simple


### PR DESCRIPTION
## What

Extends the ngram index (today only `contains(col, 'substr')`) to also accelerate `regexp_like(col, pat)` / `regexp_match(col, pat)` and infix `LIKE` (`col LIKE '%foo%bar%'`), which until now fell through to a full table scan. Closes #7130.

## How

Following Postgres `pg_trgm` and Russ Cox's [trigram-index approach](https://swtch.com/~rsc/regexp/regexp4.html), a pattern is compiled into a boolean trigram condition (`TrigramQuery`, an AND/OR tree) that is a *necessary* condition for any match. This maps onto the inverted index's set algebra: AND is posting-list intersection, OR is union. The index returns a candidate superset and the scan rechecks the true predicate, exactly as `contains` does. The derivation walks the `regex-syntax` HIR bottom-up, tracking per-node `(emptyable, exact, prefix, suffix)` sets and folding boundary trigrams across concatenation, with bounds that fold-then-discard so precision loss never drops a necessary trigram.

### Soundness

The derived condition never requires a trigram a matching string could lack, so no real match is dropped. Requirements come from the index's own tokenizer (so sub-trigram runs contribute nothing); character classes and case-insensitive folds are treated as a single unknown character (the index's normalization disagrees with Unicode case folding - `(?i)c` also matches U+2102); and patterns with no derivable trigram (`a.b`, `.*`) are left to a full scan.

### Why infix LIKE

A plain-literal `regexp_like(col, 'foo')` is rewritten to `col LIKE '%foo%'` by the optimizer before it reaches the index, so without infix-LIKE the most common "regex" query would not accelerate. The LIKE is translated to a loose regex for candidate generation only; the original LIKE stays as the recheck filter, so the candidate regex need only be a sound superset.

## Benchmark

`cargo bench -p lance --bench regex_ngram`, 200k rows, before (main) vs after:

| Query | Before | After | Change |
|---|---|---|---|
| `regexp_match(doc, 'zqxwvu.*needlexyz')` | 45.8 ms | 8.2 ms | -82% |
| `regexp_match(doc, '(zqxwvu\|qwerasdf\|needlexyz)')` | 51.7 ms | 11.6 ms | -77% |
| `regexp_match(doc, 'zqxwvu')` (rewritten to LIKE) | 36.6 ms | 8.0 ms | -78% |
| `regexp_match(doc, 'a.b')` (non-accelerable) | 77.8 ms | 76.2 ms | within noise |

## Testing

Unit tests for the regex-to-trigram derivation and the regex-flags folding; index-level search tests (AND across `.*`, alternation union, NULL exclusion, absent trigram); a multi-fragment end-to-end scan test asserting correct results and index engagement for `regexp_like`, `regexp_match`, and `LIKE`, plus a case-insensitive query that must fall back to a full recheck; and a regression test ensuring non-accelerable patterns still return all correct matches via full recheck. No binding changes are needed - Python/Java pass these filter strings through the existing scan API, so acceleration applies transparently.
