### PR TITLE
feat: branch-aware table version ops in directory and rest namespaces

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -200,7 +200,8 @@ impl BlockingDataset {
         if namespace_client_managed_versioning
             && let (Some(namespace_client), Some(tid)) = (namespace, table_id)
         {
-            let external_store = LanceNamespaceExternalManifestStore::new(namespace_client, tid);
+            let external_store =
+                LanceNamespaceExternalManifestStore::for_table_uri(namespace_client, tid, uri)?;
             let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
                 external_manifest_store: Arc::new(external_store),
             });
@@ -688,8 +689,11 @@ fn create_dataset<'local>(
     if let Some((namespace, table_id)) = namespace_info {
         // Set up commit handler only if namespace manages versioning
         if namespace_client_managed_versioning {
-            let external_store =
-                LanceNamespaceExternalManifestStore::new(namespace.clone(), table_id.clone());
+            let external_store = LanceNamespaceExternalManifestStore::for_table_uri(
+                namespace.clone(),
+                table_id.clone(),
+                &path_str,
+            )?;
             let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
                 external_manifest_store: Arc::new(external_store),
             });

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -774,12 +774,18 @@ fn inner_commit_to_dataset<'local>(
     // Set namespace commit handler only if namespace_client_managed_versioning is true
     let namespace_info = extract_namespace_info(env, &namespace_obj, &table_id_obj)?;
     let commit_handler = if namespace_client_managed_versioning {
-        namespace_info.map(|(ns, tid)| {
-            let external_store = LanceNamespaceExternalManifestStore::new(ns, tid);
-            Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            }) as Arc<dyn CommitHandler>
-        })
+        match namespace_info {
+            Some((ns, tid)) => {
+                // The store derives the branch a request targets from the base
+                // path it is handed, resolved against the table root.
+                let table_root = java_blocking_ds.inner.branch_location().find_main()?.path;
+                let external_store = LanceNamespaceExternalManifestStore::new(ns, tid, table_root);
+                Some(Arc::new(ExternalManifestCommitHandler {
+                    external_manifest_store: Arc::new(external_store),
+                }) as Arc<dyn CommitHandler>)
+            }
+            None => None,
+        }
     } else {
         None
     };
