### PR TITLE
ci: harden protoc install for Linux wheels

### DIFF
--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -41,11 +41,9 @@ runs:
         args: ${{ inputs.args }}
         maturin-version: "1.10.2"
         before-script-linux: |
-          set -e
-          yum install -y openssl-devel \
-            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$(uname -m).zip > /tmp/protoc.zip \
-            && unzip /tmp/protoc.zip -d /usr/local \
-            && rm /tmp/protoc.zip
+          set -euo pipefail
+          yum install -y openssl-devel
+          bash "${GITHUB_WORKSPACE}/.github/workflows/build_linux_wheel/install-protoc.sh"
     - name: Build x86_64 Manylinux {manylinux} wheel
       if: ${{ inputs.arm-build == 'false' && inputs.manylinux != '2_17' }}
       uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
@@ -60,11 +58,9 @@ runs:
         args: ${{ inputs.args }}
         maturin-version: "1.10.2"
         before-script-linux: |
-          set -e
-          yum install -y openssl-devel clang \
-            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$(uname -m).zip > /tmp/protoc.zip \
-            && unzip /tmp/protoc.zip -d /usr/local \
-            && rm /tmp/protoc.zip
+          set -euo pipefail
+          yum install -y openssl-devel clang
+          bash "${GITHUB_WORKSPACE}/.github/workflows/build_linux_wheel/install-protoc.sh"
     - name: Build Arm Manylinux Wheel
       if: ${{ inputs.arm-build == 'true' }}
       uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
@@ -76,8 +72,6 @@ runs:
         args: ${{ inputs.args }}
         maturin-version: "1.10.2"
         before-script-linux: |
-          set -e
-          yum install -y openssl-devel clang \
-            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip > /tmp/protoc.zip \
-            && unzip /tmp/protoc.zip -d /usr/local \
-            && rm /tmp/protoc.zip
+          set -euo pipefail
+          yum install -y openssl-devel clang
+          bash "${GITHUB_WORKSPACE}/.github/workflows/build_linux_wheel/install-protoc.sh"

--- a/.github/workflows/build_linux_wheel/install-protoc.sh
+++ b/.github/workflows/build_linux_wheel/install-protoc.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${PROTOC_VERSION:-24.4}"
+install_dir="${PROTOC_INSTALL_DIR:-/usr/local}"
+machine="${1:-$(uname -m)}"
+
+case "${machine}" in
+  aarch64 | arm64)
+    asset_arch="aarch_64"
+    ;;
+  x86_64)
+    asset_arch="x86_64"
+    ;;
+  *)
+    echo "Unsupported protoc architecture: ${machine}" >&2
+    exit 1
+    ;;
+esac
+
+zip_path="/tmp/protoc-${version}-linux-${asset_arch}.zip"
+url="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-linux-${asset_arch}.zip"
+
+for attempt in 1 2 3 4 5; do
+  rm -f "${zip_path}"
+
+  if curl -fsSL --connect-timeout 15 --max-time 120 -o "${zip_path}" "${url}" \
+    && unzip -tq "${zip_path}" >/dev/null; then
+    break
+  fi
+
+  if [[ "${attempt}" == "5" ]]; then
+    echo "Failed to download a valid protoc archive from ${url}" >&2
+    exit 1
+  fi
+
+  sleep "$((attempt * 2))"
+done
+
+unzip -q -o "${zip_path}" -d "${install_dir}"
+rm -f "${zip_path}"
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  "${install_dir}/bin/protoc" --version
+else
+  test -f "${install_dir}/bin/protoc"
+fi


### PR DESCRIPTION
This PR hardens Linux wheel protoc setup after `Python Linux 3.13 ARM` failed on PR #7148 because the manylinux before-script downloaded an invalid `/tmp/protoc.zip`, `unzip` failed inside an `&&` chain, and `maturin-action` continued until the Rust build could not find `protoc`.

The fix moves the protoc download into a small shared script that maps supported Linux architectures, retries invalid downloads, validates the archive with `unzip -tq`, and keeps the before-script commands separate under `set -euo pipefail` so setup failures stop the wheel build at the right point.
