### PR TITLE
fix: search all unindexed fragments in FTS flat match

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -10370,6 +10370,41 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         assert_query_index_field(&batch);
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_fts_multiple_unindexed_appends() {
+        // An FTS query over an indexed dataset plus more than one unindexed append
+        // must return matches from every unindexed fragment, not just the first. The
+        // flat search over unindexed data reads only a single input partition, so when
+        // the default parallelism splits the scan across partitions it used to drop
+        // every append but the first.
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, false)
+            .await
+            .unwrap();
+        test_ds.make_fts_index().await.unwrap();
+        // Two separate appends -> two unindexed fragments, each large enough that the
+        // physical optimizer parallelizes the flat scan across partitions.
+        test_ds.append_data_with_range(400, 5400).await.unwrap();
+        test_ds.append_data_with_range(5400, 10400).await.unwrap();
+
+        // Every row's `s` value contains the token "s", so FTS("s") matches all rows.
+        let total = test_ds.dataset.count_rows(None).await.unwrap();
+        let returned = test_ds
+            .dataset
+            .scan()
+            .full_text_search(FullTextSearchQuery::new("s".to_owned()))
+            .unwrap()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_fold(
+                0usize,
+                |acc, batch| async move { Ok(acc + batch.num_rows()) },
+            )
+            .await
+            .unwrap();
+        assert_eq!(returned, total);
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_fast_search_scalar_index_skips_unindexed_fragments(

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -971,6 +971,14 @@ impl ExecutionPlan for FlatMatchQueryExec {
         vec![&self.unindexed_input]
     }
 
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        // `execute()` only reads `unindexed_input.execute(partition)` for the single
+        // output partition, so the input must be coalesced to one partition. Without
+        // this, EnforceDistribution may round-robin the scan across `target_partitions`
+        // and only partition 0 is consumed, silently dropping the other fragments.
+        vec![Distribution::SinglePartition]
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,


### PR DESCRIPTION
FlatMatchQueryExec::execute() reads only unindexed_input.execute(partition) for its single output partition, but the node never declared required_input_distribution(), so it defaulted to UnspecifiedDistribution.

After EnforceDistribution was added to the physical optimizer (#7086) and target_partitions was wired to the CPU count, the optimizer is free to insert a RepartitionExec(RoundRobinBatch(N)) beneath the flat search. The per-fragment scan batches scatter across N partitions, but only partition 0 is ever read, so an FTS query over more than one unindexed append silently dropped all but the first append (no error, no false positives).

Declare required_input_distribution() = SinglePartition so the unindexed scan is coalesced before the flat match, matching MatchQueryExec and the KNNVectorDistanceExec fix from the same PR.