### PR TITLE
feat(vector)!: add approx mode for RaBitQ search

### DIFF
--- a/java/lance-jni/src/blocking_scanner.rs
+++ b/java/lance-jni/src/blocking_scanner.rs
@@ -30,6 +30,7 @@ use crate::{
     RT,
     blocking_dataset::{BlockingDataset, NATIVE_DATASET},
     traits::IntoJava,
+    utils::parse_approx_mode,
 };
 
 pub const NATIVE_SCANNER: &str = "nativeScannerHandle";
@@ -357,6 +358,9 @@ pub(crate) fn build_scanner_with_options<'a>(
             .call_method(&java_obj, "getQueryParallelism", "()I", &[])?
             .i()?;
         scanner.query_parallelism(query_parallelism);
+
+        let approx_mode_str = env.get_string_from_method(&java_obj, "getApproxModeString")?;
+        scanner.approx_mode(parse_approx_mode(&approx_mode_str)?);
         Ok(())
     })?;
 

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -268,6 +268,7 @@ pub fn get_query(env: &mut JNIEnv, query_obj: JObject) -> Result<Option<Query>> 
             use_index,
             dist_q_c: 0.0,
             query_parallelism,
+            approx_mode: Default::default(),
         })
     })?;
 

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -25,7 +25,7 @@ use crate::error::{Error, Result};
 use crate::ffi::JNIEnvExt;
 
 use crate::traits::FromJObjectWithEnv;
-use lance_index::vector::Query;
+use lance_index::vector::{ApproxMode, Query};
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -74,6 +74,18 @@ pub fn extract_base_store_params(
 
         Ok::<_, Error>(base_store_params)
     })
+}
+
+pub(crate) fn parse_approx_mode(value: &str) -> Result<ApproxMode> {
+    match value {
+        "fast" => Ok(ApproxMode::Fast),
+        "normal" => Ok(ApproxMode::Normal),
+        "accurate" => Ok(ApproxMode::Accurate),
+        _ => Err(Error::input_error(format!(
+            "Invalid approx mode '{}'. Expected one of: fast, normal, accurate",
+            value
+        ))),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -253,6 +265,8 @@ pub fn get_query(env: &mut JNIEnv, query_obj: JObject) -> Result<Option<Query>> 
         let query_parallelism = env
             .call_method(&java_obj, "getQueryParallelism", "()I", &[])?
             .i()?;
+        let approx_mode_str = env.get_string_from_method(&java_obj, "getApproxModeString")?;
+        let approx_mode = parse_approx_mode(&approx_mode_str)?;
 
         Ok(Query {
             column,
@@ -268,7 +282,7 @@ pub fn get_query(env: &mut JNIEnv, query_obj: JObject) -> Result<Option<Query>> 
             use_index,
             dist_q_c: 0.0,
             query_parallelism,
-            approx_mode: Default::default(),
+            approx_mode,
         })
     })?;
 

--- a/java/src/main/java/org/lance/ipc/ApproxMode.java
+++ b/java/src/main/java/org/lance/ipc/ApproxMode.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.ipc;
+
+/**
+ * Controls the speed / accuracy tradeoff for approximate vector search.
+ *
+ * <p>This setting currently only affects RQ-quantized vector indexes, such as IVF_RQ. Other index
+ * types ignore this setting.
+ */
+public enum ApproxMode {
+  /** Prefer faster approximate scoring when supported by the RQ index. */
+  FAST("fast"),
+
+  /** Use the index's default approximation behavior. */
+  NORMAL("normal"),
+
+  /** Prefer more accurate approximate scoring when supported by the RQ index. */
+  ACCURATE("accurate");
+
+  private final String value;
+
+  ApproxMode(String value) {
+    this.value = value;
+  }
+
+  /** Returns the lowercase value passed across the JNI boundary. */
+  public String toRustString() {
+    return value;
+  }
+}

