### PR TITLE
perf(index): query BTree lookup batch directly

### DIFF
--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -28,7 +28,7 @@ use crate::{
 use crate::{metrics::NoOpMetricsCollector, scalar::registry::TrainingCriteria};
 use crate::{pbold, scalar::btree::flat::FlatIndex};
 use arrow_arith::numeric::add;
-use arrow_array::{Array, RecordBatch, UInt32Array, new_empty_array};
+use arrow_array::{Array, ArrayAccessor, RecordBatch, UInt32Array, cast::AsArray, new_empty_array};
 use arrow_ord::ord::make_comparator;
 use arrow_schema::{DataType, Field, Schema, SortOptions};
 use async_trait::async_trait;
@@ -613,6 +613,26 @@ fn partition_point(lo: usize, hi: usize, mut pred: impl FnMut(usize) -> bool) ->
     lo
 }
 
+/// Builds a comparator over two array accessors of the same `Ord` item type,
+/// matching arrow's NULLs-first ascending order (`null < non-null`, `null == null`).
+///
+/// Unlike [`make_comparator`], the returned closure is generic (not boxed), so the
+/// element comparison inlines into the scan instead of dispatching through a vtable
+/// on every call.
+fn accessor_cmp<'a, T, L, R>(left: L, right: R) -> impl Fn(usize, usize) -> Ordering + 'a
+where
+    T: Ord,
+    L: ArrayAccessor<Item = T> + 'a,
+    R: ArrayAccessor<Item = T> + 'a,
+{
+    move |i, j| match (left.is_null(i), right.is_null(j)) {
+        (true, true) => Ordering::Equal,
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        (false, false) => left.value(i).cmp(&right.value(j)),
+    }
+}
+
 /// Satisfies scalar queries by searching the `page_lookup.lance` batch directly.
 ///
 /// The batch holds one row per page with columns `min | max | null_count | page_idx`,
@@ -783,25 +803,83 @@ impl BTreeLookup {
 
         let mins = self.batch.column(0).as_ref();
         let maxs = self.batch.column(1).as_ref();
-        let page_numbers = self.page_numbers()?;
+        let page_ids = self.page_numbers()?.values();
 
-        // The batch is sorted ascending by `min` with NULLs first; compare the
-        // query values the same way so the binary searches stay consistent.
-        let opts = SortOptions {
-            descending: false,
-            nulls_first: true,
-        };
-        // `cmp_min(i, j)` compares page `i`'s `min` against query value `j`;
-        // `cmp_max` likewise for `max`. `cmp_min_min` compares two page `min`s and
-        // is used to expand left onto a straddling page.
-        let cmp_min = make_comparator(mins, query, opts)?;
-        let cmp_max = make_comparator(maxs, query, opts)?;
-        let cmp_min_min = make_comparator(mins, mins, opts)?;
+        // For byte-like columns we downcast once and compare with native `Ord`
+        // closures that inline into the scan, instead of going through the boxed
+        // `DynComparator` (one vtable call per comparison). The query array always
+        // matches the column type, so a single match on its type covers both columns.
+        match query.data_type() {
+            DataType::Utf8 => {
+                let mins = mins.as_string::<i32>();
+                let maxs = maxs.as_string::<i32>();
+                let query = query.as_string::<i32>();
+                Ok(self.scan_equality_pages(
+                    query.len(),
+                    page_ids,
+                    |idx| maxs.is_null(idx),
+                    accessor_cmp(mins, query),
+                    accessor_cmp(maxs, query),
+                    accessor_cmp(mins, mins),
+                ))
+            }
+            DataType::LargeUtf8 => {
+                let mins = mins.as_string::<i64>();
+                let maxs = maxs.as_string::<i64>();
+                let query = query.as_string::<i64>();
+                Ok(self.scan_equality_pages(
+                    query.len(),
+                    page_ids,
+                    |idx| maxs.is_null(idx),
+                    accessor_cmp(mins, query),
+                    accessor_cmp(maxs, query),
+                    accessor_cmp(mins, mins),
+                ))
+            }
+            _ => {
+                // The batch is sorted ascending by `min` with NULLs first; compare the
+                // query values the same way so the binary searches stay consistent.
+                let opts = SortOptions {
+                    descending: false,
+                    nulls_first: true,
+                };
+                let cmp_min = make_comparator(mins, query, opts)?;
+                let cmp_max = make_comparator(maxs, query, opts)?;
+                let cmp_min_min = make_comparator(mins, mins, opts)?;
+                Ok(self.scan_equality_pages(
+                    query.len(),
+                    page_ids,
+                    |idx| maxs.is_null(idx),
+                    cmp_min,
+                    cmp_max,
+                    cmp_min_min,
+                ))
+            }
+        }
+    }
 
