### PR TITLE
ci: pin license-header-checker to fix flaky install step

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -31,9 +31,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ./bin
-          curl -sfSL "https://github.com/lluissm/license-header-checker/releases/download/v${LHC_VERSION}/license-header-checker_${LHC_VERSION}_linux_amd64.tar.gz" -o /tmp/lhc.tar.gz
-          tar -xzf /tmp/lhc.tar.gz -C ./bin license-header-checker
-          rm -f /tmp/lhc.tar.gz
+          base="https://github.com/lluissm/license-header-checker/releases/download/v${LHC_VERSION}"
+          asset="license-header-checker_${LHC_VERSION}_linux_amd64.tar.gz"
+          curl -sfSL "${base}/${asset}" -o "/tmp/${asset}"
+          curl -sfSL "${base}/checksums.txt" -o /tmp/lhc-checksums.txt
+          # Verify the download against the release checksums before extracting so a
+          # corrupted or tampered asset cannot be executed. This restores the
+          # integrity check the upstream install.sh performed via hash_sha256_verify.
+          (cd /tmp && sha256sum -c --ignore-missing lhc-checksums.txt)
+          tar -xzf "/tmp/${asset}" -C ./bin license-header-checker
+          rm -f "/tmp/${asset}" /tmp/lhc-checksums.txt
       - name: Check license headers (rust)
         run: ./bin/license-header-checker -a -v ./rust/license_header.txt rust rs && [[ -z `git status -s` ]]
       - name: Check license headers (python)

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -22,11 +22,18 @@ jobs:
       - name: Check out code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install license-header-checker
+        env:
+          # Pin to a specific release and download the asset directly from the
+          # release CDN. This avoids the flaky dynamic "latest" tag lookup in the
+          # upstream install.sh (it fetches the releases page and parses tag_name,
+          # which intermittently returns empty and fails the job).
+          LHC_VERSION: "1.5.0"
         run: |
           set -euo pipefail
-          curl -sfSL https://raw.githubusercontent.com/lluissm/license-header-checker/master/install.sh -o /tmp/install-lhc.sh
-          bash /tmp/install-lhc.sh
-          rm -f /tmp/install-lhc.sh
+          mkdir -p ./bin
+          curl -sfSL "https://github.com/lluissm/license-header-checker/releases/download/v${LHC_VERSION}/license-header-checker_${LHC_VERSION}_linux_amd64.tar.gz" -o /tmp/lhc.tar.gz
+          tar -xzf /tmp/lhc.tar.gz -C ./bin license-header-checker
+          rm -f /tmp/lhc.tar.gz
       - name: Check license headers (rust)
         run: ./bin/license-header-checker -a -v ./rust/license_header.txt rust rs && [[ -z `git status -s` ]]
       - name: Check license headers (python)


### PR DESCRIPTION
The `license-header-check` job installs the checker via the upstream `install.sh` with no pinned tag, so it resolves "latest" by fetching the GitHub releases page and parsing `tag_name`. That fetch intermittently returns empty and fails the job with `unable to find ''`, unrelated to any PR's contents.

Previous failed run (the install step, not a header violation): https://github.com/lance-format/lance/actions/runs/27094024188/job/79962732768

Reading the upstream `install.sh` shows that passing a pinned tag would not help - `github_release()` still fetches the releases page to resolve the tag. So this pins to `v1.5.0` and downloads the release asset directly from the CDN, removing the dynamic tag/JSON lookup entirely. The job runs only on `ubuntu-latest`, so the `linux_amd64` asset is used.