@@ -1560,7 +1566,8 @@ fn inner_commit_to_uri<'local>(
 
     // Set namespace commit handler only if namespace_client_managed_versioning is true
     if namespace_client_managed_versioning && let Some((namespace_client, tid)) = namespace_info {
-        let external_store = LanceNamespaceExternalManifestStore::new(namespace_client, tid);
+        let external_store =
+            LanceNamespaceExternalManifestStore::for_table_uri(namespace_client, tid, &uri_str)?;
         let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
             external_manifest_store: Arc::new(external_store),
         });

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -817,8 +817,14 @@ impl Dataset {
 
             // Set up commit handler only if namespace manages versioning
             if namespace_client_managed_versioning {
-                let external_store =
-                    LanceNamespaceExternalManifestStore::new(ns_client, tid.clone());
+                // The store derives the branch a request targets from the base
+                // path it is handed, resolved against the table root.
+                let external_store = LanceNamespaceExternalManifestStore::for_table_uri(
+                    ns_client,
+                    tid.clone(),
+                    &uri,
+                )
+                .infer_error()?;
                 let commit_handler: Arc<dyn CommitHandler> =
                     Arc::new(ExternalManifestCommitHandler {
                         external_manifest_store: Arc::new(external_store),
@@ -2615,9 +2621,16 @@ impl Dataset {
                 && let (Some(ns_client), Some(tid)) = (namespace_client, table_id)
             {
                 // Create ExternalManifestCommitHandler from namespace client and table_id
-                // only when namespace manages versioning
+                // only when namespace manages versioning. The store derives the
+                // branch a request targets from the base path it is handed,
+                // resolved against the table root.
                 let ns_client = extract_namespace_arc(ns_client.py(), ns_client)?;
-                let external_store = LanceNamespaceExternalManifestStore::new(ns_client, tid);
+                let external_store = LanceNamespaceExternalManifestStore::for_table_uri(
+                    ns_client,
+                    tid,
+                    &dest.table_root_uri()?,
+                )
+                .infer_error()?;
                 Some(Arc::new(ExternalManifestCommitHandler {
                     external_manifest_store: Arc::new(external_store),
                 }) as Arc<dyn CommitHandler>)
@@ -3578,6 +3591,15 @@ impl PyWriteDest {
             Self::Uri(uri) => WriteDestination::Uri(uri),
         }
     }
+
+    /// The table root uri of this destination (a branch dataset resolves to
+    /// its main location). Used to root the namespace manifest store.
+    pub fn table_root_uri(&self) -> PyResult<String> {
+        match self {
+            Self::Dataset(ds) => Ok(ds.ds.branch_location().find_main().infer_error()?.uri),
+            Self::Uri(uri) => Ok(uri.to_string()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -3933,7 +3955,7 @@ pub fn write_dataset(
     dest: PyWriteDest,
     options: &Bound<'_, PyDict>,
 ) -> PyResult<Dataset> {
-    let params = get_write_params(options)?;
+    let params = get_write_params(options, &dest.table_root_uri()?)?;
     let py = options.py();
     let ds = if reader.is_instance_of::<Scanner>() {
         let scanner: Scanner = reader.extract()?;
@@ -4002,8 +4024,13 @@ fn get_dict_opt<'py, D: FromPyObjectOwned<'py>>(
         .transpose()
 }
 
+/// `table_uri` is the destination table's root uri; it roots the namespace
+/// manifest store when `namespace_client_managed_versioning` is requested.
 #[allow(deprecated)]
-pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WriteParams>> {
+pub fn get_write_params(
+    options: &Bound<'_, PyDict>,
+    table_uri: &str,
+) -> PyResult<Option<WriteParams>> {
     let params = if options.is_none() {
         None
     } else {
@@ -4173,9 +4200,15 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
             && let (Some(ns_client), Some(table_id)) =
                 (namespace_client_opt.as_ref(), table_id_opt.as_ref())
         {
+            // The store derives the branch a request targets from the base path
+            // it is handed, resolved against the table root.
             let ns_client = extract_namespace_arc(options.py(), ns_client)?;
-            let external_store =
-                LanceNamespaceExternalManifestStore::new(ns_client, table_id.clone());
+            let external_store = LanceNamespaceExternalManifestStore::for_table_uri(
+                ns_client,
+                table_id.clone(),
+                table_uri,
+            )
+            .infer_error()?;
             let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
                 external_manifest_store: Arc::new(external_store),
             });

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -23,7 +23,7 @@ use lance::Error;
 use lance::dataset::fragment::FileFragment as LanceFragment;
 use lance::dataset::scanner::ColumnOrdering;
 use lance::dataset::transaction::{Operation, Transaction};
-use lance::dataset::{InsertBuilder, NewColumnTransform};
+use lance::dataset::{InsertBuilder, NewColumnTransform, WriteParams};
 use lance_core::datatypes::BlobHandling;
 use lance_io::utils::CachedFileSize;
 use lance_table::format::{
@@ -119,7 +119,7 @@ impl FileFragment {
         kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<PyLance<Fragment>> {
         let params = if let Some(kw_params) = kwargs {
-            get_write_params(kw_params)?
+            get_write_params(kw_params, dataset_uri)?
         } else {
             None
         };
@@ -435,10 +435,10 @@ fn do_write_fragments(
 ) -> PyResult<Transaction> {
     let batches = convert_reader(reader)?;
 
-    let params = kwargs
-        .and_then(|params| get_write_params(params).transpose())
-        .transpose()?
-        .unwrap_or_default();
+    let params = match kwargs {
+        Some(params) => get_write_params(params, &dest.table_root_uri()?)?.unwrap_or_default(),
+        None => WriteParams::default(),
+    };
 
     rt().block_on(
         Some(reader.py()),

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -2259,7 +2259,7 @@ impl DirectoryNamespace {
 
             for (&v, version_path) in &location_by_version {
                 let vi = v as i64;
-                if !te.ranges.iter().any(|&(s, e)| vi >= s && vi <= e) {
+                if !te.ranges.iter().any(|&(s, e)| vi >= s && (e < 0 || vi < e)) {
                     continue;
                 }
                 match self.object_store.inner.delete(version_path).await {
@@ -3203,23 +3203,22 @@ impl LanceNamespace for DirectoryNamespace {
         let ranges: Vec<(i64, i64)> = request
             .ranges
             .iter()
-            .map(|r| {
-                let start = r.start_version;
-                let end = if r.end_version > 0 {
-                    r.end_version
-                } else {
-                    start
-                };
-                (start, end)
-            })
+            .map(|r| (r.start_version, r.end_version))
             .collect();
 
-        // Reject pathological ranges up front: the manifest path below builds one
-        // id per version, so (0, i64::MAX) would exhaust memory.
+        // Reject pathological bounded ranges up front: the manifest path below
+        // builds one id per version, so (0, i64::MAX) would exhaust memory. A
+        // through-latest range (end < 0) is bounded by the manifests that exist.
         const MAX_VERSIONS_PER_REQUEST: i128 = 1_000_000;
         let requested: i128 = ranges
             .iter()
-            .map(|(s, e)| (*e as i128 - *s as i128 + 1).max(0))
+            .map(|(s, e)| {
+                if *e < 0 {
+                    0
+                } else {
+                    (*e as i128 - *s as i128).max(0)
+                }
+            })
             .sum();
         if requested > MAX_VERSIONS_PER_REQUEST {
             return Err(NamespaceError::InvalidInput {
@@ -3244,6 +3243,22 @@ impl LanceNamespace for DirectoryNamespace {
             && self.table_version_storage_enabled
             && let Some(ref manifest_ns) = self.manifest_ns
         {
+            // Through-latest ranges (end_version < 0) would require enumerating the
+            // __manifest chain up to the latest version, which is not wired up here.
+            // Reject rather than silently delete physical files while leaving the
+            // __manifest records in place.
+            if table_entries
+                .iter()
+                .any(|te| te.ranges.iter().any(|&(_, e)| e < 0))
+            {
+                return Err(NamespaceError::Unsupported {
+                    message: "through-latest delete (end_version < 0) is not supported \
+                              for managed-versioning tables"
+                        .to_string(),
+                }
+                .into());
+            }
+
             // Phase 1 (atomic commit point): Delete version records from __manifest
             // for ALL tables in a single atomic operation. This is the authoritative
             // source of truth — once __manifest entries are removed, the versions
@@ -3256,7 +3271,7 @@ impl LanceNamespace for DirectoryNamespace {
                     &te.table_id.clone().unwrap_or_default(),
                 );
                 for (start, end) in &te.ranges {
-                    for version in *start..=*end {
+                    for version in *start..*end {
                         let object_id = manifest::ManifestNamespace::build_version_object_id(
                             &table_id_str,
                             version,
@@ -5093,18 +5108,16 @@ mod tests {
         let before = list_versions(&namespace, "users", Some("exp"))
             .await
             .unwrap();
-        let min_v = before.iter().map(|v| v.version).min().unwrap();
-        let max_v = before.iter().map(|v| v.version).max().unwrap();
         let main_before = list_versions(&namespace, "users", None).await.unwrap();
 
-        // Delete the branch's whole version range. The branch manifests use V2
-        // naming (inverted, zero-padded), so a nonzero deleted_count proves the
-        // V2 fix: the old code constructed "{version}.manifest" and silently
-        // matched nothing.
+        // Delete the branch's whole history with a through-latest range (end = -1).
+        // The branch manifests use V2 naming (inverted, zero-padded), so a nonzero
+        // deleted_count proves the V2 fix: the old code constructed
+        // "{version}.manifest" and silently matched nothing.
         let req = BatchDeleteTableVersionsRequest {
             id: Some(vec!["users".to_string()]),
             branch: Some("exp".to_string()),
-            ranges: vec![VersionRange::new(min_v, max_v)],
+            ranges: vec![VersionRange::new(0, -1)],
             ..Default::default()
         };
         let resp = namespace.batch_delete_table_versions(req).await.unwrap();
@@ -5206,6 +5219,289 @@ mod tests {
             .unwrap()
             .len();
         assert_eq!(main_after, main_before, "main must be unaffected");
+    }
+
+    /// The namespace-managed commit store derives the branch a request targets
+    /// from the base path it is handed, so a single store serves every branch of
+    /// the table: a branch-qualified base resolves and commits against the
+    /// branch chain while the table root targets main.
+    #[tokio::test]
+    async fn test_external_manifest_store_resolves_branch_from_base_path() {
+        use futures::TryStreamExt;
+        use lance::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
+        use lance_table::io::commit::external_manifest::ExternalManifestStore;
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await; // main: version 1
+        let branch_uri = create_branch_with_commits(&namespace, "users", "exp", 2).await;
+
+        let namespace = Arc::new(namespace);
+        let table_id = vec!["users".to_string()];
+        let branch_ds = Dataset::open(&branch_uri).await.unwrap();
+        let branch_base = branch_ds.branch_location().path;
+        let root_base = branch_ds.branch_location().find_main().unwrap().path;
+        let store = LanceNamespaceExternalManifestStore::new(
+            namespace.clone(),
+            table_id.clone(),
+            root_base.clone(),
+        );
+
+        // The branch-qualified base resolves the branch chain, the root base
+        // resolves main: proof the base path reaches list_table_versions.
+        let (branch_latest, branch_path) = store
+            .get_latest_version(branch_base.as_ref())
+            .await
+            .unwrap()
+            .expect("branch has versions");
+        let (_main_latest, main_path) = store
+            .get_latest_version(root_base.as_ref())
+            .await
+            .unwrap()
+            .expect("main has versions");
+        assert!(
+            branch_path.contains("tree/exp"),
+            "branch latest must resolve to the branch tree: {}",
+            branch_path
+        );
+        assert!(
+            !main_path.contains("tree/exp"),
+            "main latest must not resolve to a branch tree: {}",
+            main_path
+        );
+
+        // describe (get) with the branch base also resolves to the branch tree.
+        let described = store
+            .get(branch_base.as_ref(), branch_latest)
+            .await
+            .unwrap();
+        assert!(
+            described.contains("tree/exp"),
+            "describe on the branch must resolve to the branch tree: {}",
+            described
+        );
+
+        // A base that is neither the root nor a branch chain is rejected.
+        assert!(store.get_latest_version("somewhere/else").await.is_err());
+
+        // Commit (put) with the branch base: the new version must land on the
+        // branch chain. Stage a manifest by copying an existing branch manifest.
+        let versions_dir = branch_ds.versions_dir();
+        let obj = branch_ds.object_store(None).await.unwrap();
+        let existing = obj
+            .inner
+            .list(Some(&versions_dir))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|m| {
+                m.location
+                    .filename()
+                    .map(|f| f.ends_with(".manifest"))
+                    .unwrap_or(false)
+            })
+            .expect("a branch manifest");
+        let bytes = obj
+            .inner
+            .get(&existing.location)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let size = bytes.len() as u64;
+        let staging = versions_dir.clone().join("staging_manifest");
+        obj.inner.put(&staging, bytes.into()).await.unwrap();
+
+        let committed = store
+            .put(
+                &branch_base,
+                branch_latest + 1,
+                &staging,
+                size,
+                None,
+                obj.inner.as_ref(),
+                ManifestNamingScheme::V2,
+            )
+            .await
+            .unwrap();
+        assert!(
+            committed.path.to_string().contains("tree/exp"),
+            "a commit through a branch-qualified base must land on the branch tree: {}",
+            committed.path
+        );
+    }
+
+    /// write_into_namespace_on_branch must append against the branch chain
+    /// THROUGH the managed commit handler: the version is registered with the
+    /// namespace (create_table_version), lands on the branch tree, and main's
+    /// catalog is untouched. The ops-metrics assertions exist because a
+    /// physical-only commit is invisible to DirectoryNamespace branch listing
+    /// (it lists storage), while a catalog-authoritative namespace would
+    /// silently lose the version.
+    #[tokio::test]
+    async fn test_write_into_namespace_on_branch_appends_to_branch() {
+        use lance::dataset::builder::DatasetBuilder;
+        use lance_namespace::models::CreateTableBranchRequest;
+
+        let temp = TempStdDir::default();
+        let namespace = Arc::new(
+            DirectoryNamespaceBuilder::new(temp.to_str().unwrap())
+                .manifest_enabled(true)
+                .table_version_tracking_enabled(true)
+                .table_version_storage_enabled(true)
+                .ops_metrics_enabled(true)
+                .build()
+                .await
+                .unwrap(),
+        );
+        let ns: Arc<dyn LanceNamespace> = namespace.clone();
+        let table_id = vec!["t".to_string()];
+        create_managed_table(&ns, &table_id).await; // main: v1 (id=1), v2 (id=2)
+        ns.create_table_branch(CreateTableBranchRequest {
+            id: Some(table_id.clone()),
+            name: "exp".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let main_chain_len = |ns: Arc<dyn LanceNamespace>, table_id: Vec<String>| async move {
+            ns.list_table_versions(ListTableVersionsRequest {
+                id: Some(table_id),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .versions
+            .len()
+        };
+        let main_before = main_chain_len(ns.clone(), table_id.clone()).await;
+        let commits_before = namespace
+            .retrieve_ops_metrics()
+            .get("create_table_version")
+            .copied()
+            .unwrap_or(0);
+
+        let branch_ds = Dataset::write_into_namespace_on_branch(
+            RecordBatchIterator::new(vec![Ok(single_int_batch(3))], single_int_schema()),
+            ns.clone(),
+            table_id.clone(),
+            "exp",
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(branch_ds.manifest.branch.as_deref(), Some("exp"));
+        assert_eq!(scan_id_column(&branch_ds).await, vec![1, 2, 3]);
+
+        // The append must commit through the namespace, not just write a
+        // physical manifest under the branch tree.
+        let commits_after = namespace
+            .retrieve_ops_metrics()
+            .get("create_table_version")
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(
+            commits_after,
+            commits_before + 1,
+            "the branch append must register its version via create_table_version"
+        );
+        let exp_versions = ns
+            .list_table_versions(ListTableVersionsRequest {
+                id: Some(table_id.clone()),
+                branch: Some("exp".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .versions;
+        assert!(
+            exp_versions
+                .iter()
+                .all(|v| v.manifest_path.contains("tree/exp")),
+            "branch versions must resolve to the branch tree: {:?}",
+            exp_versions
+        );
+        assert_eq!(
+            main_chain_len(ns.clone(), table_id.clone()).await,
+            main_before,
+            "main's catalog must be untouched by the branch append"
+        );
+
+        // A managed main append through the same entry point must register in
+        // the catalog too, so a fresh managed open resolves the new latest.
+        Dataset::write_into_namespace(
+            RecordBatchIterator::new(vec![Ok(single_int_batch(100))], single_int_schema()),
+            ns.clone(),
+            table_id.clone(),
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            main_chain_len(ns.clone(), table_id.clone()).await,
+            main_before + 1,
+            "a managed main append must register its version in the catalog"
+        );
+        let fresh = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(
+            scan_id_column(&fresh).await,
+            vec![1, 2, 100],
+            "a fresh managed open must resolve the appended version, not a stale latest"
+        );
+    }
+
+    /// CREATE on a branch is rejected: a branch forks from an existing version.
+    #[tokio::test]
+    async fn test_write_into_namespace_on_branch_rejects_create() {
+        use arrow::array::{Int32Array, StringArray};
+        use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        let namespace = Arc::new(namespace);
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let batch = arrow::record_batch::RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(StringArray::from(vec![Some("a")])),
+            ],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+
+        let result = Dataset::write_into_namespace_on_branch(
+            reader,
+            namespace.clone(),
+            vec!["new_table".to_string()],
+            "exp",
+            Some(WriteParams {
+                mode: WriteMode::Create,
+                ..Default::default()
+            }),
+        )
+        .await;
+        assert!(result.is_err(), "create on a branch must be rejected");
+        assert!(
+            result.unwrap_err().to_string().contains("branch"),
+            "error should mention the branch restriction"
+        );
     }
 
     #[tokio::test]
@@ -5353,10 +5649,11 @@ mod tests {
         let min_v = before.iter().map(|v| v.version).min().unwrap();
         let max_v = before.iter().map(|v| v.version).max().unwrap();
 
-        // Delete everything except the latest version.
+        // Delete everything except the latest version. end is exclusive, so
+        // [min_v, max_v) keeps max_v.
         let req = BatchDeleteTableVersionsRequest {
             id: Some(vec!["users".to_string()]),
-            ranges: vec![VersionRange::new(min_v, max_v - 1)],
+            ranges: vec![VersionRange::new(min_v, max_v)],
             ..Default::default()
         };
         let resp = namespace.batch_delete_table_versions(req).await.unwrap();
@@ -5369,6 +5666,40 @@ mod tests {
         let after = list_versions(&namespace, "users", None).await.unwrap();
         assert_eq!(after.len(), 1);
         assert_eq!(after[0].version, max_v);
+    }
+
+    /// Pins the exclusive end of VersionRange: [v, v+1) must match only v.
+    #[tokio::test]
+    async fn test_batch_delete_end_is_exclusive() {
+        use lance_namespace::models::{BatchDeleteTableVersionsRequest, VersionRange};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await; // version 1
+        let main_uri = open_dataset(&namespace, "users").await.uri().to_string();
+        append_scalar_version(&main_uri, 100).await; // version 2
+        append_scalar_version(&main_uri, 200).await; // version 3
+
+        let before = list_versions(&namespace, "users", None).await.unwrap();
+        let min_v = before.iter().map(|v| v.version).min().unwrap();
+
+        let req = BatchDeleteTableVersionsRequest {
+            id: Some(vec!["users".to_string()]),
+            ranges: vec![VersionRange::new(min_v, min_v + 1)],
+            ..Default::default()
+        };
+        let resp = namespace.batch_delete_table_versions(req).await.unwrap();
+        assert_eq!(
+            resp.deleted_count,
+            Some(1),
+            "only min_v is in [min_v, min_v+1)"
+        );
+
+        let after = list_versions(&namespace, "users", None).await.unwrap();
+        assert!(
+            !after.iter().any(|v| v.version == min_v),
+            "min_v must be deleted"
+        );
+        assert_eq!(after.len(), before.len() - 1, "exactly one version removed");
     }
 
     #[tokio::test]
@@ -5390,6 +5721,690 @@ mod tests {
         assert!(
             err.unwrap_err().to_string().contains("limit"),
             "expected a range-too-large error"
+        );
+    }
+
+    /// The managed `__manifest` delete path (the authoritative catalog) must honor
+    /// the exclusive end: `[min, max)` removes exactly min..max from `__manifest`,
+    /// keeping max. With storage tracking on, the writes register versions in
+    /// `__manifest` and `list_table_versions` reads it back, so this exercises the
+    /// Phase-1 path that the physical-path tests never reach.
+    #[tokio::test]
+    async fn test_batch_delete_managed_manifest_exclusive() {
+        use arrow::array::Int32Array;
+        use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+        use lance_namespace::models::{BatchDeleteTableVersionsRequest, VersionRange};
+
+        let temp = TempStdDir::default();
+        let ns: Arc<dyn LanceNamespace> = Arc::new(
+            DirectoryNamespaceBuilder::new(temp.to_str().unwrap())
+                .manifest_enabled(true)
+                .table_version_tracking_enabled(true)
+                .table_version_storage_enabled(true)
+                .build()
+                .await
+                .unwrap(),
+        );
+        let table_id = vec!["users".to_string()];
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = |seed: i32| {
+            arrow::record_batch::RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(vec![seed]))],
+            )
+            .unwrap()
+        };
+
+        // Register v1, v2, v3 in __manifest via the managed write flow.
+        let mut ds = Dataset::write_into_namespace(
+            RecordBatchIterator::new(vec![Ok(batch(1))], schema.clone()),
+            ns.clone(),
+            table_id.clone(),
+            Some(WriteParams {
+                mode: WriteMode::Create,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        ds.append(
+            RecordBatchIterator::new(vec![Ok(batch(2))], schema.clone()),
+            None,
+        )
+        .await
+        .unwrap();
+        ds.append(
+            RecordBatchIterator::new(vec![Ok(batch(3))], schema.clone()),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let before = ns
+            .list_table_versions(ListTableVersionsRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .versions;
+        assert!(
+            before.len() >= 3,
+            "expected v1..v3 tracked in __manifest: {:?}",
+            before
+        );
+        let min_v = before.iter().map(|v| v.version).min().unwrap();
+        let max_v = before.iter().map(|v| v.version).max().unwrap();
+
+        // [min, max): exclusive end keeps max.
+        ns.batch_delete_table_versions(BatchDeleteTableVersionsRequest {
+            id: Some(table_id.clone()),
+            ranges: vec![VersionRange::new(min_v, max_v)],
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let after = ns
+            .list_table_versions(ListTableVersionsRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .versions;
+        assert_eq!(
+            after.len(),
+            1,
+            "only the exclusive end (max) should remain in __manifest: {:?}",
+            after
+        );
+        assert_eq!(after[0].version, max_v, "max must be kept");
+    }
+
+    /// On the managed path, a through-latest delete (`end_version < 0`) is rejected
+    /// rather than silently deleting physical files while leaving `__manifest`
+    /// records in place.
+    #[tokio::test]
+    async fn test_batch_delete_managed_rejects_through_latest() {
+        use lance_namespace::models::{BatchDeleteTableVersionsRequest, VersionRange};
+
+        let temp = TempStdDir::default();
+        let ns: Arc<dyn LanceNamespace> = Arc::new(
+            DirectoryNamespaceBuilder::new(temp.to_str().unwrap())
+                .manifest_enabled(true)
+                .table_version_tracking_enabled(true)
+                .table_version_storage_enabled(true)
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let err = ns
+            .batch_delete_table_versions(BatchDeleteTableVersionsRequest {
+                id: Some(vec!["users".to_string()]),
+                ranges: vec![VersionRange::new(0, -1)],
+                ..Default::default()
+            })
+            .await;
+        assert!(
+            err.is_err(),
+            "through-latest delete must be rejected on the managed path"
+        );
+        assert!(
+            err.unwrap_err().to_string().contains("not supported"),
+            "expected a not-supported error"
+        );
+    }
+
+    /// Build a managed (manifest-tracked) namespace over `path`.
+    async fn create_managed_namespace(path: &str) -> Arc<dyn LanceNamespace> {
+        Arc::new(
+            DirectoryNamespaceBuilder::new(path)
+                .manifest_enabled(true)
+                .table_version_tracking_enabled(true)
+                .table_version_storage_enabled(true)
+                .build()
+                .await
+                .unwrap(),
+        )
+    }
+
+    fn single_int_schema() -> Arc<arrow::datatypes::Schema> {
+        use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+        Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]))
+    }
+
+    fn single_int_batch(seed: i32) -> arrow::record_batch::RecordBatch {
+        use arrow::array::Int32Array;
+        arrow::record_batch::RecordBatch::try_new(
+            single_int_schema(),
+            vec![Arc::new(Int32Array::from(vec![seed]))],
+        )
+        .unwrap()
+    }
+
+    /// Create a managed table with versions v1 (id=1) and v2 (id=2) on main and
+    /// return the main dataset handle.
+    async fn create_managed_table(ns: &Arc<dyn LanceNamespace>, table_id: &[String]) -> Dataset {
+        let mut ds = Dataset::write_into_namespace(
+            RecordBatchIterator::new(vec![Ok(single_int_batch(1))], single_int_schema()),
+            ns.clone(),
+            table_id.to_vec(),
+            Some(WriteParams {
+                mode: WriteMode::Create,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        ds.append(
+            RecordBatchIterator::new(vec![Ok(single_int_batch(2))], single_int_schema()),
+            None,
+        )
+        .await
+        .unwrap();
+        ds
+    }
+
+    /// Sorted values of the `id` column across a full scan.
+    async fn scan_id_column(ds: &Dataset) -> Vec<i32> {
+        use arrow::array::Int32Array;
+        use futures::TryStreamExt;
+        let batches: Vec<arrow::record_batch::RecordBatch> = ds
+            .scan()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let mut ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|b| {
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    /// E2e for the managed branch path through the builder: create a branch via the
+    /// namespace op, open it with `from_namespace(managed).with_branch`, commit on
+    /// it, and confirm the dataset is rooted at the branch chain (manifest, base
+    /// path and data placement) while main's catalog is untouched.
+    #[tokio::test]
+    async fn test_managed_branch_open_and_commit() {
+        use futures::TryStreamExt;
+        use lance::dataset::builder::DatasetBuilder;
+        use lance_namespace::models::CreateTableBranchRequest;
+
+        let temp = TempStdDir::default();
+        let ns = create_managed_namespace(temp.to_str().unwrap()).await;
+        let table_id = vec!["t".to_string()];
+        create_managed_table(&ns, &table_id).await;
+        let main_before = ns
+            .list_table_versions(ListTableVersionsRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .versions
+            .len();
+
+        // Create a branch via the namespace op (the FS-handler path, which succeeds
+        // on a managed table).
+        ns.create_table_branch(CreateTableBranchRequest {
+            id: Some(table_id.clone()),
+            name: "exp".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        // Open the managed table on the branch: the base path is qualified up
+        // front and the manifest store derives the branch from it.
+        let mut branch_ds = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .with_branch("exp", None)
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(
+            branch_ds.manifest.branch.as_deref(),
+            Some("exp"),
+            "with_branch on a managed table must open the branch chain"
+        );
+        let branch_base = branch_ds.branch_location().path;
+        assert!(
+            branch_base.as_ref().ends_with("tree/exp"),
+            "the branch dataset must be rooted at the branch chain: {}",
+            branch_base
+        );
+        let branch_v_before = branch_ds.version().version;
+
+        // Commit on the branch.
+        branch_ds
+            .append(
+                RecordBatchIterator::new(vec![Ok(single_int_batch(3))], single_int_schema()),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            branch_ds.manifest.branch.as_deref(),
+            Some("exp"),
+            "the commit must stay on the branch"
+        );
+        assert!(
+            branch_ds.version().version > branch_v_before,
+            "the branch version must advance after the commit"
+        );
+        assert_eq!(scan_id_column(&branch_ds).await, vec![1, 2, 3]);
+
+        // The committed data files live under the branch chain, not main's data
+        // dir, so unmanaged readers of the branch and main's cleanup see a
+        // consistent layout.
+        let store = branch_ds.object_store(None).await.unwrap();
+        let branch_data = branch_base.clone().join("data");
+        let branch_files = store
+            .inner
+            .list(Some(&branch_data))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert!(
+            !branch_files.is_empty(),
+            "the branch commit must place data files under the branch chain"
+        );
+
+        // The same branch is readable through the unmanaged (path-based) open.
+        let table_uri = ns
+            .describe_table(DescribeTableRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .location
+            .unwrap();
+        let fs_branch_ds = DatasetBuilder::from_uri(&table_uri)
+            .with_branch("exp", None)
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(fs_branch_ds.manifest.branch.as_deref(), Some("exp"));
+        assert_eq!(scan_id_column(&fs_branch_ds).await, vec![1, 2, 3]);
+
+        // Main's catalog is untouched (branches are not tracked in __manifest),
+        // and main still reads its own data.
+        let main_after = ns
+            .list_table_versions(ListTableVersionsRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .versions
+            .len();
+        assert_eq!(
+            main_after, main_before,
+            "committing on the branch must not change main's chain"
+        );
+        let main_ds = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(main_ds.manifest.branch, None);
+        assert_eq!(scan_id_column(&main_ds).await, vec![1, 2]);
+    }
+
+    /// Branch-pointing tags on a managed table: create them through the normal
+    /// API (from both the main and the branch handle), open the table at the
+    /// tag, and check the tag out from an already-open dataset. All of these
+    /// must resolve the branch chain, never main's chain.
+    #[tokio::test]
+    async fn test_managed_branch_tags() {
+        use lance::dataset::builder::DatasetBuilder;
+        use lance::dataset::refs::Ref;
+        use lance_namespace::models::CreateTableBranchRequest;
+
+        let temp = TempStdDir::default();
+        let ns = create_managed_namespace(temp.to_str().unwrap()).await;
+        let table_id = vec!["t".to_string()];
+        let main_ds = create_managed_table(&ns, &table_id).await;
+        ns.create_table_branch(CreateTableBranchRequest {
+            id: Some(table_id.clone()),
+            name: "exp".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        let mut branch_ds = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .with_branch("exp", None)
+            .load()
+            .await
+            .unwrap();
+        branch_ds
+            .append(
+                RecordBatchIterator::new(vec![Ok(single_int_batch(3))], single_int_schema()),
+                None,
+            )
+            .await
+            .unwrap();
+        let branch_version = branch_ds.version().version;
+
+        // A branch-pointing tag created from the main handle must validate
+        // against the branch chain (the version does not exist on main).
+        main_ds
+            .tags()
+            .create("exp-tag", ("exp", Some(branch_version)))
+            .await
+            .unwrap();
+        let tag = main_ds.tags().get("exp-tag").await.unwrap();
+        assert_eq!(tag.branch.as_deref(), Some("exp"));
+        assert_eq!(tag.version, branch_version);
+
+        // A tag created from the branch handle resolves the branch implicitly.
+        branch_ds
+            .tags()
+            .create("exp-tag2", branch_version)
+            .await
+            .unwrap();
+        let tag2 = branch_ds.tags().get("exp-tag2").await.unwrap();
+        assert_eq!(tag2.branch.as_deref(), Some("exp"));
+
+        // Opening the managed table at the branch-pointing tag checks out the
+        // branch chain.
+        let tag_open = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .with_tag("exp-tag")
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(tag_open.manifest.branch.as_deref(), Some("exp"));
+        assert_eq!(tag_open.version().version, branch_version);
+        assert_eq!(scan_id_column(&tag_open).await, vec![1, 2, 3]);
+
+        // So does checking the tag out from an already-open main dataset.
+        let tag_checkout = main_ds
+            .checkout_version(Ref::Tag("exp-tag".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(tag_checkout.manifest.branch.as_deref(), Some("exp"));
+        assert_eq!(scan_id_column(&tag_checkout).await, vec![1, 2, 3]);
+
+        // A missing tag on a managed table errors at open.
+        let err = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .with_tag("no-such-tag")
+            .load()
+            .await;
+        assert!(err.is_err(), "a missing tag must error");
+    }
+
+    /// Cross-branch checkout on a managed table, including version numbers that
+    /// exist on both chains (branch numbering continues from the fork point, so
+    /// overlap is the common case). Every checkout must land on the requested
+    /// chain and read that chain's data.
+    #[tokio::test]
+    async fn test_managed_cross_branch_checkout() {
+        use lance::dataset::builder::DatasetBuilder;
+        use lance::dataset::refs::Ref;
+        use lance_namespace::models::CreateTableBranchRequest;
+
+        let temp = TempStdDir::default();
+        let ns = create_managed_namespace(temp.to_str().unwrap()).await;
+        let table_id = vec!["t".to_string()];
+        let mut main_ds = create_managed_table(&ns, &table_id).await;
+        ns.create_table_branch(CreateTableBranchRequest {
+            id: Some(table_id.clone()),
+            name: "exp".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        // exp gets id=3 at its tip; main gets id=100 at the same version number.
+        let mut branch_ds = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .with_branch("exp", None)
+            .load()
+            .await
+            .unwrap();
+        branch_ds
+            .append(
+                RecordBatchIterator::new(vec![Ok(single_int_batch(3))], single_int_schema()),
+                None,
+            )
+            .await
+            .unwrap();
+        let overlap_version = branch_ds.version().version;
+        while main_ds.version().version < overlap_version {
+            main_ds
+                .append(
+                    RecordBatchIterator::new(vec![Ok(single_int_batch(100))], single_int_schema()),
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+
+        // main -> branch at the overlapping version number: must read the
+        // branch's data, not main's same-numbered version.
+        let on_branch = main_ds
+            .checkout_version(Ref::Version(Some("exp".to_string()), Some(overlap_version)))
+            .await
+            .unwrap();
+        assert_eq!(on_branch.manifest.branch.as_deref(), Some("exp"));
+        assert_eq!(scan_id_column(&on_branch).await, vec![1, 2, 3]);
+
+        // main -> branch latest.
+        let mut on_branch_latest = main_ds.checkout_branch("exp").await.unwrap();
+        assert_eq!(on_branch_latest.manifest.branch.as_deref(), Some("exp"));
+        assert_eq!(on_branch_latest.version().version, overlap_version);
+
+        // A commit through the checked-out handle (which shares main's commit
+        // handler) must land on the branch chain, not main's.
+        let main_chain_len = |ns: Arc<dyn LanceNamespace>, table_id: Vec<String>| async move {
+            ns.list_table_versions(ListTableVersionsRequest {
+                id: Some(table_id),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .versions
+            .len()
+        };
+        let main_before = main_chain_len(ns.clone(), table_id.clone()).await;
+        on_branch_latest
+            .append(
+                RecordBatchIterator::new(vec![Ok(single_int_batch(4))], single_int_schema()),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(on_branch_latest.manifest.branch.as_deref(), Some("exp"));
+        assert_eq!(scan_id_column(&on_branch_latest).await, vec![1, 2, 3, 4]);
+        assert_eq!(
+            main_chain_len(ns.clone(), table_id.clone()).await,
+            main_before,
+            "a commit on the checked-out branch must not advance main's chain"
+        );
+
+        // branch -> main at a specific version.
+        let on_main = branch_ds
+            .checkout_version(Ref::Version(None, Some(1)))
+            .await
+            .unwrap();
+        assert_eq!(on_main.manifest.branch, None);
+        assert_eq!(scan_id_column(&on_main).await, vec![1]);
+
+        // branch -> another branch.
+        ns.create_table_branch(CreateTableBranchRequest {
+            id: Some(table_id.clone()),
+            name: "exp2".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        let on_branch2 = branch_ds.checkout_branch("exp2").await.unwrap();
+        assert_eq!(on_branch2.manifest.branch.as_deref(), Some("exp2"));
+
+        // A version missing from the branch chain errors loudly.
+        let err = main_ds
+            .checkout_version(Ref::Version(Some("exp".to_string()), Some(999)))
+            .await;
+        assert!(err.is_err(), "a version missing from the branch must error");
+    }
+
+    /// CommitBuilder must honor an explicitly supplied commit handler for a
+    /// Dataset destination: a managed-versioning commit through a dataset that
+    /// was opened without the namespace handler (as the Java and Python commit
+    /// APIs allow) must still register with the catalog instead of silently
+    /// writing a physical manifest the catalog never sees.
+    #[tokio::test]
+    async fn test_commit_builder_honors_explicit_handler_for_dataset_dest() {
+        use lance::dataset::write::{CommitBuilder, InsertBuilder};
+        use lance::dataset::{WriteDestination, builder::DatasetBuilder};
+        use lance::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
+        use lance_table::io::commit::external_manifest::ExternalManifestCommitHandler;
+
+        let temp = TempStdDir::default();
+        let namespace = Arc::new(
+            DirectoryNamespaceBuilder::new(temp.to_str().unwrap())
+                .manifest_enabled(true)
+                .table_version_tracking_enabled(true)
+                .table_version_storage_enabled(true)
+                .ops_metrics_enabled(true)
+                .build()
+                .await
+                .unwrap(),
+        );
+        let ns: Arc<dyn LanceNamespace> = namespace.clone();
+        let table_id = vec!["t".to_string()];
+        create_managed_table(&ns, &table_id).await; // main: v1 (id=1), v2 (id=2)
+
+        // Open WITHOUT the namespace handler, the way a binding caller can.
+        let table_uri = ns
+            .describe_table(DescribeTableRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .location
+            .unwrap();
+        let plain_ds = Arc::new(Dataset::open(&table_uri).await.unwrap());
+
+        let transaction = InsertBuilder::new(WriteDestination::Dataset(plain_ds.clone()))
+            .with_params(&WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            })
+            .execute_uncommitted(vec![single_int_batch(3)])
+            .await
+            .unwrap();
+
+        let handler = Arc::new(ExternalManifestCommitHandler {
+            external_manifest_store: Arc::new(
+                LanceNamespaceExternalManifestStore::for_table_uri(
+                    ns.clone(),
+                    table_id.clone(),
+                    &table_uri,
+                )
+                .unwrap(),
+            ),
+        });
+        let commits_before = namespace
+            .retrieve_ops_metrics()
+            .get("create_table_version")
+            .copied()
+            .unwrap_or(0);
+        let committed = CommitBuilder::new(WriteDestination::Dataset(plain_ds))
+            .with_commit_handler(handler)
+            .execute(transaction)
+            .await
+            .unwrap();
+        assert_eq!(scan_id_column(&committed).await, vec![1, 2, 3]);
+
+        let commits_after = namespace
+            .retrieve_ops_metrics()
+            .get("create_table_version")
+            .copied()
+            .unwrap_or(0);
+        assert_eq!(
+            commits_after,
+            commits_before + 1,
+            "the explicit handler must route the commit through create_table_version"
+        );
+        let fresh = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(
+            scan_id_column(&fresh).await,
+            vec![1, 2, 3],
+            "a fresh managed open must resolve the committed version"
+        );
+    }
+
+    /// A branch forked from a non-latest version opens on its own chain.
+    #[tokio::test]
+    async fn test_managed_branch_from_non_latest_fork() {
+        use lance::dataset::builder::DatasetBuilder;
+        use lance_namespace::models::CreateTableBranchRequest;
+
+        let temp = TempStdDir::default();
+        let ns = create_managed_namespace(temp.to_str().unwrap()).await;
+        let table_id = vec!["t".to_string()];
+        create_managed_table(&ns, &table_id).await; // main: v1 (id=1), v2 (id=2)
+
+        ns.create_table_branch(CreateTableBranchRequest {
+            id: Some(table_id.clone()),
+            name: "old".to_string(),
+            from_version: Some(1),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let old_ds = DatasetBuilder::from_namespace(ns.clone(), table_id.clone())
+            .await
+            .unwrap()
+            .with_branch("old", None)
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(old_ds.manifest.branch.as_deref(), Some("old"));
+        assert_eq!(
+            scan_id_column(&old_ds).await,
+            vec![1],
+            "the fork must contain only the fork-point data"
         );
     }
 
@@ -10917,6 +11932,69 @@ mod tests {
         assert!(
             branch.parent_branch.is_none(),
             "a branch forked from main has no parent branch"
+        );
+    }
+
+    /// Forking from a NON-main source branch must clone that branch's chain.
+    /// Both chains are given a version 2 with diverged content, so a clone that
+    /// wrongly resolves the version under main succeeds silently with main's
+    /// data instead of erroring.
+    #[tokio::test]
+    async fn test_create_branch_from_other_branch() {
+        use lance::dataset::builder::DatasetBuilder;
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await; // main v1: ids [1, 2, 3]
+        // dev: forked at v1, one append (ids 100, 101) -> dev v2
+        create_branch_with_commits(&namespace, "users", "dev", 1).await;
+        // Diverge main to the same version number with different content.
+        let main_ds = open_dataset(&namespace, "users").await;
+        append_scalar_version(main_ds.uri(), 500).await; // main v2: + ids [500, 501]
+
+        namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(vec!["users".to_string()]),
+                name: "child".to_string(),
+                from_branch: Some("dev".to_string()),
+                from_version: Some(2),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let child_ds = DatasetBuilder::from_uri(main_ds.uri())
+            .with_branch("child", None)
+            .load()
+            .await
+            .unwrap();
+        let ids = scan_id_column(&child_ds).await;
+        assert!(
+            ids.contains(&100) && ids.contains(&101),
+            "child must contain dev's appended rows, got: {:?}",
+            ids
+        );
+        assert!(
+            !ids.contains(&500),
+            "child must not contain main's diverged rows, got: {:?}",
+            ids
+        );
+
+        // The recorded metadata and the cloned data must agree on the parent.
+        let listed = namespace
+            .list_table_branches(ListTableBranchesRequest {
+                id: Some(vec!["users".to_string()]),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            listed
+                .branches
+                .get("child")
+                .unwrap()
+                .parent_branch
+                .as_deref(),
+            Some("dev")
         );
     }
 

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -46,25 +46,27 @@ use std::sync::{Arc, Mutex};
 use crate::context::DynamicContextProvider;
 use lance_namespace::models::{
     AnalyzeTableQueryPlanRequest, BatchDeleteTableVersionsRequest,
-    BatchDeleteTableVersionsResponse, CountTableRowsRequest, CreateNamespaceRequest,
-    CreateNamespaceResponse, CreateTableIndexRequest, CreateTableIndexResponse, CreateTableRequest,
-    CreateTableResponse, CreateTableScalarIndexResponse, CreateTableTagRequest,
+    BatchDeleteTableVersionsResponse, BranchContents as ModelBranchContents, CountTableRowsRequest,
+    CreateNamespaceRequest, CreateNamespaceResponse, CreateTableBranchRequest,
+    CreateTableBranchResponse, CreateTableIndexRequest, CreateTableIndexResponse,
+    CreateTableRequest, CreateTableResponse, CreateTableScalarIndexResponse, CreateTableTagRequest,
     CreateTableTagResponse, CreateTableVersionRequest, CreateTableVersionResponse,
-    DeclareTableRequest, DeclareTableResponse, DeleteTableTagRequest, DeleteTableTagResponse,
-    DescribeNamespaceRequest, DescribeNamespaceResponse, DescribeTableIndexStatsRequest,
-    DescribeTableIndexStatsResponse, DescribeTableRequest, DescribeTableResponse,
-    DescribeTableVersionRequest, DescribeTableVersionResponse, DescribeTransactionRequest,
-    DescribeTransactionResponse, DropNamespaceRequest, DropNamespaceResponse,
-    DropTableIndexRequest, DropTableIndexResponse, DropTableRequest, DropTableResponse,
-    ExplainTableQueryPlanRequest, FragmentStats, FragmentSummary, GetTableStatsRequest,
-    GetTableStatsResponse, GetTableTagVersionRequest, GetTableTagVersionResponse, Identity,
-    IndexContent, InsertIntoTableRequest, InsertIntoTableResponse, ListNamespacesRequest,
-    ListNamespacesResponse, ListTableIndicesRequest, ListTableIndicesResponse,
-    ListTableTagsRequest, ListTableTagsResponse, ListTableVersionsRequest,
-    ListTableVersionsResponse, ListTablesRequest, ListTablesResponse, MergeInsertIntoTableRequest,
-    MergeInsertIntoTableResponse, NamespaceExistsRequest, QueryTableRequest,
-    QueryTableRequestColumns, QueryTableRequestVector, RestoreTableRequest, RestoreTableResponse,
-    TableExistsRequest, TableVersion, TagContents as ModelTagContents,
+    DeclareTableRequest, DeclareTableResponse, DeleteTableBranchRequest, DeleteTableBranchResponse,
+    DeleteTableTagRequest, DeleteTableTagResponse, DescribeNamespaceRequest,
+    DescribeNamespaceResponse, DescribeTableIndexStatsRequest, DescribeTableIndexStatsResponse,
+    DescribeTableRequest, DescribeTableResponse, DescribeTableVersionRequest,
+    DescribeTableVersionResponse, DescribeTransactionRequest, DescribeTransactionResponse,
+    DropNamespaceRequest, DropNamespaceResponse, DropTableIndexRequest, DropTableIndexResponse,
+    DropTableRequest, DropTableResponse, ExplainTableQueryPlanRequest, FragmentStats,
+    FragmentSummary, GetTableStatsRequest, GetTableStatsResponse, GetTableTagVersionRequest,
+    GetTableTagVersionResponse, Identity, IndexContent, InsertIntoTableRequest,
+    InsertIntoTableResponse, ListNamespacesRequest, ListNamespacesResponse,
+    ListTableBranchesRequest, ListTableBranchesResponse, ListTableIndicesRequest,
+    ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
+    ListTableVersionsRequest, ListTableVersionsResponse, ListTablesRequest, ListTablesResponse,
+    MergeInsertIntoTableRequest, MergeInsertIntoTableResponse, NamespaceExistsRequest,
+    QueryTableRequest, QueryTableRequestColumns, QueryTableRequestVector, RestoreTableRequest,
+    RestoreTableResponse, TableExistsRequest, TableVersion, TagContents as ModelTagContents,
     UpdateTableSchemaMetadataRequest, UpdateTableSchemaMetadataResponse, UpdateTableTagRequest,
     UpdateTableTagResponse,
 };
@@ -1057,6 +1059,44 @@ impl DirectoryNamespace {
                 message: format!(
                     "tag operation failed for tag '{}' on table at '{}': {}",
                     tag, table_uri, other
+                ),
+            }
+            .into(),
+        }
+    }
+
+    /// Map lance-core ref errors from branch operations to namespace errors.
+    ///
+    /// `RefConflict` is intentionally not handled here: create-time duplicates are rejected by
+    /// the existence pre-check before `create_branch` runs, and delete maps its own `RefConflict`
+    /// (branch still has dependents) inline.
+    fn map_branch_error(
+        err: lance_core::Error,
+        branch: &str,
+        table_uri: &str,
+    ) -> lance_core::Error {
+        match err {
+            lance_core::Error::RefNotFound { .. } => NamespaceError::TableBranchNotFound {
+                message: format!("branch '{}' for table at '{}'", branch, table_uri),
+            }
+            .into(),
+            lance_core::Error::InvalidRef { message } => NamespaceError::InvalidInput {
+                message: format!("invalid branch '{}': {}", branch, message),
+            }
+            .into(),
+            lance_core::Error::VersionNotFound { message } => {
+                NamespaceError::TableVersionNotFound {
+                    message: format!(
+                        "source version for branch '{}' not found for table at '{}': {}",
+                        branch, table_uri, message
+                    ),
+                }
+                .into()
+            }
+            other => NamespaceError::Internal {
+                message: format!(
+                    "branch operation failed for branch '{}' on table at '{}': {}",
+                    branch, table_uri, other
                 ),
             }
             .into(),
@@ -4400,6 +4440,156 @@ impl LanceNamespace for DirectoryNamespace {
         })
     }
 
+    async fn create_table_branch(
+        &self,
+        request: CreateTableBranchRequest,
+    ) -> Result<CreateTableBranchResponse> {
+        self.record_op("create_table_branch");
+        if request.name.is_empty() {
+            return Err(NamespaceError::InvalidInput {
+                message: "branch name must not be empty for create_table_branch".to_string(),
+            }
+            .into());
+        }
+        let from_version = match request.from_version {
+            Some(v) if v <= 0 => {
+                return Err(NamespaceError::InvalidInput {
+                    message: format!(
+                        "from_version must be a positive integer, got {} for create_table_branch",
+                        v
+                    ),
+                }
+                .into());
+            }
+            Some(v) => Some(v as u64),
+            None => None,
+        };
+
+        let table_uri = self.resolve_table_location(&request.id).await?;
+        let mut dataset = self
+            .load_dataset(&table_uri, None, "create_table_branch")
+            .await?;
+
+        // Best-effort pre-check: a duplicate returns a clean TableBranchAlreadyExists conflict
+        // instead of the opaque Internal error create_branch raises on a pre-existing branch. A
+        // concurrent create can still race past this window. Remove once lance-core create_branch
+        // returns RefConflict up front.
+        if dataset.branches().get(&request.name).await.is_ok() {
+            return Err(NamespaceError::TableBranchAlreadyExists {
+                message: format!("branch '{}' for table at '{}'", request.name, table_uri),
+            }
+            .into());
+        }
+
+        dataset
+            .create_branch(
+                &request.name,
+                (request.from_branch.as_deref(), from_version),
+                None,
+            )
+            .await
+            .map_err(|e| {
+                // After load_dataset + the dup pre-check, a DatasetNotFound from create_branch
+                // means the requested fork source (from_branch/from_version) doesn't exist.
+                if matches!(e, lance_core::Error::DatasetNotFound { .. }) {
+                    NamespaceError::InvalidInput {
+                        message: format!(
+                            "from_branch/from_version for branch '{}' refers to a source that does not exist: {}",
+                            request.name, e
+                        ),
+                    }
+                    .into()
+                } else {
+                    Self::map_branch_error(e, &request.name, &table_uri)
+                }
+            })?;
+
+        Ok(CreateTableBranchResponse {
+            transaction_id: None,
+        })
+    }
+
+    async fn list_table_branches(
+        &self,
+        request: ListTableBranchesRequest,
+    ) -> Result<ListTableBranchesResponse> {
+        self.record_op("list_table_branches");
+        let table_uri = self.resolve_table_location(&request.id).await?;
+        let dataset = self
+            .load_dataset(&table_uri, None, "list_table_branches")
+            .await?;
+
+        let raw_branches = dataset.list_branches().await.map_err(|e| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!(
+                    "Failed to list branches for table at '{}': {}",
+                    table_uri, e
+                ),
+            })
+        })?;
+
+        let branches = raw_branches
+            .into_iter()
+            .map(|(name, contents)| {
+                // The namespace `BranchContents` model has no `identifier` field, so the
+                // lance-core branch identifier is intentionally dropped here.
+                let mut branch_model = ModelBranchContents::new(
+                    contents.parent_version as i64,
+                    contents.create_at as i64,
+                    contents.manifest_size as i64,
+                );
+                branch_model.parent_branch = contents.parent_branch;
+                branch_model.metadata = if contents.metadata.is_empty() {
+                    None
+                } else {
+                    Some(contents.metadata)
+                };
+                (name, branch_model)
+            })
+            .collect();
+
+        Ok(ListTableBranchesResponse {
+            branches,
+            page_token: None,
+        })
+    }
+
+    async fn delete_table_branch(
+        &self,
+        request: DeleteTableBranchRequest,
+    ) -> Result<DeleteTableBranchResponse> {
+        self.record_op("delete_table_branch");
+        if request.name.is_empty() {
+            return Err(NamespaceError::InvalidInput {
+                message: "branch name must not be empty for delete_table_branch".to_string(),
+            }
+            .into());
+        }
+
+        let table_uri = self.resolve_table_location(&request.id).await?;
+        let mut dataset = self
+            .load_dataset(&table_uri, None, "delete_table_branch")
+            .await?;
+
+        dataset
+            .delete_branch(&request.name)
+            .await
+            .map_err(|e| match e {
+                lance_core::Error::RefConflict { message } => NamespaceError::InvalidInput {
+                    message: format!(
+                        "branch '{}' for table at '{}': {}",
+                        request.name, table_uri, message
+                    ),
+                }
+                .into(),
+                other => Self::map_branch_error(other, &request.name, &table_uri),
+            })?;
+
+        Ok(DeleteTableBranchResponse {
+            transaction_id: None,
+        })
+    }
+
     fn namespace_id(&self) -> String {
         format!("DirectoryNamespace {{ root: {:?} }}", self.root)
     }
@@ -4414,6 +4604,7 @@ mod tests {
     use lance_core::utils::tempfile::{TempStdDir, TempStrDir};
     use lance_core::utils::testing::CountingObjectStore;
     use lance_io::object_store::{providers::local::FileStoreProvider, uri_to_url};
+    use lance_namespace::error::ErrorCode;
     use lance_namespace::models::{
         CreateTableRequest, JsonArrowDataType, JsonArrowField, JsonArrowSchema, ListTablesRequest,
         QueryTableRequestColumns,
@@ -10621,6 +10812,337 @@ mod tests {
         }
 
         (namespace, temp_dir, table_id)
+    }
+
+    /// Downcast a lance-core error to its NamespaceError code for precise assertions.
+    fn namespace_code(err: &Error) -> Option<ErrorCode> {
+        match err {
+            Error::Namespace { source, .. } => {
+                source.downcast_ref::<NamespaceError>().map(|e| e.code())
+            }
+            _ => None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_and_list_branches() {
+        let (namespace, _temp_dir, table_id) = create_tagged_test_table(3).await;
+
+        namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id.clone()),
+                name: "dev".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id.clone()),
+                name: "staging".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let resp = namespace
+            .list_table_branches(ListTableBranchesRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.branches.len(),
+            2,
+            "expected 2 branches, got: {:?}",
+            resp.branches
+        );
+        assert!(resp.branches.contains_key("dev"));
+        assert!(resp.branches.contains_key("staging"));
+        assert!(resp.page_token.is_none());
+
+        // Deleting one branch is reflected in a subsequent list.
+        namespace
+            .delete_table_branch(DeleteTableBranchRequest {
+                id: Some(table_id.clone()),
+                name: "dev".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let resp = namespace
+            .list_table_branches(ListTableBranchesRequest {
+                id: Some(table_id),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(resp.branches.len(), 1, "expected 1 branch after delete");
+        assert!(!resp.branches.contains_key("dev"));
+        assert!(resp.branches.contains_key("staging"));
+    }
+
+    #[tokio::test]
+    async fn test_create_branch_from_version() {
+        let (namespace, _temp_dir, table_id) = create_tagged_test_table(3).await;
+
+        // Fork explicitly from version 1 of main.
+        namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id.clone()),
+                name: "from-v1".to_string(),
+                from_version: Some(1),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let resp = namespace
+            .list_table_branches(ListTableBranchesRequest {
+                id: Some(table_id),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let branch = resp
+            .branches
+            .get("from-v1")
+            .expect("forked branch should be listed");
+        assert_eq!(
+            branch.parent_version, 1,
+            "branch should fork from version 1"
+        );
+        assert!(
+            branch.parent_branch.is_none(),
+            "a branch forked from main has no parent branch"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_existing_branch_conflict() {
+        let (namespace, _temp_dir, table_id) = create_tagged_test_table(2).await;
+
+        namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id.clone()),
+                name: "dev".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let err = namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id),
+                name: "dev".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            namespace_code(&err),
+            Some(ErrorCode::TableBranchAlreadyExists),
+            "expected TableBranchAlreadyExists, got: {}",
+            err
+        );
+        assert!(
+            err.to_string().to_lowercase().contains("already exists"),
+            "expected already-exists message, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_unknown_branch() {
+        let (namespace, _temp_dir, table_id) = create_tagged_test_table(2).await;
+
+        let err = namespace
+            .delete_table_branch(DeleteTableBranchRequest {
+                id: Some(table_id),
+                name: "does-not-exist".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            namespace_code(&err),
+            Some(ErrorCode::TableBranchNotFound),
+            "expected TableBranchNotFound, got: {}",
+            err
+        );
+        assert!(
+            err.to_string().to_lowercase().contains("not found"),
+            "expected not-found message, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_referenced_branch_conflict() {
+        let (namespace, _temp_dir, table_id) = create_tagged_test_table(2).await;
+
+        // A child forked from `parent` (via from_branch) makes `parent` a referenced branch.
+        namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id.clone()),
+                name: "parent".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id.clone()),
+                name: "child".to_string(),
+                from_branch: Some("parent".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        // from_branch resolution: the child records its parent branch as its fork point.
+        let listed = namespace
+            .list_table_branches(ListTableBranchesRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let child = listed
+            .branches
+            .get("child")
+            .expect("child branch should be listed");
+        assert_eq!(
+            child.parent_branch.as_deref(),
+            Some("parent"),
+            "child should record parent branch as its fork point"
+        );
+        assert!(
+            child.parent_version >= 1,
+            "child should record the parent version it forked from, got {}",
+            child.parent_version
+        );
+
+        // Deleting a branch that still has dependents is refused. The delete spec has no 409,
+        // so it surfaces as a documented InvalidInput (400), not a conflict status.
+        let err = namespace
+            .delete_table_branch(DeleteTableBranchRequest {
+                id: Some(table_id),
+                name: "parent".to_string(),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            namespace_code(&err),
+            Some(ErrorCode::InvalidInput),
+            "expected InvalidInput for deleting a referenced branch, got: {}",
+            err
+        );
+        assert!(
+            err.to_string().to_lowercase().contains("referenced"),
+            "error should explain the branch is still referenced, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_branch_name_required() {
+        let (namespace, _temp_dir, table_id) = create_tagged_test_table(2).await;
+
+        let create_err = namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id.clone()),
+                name: String::new(),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            namespace_code(&create_err),
+            Some(ErrorCode::InvalidInput),
+            "empty name on create should be InvalidInput, got: {}",
+            create_err
+        );
+        assert!(
+            create_err
+                .to_string()
+                .to_lowercase()
+                .contains("must not be empty")
+        );
+
+        let delete_err = namespace
+            .delete_table_branch(DeleteTableBranchRequest {
+                id: Some(table_id),
+                name: String::new(),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            namespace_code(&delete_err),
+            Some(ErrorCode::InvalidInput),
+            "empty name on delete should be InvalidInput, got: {}",
+            delete_err
+        );
+        assert!(
+            delete_err
+                .to_string()
+                .to_lowercase()
+                .contains("must not be empty")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_branch_rejects_negative_from_version() {
+        let (namespace, _temp_dir, table_id) = create_tagged_test_table(2).await;
+
+        let err = namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id),
+                name: "dev".to_string(),
+                from_version: Some(-1),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            namespace_code(&err),
+            Some(ErrorCode::InvalidInput),
+            "negative from_version should be InvalidInput, got: {}",
+            err
+        );
+        assert!(err.to_string().to_lowercase().contains("from_version"));
+    }
+
+    #[tokio::test]
+    async fn test_create_branch_nonexistent_from_version() {
+        let (namespace, _temp_dir, table_id) = create_tagged_test_table(2).await;
+
+        // Version 999 does not exist (the table has 2 versions). create_branch's clone phase
+        // raises DatasetNotFound, which we map to a documented InvalidInput (400).
+        let err = namespace
+            .create_table_branch(CreateTableBranchRequest {
+                id: Some(table_id),
+                name: "dev".to_string(),
+                from_version: Some(999),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            namespace_code(&err),
+            Some(ErrorCode::InvalidInput),
+            "non-existent from_version should map to InvalidInput, got: {}",
+            err
+        );
+        assert!(
+            err.to_string().to_lowercase().contains("does not exist"),
+            "error should name the missing source, got: {}",
+            err
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{StreamExt, TryStreamExt};
 use lance::dataset::builder::DatasetBuilder;
+use lance::dataset::refs::check_valid_branch;
 use lance::dataset::scanner::Scanner;
 use lance::dataset::statistics::DatasetStatisticsExt;
 use lance::dataset::transaction::{Operation, Transaction};
@@ -1160,6 +1161,54 @@ impl DirectoryNamespace {
         ObjectStore::extract_path_from_uri(registry, uri)
     }
 
+    /// Normalize and validate a branch selector: `None`, empty, and `main` mean
+    /// the main branch; any other name is validated with lance's
+    /// `check_valid_branch` (lance skips this on the open path) so it cannot
+    /// escape the table root via `..`.
+    fn normalized_branch(branch: Option<&str>) -> Result<Option<&str>> {
+        match branch.filter(|b| !b.is_empty() && *b != "main") {
+            Some(branch) => {
+                check_valid_branch(branch).map_err(|e| {
+                    lance_core::Error::from(NamespaceError::InvalidInput {
+                        message: format!("invalid branch name '{}': {}", branch, e),
+                    })
+                })?;
+                Ok(Some(branch))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn open_validated_branch(&self, table_uri: &str, branch: &str) -> Result<Dataset> {
+        let dataset = self
+            .configured_builder(table_uri)
+            .with_branch(branch, None)
+            .load()
+            .await
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::TableNotFound {
+                    message: format!(
+                        "branch '{}' not found for table at '{}': {}",
+                        branch, table_uri, e
+                    ),
+                })
+            })?;
+        dataset.branches().get(branch).await.map_err(|_| {
+            lance_core::Error::from(NamespaceError::TableNotFound {
+                message: format!("branch '{}' not found for table at '{}'", branch, table_uri),
+            })
+        })?;
+        Ok(dataset)
+    }
+
+    async fn resolve_branch_location(&self, table_uri: &str, branch: &str) -> Result<String> {
+        Ok(self
+            .open_validated_branch(table_uri, branch)
+            .await?
+            .branch_location()
+            .uri)
+    }
+
     fn validate_dir_only_properties(
         properties: Option<&HashMap<String, String>>,
         operation: &str,
@@ -1217,6 +1266,13 @@ impl DirectoryNamespace {
         Ok(dataset)
     }
 
+    /// Logical table version parsed from a manifest filename, or `None` for
+    /// non-manifest / detached entries. Delegates to lance's scheme detection so
+    /// version listing and deletion stay consistent with the on-disk format.
+    fn manifest_version_from_filename(filename: &str) -> Option<u64> {
+        ManifestNamingScheme::detect_scheme(filename)?.parse_version(filename)
+    }
+
     async fn list_table_versions_from_storage(
         &self,
         table_uri: &str,
@@ -1247,17 +1303,7 @@ impl DirectoryNamespace {
             .into_iter()
             .filter_map(|meta| {
                 let filename = meta.location.filename()?;
-                let version_str = filename.strip_suffix(".manifest")?;
-                if version_str.starts_with('d') {
-                    return None;
-                }
-                let file_version: u64 = version_str.parse().ok()?;
-
-                let actual_version = if file_version > u64::MAX / 2 {
-                    u64::MAX - file_version
-                } else {
-                    file_version
-                };
+                let actual_version = Self::manifest_version_from_filename(filename)?;
 
                 Some(TableVersion {
                     version: actual_version as i64,
@@ -1525,6 +1571,19 @@ impl DirectoryNamespace {
         }
     }
 
+    /// Build a `DatasetBuilder` for `table_uri` with this namespace's storage
+    /// options and session applied. Callers add version/branch scoping.
+    fn configured_builder(&self, table_uri: &str) -> DatasetBuilder {
+        let mut builder = DatasetBuilder::from_uri(table_uri);
+        if let Some(opts) = &self.storage_options {
+            builder = builder.with_storage_options(opts.clone());
+        }
+        if let Some(sess) = &self.session {
+            builder = builder.with_session(sess.clone());
+        }
+        builder
+    }
+
     async fn load_dataset(
         &self,
         table_uri: &str,
@@ -1543,13 +1602,7 @@ impl DirectoryNamespace {
             .into());
         }
 
-        let mut builder = DatasetBuilder::from_uri(table_uri);
-        if let Some(opts) = &self.storage_options {
-            builder = builder.with_storage_options(opts.clone());
-        }
-        if let Some(sess) = &self.session {
-            builder = builder.with_session(sess.clone());
-        }
+        let builder = self.configured_builder(table_uri);
 
         let dataset = builder.load().await.map_err(|e| {
             lance_core::Error::from(NamespaceError::TableNotFound {
@@ -2130,40 +2183,66 @@ impl DirectoryNamespace {
         &self,
         table_entries: &[TableDeleteEntry],
         best_effort: bool,
+        branch: Option<&str>,
     ) -> Result<i64> {
         let mut deleted_count = 0i64;
         for te in table_entries {
             let table_uri = self.resolve_table_location(&te.table_id).await?;
+            let table_uri = match branch {
+                Some(b) => self.resolve_branch_location(&table_uri, b).await?,
+                None => table_uri,
+            };
             let table_path = self.object_store_path_from_uri(&table_uri)?;
             let versions_dir_path = table_path.clone().join(VERSIONS_DIR);
 
-            for (start, end) in &te.ranges {
-                for version in *start..=*end {
-                    let version_path = versions_dir_path
-                        .clone()
-                        .join(format!("{}.manifest", version as u64));
-                    match self.object_store.inner.delete(&version_path).await {
-                        Ok(_) => {
-                            deleted_count += 1;
-                        }
-                        Err(object_store::Error::NotFound { .. }) => {}
-                        Err(e) => {
-                            if best_effort {
-                                log::warn!(
-                                    "Failed to delete manifest file for version {} of table {:?}: {:?}",
-                                    version,
-                                    te.table_id,
-                                    e
-                                );
-                            } else {
-                                return Err(NamespaceError::Internal {
-                                    message: format!(
-                                        "Failed to delete version {} for table at '{}': {}",
-                                        version, table_uri, e
-                                    ),
-                                }
-                                .into());
+            // Match listed files, not constructed names (`{version}.manifest` misses V2).
+            let manifest_metas: Vec<_> = self
+                .object_store
+                .read_dir_all(&versions_dir_path, None)
+                .try_collect()
+                .await
+                .map_err(|e| {
+                    lance_core::Error::from(NamespaceError::Internal {
+                        message: format!(
+                            "Failed to list manifest files for table at '{}': {}",
+                            table_uri, e
+                        ),
+                    })
+                })?;
+            let location_by_version: HashMap<u64, Path> = manifest_metas
+                .into_iter()
+                .filter_map(|meta| {
+                    let version = Self::manifest_version_from_filename(meta.location.filename()?)?;
+                    Some((version, meta.location))
+                })
+                .collect();
+
+            for (&v, version_path) in &location_by_version {
+                let vi = v as i64;
+                if !te.ranges.iter().any(|&(s, e)| vi >= s && vi <= e) {
+                    continue;
+                }
+                match self.object_store.inner.delete(version_path).await {
+                    Ok(_) => {
+                        deleted_count += 1;
+                    }
+                    Err(object_store::Error::NotFound { .. }) => {}
+                    Err(e) => {
+                        if best_effort {
+                            log::warn!(
+                                "Failed to delete manifest file for version {} of table {:?}: {:?}",
+                                v,
+                                te.table_id,
+                                e
+                            );
+                        } else {
+                            return Err(NamespaceError::Internal {
+                                message: format!(
+                                    "Failed to delete version {} for table at '{}': {}",
+                                    v, table_uri, e
+                                ),
                             }
+                            .into());
                         }
                     }
                 }
@@ -2807,8 +2886,11 @@ impl LanceNamespace for DirectoryNamespace {
         request: ListTableVersionsRequest,
     ) -> Result<ListTableVersionsResponse> {
         self.record_op("list_table_versions");
-        // When table_version_storage_enabled, query from __manifest
-        if self.table_version_storage_enabled
+        let branch = Self::normalized_branch(request.branch.as_deref())?;
+        // The manifest catalog has no branch concept, so a branch lists its own
+        // version chain from storage under its tree path instead.
+        if branch.is_none()
+            && self.table_version_storage_enabled
             && let Some(ref manifest_ns) = self.manifest_ns
         {
             let table_id = request.id.clone().unwrap_or_default();
@@ -2820,6 +2902,10 @@ impl LanceNamespace for DirectoryNamespace {
 
         // Fallback when table_version_storage is not enabled: list from _versions/ directory
         let table_uri = self.resolve_table_location(&request.id).await?;
+        let table_uri = match branch {
+            Some(b) => self.resolve_branch_location(&table_uri, b).await?,
+            None => table_uri,
+        };
         let want_descending = request.descending == Some(true);
         let table_versions = self
             .list_table_versions_from_storage(&table_uri, want_descending, request.limit)
@@ -2836,7 +2922,12 @@ impl LanceNamespace for DirectoryNamespace {
         request: CreateTableVersionRequest,
     ) -> Result<CreateTableVersionResponse> {
         self.record_op("create_table_version");
+        let branch = Self::normalized_branch(request.branch.as_deref())?;
         let table_uri = self.resolve_table_location(&request.id).await?;
+        let table_uri = match branch {
+            Some(b) => self.resolve_branch_location(&table_uri, b).await?,
+            None => table_uri,
+        };
 
         let staging_manifest_path = &request.manifest_path;
         let version = request.version as u64;
@@ -2956,8 +3047,10 @@ impl LanceNamespace for DirectoryNamespace {
             );
         }
 
-        // If table_version_storage_enabled is enabled, also record in __manifest (best-effort)
-        if self.table_version_storage_enabled
+        // Also record in __manifest (best-effort). Branches aren't tracked there,
+        // so for a branch the storage manifest above is the only record.
+        if branch.is_none()
+            && self.table_version_storage_enabled
             && let Some(ref manifest_ns) = self.manifest_ns
         {
             let table_id_str =
@@ -3009,9 +3102,12 @@ impl LanceNamespace for DirectoryNamespace {
         request: DescribeTableVersionRequest,
     ) -> Result<DescribeTableVersionResponse> {
         self.record_op("describe_table_version");
+        let branch = Self::normalized_branch(request.branch.as_deref())?;
         // When table_version_storage_enabled and a specific version is requested,
-        // query from __manifest to avoid opening the entire dataset
-        if self.table_version_storage_enabled
+        // query from __manifest to avoid opening the entire dataset. A branch has
+        // no manifest-catalog entry, so it resolves from storage instead.
+        if branch.is_none()
+            && self.table_version_storage_enabled
             && let (Some(manifest_ns), Some(version)) = (&self.manifest_ns, request.version)
         {
             let table_id = request.id.clone().unwrap_or_default();
@@ -3020,6 +3116,10 @@ impl LanceNamespace for DirectoryNamespace {
 
         // Fallback when table_version_storage is not enabled: inspect physical manifests directly.
         let table_uri = self.resolve_table_location(&request.id).await?;
+        let table_uri = match branch {
+            Some(b) => self.resolve_branch_location(&table_uri, b).await?,
+            None => table_uri,
+        };
         let versions = self
             .list_table_versions_from_storage(&table_uri, true, None)
             .await?;
@@ -3057,6 +3157,7 @@ impl LanceNamespace for DirectoryNamespace {
         request: BatchDeleteTableVersionsRequest,
     ) -> Result<BatchDeleteTableVersionsResponse> {
         self.record_op("batch_delete_table_versions");
+        let branch = Self::normalized_branch(request.branch.as_deref())?;
         // Single-table mode: use `id` (from path parameter) + `ranges` to delete
         // versions from one table.
         let ranges: Vec<(i64, i64)> = request
@@ -3072,6 +3173,24 @@ impl LanceNamespace for DirectoryNamespace {
                 (start, end)
             })
             .collect();
+
+        // Reject pathological ranges up front: the manifest path below builds one
+        // id per version, so (0, i64::MAX) would exhaust memory.
+        const MAX_VERSIONS_PER_REQUEST: i128 = 1_000_000;
+        let requested: i128 = ranges
+            .iter()
+            .map(|(s, e)| (*e as i128 - *s as i128 + 1).max(0))
+            .sum();
+        if requested > MAX_VERSIONS_PER_REQUEST {
+            return Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "batch_delete requested {} versions; limit is {}",
+                    requested, MAX_VERSIONS_PER_REQUEST
+                ),
+            }
+            .into());
+        }
+
         let table_entries = vec![TableDeleteEntry {
             table_id: request.id.clone(),
             ranges,
@@ -3079,7 +3198,10 @@ impl LanceNamespace for DirectoryNamespace {
 
         let mut total_deleted_count = 0i64;
 
-        if self.table_version_storage_enabled
+        // Branches are not tracked in the manifest catalog, so a branch skips the
+        // __manifest phase entirely and deletes its physical manifests directly.
+        if branch.is_none()
+            && self.table_version_storage_enabled
             && let Some(ref manifest_ns) = self.manifest_ns
         {
             // Phase 1 (atomic commit point): Delete version records from __manifest
@@ -3115,7 +3237,7 @@ impl LanceNamespace for DirectoryNamespace {
             // __manifest, so they won't be visible to readers. Leftover files are
             // orphaned but harmless and can be cleaned up later.
             let _ = self
-                .delete_physical_version_files(&table_entries, true)
+                .delete_physical_version_files(&table_entries, true, branch)
                 .await;
 
             return Ok(BatchDeleteTableVersionsResponse {
@@ -3124,9 +3246,10 @@ impl LanceNamespace for DirectoryNamespace {
             });
         }
 
-        // Fallback when table_version_storage is not enabled: delete physical files directly (no __manifest)
+        // Direct path: delete physical files (no __manifest). Reached when storage
+        // tracking is off, or for any branch (which has no __manifest entries).
         total_deleted_count = self
-            .delete_physical_version_files(&table_entries, false)
+            .delete_physical_version_files(&table_entries, false, branch)
             .await?;
 
         Ok(BatchDeleteTableVersionsResponse {
@@ -3462,8 +3585,12 @@ impl LanceNamespace for DirectoryNamespace {
             ));
         }
 
+        let branch = Self::normalized_branch(request.branch.as_deref())?;
         let table_uri = self.resolve_table_location(&request.id).await?;
-        let mut dataset = self.load_dataset(&table_uri, None, "restore_table").await?;
+        let mut dataset = match branch {
+            Some(branch) => self.open_validated_branch(&table_uri, branch).await?,
+            None => self.load_dataset(&table_uri, None, "restore_table").await?,
+        };
 
         dataset = dataset
             .checkout_version(version as u64)
@@ -4563,6 +4690,594 @@ mod tests {
             .await
             .unwrap()
             .transaction_id
+    }
+
+    /// Fork `branch_name` from the table's current version and append
+    /// `extra_versions` commits to it (each a new version on the branch, written
+    /// with the default V2 naming). The main branch is left untouched. Returns
+    /// the branch's storage URI (`<root>/tree/<branch>`).
+    async fn create_branch_with_commits(
+        namespace: &DirectoryNamespace,
+        table_name: &str,
+        branch_name: &str,
+        extra_versions: usize,
+    ) -> String {
+        let mut main = open_dataset(namespace, table_name).await;
+        let fork_version = main.version().version;
+        let branch = main
+            .create_branch(branch_name, fork_version, None)
+            .await
+            .unwrap();
+        let branch_uri = branch.uri().to_string();
+        for i in 0..extra_versions {
+            append_scalar_version(&branch_uri, (i as i32 + 1) * 100).await;
+        }
+        branch_uri
+    }
+
+    /// Append one scalar-schema batch to the dataset at `uri`, creating a new
+    /// version (default V2 naming). Shared by branch and main chain setup.
+    async fn append_scalar_version(uri: &str, seed: i32) {
+        use arrow::array::{Int32Array, StringArray};
+        use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let batch = arrow::record_batch::RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![seed, seed + 1])),
+                Arc::new(StringArray::from(vec![Some("x"), Some("y")])),
+            ],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        Dataset::write(
+            reader,
+            uri,
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    }
+
+    /// List a table's versions on `branch` (None == main) via the namespace.
+    async fn list_versions(
+        namespace: &DirectoryNamespace,
+        table_name: &str,
+        branch: Option<&str>,
+    ) -> Result<Vec<TableVersion>> {
+        let req = ListTableVersionsRequest {
+            id: Some(vec![table_name.to_string()]),
+            branch: branch.map(|b| b.to_string()),
+            ..Default::default()
+        };
+        namespace.list_table_versions(req).await.map(|r| r.versions)
+    }
+
+    #[tokio::test]
+    async fn test_list_table_versions_on_branch() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await;
+        create_branch_with_commits(&namespace, "users", "exp", 2).await;
+
+        // The branch lists its own chain, and every version resolves to a
+        // manifest under the branch's tree path.
+        let branch_versions = list_versions(&namespace, "users", Some("exp"))
+            .await
+            .unwrap();
+        assert!(branch_versions.len() >= 2);
+        assert!(
+            branch_versions
+                .iter()
+                .all(|v| v.manifest_path.contains("tree/exp")),
+            "branch versions must resolve to branch manifests: {:?}",
+            branch_versions
+        );
+
+        // Unset and "main" behave identically and never see the tree path.
+        let main_versions = list_versions(&namespace, "users", None).await.unwrap();
+        let main_explicit = list_versions(&namespace, "users", Some("main"))
+            .await
+            .unwrap();
+        assert_eq!(main_versions.len(), main_explicit.len());
+        assert!(
+            main_versions
+                .iter()
+                .all(|v| !v.manifest_path.contains("tree/"))
+        );
+
+        // A non-existent branch is a clean not-found, not an empty list.
+        let missing = list_versions(&namespace, "users", Some("does-not-exist")).await;
+        assert!(missing.is_err());
+        assert!(missing.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_describe_table_version_on_branch() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await;
+        create_branch_with_commits(&namespace, "users", "exp", 2).await;
+
+        let branch_versions = list_versions(&namespace, "users", Some("exp"))
+            .await
+            .unwrap();
+        let latest = branch_versions.iter().map(|v| v.version).max().unwrap();
+
+        // Describe latest on the branch returns the branch's manifest_path.
+        let req = DescribeTableVersionRequest {
+            id: Some(vec!["users".to_string()]),
+            branch: Some("exp".to_string()),
+            ..Default::default()
+        };
+        let resp = namespace.describe_table_version(req).await.unwrap();
+        assert_eq!(resp.version.version, latest);
+        assert!(resp.version.manifest_path.contains("tree/exp"));
+
+        // A specific existing branch version resolves.
+        let req = DescribeTableVersionRequest {
+            id: Some(vec!["users".to_string()]),
+            version: Some(latest),
+            branch: Some("exp".to_string()),
+            ..Default::default()
+        };
+        assert!(namespace.describe_table_version(req).await.is_ok());
+
+        // A version absent on the branch is not found.
+        let req = DescribeTableVersionRequest {
+            id: Some(vec!["users".to_string()]),
+            version: Some(999_999),
+            branch: Some("exp".to_string()),
+            ..Default::default()
+        };
+        assert!(namespace.describe_table_version(req).await.is_err());
+
+        // A non-existent branch is not found.
+        let req = DescribeTableVersionRequest {
+            id: Some(vec!["users".to_string()]),
+            branch: Some("nope".to_string()),
+            ..Default::default()
+        };
+        let err = namespace.describe_table_version(req).await;
+        assert!(err.is_err() && err.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_restore_table_on_branch() {
+        use lance_namespace::models::RestoreTableRequest;
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await;
+        create_branch_with_commits(&namespace, "users", "exp", 2).await;
+
+        let before = list_versions(&namespace, "users", Some("exp"))
+            .await
+            .unwrap();
+        let branch_latest = before.iter().map(|v| v.version).max().unwrap();
+        let earliest = before.iter().map(|v| v.version).min().unwrap();
+        let main_before = list_versions(&namespace, "users", None)
+            .await
+            .unwrap()
+            .len();
+
+        // Restoring the branch to an earlier version commits a NEW version on
+        // the branch (restore is itself a commit), and must not touch main.
+        let req = RestoreTableRequest {
+            id: Some(vec!["users".to_string()]),
+            version: earliest,
+            branch: Some("exp".to_string()),
+            ..Default::default()
+        };
+        let resp = namespace.restore_table(req).await.unwrap();
+        assert!(resp.transaction_id.is_some());
+
+        let after = list_versions(&namespace, "users", Some("exp"))
+            .await
+            .unwrap();
+        let new_latest = after.iter().map(|v| v.version).max().unwrap();
+        assert!(
+            new_latest > branch_latest,
+            "restore should add a branch version"
+        );
+
+        let main_after = list_versions(&namespace, "users", None)
+            .await
+            .unwrap()
+            .len();
+        assert_eq!(main_after, main_before, "main must be unaffected");
+    }
+
+    #[tokio::test]
+    async fn test_batch_delete_table_versions_on_branch() {
+        use lance_namespace::models::{BatchDeleteTableVersionsRequest, VersionRange};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await;
+        create_branch_with_commits(&namespace, "users", "exp", 2).await;
+
+        let before = list_versions(&namespace, "users", Some("exp"))
+            .await
+            .unwrap();
+        let min_v = before.iter().map(|v| v.version).min().unwrap();
+        let max_v = before.iter().map(|v| v.version).max().unwrap();
+        let main_before = list_versions(&namespace, "users", None).await.unwrap();
+
+        // Delete the branch's whole version range. The branch manifests use V2
+        // naming (inverted, zero-padded), so a nonzero deleted_count proves the
+        // V2 fix: the old code constructed "{version}.manifest" and silently
+        // matched nothing.
+        let req = BatchDeleteTableVersionsRequest {
+            id: Some(vec!["users".to_string()]),
+            branch: Some("exp".to_string()),
+            ranges: vec![VersionRange::new(min_v, max_v)],
+            ..Default::default()
+        };
+        let resp = namespace.batch_delete_table_versions(req).await.unwrap();
+        assert_eq!(
+            resp.deleted_count,
+            Some(before.len() as i64),
+            "every branch manifest should be physically deleted"
+        );
+
+        // The emptied branch now reads as not-found, and main is untouched.
+        assert!(
+            list_versions(&namespace, "users", Some("exp"))
+                .await
+                .is_err()
+        );
+        let main_after = list_versions(&namespace, "users", None).await.unwrap();
+        assert_eq!(
+            main_after.len(),
+            main_before.len(),
+            "main must be untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_table_version_on_branch() {
+        use futures::TryStreamExt;
+        use lance_namespace::models::CreateTableVersionRequest;
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await;
+        let branch_uri = create_branch_with_commits(&namespace, "users", "exp", 1).await;
+
+        // Stage a manifest by copying one of the branch's existing manifests.
+        let branch_ds = Dataset::open(&branch_uri).await.unwrap();
+        let versions_dir = branch_ds.versions_dir();
+        let store = branch_ds.object_store(None).await.unwrap();
+        let existing = store
+            .inner
+            .list(Some(&versions_dir))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|m| {
+                m.location
+                    .filename()
+                    .map(|f| f.ends_with(".manifest"))
+                    .unwrap_or(false)
+            })
+            .expect("a branch manifest");
+        let bytes = store
+            .inner
+            .get(&existing.location)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let staging = versions_dir.join("staging_manifest");
+        store.inner.put(&staging, bytes.into()).await.unwrap();
+
+        let main_before = list_versions(&namespace, "users", None)
+            .await
+            .unwrap()
+            .len();
+        let new_version = list_versions(&namespace, "users", Some("exp"))
+            .await
+            .unwrap()
+            .iter()
+            .map(|v| v.version)
+            .max()
+            .unwrap()
+            + 1;
+
+        let req = CreateTableVersionRequest {
+            id: Some(vec!["users".to_string()]),
+            version: new_version,
+            manifest_path: staging.to_string(),
+            naming_scheme: Some("V2".to_string()),
+            branch: Some("exp".to_string()),
+            ..Default::default()
+        };
+        let resp = namespace.create_table_version(req).await.unwrap();
+        let info = resp.version.expect("version info");
+        // The new manifest must land under the branch's tree path.
+        assert!(
+            info.manifest_path.contains("tree/exp"),
+            "got {}",
+            info.manifest_path
+        );
+
+        // It is visible on the branch, and main did not gain a version.
+        let after = list_versions(&namespace, "users", Some("exp"))
+            .await
+            .unwrap();
+        assert!(after.iter().any(|v| v.version == new_version));
+        let main_after = list_versions(&namespace, "users", None)
+            .await
+            .unwrap()
+            .len();
+        assert_eq!(main_after, main_before, "main must be unaffected");
+    }
+
+    #[tokio::test]
+    async fn test_branch_name_validation_rejects_traversal() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await;
+
+        // A traversal-style branch name is rejected as invalid input before any
+        // storage path is built from it.
+        let err = list_versions(&namespace, "users", Some("../evil")).await;
+        assert!(err.is_err());
+        assert!(err.unwrap_err().to_string().contains("invalid branch name"));
+    }
+
+    #[tokio::test]
+    async fn test_branch_ops_reject_zombie_branch() {
+        use futures::TryStreamExt;
+        use lance_namespace::models::{
+            BatchDeleteTableVersionsRequest, CreateTableVersionRequest, RestoreTableRequest,
+            VersionRange,
+        };
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await;
+
+        // Stage a real (loadable) manifest under tree/ghost/_versions/ without
+        // create_branch, so the path exists but has no BranchContents ref.
+        let dataset = open_dataset(&namespace, "users").await;
+        let store = dataset.object_store(None).await.unwrap();
+        let manifest = store
+            .inner
+            .list(Some(&dataset.versions_dir()))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|m| {
+                m.location
+                    .filename()
+                    .map(|f| f.ends_with(".manifest"))
+                    .unwrap_or(false)
+            })
+            .expect("a manifest");
+        let bytes = store
+            .inner
+            .get(&manifest.location)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let zombie = Path::from(format!(
+            "{}/tree/ghost/_versions/{}",
+            dataset.branch_location().path,
+            manifest.location.filename().unwrap()
+        ));
+        store.inner.put(&zombie, bytes.into()).await.unwrap();
+
+        // The directory is physically present, but the source of truth has no
+        // such branch -- this is what makes every op below reject it.
+        assert!(dataset.branches().get("ghost").await.is_err());
+
+        fn rejected<T: std::fmt::Debug>(label: &str, r: Result<T>) {
+            match r {
+                Ok(v) => panic!("{label} must reject the zombie branch, got Ok({v:?})"),
+                Err(e) => assert!(e.to_string().contains("not found"), "{label}: {e}"),
+            }
+        }
+
+        rejected(
+            "list",
+            list_versions(&namespace, "users", Some("ghost")).await,
+        );
+        rejected(
+            "describe",
+            namespace
+                .describe_table_version(DescribeTableVersionRequest {
+                    id: Some(vec!["users".to_string()]),
+                    branch: Some("ghost".to_string()),
+                    ..Default::default()
+                })
+                .await,
+        );
+        rejected(
+            "create",
+            namespace
+                .create_table_version(CreateTableVersionRequest {
+                    id: Some(vec!["users".to_string()]),
+                    version: 2,
+                    manifest_path: zombie.to_string(),
+                    branch: Some("ghost".to_string()),
+                    ..Default::default()
+                })
+                .await,
+        );
+        rejected(
+            "restore",
+            namespace
+                .restore_table(RestoreTableRequest {
+                    id: Some(vec!["users".to_string()]),
+                    version: 1,
+                    branch: Some("ghost".to_string()),
+                    ..Default::default()
+                })
+                .await,
+        );
+        rejected(
+            "batch_delete",
+            namespace
+                .batch_delete_table_versions(BatchDeleteTableVersionsRequest {
+                    id: Some(vec!["users".to_string()]),
+                    branch: Some("ghost".to_string()),
+                    ranges: vec![VersionRange::new(1, 1)],
+                    ..Default::default()
+                })
+                .await,
+        );
+    }
+
+    /// V2 is the default naming scheme, and the pre-rewrite delete path
+    /// constructed `{version}.manifest` (a V1 name) and silently matched nothing
+    /// on a V2 table, returning deleted_count 0. This pins the fix on the main
+    /// chain (branch=None), which previously had no batch_delete coverage at all.
+    #[tokio::test]
+    async fn test_batch_delete_table_versions_main_v2() {
+        use lance_namespace::models::{BatchDeleteTableVersionsRequest, VersionRange};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await; // version 1
+        let main_uri = open_dataset(&namespace, "users").await.uri().to_string();
+        append_scalar_version(&main_uri, 100).await; // version 2
+        append_scalar_version(&main_uri, 200).await; // version 3
+
+        let before = list_versions(&namespace, "users", None).await.unwrap();
+        assert!(before.len() >= 3);
+        // Confirm these really are V2-named manifests (20-digit inverted version
+        // + ".manifest" == 29 chars), i.e. the case the old code skipped.
+        assert!(
+            before
+                .iter()
+                .all(|v| v.manifest_path.rsplit('/').next().unwrap().len() == 29),
+            "expected V2-named manifests: {:?}",
+            before
+        );
+        let min_v = before.iter().map(|v| v.version).min().unwrap();
+        let max_v = before.iter().map(|v| v.version).max().unwrap();
+
+        // Delete everything except the latest version.
+        let req = BatchDeleteTableVersionsRequest {
+            id: Some(vec!["users".to_string()]),
+            ranges: vec![VersionRange::new(min_v, max_v - 1)],
+            ..Default::default()
+        };
+        let resp = namespace.batch_delete_table_versions(req).await.unwrap();
+        assert_eq!(
+            resp.deleted_count,
+            Some((before.len() - 1) as i64),
+            "V2 manifests must actually be deleted (was 0 before the fix)"
+        );
+
+        let after = list_versions(&namespace, "users", None).await.unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].version, max_v);
+    }
+
+    #[tokio::test]
+    async fn test_batch_delete_rejects_unbounded_range() {
+        use lance_namespace::models::{BatchDeleteTableVersionsRequest, VersionRange};
+
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        create_scalar_table(&namespace, "users").await;
+
+        // An unbounded range must be rejected up front, not turned into ~10^19
+        // iterations / an unbounded id list.
+        let req = BatchDeleteTableVersionsRequest {
+            id: Some(vec!["users".to_string()]),
+            ranges: vec![VersionRange::new(0, i64::MAX)],
+            ..Default::default()
+        };
+        let err = namespace.batch_delete_table_versions(req).await;
+        assert!(err.is_err());
+        assert!(
+            err.unwrap_err().to_string().contains("limit"),
+            "expected a range-too-large error"
+        );
+    }
+
+    /// The shared parser must decode both naming schemes; this is the cheap
+    /// V1 no-regression guard (creating a real V1 table is not exposed here).
+    #[test]
+    fn test_manifest_version_from_filename() {
+        // V1: the plain version number.
+        assert_eq!(
+            DirectoryNamespace::manifest_version_from_filename("5.manifest"),
+            Some(5)
+        );
+        assert_eq!(
+            DirectoryNamespace::manifest_version_from_filename("0.manifest"),
+            Some(0)
+        );
+        // V2: version stored as u64::MAX - version, zero-padded to 20 digits.
+        let v2_five = format!("{:020}.manifest", u64::MAX - 5);
+        assert_eq!(
+            DirectoryNamespace::manifest_version_from_filename(&v2_five),
+            Some(5)
+        );
+        let v2_zero = format!("{:020}.manifest", u64::MAX);
+        assert_eq!(
+            DirectoryNamespace::manifest_version_from_filename(&v2_zero),
+            Some(0)
+        );
+        // Non-manifest and detached (`d`-prefixed) entries are ignored.
+        assert_eq!(
+            DirectoryNamespace::manifest_version_from_filename("data.lance"),
+            None
+        );
+        assert_eq!(
+            DirectoryNamespace::manifest_version_from_filename("d5.manifest"),
+            None
+        );
+    }
+
+    /// With the manifest store enabled, branch ops must still bypass the catalog
+    /// fast-path and read the chain from `tree/<branch>/_versions/`. Without the
+    /// `branch.is_none()` guard this would query `__manifest` (which has no
+    /// branch entries) and return the wrong result. The other branch tests use a
+    /// store-disabled namespace, so this pins the enabled path specifically.
+    #[tokio::test]
+    async fn test_branch_ops_skip_manifest_store_when_enabled() {
+        let temp_dir = TempStdDir::default();
+        let namespace = DirectoryNamespaceBuilder::new(temp_dir.to_str().unwrap())
+            .manifest_enabled(true)
+            .table_version_storage_enabled(true)
+            .build()
+            .await
+            .unwrap();
+
+        create_scalar_table(&namespace, "users").await;
+        create_branch_with_commits(&namespace, "users", "exp", 2).await;
+
+        // list resolves the branch chain from storage despite storage tracking
+        // being on (a successful result with tree/exp paths proves the bypass:
+        // the catalog has no "exp" entry, so the fast-path would not return these).
+        let branch_versions = list_versions(&namespace, "users", Some("exp"))
+            .await
+            .unwrap();
+        assert!(branch_versions.len() >= 2);
+        assert!(
+            branch_versions
+                .iter()
+                .all(|v| v.manifest_path.contains("tree/exp")),
+            "branch versions must come from branch storage with the store enabled: {:?}",
+            branch_versions
+        );
+
+        // describe likewise resolves from the branch's storage.
+        let req = DescribeTableVersionRequest {
+            id: Some(vec!["users".to_string()]),
+            branch: Some("exp".to_string()),
+            ..Default::default()
+        };
+        let resp = namespace.describe_table_version(req).await.unwrap();
+        assert!(resp.version.manifest_path.contains("tree/exp"));
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/rest.rs
+++ b/rust/lance-namespace-impls/src/rest.rs
@@ -1294,6 +1294,13 @@ impl LanceNamespace for RestNamespace {
             descending_str = descending.to_string();
             query.push(("descending", descending_str.as_str()));
         }
+        // Forward branch as a query param (this op sends no body).
+        // describe_table_version differs: branch rides its body, already serialized.
+        let branch_str;
+        if let Some(ref branch) = request.branch {
+            branch_str = branch.clone();
+            query.push(("branch", branch_str.as_str()));
+        }
         self.post_json(&path, &query, &(), "list_table_versions", &id)
             .await
     }

--- a/rust/lance-namespace-impls/src/rest.rs
+++ b/rust/lance-namespace-impls/src/rest.rs
@@ -23,11 +23,13 @@ use lance_namespace::models::{
     AlterTransactionRequest, AlterTransactionResponse, AnalyzeTableQueryPlanRequest,
     BatchDeleteTableVersionsRequest, BatchDeleteTableVersionsResponse, CountTableRowsRequest,
     CreateMaterializedViewRequest, CreateMaterializedViewResponse, CreateNamespaceRequest,
-    CreateNamespaceResponse, CreateTableIndexRequest, CreateTableIndexResponse, CreateTableRequest,
-    CreateTableResponse, CreateTableScalarIndexResponse, CreateTableTagRequest,
-    CreateTableTagResponse, CreateTableVersionRequest, CreateTableVersionResponse,
-    DeclareTableRequest, DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
-    DeleteTableTagRequest, DeleteTableTagResponse, DeregisterTableRequest, DeregisterTableResponse,
+    CreateNamespaceResponse, CreateTableBranchRequest, CreateTableBranchResponse,
+    CreateTableIndexRequest, CreateTableIndexResponse, CreateTableRequest, CreateTableResponse,
+    CreateTableScalarIndexResponse, CreateTableTagRequest, CreateTableTagResponse,
+    CreateTableVersionRequest, CreateTableVersionResponse, DeclareTableRequest,
+    DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
+    DeleteTableBranchRequest, DeleteTableBranchResponse, DeleteTableTagRequest,
+    DeleteTableTagResponse, DeregisterTableRequest, DeregisterTableResponse,
     DescribeNamespaceRequest, DescribeNamespaceResponse, DescribeTableIndexStatsRequest,
     DescribeTableIndexStatsResponse, DescribeTableRequest, DescribeTableResponse,
     DescribeTableVersionRequest, DescribeTableVersionResponse, DescribeTransactionRequest,
@@ -36,7 +38,8 @@ use lance_namespace::models::{
     ErrorResponse, ExplainTableQueryPlanRequest, GetTableStatsRequest, GetTableStatsResponse,
     GetTableTagVersionRequest, GetTableTagVersionResponse, InsertIntoTableRequest,
     InsertIntoTableResponse, ListNamespacesRequest, ListNamespacesResponse,
-    ListTableIndicesRequest, ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
+    ListTableBranchesRequest, ListTableBranchesResponse, ListTableIndicesRequest,
+    ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
     ListTableVersionsRequest, ListTableVersionsResponse, ListTablesRequest, ListTablesResponse,
     MergeInsertIntoTableRequest, MergeInsertIntoTableResponse, NamespaceExistsRequest,
     QueryTableRequest, RefreshMaterializedViewRequest, RefreshMaterializedViewResponse,
@@ -1557,6 +1560,55 @@ impl LanceNamespace for RestNamespace {
         let path = format!("/v1/table/{}/tags/update", encoded_id);
         let query = [("delimiter", self.delimiter.as_str())];
         self.post_json(&path, &query, &request, "update_table_tag", &id)
+            .await
+    }
+
+    async fn create_table_branch(
+        &self,
+        request: CreateTableBranchRequest,
+    ) -> Result<CreateTableBranchResponse> {
+        self.record_op("create_table_branch");
+        let id = object_id_str(&request.id, &self.delimiter)?;
+        let encoded_id = urlencode(&id);
+        let path = format!("/v1/table/{}/branches/create", encoded_id);
+        let query = [("delimiter", self.delimiter.as_str())];
+        self.post_json(&path, &query, &request, "create_table_branch", &id)
+            .await
+    }
+
+    async fn list_table_branches(
+        &self,
+        request: ListTableBranchesRequest,
+    ) -> Result<ListTableBranchesResponse> {
+        self.record_op("list_table_branches");
+        let id = object_id_str(&request.id, &self.delimiter)?;
+        let encoded_id = urlencode(&id);
+        let path = format!("/v1/table/{}/branches/list", encoded_id);
+        let mut query = vec![("delimiter", self.delimiter.as_str())];
+        let page_token_str;
+        if let Some(ref pt) = request.page_token {
+            page_token_str = pt.clone();
+            query.push(("page_token", page_token_str.as_str()));
+        }
+        let limit_str;
+        if let Some(limit) = request.limit {
+            limit_str = limit.to_string();
+            query.push(("limit", limit_str.as_str()));
+        }
+        self.post_json(&path, &query, &request, "list_table_branches", &id)
+            .await
+    }
+
+    async fn delete_table_branch(
+        &self,
+        request: DeleteTableBranchRequest,
+    ) -> Result<DeleteTableBranchResponse> {
+        self.record_op("delete_table_branch");
+        let id = object_id_str(&request.id, &self.delimiter)?;
+        let encoded_id = urlencode(&id);
+        let path = format!("/v1/table/{}/branches/delete", encoded_id);
+        let query = [("delimiter", self.delimiter.as_str())];
+        self.post_json(&path, &query, &request, "delete_table_branch", &id)
             .await
     }
 

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -1523,15 +1523,28 @@ mod tests {
 
         impl RestServerFixture {
             async fn new() -> Self {
+                Self::build(false).await
+            }
+
+            /// Like [`Self::new`], with managed versioning (table version
+            /// tracking through the `__manifest` catalog) enabled on the
+            /// backend.
+            async fn new_managed() -> Self {
+                Self::build(true).await
+            }
+
+            async fn build(managed_versioning: bool) -> Self {
                 let temp_dir = TempDir::new().unwrap();
                 let temp_path = temp_dir.path().to_str().unwrap().to_string();
 
                 // Create DirectoryNamespace backend with manifest enabled
-                let backend = DirectoryNamespaceBuilder::new(&temp_path)
-                    .manifest_enabled(true)
-                    .build()
-                    .await
-                    .unwrap();
+                let mut builder = DirectoryNamespaceBuilder::new(&temp_path).manifest_enabled(true);
+                if managed_versioning {
+                    builder = builder
+                        .table_version_tracking_enabled(true)
+                        .table_version_storage_enabled(true);
+                }
+                let backend = builder.build().await.unwrap();
                 let backend = Arc::new(backend);
 
                 // Start REST server with port 0 (OS assigns available port)
@@ -3450,6 +3463,190 @@ mod tests {
                 "deleting a missing branch should map to 404, got {}",
                 resp.status()
             );
+
+            fixture.server_handle.shutdown();
+        }
+
+        /// The managed (manifest-tracked) branch flow over REST: create a
+        /// managed table and a branch through the RestNamespace client, open
+        /// the branch via `from_namespace(...).with_branch`, commit on it,
+        /// check out across branches at an overlapping version number, and
+        /// round-trip a branch-pointing tag. Mirrors the DirectoryNamespace
+        /// e2e to prove the REST layer forwards everything the managed commit
+        /// store needs.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_namespace_managed_branch_e2e() {
+            use arrow::array::Int32Array;
+            use arrow::datatypes::{DataType, Field as ArrowField, Schema as ArrowSchema};
+            use arrow::record_batch::{RecordBatch, RecordBatchIterator};
+            use futures::TryStreamExt;
+            use lance::dataset::builder::DatasetBuilder;
+            use lance::dataset::refs::Ref;
+            use lance::dataset::{Dataset, WriteMode, WriteParams};
+            use lance_namespace::LanceNamespace;
+
+            async fn scan_ids(ds: &Dataset) -> Vec<i32> {
+                let batches: Vec<RecordBatch> = ds
+                    .scan()
+                    .try_into_stream()
+                    .await
+                    .unwrap()
+                    .try_collect()
+                    .await
+                    .unwrap();
+                let mut ids: Vec<i32> = batches
+                    .iter()
+                    .flat_map(|b| {
+                        b.column(0)
+                            .as_any()
+                            .downcast_ref::<Int32Array>()
+                            .unwrap()
+                            .values()
+                            .to_vec()
+                    })
+                    .collect();
+                ids.sort();
+                ids
+            }
+
+            let fixture = RestServerFixture::new_managed().await;
+            let namespace = Arc::new(fixture.namespace.clone()) as Arc<dyn LanceNamespace>;
+            let table_id = vec!["mb_table".to_string()];
+
+            let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                "id",
+                DataType::Int32,
+                false,
+            )]));
+            let batch = |seed: i32| {
+                RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![seed]))])
+                    .unwrap()
+            };
+
+            // Managed main: v1 (id=1), v2 (id=2).
+            let mut main_ds = Dataset::write_into_namespace(
+                RecordBatchIterator::new(vec![Ok(batch(1))], schema.clone()),
+                namespace.clone(),
+                table_id.clone(),
+                Some(WriteParams {
+                    mode: WriteMode::Create,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+            main_ds
+                .append(
+                    RecordBatchIterator::new(vec![Ok(batch(2))], schema.clone()),
+                    None,
+                )
+                .await
+                .unwrap();
+
+            // The REST layer must surface managed versioning for the deferred
+            // commit handler to engage.
+            let described = namespace
+                .describe_table(DescribeTableRequest {
+                    id: Some(table_id.clone()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            assert_eq!(
+                described.managed_versioning,
+                Some(true),
+                "managed_versioning must survive the REST round trip"
+            );
+            let main_chain_len = |ns: Arc<dyn LanceNamespace>, table_id: Vec<String>| async move {
+                ns.list_table_versions(ListTableVersionsRequest {
+                    id: Some(table_id),
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .versions
+                .len()
+            };
+            assert_eq!(main_chain_len(namespace.clone(), table_id.clone()).await, 2);
+
+            // Branch via the REST client, then open and commit on it.
+            namespace
+                .create_table_branch(CreateTableBranchRequest {
+                    id: Some(table_id.clone()),
+                    name: "exp".to_string(),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            let mut branch_ds = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+                .await
+                .unwrap()
+                .with_branch("exp", None)
+                .load()
+                .await
+                .unwrap();
+            assert_eq!(branch_ds.manifest().branch.as_deref(), Some("exp"));
+            assert!(
+                branch_ds
+                    .branch_location()
+                    .path
+                    .as_ref()
+                    .ends_with("tree/exp"),
+                "the branch dataset must be rooted at the branch chain"
+            );
+            branch_ds
+                .append(
+                    RecordBatchIterator::new(vec![Ok(batch(3))], schema.clone()),
+                    None,
+                )
+                .await
+                .unwrap();
+            assert_eq!(branch_ds.manifest().branch.as_deref(), Some("exp"));
+            assert_eq!(scan_ids(&branch_ds).await, vec![1, 2, 3]);
+            assert_eq!(
+                main_chain_len(namespace.clone(), table_id.clone()).await,
+                2,
+                "a branch commit must not advance main's chain"
+            );
+
+            // Cross-branch checkout at an overlapping version number must land
+            // on the branch chain (branch numbering continues from the fork
+            // point, so both chains have this version).
+            let overlap_version = branch_ds.version().version;
+            while main_ds.version().version < overlap_version {
+                main_ds
+                    .append(
+                        RecordBatchIterator::new(vec![Ok(batch(100))], schema.clone()),
+                        None,
+                    )
+                    .await
+                    .unwrap();
+            }
+            let on_branch = main_ds
+                .checkout_version(Ref::Version(Some("exp".to_string()), Some(overlap_version)))
+                .await
+                .unwrap();
+            assert_eq!(on_branch.manifest().branch.as_deref(), Some("exp"));
+            assert_eq!(scan_ids(&on_branch).await, vec![1, 2, 3]);
+            let on_branch_latest = main_ds.checkout_branch("exp").await.unwrap();
+            assert_eq!(on_branch_latest.manifest().branch.as_deref(), Some("exp"));
+
+            // Branch-pointing tag round trip through the builder.
+            main_ds
+                .tags()
+                .create("exp-tag", ("exp", Some(overlap_version)))
+                .await
+                .unwrap();
+            let tag_open = DatasetBuilder::from_namespace(namespace.clone(), table_id.clone())
+                .await
+                .unwrap()
+                .with_tag("exp-tag")
+                .load()
+                .await
+                .unwrap();
+            assert_eq!(tag_open.manifest().branch.as_deref(), Some("exp"));
+            assert_eq!(tag_open.version().version, overlap_version);
+            assert_eq!(scan_ids(&tag_open).await, vec![1, 2, 3]);
 
             fixture.server_handle.shutdown();
         }

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -302,6 +302,7 @@ struct PaginationQuery {
     limit: Option<i32>,
     include_declared: Option<bool>,
     descending: Option<bool>,
+    branch: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -847,6 +848,7 @@ async fn list_table_versions(
         page_token: params.page_token,
         limit: params.limit,
         descending: params.descending,
+        branch: params.branch,
         identity: extract_identity(&headers),
         ..Default::default()
     };
@@ -872,6 +874,7 @@ async fn create_table_version(
         manifest_size: body.manifest_size,
         e_tag: body.e_tag,
         metadata: body.metadata,
+        branch: body.branch,
         ..Default::default()
     };
 
@@ -891,6 +894,7 @@ async fn describe_table_version(
     let request = DescribeTableVersionRequest {
         id: Some(parse_id(&id, query.delimiter.as_deref())),
         version: body.version,
+        branch: body.branch,
         identity: extract_identity(&headers),
         ..Default::default()
     };
@@ -912,6 +916,7 @@ async fn batch_delete_table_versions(
         id: Some(parse_id(&id, params.delimiter.as_deref())),
         identity: extract_identity(&headers),
         ranges: body.ranges,
+        branch: body.branch,
         ..Default::default()
     };
 
@@ -3187,6 +3192,79 @@ mod tests {
                 "Failed to list table versions with ascending: {:?}",
                 result
             );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_branch_param_forwarded_end_to_end() {
+            let fixture = RestServerFixture::new().await;
+
+            fixture
+                .namespace
+                .create_namespace(CreateNamespaceRequest {
+                    id: Some(vec!["branch_fwd_ns".to_string()]),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            fixture
+                .namespace
+                .create_table(
+                    CreateTableRequest {
+                        id: Some(vec![
+                            "branch_fwd_ns".to_string(),
+                            "branch_fwd_table".to_string(),
+                        ]),
+                        mode: Some("create".to_string()),
+                        ..Default::default()
+                    },
+                    create_test_arrow_data(),
+                )
+                .await
+                .unwrap();
+
+            let id = vec!["branch_fwd_ns".to_string(), "branch_fwd_table".to_string()];
+
+            // Control: no branch succeeds (resolves the main chain).
+            assert!(
+                fixture
+                    .namespace
+                    .list_table_versions(ListTableVersionsRequest {
+                        id: Some(id.clone()),
+                        ..Default::default()
+                    })
+                    .await
+                    .is_ok()
+            );
+
+            // list forwards branch as a query param; a bogus branch 404s at the backend.
+            assert!(
+                fixture
+                    .namespace
+                    .list_table_versions(ListTableVersionsRequest {
+                        id: Some(id.clone()),
+                        branch: Some("ghost".to_string()),
+                        ..Default::default()
+                    })
+                    .await
+                    .is_err(),
+                "branch must be forwarded as a query param and honored by the backend"
+            );
+
+            // describe carries branch in the request body; a bogus branch likewise 404s.
+            assert!(
+                fixture
+                    .namespace
+                    .describe_table_version(DescribeTableVersionRequest {
+                        id: Some(id.clone()),
+                        branch: Some("ghost".to_string()),
+                        ..Default::default()
+                    })
+                    .await
+                    .is_err(),
+                "branch must be forwarded in the request body and honored by the backend"
+            );
+
+            fixture.server_handle.shutdown();
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -141,6 +141,10 @@ impl RestAdapter {
             .route("/v1/table/:id/tags/create", post(create_table_tag))
             .route("/v1/table/:id/tags/delete", post(delete_table_tag))
             .route("/v1/table/:id/tags/update", post(update_table_tag))
+            // Branch operations
+            .route("/v1/table/:id/branches/create", post(create_table_branch))
+            .route("/v1/table/:id/branches/list", post(list_table_branches))
+            .route("/v1/table/:id/branches/delete", post(delete_table_branch))
             // Query plan operations
             .route("/v1/table/:id/explain_plan", post(explain_table_query_plan))
             .route("/v1/table/:id/analyze_plan", post(analyze_table_query_plan))
@@ -326,11 +330,13 @@ fn error_code_to_status(code: u32) -> StatusCode {
         | Some(lance_namespace::error::ErrorCode::TableTagNotFound)
         | Some(lance_namespace::error::ErrorCode::TransactionNotFound)
         | Some(lance_namespace::error::ErrorCode::TableVersionNotFound)
-        | Some(lance_namespace::error::ErrorCode::TableColumnNotFound) => StatusCode::NOT_FOUND,
+        | Some(lance_namespace::error::ErrorCode::TableColumnNotFound)
+        | Some(lance_namespace::error::ErrorCode::TableBranchNotFound) => StatusCode::NOT_FOUND,
         Some(lance_namespace::error::ErrorCode::NamespaceAlreadyExists)
         | Some(lance_namespace::error::ErrorCode::TableAlreadyExists)
         | Some(lance_namespace::error::ErrorCode::TableIndexAlreadyExists)
         | Some(lance_namespace::error::ErrorCode::TableTagAlreadyExists)
+        | Some(lance_namespace::error::ErrorCode::TableBranchAlreadyExists)
         | Some(lance_namespace::error::ErrorCode::ConcurrentModification) => StatusCode::CONFLICT,
         Some(lance_namespace::error::ErrorCode::NamespaceNotEmpty)
         | Some(lance_namespace::error::ErrorCode::InvalidTableState) => StatusCode::CONFLICT,
@@ -1261,6 +1267,62 @@ async fn update_table_tag(
     request.identity = extract_identity(&headers);
 
     match backend.update_table_tag(request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(e) => error_to_response(e),
+    }
+}
+
+// ============================================================================
+// Branch Operation Handlers
+// ============================================================================
+
+async fn create_table_branch(
+    State(backend): State<Arc<dyn LanceNamespace>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Query(params): Query<DelimiterQuery>,
+    Json(mut request): Json<CreateTableBranchRequest>,
+) -> Response {
+    request.id = Some(parse_id(&id, params.delimiter.as_deref()));
+    request.identity = extract_identity(&headers);
+
+    match backend.create_table_branch(request).await {
+        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Err(e) => error_to_response(e),
+    }
+}
+
+async fn list_table_branches(
+    State(backend): State<Arc<dyn LanceNamespace>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Query(params): Query<PaginationQuery>,
+) -> Response {
+    let request = ListTableBranchesRequest {
+        id: Some(parse_id(&id, params.delimiter.as_deref())),
+        page_token: params.page_token,
+        limit: params.limit,
+        identity: extract_identity(&headers),
+        ..Default::default()
+    };
+
+    match backend.list_table_branches(request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(e) => error_to_response(e),
+    }
+}
+
+async fn delete_table_branch(
+    State(backend): State<Arc<dyn LanceNamespace>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Query(params): Query<DelimiterQuery>,
+    Json(mut request): Json<DeleteTableBranchRequest>,
+) -> Response {
+    request.id = Some(parse_id(&id, params.delimiter.as_deref()));
+    request.identity = extract_identity(&headers);
+
+    match backend.delete_table_branch(request).await {
         Ok(response) => (StatusCode::OK, Json(response)).into_response(),
         Err(e) => error_to_response(e),
     }
@@ -3262,6 +3324,198 @@ mod tests {
                     .await
                     .is_err(),
                 "branch must be forwarded in the request body and honored by the backend"
+            );
+
+            fixture.server_handle.shutdown();
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_branch_crud_end_to_end() {
+            let fixture = RestServerFixture::new().await;
+
+            fixture
+                .namespace
+                .create_namespace(CreateNamespaceRequest {
+                    id: Some(vec!["branch_crud_ns".to_string()]),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            fixture
+                .namespace
+                .create_table(
+                    CreateTableRequest {
+                        id: Some(vec![
+                            "branch_crud_ns".to_string(),
+                            "branch_crud_table".to_string(),
+                        ]),
+                        mode: Some("create".to_string()),
+                        ..Default::default()
+                    },
+                    create_test_arrow_data(),
+                )
+                .await
+                .unwrap();
+
+            let id = vec![
+                "branch_crud_ns".to_string(),
+                "branch_crud_table".to_string(),
+            ];
+
+            // create -> list shows it (client -> server -> directory backend)
+            fixture
+                .namespace
+                .create_table_branch(CreateTableBranchRequest {
+                    id: Some(id.clone()),
+                    name: "dev".to_string(),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+
+            let listed = fixture
+                .namespace
+                .list_table_branches(ListTableBranchesRequest {
+                    id: Some(id.clone()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            assert!(
+                listed.branches.contains_key("dev"),
+                "created branch should appear in list: {:?}",
+                listed.branches
+            );
+
+            // duplicate create -> 409 Conflict
+            let port = fixture.server_handle.port();
+            let client = reqwest::Client::new();
+            let table_path = "branch_crud_ns%24branch_crud_table";
+            let resp = client
+                .post(format!(
+                    "http://127.0.0.1:{}/v1/table/{}/branches/create",
+                    port, table_path
+                ))
+                .query(&[("delimiter", "$")])
+                .json(&serde_json::json!({ "name": "dev" }))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                409,
+                "duplicate branch create should map to 409, got {}",
+                resp.status()
+            );
+
+            // delete -> list no longer shows it
+            fixture
+                .namespace
+                .delete_table_branch(DeleteTableBranchRequest {
+                    id: Some(id.clone()),
+                    name: "dev".to_string(),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+
+            let listed = fixture
+                .namespace
+                .list_table_branches(ListTableBranchesRequest {
+                    id: Some(id.clone()),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            assert!(
+                !listed.branches.contains_key("dev"),
+                "deleted branch must not appear in list: {:?}",
+                listed.branches
+            );
+
+            // delete missing -> 404 Not Found (raw HTTP validates TableBranchNotFound -> 404).
+            let resp = client
+                .post(format!(
+                    "http://127.0.0.1:{}/v1/table/{}/branches/delete",
+                    port, table_path
+                ))
+                .query(&[("delimiter", "$")])
+                .json(&serde_json::json!({ "name": "dev" }))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                404,
+                "deleting a missing branch should map to 404, got {}",
+                resp.status()
+            );
+
+            fixture.server_handle.shutdown();
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_list_branches_bodyless_post() {
+            let fixture = RestServerFixture::new().await;
+
+            fixture
+                .namespace
+                .create_namespace(CreateNamespaceRequest {
+                    id: Some(vec!["list_post_ns".to_string()]),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            fixture
+                .namespace
+                .create_table(
+                    CreateTableRequest {
+                        id: Some(vec![
+                            "list_post_ns".to_string(),
+                            "list_post_table".to_string(),
+                        ]),
+                        mode: Some("create".to_string()),
+                        ..Default::default()
+                    },
+                    create_test_arrow_data(),
+                )
+                .await
+                .unwrap();
+            fixture
+                .namespace
+                .create_table_branch(CreateTableBranchRequest {
+                    id: Some(vec![
+                        "list_post_ns".to_string(),
+                        "list_post_table".to_string(),
+                    ]),
+                    name: "dev".to_string(),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+
+            let port = fixture.server_handle.port();
+            let client = reqwest::Client::new();
+            let resp = client
+                .post(format!(
+                    "http://127.0.0.1:{}/v1/table/list_post_ns%24list_post_table/branches/list",
+                    port
+                ))
+                .query(&[("delimiter", "$")])
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                200,
+                "bodyless list POST should succeed, got {}",
+                resp.status()
+            );
+            let body: ListTableBranchesResponse = resp.json().await.unwrap();
+            assert!(
+                body.branches.contains_key("dev"),
+                "bodyless list should return the branch, got: {:?}",
+                body.branches
             );
 
             fixture.server_handle.shutdown();

--- a/rust/lance-namespace/src/error.rs
+++ b/rust/lance-namespace/src/error.rs
@@ -78,6 +78,10 @@ pub enum ErrorCode {
     TableSchemaValidationError = 20,
     /// Request was throttled due to rate limiting or too many concurrent operations
     Throttling = 21,
+    /// The specified table branch does not exist
+    TableBranchNotFound = 22,
+    /// A table branch with this name already exists
+    TableBranchAlreadyExists = 23,
 }
 
 impl ErrorCode {
@@ -113,6 +117,8 @@ impl ErrorCode {
             19 => Some(Self::InvalidTableState),
             20 => Some(Self::TableSchemaValidationError),
             21 => Some(Self::Throttling),
+            22 => Some(Self::TableBranchNotFound),
+            23 => Some(Self::TableBranchAlreadyExists),
             _ => None,
         }
     }
@@ -143,6 +149,8 @@ impl std::fmt::Display for ErrorCode {
             Self::InvalidTableState => "InvalidTableState",
             Self::TableSchemaValidationError => "TableSchemaValidationError",
             Self::Throttling => "Throttling",
+            Self::TableBranchNotFound => "TableBranchNotFound",
+            Self::TableBranchAlreadyExists => "TableBranchAlreadyExists",
         };
         write!(f, "{}", name)
     }
@@ -260,6 +268,14 @@ pub enum NamespaceError {
     /// Request was throttled due to rate limiting or too many concurrent operations.
     #[snafu(display("Throttling: {message}"))]
     Throttling { message: String },
+
+    /// The specified table branch does not exist.
+    #[snafu(display("Table branch not found: {message}"))]
+    TableBranchNotFound { message: String },
+
+    /// A table branch with this name already exists.
+    #[snafu(display("Table branch already exists: {message}"))]
+    TableBranchAlreadyExists { message: String },
 }
 
 impl NamespaceError {
@@ -291,7 +307,9 @@ impl NamespaceError {
             | Self::Internal { message }
             | Self::InvalidTableState { message }
             | Self::TableSchemaValidationError { message }
-            | Self::Throttling { message } => message,
+            | Self::Throttling { message }
+            | Self::TableBranchNotFound { message }
+            | Self::TableBranchAlreadyExists { message } => message,
         }
     }
 
@@ -322,6 +340,8 @@ impl NamespaceError {
             Self::InvalidTableState { .. } => ErrorCode::InvalidTableState,
             Self::TableSchemaValidationError { .. } => ErrorCode::TableSchemaValidationError,
             Self::Throttling { .. } => ErrorCode::Throttling,
+            Self::TableBranchNotFound { .. } => ErrorCode::TableBranchNotFound,
+            Self::TableBranchAlreadyExists { .. } => ErrorCode::TableBranchAlreadyExists,
         }
     }
 
@@ -355,6 +375,8 @@ impl NamespaceError {
                 Self::TableSchemaValidationError { message }
             }
             Some(ErrorCode::Throttling) => Self::Throttling { message },
+            Some(ErrorCode::TableBranchNotFound) => Self::TableBranchNotFound { message },
+            Some(ErrorCode::TableBranchAlreadyExists) => Self::TableBranchAlreadyExists { message },
             None => Self::Internal { message },
         }
     }
@@ -380,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_error_code_roundtrip() {
-        for code in 0..=21 {
+        for code in 0..=23 {
             let error_code = ErrorCode::from_u32(code).unwrap();
             assert_eq!(error_code.as_u32(), code);
         }

--- a/rust/lance-namespace/src/namespace.rs
+++ b/rust/lance-namespace/src/namespace.rs
@@ -14,11 +14,13 @@ use lance_namespace_reqwest_client::models::{
     AlterTransactionRequest, AlterTransactionResponse, AnalyzeTableQueryPlanRequest,
     BatchDeleteTableVersionsRequest, BatchDeleteTableVersionsResponse, CountTableRowsRequest,
     CreateMaterializedViewRequest, CreateMaterializedViewResponse, CreateNamespaceRequest,
-    CreateNamespaceResponse, CreateTableIndexRequest, CreateTableIndexResponse, CreateTableRequest,
-    CreateTableResponse, CreateTableScalarIndexResponse, CreateTableTagRequest,
-    CreateTableTagResponse, CreateTableVersionRequest, CreateTableVersionResponse,
-    DeclareTableRequest, DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
-    DeleteTableTagRequest, DeleteTableTagResponse, DeregisterTableRequest, DeregisterTableResponse,
+    CreateNamespaceResponse, CreateTableBranchRequest, CreateTableBranchResponse,
+    CreateTableIndexRequest, CreateTableIndexResponse, CreateTableRequest, CreateTableResponse,
+    CreateTableScalarIndexResponse, CreateTableTagRequest, CreateTableTagResponse,
+    CreateTableVersionRequest, CreateTableVersionResponse, DeclareTableRequest,
+    DeclareTableResponse, DeleteFromTableRequest, DeleteFromTableResponse,
+    DeleteTableBranchRequest, DeleteTableBranchResponse, DeleteTableTagRequest,
+    DeleteTableTagResponse, DeregisterTableRequest, DeregisterTableResponse,
     DescribeNamespaceRequest, DescribeNamespaceResponse, DescribeTableIndexStatsRequest,
     DescribeTableIndexStatsResponse, DescribeTableRequest, DescribeTableResponse,
     DescribeTableVersionRequest, DescribeTableVersionResponse, DescribeTransactionRequest,
@@ -27,7 +29,8 @@ use lance_namespace_reqwest_client::models::{
     ExplainTableQueryPlanRequest, GetTableStatsRequest, GetTableStatsResponse,
     GetTableTagVersionRequest, GetTableTagVersionResponse, InsertIntoTableRequest,
     InsertIntoTableResponse, ListNamespacesRequest, ListNamespacesResponse,
-    ListTableIndicesRequest, ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
+    ListTableBranchesRequest, ListTableBranchesResponse, ListTableIndicesRequest,
+    ListTableIndicesResponse, ListTableTagsRequest, ListTableTagsResponse,
     ListTableVersionsRequest, ListTableVersionsResponse, ListTablesRequest, ListTablesResponse,
     MergeInsertIntoTableRequest, MergeInsertIntoTableResponse, NamespaceExistsRequest,
     QueryTableRequest, RefreshMaterializedViewRequest, RefreshMaterializedViewResponse,
@@ -498,6 +501,44 @@ pub trait LanceNamespace: Send + Sync + std::fmt::Debug {
         _request: UpdateTableTagRequest,
     ) -> Result<UpdateTableTagResponse> {
         Err(Error::not_supported("update_table_tag not implemented"))
+    }
+
+    /// Create a branch for a table.
+    ///
+    /// The new branch forks from the source ref selected by `from_branch` and
+    /// `from_version`, defaulting to the latest version of the main branch when
+    /// both are omitted.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`crate::ErrorCode::TableBranchAlreadyExists`] if a branch with the same name already exists.
+    /// - Returns [`crate::ErrorCode::TableNotFound`] if the table does not exist.
+    /// - Returns [`crate::ErrorCode::InvalidInput`] if `from_branch` or `from_version` references a source that does not exist.
+    async fn create_table_branch(
+        &self,
+        _request: CreateTableBranchRequest,
+    ) -> Result<CreateTableBranchResponse> {
+        Err(Error::not_supported("create_table_branch not implemented"))
+    }
+
+    /// List all branches for a table.
+    async fn list_table_branches(
+        &self,
+        _request: ListTableBranchesRequest,
+    ) -> Result<ListTableBranchesResponse> {
+        Err(Error::not_supported("list_table_branches not implemented"))
+    }
+
+    /// Delete a branch from a table.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::ErrorCode::TableBranchNotFound`] if the branch does not exist.
+    async fn delete_table_branch(
+        &self,
+        _request: DeleteTableBranchRequest,
+    ) -> Result<DeleteTableBranchResponse> {
+        Err(Error::not_supported("delete_table_branch not implemented"))
     }
 
     /// Return a human-readable unique identifier for this namespace instance.

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -69,7 +69,7 @@ use std::sync::Arc;
 use tracing::{info, instrument};
 
 pub(crate) mod blob;
-mod branch_location;
+pub(crate) mod branch_location;
 pub mod builder;
 pub mod cleanup;
 pub mod delta;
@@ -500,11 +500,14 @@ impl Dataset {
     ) -> Result<Self> {
         let (source_branch, version_number) = self.resolve_reference(version.into()).await?;
         let branch_location = self.branch_location().find_branch(Some(branch))?;
+        let source_location = self
+            .branch_location()
+            .find_branch(source_branch.as_deref())?;
         let clone_op = Operation::Clone {
             is_shallow: true,
             ref_name: source_branch.clone(),
             ref_version: version_number,
-            ref_path: String::from(self.uri()),
+            ref_path: source_location.uri,
             branch_name: Some(branch.to_string()),
         };
         let transaction = Transaction::new(version_number, clone_op, None);
@@ -556,6 +559,15 @@ impl Dataset {
         version_number: Option<u64>,
         branch: Option<&str>,
     ) -> Result<Self> {
+        // Reject malformed names at the boundary (mirroring the branch CRUD
+        // paths) so they fail as InvalidRef instead of tripping the wrong-chain
+        // check below
+        if let Some(branch_name) = branch
+            && !Branches::is_main_branch(branch)
+        {
+            refs::check_valid_branch(branch_name)?;
+        }
+
         let new_location = self.branch_location().find_branch(branch)?;
 
         let manifest_location = if let Some(version_number) = version_number {
@@ -583,6 +595,21 @@ impl Dataset {
             self.session.as_ref(),
         )
         .await?;
+
+        // The resolved manifest must belong to the requested branch. A mismatch
+        // means the commit handler resolved against a different chain (for
+        // example an external manifest store that ignores branch-qualified
+        // paths); error loudly rather than hand back another branch's data.
+        let requested_branch = branch.and_then(refs::standardize_branch);
+        if manifest.branch.as_deref() != requested_branch.as_deref() {
+            return Err(Error::internal(format!(
+                "checkout of branch '{}' at version {} resolved a manifest belonging to branch '{}'",
+                refs::normalize_branch(branch),
+                manifest.version,
+                refs::normalize_branch(manifest.branch.as_deref()),
+            )));
+        }
+
         Self::checkout_manifest(
             self.object_store.clone(),
             new_location.path,
@@ -779,12 +806,50 @@ impl Dataset {
         batches: impl RecordBatchReader + Send + 'static,
         namespace_client: Arc<dyn LanceNamespace>,
         table_id: Vec<String>,
+        params: Option<WriteParams>,
+    ) -> Result<Self> {
+        Self::write_into_namespace_impl(batches, namespace_client, table_id, None, params).await
+    }
+
+    /// Write into a branch of a namespace client-managed table.
+    ///
+    /// Behaves like [`write_into_namespace`](Self::write_into_namespace), but APPEND and
+    /// OVERWRITE open and commit against `branch` instead of main. CREATE is rejected,
+    /// since a branch forks from an existing version.
+    pub async fn write_into_namespace_on_branch(
+        batches: impl RecordBatchReader + Send + 'static,
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        branch: &str,
+        params: Option<WriteParams>,
+    ) -> Result<Self> {
+        Self::write_into_namespace_impl(
+            batches,
+            namespace_client,
+            table_id,
+            Some(branch.to_string()),
+            params,
+        )
+        .await
+    }
+
+    async fn write_into_namespace_impl(
+        batches: impl RecordBatchReader + Send + 'static,
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        branch: Option<String>,
         mut params: Option<WriteParams>,
     ) -> Result<Self> {
         let mut write_params = params.take().unwrap_or_default();
 
         match write_params.mode {
             WriteMode::Create => {
+                if branch.is_some() {
+                    return Err(Error::not_supported_source(
+                        "cannot create a table on a branch; create on main first, then branch it"
+                            .into(),
+                    ));
+                }
                 let declare_request = DeclareTableRequest {
                     id: Some(table_id.clone()),
                     ..Default::default()
@@ -802,10 +867,13 @@ impl Dataset {
 
                 // Set up commit handler when managed_versioning is enabled
                 if response.managed_versioning == Some(true) {
-                    let external_store = LanceNamespaceExternalManifestStore::new(
+                    // The store derives the branch a request targets from the
+                    // base path it is handed, resolved against the table root.
+                    let external_store = LanceNamespaceExternalManifestStore::for_table_uri(
                         namespace_client.clone(),
                         table_id.clone(),
-                    );
+                        &uri,
+                    )?;
                     let commit_handler: Arc<dyn CommitHandler> =
                         Arc::new(ExternalManifestCommitHandler {
                             external_manifest_store: Arc::new(external_store),
@@ -857,18 +925,25 @@ impl Dataset {
                     )))
                 })?;
 
-                // Set up commit handler when managed_versioning is enabled
-                if response.managed_versioning == Some(true) {
-                    let external_store = LanceNamespaceExternalManifestStore::new(
-                        namespace_client.clone(),
-                        table_id.clone(),
-                    );
-                    let commit_handler: Arc<dyn CommitHandler> =
-                        Arc::new(ExternalManifestCommitHandler {
+                // Set up commit handler when managed_versioning is enabled.
+                // It must ride on the dataset opened below: InsertBuilder
+                // commits through the destination dataset's handler and does
+                // not consult write params for Dataset destinations.
+                let commit_handler: Option<Arc<dyn CommitHandler>> =
+                    if response.managed_versioning == Some(true) {
+                        // The store derives the branch a request targets from the
+                        // base path it is handed, resolved against the table root.
+                        let external_store = LanceNamespaceExternalManifestStore::for_table_uri(
+                            namespace_client.clone(),
+                            table_id.clone(),
+                            uri.as_str(),
+                        )?;
+                        Some(Arc::new(ExternalManifestCommitHandler {
                             external_manifest_store: Arc::new(external_store),
-                        });
-                    write_params.commit_handler = Some(commit_handler);
-                }
+                        }))
+                    } else {
+                        None
+                    };
 
                 // Set initial credentials and provider from namespace_client
                 if let Some(namespace_storage_options) = response.storage_options {
@@ -906,6 +981,12 @@ impl Dataset {
                     && let Some(accessor) = &store_params.storage_options_accessor
                 {
                     builder = builder.with_storage_options_accessor(accessor.clone());
+                }
+                if let Some(commit_handler) = commit_handler {
+                    builder = builder.with_commit_handler(commit_handler);
+                }
+                if let Some(branch) = &branch {
+                    builder = builder.with_branch(branch, None);
                 }
                 let dataset = Arc::new(builder.load().await?);
 
@@ -2510,11 +2591,12 @@ impl Dataset {
         store_params: Option<ObjectStoreParams>,
     ) -> Result<Self> {
         let (ref_name, version_number) = self.resolve_reference(version.into()).await?;
+        let source_location = self.branch_location().find_branch(ref_name.as_deref())?;
         let clone_op = Operation::Clone {
             is_shallow: true,
             ref_name,
             ref_version: version_number,
-            ref_path: self.uri.clone(),
+            ref_path: source_location.uri,
             branch_name: None,
         };
         let transaction = Transaction::new(version_number, clone_op, None);

--- a/rust/lance/src/dataset/branch_location.rs
+++ b/rust/lance/src/dataset/branch_location.rs
@@ -62,6 +62,38 @@ impl BranchLocation {
         Ok(root_path_str)
     }
 
+    /// The branch a location under `root` targets: the inverse of
+    /// [`Self::find_branch`]. `location` must be either `root` itself (main)
+    /// or `<root>/tree/<branch>`; anything else is rejected so a caller never
+    /// misattributes an unrelated location to a branch.
+    pub fn branch_of(root: &str, location: &str) -> Result<Option<String>> {
+        if location == root {
+            return Ok(None);
+        }
+        // Require the `/` component boundary after the root so a sibling path
+        // that merely shares the root as a string prefix is rejected.
+        let branch = location
+            .strip_prefix(root)
+            .and_then(|rel| {
+                if root.is_empty() {
+                    Some(rel)
+                } else {
+                    rel.strip_prefix('/')
+                }
+            })
+            .and_then(|rel| rel.strip_prefix(BRANCH_DIR))
+            .and_then(|rel| rel.strip_prefix('/'))
+            .filter(|name| !name.is_empty());
+
+        match branch {
+            Some(name) => Ok(Some(name.to_string())),
+            None => Err(Error::invalid_input(format!(
+                "cannot derive a branch for location '{}': expected the table root '{}' or a branch chain under '{}/{}'",
+                location, root, root, BRANCH_DIR
+            ))),
+        }
+    }
+
     /// Find the target branch location
     pub fn find_branch(&self, branch_name: Option<&str>) -> Result<Self> {
         if branch_name == self.branch.as_deref() {
@@ -221,6 +253,35 @@ mod tests {
             format!("{}/tree/bugfix/issue-123", main_location.uri)
         );
         assert!(fs::create_dir_all(std::path::Path::new(new_location.uri.as_str())).is_ok());
+    }
+
+    #[test]
+    fn test_branch_of() {
+        let derive = |root: &str, location: &str| BranchLocation::branch_of(root, location);
+
+        // The table root targets main.
+        assert_eq!(derive("data/t.lance", "data/t.lance").unwrap(), None);
+
+        // Branch chains, including multi-segment branch names.
+        assert_eq!(
+            derive("data/t.lance", "data/t.lance/tree/exp").unwrap(),
+            Some("exp".to_string())
+        );
+        assert_eq!(
+            derive("data/t.lance", "data/t.lance/tree/bugfix/issue-123").unwrap(),
+            Some("bugfix/issue-123".to_string())
+        );
+
+        // A sibling path sharing the root as a string prefix is not a branch.
+        assert!(derive("data/t", "data/tx/tree/exp").is_err());
+        // Neither is a sub-path outside the branch directory.
+        assert!(derive("data/t.lance", "data/t.lance/other/exp").is_err());
+        // Nor a path missing the component boundary after the branch dir.
+        assert!(derive("data/t.lance", "data/t.lance/treex").is_err());
+        // An empty branch name is invalid.
+        assert!(derive("data/t.lance", "data/t.lance/tree").is_err());
+        // An unrelated location is invalid.
+        assert!(derive("data/t.lance", "elsewhere/u.lance").is_err());
     }
 
     #[test]

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use lance_core::cache::CacheBackend;
 
-use super::refs::{Ref, Refs};
+use super::refs::{Branches, Ref, Refs, check_valid_branch, normalize_branch, standardize_branch};
 use super::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE, ReadParams, WriteParams};
 use crate::dataset::branch_location::BranchLocation;
 use crate::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
@@ -53,6 +53,12 @@ pub struct DatasetBuilder {
     storage_options_override: Option<HashMap<String, String>>,
     /// Runtime-only exact object store bindings keyed by base path URI.
     base_store_params: HashMap<String, ObjectStoreParams>,
+    /// Namespace-managed table info `(client, table_id)`, set by `from_namespace`
+    /// when the table uses managed versioning. The commit handler is built in
+    /// `build_object_store`, rooted at the resolved table path; the branch a
+    /// namespace request targets is derived per call from the base path the
+    /// handler is handed.
+    namespace_managed: Option<(Arc<dyn LanceNamespace>, Vec<String>)>,
 }
 
 impl std::fmt::Debug for DatasetBuilder {
@@ -71,6 +77,7 @@ impl std::fmt::Debug for DatasetBuilder {
                 &self.storage_options_override.is_some(),
             )
             .field("base_store_params", &!self.base_store_params.is_empty())
+            .field("namespace_managed", &self.namespace_managed.is_some())
             .finish()
     }
 }
@@ -90,6 +97,7 @@ impl DatasetBuilder {
             file_reader_options: None,
             storage_options_override: None,
             base_store_params: HashMap::new(),
+            namespace_managed: None,
         }
     }
 
@@ -149,16 +157,11 @@ impl DatasetBuilder {
 
         let mut builder = Self::from_uri(&table_uri);
 
-        // Check managed_versioning flag to determine if namespace-managed commits should be used
+        // Defer building the commit handler to load(): the manifest store is
+        // rooted at the resolved table path, which is only known once the
+        // object store is built.
         if response.managed_versioning == Some(true) {
-            let external_store = LanceNamespaceExternalManifestStore::new(
-                namespace_client.clone(),
-                table_id.clone(),
-            );
-            let commit_handler: Arc<dyn CommitHandler> = Arc::new(ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(external_store),
-            });
-            builder.commit_handler = Some(commit_handler);
+            builder.namespace_managed = Some((namespace_client.clone(), table_id.clone()));
         }
 
         // Use namespace storage options if available
@@ -524,13 +527,8 @@ impl DatasetBuilder {
 
     /// Build a lance object store for the given config
     pub async fn build_object_store(
-        self,
+        mut self,
     ) -> Result<(Arc<ObjectStore>, Path, Arc<dyn CommitHandler>)> {
-        let commit_handler = match self.commit_handler {
-            Some(commit_handler) => Ok(commit_handler),
-            None => commit_handler_from_url(&self.table_uri, &Some(self.options.clone())).await,
-        }?;
-
         let storage_options = self
             .options
             .storage_options()
@@ -546,13 +544,13 @@ impl DatasetBuilder {
             .unwrap_or_default();
 
         #[allow(deprecated)]
-        match &self.options.object_store {
-            Some(store) => Ok((
+        let (object_store, base_path) = match &self.options.object_store {
+            Some(store) => (
                 Arc::new(ObjectStore::new(
                     store.0.clone(),
                     store.1.clone(),
                     self.options.block_size,
-                    self.options.object_store_wrapper,
+                    self.options.object_store_wrapper.clone(),
                     self.options.use_constant_size_upload_parts,
                     store.1.scheme() != "file",
                     // If user supplied an object store then we just assume it's probably
@@ -562,18 +560,35 @@ impl DatasetBuilder {
                     None, // No storage_options available here
                 )),
                 Path::from(store.1.path()),
-                commit_handler,
-            )),
+            ),
             None => {
-                let (store, path) = ObjectStore::from_uri_and_params(
-                    store_registry,
-                    &self.table_uri,
-                    &self.options,
-                )
-                .await?;
-                Ok((store, path, commit_handler))
+                ObjectStore::from_uri_and_params(store_registry, &self.table_uri, &self.options)
+                    .await?
             }
-        }
+        };
+
+        // Resolve the commit handler: an explicitly set one wins; otherwise a
+        // namespace-managed table builds a manifest store rooted at the resolved
+        // table path (the branch a request targets is derived per call from the
+        // base path the handler is handed); otherwise fall back to the default
+        // for the uri. Resolving here (not in load) keeps this pub method
+        // consistent for every caller.
+        let commit_handler: Arc<dyn CommitHandler> =
+            if let Some(commit_handler) = self.commit_handler.take() {
+                commit_handler
+            } else if let Some((namespace_client, table_id)) = self.namespace_managed.take() {
+                Arc::new(ExternalManifestCommitHandler {
+                    external_manifest_store: Arc::new(LanceNamespaceExternalManifestStore::new(
+                        namespace_client,
+                        table_id,
+                        base_path.clone(),
+                    )),
+                })
+            } else {
+                commit_handler_from_url(&self.table_uri, &Some(self.options.clone())).await?
+            };
+
+        Ok((object_store, base_path, commit_handler))
     }
 
     #[instrument(skip_all)]
@@ -656,6 +671,14 @@ impl DatasetBuilder {
         let store_params = self.options.clone();
         let base_store_params = (!self.base_store_params.is_empty())
             .then(|| Arc::new(std::mem::take(&mut self.base_store_params)));
+
+        // A namespace-managed table is always addressed at its root uri, so the
+        // effective branch is resolvable before loading: the base path is
+        // qualified up front and the manifest store derives the branch from it.
+        // An explicitly supplied commit handler opts out of the managed flow.
+        let managed_store_active =
+            self.namespace_managed.is_some() && self.commit_handler.is_none();
+
         let (object_store, base_path, commit_handler) = self.build_object_store().await?;
 
         // Two cases that need to check out after loading the manifest:
@@ -667,7 +690,7 @@ impl DatasetBuilder {
         let mut need_delay_checkout = false;
         let (mut branch, mut version_number) = match target_ref.clone() {
             Some(Ref::Version(branch, version_number)) => {
-                if branch.is_some() {
+                if branch.is_some() && !managed_store_active {
                     need_delay_checkout = true;
                 }
                 (branch, version_number)
@@ -687,15 +710,55 @@ impl DatasetBuilder {
                         branch: None,
                     },
                 );
-                let tag_content = refs.tags().get(&tag_name).await;
-                if let Ok(tag_content) = tag_content {
-                    (tag_content.branch.clone(), Some(tag_content.version))
-                } else {
-                    need_delay_checkout = true;
-                    (None, None)
+                match refs.tags().get(&tag_name).await {
+                    Ok(tag_content) => {
+                        if tag_content.branch.is_some() && !managed_store_active {
+                            // The tag's chain lives under a different base path
+                            // and the unmanaged handler resolves versions by
+                            // base path only, so load the root's latest first
+                            // and check the tag's branch/version out from it.
+                            need_delay_checkout = true;
+                            (tag_content.branch, None)
+                        } else {
+                            (tag_content.branch.clone(), Some(tag_content.version))
+                        }
+                    }
+                    Err(e) => {
+                        // A managed table is always rooted at the namespace
+                        // location, so a tag missing here is missing.
+                        if managed_store_active {
+                            return Err(e);
+                        }
+                        need_delay_checkout = true;
+                        (None, None)
+                    }
                 }
             }
             None => (None, None),
+        };
+
+        // Reject malformed branch names at the boundary (mirroring the branch
+        // CRUD paths) so they fail as InvalidRef instead of resolving oddly
+        if let Some(branch_name) = branch.as_deref()
+            && !Branches::is_main_branch(Some(branch_name))
+        {
+            check_valid_branch(branch_name)?;
+        }
+
+        // For a managed table the branch is known before loading; point the base
+        // path and uri at the branch chain so the loaded dataset is rooted there
+        // (data placement, refs and the path-derived store branch all follow the
+        // base path).
+        let (base_path, table_uri) = if managed_store_active && branch.is_some() {
+            let branch_location = BranchLocation {
+                path: base_path,
+                uri: table_uri,
+                branch: None,
+            }
+            .find_branch(branch.as_deref())?;
+            (branch_location.path, branch_location.uri)
+        } else {
+            (base_path, table_uri)
         };
 
         let dataset = Self::load_by_uri(
@@ -711,6 +774,20 @@ impl DatasetBuilder {
             base_store_params,
         )
         .await?;
+
+        if managed_store_active {
+            // The base path was qualified above, so the loaded manifest must
+            // already be on the requested branch; a mismatch means the namespace
+            // resolved another chain.
+            let requested_branch = branch.as_deref().and_then(standardize_branch);
+            if dataset.manifest.branch.as_deref() != requested_branch.as_deref() {
+                return Err(Error::internal(format!(
+                    "open of branch '{}' resolved a manifest belonging to branch '{}'",
+                    normalize_branch(branch.as_deref()),
+                    normalize_branch(dataset.manifest.branch.as_deref()),
+                )));
+            }
+        }
 
         if need_delay_checkout {
             if let Some(Ref::Tag(tag_name)) = target_ref {

--- a/rust/lance/src/dataset/tests/dataset_versioning.rs
+++ b/rust/lance/src/dataset/tests/dataset_versioning.rs
@@ -565,6 +565,65 @@ async fn test_fragment_id_never_reset() {
     assert_eq!(dataset.manifest.max_fragment_id(), Some(4));
 }
 
+/// create_branch and shallow_clone must read the SOURCE ref's chain, not the
+/// receiver's. Both chains get a version 2 with diverged row counts so a clone
+/// that wrongly resolves the version under the receiver succeeds silently with
+/// the wrong data.
+#[tokio::test]
+async fn test_create_branch_and_shallow_clone_from_other_branch() {
+    let tempdir = TempDir::default();
+    let test_uri = tempdir.path_str();
+
+    let gen_rows = |start: i32, rows: u64| {
+        gen_batch()
+            .col("id", array::step_custom::<Int32Type>(start, 1))
+            .into_reader_rows(RowCount::from(rows), BatchCount::from(1))
+    };
+    let write = |uri: String, start: i32, rows: u64, mode: WriteMode| async move {
+        Dataset::write(
+            gen_rows(start, rows),
+            uri.as_str(),
+            Some(WriteParams {
+                mode,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap()
+    };
+
+    // main v1: 50 rows.
+    let mut main_ds = write(test_uri.clone(), 0, 50, WriteMode::Create).await;
+    // dev: forked at v1, appended 30 rows -> dev v2 has 80 rows.
+    let dev_ds = main_ds.create_branch("dev", 1, None).await.unwrap();
+    write(dev_ds.uri().to_string(), 1000, 30, WriteMode::Append).await;
+    // Diverge main to the same version number with a different row count.
+    let mut main_ds = write(test_uri.clone(), 5000, 10, WriteMode::Append).await; // main v2: 60 rows
+
+    // Cross-source create_branch: receiver is main, source is dev.
+    let child_ds = main_ds
+        .create_branch("child", ("dev", 2), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        child_ds.count_rows(None).await.unwrap(),
+        80,
+        "child must clone dev@2, not main@2"
+    );
+
+    // Cross-source shallow_clone: same rule.
+    let clone_uri = format!("{}_clone", test_uri);
+    let cloned_ds = main_ds
+        .shallow_clone(&clone_uri, ("dev", 2), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        cloned_ds.count_rows(None).await.unwrap(),
+        80,
+        "shallow clone must read dev@2, not main@2"
+    );
+}
+
 #[tokio::test]
 async fn test_branch() {
     let tempdir = TempDir::default();
@@ -796,6 +855,86 @@ async fn test_branch() {
         checkout_branch1.manifest.branch.as_deref().unwrap(),
         "branch1"
     );
+
+    // Opening at a branch-pointing tag through the builder must check out the
+    // tag's branch chain, not main's chain at the tag's version number.
+    let tag_open = DatasetBuilder::from_uri(&test_uri)
+        .with_tag("tag1")
+        .load()
+        .await
+        .unwrap();
+    assert_eq!(tag_open.manifest.branch.as_deref(), Some("dev/branch2"));
+    assert_eq!(tag_open.version().version, 3);
+    assert_eq!(tag_open.count_rows(None).await.unwrap(), 100);
+
+    // Malformed branch names are rejected at the boundary
+    for bad_name in ["", "branch1/"] {
+        let err = main_dataset
+            .checkout_version((Some(bad_name), None::<u64>))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidRef { .. }),
+            "checkout of {:?} must be rejected as InvalidRef, got: {}",
+            bad_name,
+            err
+        );
+        let err = DatasetBuilder::from_uri(&test_uri)
+            .with_branch(bad_name, None)
+            .load()
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidRef { .. }),
+            "open of {:?} must be rejected as InvalidRef, got: {}",
+            bad_name,
+            err
+        );
+    }
+
+    // "main" stays a valid spelling of the main branch on checkout; the JNI
+    // bindings construct Ref::Version(Some("main"), _) directly.
+    let main_by_name = checkout_branch1.checkout_branch("main").await.unwrap();
+    assert_eq!(main_by_name.manifest.branch, None);
+    assert_eq!(main_by_name.version().version, 1);
+    let main_by_ref = checkout_branch1
+        .checkout_version(crate::dataset::refs::Ref::Version(
+            Some("main".to_string()),
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(main_by_ref.manifest.branch, None);
+
+    // A checkout whose resolved manifest is not on the requested branch must
+    // error loudly instead of handing back another branch's data: stage main's
+    // manifest under a branch path that was never created, so resolution finds
+    // a manifest belonging to main.
+    use object_store::ObjectStoreExt as _;
+    let staged_manifest = main_dataset.manifest_location().path.clone();
+    let staged_copy = Path::parse(format!(
+        "{}/tree/ghost/_versions/{}",
+        test_uri,
+        staged_manifest.filename().unwrap()
+    ))
+    .unwrap();
+    main_dataset
+        .object_store
+        .inner
+        .copy(&staged_manifest, &staged_copy)
+        .await
+        .unwrap();
+    let err = main_dataset.checkout_branch("ghost").await.unwrap_err();
+    assert!(
+        err.to_string().contains("resolved a manifest belonging to"),
+        "expected the branch-mismatch guardrail, got: {}",
+        err
+    );
+    main_dataset
+        .object_store
+        .remove_dir_all(Path::parse(format!("{}/tree/ghost", test_uri)).unwrap())
+        .await
+        .unwrap();
 
     let mut dataset = main_dataset;
     // Finally delete all branches

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -104,6 +104,10 @@ impl<'a> CommitBuilder<'a> {
     }
 
     /// Pass a commit handler to use for the dataset.
+    ///
+    /// Takes precedence over the destination dataset's own handler. If not
+    /// set, a `Dataset` destination commits through its own handler and a
+    /// `Uri` destination resolves one from the uri.
     pub fn with_commit_handler(mut self, commit_handler: Arc<dyn CommitHandler>) -> Self {
         self.commit_handler = Some(commit_handler);
         self
@@ -241,7 +245,9 @@ impl<'a> CommitBuilder<'a> {
             WriteDestination::Dataset(dataset) => (
                 dataset.object_store.clone(),
                 dataset.base.clone(),
-                dataset.commit_handler.clone(),
+                self.commit_handler
+                    .clone()
+                    .unwrap_or_else(|| dataset.commit_handler.clone()),
             ),
             WriteDestination::Uri(uri) => {
                 let commit_handler = if let (Some(_), Some(commit_handler)) =

--- a/rust/lance/src/io/commit/namespace_manifest.rs
+++ b/rust/lance/src/io/commit/namespace_manifest.rs
@@ -14,27 +14,61 @@ use lance_table::io::commit::{ManifestLocation, ManifestNamingScheme};
 use object_store::ObjectStore as OSObjectStore;
 use object_store::path::Path;
 
+use crate::dataset::branch_location::BranchLocation;
+
 #[derive(Debug)]
 pub struct LanceNamespaceExternalManifestStore {
     namespace_client: Arc<dyn LanceNamespace>,
     table_id: Vec<String>,
+    /// Object-store path of the table root (the main branch). The base path the
+    /// trait methods receive is resolved against this to derive which branch a
+    /// request targets, so a single store serves every branch of the table.
+    table_root: Path,
 }
 
 impl LanceNamespaceExternalManifestStore {
-    pub fn new(namespace_client: Arc<dyn LanceNamespace>, table_id: Vec<String>) -> Self {
+    pub fn new(
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        table_root: Path,
+    ) -> Self {
         Self {
             namespace_client,
             table_id,
+            table_root,
         }
+    }
+
+    /// Build a store for the table rooted at `table_uri`, resolving the root
+    /// path from the uri without initializing an object store.
+    pub fn for_table_uri(
+        namespace_client: Arc<dyn LanceNamespace>,
+        table_id: Vec<String>,
+        table_uri: &str,
+    ) -> Result<Self> {
+        let table_root = lance_io::object_store::ObjectStore::extract_path_from_uri(
+            Arc::new(lance_io::object_store::ObjectStoreRegistry::default()),
+            table_uri,
+        )?;
+        Ok(Self::new(namespace_client, table_id, table_root))
+    }
+
+    /// Derive the branch targeted by `base` (the table root for main, or a
+    /// branch chain produced by `BranchLocation::find_branch`). The branch
+    /// path layout is owned by [`BranchLocation`]; this store never parses or
+    /// constructs it directly.
+    fn branch_for_base(&self, base: &str) -> Result<Option<String>> {
+        BranchLocation::branch_of(self.table_root.as_ref(), base)
     }
 }
 
 #[async_trait]
 impl ExternalManifestStore for LanceNamespaceExternalManifestStore {
-    async fn get(&self, _base_uri: &str, version: u64) -> Result<String> {
+    async fn get(&self, base_uri: &str, version: u64) -> Result<String> {
         let request = DescribeTableVersionRequest {
             id: Some(self.table_id.clone()),
             version: Some(version as i64),
+            branch: self.branch_for_base(base_uri)?,
             ..Default::default()
         };
 
@@ -47,11 +81,12 @@ impl ExternalManifestStore for LanceNamespaceExternalManifestStore {
         Ok(response.version.manifest_path)
     }
 
-    async fn get_latest_version(&self, _base_uri: &str) -> Result<Option<(u64, String)>> {
+    async fn get_latest_version(&self, base_uri: &str) -> Result<Option<(u64, String)>> {
         let request = ListTableVersionsRequest {
             id: Some(self.table_id.clone()),
             descending: Some(true),
             limit: Some(1),
+            branch: self.branch_for_base(base_uri)?,
             ..Default::default()
         };
 
@@ -73,7 +108,7 @@ impl ExternalManifestStore for LanceNamespaceExternalManifestStore {
     /// Put the manifest to the namespace store.
     async fn put(
         &self,
-        _base_path: &Path,
+        base_path: &Path,
         version: u64,
         staging_path: &Path,
         size: u64,
@@ -94,6 +129,7 @@ impl ExternalManifestStore for LanceNamespaceExternalManifestStore {
             manifest_size: Some(size as i64),
             e_tag: e_tag.clone(),
             naming_scheme: Some(naming_scheme_str.to_string()),
+            branch: self.branch_for_base(base_path.as_ref())?,
             ..Default::default()
         };
 


### PR DESCRIPTION
### Description

Branch-aware table version operations. Table version operations in DirectoryNamespace and RestNamespace now operate on a branch's own version chain when a branch is supplied. Branches are already a first-class ref in the Lance table format; this brings the namespace operations in line. An absent branch (or "main") behaves exactly as before.

Branch lifecycle operations. Adds CreateTableBranch, ListTableBranches, and DeleteTableBranch to DirectoryNamespace and RestNamespace, exposed by the rest_adapter at POST /v1/table/{id}/branches/{create,list,delete}. These wrap Lance's first-class Dataset branch APIs and mirror the existing tag operations, so the three layers stay uniform.

Managed versioning now supports branches end to end. Previously the namespace-managed commit store (LanceNamespaceExternalManifestStore) was bound to one branch at construction and ignored the base path handed to it, and a branch-opened managed dataset stayed rooted at the table root.

Drive-by fix. batch_delete_table_versions constructed {version}.manifest to delete, which is V1-only naming and silently matched nothing under V2 (the default scheme). It now matches actual manifests via Lance's ManifestNamingScheme.

### Testing
- Branch round-trips for all version operations in DirectoryNamespace.
- Managed branch e2e (DirectoryNamespace and rest_adapter loopback): with_branch open and commit, data files under tree/<branch>/data/, unmanaged interop read, cross-branch checkout at overlapping version numbers, branch tags via with_tag and Ref::Tag, non-latest fork; asserts managed_versioning survives the REST round trip.