--- a/java/src/main/java/org/lance/ipc/Query.java
+++ b/java/src/main/java/org/lance/ipc/Query.java
@@ -32,6 +32,7 @@ public class Query {
   private final Optional<DistanceType> distanceType;
   private final boolean useIndex;
   private final int queryParallelism;
+  private final ApproxMode approxMode;
 
   private Query(Builder builder) {
     this.column = Preconditions.checkNotNull(builder.column, "Columns must be set");
@@ -52,6 +53,7 @@ public class Query {
     this.distanceType = builder.distanceType;
     this.useIndex = builder.useIndex;
     this.queryParallelism = builder.queryParallelism;
+    this.approxMode = builder.approxMode;
   }
 
   public String getColumn() {
@@ -98,6 +100,14 @@ public class Query {
     return queryParallelism;
   }
 
+  public ApproxMode getApproxMode() {
+    return approxMode;
+  }
+
+  public String getApproxModeString() {
+    return approxMode.toRustString();
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -111,6 +121,7 @@ public class Query {
         .add("distanceType", distanceType.orElse(null))
         .add("useIndex", useIndex)
         .add("queryParallelism", queryParallelism)
+        .add("approxMode", approxMode)
         .toString();
   }
 
@@ -125,6 +136,7 @@ public class Query {
     private Optional<DistanceType> distanceType = Optional.empty();
     private boolean useIndex = true;
     private int queryParallelism = 0;
+    private ApproxMode approxMode = ApproxMode.NORMAL;
 
     /**
      * Sets the column to be searched.
@@ -272,6 +284,20 @@ public class Query {
       Preconditions.checkArgument(
           queryParallelism >= -1, "Query parallelism must be greater than or equal to -1");
       this.queryParallelism = queryParallelism;
+      return this;
+    }
+
+    /**
+     * Sets the speed / accuracy tradeoff for approximate vector search.
+     *
+     * <p>This setting currently only affects RQ-quantized vector indexes, such as IVF_RQ. Other
+     * index types ignore this setting.
+     *
+     * @param approxMode The approximate search mode to use for the query.
+     * @return The Builder instance for method chaining.
+     */
+    public Builder setApproxMode(ApproxMode approxMode) {
+      this.approxMode = Preconditions.checkNotNull(approxMode, "ApproxMode must not be null");
       return this;
     }
 

--- a/java/src/test/java/org/lance/JNITest.java
+++ b/java/src/test/java/org/lance/JNITest.java
@@ -20,6 +20,7 @@ import org.lance.index.vector.IvfBuildParams;
 import org.lance.index.vector.PQBuildParams;
 import org.lance.index.vector.SQBuildParams;
 import org.lance.index.vector.VectorIndexParams;
+import org.lance.ipc.ApproxMode;
 import org.lance.ipc.Query;
 import org.lance.test.JniTestHelper;
 
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JNITest {
@@ -48,6 +50,10 @@ public class JNITest {
 
   @Test
   public void testQuery() {
+    Query defaultQuery =
+        new Query.Builder().setColumn("column").setKey(new float[] {1.0f, 2.0f, 3.0f}).build();
+    assertEquals(ApproxMode.NORMAL, defaultQuery.getApproxMode());
+
     JniTestHelper.parseQuery(
         Optional.of(
             new Query.Builder()
@@ -60,6 +66,7 @@ public class JNITest {
                 .setDistanceType(DistanceType.L2)
                 .setUseIndex(true)
                 .setQueryParallelism(-1)
+                .setApproxMode(ApproxMode.ACCURATE)
                 .build()));
   }
 

--- a/protos/ann.proto
+++ b/protos/ann.proto
@@ -32,6 +32,8 @@ message VectorQueryProto {
   bool use_index = 11;
   optional float dist_q_c = 12;
   optional int32 query_parallelism = 13;
+  // Currently only affects RQ-quantized vector indexes, such as IVF_RQ.
+  // Other index types ignore this setting.
   VectorApproxMode approx_mode = 14;
 }
 

--- a/protos/ann.proto
+++ b/protos/ann.proto
@@ -14,11 +14,12 @@ import "index.proto";
 // This currently only affects RQ-quantized vector indexes, such as IVF_RQ.
 // Other index types ignore this setting.
 enum VectorApproxMode {
-  // Use the default Lance search path.
+  // Use all RQ bits for query-time scoring with u8-quantized lookup tables.
   Normal = 0;
-  // Prefer lower latency by forcing 1-bit RQ scoring at query time.
+  // Use only one RQ bit for query-time scoring, even for multi-bit indexes.
   Fast = 1;
-  // Prefer higher accuracy by using the high-accuracy RQ estimator.
+  // Use all RQ bits for query-time scoring with u16-quantized lookup tables
+  // to reduce estimator quantization error.
   Accurate = 2;
 }
 

--- a/protos/ann.proto
+++ b/protos/ann.proto
@@ -9,6 +9,12 @@ import "table_identifier.proto";
 import "table.proto";
 import "index.proto";
 
+enum VectorApproxMode {
+  Normal = 0;
+  Fast = 1;
+  Accurate = 2;
+}
+
 // Serialized vector query parameters.
 message VectorQueryProto {
   // Query vector as Arrow IPC bytes (supports Float16, Float32, Float64, UInt8, etc.)
@@ -26,6 +32,7 @@ message VectorQueryProto {
   bool use_index = 11;
   optional float dist_q_c = 12;
   optional int32 query_parallelism = 13;
+  VectorApproxMode approx_mode = 14;
 }
 
 // Serializable form of ANNIvfSubIndexExec — the IVF sub-index search node.

--- a/protos/ann.proto
+++ b/protos/ann.proto
@@ -9,9 +9,16 @@ import "table_identifier.proto";
 import "table.proto";
 import "index.proto";
 
+// Query-time approximation mode for vector search.
+//
+// This currently only affects RQ-quantized vector indexes, such as IVF_RQ.
+// Other index types ignore this setting.
 enum VectorApproxMode {
+  // Use the default Lance search path.
   Normal = 0;
+  // Prefer lower latency by forcing 1-bit RQ scoring at query time.
   Fast = 1;
+  // Prefer higher accuracy by using the high-accuracy RQ estimator.
   Accurate = 2;
 }
 
@@ -32,8 +39,8 @@ message VectorQueryProto {
   bool use_index = 11;
   optional float dist_q_c = 12;
   optional int32 query_parallelism = 13;
-  // Currently only affects RQ-quantized vector indexes, such as IVF_RQ.
-  // Other index types ignore this setting.
+  // Query-time approximation mode. Currently only affects RQ-quantized vector
+  // indexes, such as IVF_RQ. Other index types ignore this setting.
   VectorApproxMode approx_mode = 14;
 }
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6253,6 +6253,7 @@ class ScannerBuilder:
         use_index: bool = True,
         ef: Optional[int] = None,
         query_parallelism: Optional[int] = None,
+        approx_mode: Literal["fast", "normal", "accurate"] = "normal",
         distance_range: Optional[tuple[Optional[float], Optional[float]]] = None,
     ) -> ScannerBuilder:
         """Configure nearest neighbor search.
@@ -6276,6 +6277,9 @@ class ScannerBuilder:
             the CPU pool size. Value 1 uses the single-worker sequential path.
             Values >= 2 use the partition-parallel path and are clamped to the
             CPU pool size.
+        approx_mode: {"fast", "normal", "accurate"}, default "normal"
+            Controls the speed / accuracy tradeoff for approximate vector search
+            when supported by the selected index.
         """
         self._nearest = _build_vector_search_query(
             column,
@@ -6290,6 +6294,7 @@ class ScannerBuilder:
             use_index=use_index,
             ef=ef,
             query_parallelism=query_parallelism,
+            approx_mode=approx_mode,
             distance_range=distance_range,
         )
         return self
@@ -7412,6 +7417,7 @@ def _build_vector_search_query(
     use_index: bool = True,
     ef: Optional[int] = None,
     query_parallelism: Optional[int] = None,
+    approx_mode: Literal["fast", "normal", "accurate"] = "normal",
     distance_range: Optional[tuple[Optional[float], Optional[float]]] = None,
 ) -> dict:
     """Configure nearest neighbor search.
@@ -7453,6 +7459,9 @@ def _build_vector_search_query(
         maps to the single-worker sequential path. Value -1 uses the CPU pool
         size. Value 1 uses the single-worker sequential path. Values >= 2 use
         the partition-parallel path and are clamped to the CPU pool size.
+    approx_mode: {"fast", "normal", "accurate"}, default "normal"
+        Controls the speed / accuracy tradeoff for approximate vector search
+        when supported by the selected index.
     distance_range: tuple[Optional[float], Optional[float]], optional
         A tuple of (lower_bound, upper_bound) to filter results by distance.
         Both bounds are optional. The lower bound is inclusive and the upper
@@ -7526,6 +7535,12 @@ def _build_vector_search_query(
     if query_parallelism is not None and query_parallelism < -1:
         raise ValueError("query_parallelism must be >= -1")
 
+    if approx_mode not in {"fast", "normal", "accurate"}:
+        raise ValueError(
+            "approx_mode must be one of 'fast', 'normal', or 'accurate', "
+            f"got {approx_mode!r}"
+        )
+
     if distance_range is not None:
         if len(distance_range) != 2:
             raise ValueError(
@@ -7543,6 +7558,7 @@ def _build_vector_search_query(
         "use_index": use_index,
         "ef": ef,
         "query_parallelism": query_parallelism,
+        "approx_mode": approx_mode,
         "distance_range": distance_range,
     }
 
@@ -7699,6 +7715,7 @@ class VectorSearchQuery:
         use_index: bool = True,
         ef: Optional[int] = None,
         query_parallelism: Optional[int] = None,
+        approx_mode: Literal["fast", "normal", "accurate"] = "normal",
     ):
         self._inner = _build_vector_search_query(
             column,
@@ -7712,6 +7729,7 @@ class VectorSearchQuery:
             use_index=use_index,
             ef=ef,
             query_parallelism=query_parallelism,
+            approx_mode=approx_mode,
         )
 
     def inner(self):

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6281,10 +6281,9 @@ class ScannerBuilder:
             Controls the speed / accuracy tradeoff for approximate vector search
             when supported by the selected index. This currently only affects
             RQ-quantized indexes, such as IVF_RQ. Other index types ignore this
-            setting. ``fast`` uses one RQ bit for query-time scoring.
-            ``normal`` uses all RQ bits with u8-quantized lookup tables.
-            ``accurate`` uses all RQ bits with u16-quantized lookup tables to
-            reduce estimator quantization error.
+            setting. ``fast`` favors lower latency and may reduce recall,
+            ``normal`` uses the default balance, and ``accurate`` favors higher
+            recall and may increase latency.
         """
         self._nearest = _build_vector_search_query(
             column,
@@ -7468,10 +7467,9 @@ def _build_vector_search_query(
         Controls the speed / accuracy tradeoff for approximate vector search
         when supported by the selected index. This currently only affects
         RQ-quantized indexes, such as IVF_RQ. Other index types ignore this
-        setting. ``fast`` uses one RQ bit for query-time scoring. ``normal``
-        uses all RQ bits with u8-quantized lookup tables. ``accurate`` uses all
-        RQ bits with u16-quantized lookup tables to reduce estimator
-        quantization error.
+        setting. ``fast`` favors lower latency and may reduce recall,
+        ``normal`` uses the default balance, and ``accurate`` favors higher
+        recall and may increase latency.
     distance_range: tuple[Optional[float], Optional[float]], optional
         A tuple of (lower_bound, upper_bound) to filter results by distance.
         Both bounds are optional. The lower bound is inclusive and the upper

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6279,7 +6279,9 @@ class ScannerBuilder:
             CPU pool size.
         approx_mode: {"fast", "normal", "accurate"}, default "normal"
             Controls the speed / accuracy tradeoff for approximate vector search
-            when supported by the selected index.
+            when supported by the selected index. This currently only affects
+            RQ-quantized indexes, such as IVF_RQ. Other index types ignore this
+            setting.
         """
         self._nearest = _build_vector_search_query(
             column,
@@ -7461,7 +7463,9 @@ def _build_vector_search_query(
         the partition-parallel path and are clamped to the CPU pool size.
     approx_mode: {"fast", "normal", "accurate"}, default "normal"
         Controls the speed / accuracy tradeoff for approximate vector search
-        when supported by the selected index.
+        when supported by the selected index. This currently only affects
+        RQ-quantized indexes, such as IVF_RQ. Other index types ignore this
+        setting.
     distance_range: tuple[Optional[float], Optional[float]], optional
         A tuple of (lower_bound, upper_bound) to filter results by distance.
         Both bounds are optional. The lower bound is inclusive and the upper

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6281,7 +6281,10 @@ class ScannerBuilder:
             Controls the speed / accuracy tradeoff for approximate vector search
             when supported by the selected index. This currently only affects
             RQ-quantized indexes, such as IVF_RQ. Other index types ignore this
-            setting.
+            setting. ``fast`` uses one RQ bit for query-time scoring.
+            ``normal`` uses all RQ bits with u8-quantized lookup tables.
+            ``accurate`` uses all RQ bits with u16-quantized lookup tables to
+            reduce estimator quantization error.
         """
         self._nearest = _build_vector_search_query(
             column,
@@ -7465,7 +7468,10 @@ def _build_vector_search_query(
         Controls the speed / accuracy tradeoff for approximate vector search
         when supported by the selected index. This currently only affects
         RQ-quantized indexes, such as IVF_RQ. Other index types ignore this
-        setting.
+        setting. ``fast`` uses one RQ bit for query-time scoring. ``normal``
+        uses all RQ bits with u8-quantized lookup tables. ``accurate`` uses all
+        RQ bits with u16-quantized lookup tables to reduce estimator
+        quantization error.
     distance_range: tuple[Optional[float], Optional[float]], optional
         A tuple of (lower_bound, upper_bound) to filter results by distance.
         Both bounds are optional. The lower bound is inclusive and the upper

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1101,6 +1101,17 @@ def test_create_ivf_rq_multi_bit_searches_l2_and_cosine():
     stats = ds.stats.index_stats("vector_idx")
     assert stats["indices"][0]["sub_index"]["num_bits"] == 9
     assert stats["indices"][0]["sub_index"]["query_estimator"] == "raw_query"
+    for approx_mode in ["fast", "normal", "accurate"]:
+        result = ds.to_table(
+            nearest={
+                "column": "vector",
+                "q": mat[0],
+                "k": 10,
+                "approx_mode": approx_mode,
+            },
+            columns=["id"],
+        )
+        assert result.num_rows == 10
 
     cosine_ds = lance.write_dataset(tbl, "memory://")
     cosine_ds = _assert_recall_at_least(cosine_ds, mat[1], metric="cosine")
@@ -2093,6 +2104,33 @@ def test_vector_index_invalid_query_parallelism(indexed_dataset):
                 "q": np.random.randn(128),
                 "k": 10,
                 "query_parallelism": -2,
+            }
+        )
+
+
+def test_vector_index_with_approx_mode(indexed_dataset):
+    q = np.random.randn(128)
+
+    for approx_mode in ["fast", "normal", "accurate"]:
+        result = indexed_dataset.to_table(
+            nearest={
+                "column": "vector",
+                "q": q,
+                "k": 10,
+                "approx_mode": approx_mode,
+            }
+        )
+        assert len(result) == 10
+
+
+def test_vector_index_invalid_approx_mode(indexed_dataset):
+    with pytest.raises(ValueError, match="approx_mode"):
+        indexed_dataset.scanner(
+            nearest={
+                "column": "vector",
+                "q": np.random.randn(128),
+                "k": 10,
+                "approx_mode": "hacc",
             }
         )
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -78,8 +78,9 @@ use lance_index::{
     progress::{IndexBuildProgress, NoopIndexBuildProgress},
     scalar::{FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams},
     vector::{
-        DEFAULT_QUERY_PARALLELISM, Query as VectorQuery, hnsw::builder::HnswBuildParams,
-        ivf::IvfBuildParams, pq::PQBuildParams, sq::builder::SQBuildParams,
+        ApproxMode, DEFAULT_QUERY_PARALLELISM, Query as VectorQuery,
+        hnsw::builder::HnswBuildParams, ivf::IvfBuildParams, pq::PQBuildParams,
+        sq::builder::SQBuildParams,
     },
 };
 use lance_io::object_store::{
@@ -1227,6 +1228,7 @@ impl Dataset {
                 use_index,
                 ef,
                 query_parallelism,
+                approx_mode,
             ) = vector_query_params_from_dict(nearest, default_k)?;
 
             let (_, element_type) = get_vector_type(self_.ds.schema(), &column)
@@ -1293,6 +1295,7 @@ impl Dataset {
                         s = s.ef(ef);
                     }
                     s = s.query_parallelism(query_parallelism);
+                    s = s.approx_mode(approx_mode);
                     s.use_index(use_index);
                     if let Some((lower, upper)) = distance_range {
                         s.distance_range(lower, upper);
@@ -4684,6 +4687,7 @@ type VectorQueryParams = (
     bool,
     Option<usize>,
     i32,
+    ApproxMode,
 );
 
 fn extract_query_parallelism(value: &Bound<'_, PyAny>) -> PyResult<i32> {
@@ -4702,6 +4706,23 @@ fn vector_query_query_parallelism_from_dict(dict: &Bound<'_, PyDict>) -> PyResul
         extract_query_parallelism(&query_parallelism)
     } else {
         Ok(DEFAULT_QUERY_PARALLELISM)
+    }
+}
+
+fn vector_query_approx_mode_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<ApproxMode> {
+    if let Some(approx_mode) = dict.get_item("approx_mode")?
+        && !approx_mode.is_none()
+    {
+        match approx_mode.to_string().to_lowercase().as_str() {
+            "fast" => Ok(ApproxMode::Fast),
+            "normal" => Ok(ApproxMode::Normal),
+            "accurate" => Ok(ApproxMode::Accurate),
+            value => Err(PyValueError::new_err(format!(
+                "approx_mode must be one of 'fast', 'normal', or 'accurate', got '{value}'"
+            ))),
+        }
+    } else {
+        Ok(ApproxMode::Normal)
     }
 }
 
@@ -4811,6 +4832,7 @@ fn vector_query_params_from_dict(
     };
 
     let query_parallelism = vector_query_query_parallelism_from_dict(dict)?;
+    let approx_mode = vector_query_approx_mode_from_dict(dict)?;
 
     Ok((
         column,
@@ -4823,6 +4845,7 @@ fn vector_query_params_from_dict(
         use_index,
         ef,
         query_parallelism,
+        approx_mode,
     ))
 }
 
@@ -4859,6 +4882,7 @@ impl PySearchFilter {
             use_index,
             ef,
             query_parallelism,
+            approx_mode,
         ) = vector_query_params_from_dict(query, default_k)?;
 
         let metric_type = Some(metric_type_opt.unwrap_or(MetricType::L2));
@@ -4877,6 +4901,7 @@ impl PySearchFilter {
             use_index,
             query_parallelism,
             dist_q_c: 0.0,
+            approx_mode,
         };
 
         Ok(Self {

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -83,16 +83,19 @@ pub static CENTROID_DIST_FIELD: LazyLock<arrow_schema::Field> = LazyLock::new(||
 pub const DEFAULT_QUERY_PARALLELISM: i32 = 0;
 
 /// Controls the speed / accuracy tradeoff for approximate vector search.
+///
+/// This currently only affects RQ-quantized vector indexes, such as IVF_RQ.
+/// Other index types ignore this setting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ApproxMode {
-    /// Prefer faster approximate scoring when supported by the index.
+    /// Prefer faster approximate scoring when supported by the RQ index.
     Fast,
 
     /// Use the index's default approximation behavior.
     #[default]
     Normal,
 
-    /// Prefer more accurate approximate scoring when supported by the index.
+    /// Prefer more accurate approximate scoring when supported by the RQ index.
     Accurate,
 }
 
@@ -157,6 +160,9 @@ pub struct Query {
     pub dist_q_c: f32,
 
     /// Controls the speed / accuracy tradeoff for approximate vector search.
+    ///
+    /// This currently only affects RQ-quantized vector indexes, such as IVF_RQ.
+    /// Other index types ignore this setting.
     pub approx_mode: ApproxMode,
 }
 

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -88,14 +88,15 @@ pub const DEFAULT_QUERY_PARALLELISM: i32 = 0;
 /// Other index types ignore this setting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ApproxMode {
-    /// Prefer faster approximate scoring when supported by the RQ index.
+    /// Use only one RQ bit for query-time scoring, even for multi-bit indexes.
     Fast,
 
-    /// Use the index's default approximation behavior.
+    /// Use all RQ bits for query-time scoring with u8-quantized lookup tables.
     #[default]
     Normal,
 
-    /// Prefer more accurate approximate scoring when supported by the RQ index.
+    /// Use all RQ bits for query-time scoring with u16-quantized lookup tables
+    /// to reduce estimator quantization error.
     Accurate,
 }
 

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -88,15 +88,14 @@ pub const DEFAULT_QUERY_PARALLELISM: i32 = 0;
 /// Other index types ignore this setting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ApproxMode {
-    /// Use only one RQ bit for query-time scoring, even for multi-bit indexes.
+    /// Prefer lower query latency, which can reduce recall.
     Fast,
 
-    /// Use all RQ bits for query-time scoring with u8-quantized lookup tables.
+    /// Use the default balance between query latency and recall.
     #[default]
     Normal,
 
-    /// Use all RQ bits for query-time scoring with u16-quantized lookup tables
-    /// to reduce estimator quantization error.
+    /// Prefer higher recall, which can increase query latency.
     Accurate,
 }
 

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -82,6 +82,20 @@ pub static CENTROID_DIST_FIELD: LazyLock<arrow_schema::Field> = LazyLock::new(||
 
 pub const DEFAULT_QUERY_PARALLELISM: i32 = 0;
 
+/// Controls the speed / accuracy tradeoff for approximate vector search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ApproxMode {
+    /// Prefer faster approximate scoring when supported by the index.
+    Fast,
+
+    /// Use the index's default approximation behavior.
+    #[default]
+    Normal,
+
+    /// Prefer more accurate approximate scoring when supported by the index.
+    Accurate,
+}
+
 /// Query parameters for the vector indices
 
 #[derive(Debug, Clone)]
@@ -141,6 +155,9 @@ pub struct Query {
     /// the distance between the query and the centroid
     /// this is only used for IVF index with Rabit quantization
     pub dist_q_c: f32,
+
+    /// Controls the speed / accuracy tradeoff for approximate vector search.
+    pub approx_mode: ApproxMode,
 }
 
 impl From<pb::VectorMetricType> for DistanceType {

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::frag_reuse::FragReuseIndex;
 use crate::pb;
+use crate::vector::ApproxMode;
 use crate::vector::bq::rotation::{apply_fast_rotation, apply_fast_rotation_in_place};
 use crate::vector::bq::transform::{
     ADD_FACTORS_COLUMN, ERROR_FACTORS_COLUMN, EX_ADD_FACTORS_COLUMN, EX_SCALE_FACTORS_COLUMN,
@@ -52,7 +53,9 @@ use crate::vector::bq::{
 use crate::vector::graph::{OrderedFloat, OrderedNode};
 use crate::vector::pq::storage::transpose;
 use crate::vector::quantizer::{QuantizerMetadata, QuantizerStorage};
-use crate::vector::storage::{DistCalculator, QueryResidual, RabitRawQueryContext, VectorStore};
+use crate::vector::storage::{
+    DistCalculator, DistanceCalculatorOptions, QueryResidual, RabitRawQueryContext, VectorStore,
+};
 
 pub const RABIT_METADATA_KEY: &str = "lance:rabit";
 pub const RABIT_CODE_COLUMN: &str = "_rabit_codes";
@@ -558,6 +561,7 @@ impl RabitQuantizationStorage {
         sum_q: f32,
         query_factor: f32,
         query_error: f32,
+        approx_mode: ApproxMode,
     ) -> RabitDistCalculator<'a> {
         let ex_codes = self
             .ex_codes
@@ -590,6 +594,7 @@ impl RabitQuantizationStorage {
             packed_ex_codes,
             query_factor,
             query_error,
+            approx_mode,
         )
     }
 
@@ -776,6 +781,7 @@ pub struct RabitDistCalculator<'a> {
     packed_ex_codes: Option<&'a [u8]>,
     query_factor: f32,
     query_error: f32,
+    approx_mode: ApproxMode,
 
     sum_q: f32,
     sqrt_d: f32,
@@ -800,6 +806,7 @@ impl<'a> RabitDistCalculator<'a> {
         packed_ex_codes: Option<&'a [u8]>,
         query_factor: f32,
         query_error: f32,
+        approx_mode: ApproxMode,
     ) -> Self {
         Self {
             dim,
@@ -817,6 +824,7 @@ impl<'a> RabitDistCalculator<'a> {
             packed_ex_codes,
             query_factor,
             query_error,
+            approx_mode,
             sqrt_d: (dim as f32 * num_bits as f32).sqrt(),
             sum_q,
         }
@@ -830,7 +838,18 @@ impl<'a> RabitDistCalculator<'a> {
         dists: &mut Vec<f32>,
         quantized_dists: &mut Vec<u16>,
         quantized_dists_table: &mut Vec<u8>,
+        hacc_quantized_dists: &mut Vec<u32>,
     ) -> usize {
+        if self.approx_mode == ApproxMode::Accurate {
+            return self.binary_distances_hacc_with_scratch(
+                n,
+                code_len,
+                dists,
+                quantized_dists,
+                hacc_quantized_dists,
+            );
+        }
+
         let (qmin, qmax) = quantize_dist_table_into(&self.dist_table, quantized_dists_table);
         let remainder = n % BATCH_SIZE;
         let simd_len = n - remainder;
@@ -881,6 +900,65 @@ impl<'a> RabitDistCalculator<'a> {
         simd_len
     }
 
+    #[allow(clippy::uninit_vec)]
+    fn binary_distances_hacc_with_scratch(
+        &self,
+        n: usize,
+        code_len: usize,
+        dists: &mut Vec<f32>,
+        quantized_dist_table: &mut Vec<u16>,
+        quantized_dists: &mut Vec<u32>,
+    ) -> usize {
+        let (qmin, qmax) = quantize_dist_table_u16_into(&self.dist_table, quantized_dist_table);
+        let remainder = n % BATCH_SIZE;
+        let simd_len = n - remainder;
+        quantized_dists.clear();
+        quantized_dists.reserve(simd_len);
+        // SAFETY: sum_4bit_dist_table_u16 overwrites each element in the batch range.
+        unsafe {
+            quantized_dists.set_len(simd_len);
+        }
+        simd::dist_table::sum_4bit_dist_table_u16(
+            simd_len,
+            code_len,
+            self.codes,
+            quantized_dist_table,
+            quantized_dists,
+        );
+
+        let range = (qmax - qmin) / u16::MAX as f32;
+        let num_tables = quantized_dist_table.len() / SEGMENT_NUM_CODES;
+        let sum_min = num_tables as f32 * qmin;
+        dists.clear();
+        dists.reserve(n);
+        // SAFETY: the batch section writes [0, simd_len), and the
+        // remainder section writes [simd_len, n).
+        unsafe {
+            dists.set_len(n);
+        }
+        let (simd_dists, remainder_dists) = dists.split_at_mut(simd_len);
+        simd_dists
+            .iter_mut()
+            .zip(quantized_dists.iter())
+            .for_each(|(dist, q_dist)| {
+                *dist = (*q_dist as f32) * range + sum_min;
+            });
+
+        remainder_dists
+            .iter_mut()
+            .enumerate()
+            .for_each(|(id, dist)| {
+                *dist = compute_single_rq_distance(
+                    self.codes,
+                    simd_len + id,
+                    n,
+                    code_len,
+                    &self.dist_table,
+                );
+            });
+        simd_len
+    }
+
     #[inline]
     fn binary_distance_factor_params(&self) -> (f32, f32) {
         match self.query_estimator {
@@ -897,61 +975,25 @@ impl<'a> RabitDistCalculator<'a> {
         dists: &mut Vec<f32>,
         quantized_dists: &mut Vec<u16>,
         quantized_dists_table: &mut Vec<u8>,
+        hacc_quantized_dists: &mut Vec<u32>,
     ) {
-        let (qmin, qmax) = quantize_dist_table_into(&self.dist_table, quantized_dists_table);
-        let remainder = n % BATCH_SIZE;
-        let simd_len = n - remainder;
-        quantized_dists.clear();
-        quantized_dists.reserve(simd_len);
-        // SAFETY: sum_4bit_dist_table overwrites each element in the SIMD batch range.
-        unsafe {
-            quantized_dists.set_len(simd_len);
-        }
-        simd::dist_table::sum_4bit_dist_table(
-            simd_len,
+        self.binary_distances_with_scratch(
+            n,
             code_len,
-            self.codes,
-            quantized_dists_table,
+            dists,
             quantized_dists,
+            quantized_dists_table,
+            hacc_quantized_dists,
         );
-
-        let range = (qmax - qmin) / 255.0;
-        let num_tables = quantized_dists_table.len() / SEGMENT_NUM_CODES;
-        let sum_min = num_tables as f32 * qmin;
         let (binary_distance_multiplier, binary_distance_offset) =
             self.binary_distance_factor_params();
-        dists.clear();
-        dists.reserve(n);
-        // SAFETY: the SIMD section below writes [0, simd_len), and the
-        // remainder section writes [simd_len, n).
-        unsafe {
-            dists.set_len(n);
-        }
-        let (simd_dists, remainder_dists) = dists.split_at_mut(simd_len);
-        simd_dists
-            .iter_mut()
-            .zip(quantized_dists.iter())
-            .enumerate()
-            .for_each(|(id, (dist, q_dist))| {
-                let binary_dist = (*q_dist as f32) * range + sum_min;
-                *dist = (binary_dist * binary_distance_multiplier + binary_distance_offset)
-                    * self.scale_factors[id]
-                    + self.add_factors[id]
-                    + self.query_factor;
-            });
-
-        remainder_dists
-            .iter_mut()
-            .enumerate()
-            .for_each(|(offset, dist)| {
-                let id = simd_len + offset;
-                let binary_dist =
-                    compute_single_rq_distance(self.codes, id, n, code_len, &self.dist_table);
-                *dist = (binary_dist * binary_distance_multiplier + binary_distance_offset)
-                    * self.scale_factors[id]
-                    + self.add_factors[id]
-                    + self.query_factor;
-            });
+        dists.iter_mut().enumerate().for_each(|(id, dist)| {
+            let binary_dist = *dist;
+            *dist = (binary_dist * binary_distance_multiplier + binary_distance_offset)
+                * self.scale_factors[id]
+                + self.add_factors[id]
+                + self.query_factor;
+        });
     }
 
     #[allow(clippy::uninit_vec)]
@@ -1092,12 +1134,14 @@ impl<'a> RabitDistCalculator<'a> {
         dists: &mut Vec<f32>,
         quantized_dists: &mut Vec<u16>,
         quantized_dists_table: &mut Vec<u8>,
+        hacc_quantized_dists: &mut Vec<u32>,
     ) {
         let code_len = rabit_binary_code_bytes(self.dim);
         let n = self.codes.len() / code_len;
         if n == 0 {
             dists.clear();
             quantized_dists.clear();
+            hacc_quantized_dists.clear();
             return;
         }
 
@@ -1107,6 +1151,7 @@ impl<'a> RabitDistCalculator<'a> {
             dists,
             quantized_dists,
             quantized_dists_table,
+            hacc_quantized_dists,
         );
 
         let ex_bits = self.num_bits - 1;
@@ -1183,7 +1228,9 @@ impl<'a> RabitDistCalculator<'a> {
     }
 
     fn raw_query_lower_bound_gating_disabled_reason(&self) -> Option<&'static str> {
-        if self.query_estimator != RabitQueryEstimator::RawQuery {
+        if self.approx_mode == ApproxMode::Fast {
+            Some("approx_mode_fast")
+        } else if self.query_estimator != RabitQueryEstimator::RawQuery {
             Some("residual_query_estimator")
         } else if self.num_bits <= 1 {
             Some("num_bits_le_one")
@@ -1297,6 +1344,38 @@ fn quantize_dist_table_into(dist_table: &[f32], quantized_dist_table: &mut Vec<u
     let spare = quantized_dist_table.spare_capacity_mut();
     for (quantized, &d) in spare[..dist_table.len()].iter_mut().zip(dist_table.iter()) {
         quantized.write(((d - qmin) * factor).round() as u8);
+    }
+    // SAFETY: every element in the reserved range was initialized in the loop above.
+    unsafe {
+        quantized_dist_table.set_len(dist_table.len());
+    }
+
+    (qmin, qmax)
+}
+
+#[inline]
+fn quantize_dist_table_u16_into(
+    dist_table: &[f32],
+    quantized_dist_table: &mut Vec<u16>,
+) -> (f32, f32) {
+    let (qmin, qmax) = dist_table
+        .iter()
+        .cloned()
+        .minmax_by(|a, b| a.total_cmp(b))
+        .into_option()
+        .unwrap();
+    if qmin == qmax {
+        quantized_dist_table.clear();
+        quantized_dist_table.resize(dist_table.len(), 0);
+        return (qmin, qmax);
+    }
+
+    let factor = u16::MAX as f32 / (qmax - qmin);
+    quantized_dist_table.clear();
+    quantized_dist_table.reserve(dist_table.len());
+    let spare = quantized_dist_table.spare_capacity_mut();
+    for (quantized, &d) in spare[..dist_table.len()].iter_mut().zip(dist_table.iter()) {
+        quantized.write(((d - qmin) * factor).round() as u16);
     }
     // SAFETY: every element in the reserved range was initialized in the loop above.
     unsafe {
@@ -1472,11 +1551,8 @@ impl DistCalculator for RabitDistCalculator<'_> {
             }
             RabitQueryEstimator::RawQuery => {
                 let ex_bits = self.num_bits - 1;
-                if ex_bits == 0 {
-                    let binary_dot = dist - 0.5 * self.sum_q;
-                    return binary_dot * self.scale_factors[id]
-                        + self.add_factors[id]
-                        + self.query_factor;
+                if ex_bits == 0 || self.approx_mode == ApproxMode::Fast {
+                    return self.raw_query_binary_distance(id, dist);
                 }
 
                 let ex_codes = self
@@ -1508,11 +1584,13 @@ impl DistCalculator for RabitDistCalculator<'_> {
         let mut dists = Vec::new();
         let mut quantized_dists = Vec::new();
         let mut quantized_dists_table = Vec::new();
+        let mut hacc_quantized_dists = Vec::new();
         self.distance_all_with_scratch(
             0,
             &mut dists,
             &mut quantized_dists,
             &mut quantized_dists_table,
+            &mut hacc_quantized_dists,
         );
         dists
     }
@@ -1525,6 +1603,7 @@ impl DistCalculator for RabitDistCalculator<'_> {
         dists: &mut Vec<f32>,
         quantized_dists: &mut Vec<u16>,
         quantized_dists_table: &mut Vec<u8>,
+        hacc_quantized_dists: &mut Vec<u32>,
     ) {
         let code_len = rabit_binary_code_bytes(self.dim);
         let n = self.codes.len() / code_len;
@@ -1534,13 +1613,17 @@ impl DistCalculator for RabitDistCalculator<'_> {
             return;
         }
 
-        if self.query_estimator == RabitQueryEstimator::ResidualQuery || self.num_bits == 1 {
+        if self.query_estimator == RabitQueryEstimator::ResidualQuery
+            || self.num_bits == 1
+            || self.approx_mode == ApproxMode::Fast
+        {
             self.one_bit_distances_with_scratch(
                 n,
                 code_len,
                 dists,
                 quantized_dists,
                 quantized_dists_table,
+                hacc_quantized_dists,
             );
             return;
         }
@@ -1551,6 +1634,7 @@ impl DistCalculator for RabitDistCalculator<'_> {
             dists,
             quantized_dists,
             quantized_dists_table,
+            hacc_quantized_dists,
         );
 
         self.apply_raw_query_multi_bit_distances(
@@ -1572,13 +1656,20 @@ impl DistCalculator for RabitDistCalculator<'_> {
         dists: &mut Vec<f32>,
         quantized_dists: &mut Vec<u16>,
         quantized_dists_table: &mut Vec<u8>,
+        hacc_quantized_dists: &mut Vec<u32>,
     ) {
         if k == 0 {
             return;
         }
         if let Some(reason) = self.raw_query_lower_bound_gating_disabled_reason() {
             record_rabit_prune_bypass(reason);
-            self.distance_all_with_scratch(k, dists, quantized_dists, quantized_dists_table);
+            self.distance_all_with_scratch(
+                k,
+                dists,
+                quantized_dists,
+                quantized_dists_table,
+                hacc_quantized_dists,
+            );
             accumulate_distances_into_heap(k, lower_bound, upper_bound, row_id, res, dists);
             return;
         }
@@ -1594,6 +1685,7 @@ impl DistCalculator for RabitDistCalculator<'_> {
             dists,
             quantized_dists,
             quantized_dists_table,
+            hacc_quantized_dists,
         );
     }
 
@@ -1609,13 +1701,20 @@ impl DistCalculator for RabitDistCalculator<'_> {
         dists: &mut Vec<f32>,
         quantized_dists: &mut Vec<u16>,
         quantized_dists_table: &mut Vec<u8>,
+        hacc_quantized_dists: &mut Vec<u32>,
     ) {
         if k == 0 {
             return;
         }
         if let Some(reason) = self.raw_query_lower_bound_gating_disabled_reason() {
             record_rabit_prune_bypass(reason);
-            self.distance_all_with_scratch(k, dists, quantized_dists, quantized_dists_table);
+            self.distance_all_with_scratch(
+                k,
+                dists,
+                quantized_dists,
+                quantized_dists_table,
+                hacc_quantized_dists,
+            );
             accumulate_filtered_distances_into_heap(
                 k,
                 lower_bound,
@@ -1639,6 +1738,7 @@ impl DistCalculator for RabitDistCalculator<'_> {
             dists,
             quantized_dists,
             quantized_dists_table,
+            hacc_quantized_dists,
         );
     }
 }
@@ -1770,6 +1870,7 @@ impl VectorStore for RabitQuantizationStorage {
             sum_q,
             query_factor,
             query_error,
+            ApproxMode::Normal,
         )
     }
 
@@ -1781,6 +1882,7 @@ impl VectorStore for RabitQuantizationStorage {
         dist_q_c: f32,
         residual: Option<QueryResidual<'a>>,
         f32_scratch: &'a mut Vec<f32>,
+        options: DistanceCalculatorOptions,
     ) -> Self::DistanceCalculator<'a> {
         let code_dim = self.code_dim();
         if let (
@@ -1807,6 +1909,7 @@ impl VectorStore for RabitQuantizationStorage {
                 raw_query.sum_q,
                 query_factor,
                 query_error,
+                options.approx_mode,
             );
         }
 
@@ -1876,6 +1979,7 @@ impl VectorStore for RabitQuantizationStorage {
             sum_q,
             query_factor,
             query_error,
+            options.approx_mode,
         )
     }
 
@@ -2420,8 +2524,13 @@ mod tests {
         let mut scratch = Vec::with_capacity(expected_scratch_len);
         let initial_ptr = scratch.as_ptr();
         {
-            let calc =
-                storage.dist_calculator_with_scratch(query.clone(), 0.25, None, &mut scratch);
+            let calc = storage.dist_calculator_with_scratch(
+                query.clone(),
+                0.25,
+                None,
+                &mut scratch,
+                DistanceCalculatorOptions::default(),
+            );
             assert_eq!(calc.distance_all(0), expected);
         }
         assert_eq!(scratch.len(), expected_scratch_len);
@@ -2429,7 +2538,13 @@ mod tests {
 
         scratch.fill(f32::NAN);
         {
-            let calc = storage.dist_calculator_with_scratch(query, 0.25, None, &mut scratch);
+            let calc = storage.dist_calculator_with_scratch(
+                query,
+                0.25,
+                None,
+                &mut scratch,
+                DistanceCalculatorOptions::default(),
+            );
             assert_eq!(calc.distance_all(0), expected);
         }
         assert_eq!(scratch.as_ptr(), initial_ptr);
@@ -2470,6 +2585,7 @@ mod tests {
             0.25,
             Some(QueryResidual::Centroid(centroid.as_ref())),
             &mut scratch,
+            DistanceCalculatorOptions::default(),
         );
 
         assert_eq!(calc.distance_all(0), expected);
@@ -2508,6 +2624,7 @@ mod tests {
             0.25,
             Some(QueryResidual::Centroid(centroid.as_ref())),
             &mut scratch,
+            DistanceCalculatorOptions::default(),
         );
 
         assert_eq!(calc.distance_all(0), expected);
@@ -2754,8 +2871,172 @@ mod tests {
         let mut distances = Vec::new();
         let mut u16_scratch = Vec::new();
         let mut u8_scratch = Vec::new();
-        calc.distance_all_with_scratch(0, &mut distances, &mut u16_scratch, &mut u8_scratch);
+        let mut u32_scratch = Vec::new();
+        calc.distance_all_with_scratch(
+            0,
+            &mut distances,
+            &mut u16_scratch,
+            &mut u8_scratch,
+            &mut u32_scratch,
+        );
         assert_eq!(distances, vec![104.0, 22.0]);
+    }
+
+    #[test]
+    fn test_fast_approx_mode_uses_one_bit_scores_for_multi_bit_raw_query() {
+        let code_dim = 8usize;
+        let identity = Float32Array::from_iter_values(
+            (0..code_dim)
+                .flat_map(|row| (0..code_dim).map(move |col| if row == col { 1.0 } else { 0.0 })),
+        );
+        let rotate_mat =
+            FixedSizeListArray::try_new_from_values(identity, code_dim as i32).unwrap();
+        let metadata = RabitQuantizationMetadata {
+            rotate_mat: Some(rotate_mat),
+            rotate_mat_position: None,
+            fast_rotation_signs: None,
+            rotation_type: RQRotationType::Matrix,
+            code_dim: code_dim as u32,
+            num_bits: 2,
+            packed: false,
+            query_estimator: RabitQueryEstimator::RawQuery,
+        };
+        let codes =
+            FixedSizeListArray::try_new_from_values(UInt8Array::from(vec![0xff, 0xff]), 1).unwrap();
+        let ex_codes =
+            FixedSizeListArray::try_new_from_values(UInt8Array::from(vec![0x00, 0xff]), 1).unwrap();
+        let batch = make_test_batch_with_ex(codes, ex_codes)
+            .replace_column_by_name(
+                SCALE_FACTORS_COLUMN,
+                Arc::new(Float32Array::from(vec![0.0, 0.0])),
+            )
+            .unwrap();
+        let storage =
+            RabitQuantizationStorage::try_from_batch(batch, &metadata, DistanceType::L2, None)
+                .unwrap();
+        let query = Arc::new(Float32Array::from(vec![1.0; code_dim])) as ArrayRef;
+        let normal = storage.dist_calculator(query.clone(), 0.0).distance_all(0);
+
+        let mut f32_scratch = Vec::new();
+        let calc = storage.dist_calculator_with_scratch(
+            query,
+            0.0,
+            None,
+            &mut f32_scratch,
+            DistanceCalculatorOptions {
+                approx_mode: ApproxMode::Fast,
+            },
+        );
+        let mut distances = Vec::new();
+        let mut u16_scratch = Vec::new();
+        let mut u8_scratch = Vec::new();
+        let mut u32_scratch = Vec::new();
+        calc.distance_all_with_scratch(
+            0,
+            &mut distances,
+            &mut u16_scratch,
+            &mut u8_scratch,
+            &mut u32_scratch,
+        );
+
+        let expected_fast = (0..2)
+            .map(|id| calc.distance(id as u32))
+            .collect::<Vec<_>>();
+        assert_ne!(normal, distances);
+        assert_eq!(distances, expected_fast);
+        assert_eq!(
+            calc.raw_query_lower_bound_gating_disabled_reason(),
+            Some("approx_mode_fast")
+        );
+    }
+
+    #[test]
+    fn test_accurate_approx_mode_reduces_binary_lut_quantization_error() {
+        let code_dim = 64usize;
+        let num_rows = BATCH_SIZE;
+        let original_codes = make_test_codes(num_rows, code_dim as i32);
+        let metadata = make_test_metadata(code_dim);
+        let storage = RabitQuantizationStorage::try_from_batch(
+            make_test_batch(original_codes),
+            &metadata,
+            DistanceType::L2,
+            None,
+        )
+        .unwrap();
+        let query = Arc::new(Float32Array::from_iter_values(
+            (0..code_dim).map(|idx| (idx as f32 * 0.137).sin() + idx as f32 * 0.003),
+        )) as ArrayRef;
+        let exact_calc = storage.dist_calculator(query.clone(), 0.0);
+        let exact = (0..num_rows)
+            .map(|id| exact_calc.distance(id as u32))
+            .collect::<Vec<_>>();
+
+        let normal = {
+            let mut f32_scratch = Vec::new();
+            let calc = storage.dist_calculator_with_scratch(
+                query.clone(),
+                0.0,
+                None,
+                &mut f32_scratch,
+                DistanceCalculatorOptions::default(),
+            );
+            let mut distances = Vec::new();
+            let mut u16_scratch = Vec::new();
+            let mut u8_scratch = Vec::new();
+            let mut u32_scratch = Vec::new();
+            calc.distance_all_with_scratch(
+                0,
+                &mut distances,
+                &mut u16_scratch,
+                &mut u8_scratch,
+                &mut u32_scratch,
+            );
+            distances
+        };
+
+        let (accurate, hacc_table_len, hacc_accum_len) = {
+            let mut f32_scratch = Vec::new();
+            let calc = storage.dist_calculator_with_scratch(
+                query,
+                0.0,
+                None,
+                &mut f32_scratch,
+                DistanceCalculatorOptions {
+                    approx_mode: ApproxMode::Accurate,
+                },
+            );
+            let mut distances = Vec::new();
+            let mut u16_scratch = Vec::new();
+            let mut u8_scratch = Vec::new();
+            let mut u32_scratch = Vec::new();
+            calc.distance_all_with_scratch(
+                0,
+                &mut distances,
+                &mut u16_scratch,
+                &mut u8_scratch,
+                &mut u32_scratch,
+            );
+            (distances, u16_scratch.len(), u32_scratch.len())
+        };
+
+        let normal_error = normal
+            .iter()
+            .zip(exact.iter())
+            .map(|(actual, expected)| (actual - expected).abs())
+            .sum::<f32>();
+        let accurate_error = accurate
+            .iter()
+            .zip(exact.iter())
+            .map(|(actual, expected)| (actual - expected).abs())
+            .sum::<f32>();
+
+        assert!(normal_error > 0.0);
+        assert!(
+            accurate_error < normal_error,
+            "accurate_error={accurate_error}, normal_error={normal_error}"
+        );
+        assert_eq!(hacc_table_len, code_dim * 4);
+        assert_eq!(hacc_accum_len, num_rows);
     }
 
     fn assert_raw_query_multi_bit_distance_all_uses_fastscan(num_bits: u8) {
@@ -2826,7 +3107,14 @@ mod tests {
         let mut distances = Vec::new();
         let mut u16_scratch = Vec::new();
         let mut u8_scratch = Vec::new();
-        calc.distance_all_with_scratch(0, &mut distances, &mut u16_scratch, &mut u8_scratch);
+        let mut u32_scratch = Vec::new();
+        calc.distance_all_with_scratch(
+            0,
+            &mut distances,
+            &mut u16_scratch,
+            &mut u8_scratch,
+            &mut u32_scratch,
+        );
 
         assert_eq!(distances.len(), num_rows);
         assert_eq!(u16_scratch.len(), BATCH_SIZE);
@@ -2906,12 +3194,14 @@ mod tests {
         let mut binary_ips = Vec::new();
         let mut binary_u16_scratch = Vec::new();
         let mut binary_u8_scratch = Vec::new();
+        let mut binary_u32_scratch = Vec::new();
         calc.binary_distances_with_scratch(
             num_rows,
             rabit_binary_code_bytes(code_dim),
             &mut binary_ips,
             &mut binary_u16_scratch,
             &mut binary_u8_scratch,
+            &mut binary_u32_scratch,
         );
         let ex_codes = calc.ex_codes.unwrap();
         let ex_add_factors = calc.ex_add_factors.unwrap();
@@ -2947,6 +3237,7 @@ mod tests {
         let mut distances = Vec::new();
         let mut u16_scratch = Vec::new();
         let mut u8_scratch = Vec::new();
+        let mut u32_scratch = Vec::new();
         calc.accumulate_topk_with_scratch(
             k,
             None,
@@ -2956,6 +3247,7 @@ mod tests {
             &mut distances,
             &mut u16_scratch,
             &mut u8_scratch,
+            &mut u32_scratch,
         );
         let mut actual = heap
             .into_iter()
@@ -3053,6 +3345,7 @@ mod tests {
                     query: None,
                 }),
                 &mut fallback_scratch,
+                DistanceCalculatorOptions::default(),
             )
             .distance_all(0);
 
@@ -3066,6 +3359,7 @@ mod tests {
                     query: Some(&raw_query),
                 }),
                 &mut prepared_scratch,
+                DistanceCalculatorOptions::default(),
             )
             .distance_all(0);
 

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -555,14 +555,17 @@ impl RabitQuantizationStorage {
 
     fn distance_calculator_from_parts<'a>(
         &'a self,
-        dim: usize,
-        dist_table: Cow<'a, [f32]>,
-        ex_dist_table: Cow<'a, [f32]>,
-        sum_q: f32,
-        query_factor: f32,
-        query_error: f32,
-        approx_mode: ApproxMode,
+        parts: RabitDistCalculatorParts<'a>,
     ) -> RabitDistCalculator<'a> {
+        let RabitDistCalculatorParts {
+            dim,
+            dist_table,
+            ex_dist_table,
+            sum_q,
+            query_factor,
+            query_error,
+            approx_mode,
+        } = parts;
         let ex_codes = self
             .ex_codes
             .as_ref()
@@ -759,6 +762,16 @@ fn copy_subtract_f32(lhs: &[f32], rhs: &[f32], output: &mut [f32]) {
     if input_len < output.len() {
         output[input_len..].fill(0.0);
     }
+}
+
+struct RabitDistCalculatorParts<'a> {
+    dim: usize,
+    dist_table: Cow<'a, [f32]>,
+    ex_dist_table: Cow<'a, [f32]>,
+    sum_q: f32,
+    query_factor: f32,
+    query_error: f32,
+    approx_mode: ApproxMode,
 }
 
 pub struct RabitDistCalculator<'a> {
@@ -1863,15 +1876,15 @@ impl VectorStore for RabitQuantizationStorage {
         };
         let sum_q = rotated_qr.into_iter().sum();
 
-        self.distance_calculator_from_parts(
-            code_dim,
-            Cow::Owned(dist_table),
-            Cow::Owned(ex_dist_table),
+        self.distance_calculator_from_parts(RabitDistCalculatorParts {
+            dim: code_dim,
+            dist_table: Cow::Owned(dist_table),
+            ex_dist_table: Cow::Owned(ex_dist_table),
             sum_q,
             query_factor,
             query_error,
-            ApproxMode::Normal,
-        )
+            approx_mode: ApproxMode::Normal,
+        })
     }
 
     // qr = (q-c)
@@ -1902,15 +1915,15 @@ impl VectorStore for RabitQuantizationStorage {
                 &raw_query.rotated_query,
                 rotated_centroid,
             );
-            return self.distance_calculator_from_parts(
-                code_dim,
-                Cow::Borrowed(&raw_query.dist_table),
-                Cow::Borrowed(&raw_query.ex_dist_table),
-                raw_query.sum_q,
+            return self.distance_calculator_from_parts(RabitDistCalculatorParts {
+                dim: code_dim,
+                dist_table: Cow::Borrowed(&raw_query.dist_table),
+                ex_dist_table: Cow::Borrowed(&raw_query.ex_dist_table),
+                sum_q: raw_query.sum_q,
                 query_factor,
                 query_error,
-                options.approx_mode,
-            );
+                approx_mode: options.approx_mode,
+            });
         }
 
         let dist_table_len = code_dim * 4;
@@ -1969,18 +1982,18 @@ impl VectorStore for RabitQuantizationStorage {
             rotated_qr.iter().copied().sum()
         };
 
-        self.distance_calculator_from_parts(
-            code_dim,
-            Cow::Borrowed(&f32_scratch[code_dim..code_dim + dist_table_len]),
-            Cow::Borrowed(
+        self.distance_calculator_from_parts(RabitDistCalculatorParts {
+            dim: code_dim,
+            dist_table: Cow::Borrowed(&f32_scratch[code_dim..code_dim + dist_table_len]),
+            ex_dist_table: Cow::Borrowed(
                 &f32_scratch
                     [code_dim + dist_table_len..code_dim + dist_table_len + ex_dist_table_len],
             ),
             sum_q,
             query_factor,
             query_error,
-            options.approx_mode,
-        )
+            approx_mode: options.approx_mode,
+        })
     }
 
     // TODO: implement this

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -859,6 +859,7 @@ impl<'a> RabitDistCalculator<'a> {
                 code_len,
                 dists,
                 quantized_dists,
+                quantized_dists_table,
                 hacc_quantized_dists,
             );
         }
@@ -920,22 +921,24 @@ impl<'a> RabitDistCalculator<'a> {
         code_len: usize,
         dists: &mut Vec<f32>,
         quantized_dist_table: &mut Vec<u16>,
+        hacc_dist_table: &mut Vec<u8>,
         quantized_dists: &mut Vec<u32>,
     ) -> usize {
         let (qmin, qmax) = quantize_dist_table_u16_into(&self.dist_table, quantized_dist_table);
+        simd::dist_table::transfer_4bit_dist_table_u16(quantized_dist_table, hacc_dist_table);
         let remainder = n % BATCH_SIZE;
         let simd_len = n - remainder;
         quantized_dists.clear();
         quantized_dists.reserve(simd_len);
-        // SAFETY: sum_4bit_dist_table_u16 overwrites each element in the batch range.
+        // SAFETY: sum_4bit_hacc_dist_table overwrites each element in the batch range.
         unsafe {
             quantized_dists.set_len(simd_len);
         }
-        simd::dist_table::sum_4bit_dist_table_u16(
+        simd::dist_table::sum_4bit_hacc_dist_table(
             simd_len,
             code_len,
             self.codes,
-            quantized_dist_table,
+            hacc_dist_table,
             quantized_dists,
         );
 
@@ -3007,7 +3010,7 @@ mod tests {
             distances
         };
 
-        let (accurate, hacc_table_len, hacc_accum_len) = {
+        let (accurate, hacc_table_len, hacc_packed_table_len, hacc_accum_len) = {
             let mut f32_scratch = Vec::new();
             let calc = storage.dist_calculator_with_scratch(
                 query,
@@ -3029,7 +3032,12 @@ mod tests {
                 &mut u8_scratch,
                 &mut u32_scratch,
             );
-            (distances, u16_scratch.len(), u32_scratch.len())
+            (
+                distances,
+                u16_scratch.len(),
+                u8_scratch.len(),
+                u32_scratch.len(),
+            )
         };
 
         let normal_error = normal
@@ -3049,6 +3057,7 @@ mod tests {
             "accurate_error={accurate_error}, normal_error={normal_error}"
         );
         assert_eq!(hacc_table_len, code_dim * 4);
+        assert_eq!(hacc_packed_table_len, code_dim * 8);
         assert_eq!(hacc_accum_len, num_rows);
     }
 

--- a/rust/lance-index/src/vector/flat/index.rs
+++ b/rust/lance-index/src/vector/flat/index.rs
@@ -20,10 +20,12 @@ use crate::{
     metrics::MetricsCollector,
     prefilter::PreFilter,
     vector::{
-        DIST_COL, Query,
+        ApproxMode, DIST_COL, Query,
         graph::{OrderedFloat, OrderedNode},
         quantizer::{Quantization, QuantizationType, Quantizer, QuantizerMetadata},
-        storage::{DistCalculator, QueryResidual, QueryScratch, VectorStore},
+        storage::{
+            DistCalculator, DistanceCalculatorOptions, QueryResidual, QueryScratch, VectorStore,
+        },
         v3::subindex::IvfSubIndex,
     },
 };
@@ -68,6 +70,7 @@ pub struct FlatQueryParams {
     lower_bound: Option<f32>,
     upper_bound: Option<f32>,
     dist_q_c: f32,
+    approx_mode: ApproxMode,
 }
 
 impl From<&Query> for FlatQueryParams {
@@ -76,6 +79,7 @@ impl From<&Query> for FlatQueryParams {
             lower_bound: q.lower_bound,
             upper_bound: q.upper_bound,
             dist_q_c: q.dist_q_c,
+            approx_mode: q.approx_mode,
         }
     }
 }
@@ -136,6 +140,9 @@ impl IvfSubIndex for FlatIndex {
             params.dist_q_c,
             residual,
             &mut scratch.query_f32,
+            DistanceCalculatorOptions {
+                approx_mode: params.approx_mode,
+            },
         );
         let mut res = BinaryHeap::with_capacity(k);
         metrics.record_comparisons(storage.len());
@@ -147,6 +154,7 @@ impl IvfSubIndex for FlatIndex {
                     &mut scratch.distances,
                     &mut scratch.u16,
                     &mut scratch.u8,
+                    &mut scratch.u32,
                 );
                 let dists = scratch.distances.iter().copied();
 
@@ -254,6 +262,9 @@ impl IvfSubIndex for FlatIndex {
             params.dist_q_c,
             residual,
             &mut scratch.query_f32,
+            DistanceCalculatorOptions {
+                approx_mode: params.approx_mode,
+            },
         );
         metrics.record_comparisons(storage.len());
 
@@ -268,6 +279,7 @@ impl IvfSubIndex for FlatIndex {
                     &mut scratch.distances,
                     &mut scratch.u16,
                     &mut scratch.u8,
+                    &mut scratch.u32,
                 );
             }
             false => {
@@ -282,6 +294,7 @@ impl IvfSubIndex for FlatIndex {
                     &mut scratch.distances,
                     &mut scratch.u16,
                     &mut scratch.u8,
+                    &mut scratch.u32,
                 );
             }
         };

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -35,10 +35,10 @@ use crate::{
     },
 };
 
-use super::DISTANCE_TYPE_KEY;
 use super::graph::OrderedFloat;
 use super::graph::OrderedNode;
 use super::quantizer::{Quantizer, QuantizerMetadata};
+use super::{ApproxMode, DISTANCE_TYPE_KEY};
 
 /// <section class="warning">
 ///  Internal API
@@ -59,6 +59,7 @@ pub trait DistCalculator {
         dists: &mut Vec<f32>,
         _u16_scratch: &mut Vec<u16>,
         _u8_scratch: &mut Vec<u8>,
+        _u32_scratch: &mut Vec<u32>,
     ) {
         *dists = self.distance_all(k_hint);
     }
@@ -76,12 +77,13 @@ pub trait DistCalculator {
         dists: &mut Vec<f32>,
         u16_scratch: &mut Vec<u16>,
         u8_scratch: &mut Vec<u8>,
+        u32_scratch: &mut Vec<u32>,
     ) {
         if k == 0 {
             return;
         }
 
-        self.distance_all_with_scratch(k, dists, u16_scratch, u8_scratch);
+        self.distance_all_with_scratch(k, dists, u16_scratch, u8_scratch, u32_scratch);
         let lower_bound = lower_bound.unwrap_or(f32::MIN).into();
         let upper_bound = upper_bound.unwrap_or(f32::MAX).into();
         let mut max_dist = res.peek().map(|node| node.dist);
@@ -116,6 +118,7 @@ pub trait DistCalculator {
         _dists: &mut Vec<f32>,
         _u16_scratch: &mut Vec<u16>,
         _u8_scratch: &mut Vec<u8>,
+        _u32_scratch: &mut Vec<u32>,
     ) {
         if k == 0 {
             return;
@@ -155,6 +158,7 @@ pub struct QueryScratch {
     pub query_f32: Vec<f32>,
     pub u16: Vec<u16>,
     pub u8: Vec<u8>,
+    pub u32: Vec<u32>,
 }
 
 impl QueryScratch {
@@ -164,6 +168,7 @@ impl QueryScratch {
             query_f32: Vec::new(),
             u16: Vec::new(),
             u8: Vec::new(),
+            u32: Vec::new(),
         }
     }
 
@@ -173,6 +178,7 @@ impl QueryScratch {
             query_f32: vec![0.0; capacity.query_f32],
             u16: vec![0; capacity.u16],
             u8: vec![0; capacity.u8],
+            u32: vec![0; capacity.u32],
         }
     }
 }
@@ -189,6 +195,7 @@ impl DeepSizeOf for QueryScratch {
             + self.query_f32.capacity() * size_of::<f32>()
             + self.u16.capacity() * size_of::<u16>()
             + self.u8.capacity() * size_of::<u8>()
+            + self.u32.capacity() * size_of::<u32>()
     }
 }
 
@@ -198,15 +205,27 @@ pub struct QueryScratchCapacity {
     pub query_f32: usize,
     pub u16: usize,
     pub u8: usize,
+    pub u32: usize,
 }
 
 impl QueryScratchCapacity {
     pub const fn new(distances: usize, query_f32: usize, u16: usize, u8: usize) -> Self {
+        Self::new_with_u32(distances, query_f32, u16, u8, 0)
+    }
+
+    pub const fn new_with_u32(
+        distances: usize,
+        query_f32: usize,
+        u16: usize,
+        u8: usize,
+        u32: usize,
+    ) -> Self {
         Self {
             distances,
             query_f32,
             u16,
             u8,
+            u32,
         }
     }
 
@@ -215,7 +234,13 @@ impl QueryScratchCapacity {
             + self.query_f32 * size_of::<f32>()
             + self.u16 * size_of::<u16>()
             + self.u8 * size_of::<u8>()
+            + self.u32 * size_of::<u32>()
     }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DistanceCalculatorOptions {
+    pub approx_mode: ApproxMode,
 }
 
 #[derive(Debug)]
@@ -393,6 +418,7 @@ pub trait VectorStore: Send + Sync + Sized + Clone {
         dist_q_c: f32,
         _residual: Option<QueryResidual<'a>>,
         _f32_scratch: &'a mut Vec<f32>,
+        _options: DistanceCalculatorOptions,
     ) -> Self::DistanceCalculator<'a> {
         self.dist_calculator(query, dist_q_c)
     }
@@ -641,11 +667,14 @@ mod tests {
             scratch.u16.resize(4, 3);
             scratch.u8.clear();
             scratch.u8.resize(2, 4);
+            scratch.u32.clear();
+            scratch.u32.resize(3, 5);
             (
                 scratch.query_f32.as_ptr(),
                 scratch.distances.as_ptr(),
                 scratch.u16.as_ptr(),
                 scratch.u8.as_ptr(),
+                scratch.u32.as_ptr(),
             )
         });
 
@@ -658,11 +687,14 @@ mod tests {
             assert!(scratch.u16.iter().all(|value| *value == 3));
             assert_eq!(scratch.u8.len(), 2);
             assert!(scratch.u8.iter().all(|value| *value == 4));
+            assert_eq!(scratch.u32.len(), 3);
+            assert!(scratch.u32.iter().all(|value| *value == 5));
             (
                 scratch.query_f32.as_ptr(),
                 scratch.distances.as_ptr(),
                 scratch.u16.as_ptr(),
                 scratch.u8.as_ptr(),
+                scratch.u32.as_ptr(),
             )
         });
 
@@ -688,7 +720,8 @@ mod tests {
 
     #[test]
     fn test_query_scratch_pool_uses_temporary_scratch_when_empty() {
-        let pool = QueryScratchPool::with_capacity(1, QueryScratchCapacity::new(8, 16, 4, 2));
+        let pool =
+            QueryScratchPool::with_capacity(1, QueryScratchCapacity::new_with_u32(8, 16, 4, 2, 3));
         let pooled = pool.scratch();
         assert!(pooled.pooled);
 
@@ -698,12 +731,14 @@ mod tests {
         assert_eq!(temporary.query_f32.len(), 16);
         assert_eq!(temporary.u16.len(), 4);
         assert_eq!(temporary.u8.len(), 2);
+        assert_eq!(temporary.u32.len(), 3);
     }
 
     #[test]
     fn test_query_scratch_pool_deep_size_includes_buffer_capacity() {
         let empty_size = QueryScratchPool::new(1).deep_size_of();
-        let pool = QueryScratchPool::with_capacity(1, QueryScratchCapacity::new(8, 16, 4, 2));
+        let pool =
+            QueryScratchPool::with_capacity(1, QueryScratchCapacity::new_with_u32(8, 16, 4, 2, 3));
 
         assert!(pool.deep_size_of() > empty_size);
 
@@ -715,7 +750,8 @@ mod tests {
 
     #[test]
     fn test_query_scratch_pool_initializes_buffer_capacity() {
-        let pool = QueryScratchPool::with_capacity(1, QueryScratchCapacity::new(8, 16, 4, 2));
+        let pool =
+            QueryScratchPool::with_capacity(1, QueryScratchCapacity::new_with_u32(8, 16, 4, 2, 3));
 
         pool.with_scratch(|scratch| {
             assert_eq!(scratch.distances.len(), 8);
@@ -726,6 +762,8 @@ mod tests {
             assert_eq!(scratch.u16.capacity(), 4);
             assert_eq!(scratch.u8.len(), 2);
             assert_eq!(scratch.u8.capacity(), 2);
+            assert_eq!(scratch.u32.len(), 3);
+            assert_eq!(scratch.u32.capacity(), 3);
         });
     }
 }

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -134,6 +134,89 @@ pub fn sum_4bit_dist_table_u16(
 }
 
 #[inline]
+pub fn transfer_4bit_dist_table_u16(dist_table: &[u16], hacc_dist_table: &mut Vec<u8>) {
+    debug_assert!(dist_table.len().is_multiple_of(32));
+
+    let num_tables = dist_table.len() / 16;
+    hacc_dist_table.clear();
+    hacc_dist_table.resize(dist_table.len() * 2, 0);
+
+    for table_idx in 0..num_tables {
+        let table = &dist_table[table_idx * 16..(table_idx + 1) * 16];
+        let low_offset = (table_idx / 2) * 64 + (table_idx % 2) * 16;
+        let high_offset = low_offset + 32;
+        for (code, value) in table.iter().enumerate() {
+            hacc_dist_table[low_offset + code] = *value as u8;
+            hacc_dist_table[high_offset + code] = (value >> 8) as u8;
+        }
+    }
+}
+
+#[inline]
+pub fn sum_4bit_hacc_dist_table(
+    n: usize,
+    code_len: usize,
+    codes: &[u8],
+    hacc_dist_table: &[u8],
+    dists: &mut [u32],
+) {
+    debug_assert!(n.is_multiple_of(BATCH_SIZE));
+    debug_assert!(dists.len() >= n);
+    debug_assert!(codes.len() >= n * code_len);
+    debug_assert!(hacc_dist_table.len() >= code_len * 64);
+
+    match *SIMD_SUPPORT {
+        #[cfg(target_arch = "x86_64")]
+        SimdSupport::Avx512 | SimdSupport::Avx512FP16 | SimdSupport::Avx2
+            if std::arch::is_x86_feature_detected!("avx2") =>
+        {
+            sum_4bit_hacc_dist_table_avx2(n, code_len, codes, hacc_dist_table, dists);
+        }
+        _ => sum_4bit_hacc_dist_table_scalar(code_len, codes, hacc_dist_table, dists),
+    }
+}
+
+#[inline]
+#[allow(unused)]
+pub fn sum_4bit_hacc_dist_table_scalar(
+    code_len: usize,
+    codes: &[u8],
+    hacc_dist_table: &[u8],
+    dists: &mut [u32],
+) {
+    let num_full_vectors = codes.len() / (BATCH_SIZE * code_len) * BATCH_SIZE;
+    dists[..num_full_vectors].fill(0);
+
+    for (vec_block_idx, blocks) in codes.chunks_exact(BATCH_SIZE * code_len).enumerate() {
+        for (sub_vec_idx, block) in blocks.chunks_exact(BATCH_SIZE).enumerate() {
+            let table_offset = sub_vec_idx * 64;
+            let current_low = &hacc_dist_table[table_offset..table_offset + 16];
+            let next_low = &hacc_dist_table[table_offset + 16..table_offset + 32];
+            let current_high = &hacc_dist_table[table_offset + 32..table_offset + 48];
+            let next_high = &hacc_dist_table[table_offset + 48..table_offset + 64];
+
+            for j in 0..16 {
+                let low_current_code = (block[j] & 0x0F) as usize;
+                let high_current_code = (block[j] >> 4) as usize;
+                let low_next_code = (block[j + 16] & 0x0F) as usize;
+                let high_next_code = (block[j + 16] >> 4) as usize;
+
+                let lower_id = vec_block_idx * BATCH_SIZE + PERM0[j];
+                let higher_id = lower_id + 16;
+                dists[lower_id] += ((current_high[low_current_code] as u32) << 8)
+                    + current_low[low_current_code] as u32
+                    + ((next_high[low_next_code] as u32) << 8)
+                    + next_low[low_next_code] as u32;
+                dists[higher_id] += ((current_high[high_current_code] as u32) << 8)
+                    + current_low[high_current_code] as u32
+                    + ((next_high[high_next_code] as u32) << 8)
+                    + next_low[high_next_code] as u32;
+            }
+        }
+    }
+}
+
+#[inline]
 #[allow(unused)]
 pub fn sum_4bit_dist_table_u16_scalar(
     code_len: usize,
@@ -165,6 +248,137 @@ pub fn sum_4bit_dist_table_u16_scalar(
             }
         }
     }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn sum_4bit_hacc_dist_table_avx2(
+    n: usize,
+    code_len: usize,
+    codes: &[u8],
+    hacc_dist_table: &[u8],
+    dists: &mut [u32],
+) {
+    const SAFE_CODE_LEN: usize = 128;
+
+    for i in (0..n).step_by(BATCH_SIZE) {
+        let batch_codes = &codes[i * code_len..(i + BATCH_SIZE) * code_len];
+        let batch_dists = &mut dists[i..i + BATCH_SIZE];
+        batch_dists.fill(0);
+
+        for code_start in (0..code_len).step_by(SAFE_CODE_LEN) {
+            let code_end = (code_start + SAFE_CODE_LEN).min(code_len);
+            let code_range = code_start * BATCH_SIZE..code_end * BATCH_SIZE;
+            let table_range = code_start * 64..code_end * 64;
+            if code_start == 0 && code_end == code_len {
+                unsafe {
+                    sum_hacc_dist_table_32bytes_batch_avx2(
+                        &batch_codes[code_range],
+                        &hacc_dist_table[table_range],
+                        batch_dists,
+                    );
+                }
+            } else {
+                let mut chunk_dists = [0u32; BATCH_SIZE];
+                unsafe {
+                    sum_hacc_dist_table_32bytes_batch_avx2(
+                        &batch_codes[code_range],
+                        &hacc_dist_table[table_range],
+                        &mut chunk_dists,
+                    );
+                }
+                batch_dists
+                    .iter_mut()
+                    .zip(chunk_dists.iter())
+                    .for_each(|(dist, chunk_dist)| *dist += *chunk_dist);
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+#[inline]
+#[allow(unused)]
+unsafe fn sum_hacc_dist_table_32bytes_batch_avx2(
+    codes: &[u8],
+    hacc_dist_table: &[u8],
+    dists: &mut [u32],
+) {
+    let low_mask = _mm256_set1_epi8(0x0f);
+    let mut low_accu0 = _mm256_setzero_si256();
+    let mut low_accu1 = _mm256_setzero_si256();
+    let mut low_accu2 = _mm256_setzero_si256();
+    let mut low_accu3 = _mm256_setzero_si256();
+    let mut high_accu0 = _mm256_setzero_si256();
+    let mut high_accu1 = _mm256_setzero_si256();
+    let mut high_accu2 = _mm256_setzero_si256();
+    let mut high_accu3 = _mm256_setzero_si256();
+
+    for code_offset in (0..codes.len()).step_by(BATCH_SIZE) {
+        let table_offset = code_offset * 2;
+        let c = _mm256_loadu_si256(codes.as_ptr().add(code_offset) as *const __m256i);
+        let lo = _mm256_and_si256(c, low_mask);
+        let hi = _mm256_and_si256(_mm256_srli_epi16(c, 4), low_mask);
+
+        let low_lut =
+            _mm256_loadu_si256(hacc_dist_table.as_ptr().add(table_offset) as *const __m256i);
+        let low_res_lo = _mm256_shuffle_epi8(low_lut, lo);
+        let low_res_hi = _mm256_shuffle_epi8(low_lut, hi);
+        low_accu0 = _mm256_add_epi16(low_accu0, low_res_lo);
+        low_accu1 = _mm256_add_epi16(low_accu1, _mm256_srli_epi16(low_res_lo, 8));
+        low_accu2 = _mm256_add_epi16(low_accu2, low_res_hi);
+        low_accu3 = _mm256_add_epi16(low_accu3, _mm256_srli_epi16(low_res_hi, 8));
+
+        let high_lut =
+            _mm256_loadu_si256(hacc_dist_table.as_ptr().add(table_offset + 32) as *const __m256i);
+        let high_res_lo = _mm256_shuffle_epi8(high_lut, lo);
+        let high_res_hi = _mm256_shuffle_epi8(high_lut, hi);
+        high_accu0 = _mm256_add_epi16(high_accu0, high_res_lo);
+        high_accu1 = _mm256_add_epi16(high_accu1, _mm256_srli_epi16(high_res_lo, 8));
+        high_accu2 = _mm256_add_epi16(high_accu2, high_res_hi);
+        high_accu3 = _mm256_add_epi16(high_accu3, _mm256_srli_epi16(high_res_hi, 8));
+    }
+
+    low_accu0 = _mm256_sub_epi16(low_accu0, _mm256_slli_epi16(low_accu1, 8));
+    let low_dis0 = _mm256_add_epi16(
+        _mm256_permute2f128_si256(low_accu0, low_accu1, 0x21),
+        _mm256_blend_epi32(low_accu0, low_accu1, 0xF0),
+    );
+    low_accu2 = _mm256_sub_epi16(low_accu2, _mm256_slli_epi16(low_accu3, 8));
+    let low_dis1 = _mm256_add_epi16(
+        _mm256_permute2f128_si256(low_accu2, low_accu3, 0x21),
+        _mm256_blend_epi32(low_accu2, low_accu3, 0xF0),
+    );
+
+    high_accu0 = _mm256_sub_epi16(high_accu0, _mm256_slli_epi16(high_accu1, 8));
+    let high_dis0 = _mm256_add_epi16(
+        _mm256_permute2f128_si256(high_accu0, high_accu1, 0x21),
+        _mm256_blend_epi32(high_accu0, high_accu1, 0xF0),
+    );
+    high_accu2 = _mm256_sub_epi16(high_accu2, _mm256_slli_epi16(high_accu3, 8));
+    let high_dis1 = _mm256_add_epi16(
+        _mm256_permute2f128_si256(high_accu2, high_accu3, 0x21),
+        _mm256_blend_epi32(high_accu2, high_accu3, 0xF0),
+    );
+
+    let low0 = _mm256_cvtepu16_epi32(_mm256_castsi256_si128(low_dis0));
+    let low1 = _mm256_cvtepu16_epi32(_mm256_extracti128_si256(low_dis0, 1));
+    let high0 = _mm256_cvtepu16_epi32(_mm256_castsi256_si128(high_dis0));
+    let high1 = _mm256_cvtepu16_epi32(_mm256_extracti128_si256(high_dis0, 1));
+    let res0 = _mm256_add_epi32(low0, _mm256_slli_epi32(high0, 8));
+    let res1 = _mm256_add_epi32(low1, _mm256_slli_epi32(high1, 8));
+    _mm256_storeu_si256(dists.as_mut_ptr() as *mut __m256i, res0);
+    _mm256_storeu_si256(dists.as_mut_ptr().add(8) as *mut __m256i, res1);
+
+    let low2 = _mm256_cvtepu16_epi32(_mm256_castsi256_si128(low_dis1));
+    let low3 = _mm256_cvtepu16_epi32(_mm256_extracti128_si256(low_dis1, 1));
+    let high2 = _mm256_cvtepu16_epi32(_mm256_castsi256_si128(high_dis1));
+    let high3 = _mm256_cvtepu16_epi32(_mm256_extracti128_si256(high_dis1, 1));
+    let res2 = _mm256_add_epi32(low2, _mm256_slli_epi32(high2, 8));
+    let res3 = _mm256_add_epi32(low3, _mm256_slli_epi32(high3, 8));
+    _mm256_storeu_si256(dists.as_mut_ptr().add(16) as *mut __m256i, res2);
+    _mm256_storeu_si256(dists.as_mut_ptr().add(24) as *mut __m256i, res3);
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -411,6 +625,24 @@ mod tests {
     }
 
     #[test]
+    fn test_transfer_4bit_dist_table_u16_layout() {
+        let dist_table: Vec<u16> = (0..32).map(|idx| 0x1200 + idx as u16).collect();
+        let mut hacc_dist_table = Vec::new();
+        transfer_4bit_dist_table_u16(&dist_table, &mut hacc_dist_table);
+
+        assert_eq!(hacc_dist_table.len(), 64);
+        for code in 0..16 {
+            assert_eq!(hacc_dist_table[code], dist_table[code] as u8);
+            assert_eq!(hacc_dist_table[16 + code], dist_table[16 + code] as u8);
+            assert_eq!(hacc_dist_table[32 + code], (dist_table[code] >> 8) as u8);
+            assert_eq!(
+                hacc_dist_table[48 + code],
+                (dist_table[16 + code] >> 8) as u8
+            );
+        }
+    }
+
+    #[test]
     fn test_sum_4bit_dist_table_u16_matches_reference_multi_batch() {
         use rand::{Rng, SeedableRng};
         let mut rng = rand::rngs::StdRng::seed_from_u64(99);
@@ -432,6 +664,37 @@ mod tests {
                 actual,
                 expected,
                 "u16 dist-table mismatch for code_len={} (DIM={})",
+                code_len,
+                code_len * 8,
+            );
+        }
+    }
+
+    #[test]
+    fn test_sum_4bit_hacc_dist_table_matches_u16_reference_multi_batch() {
+        use rand::{Rng, SeedableRng};
+        let mut rng = rand::rngs::StdRng::seed_from_u64(101);
+
+        for code_len in [1, 3, 16, 191, 192, 1024] {
+            let n = BATCH_SIZE * 4;
+            let codes: Vec<u8> = (0..n * code_len).map(|_| rng.random::<u8>()).collect();
+            let dist_table: Vec<u16> = (0..BATCH_SIZE * code_len)
+                .map(|_| rng.random::<u16>())
+                .collect();
+
+            let mut hacc_dist_table = Vec::new();
+            transfer_4bit_dist_table_u16(&dist_table, &mut hacc_dist_table);
+
+            let mut expected = vec![0u32; n];
+            sum_4bit_dist_table_u16_scalar(code_len, &codes, &dist_table, &mut expected);
+
+            let mut actual = vec![u32::MAX; n];
+            sum_4bit_hacc_dist_table(n, code_len, &codes, &hacc_dist_table, &mut actual);
+
+            assert_eq!(
+                actual,
+                expected,
+                "hacc dist-table mismatch for code_len={} (DIM={})",
                 code_len,
                 code_len * 8,
             );

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -113,6 +113,60 @@ pub fn sum_4bit_dist_table_scalar(
     }
 }
 
+#[inline]
+#[allow(unused)]
+pub fn sum_4bit_dist_table_u16(
+    n: usize,
+    code_len: usize,
+    codes: &[u8],
+    dist_table: &[u16],
+    dists: &mut [u32],
+) {
+    debug_assert!(n.is_multiple_of(BATCH_SIZE));
+    debug_assert!(dists.len() >= n);
+    debug_assert!(codes.len() >= n * code_len);
+    sum_4bit_dist_table_u16_scalar(
+        code_len,
+        &codes[..n * code_len],
+        dist_table,
+        &mut dists[..n],
+    );
+}
+
+#[inline]
+#[allow(unused)]
+pub fn sum_4bit_dist_table_u16_scalar(
+    code_len: usize,
+    codes: &[u8],
+    dist_table: &[u16],
+    dists: &mut [u32],
+) {
+    let num_full_vectors = codes.len() / (BATCH_SIZE * code_len) * BATCH_SIZE;
+    dists[..num_full_vectors].fill(0);
+
+    for (vec_block_idx, blocks) in codes.chunks_exact(BATCH_SIZE * code_len).enumerate() {
+        for (sub_vec_idx, block) in blocks.chunks_exact(BATCH_SIZE).enumerate() {
+            let current_dist_table = &dist_table[sub_vec_idx * 2 * 16..(sub_vec_idx * 2 + 1) * 16];
+            let next_dist_table =
+                &dist_table[(sub_vec_idx * 2 + 1) * 16..(sub_vec_idx * 2 + 2) * 16];
+
+            for j in 0..16 {
+                let low_current_code = (block[j] & 0x0F) as usize;
+                let high_current_code = (block[j] >> 4) as usize;
+                let low_next_code = (block[j + 16] & 0x0F) as usize;
+                let high_next_code = (block[j + 16] >> 4) as usize;
+
+                let lower_id = vec_block_idx * BATCH_SIZE + PERM0[j];
+                let higher_id = lower_id + 16;
+                dists[lower_id] += current_dist_table[low_current_code] as u32
+                    + next_dist_table[low_next_code] as u32;
+                dists[higher_id] += current_dist_table[high_current_code] as u32
+                    + next_dist_table[high_next_code] as u32;
+            }
+        }
+    }
+}
+
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 #[inline]
@@ -336,6 +390,52 @@ mod tests {
 
         assert_eq!(actual, expected);
         assert!(actual.iter().all(|dist| *dist != u16::MAX));
+    }
+
+    #[test]
+    fn test_sum_4bit_dist_table_u16_basic() {
+        let n = BATCH_SIZE;
+        let code_len = 2;
+        let codes = [
+            0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+            0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x12, 0x34, 0x56, 0x78,
+            0x9a, 0xbc, 0xde, 0xf0,
+        ];
+        let codes = codes.repeat(n * code_len / codes.len());
+        let dist_table: Vec<u16> = (0..16 * 4).map(|idx| (idx % 16 + 1) as u16).collect();
+
+        let mut dists = vec![0u32; n];
+        sum_4bit_dist_table_u16(n, code_len, &codes, &dist_table, &mut dists);
+
+        assert_eq!(dists[1], 38);
+    }
+
+    #[test]
+    fn test_sum_4bit_dist_table_u16_matches_reference_multi_batch() {
+        use rand::{Rng, SeedableRng};
+        let mut rng = rand::rngs::StdRng::seed_from_u64(99);
+
+        for code_len in [1, 3, 16, 191, 192, 1024] {
+            let n = BATCH_SIZE * 4;
+            let codes: Vec<u8> = (0..n * code_len).map(|_| rng.random::<u8>()).collect();
+            let dist_table: Vec<u16> = (0..BATCH_SIZE * code_len)
+                .map(|_| rng.random::<u16>())
+                .collect();
+
+            let mut expected = vec![0u32; n];
+            sum_4bit_dist_table_u16_scalar(code_len, &codes, &dist_table, &mut expected);
+
+            let mut actual = vec![u32::MAX; n];
+            sum_4bit_dist_table_u16(n, code_len, &codes, &dist_table, &mut actual);
+
+            assert_eq!(
+                actual,
+                expected,
+                "u16 dist-table mismatch for code_len={} (DIM={})",
+                code_len,
+                code_len * 8,
+            );
+        }
     }
 
     /// Test that the SIMD path (NEON on ARM, AVX2 on x86) produces identical

--- a/rust/lance/benches/mem_wal/vector/hnsw/mem_wal_recall_hnsw.rs
+++ b/rust/lance/benches/mem_wal/vector/hnsw/mem_wal_recall_hnsw.rs
@@ -589,6 +589,7 @@ async fn run_checkpoint(
                     use_index: true,
                     query_parallelism: 1,
                     dist_q_c: 0.0,
+                    approx_mode: Default::default(),
                 };
                 // IVFIndex::search is intentionally unimplemented (top-level does
                 // partition-aware search); replicate the ANN exec node: pick the

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1763,8 +1763,8 @@ impl Scanner {
 
     /// Configure the speed / accuracy tradeoff for approximate vector search.
     ///
-    /// This setting is only used by index implementations that support multiple
-    /// approximation modes.
+    /// This setting is currently only used by RQ-quantized indexes, such as
+    /// IVF_RQ. Other index types ignore this setting.
     pub fn approx_mode(&mut self, approx_mode: ApproxMode) -> &mut Self {
         if let Some(q) = self.nearest.as_mut() {
             q.approx_mode = approx_mode;

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -72,7 +72,7 @@ use lance_index::scalar::inverted::query::{
     FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, PhraseQuery, fill_fts_query_column,
 };
 use lance_index::scalar::inverted::{SCORE_COL, SCORE_FIELD};
-use lance_index::vector::{DEFAULT_QUERY_PARALLELISM, DIST_COL, Query};
+use lance_index::vector::{ApproxMode, DEFAULT_QUERY_PARALLELISM, DIST_COL, Query};
 use lance_index::{metrics::NoOpMetricsCollector, scalar::inverted::FTS_SCHEMA};
 use lance_io::stream::RecordBatchStream;
 use lance_linalg::distance::MetricType;
@@ -1592,6 +1592,7 @@ impl Scanner {
             use_index: true,
             query_parallelism: DEFAULT_QUERY_PARALLELISM,
             dist_q_c: 0.0,
+            approx_mode: Default::default(),
         });
         self.nearest_query_count = query_count;
         self.is_batch_nearest = is_batch_nearest;
@@ -1756,6 +1757,19 @@ impl Scanner {
     pub fn use_index(&mut self, use_index: bool) -> &mut Self {
         if let Some(q) = self.nearest.as_mut() {
             q.use_index = use_index
+        }
+        self
+    }
+
+    /// Configure the speed / accuracy tradeoff for approximate vector search.
+    ///
+    /// This setting is only used by index implementations that support multiple
+    /// approximation modes.
+    pub fn approx_mode(&mut self, approx_mode: ApproxMode) -> &mut Self {
+        if let Some(q) = self.nearest.as_mut() {
+            q.approx_mode = approx_mode;
+        } else {
+            log::warn!("approx_mode is not set because nearest has not been called yet");
         }
         self
     }
@@ -10848,6 +10862,26 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
 
         scanner.query_parallelism(-1);
         assert_eq!(scanner.nearest_mut().unwrap().query_parallelism, -1);
+    }
+
+    #[tokio::test]
+    async fn test_knn_approx_mode_defaults_and_setter() {
+        let test_ds = TestVectorDataset::new(LanceFileVersion::Stable, false)
+            .await
+            .unwrap();
+        let query_vector = Float32Array::from(vec![0.0; 32]);
+        let mut scanner = test_ds.dataset.scan();
+        scanner.nearest("vec", &query_vector, 5).unwrap();
+        assert_eq!(
+            scanner.nearest_mut().unwrap().approx_mode,
+            ApproxMode::Normal
+        );
+
+        scanner.approx_mode(ApproxMode::Accurate);
+        assert_eq!(
+            scanner.nearest_mut().unwrap().approx_mode,
+            ApproxMode::Accurate
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/tests/dataset_scanner.rs
+++ b/rust/lance/src/dataset/tests/dataset_scanner.rs
@@ -62,6 +62,7 @@ async fn test_vector_filter_fts_search() {
         use_index: true,
         query_parallelism: DEFAULT_QUERY_PARALLELISM,
         dist_q_c: 0.0,
+        approx_mode: Default::default(),
     };
 
     // Case 1: search with prefilter=true, query_filter=vector([300,300,300,300])

--- a/rust/lance/src/index/vector/fixture_test.rs
+++ b/rust/lance/src/index/vector/fixture_test.rs
@@ -269,6 +269,7 @@ mod test {
                 use_index: true,
                 query_parallelism: lance_index::vector::DEFAULT_QUERY_PARALLELISM,
                 dist_q_c: 0.0,
+                approx_mode: Default::default(),
             };
             let idx = make_idx.clone()(expected_query_at_subindex, metric).await;
             let (partition_ids, _) = idx.find_partitions(&q).unwrap();

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -4523,6 +4523,7 @@ mod tests {
                     use_index: true,
                     query_parallelism: lance_index::vector::DEFAULT_QUERY_PARALLELISM,
                     dist_q_c: 0.0,
+                    approx_mode: Default::default(),
                 };
                 let (partitions, _) = index.find_partitions(&query).unwrap();
                 let nearest_partition_id = partitions.value(0) as usize;

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -177,6 +177,23 @@ fn rabit_u8_scratch_len(dim: usize, num_bits: u8) -> usize {
     binary_dist_table_len.max(ex_dist_table_len)
 }
 
+fn rabit_query_scratch_capacity(
+    dim: usize,
+    max_partition_len: usize,
+    num_bits: u8,
+) -> QueryScratchCapacity {
+    let dist_table_len = dim * 4;
+    let ex_dist_table_len = rabit_ex_dist_table_len(dim, num_bits);
+    let u8_scratch_len = rabit_u8_scratch_len(dim, num_bits);
+
+    QueryScratchCapacity::new(
+        max_partition_len,
+        dim + dist_table_len + ex_dist_table_len,
+        max_partition_len.max(dist_table_len),
+        u8_scratch_len,
+    )
+}
+
 impl<Q: Quantization> DeepSizeOf for IvfIndexState<Q> {
     fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
         self.index_file_path.deep_size_of_children(context)
@@ -934,26 +951,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         }
 
         let dim = ivf.dimension();
-        let dist_table_len = dim * 4;
-        let (ex_dist_table_len, u8_scratch_len) = match storage.quantizer() {
-            Ok(Quantizer::Rabit(rq)) => {
-                let num_bits = rq.metadata_ref().num_bits;
-                (
-                    rabit_ex_dist_table_len(dim, num_bits),
-                    rabit_u8_scratch_len(dim, num_bits),
-                )
-            }
-            _ => (dim * 256, dim * 32),
-        };
         let max_partition_len = ivf.lengths.iter().copied().max().unwrap_or_default() as usize;
+        let num_bits = match storage.quantizer() {
+            Ok(Quantizer::Rabit(rq)) => rq.metadata_ref().num_bits,
+            _ => 9,
+        };
 
-        QueryScratchCapacity::new_with_u32(
-            max_partition_len,
-            dim + dist_table_len + ex_dist_table_len,
-            max_partition_len.max(dist_table_len),
-            u8_scratch_len,
-            max_partition_len,
-        )
+        rabit_query_scratch_capacity(dim, max_partition_len, num_bits)
     }
 
     fn use_residual_scratch(ivf: &IvfModel, use_query_residual: bool) -> bool {
@@ -1998,6 +2002,20 @@ mod tests {
         assert_eq!(super::rabit_u8_scratch_len(dim, 5), dim * 16);
         assert_eq!(super::rabit_u8_scratch_len(dim, 7), dim * 4);
         assert_eq!(super::rabit_u8_scratch_len(dim, 9), dim * 32);
+    }
+
+    #[test]
+    fn test_rabit_query_scratch_capacity_does_not_preallocate_u32() {
+        let dim = 960;
+        let max_partition_len = 4096;
+
+        let capacity = super::rabit_query_scratch_capacity(dim, max_partition_len, 5);
+
+        assert_eq!(capacity.distances, max_partition_len);
+        assert_eq!(capacity.query_f32, dim + dim * 4 + dim * 16);
+        assert_eq!(capacity.u16, max_partition_len);
+        assert_eq!(capacity.u8, dim * 16);
+        assert_eq!(capacity.u32, 0);
     }
 
     async fn generate_test_dataset<T: ArrowPrimitiveType>(

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -947,11 +947,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         };
         let max_partition_len = ivf.lengths.iter().copied().max().unwrap_or_default() as usize;
 
-        QueryScratchCapacity::new(
+        QueryScratchCapacity::new_with_u32(
             max_partition_len,
             dim + dist_table_len + ex_dist_table_len,
-            max_partition_len,
+            max_partition_len.max(dist_table_len),
             u8_scratch_len,
+            max_partition_len,
         )
     }
 

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -911,6 +911,7 @@ mod tests {
             use_index: true,
             query_parallelism: DEFAULT_QUERY_PARALLELISM,
             dist_q_c: 0.0,
+            approx_mode: Default::default(),
         };
         let is_empty_threads = Arc::new(Mutex::new(Vec::new()));
         let pre_filter = Arc::new(TestPreFilter::with_thread_capture(

--- a/rust/lance/src/io/exec/ann_proto.rs
+++ b/rust/lance/src/io/exec/ann_proto.rs
@@ -16,7 +16,7 @@ use arrow_array::RecordBatch;
 use arrow_schema::{Field, Schema as ArrowSchema};
 use lance_core::{Error, Result};
 use lance_index::pb as index_pb;
-use lance_index::vector::{DEFAULT_QUERY_PARALLELISM, Query};
+use lance_index::vector::{ApproxMode, DEFAULT_QUERY_PARALLELISM, Query};
 use lance_linalg::distance::DistanceType;
 use lance_table::format::IndexMetadata;
 use lance_table::format::pb as table_pb;
@@ -80,6 +80,22 @@ fn query_vector_from_ipc_bytes(bytes: &[u8]) -> Result<arrow_array::ArrayRef> {
     Ok(batches[0].column(0).clone())
 }
 
+fn approx_mode_to_proto(mode: ApproxMode) -> pb::VectorApproxMode {
+    match mode {
+        ApproxMode::Fast => pb::VectorApproxMode::Fast,
+        ApproxMode::Normal => pb::VectorApproxMode::Normal,
+        ApproxMode::Accurate => pb::VectorApproxMode::Accurate,
+    }
+}
+
+fn approx_mode_from_proto(value: i32) -> ApproxMode {
+    match pb::VectorApproxMode::try_from(value).unwrap_or(pb::VectorApproxMode::Normal) {
+        pb::VectorApproxMode::Fast => ApproxMode::Fast,
+        pb::VectorApproxMode::Normal => ApproxMode::Normal,
+        pb::VectorApproxMode::Accurate => ApproxMode::Accurate,
+    }
+}
+
 pub fn query_to_proto(query: &Query) -> Result<pb::VectorQueryProto> {
     let query_vector_arrow_ipc = query_vector_to_ipc_bytes(query.key.as_ref())?;
 
@@ -101,6 +117,7 @@ pub fn query_to_proto(query: &Query) -> Result<pb::VectorQueryProto> {
         use_index: query.use_index,
         dist_q_c: Some(query.dist_q_c),
         query_parallelism: Some(query.query_parallelism),
+        approx_mode: approx_mode_to_proto(query.approx_mode) as i32,
     })
 }
 
@@ -130,6 +147,7 @@ pub fn query_from_proto(proto: pb::VectorQueryProto) -> Result<Query> {
         use_index: proto.use_index,
         query_parallelism: proto.query_parallelism.unwrap_or(DEFAULT_QUERY_PARALLELISM),
         dist_q_c: proto.dist_q_c.unwrap_or(0.0),
+        approx_mode: approx_mode_from_proto(proto.approx_mode),
     })
 }
 
@@ -335,6 +353,7 @@ mod tests {
             use_index: true,
             query_parallelism: -1,
             dist_q_c: 0.42,
+            approx_mode: ApproxMode::Accurate,
         };
 
         let proto = query_to_proto(&query).unwrap();
@@ -352,6 +371,7 @@ mod tests {
         assert_eq!(query.use_index, back.use_index);
         assert_eq!(query.query_parallelism, back.query_parallelism);
         assert_eq!(query.dist_q_c, back.dist_q_c);
+        assert_eq!(query.approx_mode, back.approx_mode);
         assert_eq!(query.key.len(), back.key.len());
         assert_eq!(query.key.data_type(), back.key.data_type());
     }
@@ -373,12 +393,19 @@ mod tests {
             use_index: false,
             query_parallelism: DEFAULT_QUERY_PARALLELISM,
             dist_q_c: 0.0,
+            approx_mode: ApproxMode::Normal,
         };
 
         let proto = query_to_proto(&query).unwrap();
         let back = query_from_proto(proto).unwrap();
         assert!(back.metric_type.is_none());
         assert!(!back.use_index);
+        assert_eq!(back.approx_mode, ApproxMode::Normal);
+
+        let mut proto = query_to_proto(&query).unwrap();
+        proto.approx_mode = i32::MAX;
+        let back = query_from_proto(proto).unwrap();
+        assert_eq!(back.approx_mode, ApproxMode::Normal);
     }
 
     async fn make_vector_dataset() -> (Arc<Dataset>, tempfile::TempDir) {
@@ -444,6 +471,7 @@ mod tests {
             use_index: true,
             query_parallelism: DEFAULT_QUERY_PARALLELISM,
             dist_q_c: 0.0,
+            approx_mode: ApproxMode::Normal,
         };
 
         let exec = ANNIvfPartitionExec::try_new(
@@ -491,6 +519,7 @@ mod tests {
             use_index: true,
             query_parallelism: DEFAULT_QUERY_PARALLELISM,
             dist_q_c: 0.0,
+            approx_mode: ApproxMode::Normal,
         };
 
         // Use a TestMemoryExec as a mock input child (provides the KNN_PARTITION_SCHEMA)
@@ -554,6 +583,7 @@ mod tests {
             use_index: true,
             query_parallelism: DEFAULT_QUERY_PARALLELISM,
             dist_q_c: 0.0,
+            approx_mode: ApproxMode::Normal,
         };
         let input: Arc<dyn datafusion::physical_plan::ExecutionPlan> =
             TestMemoryExec::try_new_exec(

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -1934,6 +1934,7 @@ mod tests {
             use_index: true,
             query_parallelism: DEFAULT_QUERY_PARALLELISM,
             dist_q_c: 0.0,
+            approx_mode: Default::default(),
         }
     }
 
@@ -2693,6 +2694,7 @@ mod tests {
             use_index: true,
             query_parallelism: DEFAULT_QUERY_PARALLELISM,
             dist_q_c: 0.0,
+            approx_mode: Default::default(),
         };
 
         async fn multivector_scoring(


### PR DESCRIPTION
## Feature

This PR adds a public `approx_mode` setting for vector search with `fast`, `normal`, and `accurate` values. The public API avoids exposing RaBitQ/HACC terminology while still allowing callers to choose the speed/accuracy tradeoff when the backing index supports it.

## Implementation

- Adds `ApproxMode` to vector queries and threads it through Rust scanner, ANN proto serialization, Python query parsing, and FlatIndex distance calculator options.
- Implements RaBitQ behavior for each mode:
  - `fast`: force 1-bit query-time scoring for RaBitQ.
  - `normal`: preserve the existing search path.
  - `accurate`: use a 16-bit LUT accumulation path for the binary RaBitQ estimator.
- Extends query scratch with a wider accumulation buffer while keeping the existing `QueryScratchCapacity::new(...)` API compatible.
- Adds Python API support via `approx_mode="fast" | "normal" | "accurate"` and rejects invalid values.


## Benchmark

IVF_RQ on dbpedia, `num_bits=5`, no `refine_factor`. The plot shows `approx_mode=fast`, `normal`, and `accurate` as separate curves.

![IVF_RQ dbpedia approx_mode benchmark, num_bits=5](https://raw.githubusercontent.com/lance-format/lance/yang/pr-7179-assets/pr-assets/7179/ivfrq-dbpedia-num-bits-5.png)

## Breaking Change

BREAKING CHANGE: The ANN protobuf schema now includes `VectorApproxMode approx_mode` on vector query serialization. Consumers that regenerate or explicitly match Lance's serialized ANN query proto should update to the new schema.

## Validation

- `cargo fmt --all`
- `cargo test -p lance-linalg simd::dist_table`
- `cargo test -p lance-index vector::bq::storage`
- `cargo test -p lance-index vector::storage::tests`
- `cargo test -p lance --features substrait test_query_roundtrip`
- `cargo test -p lance test_knn_approx_mode_defaults_and_setter`
- `cargo check --workspace --tests --benches`
- `cd python && make install`
- `cd python && uv run pytest python/tests/test_vector_index.py::test_vector_index_with_approx_mode python/tests/test_vector_index.py::test_vector_index_invalid_approx_mode`
- `cd python && uv run pytest python/tests/test_vector_index.py::test_create_ivf_rq_multi_bit_searches_l2_and_cosine`
- `git diff --check`