### PR TITLE
docs: clarify distributed vector model scopes

### DIFF
--- a/docs/src/guide/distributed_indexing.md
+++ b/docs/src/guide/distributed_indexing.md
@@ -105,6 +105,37 @@ or merged into larger segments:
 
 Within a single commit, built segments must have disjoint fragment coverage.
 
+### Vector Model Scope
+
+Distributed vector builds support two model scopes.
+
+**Shared model artifacts**: the caller trains or provides IVF centroids once and
+passes the same artifacts to every worker. For IVF-PQ segments that should be
+physically mergeable, workers should also use the same PQ codebook. This makes
+partition ids and quantizer state have the same meaning across segments.
+
+**Independent segment models**: each worker trains the IVF/PQ model for its own
+`fragment_ids`. The resulting segments can be committed together as one logical
+index without sharing centroids or codebooks.
+
+At query time, Lance searches each physical segment independently:
+
+1. Lance opens each segment by index UUID
+2. each segment ranks IVF partitions using its own centroids
+3. each segment searches the selected partitions using its own quantizer storage
+4. Lance merges the candidate rows from all segments by `_distance`
+
+Because partition ids are interpreted only within a segment during this fanout
+query path, independently trained committed segments can return valid results.
+For L2 and cosine IVF-PQ, each segment computes residuals against its own IVF
+centroid during both build and query, so distances remain estimates of the
+original query-to-vector metric.
+
+Physical merge is a separate operation. It rewrites several segment artifacts
+into one artifact with one model metadata scope. Use shared compatible model
+artifacts for segments you plan to merge physically, or keep independently
+trained segments as separate physical segments.
+
 ## Internal Finalize Model
 
 Internally, Lance models distributed vector segment build as:

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3801,6 +3801,17 @@ class LanceDataset(pa.dataset.Dataset):
             to the dataset. The returned metadata can be passed to
             ``merge_existing_index_segments(...)`` if grouping is needed and then
             committed with ``commit_existing_index_segments(...)``.
+
+            Vector segments support both shared and independent model scopes. If
+            the caller provides the same IVF centroids, and for IVF_PQ the same
+            PQ codebook, to each worker, the resulting segments share model
+            semantics and are suitable for workflows that physically merge
+            compatible segments. If those artifacts are omitted, each segment can
+            train its own IVF/PQ model for its assigned fragments. Such segments
+            can be committed together and are queried independently by segment
+            UUID; partition ids are interpreted within each segment's own model.
+            Keep independently trained segments as separate physical segments
+            unless the merge workflow can preserve or reconcile the model state.
         index_uuid : str, optional
             A UUID to use for the segment written by this call.
             If not provided, a new UUID will be generated.
@@ -4017,6 +4028,15 @@ class LanceDataset(pa.dataset.Dataset):
         requirement:
 
         - ``fragment_ids`` must be provided
+        - Vector segments support both shared and independent model scopes. Pass
+          the same IVF centroids, and for IVF_PQ the same PQ codebook, to each
+          worker when segments need shared model semantics or physical merge
+          compatibility. If these artifacts are omitted, each segment may train
+          its own IVF/PQ model and can be committed with other segments as one
+          logical index; query execution searches each segment by UUID and
+          interprets partition ids within that segment. Keep independently
+          trained segments as separate physical segments unless the merge
+          workflow can preserve or reconcile the model state.
         - ``rabitq_model`` (``IVF_RQ`` only): a JSON string produced by
           ``lance.lance.indices.build_rq_model``. It must be identical across all
           workers for their segments to be mergeable, since it pins the RaBitQ


### PR DESCRIPTION
## Summary

Clarifies the distributed vector indexing docs to describe both supported model scopes: shared model artifacts and independent per-segment models. The guide and Python API docs now explain that independently trained IVF/IVF-PQ segments can be committed together because query execution searches each physical segment by UUID, while physical merge remains constrained by compatible model metadata.