+    /// Binary-search + forward-scan the page batch for equality candidates.
+    ///
+    /// Monomorphized over the comparator closures so a typed-native comparator
+    /// inlines (no per-call vtable dispatch). The closures encode NULLs-first,
+    /// ascending order:
+    ///   * `cmp_min(i, j)` — page `i`'s `min` vs query value `j`
+    ///   * `cmp_max(i, j)` — page `i`'s `max` vs query value `j`
+    ///   * `cmp_min_min(i, anchor)` — two page `min`s, to expand left onto a straddle
+    fn scan_equality_pages(
+        &self,
+        num_query: usize,
+        page_ids: &[u32],
+        max_is_null: impl Fn(usize) -> bool,
+        cmp_min: impl Fn(usize, usize) -> Ordering,
+        cmp_max: impl Fn(usize, usize) -> Ordering,
+        cmp_min_min: impl Fn(usize, usize) -> Ordering,
+    ) -> Vec<u32> {
+        let num_rows = self.batch.num_rows();
         // High-cardinality lookups hit ~one page per value; presize to avoid the
         // element-by-element `RawVec` growth that profiling flagged.
-        let mut pages = Vec::with_capacity(query.len());
-        for j in 0..query.len() {
+        let mut pages = Vec::with_capacity(num_query);
+        for j in 0..num_query {
             // Start row: peek a little to the left of the value. A query for 7 must
             // still reach a page like [5, 10], so we include every page whose `min`
             // equals the largest `min` strictly less than the value.
@@ -825,16 +903,16 @@ impl BTreeLookup {
             //     min == value`) and can't have a null `max` (all-null pages sort to
             //     the front, before `search_start <= start`), so we copy them in one
             //     slice instead of pushing per row.
-            let page_ids = page_numbers.values();
             let bulk_start = p.max(start);
-            for idx in start..bulk_start {
+            for (offset, &page_id) in page_ids[start..bulk_start].iter().enumerate() {
+                let idx = start + offset;
                 // All-null pages are only matched by IS NULL queries.
-                if maxs.is_null(idx) {
+                if max_is_null(idx) {
                     continue;
                 }
                 // Candidate when the page's `max` reaches the value (`max >= value`).
                 if cmp_max(idx, j) != Ordering::Less {
-                    pages.push(page_ids[idx]);
+                    pages.push(page_id);
                 }
             }
             pages.extend_from_slice(&page_ids[bulk_start..end]);
@@ -842,7 +920,7 @@ impl BTreeLookup {
 
         pages.sort_unstable();
         pages.dedup();
-        Ok(pages)
+        pages
     }
 
     // All pages that could have a value in the range

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -687,9 +687,8 @@ where
 ///
 /// The batch holds one row per page with columns `min | max | null_count | page_idx`,
 /// sorted ascending by `min` with NULLs first (the order the index is trained in).
-/// The batch is the single source of truth, avoiding a parallel `BTreeMap` of owned
-/// `ScalarValue`s alongside the Arrow buffers. Both query paths binary-search the
-/// sorted `min` column for a starting row and scan forward filtering by `max`:
+/// Both query paths binary-search the sorted `min` column for a starting row and
+/// scan forward filtering by `max`:
 ///
 /// - Equality / `IN` (`candidate_pages_for_values`) dispatch on the query's
 ///   *physical storage type* to a monomorphized, inlined comparator: numerics go
@@ -698,7 +697,7 @@ where
 ///   without a native fast path (struct-backed intervals, booleans) fall back to the
 ///   boxed [`make_comparator`] via `scan_fallback`.
 /// - Range searches (`pages_between`) currently use [`make_comparator`] directly.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, DeepSizeOf)]
 pub struct BTreeLookup {
     /// One row per page (`min | max | null_count | page_idx`), sorted by `min`.
     batch: RecordBatch,
@@ -709,23 +708,6 @@ pub struct BTreeLookup {
     /// Index of the first row whose `max` is non-null. Entirely-null pages sort to
     /// the front (NULLs first) and are skipped when searching value ranges.
     search_start: usize,
-}
-
-impl PartialEq for BTreeLookup {
-    fn eq(&self, other: &Self) -> bool {
-        self.batch == other.batch
-            && self.null_pages == other.null_pages
-            && self.all_null_pages == other.all_null_pages
-            && self.search_start == other.search_start
-    }
-}
-
-impl DeepSizeOf for BTreeLookup {
-    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
-        self.batch.get_array_memory_size()
-            + self.null_pages.deep_size_of_children(context)
-            + self.all_null_pages.deep_size_of_children(context)
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -1393,10 +1375,10 @@ struct BTreeIndexState {
 }
 
 impl DeepSizeOf for BTreeIndexState {
-    fn deep_size_of_children(&self, _context: &mut lance_core::deepsize::Context) -> usize {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
         // `ranges_to_files` is tiny and `RangeInclusiveMap` is not `DeepSizeOf`;
         // the lookup batch dominates, matching how `BTreeIndex` accounts for itself.
-        self.lookup_batch.get_array_memory_size()
+        self.lookup_batch.deep_size_of_children(context)
     }
 }
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -4,7 +4,7 @@
 use std::{
     any::Any,
     cmp::Ordering,
-    collections::{BTreeMap, BinaryHeap, HashMap, HashSet},
+    collections::{BinaryHeap, HashMap, HashSet},
     fmt::{Debug, Display},
     ops::Bound,
     sync::Arc,
@@ -29,6 +29,7 @@ use crate::{metrics::NoOpMetricsCollector, scalar::registry::TrainingCriteria};
 use crate::{pbold, scalar::btree::flat::FlatIndex};
 use arrow_arith::numeric::add;
 use arrow_array::{Array, RecordBatch, UInt32Array, new_empty_array};
+use arrow_ord::ord::make_comparator;
 use arrow_schema::{DataType, Field, Schema, SortOptions};
 use async_trait::async_trait;
 use datafusion::physical_plan::{
@@ -594,44 +595,63 @@ impl Ord for OrderableScalarValue {
     }
 }
 
-#[derive(Debug, DeepSizeOf, PartialEq, Eq)]
-struct PageRecord {
-    max: OrderableScalarValue,
-    page_number: u32,
-}
-
-trait BTreeMapExt<K, V> {
-    fn largest_node_less(&self, key: &K) -> Option<(&K, &V)>;
-}
-
-impl<K: Ord, V> BTreeMapExt<K, V> for BTreeMap<K, V> {
-    fn largest_node_less(&self, key: &K) -> Option<(&K, &V)> {
-        self.range((Bound::Unbounded, Bound::Excluded(key)))
-            .next_back()
-    }
-}
-
-/// An in-memory structure that can quickly satisfy scalar queries using a btree of ScalarValue
-#[derive(Debug, DeepSizeOf, PartialEq, Eq)]
-pub struct BTreeLookup {
-    tree: BTreeMap<OrderableScalarValue, Vec<PageRecord>>,
-    /// Pages where the value may be null (does not include all_null_pages)
-    null_pages: Vec<u32>,
-    /// Pages that are entirely null
-    all_null_pages: Vec<u32>,
-}
-
-impl BTreeLookup {
-    fn empty() -> Self {
-        Self {
-            tree: BTreeMap::new(),
-            null_pages: Vec::new(),
-            all_null_pages: Vec::new(),
+/// Returns the first index `i` in `[lo, hi)` for which `pred(i)` is `false`.
+///
+/// `pred` must be `true` for a (possibly empty) prefix of the range and `false`
+/// for the rest, i.e. the range is partitioned by `pred`.
+fn partition_point(lo: usize, hi: usize, mut pred: impl FnMut(usize) -> bool) -> usize {
+    let mut lo = lo;
+    let mut hi = hi;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if pred(mid) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
         }
     }
+    lo
 }
 
-#[derive(Debug, Copy, Clone)]
+/// Satisfies scalar queries by searching the `page_lookup.lance` batch directly.
+///
+/// The batch holds one row per page with columns `min | max | null_count | page_idx`,
+/// sorted ascending by `min` with NULLs first (the order the index is trained in).
+/// The batch is the single source of truth: range searches binary-search the `min`
+/// column for a starting row and scan forward filtering by `max`, type-dispatched
+/// per column type via [`make_comparator`]. This avoids materializing a parallel
+/// `BTreeMap` of owned `ScalarValue`s alongside the Arrow buffers.
+#[derive(Debug)]
+pub struct BTreeLookup {
+    /// One row per page (`min | max | null_count | page_idx`), sorted by `min`.
+    batch: RecordBatch,
+    /// Pages with at least one null value (does not include `all_null_pages`).
+    null_pages: Vec<u32>,
+    /// Pages that are entirely null.
+    all_null_pages: Vec<u32>,
+    /// Index of the first row whose `max` is non-null. Entirely-null pages sort to
+    /// the front (NULLs first) and are skipped when searching value ranges.
+    search_start: usize,
+}
+
+impl PartialEq for BTreeLookup {
+    fn eq(&self, other: &Self) -> bool {
+        self.batch == other.batch
+            && self.null_pages == other.null_pages
+            && self.all_null_pages == other.all_null_pages
+            && self.search_start == other.search_start
+    }
+}
+
+impl DeepSizeOf for BTreeLookup {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        self.batch.get_array_memory_size()
+            + self.null_pages.deep_size_of_children(context)
+            + self.all_null_pages.deep_size_of_children(context)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum Matches {
     Some(u32),
     All(u32),
@@ -647,39 +667,86 @@ impl Matches {
 }
 
 impl BTreeLookup {
-    fn new(
-        tree: BTreeMap<OrderableScalarValue, Vec<PageRecord>>,
-        null_pages: Vec<u32>,
-        all_null_pages: Vec<u32>,
-    ) -> Self {
-        Self {
-            tree,
+    /// Build a lookup over the `page_lookup.lance` batch. The batch is retained as
+    /// the source of truth; only the small null-page index lists are precomputed.
+    fn try_new(batch: RecordBatch) -> Result<Self> {
+        let mut null_pages = Vec::new();
+        let mut all_null_pages = Vec::new();
+        let mut search_start = batch.num_rows();
+
+        if batch.num_rows() > 0 {
+            let maxs = batch.column(1);
+            let null_counts = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .ok_or_else(|| Error::internal("BTree lookup null_count column must be UInt32"))?;
+            let page_numbers = batch
+                .column(3)
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .ok_or_else(|| Error::internal("BTree lookup page_idx column must be UInt32"))?;
+
+            for idx in 0..batch.num_rows() {
+                let page_number = page_numbers.values()[idx];
+                // An entirely-null page has a null `max`; it is never searched by value.
+                if maxs.is_null(idx) {
+                    all_null_pages.push(page_number);
+                    continue;
+                }
+                if search_start == batch.num_rows() {
+                    search_start = idx;
+                }
+                if null_counts.values()[idx] > 0 {
+                    null_pages.push(page_number);
+                }
+            }
+        } else {
+            search_start = 0;
+        }
+
+        Ok(Self {
+            batch,
             null_pages,
             all_null_pages,
-        }
+            search_start,
+        })
+    }
+
+    fn page_numbers(&self) -> Result<&UInt32Array> {
+        self.batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .ok_or_else(|| Error::internal("BTree lookup page_idx column must be UInt32"))
     }
 
     // All pages that could have a value equal to val
-    fn pages_eq(&self, query: &OrderableScalarValue) -> Vec<Matches> {
+    fn pages_eq(&self, query: &OrderableScalarValue) -> Result<Vec<Matches>> {
         if query.0.is_null() {
-            self.pages_null()
+            Ok(self.pages_null())
         } else {
             self.pages_between((Bound::Included(query), Bound::Excluded(query)))
         }
     }
 
     // All pages that could have a value equal to one of the values
-    fn pages_in(&self, values: impl IntoIterator<Item = OrderableScalarValue>) -> Vec<Matches> {
+    fn pages_in(
+        &self,
+        values: impl IntoIterator<Item = OrderableScalarValue>,
+    ) -> Result<Vec<Matches>> {
         // TODO: Right now we convert all Matches::All into Matches::Some.  We could refine this.
         // It would improve performance on low cardinality data.
         let page_lists = values
             .into_iter()
             .map(|val| {
-                self.pages_eq(&val)
+                Ok(self
+                    .pages_eq(&val)?
                     .into_iter()
                     .map(|matches| matches.page_id())
+                    .collect::<Vec<_>>())
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
         let total_size = page_lists.iter().map(|set| set.len()).sum();
         let mut heap = BinaryHeap::with_capacity(total_size);
         for page_list in page_lists {
@@ -687,144 +754,147 @@ impl BTreeLookup {
         }
         let mut all_pages = heap.into_sorted_vec();
         all_pages.dedup();
-        all_pages.into_iter().map(Matches::Some).collect()
+        Ok(all_pages.into_iter().map(Matches::Some).collect())
     }
 
     // All pages that could have a value in the range
     fn pages_between(
         &self,
         range: (Bound<&OrderableScalarValue>, Bound<&OrderableScalarValue>),
-    ) -> Vec<Matches> {
-        // We need to grab a little bit left of the given range because the query might be 7
-        // and the first page might be something like 5-10.
-        let lower_bound = match range.0 {
-            Bound::Unbounded => Bound::Unbounded,
-            // It doesn't matter if the bound is exclusive or inclusive.  We are going to grab
-            // the first node whose min is strictly less than the given bound.  Then we grab
-            // all nodes greater than or equal to that
-            //
-            // We have to peek a bit to the left because we might have something like a lower
-            // bound of 7 and there is a page [5-10] we want to search for.
-            Bound::Included(lower) => self
-                .tree
-                .largest_node_less(lower)
-                .map(|val| Bound::Included(val.0))
-                .unwrap_or(Bound::Unbounded),
-            Bound::Excluded(lower) => self
-                .tree
-                .largest_node_less(lower)
-                .map(|val| Bound::Included(val.0))
-                .unwrap_or(Bound::Unbounded),
+    ) -> Result<Vec<Matches>> {
+        let num_rows = self.batch.num_rows();
+        // No searchable (non-all-null) pages.
+        if self.search_start >= num_rows {
+            return Ok(vec![]);
+        }
+
+        let mins = self.batch.column(0).as_ref();
+        let maxs = self.batch.column(1).as_ref();
+        let page_numbers = self.page_numbers()?;
+
+        // The batch is sorted ascending by `min` with NULLs first; compare bounds
+        // the same way so the binary searches and the null `min` of a straddling
+        // page are handled consistently.
+        let opts = SortOptions {
+            descending: false,
+            nulls_first: true,
         };
-        let upper_bound = match range.1 {
-            Bound::Unbounded => Bound::Unbounded,
-            Bound::Included(upper) => Bound::Included(upper),
-            // Even if the upper bound is excluded we need to include it on an [x, x) query.  This is because the
-            // query might be [x, x).  Our lower bound might find some [a-x] bucket and we still
-            // want to include any [x, z] bucket.
-            //
-            // We could be slightly more accurate here and only include the upper bound if the lower bound
-            // is defined, inclusive, and equal to the upper bound.  However, let's keep it simple for now.  This
-            // should only affect the probably rare case that our query is a true range query and the value
-            // matches an upper bound.  This will all be moot if/when we merge pages.
-            Bound::Excluded(upper) => Bound::Included(upper),
+        // Bounds become 1-row arrays of the column type so arrow's type-dispatched
+        // comparator can compare them against the `min`/`max` columns.
+        let lower_arr = match range.0 {
+            Bound::Unbounded => None,
+            Bound::Included(v) | Bound::Excluded(v) => Some(v.0.to_array_of_size(1)?),
+        };
+        let upper_arr = match range.1 {
+            Bound::Unbounded => None,
+            Bound::Included(v) | Bound::Excluded(v) => Some(v.0.to_array_of_size(1)?),
         };
 
-        match (lower_bound, upper_bound) {
-            (Bound::Excluded(lower), Bound::Excluded(upper))
-            | (Bound::Excluded(lower), Bound::Included(upper))
-            | (Bound::Included(lower), Bound::Excluded(upper)) => {
-                // It's not really clear what (Included(5), Excluded(5)) would mean so we
-                // interpret it as an empty range which matches rust's BTreeMap behavior
-                if lower >= upper {
-                    return vec![];
+        // Start row: peek a little to the left of the lower bound. A query for 7
+        // must still reach a page like [5, 10], so we include every page whose
+        // `min` equals the largest `min` strictly less than the lower bound.
+        let start = match &lower_arr {
+            None => self.search_start,
+            Some(lower) => {
+                let cmp = make_comparator(mins, lower.as_ref(), opts)?;
+                // first row with min >= lower
+                let p = partition_point(0, num_rows, |i| cmp(i, 0) == Ordering::Less);
+                if p == 0 {
+                    self.search_start
+                } else {
+                    // first row sharing the straddling page's `min`
+                    let straddle = mins.slice(p - 1, 1);
+                    let cmp = make_comparator(mins, straddle.as_ref(), opts)?;
+                    partition_point(0, p, |i| cmp(i, 0) == Ordering::Less)
                 }
             }
-            (Bound::Included(lower), Bound::Included(upper)) => {
-                if lower > upper {
-                    return vec![];
-                }
-            }
-            _ => {}
         }
+        .max(self.search_start);
+
+        // End row: pages whose `min` exceeds the upper bound cannot match. The
+        // upper bound is treated as inclusive even when the query bound is
+        // exclusive, so an [x, x) query still reaches a page whose `min` == x.
+        let end = match &upper_arr {
+            None => num_rows,
+            Some(upper) => {
+                let cmp = make_comparator(mins, upper.as_ref(), opts)?;
+                partition_point(start, num_rows, |i| cmp(i, 0) != Ordering::Greater)
+            }
+        };
+
+        if start >= end {
+            return Ok(vec![]);
+        }
+
+        // Comparators reused across the candidate rows.
+        let cmp_max_lower = lower_arr
+            .as_ref()
+            .map(|l| make_comparator(maxs, l.as_ref(), opts))
+            .transpose()?;
+        let cmp_min_lower = lower_arr
+            .as_ref()
+            .map(|l| make_comparator(mins, l.as_ref(), opts))
+            .transpose()?;
+        let cmp_max_upper = upper_arr
+            .as_ref()
+            .map(|u| make_comparator(maxs, u.as_ref(), opts))
+            .transpose()?;
 
         let mut matches = Vec::new();
+        for idx in start..end {
+            // All-null pages are only matched by IS NULL queries.
+            if maxs.is_null(idx) {
+                continue;
+            }
 
-        for (min, page_records) in self.tree.range((lower_bound, upper_bound)) {
-            for page_record in page_records {
-                match lower_bound {
-                    Bound::Unbounded => {}
-                    Bound::Included(lower) => {
-                        if page_record.max.cmp(lower) == Ordering::Less {
-                            continue;
-                        }
-                    }
-                    Bound::Excluded(lower) => {
-                        if page_record.max.cmp(lower) != Ordering::Greater {
-                            continue;
-                        }
-                    }
-                }
-                // At this point we know the page record matches at least some values.
-                // We should test to see if ALL values are a match.
+            // Candidate filter: the page's `max` reaches the lower bound.
+            let lower_ok = match (range.0, &cmp_max_lower) {
+                (Bound::Unbounded, _) => true,
+                (Bound::Included(_), Some(cmp)) => cmp(idx, 0) != Ordering::Less, // max >= lower
+                (Bound::Excluded(_), Some(cmp)) => cmp(idx, 0) == Ordering::Greater, // max > lower
+                _ => unreachable!("lower bound and its comparator are constructed together"),
+            };
+            if !lower_ok {
+                continue;
+            }
 
-                if min.0.is_null() || page_record.max.0.is_null() {
-                    // If there are nulls then we just use Matches::Some
-                    matches.push(Matches::Some(page_record.page_number));
-                    continue;
-                }
+            let page_number = page_numbers.values()[idx];
 
-                match range.0 {
-                    // range.0 < X therefore if the smallest value is not strictly greater than
-                    // the lower bound we only have partial match
-                    Bound::Excluded(lower) => {
-                        if min.cmp(lower) != Ordering::Greater {
-                            matches.push(Matches::Some(page_record.page_number));
-                            continue;
-                        }
-                    }
-                    // range.0 <= X therefore if the smallest value is not greater than or equal
-                    // to the lower bound we only have partial match
-                    Bound::Included(lower) => {
-                        if min.cmp(lower) == Ordering::Less {
-                            matches.push(Matches::Some(page_record.page_number));
-                            continue;
-                        }
-                    }
-                    Bound::Unbounded => {}
-                }
-                match range.1 {
-                    // X < range.1 therefore if the largest value is not strictly less than
-                    // the upper bound we only have partial match
-                    Bound::Excluded(upper) => {
-                        if page_record.max.cmp(upper) != Ordering::Less {
-                            matches.push(Matches::Some(page_record.page_number));
-                            continue;
-                        }
-                    }
-                    // X <= range.1 therefore if the largest value is not less than or equal to
-                    // the upper bound we only have partial match
-                    Bound::Included(upper) => {
-                        if page_record.max.cmp(upper) == Ordering::Greater {
-                            matches.push(Matches::Some(page_record.page_number));
-                            continue;
-                        }
-                    }
-                    Bound::Unbounded => {}
-                }
-                // The min is greater than the lower bound and the max is less than the upper bound
-                // so we have a full match
-                matches.push(Matches::All(page_record.page_number));
+            // A page with a null `min` straddles the NULL/non-NULL boundary, so it
+            // is only ever a partial match.
+            if mins.is_null(idx) {
+                matches.push(Matches::Some(page_number));
+                continue;
+            }
+
+            // Full match requires the page to sit entirely within the query range.
+            let lower_full = match (range.0, &cmp_min_lower) {
+                (Bound::Unbounded, _) => true,
+                (Bound::Included(_), Some(cmp)) => cmp(idx, 0) != Ordering::Less, // min >= lower
+                (Bound::Excluded(_), Some(cmp)) => cmp(idx, 0) == Ordering::Greater, // min > lower
+                _ => unreachable!("lower bound and its comparator are constructed together"),
+            };
+            let upper_full = match (range.1, &cmp_max_upper) {
+                (Bound::Unbounded, _) => true,
+                (Bound::Included(_), Some(cmp)) => cmp(idx, 0) != Ordering::Greater, // max <= upper
+                (Bound::Excluded(_), Some(cmp)) => cmp(idx, 0) == Ordering::Less,    // max < upper
+                _ => unreachable!("upper bound and its comparator are constructed together"),
+            };
+            if lower_full && upper_full {
+                matches.push(Matches::All(page_number));
+            } else {
+                matches.push(Matches::Some(page_number));
             }
         }
 
-        matches
+        Ok(matches)
     }
 
     fn pages_null(&self) -> Vec<Matches> {
         self.null_pages
             .iter()
-            .map(|page_id| Matches::Some(*page_id))
+            .copied()
+            .map(Matches::Some)
             .chain(self.all_null_pages.iter().copied().map(Matches::All))
             .collect()
     }
@@ -1207,26 +1277,14 @@ pub struct BTreeIndex {
     /// - The system now knows to read page `42` from the file `part_2_page_file.lance`.
     ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
-
-    /// The raw lookup batch this index was built from (the contents of
-    /// `page_lookup.lance`). Retained so the index can be serialized into a
-    /// cache as a [`BTreeIndexState`] without re-reading it from storage.
-    ///
-    /// TODO: this duplicates the min/max values already held in `page_lookup`.
-    /// A follow-up could rewrite `BTreeLookup` to query this batch directly
-    /// (binary search on the sorted `min` column + linear scan, type-dispatched
-    /// per column type), eliminating the duplication and making this batch the
-    /// single source of truth.
-    lookup_batch: RecordBatch,
 }
 
 impl DeepSizeOf for BTreeIndex {
     fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
         // We don't include the index cache, or anything stored in it. For example:
-        // sub_index and fri.
-        self.page_lookup.deep_size_of_children(context)
-            + self.store.deep_size_of_children(context)
-            + self.lookup_batch.get_array_memory_size()
+        // sub_index and fri. `page_lookup` owns the lookup batch (the single source
+        // of truth), so accounting for it covers the lookup data.
+        self.page_lookup.deep_size_of_children(context) + self.store.deep_size_of_children(context)
     }
 }
 
@@ -1240,7 +1298,6 @@ impl BTreeIndex {
         batch_size: u64,
         ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        lookup_batch: RecordBatch,
     ) -> Self {
         Self {
             page_lookup,
@@ -1250,7 +1307,6 @@ impl BTreeIndex {
             batch_size,
             ranges_to_files,
             frag_reuse_index,
-            lookup_batch,
         }
     }
 
@@ -1323,68 +1379,8 @@ impl BTreeIndex {
         ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<Self> {
-        let mut map = BTreeMap::<OrderableScalarValue, Vec<PageRecord>>::new();
-        // Pages that have at least one null value
-        let mut null_pages = Vec::<u32>::new();
-        // Pages that are entirely null
-        let mut all_null_pages = Vec::<u32>::new();
-
-        if data.num_rows() == 0 {
-            let data_type = data.column(0).data_type().clone();
-            let page_lookup = Arc::new(BTreeLookup::empty());
-            return Ok(Self::new(
-                page_lookup,
-                store,
-                data_type,
-                WeakLanceCache::from(index_cache),
-                batch_size,
-                ranges_to_files,
-                frag_reuse_index,
-                data,
-            ));
-        }
-
-        let mins = data.column(0);
-        let maxs = data.column(1);
-        let null_counts = data
-            .column(2)
-            .as_any()
-            .downcast_ref::<UInt32Array>()
-            .unwrap();
-        let page_numbers = data
-            .column(3)
-            .as_any()
-            .downcast_ref::<UInt32Array>()
-            .unwrap();
-
-        for idx in 0..data.num_rows() {
-            let min = OrderableScalarValue(ScalarValue::try_from_array(&mins, idx)?);
-            let max = OrderableScalarValue(ScalarValue::try_from_array(&maxs, idx)?);
-            let null_count = null_counts.values()[idx];
-            let page_number = page_numbers.values()[idx];
-
-            // If the page is entirely null don't even bother putting it in the tree
-            if max.0.is_null() {
-                all_null_pages.push(page_number);
-                // continue so we don't add it to the null_pages
-                continue;
-            } else {
-                map.entry(min)
-                    .or_default()
-                    .push(PageRecord { max, page_number });
-            }
-
-            if null_count > 0 {
-                null_pages.push(page_number);
-            }
-        }
-
-        let last_max = ScalarValue::try_from_array(&maxs, data.num_rows() - 1)?;
-        map.entry(OrderableScalarValue(last_max)).or_default();
-
-        let data_type = mins.data_type().clone();
-
-        let page_lookup = Arc::new(BTreeLookup::new(map, null_pages, all_null_pages));
+        let data_type = data.column(0).data_type().clone();
+        let page_lookup = Arc::new(BTreeLookup::try_new(data)?);
 
         Ok(Self::new(
             page_lookup,
@@ -1394,7 +1390,6 @@ impl BTreeIndex {
             batch_size,
             ranges_to_files,
             frag_reuse_index,
-            data,
         ))
     }
 
@@ -1695,18 +1690,25 @@ impl Index for BTreeIndex {
     }
 
     fn statistics(&self) -> Result<serde_json::Value> {
-        let min = self
-            .page_lookup
-            .tree
-            .first_key_value()
-            .map(|(k, _)| k.clone());
-        let max = self
-            .page_lookup
-            .tree
-            .last_key_value()
-            .map(|(k, _)| k.clone());
+        let lookup = &self.page_lookup;
+        let batch = &lookup.batch;
+        let num_rows = batch.num_rows();
+        // The batch is sorted by `min`, so the smallest searchable value is the
+        // `min` of the first non-all-null page and the largest is the `max` of the
+        // last page.
+        let (min, max) = if lookup.search_start >= num_rows {
+            (None, None)
+        } else {
+            let min = OrderableScalarValue(ScalarValue::try_from_array(
+                batch.column(0),
+                lookup.search_start,
+            )?);
+            let max =
+                OrderableScalarValue(ScalarValue::try_from_array(batch.column(1), num_rows - 1)?);
+            (Some(min), Some(max))
+        };
         serde_json::to_value(&BTreeStatistics {
-            num_pages: self.page_lookup.tree.len() as u32,
+            num_pages: num_rows as u32,
             min,
             max,
         })
@@ -1753,7 +1755,7 @@ impl ScalarIndex for BTreeIndex {
                     "full text search is not supported for BTree index, build a inverted index for it",
                 ));
             }
-            SargableQuery::IsNull() => self.page_lookup.pages_null(),
+            SargableQuery::IsNull() => Ok(self.page_lookup.pages_null()),
             SargableQuery::LikePrefix(prefix) => {
                 // Convert LikePrefix to a range query: [prefix, next_prefix)
                 match prefix {
@@ -1787,7 +1789,7 @@ impl ScalarIndex for BTreeIndex {
                     }
                 }
             }
-        };
+        }?;
 
         // For non-IsNull queries, also include null pages so that null row IDs
         // are tracked in the result. Any comparison with NULL yields NULL, and
@@ -1798,6 +1800,11 @@ impl ScalarIndex for BTreeIndex {
         // We add them as Matches::Some (not Matches::All) so that
         // FlatIndex::search() evaluates the predicate and correctly marks
         // the rows as NULL rather than TRUE.
+        //
+        // TODO: the lookup batch retains a per-page `null_count`. A fully-covered
+        // page with zero nulls is a true Matches::All, while one with nulls needs
+        // Matches::Some only to track the null rows; surfacing `null_count` here
+        // could refine that classification (see #6802).
         if !matches!(query, SargableQuery::IsNull()) {
             let existing: HashSet<u32> = pages.iter().map(|m| m.page_id()).collect();
             for &page_id in self
@@ -2941,7 +2948,7 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
             Error::internal("BTreeIndexPlugin::put_in_cache called with a non-BTree index")
         })?;
         let state = BTreeIndexState {
-            lookup_batch: btree.lookup_batch.clone(),
+            lookup_batch: btree.page_lookup.batch.clone(),
             batch_size: btree.batch_size,
             ranges_to_files: btree.ranges_to_files.clone(),
         };
@@ -2988,8 +2995,9 @@ mod tests {
     };
 
     use super::{
-        BTreeIndexPlugin, BTreeIndexState, BTreePageKey, DEFAULT_BTREE_BATCH_SIZE,
-        OrderableScalarValue, part_lookup_file_path, part_page_data_file_path, train_btree_index,
+        BTreeIndexPlugin, BTreeIndexState, BTreeLookup, BTreePageKey, DEFAULT_BTREE_BATCH_SIZE,
+        Matches, OrderableScalarValue, part_lookup_file_path, part_page_data_file_path,
+        train_btree_index,
     };
     use crate::scalar::registry::ScalarIndexPlugin;
     use arrow_array::RecordBatch;
@@ -4981,6 +4989,87 @@ mod tests {
         .unwrap()
     }
 
+    fn osv(v: i32) -> OrderableScalarValue {
+        OrderableScalarValue(ScalarValue::Int32(Some(v)))
+    }
+
+    /// The rewritten [`BTreeLookup`] searches the lookup batch directly, so this
+    /// exercises the binary-search bounds, duplicate `min` values, a partial-null
+    /// (null `min`) straddling page, and the `Matches::Some`/`All` classification.
+    #[test]
+    fn test_btree_lookup_pages_between() {
+        // Pages sorted by `min`, NULLs first. Page 0 straddles the NULL/non-NULL
+        // boundary; pages 2 and 3 share a `min` of 20.
+        let batch = record_batch!(
+            ("min", Int32, [None, Some(10), Some(20), Some(20), Some(40)]),
+            (
+                "max",
+                Int32,
+                [Some(5), Some(20), Some(20), Some(30), Some(50)]
+            ),
+            ("null_count", UInt32, [2, 0, 0, 0, 0]),
+            ("page_idx", UInt32, [0, 1, 2, 3, 4])
+        )
+        .unwrap();
+        let lookup = BTreeLookup::try_new(batch).unwrap();
+        assert_eq!(lookup.null_pages, vec![0]);
+        assert!(lookup.all_null_pages.is_empty());
+        assert_eq!(lookup.search_start, 0);
+
+        let between = |lo: i32, hi: i32| {
+            let mut m = lookup
+                .pages_between((
+                    std::ops::Bound::Included(&osv(lo)),
+                    std::ops::Bound::Included(&osv(hi)),
+                ))
+                .unwrap();
+            m.sort_by_key(|m| m.page_id());
+            m
+        };
+
+        // Equality only ever yields partial (Some) matches.
+        assert_eq!(lookup.pages_eq(&osv(15)).unwrap(), vec![Matches::Some(1)]);
+        assert_eq!(
+            lookup.pages_eq(&osv(20)).unwrap(),
+            vec![Matches::Some(1), Matches::Some(2), Matches::Some(3)]
+        );
+        assert!(lookup.pages_eq(&osv(35)).unwrap().is_empty());
+
+        // [20, 25]: page 2 ([20, 20]) sits entirely inside -> All; pages 1 and 3
+        // only partially overlap -> Some. The null-min page 0 (max 5) is excluded.
+        assert_eq!(
+            between(20, 25),
+            vec![Matches::Some(1), Matches::All(2), Matches::Some(3)]
+        );
+
+        // A query below all non-null data still reaches the straddling page 0,
+        // which is only ever a partial match because its `min` is NULL.
+        assert_eq!(between(0, 5), vec![Matches::Some(0)]);
+
+        // Unbounded above: page 4 ([40, 50]) is fully covered from 40 onward.
+        assert_eq!(
+            lookup
+                .pages_between((
+                    std::ops::Bound::Included(&osv(40)),
+                    std::ops::Bound::Unbounded
+                ))
+                .unwrap(),
+            vec![Matches::All(4)]
+        );
+
+        // Empty / inverted ranges select nothing.
+        assert!(between(31, 39).is_empty());
+        assert!(
+            lookup
+                .pages_between((
+                    std::ops::Bound::Included(&osv(25)),
+                    std::ops::Bound::Included(&osv(15))
+                ))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
     fn assert_state_roundtrips(state: &BTreeIndexState) {
         let mut buf = Vec::new();
         state.serialize(&mut buf).unwrap();
@@ -5049,7 +5138,7 @@ mod tests {
 
         // Round-trip the state through the codec and reconstruct an index from it.
         let state = BTreeIndexState {
-            lookup_batch: index.lookup_batch.clone(),
+            lookup_batch: index.page_lookup.batch.clone(),
             batch_size: index.batch_size,
             ranges_to_files: index.ranges_to_files.clone(),
         };
@@ -5131,7 +5220,7 @@ mod tests {
             .await
             .unwrap();
         let state = BTreeIndexState {
-            lookup_batch: index.lookup_batch.clone(),
+            lookup_batch: index.page_lookup.batch.clone(),
             batch_size: index.batch_size,
             ranges_to_files: index.ranges_to_files.clone(),
         };

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -817,16 +817,27 @@ impl BTreeLookup {
             // End row: pages whose `min` exceeds the value cannot match.
             let end = partition_point(start, num_rows, |i| cmp_min(i, j) != Ordering::Greater);
 
-            for idx in start..end {
+            // The window splits at `p` (first row with `min >= value`):
+            //   * `[start, p)` — the peek-left/straddle region (`min < value`). A page
+            //     here matches only if its `max` reaches the value, so it needs the
+            //     filter, and it may include a null-`min`/null-`max` straddle page.
+            //   * `[p, end)` — rows with `min == value`. These always match (`max >=
+            //     min == value`) and can't have a null `max` (all-null pages sort to
+            //     the front, before `search_start <= start`), so we copy them in one
+            //     slice instead of pushing per row.
+            let page_ids = page_numbers.values();
+            let bulk_start = p.max(start);
+            for idx in start..bulk_start {
                 // All-null pages are only matched by IS NULL queries.
                 if maxs.is_null(idx) {
                     continue;
                 }
                 // Candidate when the page's `max` reaches the value (`max >= value`).
                 if cmp_max(idx, j) != Ordering::Less {
-                    pages.push(page_numbers.values()[idx]);
+                    pages.push(page_ids[idx]);
                 }
             }
+            pages.extend_from_slice(&page_ids[bulk_start..end]);
         }
 
         pages.sort_unstable();

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -30,10 +30,15 @@ use crate::{pbold, scalar::btree::flat::FlatIndex};
 use arrow_arith::numeric::add;
 use arrow_array::{
     Array, ArrayAccessor, ArrowNativeTypeOp, PrimitiveArray, RecordBatch, UInt32Array,
-    cast::AsArray, downcast_primitive, new_empty_array, types::ArrowPrimitiveType,
+    cast::AsArray,
+    new_empty_array,
+    types::{
+        ArrowPrimitiveType, Decimal128Type, Decimal256Type, Float16Type, Float32Type, Float64Type,
+        Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
+    },
 };
 use arrow_ord::ord::make_comparator;
-use arrow_schema::{DataType, Field, Schema, SortOptions};
+use arrow_schema::{DataType, Field, IntervalUnit, Schema, SortOptions};
 use async_trait::async_trait;
 use datafusion::physical_plan::{
     ExecutionPlan, SendableRecordBatchStream,
@@ -636,6 +641,30 @@ where
     }
 }
 
+/// Views `arr` as `PrimitiveArray<K>` for comparison. Zero-copy (shared buffers)
+/// when `arr` already has type `K`; otherwise — a logical type whose physical
+/// storage is `K::Native`, e.g. `Date32`/`Time32` over `i32` or `Timestamp`/
+/// `Duration` over `i64` — the array data is relabeled to `K` without copying the
+/// values, so all such logical types share one comparison path.
+fn reinterpret_primitive<K: ArrowPrimitiveType>(arr: &dyn Array) -> Result<PrimitiveArray<K>> {
+    if let Some(arr) = arr.as_primitive_opt::<K>() {
+        return Ok(arr.clone());
+    }
+    let data = arr
+        .to_data()
+        .into_builder()
+        .data_type(K::DATA_TYPE)
+        .build()
+        .map_err(|e| {
+            Error::internal(format!(
+                "failed to reinterpret {} as {}: {e}",
+                arr.data_type(),
+                K::DATA_TYPE
+            ))
+        })?;
+    Ok(PrimitiveArray::<K>::from(data))
+}
+
 /// Like [`accessor_cmp`] but for primitive columns, comparing native values with
 /// [`ArrowNativeTypeOp::compare`] (total order, so floats match arrow's NaN-last
 /// `make_comparator` ordering).
@@ -826,79 +855,136 @@ impl BTreeLookup {
         let maxs = self.batch.column(1).as_ref();
         let page_ids = self.page_numbers()?.values();
 
-        // For primitive and byte-like columns we downcast once and compare with
-        // native closures that inline into the scan, instead of going through the
-        // boxed `DynComparator` (one vtable call per comparison). The query array
-        // always matches the column type, so its type selects both columns' branch.
-        macro_rules! scan_primitive {
-            ($t:ty) => {{
-                let mins = mins.as_primitive::<$t>();
-                let maxs = maxs.as_primitive::<$t>();
-                let query = query.as_primitive::<$t>();
-                self.scan_equality_pages(
-                    query.len(),
-                    page_ids,
-                    |idx| maxs.is_null(idx),
-                    primitive_cmp(mins, query),
-                    primitive_cmp(maxs, query),
-                    primitive_cmp(mins, mins),
-                )
-            }};
+        // Compare against the page columns with a native, monomorphized comparator
+        // that inlines, rather than the boxed `DynComparator` from `make_comparator`
+        // (one vtable call per comparison). Logical types that share a physical
+        // storage type route to one path via a zero-copy reinterpret, so e.g. every
+        // date/time/timestamp/duration type reuses the `i32`/`i64` path instead of
+        // generating its own. Types with no native path (intervals with struct
+        // natives, booleans, ...) take the `make_comparator` fallback. The query
+        // array always matches the column type, so its type selects the branch.
+        use DataType::*;
+        match query.data_type() {
+            Int8 => self.scan_native::<Int8Type>(mins, maxs, query, page_ids),
+            Int16 => self.scan_native::<Int16Type>(mins, maxs, query, page_ids),
+            // i32-backed: Int32, Date32, Time32, Decimal32, year-month intervals.
+            Int32 | Date32 | Time32(_) | Decimal32(_, _) | Interval(IntervalUnit::YearMonth) => {
+                self.scan_native::<Int32Type>(mins, maxs, query, page_ids)
+            }
+            // i64-backed: Int64, Date64, Time64, Timestamp, Duration, Decimal64.
+            Int64 | Date64 | Time64(_) | Timestamp(_, _) | Duration(_) | Decimal64(_, _) => {
+                self.scan_native::<Int64Type>(mins, maxs, query, page_ids)
+            }
+            UInt8 => self.scan_native::<UInt8Type>(mins, maxs, query, page_ids),
+            UInt16 => self.scan_native::<UInt16Type>(mins, maxs, query, page_ids),
+            UInt32 => self.scan_native::<UInt32Type>(mins, maxs, query, page_ids),
+            UInt64 => self.scan_native::<UInt64Type>(mins, maxs, query, page_ids),
+            Float16 => self.scan_native::<Float16Type>(mins, maxs, query, page_ids),
+            Float32 => self.scan_native::<Float32Type>(mins, maxs, query, page_ids),
+            Float64 => self.scan_native::<Float64Type>(mins, maxs, query, page_ids),
+            Decimal128(_, _) => self.scan_native::<Decimal128Type>(mins, maxs, query, page_ids),
+            Decimal256(_, _) => self.scan_native::<Decimal256Type>(mins, maxs, query, page_ids),
+            Utf8 => Ok(self.scan_accessor(
+                mins.as_string::<i32>(),
+                maxs.as_string::<i32>(),
+                query.as_string::<i32>(),
+                page_ids,
+            )),
+            LargeUtf8 => Ok(self.scan_accessor(
+                mins.as_string::<i64>(),
+                maxs.as_string::<i64>(),
+                query.as_string::<i64>(),
+                page_ids,
+            )),
+            Binary => Ok(self.scan_accessor(
+                mins.as_binary::<i32>(),
+                maxs.as_binary::<i32>(),
+                query.as_binary::<i32>(),
+                page_ids,
+            )),
+            LargeBinary => Ok(self.scan_accessor(
+                mins.as_binary::<i64>(),
+                maxs.as_binary::<i64>(),
+                query.as_binary::<i64>(),
+                page_ids,
+            )),
+            FixedSizeBinary(_) => Ok(self.scan_accessor(
+                mins.as_fixed_size_binary(),
+                maxs.as_fixed_size_binary(),
+                query.as_fixed_size_binary(),
+                page_ids,
+            )),
+            _ => self.scan_fallback(mins, maxs, query, page_ids),
         }
-        macro_rules! scan_bytes {
-            ($mins:expr, $maxs:expr, $query:expr) => {{
-                let mins = $mins;
-                let maxs = $maxs;
-                let query = $query;
-                self.scan_equality_pages(
-                    query.len(),
-                    page_ids,
-                    |idx| maxs.is_null(idx),
-                    accessor_cmp(mins, query),
-                    accessor_cmp(maxs, query),
-                    accessor_cmp(mins, mins),
-                )
-            }};
-        }
+    }
 
-        let pages = downcast_primitive! {
-            query.data_type() => (scan_primitive),
-            DataType::Utf8 => {
-                scan_bytes!(mins.as_string::<i32>(), maxs.as_string::<i32>(), query.as_string::<i32>())
-            }
-            DataType::LargeUtf8 => {
-                scan_bytes!(mins.as_string::<i64>(), maxs.as_string::<i64>(), query.as_string::<i64>())
-            }
-            DataType::Binary => {
-                scan_bytes!(mins.as_binary::<i32>(), maxs.as_binary::<i32>(), query.as_binary::<i32>())
-            }
-            DataType::LargeBinary => {
-                scan_bytes!(mins.as_binary::<i64>(), maxs.as_binary::<i64>(), query.as_binary::<i64>())
-            }
-            DataType::FixedSizeBinary(_) => {
-                scan_bytes!(mins.as_fixed_size_binary(), maxs.as_fixed_size_binary(), query.as_fixed_size_binary())
-            }
-            _ => {
-                // The batch is sorted ascending by `min` with NULLs first; compare the
-                // query values the same way so the binary searches stay consistent.
-                let opts = SortOptions {
-                    descending: false,
-                    nulls_first: true,
-                };
-                let cmp_min = make_comparator(mins, query, opts)?;
-                let cmp_max = make_comparator(maxs, query, opts)?;
-                let cmp_min_min = make_comparator(mins, mins, opts)?;
-                self.scan_equality_pages(
-                    query.len(),
-                    page_ids,
-                    |idx| maxs.is_null(idx),
-                    cmp_min,
-                    cmp_max,
-                    cmp_min_min,
-                )
-            }
+    /// Native-comparator equality scan for a primitive physical type `K`. The page
+    /// columns and `query` are reinterpreted to `PrimitiveArray<K>` (zero-copy when
+    /// already that type) and compared with [`primitive_cmp`].
+    fn scan_native<K: ArrowPrimitiveType>(
+        &self,
+        mins: &dyn Array,
+        maxs: &dyn Array,
+        query: &dyn Array,
+        page_ids: &[u32],
+    ) -> Result<Vec<u32>> {
+        let mins = reinterpret_primitive::<K>(mins)?;
+        let maxs = reinterpret_primitive::<K>(maxs)?;
+        let query = reinterpret_primitive::<K>(query)?;
+        Ok(self.scan_equality_pages(
+            query.len(),
+            page_ids,
+            |idx| maxs.is_null(idx),
+            primitive_cmp(&mins, &query),
+            primitive_cmp(&maxs, &query),
+            primitive_cmp(&mins, &mins),
+        ))
+    }
+
+    /// Native-comparator equality scan for byte-like columns (`Utf8`/`Binary`/
+    /// `FixedSizeBinary` and their large variants), compared lexicographically via
+    /// [`accessor_cmp`].
+    fn scan_accessor<T, A>(&self, mins: A, maxs: A, query: A, page_ids: &[u32]) -> Vec<u32>
+    where
+        T: Ord,
+        A: ArrayAccessor<Item = T> + Copy,
+    {
+        self.scan_equality_pages(
+            query.len(),
+            page_ids,
+            |idx| maxs.is_null(idx),
+            accessor_cmp(mins, query),
+            accessor_cmp(maxs, query),
+            accessor_cmp(mins, mins),
+        )
+    }
+
+    /// Fallback equality scan for types without a native path (intervals with struct
+    /// natives, booleans, ...), using arrow's boxed `make_comparator`.
+    fn scan_fallback(
+        &self,
+        mins: &dyn Array,
+        maxs: &dyn Array,
+        query: &dyn Array,
+        page_ids: &[u32],
+    ) -> Result<Vec<u32>> {
+        // The batch is sorted ascending by `min` with NULLs first; compare the query
+        // values the same way so the binary searches stay consistent.
+        let opts = SortOptions {
+            descending: false,
+            nulls_first: true,
         };
-        Ok(pages)
+        let cmp_min = make_comparator(mins, query, opts)?;
+        let cmp_max = make_comparator(maxs, query, opts)?;
+        let cmp_min_min = make_comparator(mins, mins, opts)?;
+        Ok(self.scan_equality_pages(
+            query.len(),
+            page_ids,
+            |idx| maxs.is_null(idx),
+            cmp_min,
+            cmp_max,
+            cmp_min_min,
+        ))
     }
 
     /// Binary-search + forward-scan the page batch for equality candidates.
@@ -5364,6 +5450,90 @@ mod tests {
         assert_byte_lookup(bin(&mins), bin(&maxs), &|v| {
             ScalarValue::Binary(Some(be(v).to_vec()))
         });
+    }
+
+    /// Exercises the physical-type reinterpret path: temporal columns (`Date32`
+    /// over `i32`, `Timestamp` over `i64`) are compared through the integer native
+    /// path without a dedicated per-type branch.
+    #[test]
+    fn test_btree_lookup_pages_eq_temporal() {
+        use arrow_array::{ArrayRef, Date32Array, TimestampMicrosecondArray, UInt32Array};
+        use arrow_schema::{DataType, Field, Schema};
+
+        let null_count = UInt32Array::from(vec![2u32, 0, 0, 0, 0]);
+        let page_idx = UInt32Array::from(vec![0u32, 1, 2, 3, 4]);
+
+        let assert_lookup =
+            |min_arr: ArrayRef, max_arr: ArrayRef, sv: &dyn Fn(i64) -> ScalarValue| {
+                let batch = RecordBatch::try_new(
+                    Arc::new(Schema::new(vec![
+                        Field::new("min", min_arr.data_type().clone(), true),
+                        Field::new("max", max_arr.data_type().clone(), true),
+                        Field::new("null_count", DataType::UInt32, false),
+                        Field::new("page_idx", DataType::UInt32, false),
+                    ])),
+                    vec![
+                        min_arr,
+                        max_arr,
+                        Arc::new(null_count.clone()),
+                        Arc::new(page_idx.clone()),
+                    ],
+                )
+                .unwrap();
+                let lookup = BTreeLookup::try_new(batch).unwrap();
+                let eq = |v: i64| {
+                    let mut p: Vec<u32> = lookup
+                        .pages_eq(&OrderableScalarValue(sv(v)))
+                        .unwrap()
+                        .into_iter()
+                        .map(|m| m.page_id())
+                        .collect();
+                    p.sort_unstable();
+                    p
+                };
+                assert_eq!(eq(15), vec![1]); // only page 1 ([10, 20])
+                assert_eq!(eq(20), vec![1, 2, 3]); // shared min of 2 & 3, max of 1
+                assert!(eq(35).is_empty()); // gap between pages 3 and 4
+                assert_eq!(eq(5), vec![0]); // reaches the null-min straddle via its max
+            };
+
+        // Timestamp (i64-backed) → Int64 native path.
+        assert_lookup(
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                None,
+                Some(10),
+                Some(20),
+                Some(20),
+                Some(40),
+            ])),
+            Arc::new(TimestampMicrosecondArray::from(vec![
+                Some(5),
+                Some(20),
+                Some(20),
+                Some(30),
+                Some(50),
+            ])),
+            &|v| ScalarValue::TimestampMicrosecond(Some(v), None),
+        );
+
+        // Date32 (i32-backed) → Int32 native path.
+        assert_lookup(
+            Arc::new(Date32Array::from(vec![
+                None,
+                Some(10),
+                Some(20),
+                Some(20),
+                Some(40),
+            ])),
+            Arc::new(Date32Array::from(vec![
+                Some(5),
+                Some(20),
+                Some(20),
+                Some(30),
+                Some(50),
+            ])),
+            &|v| ScalarValue::Date32(Some(v as i32)),
+        );
     }
 
     fn assert_state_roundtrips(state: &BTreeIndexState) {

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -615,20 +615,18 @@ impl<K: Ord, V> BTreeMapExt<K, V> for BTreeMap<K, V> {
 #[derive(Debug, DeepSizeOf, PartialEq, Eq)]
 pub struct BTreeLookup {
     tree: BTreeMap<OrderableScalarValue, Vec<PageRecord>>,
-    /// Pages where the value may be null (does not include all_null_pages),
-    /// keyed by page number with the exact null count in that page.
-    null_pages: HashMap<u32, u32>,
-    /// Pages that are entirely null, keyed by page number with the exact null
-    /// count in that page.
-    all_null_pages: HashMap<u32, u32>,
+    /// Pages where the value may be null (does not include all_null_pages)
+    null_pages: Vec<u32>,
+    /// Pages that are entirely null
+    all_null_pages: Vec<u32>,
 }
 
 impl BTreeLookup {
     fn empty() -> Self {
         Self {
             tree: BTreeMap::new(),
-            null_pages: HashMap::new(),
-            all_null_pages: HashMap::new(),
+            null_pages: Vec::new(),
+            all_null_pages: Vec::new(),
         }
     }
 }
@@ -651,8 +649,8 @@ impl Matches {
 impl BTreeLookup {
     fn new(
         tree: BTreeMap<OrderableScalarValue, Vec<PageRecord>>,
-        null_pages: HashMap<u32, u32>,
-        all_null_pages: HashMap<u32, u32>,
+        null_pages: Vec<u32>,
+        all_null_pages: Vec<u32>,
     ) -> Self {
         Self {
             tree,
@@ -825,10 +823,9 @@ impl BTreeLookup {
 
     fn pages_null(&self) -> Vec<Matches> {
         self.null_pages
-            .keys()
-            .copied()
-            .map(Matches::Some)
-            .chain(self.all_null_pages.keys().copied().map(Matches::All))
+            .iter()
+            .map(|page_id| Matches::Some(*page_id))
+            .chain(self.all_null_pages.iter().copied().map(Matches::All))
             .collect()
     }
 }
@@ -1008,148 +1005,25 @@ impl CacheKey for BTreePageKey {
     }
 }
 
-fn parse_btree_lookup(data: &RecordBatch) -> Result<(Arc<BTreeLookup>, DataType)> {
-    let data_type = data.column(0).data_type().clone();
-    if data.num_rows() == 0 {
-        return Ok((Arc::new(BTreeLookup::empty()), data_type));
-    }
-
-    let mins = data.column(0);
-    let maxs = data.column(1);
-    let null_counts = data
-        .column(2)
-        .as_any()
-        .downcast_ref::<UInt32Array>()
-        .ok_or_else(|| Error::internal("BTree lookup null_count column must be UInt32"))?;
-    let page_numbers = data
-        .column(3)
-        .as_any()
-        .downcast_ref::<UInt32Array>()
-        .ok_or_else(|| Error::internal("BTree lookup page_idx column must be UInt32"))?;
-
-    let mut map = BTreeMap::<OrderableScalarValue, Vec<PageRecord>>::new();
-    let mut null_pages = HashMap::<u32, u32>::new();
-    let mut all_null_pages = HashMap::<u32, u32>::new();
-
-    for idx in 0..data.num_rows() {
-        let min = OrderableScalarValue(ScalarValue::try_from_array(&mins, idx)?);
-        let max = OrderableScalarValue(ScalarValue::try_from_array(&maxs, idx)?);
-        let null_count = null_counts.values()[idx];
-        let page_number = page_numbers.values()[idx];
-
-        // If the page is entirely null don't even bother putting it in the tree.
-        if max.0.is_null() {
-            all_null_pages.insert(page_number, null_count);
-            continue;
-        } else {
-            map.entry(min)
-                .or_default()
-                .push(PageRecord { max, page_number });
-        }
-
-        if null_count > 0 {
-            null_pages.insert(page_number, null_count);
-        }
-    }
-
-    let last_max = ScalarValue::try_from_array(&maxs, data.num_rows() - 1)?;
-    map.entry(OrderableScalarValue(last_max)).or_default();
-
-    Ok((
-        Arc::new(BTreeLookup::new(map, null_pages, all_null_pages)),
-        data_type,
-    ))
-}
-
-fn btree_lookup_as_batch(lookup: &BTreeLookup, data_type: &DataType) -> Result<RecordBatch> {
-    let mut mins = Vec::new();
-    let mut maxs = Vec::new();
-    let mut null_counts = Vec::new();
-    let mut page_numbers = Vec::new();
-
-    // Keep all-null rows first so the regenerated lookup batch remains sorted
-    // with NULLs before non-NULL values. `parse_btree_lookup` adds a sentinel
-    // from the final row's max value, and that sentinel must not be NULL when
-    // the lookup also has non-null pages.
-    let null_value = ScalarValue::try_new_null(data_type)?;
-    let mut all_null_pages = lookup.all_null_pages.iter().collect::<Vec<_>>();
-    all_null_pages.sort_by_key(|(page_number, _)| **page_number);
-    for (page_number, null_count) in all_null_pages {
-        mins.push(null_value.clone());
-        maxs.push(null_value.clone());
-        null_counts.push(*null_count);
-        page_numbers.push(*page_number);
-    }
-
-    // Preserve the exact null_count from the lookup batch. Query execution only
-    // needs `null_count > 0` to route IS NULL queries, but the lookup wire
-    // format stores exact counts and future costing / selectivity logic may use
-    // them.
-    for (min, page_records) in &lookup.tree {
-        for page_record in page_records {
-            mins.push(min.0.clone());
-            maxs.push(page_record.max.0.clone());
-            null_counts.push(
-                lookup
-                    .null_pages
-                    .get(&page_record.page_number)
-                    .copied()
-                    .unwrap_or(0),
-            );
-            page_numbers.push(page_record.page_number);
-        }
-    }
-
-    let min_array = if mins.is_empty() {
-        new_empty_array(data_type)
-    } else {
-        ScalarValue::iter_to_array(mins)?
-    };
-    let max_array = if maxs.is_empty() {
-        new_empty_array(data_type)
-    } else {
-        ScalarValue::iter_to_array(maxs)?
-    };
-
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("min", data_type.clone(), true),
-        Field::new("max", data_type.clone(), true),
-        Field::new("null_count", DataType::UInt32, false),
-        Field::new("page_idx", DataType::UInt32, false),
-    ]));
-    Ok(RecordBatch::try_new(
-        schema,
-        vec![
-            min_array,
-            max_array,
-            Arc::new(UInt32Array::from_iter_values(null_counts)),
-            Arc::new(UInt32Array::from_iter_values(page_numbers)),
-        ],
-    )?)
-}
-
 /// The serializable state of a [`BTreeIndex`].
 ///
-/// A `BTreeIndex` also holds non-serializable infrastructure such as an
-/// `IndexStore`, a cache handle, and an optional fragment-reuse index. This
-/// state keeps only the parsed lookup tree and small routing metadata needed to
-/// rebuild the index without re-reading from blob storage. Once this state is
-/// resident in memory, reconstructing a `BTreeIndex` does not reparse the
-/// lookup. Restoring this state from a persistent cache still parses the
-/// embedded IPC lookup payload into this parsed form.
+/// A `BTreeIndex` holds non-serializable infrastructure (an `IndexStore`, a
+/// cache handle, a fragment-reuse index). `BTreeIndexState` captures just the
+/// data needed to rebuild it: the `page_lookup.lance` batch (from which
+/// `BTreeIndex::try_from_serialized` reconstructs the in-memory lookup with
+/// no IO) plus the page batch size and range-partition map.
 #[derive(Debug, Clone)]
-struct BTreeIndexState {
-    page_lookup: Arc<BTreeLookup>,
-    data_type: DataType,
+pub struct BTreeIndexState {
+    lookup_batch: RecordBatch,
     batch_size: u64,
     ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
 }
 
 impl DeepSizeOf for BTreeIndexState {
-    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
-        // `ranges_to_files` is tiny and `RangeInclusiveMap` is not `DeepSizeOf`.
-        // The parsed lookup tree is the resident memory we need to charge.
-        self.page_lookup.deep_size_of_children(context)
+    fn deep_size_of_children(&self, _context: &mut lance_core::deepsize::Context) -> usize {
+        // `ranges_to_files` is tiny and `RangeInclusiveMap` is not `DeepSizeOf`;
+        // the lookup batch dominates, matching how `BTreeIndex` accounts for itself.
+        self.lookup_batch.get_array_memory_size()
     }
 }
 
@@ -1160,28 +1034,28 @@ impl BTreeIndexState {
         index_cache: &LanceCache,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<Arc<dyn ScalarIndex>> {
-        let index = BTreeIndex::new(
-            self.page_lookup.clone(),
+        let index = BTreeIndex::try_from_serialized(
+            self.lookup_batch.clone(),
             store,
-            self.data_type.clone(),
-            WeakLanceCache::from(index_cache),
+            index_cache,
             self.batch_size,
             self.ranges_to_files.clone(),
             frag_reuse_index,
-        );
+        )?;
         Ok(Arc::new(index) as Arc<dyn ScalarIndex>)
     }
 }
 
 impl CacheCodecImpl for BTreeIndexState {
-    /// Wire format (cache-internal, no stability guarantee):
+    /// Wire format (no stability guarantees yet — the cache is rebuilt from
+    /// source on any version mismatch):
     /// ```text
     /// u64 batch_size (LE)
     /// u8  has_ranges (0 = None, 1 = Some)
     /// if has_ranges:
     ///   u32 entry_count (LE)
     ///   per entry: u32 start | u32 end | u32 offset | u32 path_len | path bytes
-    /// lookup batch regenerated from the parsed BTreeLookup (Arrow IPC stream)
+    /// lookup batch (Arrow IPC stream)
     /// ```
     fn serialize(&self, writer: &mut dyn std::io::Write) -> Result<()> {
         writer.write_all(&self.batch_size.to_le_bytes())?;
@@ -1205,8 +1079,7 @@ impl CacheCodecImpl for BTreeIndexState {
                 }
             }
         }
-        let lookup_batch = btree_lookup_as_batch(&self.page_lookup, &self.data_type)?;
-        write_ipc_stream(&lookup_batch, writer)?;
+        write_ipc_stream(&self.lookup_batch, writer)?;
         Ok(())
     }
 
@@ -1239,10 +1112,8 @@ impl CacheCodecImpl for BTreeIndexState {
             }
         };
         let lookup_batch = read_ipc_stream_single_at(data, &mut offset)?;
-        let (page_lookup, data_type) = parse_btree_lookup(&lookup_batch)?;
         Ok(Self {
-            page_lookup,
-            data_type,
+            lookup_batch,
             batch_size,
             ranges_to_files,
         })
@@ -1336,13 +1207,26 @@ pub struct BTreeIndex {
     /// - The system now knows to read page `42` from the file `part_2_page_file.lance`.
     ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
+
+    /// The raw lookup batch this index was built from (the contents of
+    /// `page_lookup.lance`). Retained so the index can be serialized into a
+    /// cache as a [`BTreeIndexState`] without re-reading it from storage.
+    ///
+    /// TODO: this duplicates the min/max values already held in `page_lookup`.
+    /// A follow-up could rewrite `BTreeLookup` to query this batch directly
+    /// (binary search on the sorted `min` column + linear scan, type-dispatched
+    /// per column type), eliminating the duplication and making this batch the
+    /// single source of truth.
+    lookup_batch: RecordBatch,
 }
 
 impl DeepSizeOf for BTreeIndex {
     fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
         // We don't include the index cache, or anything stored in it. For example:
         // sub_index and fri.
-        self.page_lookup.deep_size_of_children(context) + self.store.deep_size_of_children(context)
+        self.page_lookup.deep_size_of_children(context)
+            + self.store.deep_size_of_children(context)
+            + self.lookup_batch.get_array_memory_size()
     }
 }
 
@@ -1356,6 +1240,7 @@ impl BTreeIndex {
         batch_size: u64,
         ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        lookup_batch: RecordBatch,
     ) -> Self {
         Self {
             page_lookup,
@@ -1365,6 +1250,7 @@ impl BTreeIndex {
             batch_size,
             ranges_to_files,
             frag_reuse_index,
+            lookup_batch,
         }
     }
 
@@ -1437,7 +1323,69 @@ impl BTreeIndex {
         ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<Self> {
-        let (page_lookup, data_type) = parse_btree_lookup(&data)?;
+        let mut map = BTreeMap::<OrderableScalarValue, Vec<PageRecord>>::new();
+        // Pages that have at least one null value
+        let mut null_pages = Vec::<u32>::new();
+        // Pages that are entirely null
+        let mut all_null_pages = Vec::<u32>::new();
+
+        if data.num_rows() == 0 {
+            let data_type = data.column(0).data_type().clone();
+            let page_lookup = Arc::new(BTreeLookup::empty());
+            return Ok(Self::new(
+                page_lookup,
+                store,
+                data_type,
+                WeakLanceCache::from(index_cache),
+                batch_size,
+                ranges_to_files,
+                frag_reuse_index,
+                data,
+            ));
+        }
+
+        let mins = data.column(0);
+        let maxs = data.column(1);
+        let null_counts = data
+            .column(2)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        let page_numbers = data
+            .column(3)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+
+        for idx in 0..data.num_rows() {
+            let min = OrderableScalarValue(ScalarValue::try_from_array(&mins, idx)?);
+            let max = OrderableScalarValue(ScalarValue::try_from_array(&maxs, idx)?);
+            let null_count = null_counts.values()[idx];
+            let page_number = page_numbers.values()[idx];
+
+            // If the page is entirely null don't even bother putting it in the tree
+            if max.0.is_null() {
+                all_null_pages.push(page_number);
+                // continue so we don't add it to the null_pages
+                continue;
+            } else {
+                map.entry(min)
+                    .or_default()
+                    .push(PageRecord { max, page_number });
+            }
+
+            if null_count > 0 {
+                null_pages.push(page_number);
+            }
+        }
+
+        let last_max = ScalarValue::try_from_array(&maxs, data.num_rows() - 1)?;
+        map.entry(OrderableScalarValue(last_max)).or_default();
+
+        let data_type = mins.data_type().clone();
+
+        let page_lookup = Arc::new(BTreeLookup::new(map, null_pages, all_null_pages));
+
         Ok(Self::new(
             page_lookup,
             store,
@@ -1446,6 +1394,7 @@ impl BTreeIndex {
             batch_size,
             ranges_to_files,
             frag_reuse_index,
+            data,
         ))
     }
 
@@ -1854,8 +1803,8 @@ impl ScalarIndex for BTreeIndex {
             for &page_id in self
                 .page_lookup
                 .null_pages
-                .keys()
-                .chain(self.page_lookup.all_null_pages.keys())
+                .iter()
+                .chain(self.page_lookup.all_null_pages.iter())
             {
                 if !existing.contains(&page_id) {
                     pages.push(Matches::Some(page_id));
@@ -2992,8 +2941,7 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
             Error::internal("BTreeIndexPlugin::put_in_cache called with a non-BTree index")
         })?;
         let state = BTreeIndexState {
-            page_lookup: btree.page_lookup.clone(),
-            data_type: btree.data_type.clone(),
+            lookup_batch: btree.lookup_batch.clone(),
             batch_size: btree.batch_size,
             ranges_to_files: btree.ranges_to_files.clone(),
         };
@@ -3010,7 +2958,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use arrow::datatypes::{Float32Type, Float64Type, Int32Type, UInt64Type};
-    use arrow_array::{FixedSizeListArray, RecordBatch, record_batch};
+    use arrow_array::{FixedSizeListArray, record_batch};
     use datafusion::{
         execution::{SendableRecordBatchStream, TaskContext},
         physical_plan::{ExecutionPlan, sorts::sort::SortExec, stream::RecordBatchStreamAdapter},
@@ -3027,7 +2975,6 @@ mod tests {
     use lance_io::object_store::ObjectStore;
     use lance_select::{RowAddrTreeMap, RowSetOps};
     use object_store::path::Path;
-    use rangemap::RangeInclusiveMap;
 
     use crate::metrics::LocalMetricsCollector;
     use crate::progress::{IndexBuildProgress, noop_progress};
@@ -3041,12 +2988,13 @@ mod tests {
     };
 
     use super::{
-        BTreeIndexPlugin, BTreeIndexState, BTreeIndexStateKey, BTreePageKey,
-        DEFAULT_BTREE_BATCH_SIZE, OrderableScalarValue, btree_lookup_as_batch, parse_btree_lookup,
-        part_lookup_file_path, part_page_data_file_path, train_btree_index,
+        BTreeIndexPlugin, BTreeIndexState, BTreePageKey, DEFAULT_BTREE_BATCH_SIZE,
+        OrderableScalarValue, part_lookup_file_path, part_page_data_file_path, train_btree_index,
     };
     use crate::scalar::registry::ScalarIndexPlugin;
+    use arrow_array::RecordBatch;
     use lance_core::cache::{CacheCodecImpl, CacheKey};
+    use rangemap::RangeInclusiveMap;
 
     lance_testing::define_stage_event_progress!(
         RecordingProgress,
@@ -5023,12 +4971,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_btree_page_key_codec() {
-        // FlatIndex pages can be serialized by a persistent cache backend.
-        assert!(BTreePageKey::codec().is_some());
-    }
-
     fn sample_lookup_batch() -> RecordBatch {
         record_batch!(
             ("min", Int32, [Some(0), Some(10), Some(20)]),
@@ -5039,62 +4981,29 @@ mod tests {
         .unwrap()
     }
 
-    fn mixed_null_lookup_batch() -> RecordBatch {
-        record_batch!(
-            ("min", Int32, [None, Some(0), Some(10)]),
-            ("max", Int32, [None, Some(9), Some(19)]),
-            ("null_count", UInt32, [1, 0, 2]),
-            ("page_idx", UInt32, [42, 0, 1])
-        )
-        .unwrap()
-    }
-
-    fn btree_state(
-        lookup_batch: RecordBatch,
-        batch_size: u64,
-        ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
-    ) -> BTreeIndexState {
-        let (page_lookup, data_type) = parse_btree_lookup(&lookup_batch).unwrap();
-        BTreeIndexState {
-            page_lookup,
-            data_type,
-            batch_size,
-            ranges_to_files,
-        }
-    }
-
-    fn btree_state_from_index(index: &BTreeIndex) -> BTreeIndexState {
-        BTreeIndexState {
-            page_lookup: index.page_lookup.clone(),
-            data_type: index.data_type.clone(),
-            batch_size: index.batch_size,
-            ranges_to_files: index.ranges_to_files.clone(),
-        }
-    }
-
     fn assert_state_roundtrips(state: &BTreeIndexState) {
         let mut buf = Vec::new();
         state.serialize(&mut buf).unwrap();
         let restored = BTreeIndexState::deserialize(&bytes::Bytes::from(buf)).unwrap();
-        assert_eq!(restored.page_lookup, state.page_lookup);
-        assert_eq!(restored.data_type, state.data_type);
+        assert_eq!(restored.lookup_batch, state.lookup_batch);
         assert_eq!(restored.batch_size, state.batch_size);
         assert_eq!(restored.ranges_to_files, state.ranges_to_files);
+    }
 
-        let restored_batch =
-            btree_lookup_as_batch(&restored.page_lookup, &restored.data_type).unwrap();
-        let (parsed_again, _) = parse_btree_lookup(&restored_batch).unwrap();
-        assert_eq!(parsed_again, restored.page_lookup);
+    #[test]
+    fn test_btree_page_key_codec() {
+        // FlatIndex pages can be serialized by a persistent cache backend.
+        assert!(BTreePageKey::codec().is_some());
     }
 
     #[test]
     fn test_btree_index_state_roundtrip() {
         // Not range-partitioned.
-        assert_state_roundtrips(&btree_state(
-            sample_lookup_batch(),
-            DEFAULT_BTREE_BATCH_SIZE,
-            None,
-        ));
+        assert_state_roundtrips(&BTreeIndexState {
+            lookup_batch: sample_lookup_batch(),
+            batch_size: DEFAULT_BTREE_BATCH_SIZE,
+            ranges_to_files: None,
+        });
 
         // Range-partitioned across multiple files.
         let ranges: RangeInclusiveMap<u32, (String, u32)> = [
@@ -5103,30 +5012,22 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        assert_state_roundtrips(&btree_state(
-            sample_lookup_batch(),
-            8192,
-            Some(Arc::new(ranges)),
-        ));
+        assert_state_roundtrips(&BTreeIndexState {
+            lookup_batch: sample_lookup_batch(),
+            batch_size: 8192,
+            ranges_to_files: Some(Arc::new(ranges)),
+        });
 
-        // Empty index keeps its data type even though it has no lookup rows.
-        assert_state_roundtrips(&btree_state(
-            RecordBatch::new_empty(sample_lookup_batch().schema()),
-            DEFAULT_BTREE_BATCH_SIZE,
-            None,
-        ));
-
-        // Mixed all-null and non-null pages must round-trip without creating a
-        // NULL sentinel in a non-empty lookup tree.
-        assert_state_roundtrips(&btree_state(
-            mixed_null_lookup_batch(),
-            DEFAULT_BTREE_BATCH_SIZE,
-            None,
-        ));
+        // Empty index.
+        assert_state_roundtrips(&BTreeIndexState {
+            lookup_batch: RecordBatch::new_empty(sample_lookup_batch().schema()),
+            batch_size: DEFAULT_BTREE_BATCH_SIZE,
+            ranges_to_files: None,
+        });
     }
 
     #[tokio::test]
-    async fn test_btree_plugin_cache_returns_deserialized_index() {
+    async fn test_btree_index_state_reconstruct_and_plugin_cache() {
         let tmpdir = TempObjDir::default();
         let test_store = Arc::new(LanceIndexStore::new(
             Arc::new(ObjectStore::local()),
@@ -5145,23 +5046,37 @@ mod tests {
         let index = BTreeIndex::load(test_store.clone(), None, &LanceCache::no_cache())
             .await
             .unwrap();
-        let index_dyn: Arc<dyn ScalarIndex> = index.clone();
+
+        // Round-trip the state through the codec and reconstruct an index from it.
+        let state = BTreeIndexState {
+            lookup_batch: index.lookup_batch.clone(),
+            batch_size: index.batch_size,
+            ranges_to_files: index.ranges_to_files.clone(),
+        };
+        let mut buf = Vec::new();
+        state.serialize(&mut buf).unwrap();
+        let restored = BTreeIndexState::deserialize(&bytes::Bytes::from(buf)).unwrap();
+        let reconstructed = restored
+            .reconstruct(test_store.clone(), &LanceCache::no_cache(), None)
+            .unwrap();
+        assert_eq!(
+            reconstructed
+                .as_any()
+                .downcast_ref::<BTreeIndex>()
+                .unwrap()
+                .page_lookup,
+            index.page_lookup
+        );
+
+        // The plugin's put/get hooks round-trip through a real cache + the codec.
         let cache = LanceCache::with_capacity(64 * 1024 * 1024);
         let plugin = BTreeIndexPlugin;
-        plugin
-            .put_in_cache(&cache, index_dyn.clone())
-            .await
-            .unwrap();
+        plugin.put_in_cache(&cache, index.clone()).await.unwrap();
         let from_cache = plugin
             .get_from_cache(test_store.clone(), None, &cache)
             .await
             .unwrap()
             .expect("index should be served from the cache");
-        let cached_btree = from_cache.as_any().downcast_ref::<BTreeIndex>().unwrap();
-        assert!(
-            Arc::ptr_eq(&cached_btree.page_lookup, &index.page_lookup),
-            "BTree cache should reuse the parsed lookup tree"
-        );
 
         // Searches against the cached index match the original.
         let query = SargableQuery::Range(
@@ -5176,51 +5091,9 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[tokio::test]
-    async fn test_btree_index_state_cache_size_includes_parsed_lookup() {
-        let tmpdir = TempObjDir::default();
-        let test_store = Arc::new(LanceIndexStore::new(
-            Arc::new(ObjectStore::local()),
-            tmpdir.clone(),
-            Arc::new(LanceCache::no_cache()),
-        ));
-
-        let stream = gen_batch()
-            .col("value", array::step::<Int32Type>())
-            .col("_rowid", array::step::<UInt64Type>())
-            .into_df_stream(RowCount::from(1000), BatchCount::from(5));
-        train_btree_index(stream, test_store.as_ref(), 1000, None, None)
-            .await
-            .unwrap();
-
-        let index = BTreeIndex::load(test_store.clone(), None, &LanceCache::no_cache())
-            .await
-            .unwrap();
-        let cache = LanceCache::with_capacity(64 * 1024 * 1024);
-        let plugin = BTreeIndexPlugin;
-        plugin.put_in_cache(&cache, index.clone()).await.unwrap();
-
-        let cached_state = cache
-            .get_with_key(&BTreeIndexStateKey)
-            .await
-            .expect("state should be cached");
-        assert!(
-            Arc::ptr_eq(&cached_state.page_lookup, &index.page_lookup),
-            "cached state should retain the parsed lookup tree"
-        );
-
-        let arc_overhead = std::mem::size_of::<std::sync::atomic::AtomicUsize>() * 2;
-        let expected_size = cached_state.deep_size_of() + arc_overhead;
-        let charged_size = cache.size_bytes().await;
-        let size_diff = charged_size.abs_diff(expected_size);
-        assert!(
-            size_diff <= std::mem::size_of::<usize>() * 2,
-            "cache charged {charged_size} bytes, expected about {expected_size} bytes"
-        );
-    }
-
     #[test]
     fn test_btree_index_state_rejects_invalid_has_ranges_tag() {
+        // u64 batch_size (any) then a bad has_ranges tag.
         let mut buf = Vec::new();
         buf.extend_from_slice(&1000u64.to_le_bytes());
         buf.push(7u8);
@@ -5229,67 +5102,6 @@ mod tests {
         assert!(
             msg.contains("has_ranges") && msg.contains("7"),
             "expected error to mention the bad has_ranges tag, got: {msg}"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_btree_load_applies_frag_reuse_index() {
-        use crate::frag_reuse::{FragReuseIndex, FragReuseIndexDetails};
-        use std::collections::HashMap;
-        use uuid::Uuid;
-
-        let tmpdir = TempObjDir::default();
-        let test_store = Arc::new(LanceIndexStore::new(
-            Arc::new(ObjectStore::local()),
-            tmpdir.clone(),
-            Arc::new(LanceCache::no_cache()),
-        ));
-
-        // value == _rowid for all rows in [0, 1000).
-        let stream = gen_batch()
-            .col("value", array::step::<Int32Type>())
-            .col("_rowid", array::step::<UInt64Type>())
-            .into_df_stream(RowCount::from(1000), BatchCount::from(1));
-        train_btree_index(stream, test_store.as_ref(), 1000, None, None)
-            .await
-            .unwrap();
-
-        // Remap row 0 -> row 5000 (outside the original [0, 1000) range so no collision).
-        // Querying for value == 0 should now return row 5000, confirming the
-        // BTree load path threads the FragReuseIndex into the index.
-        let frag_reuse_index = Arc::new(FragReuseIndex::new(
-            Uuid::new_v4(),
-            vec![HashMap::from([(0u64, Some(5000u64))])],
-            FragReuseIndexDetails { versions: vec![] },
-        ));
-        let index = BTreeIndex::load(
-            test_store.clone(),
-            Some(frag_reuse_index),
-            &LanceCache::no_cache(),
-        )
-        .await
-        .unwrap();
-
-        let result = index
-            .search(
-                &SargableQuery::Equals(ScalarValue::Int32(Some(0))),
-                &NoOpMetricsCollector,
-            )
-            .await
-            .unwrap();
-        let row_ids: Vec<u64> = match &result {
-            SearchResult::Exact(set) => set
-                .true_rows()
-                .row_addrs()
-                .unwrap()
-                .map(u64::from)
-                .collect(),
-            other => panic!("expected Exact, got {other:?}"),
-        };
-        assert_eq!(
-            row_ids,
-            vec![5000],
-            "frag_reuse_index remap was not applied"
         );
     }
 
@@ -5318,8 +5130,15 @@ mod tests {
         let index = BTreeIndex::load(test_store.clone(), None, &LanceCache::no_cache())
             .await
             .unwrap();
-        let state = btree_state_from_index(&index);
+        let state = BTreeIndexState {
+            lookup_batch: index.lookup_batch.clone(),
+            batch_size: index.batch_size,
+            ranges_to_files: index.ranges_to_files.clone(),
+        };
 
+        // Remap row 0 -> row 5000 (outside the original [0, 1000) range so no collision).
+        // Querying for value == 0 should now return row 5000, confirming reconstruct threaded
+        // the FragReuseIndex through to the rebuilt BTreeIndex.
         let frag_reuse_index = Arc::new(FragReuseIndex::new(
             Uuid::new_v4(),
             vec![HashMap::from([(0u64, Some(5000u64))])],
@@ -5357,10 +5176,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_btree_range_partitioned_plugin_cache_roundtrip() {
+    async fn test_btree_index_state_range_partitioned_plugin_cache_roundtrip() {
         // Build a range-partitioned BTree (two range partitions merged into one index) and
         // round-trip it through the plugin's cache hooks. This exercises the
-        // `ranges_to_files = Some` path end-to-end.
+        // `ranges_to_files = Some` path end-to-end through serialize/deserialize/reconstruct.
         let tmpdir = TempObjDir::default();
         let store = Arc::new(LanceIndexStore::new(
             Arc::new(ObjectStore::local()),

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -687,10 +687,17 @@ where
 ///
 /// The batch holds one row per page with columns `min | max | null_count | page_idx`,
 /// sorted ascending by `min` with NULLs first (the order the index is trained in).
-/// The batch is the single source of truth: range searches binary-search the `min`
-/// column for a starting row and scan forward filtering by `max`, type-dispatched
-/// per column type via [`make_comparator`]. This avoids materializing a parallel
-/// `BTreeMap` of owned `ScalarValue`s alongside the Arrow buffers.
+/// The batch is the single source of truth, avoiding a parallel `BTreeMap` of owned
+/// `ScalarValue`s alongside the Arrow buffers. Both query paths binary-search the
+/// sorted `min` column for a starting row and scan forward filtering by `max`:
+///
+/// - Equality / `IN` (`candidate_pages_for_values`) dispatch on the query's
+///   *physical storage type* to a monomorphized, inlined comparator: numerics go
+///   through `scan_native` (logical types sharing a native — e.g. `Date32` and
+///   `Int32` — fold to one path), byte-likes through `scan_accessor`. Only types
+///   without a native fast path (struct-backed intervals, booleans) fall back to the
+///   boxed [`make_comparator`] via `scan_fallback`.
+/// - Range searches (`pages_between`) currently use [`make_comparator`] directly.
 #[derive(Debug)]
 pub struct BTreeLookup {
     /// One row per page (`min | max | null_count | page_idx`), sorted by `min`.
@@ -992,6 +999,7 @@ impl BTreeLookup {
     /// Monomorphized over the comparator closures so a typed-native comparator
     /// inlines (no per-call vtable dispatch). The closures encode NULLs-first,
     /// ascending order:
+    ///   * `max_is_null(i)` — whether page `i`'s `max` is null (an all-null page)
     ///   * `cmp_min(i, j)` — page `i`'s `min` vs query value `j`
     ///   * `cmp_max(i, j)` — page `i`'s `max` vs query value `j`
     ///   * `cmp_min_min(i, anchor)` — two page `min`s, to expand left onto a straddle
@@ -1378,7 +1386,7 @@ impl CacheKey for BTreePageKey {
 /// `BTreeIndex::try_from_serialized` reconstructs the in-memory lookup with
 /// no IO) plus the page batch size and range-partition map.
 #[derive(Debug, Clone)]
-pub struct BTreeIndexState {
+struct BTreeIndexState {
     lookup_batch: RecordBatch,
     batch_size: u64,
     ranges_to_files: Option<Arc<RangeInclusiveMap<u32, (String, u32)>>>,
@@ -5370,7 +5378,10 @@ mod tests {
     /// columns, including the null-min straddle page and duplicate `min`s.
     #[test]
     fn test_btree_lookup_pages_eq_bytes() {
-        use arrow_array::{ArrayRef, BinaryArray, FixedSizeBinaryArray, UInt32Array};
+        use arrow_array::{
+            ArrayRef, BinaryArray, FixedSizeBinaryArray, LargeBinaryArray, LargeStringArray,
+            UInt32Array,
+        };
         use arrow_schema::{DataType, Field, Schema};
 
         // 2-byte big-endian keys, so lexicographic byte order matches numeric
@@ -5449,6 +5460,26 @@ mod tests {
         };
         assert_byte_lookup(bin(&mins), bin(&maxs), &|v| {
             ScalarValue::Binary(Some(be(v).to_vec()))
+        });
+
+        let lbin = |arr: &[Option<u16>]| -> ArrayRef {
+            Arc::new(LargeBinaryArray::from_iter(
+                arr.iter().copied().map(|o| o.map(|v| be(v).to_vec())),
+            ))
+        };
+        assert_byte_lookup(lbin(&mins), lbin(&maxs), &|v| {
+            ScalarValue::LargeBinary(Some(be(v).to_vec()))
+        });
+
+        // `LargeUtf8` over zero-padded decimal strings, whose lexicographic order
+        // matches the numeric order of the keys.
+        let lstr = |arr: &[Option<u16>]| -> ArrayRef {
+            Arc::new(LargeStringArray::from_iter(
+                arr.iter().copied().map(|o| o.map(|v| format!("{v:02}"))),
+            ))
+        };
+        assert_byte_lookup(lstr(&mins), lstr(&maxs), &|v| {
+            ScalarValue::LargeUtf8(Some(format!("{v:02}")))
         });
     }
 
@@ -5533,6 +5564,344 @@ mod tests {
                 Some(50),
             ])),
             &|v| ScalarValue::Date32(Some(v as i32)),
+        );
+    }
+
+    /// Exercises the remaining physical-type dispatch arms that the temporal and
+    /// byte tests don't reach: every integer width and signedness, `Float16`, and
+    /// the 128-/256-bit decimal paths. All share the temporal test's numeric layout
+    /// (mins `[_, 10, 20, 20, 40]`, maxs `[5, 20, 20, 30, 50]`) so the assertions are
+    /// identical; only the array/scalar type varies.
+    #[test]
+    fn test_btree_lookup_pages_eq_numeric_widths() {
+        use arrow::datatypes::i256;
+        use arrow_array::{
+            ArrayRef, Decimal128Array, Decimal256Array, Float16Array, Int8Array, Int16Array,
+            UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+        };
+        use arrow_schema::{DataType, Field, Schema};
+        use half::f16;
+
+        let null_count = UInt32Array::from(vec![2u32, 0, 0, 0, 0]);
+        let page_idx = UInt32Array::from(vec![0u32, 1, 2, 3, 4]);
+        let assert_lookup =
+            |min_arr: ArrayRef, max_arr: ArrayRef, sv: &dyn Fn(i64) -> ScalarValue| {
+                let batch = RecordBatch::try_new(
+                    Arc::new(Schema::new(vec![
+                        Field::new("min", min_arr.data_type().clone(), true),
+                        Field::new("max", max_arr.data_type().clone(), true),
+                        Field::new("null_count", DataType::UInt32, false),
+                        Field::new("page_idx", DataType::UInt32, false),
+                    ])),
+                    vec![
+                        min_arr,
+                        max_arr,
+                        Arc::new(null_count.clone()),
+                        Arc::new(page_idx.clone()),
+                    ],
+                )
+                .unwrap();
+                let lookup = BTreeLookup::try_new(batch).unwrap();
+                let eq = |v: i64| {
+                    let mut p: Vec<u32> = lookup
+                        .pages_eq(&OrderableScalarValue(sv(v)))
+                        .unwrap()
+                        .into_iter()
+                        .map(|m| m.page_id())
+                        .collect();
+                    p.sort_unstable();
+                    p
+                };
+                assert_eq!(eq(15), vec![1]); // only page 1 ([10, 20])
+                assert_eq!(eq(20), vec![1, 2, 3]); // shared min of 2 & 3, max of 1
+                assert!(eq(35).is_empty()); // gap between pages 3 and 4
+                assert_eq!(eq(5), vec![0]); // reaches the null-min straddle via its max
+            };
+
+        assert_lookup(
+            Arc::new(Int8Array::from(vec![
+                None,
+                Some(10),
+                Some(20),
+                Some(20),
+                Some(40),
+            ])),
+            Arc::new(Int8Array::from(vec![
+                Some(5),
+                Some(20),
+                Some(20),
+                Some(30),
+                Some(50),
+            ])),
+            &|v| ScalarValue::Int8(Some(v as i8)),
+        );
+        assert_lookup(
+            Arc::new(Int16Array::from(vec![
+                None,
+                Some(10),
+                Some(20),
+                Some(20),
+                Some(40),
+            ])),
+            Arc::new(Int16Array::from(vec![
+                Some(5),
+                Some(20),
+                Some(20),
+                Some(30),
+                Some(50),
+            ])),
+            &|v| ScalarValue::Int16(Some(v as i16)),
+        );
+        assert_lookup(
+            Arc::new(UInt8Array::from(vec![
+                None,
+                Some(10),
+                Some(20),
+                Some(20),
+                Some(40),
+            ])),
+            Arc::new(UInt8Array::from(vec![
+                Some(5),
+                Some(20),
+                Some(20),
+                Some(30),
+                Some(50),
+            ])),
+            &|v| ScalarValue::UInt8(Some(v as u8)),
+        );
+        assert_lookup(
+            Arc::new(UInt16Array::from(vec![
+                None,
+                Some(10),
+                Some(20),
+                Some(20),
+                Some(40),
+            ])),
+            Arc::new(UInt16Array::from(vec![
+                Some(5),
+                Some(20),
+                Some(20),
+                Some(30),
+                Some(50),
+            ])),
+            &|v| ScalarValue::UInt16(Some(v as u16)),
+        );
+        assert_lookup(
+            Arc::new(UInt32Array::from(vec![
+                None,
+                Some(10),
+                Some(20),
+                Some(20),
+                Some(40),
+            ])),
+            Arc::new(UInt32Array::from(vec![
+                Some(5),
+                Some(20),
+                Some(20),
+                Some(30),
+                Some(50),
+            ])),
+            &|v| ScalarValue::UInt32(Some(v as u32)),
+        );
+        assert_lookup(
+            Arc::new(UInt64Array::from(vec![
+                None,
+                Some(10),
+                Some(20),
+                Some(20),
+                Some(40),
+            ])),
+            Arc::new(UInt64Array::from(vec![
+                Some(5),
+                Some(20),
+                Some(20),
+                Some(30),
+                Some(50),
+            ])),
+            &|v| ScalarValue::UInt64(Some(v as u64)),
+        );
+
+        let f = |v: f64| f16::from_f64(v);
+        assert_lookup(
+            Arc::new(Float16Array::from(vec![
+                None,
+                Some(f(10.0)),
+                Some(f(20.0)),
+                Some(f(20.0)),
+                Some(f(40.0)),
+            ])),
+            Arc::new(Float16Array::from(vec![
+                Some(f(5.0)),
+                Some(f(20.0)),
+                Some(f(20.0)),
+                Some(f(30.0)),
+                Some(f(50.0)),
+            ])),
+            &|v| ScalarValue::Float16(Some(f(v as f64))),
+        );
+
+        // Decimal128 (i128 native path). Comparison is on the raw integer, so a
+        // scale of 0 lets the values double as plain integers.
+        let dec128 = |vals: Vec<Option<i128>>| -> ArrayRef {
+            Arc::new(
+                Decimal128Array::from(vals)
+                    .with_precision_and_scale(18, 0)
+                    .unwrap(),
+            )
+        };
+        assert_lookup(
+            dec128(vec![None, Some(10), Some(20), Some(20), Some(40)]),
+            dec128(vec![Some(5), Some(20), Some(20), Some(30), Some(50)]),
+            &|v| ScalarValue::Decimal128(Some(v as i128), 18, 0),
+        );
+
+        // Decimal256 (i256 native path).
+        let dec256 = |vals: Vec<Option<i128>>| -> ArrayRef {
+            Arc::new(
+                Decimal256Array::from(
+                    vals.into_iter()
+                        .map(|o| o.map(i256::from_i128))
+                        .collect::<Vec<_>>(),
+                )
+                .with_precision_and_scale(40, 0)
+                .unwrap(),
+            )
+        };
+        assert_lookup(
+            dec256(vec![None, Some(10), Some(20), Some(20), Some(40)]),
+            dec256(vec![Some(5), Some(20), Some(20), Some(30), Some(50)]),
+            &|v| ScalarValue::Decimal256(Some(i256::from_i128(v as i128)), 40, 0),
+        );
+    }
+
+    /// Exercises the NULL paths of the lookup directly: `pages_eq(NULL)` and
+    /// `pages_in` with a NULL in the value list (and a NULL-only list), including
+    /// the partial-null (`Some`) vs entirely-null (`All`) page classification.
+    #[test]
+    fn test_btree_lookup_pages_null() {
+        // Page 0 is entirely null (null max -> All); page 1 is a partial-null
+        // straddle (max 5, null_count > 0 -> Some); page 2 also carries a null.
+        let batch = record_batch!(
+            ("min", Int32, [None, None, Some(10), Some(20), Some(40)]),
+            ("max", Int32, [None, Some(5), Some(20), Some(30), Some(50)]),
+            ("null_count", UInt32, [3, 2, 1, 0, 0]),
+            ("page_idx", UInt32, [0, 1, 2, 3, 4])
+        )
+        .unwrap();
+        let lookup = BTreeLookup::try_new(batch).unwrap();
+        assert_eq!(lookup.all_null_pages, vec![0]);
+        assert_eq!(lookup.null_pages, vec![1, 2]);
+
+        // pages_eq(NULL) short-circuits to the null pages: partial-null pages are
+        // `Some`, the entirely-null page is `All`.
+        assert_eq!(
+            lookup
+                .pages_eq(&OrderableScalarValue(ScalarValue::Int32(None)))
+                .unwrap(),
+            vec![Matches::Some(1), Matches::Some(2), Matches::All(0)]
+        );
+
+        let in_ids = |vals: Vec<Option<i32>>| {
+            let mut p: Vec<u32> = lookup
+                .pages_in(
+                    vals.into_iter()
+                        .map(|v| OrderableScalarValue(ScalarValue::Int32(v))),
+                )
+                .unwrap()
+                .into_iter()
+                .map(|m| m.page_id())
+                .collect();
+            p.sort_unstable();
+            p
+        };
+        // Baseline: a non-null value only -> just its value page.
+        assert_eq!(in_ids(vec![Some(45)]), vec![4]);
+        // A NULL in the list unions in every null page (0, 1, 2).
+        assert_eq!(in_ids(vec![Some(45), None]), vec![0, 1, 2, 4]);
+        // A NULL-only list (empty non-null set) returns exactly the null pages.
+        assert_eq!(in_ids(vec![None]), vec![0, 1, 2]);
+    }
+
+    /// A 0-row page_lookup batch (an index over an empty dataset) must yield no
+    /// candidates for any query rather than panicking on the binary-search bounds.
+    #[test]
+    fn test_btree_lookup_empty_batch() {
+        use arrow_schema::{DataType, Field, Schema};
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("min", DataType::Int32, true),
+            Field::new("max", DataType::Int32, true),
+            Field::new("null_count", DataType::UInt32, false),
+            Field::new("page_idx", DataType::UInt32, false),
+        ]));
+        let lookup = BTreeLookup::try_new(RecordBatch::new_empty(schema)).unwrap();
+        assert_eq!(lookup.search_start, 0);
+        assert!(lookup.null_pages.is_empty());
+        assert!(lookup.all_null_pages.is_empty());
+
+        assert!(lookup.pages_eq(&osv(5)).unwrap().is_empty());
+        assert!(lookup.pages_in([osv(5)]).unwrap().is_empty());
+        assert!(
+            lookup
+                .pages_between((
+                    std::ops::Bound::Included(&osv(0)),
+                    std::ops::Bound::Included(&osv(100)),
+                ))
+                .unwrap()
+                .is_empty()
+        );
+        assert!(lookup.pages_null().is_empty());
+    }
+
+    /// A straddle page (null `min`, non-null `max`) can sort ahead of an entirely-
+    /// null page within the leading NULL-`min` group. When it does, `search_start`
+    /// points at the straddle and the all-null page falls inside the forward-scan
+    /// window, so both the equality and range scans must skip it (it matches only
+    /// IS NULL).
+    #[test]
+    fn test_btree_lookup_skips_all_null_page_in_scan_window() {
+        // Page 0: straddle (null min, max 5). Page 1: entirely null (null min/max).
+        let batch = record_batch!(
+            ("min", Int32, [None, None, Some(10), Some(20), Some(40)]),
+            ("max", Int32, [Some(5), None, Some(20), Some(30), Some(50)]),
+            ("null_count", UInt32, [2, 3, 0, 0, 0]),
+            ("page_idx", UInt32, [0, 1, 2, 3, 4])
+        )
+        .unwrap();
+        let lookup = BTreeLookup::try_new(batch).unwrap();
+        assert_eq!(lookup.search_start, 0); // straddle page 0 has a non-null max
+        assert_eq!(lookup.all_null_pages, vec![1]);
+        assert_eq!(lookup.null_pages, vec![0]);
+
+        // Equality for 5 peeks left across the all-null page 1 (index 1, inside the
+        // scan window) and must skip it, reaching only the straddle page 0.
+        assert_eq!(
+            lookup
+                .pages_eq(&osv(5))
+                .unwrap()
+                .into_iter()
+                .map(|m| m.page_id())
+                .collect::<Vec<_>>(),
+            vec![0]
+        );
+
+        // The same all-null page sits inside the range scan window and is skipped:
+        // page 0 (straddle) is a partial match, pages 2-4 are fully covered.
+        let mut between = lookup
+            .pages_between((
+                std::ops::Bound::Included(&osv(0)),
+                std::ops::Bound::Included(&osv(100)),
+            ))
+            .unwrap();
+        between.sort_by_key(|m| m.page_id());
+        assert_eq!(
+            between,
+            vec![
+                Matches::Some(0),
+                Matches::All(2),
+                Matches::All(3),
+                Matches::All(4),
+            ]
         );
     }
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -741,8 +741,9 @@ impl BTreeLookup {
         // single value cannot cover an entire page's range, so every candidate is
         // `Matches::Some`. Refining this for low-cardinality data is the TODO in
         // `pages_between`.
+        let values = values.into_iter();
         let mut has_null = false;
-        let mut non_null = Vec::new();
+        let mut non_null = Vec::with_capacity(values.size_hint().0);
         for val in values {
             if val.0.is_null() {
                 has_null = true;
@@ -797,7 +798,9 @@ impl BTreeLookup {
         let cmp_max = make_comparator(maxs, query, opts)?;
         let cmp_min_min = make_comparator(mins, mins, opts)?;
 
-        let mut pages = Vec::new();
+        // High-cardinality lookups hit ~one page per value; presize to avoid the
+        // element-by-element `RawVec` growth that profiling flagged.
+        let mut pages = Vec::with_capacity(query.len());
         for j in 0..query.len() {
             // Start row: peek a little to the left of the value. A query for 7 must
             // still reach a page like [5, 10], so we include every page whose `min`

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -28,7 +28,10 @@ use crate::{
 use crate::{metrics::NoOpMetricsCollector, scalar::registry::TrainingCriteria};
 use crate::{pbold, scalar::btree::flat::FlatIndex};
 use arrow_arith::numeric::add;
-use arrow_array::{Array, ArrayAccessor, RecordBatch, UInt32Array, cast::AsArray, new_empty_array};
+use arrow_array::{
+    Array, ArrayAccessor, ArrowNativeTypeOp, PrimitiveArray, RecordBatch, UInt32Array,
+    cast::AsArray, downcast_primitive, new_empty_array, types::ArrowPrimitiveType,
+};
 use arrow_ord::ord::make_comparator;
 use arrow_schema::{DataType, Field, Schema, SortOptions};
 use async_trait::async_trait;
@@ -633,6 +636,24 @@ where
     }
 }
 
+/// Like [`accessor_cmp`] but for primitive columns, comparing native values with
+/// [`ArrowNativeTypeOp::compare`] (total order, so floats match arrow's NaN-last
+/// `make_comparator` ordering).
+fn primitive_cmp<'a, T>(
+    left: &'a PrimitiveArray<T>,
+    right: &'a PrimitiveArray<T>,
+) -> impl Fn(usize, usize) -> Ordering + 'a
+where
+    T: ArrowPrimitiveType,
+{
+    move |i, j| match (left.is_null(i), right.is_null(j)) {
+        (true, true) => Ordering::Equal,
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        (false, false) => left.value(i).compare(right.value(j)),
+    }
+}
+
 /// Satisfies scalar queries by searching the `page_lookup.lance` batch directly.
 ///
 /// The batch holds one row per page with columns `min | max | null_count | page_idx`,
@@ -805,36 +826,57 @@ impl BTreeLookup {
         let maxs = self.batch.column(1).as_ref();
         let page_ids = self.page_numbers()?.values();
 
-        // For byte-like columns we downcast once and compare with native `Ord`
-        // closures that inline into the scan, instead of going through the boxed
-        // `DynComparator` (one vtable call per comparison). The query array always
-        // matches the column type, so a single match on its type covers both columns.
-        match query.data_type() {
-            DataType::Utf8 => {
-                let mins = mins.as_string::<i32>();
-                let maxs = maxs.as_string::<i32>();
-                let query = query.as_string::<i32>();
-                Ok(self.scan_equality_pages(
+        // For primitive and byte-like columns we downcast once and compare with
+        // native closures that inline into the scan, instead of going through the
+        // boxed `DynComparator` (one vtable call per comparison). The query array
+        // always matches the column type, so its type selects both columns' branch.
+        macro_rules! scan_primitive {
+            ($t:ty) => {{
+                let mins = mins.as_primitive::<$t>();
+                let maxs = maxs.as_primitive::<$t>();
+                let query = query.as_primitive::<$t>();
+                self.scan_equality_pages(
+                    query.len(),
+                    page_ids,
+                    |idx| maxs.is_null(idx),
+                    primitive_cmp(mins, query),
+                    primitive_cmp(maxs, query),
+                    primitive_cmp(mins, mins),
+                )
+            }};
+        }
+        macro_rules! scan_bytes {
+            ($mins:expr, $maxs:expr, $query:expr) => {{
+                let mins = $mins;
+                let maxs = $maxs;
+                let query = $query;
+                self.scan_equality_pages(
                     query.len(),
                     page_ids,
                     |idx| maxs.is_null(idx),
                     accessor_cmp(mins, query),
                     accessor_cmp(maxs, query),
                     accessor_cmp(mins, mins),
-                ))
+                )
+            }};
+        }
+
+        let pages = downcast_primitive! {
+            query.data_type() => (scan_primitive),
+            DataType::Utf8 => {
+                scan_bytes!(mins.as_string::<i32>(), maxs.as_string::<i32>(), query.as_string::<i32>())
             }
             DataType::LargeUtf8 => {
-                let mins = mins.as_string::<i64>();
-                let maxs = maxs.as_string::<i64>();
-                let query = query.as_string::<i64>();
-                Ok(self.scan_equality_pages(
-                    query.len(),
-                    page_ids,
-                    |idx| maxs.is_null(idx),
-                    accessor_cmp(mins, query),
-                    accessor_cmp(maxs, query),
-                    accessor_cmp(mins, mins),
-                ))
+                scan_bytes!(mins.as_string::<i64>(), maxs.as_string::<i64>(), query.as_string::<i64>())
+            }
+            DataType::Binary => {
+                scan_bytes!(mins.as_binary::<i32>(), maxs.as_binary::<i32>(), query.as_binary::<i32>())
+            }
+            DataType::LargeBinary => {
+                scan_bytes!(mins.as_binary::<i64>(), maxs.as_binary::<i64>(), query.as_binary::<i64>())
+            }
+            DataType::FixedSizeBinary(_) => {
+                scan_bytes!(mins.as_fixed_size_binary(), maxs.as_fixed_size_binary(), query.as_fixed_size_binary())
             }
             _ => {
                 // The batch is sorted ascending by `min` with NULLs first; compare the
@@ -846,16 +888,17 @@ impl BTreeLookup {
                 let cmp_min = make_comparator(mins, query, opts)?;
                 let cmp_max = make_comparator(maxs, query, opts)?;
                 let cmp_min_min = make_comparator(mins, mins, opts)?;
-                Ok(self.scan_equality_pages(
+                self.scan_equality_pages(
                     query.len(),
                     page_ids,
                     |idx| maxs.is_null(idx),
                     cmp_min,
                     cmp_max,
                     cmp_min_min,
-                ))
+                )
             }
-        }
+        };
+        Ok(pages)
     }
 
     /// Binary-search + forward-scan the page batch for equality candidates.
@@ -5234,6 +5277,93 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    /// Exercises the native byte comparator path (`accessor_cmp`) for
+    /// variable-length `Binary` and fixed-width `FixedSizeBinary` (e.g. UUID)
+    /// columns, including the null-min straddle page and duplicate `min`s.
+    #[test]
+    fn test_btree_lookup_pages_eq_bytes() {
+        use arrow_array::{ArrayRef, BinaryArray, FixedSizeBinaryArray, UInt32Array};
+        use arrow_schema::{DataType, Field, Schema};
+
+        // 2-byte big-endian keys, so lexicographic byte order matches numeric
+        // order. Same layout as the int test: page 0 is a null-min straddle,
+        // pages 2 and 3 share `min` 20, and 35 falls in a gap.
+        fn be(v: u16) -> [u8; 2] {
+            v.to_be_bytes()
+        }
+        let mins = [None, Some(10u16), Some(20), Some(20), Some(40)];
+        let maxs = [Some(5u16), Some(20), Some(20), Some(30), Some(50)];
+        let null_count = UInt32Array::from(vec![2u32, 0, 0, 0, 0]);
+        let page_idx = UInt32Array::from(vec![0u32, 1, 2, 3, 4]);
+
+        let assert_byte_lookup =
+            |min_arr: ArrayRef, max_arr: ArrayRef, sv: &dyn Fn(u16) -> ScalarValue| {
+                let batch = RecordBatch::try_new(
+                    Arc::new(Schema::new(vec![
+                        Field::new("min", min_arr.data_type().clone(), true),
+                        Field::new("max", max_arr.data_type().clone(), true),
+                        Field::new("null_count", DataType::UInt32, false),
+                        Field::new("page_idx", DataType::UInt32, false),
+                    ])),
+                    vec![
+                        min_arr,
+                        max_arr,
+                        Arc::new(null_count.clone()),
+                        Arc::new(page_idx.clone()),
+                    ],
+                )
+                .unwrap();
+                let lookup = BTreeLookup::try_new(batch).unwrap();
+
+                let eq = |v: u16| {
+                    let mut p: Vec<u32> = lookup
+                        .pages_eq(&OrderableScalarValue(sv(v)))
+                        .unwrap()
+                        .into_iter()
+                        .map(|m| m.page_id())
+                        .collect();
+                    p.sort_unstable();
+                    p
+                };
+                assert_eq!(eq(15), vec![1]); // only page 1 ([10, 20])
+                assert_eq!(eq(20), vec![1, 2, 3]); // shared min of 2 & 3, max of 1
+                assert!(eq(35).is_empty()); // gap between pages 3 and 4
+                assert_eq!(eq(5), vec![0]); // reaches the null-min straddle via its max
+
+                // IN merges and dedups across values.
+                let mut in_pages: Vec<u32> = lookup
+                    .pages_in([5u16, 15].into_iter().map(|v| OrderableScalarValue(sv(v))))
+                    .unwrap()
+                    .into_iter()
+                    .map(|m| m.page_id())
+                    .collect();
+                in_pages.sort_unstable();
+                assert_eq!(in_pages, vec![0, 1]);
+            };
+
+        let fsb = |arr: &[Option<u16>]| -> ArrayRef {
+            Arc::new(
+                FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+                    arr.iter().copied().map(|o| o.map(be)),
+                    2,
+                )
+                .unwrap(),
+            )
+        };
+        assert_byte_lookup(fsb(&mins), fsb(&maxs), &|v| {
+            ScalarValue::FixedSizeBinary(2, Some(be(v).to_vec()))
+        });
+
+        let bin = |arr: &[Option<u16>]| -> ArrayRef {
+            Arc::new(BinaryArray::from_iter(
+                arr.iter().copied().map(|o| o.map(|v| be(v).to_vec())),
+            ))
+        };
+        assert_byte_lookup(bin(&mins), bin(&maxs), &|v| {
+            ScalarValue::Binary(Some(be(v).to_vec()))
+        });
     }
 
     fn assert_state_roundtrips(state: &BTreeIndexState) {

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -4,7 +4,7 @@
 use std::{
     any::Any,
     cmp::Ordering,
-    collections::{BinaryHeap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     fmt::{Debug, Display},
     ops::Bound,
     sync::Arc,
@@ -726,7 +726,9 @@ impl BTreeLookup {
         if query.0.is_null() {
             Ok(self.pages_null())
         } else {
-            self.pages_between((Bound::Included(query), Bound::Excluded(query)))
+            let query_arr = query.0.to_array_of_size(1)?;
+            let pages = self.candidate_pages_for_values(query_arr.as_ref())?;
+            Ok(pages.into_iter().map(Matches::Some).collect())
         }
     }
 
@@ -735,26 +737,98 @@ impl BTreeLookup {
         &self,
         values: impl IntoIterator<Item = OrderableScalarValue>,
     ) -> Result<Vec<Matches>> {
-        // TODO: Right now we convert all Matches::All into Matches::Some.  We could refine this.
-        // It would improve performance on low cardinality data.
-        let page_lists = values
-            .into_iter()
-            .map(|val| {
-                Ok(self
-                    .pages_eq(&val)?
-                    .into_iter()
-                    .map(|matches| matches.page_id())
-                    .collect::<Vec<_>>())
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let total_size = page_lists.iter().map(|set| set.len()).sum();
-        let mut heap = BinaryHeap::with_capacity(total_size);
-        for page_list in page_lists {
-            heap.extend(page_list);
+        // Equality lookups never produce a full-page (`Matches::All`) match because a
+        // single value cannot cover an entire page's range, so every candidate is
+        // `Matches::Some`. Refining this for low-cardinality data is the TODO in
+        // `pages_between`.
+        let mut has_null = false;
+        let mut non_null = Vec::new();
+        for val in values {
+            if val.0.is_null() {
+                has_null = true;
+            } else {
+                non_null.push(val.0);
+            }
         }
-        let mut all_pages = heap.into_sorted_vec();
+
+        // Build a single array holding every queried value so the comparators are
+        // constructed once and reused across all of them, rather than per value.
+        let mut all_pages = if non_null.is_empty() {
+            Vec::new()
+        } else {
+            let query_arr = ScalarValue::iter_to_array(non_null)?;
+            self.candidate_pages_for_values(query_arr.as_ref())?
+        };
+        if has_null {
+            all_pages.extend(self.pages_null().into_iter().map(|m| m.page_id()));
+        }
+        all_pages.sort_unstable();
         all_pages.dedup();
         Ok(all_pages.into_iter().map(Matches::Some).collect())
+    }
+
+    /// Candidate page numbers (deduped, ascending) for an equality search against
+    /// every value in `query`. A page is a candidate when its `[min, max]` range
+    /// could contain the value, i.e. `min <= value <= max`.
+    ///
+    /// The comparators are built once over the whole `query` array and reused for
+    /// each value, so an N-value `IN` costs three comparator constructions instead
+    /// of three per value.
+    fn candidate_pages_for_values(&self, query: &dyn Array) -> Result<Vec<u32>> {
+        let num_rows = self.batch.num_rows();
+        if self.search_start >= num_rows || query.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mins = self.batch.column(0).as_ref();
+        let maxs = self.batch.column(1).as_ref();
+        let page_numbers = self.page_numbers()?;
+
+        // The batch is sorted ascending by `min` with NULLs first; compare the
+        // query values the same way so the binary searches stay consistent.
+        let opts = SortOptions {
+            descending: false,
+            nulls_first: true,
+        };
+        // `cmp_min(i, j)` compares page `i`'s `min` against query value `j`;
+        // `cmp_max` likewise for `max`. `cmp_min_min` compares two page `min`s and
+        // is used to expand left onto a straddling page.
+        let cmp_min = make_comparator(mins, query, opts)?;
+        let cmp_max = make_comparator(maxs, query, opts)?;
+        let cmp_min_min = make_comparator(mins, mins, opts)?;
+
+        let mut pages = Vec::new();
+        for j in 0..query.len() {
+            // Start row: peek a little to the left of the value. A query for 7 must
+            // still reach a page like [5, 10], so we include every page whose `min`
+            // equals the largest `min` strictly less than the value.
+            let p = partition_point(0, num_rows, |i| cmp_min(i, j) == Ordering::Less);
+            let start = if p == 0 {
+                self.search_start
+            } else {
+                let anchor = p - 1;
+                partition_point(0, p, |i| cmp_min_min(i, anchor) == Ordering::Less)
+            }
+            .max(self.search_start);
+
+            // End row: pages whose `min` exceeds the value cannot match.
+            let end = partition_point(start, num_rows, |i| cmp_min(i, j) != Ordering::Greater);
+
+            for idx in start..end {
+                // All-null pages are only matched by IS NULL queries.
+                if maxs.is_null(idx) {
+                    continue;
+                }
+                // Candidate when the page's `max` reaches the value (`max >= value`).
+                if cmp_max(idx, j) != Ordering::Less {
+                    pages.push(page_numbers.values()[idx]);
+                }
+            }
+        }
+
+        pages.sort_unstable();
+        pages.dedup();
+        Ok(pages)
     }
 
     // All pages that could have a value in the range


### PR DESCRIPTION
Closes #6802.

`BTreeIndex` held both the `page_lookup.lance` batch and a parallel `BTreeLookup` (a `BTreeMap<OrderableScalarValue, Vec<PageRecord>>` plus null-page lists), duplicating every min/max value as owned `ScalarValue`s alongside the Arrow buffers.

This PR rewrites `BTreeLookup` to wrap the lookup batch as the single source of truth:

- Range searches binary-search the sorted `min` column via `arrow_ord::make_comparator`, then scan forward filtering by `max` and classify `Matches::Some`/`All` — same big-O as before, with packed Arrow buffers instead of scattered tree nodes. Only the small all-null / partial-null page index lists are precomputed.
- Equality / `IN` lookups go through a shared `candidate_pages_for_values` that compares query values against the page columns with a native, inlined comparator (no boxed `DynComparator` vtable call per comparison). Dispatch is on the **physical storage type**: logical types backed by the same native are reinterpreted to one path — zero-copy when already that type, otherwise an O(1) `ArrayData` relabel with no value copy — so every `Date32`/`Time32`/`Decimal32`/`IntervalYearMonth` reuses the `i32` path and every `Date64`/`Time64`/`Timestamp`/`Duration`/`Decimal64` reuses the `i64` path, rather than each generating its own. Byte-like columns (`Utf8`/`LargeUtf8`/`Binary`/`LargeBinary`/`FixedSizeBinary`) compare lexicographically via `ArrayAccessor`; intervals with struct natives and booleans fall back to `make_comparator`. Comparators are built once per query and reused across all values. This keeps the scan to ~19 monomorphizations instead of one per logical type.
- `BTreeIndex` no longer stores a separate `lookup_batch`; `statistics()` reads bounds from the batch and cache serialization clones the batch out of `page_lookup`.
- Float ordering uses `total_cmp` (`ArrowNativeTypeOp::compare` on the native path, `make_comparator` on the fallback), matching the previous `OrderableScalarValue` ordering — so the NaN caveat in the issue is a non-issue.

The first commit reverts #7161, which had taken the opposite approach (caching the parsed tree and regenerating the batch on serialize); that machinery is obsolete once the batch is the source of truth.

## Testing
- `cargo test -p lance-index --lib` (all pass, incl. NaN ordering, null handling, range/fragment consistency)
- `test_btree_lookup_pages_between` covers duplicate `min`s, a null-`min` straddling page, Some/All classification, and empty/inverted ranges.
- `test_btree_lookup_pages_eq_bytes` covers the native byte path for `Binary` and `FixedSizeBinary` (e.g. UUID columns).
- `test_btree_lookup_pages_eq_temporal` covers the physical-type reinterpret (`Date32`→`i32`, `Timestamp`→`i64`).

## Benchmarks

`cargo bench -p lance-index --bench btree` (the existing suite: numeric + string, high/low cardinality, equality / range / `IN`, cached + uncached). Compared against current `main` (which includes #7161) using criterion's baseline significance test — `--load-baseline <pr> --baseline main` — so the numbers below are criterion's own bootstrapped change estimate `[lower, upper]` around the median, with its p-value. Config: `sample_size = 10`, `measurement_time = 10s`, default 2% noise threshold. Run on a single dev machine (macOS arm64), so absolute timings are machine-specific; the verdicts are what matter. Equality/`IN` are from the current HEAD; `range_*` exercises `pages_between`, which the equality/IN dispatch work did not touch, so those numbers reflect the same code.

### Wins — low-cardinality and load/deserialize-bound cases

No longer rebuilding a `BTreeMap` on load, plus the native comparator inlining:

| case | change | p | verdict |
|---|---|---|---|
| equality/int_low_card/no_cache | −27.5% [−30.7, −24.3] | 0.00 | improved |
| equality/string_low_card/no_cache | −26.6% [−29.3, −24.3] | 0.00 | improved |
| range_few/int_low_card/no_cache | −23.7% [−26.5, −21.4] | 0.00 | improved |
| range_few/string_low_card/no_cache | −23.5% [−24.7, −21.9] | 0.00 | improved |
| equality/string_low_card/cached | −20.3% [−22.8, −18.5] | 0.00 | improved |
| range_few/string_low_card/cached | −18.0% [−19.4, −16.3] | 0.00 | improved |
| equality/int_low_card/cached | −6.64% [−7.90, −5.61] | 0.00 | improved |
| range_few/int_low_card/cached | −6.34% [−8.02, −4.49] | 0.00 | improved |

### Hot-path point / `IN` lookups (native physical-type dispatch)

An earlier iteration that queried the batch through the boxed `make_comparator` (one vtable call per comparison) regressed warm-cache high-cardinality lookups by up to +44% on a 30-value `IN`. The native comparators remove that. **Vs `main`, all 32 equality+IN benchmarks are improved or at parity — zero regressions.** High-cardinality warm-cache equality is back to parity; warm-cache `IN` is improved:

| case | change vs main | p | verdict |
|---|---|---|---|
| equality/int_unique/cached | parity | — | no change |
| equality/string_unique/cached | parity | — | no change |
| in_30/int_unique/cached | −9.67% [−10.7, −9.0] | 0.00 | improved |
| in_20/int_unique/cached | −3.81% [−4.11, −3.57] | 0.00 | improved |
| in_10/int_unique/cached | −2.80% [−4.84, −1.27] | 0.00 | improved |
| in_20/string_low_card/cached | −5.40% [−8.39, −2.96] | 0.00 | improved |
| in_10/string_low_card/cached | −3.05% [−4.36, −1.94] | 0.00 | improved |
| in_30/string_low_card/cached | −2.06% [−3.15, −1.23] | 0.00 | improved |

### Noise calibration

To measure the harness noise floor, comparing two runs of **identical code** (same binary behavior) still produces "significant" verdicts:

| case (identical code) | change | p | verdict |
|---|---|---|---|
| in_10/string_unique/cached | −4.29% [−7.41, −1.86] | 0.01 | "improved" |
| equality/int_unique/cached | −2.87% [−5.60, −0.68] | 0.02 | "improved" |
| equality/int_unique/no_cache | −3.14% [−4.42, −2.02] | 0.00 | "improved" |

The code did not change, so these p < 0.05 verdicts are run-to-run variance. Consistent with that, `in_10/int_unique/cached` has read anywhere from −4.2% to +9.3% across runs. At `sample_size = 10` on warm multi-µs benchmarks, swings of ±5% earn p < 0.05 from variance alone, so single-digit-percent deltas on the warm high-cardinality cases are not reliable signal.

### Residual cost

`range_*/unique/cached` shows small regressions — e.g. `range_few/string_unique/cached +2.7%`, `range_few/int_unique/cached +3.8%`. `pages_between` (the range path) still uses `make_comparator`; the native physical-type dispatch was added only to the equality/`IN` path. These sit at the edge of the calibrated noise band but are plausibly a small real cost — the deliberate tradeoff for not duplicating every min/max as an owned `ScalarValue` in memory, and a candidate for extending the physical-type dispatch to ranges in a follow-up. All other cases report "no change in performance detected."
