### PR TITLE
ci: add missing bumpversion entry for lance-derive

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -57,6 +57,11 @@ replace = 'lance-datagen = {{ version = "={new_version}"'
 
 [[tool.bumpversion.files]]
 filename = "Cargo.toml"
+search = 'lance-derive = {{ version = "={current_version}"'
+replace = 'lance-derive = {{ version = "={new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "Cargo.toml"
 search = 'lance-encoding = {{ version = "={current_version}"'
 replace = 'lance-encoding = {{ version = "={new_version}"'
 


### PR DESCRIPTION
## Summary
- Adds a `[[tool.bumpversion.files]]` entry for `lance-derive` in `.bumpversion.toml` so its workspace dependency line in `Cargo.toml` is bumped alongside the other lance crates during beta releases.

## Why
The `lance-derive` crate (added in #6229) was missing from `.bumpversion.toml`. As a result, during the most recent `publish-beta` run, `[workspace.package].version` was bumped from `8.0.0-beta.7` → `8.0.0-beta.8` (which bumped `rust/lance-derive/Cargo.toml`), but the workspace dependency line in the root `Cargo.toml` stayed at `lance-derive = { version = "=8.0.0-beta.7", ... }`. Cargo then failed:

```
error: failed to select a version for the requirement `lance-derive = "=8.0.0-beta.7"`
```

Failing run: https://github.com/lance-format/lance/actions/runs/27225140622/job/80390190228

Same fix pattern as #6526 (lance-tokenizer) and #4572 (fsst, bitpacking).

## Test plan
- [ ] Next `publish-beta` run succeeds and bumps `lance-derive` in lockstep with the other crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)