### PR TITLE
fix(fts): recompute next_id when loading FST token set

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -3162,6 +3162,80 @@ mod tests {
         assert!((zeta_id as usize) < first.posting_lists.len());
     }
 
+    // FST token file with a stale next_id (above the token count), as a pre-#7115 writer left.
+    async fn write_stale_next_id_token_file(store: &dyn IndexStore, partition_id: u64) {
+        let mut tokens = TokenSet::default();
+        tokens.add("alpha".to_owned());
+        tokens.add("gamma".to_owned());
+        assert_eq!(tokens.len(), 2);
+        tokens.next_id = 9;
+        let batch = tokens.to_batch(TokenSetFormat::Fst).unwrap();
+        let mut writer = store
+            .new_index_file(&token_file_path(partition_id), batch.schema())
+            .await
+            .unwrap();
+        writer.write_record_batch(batch).await.unwrap();
+        writer.finish().await.unwrap();
+    }
+
+    // load_fst recomputes next_id from the token count rather than trusting the persisted value.
+    #[tokio::test]
+    async fn test_load_fst_recomputes_stale_next_id() {
+        let index_dir = TempDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            index_dir.obj_path(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        write_stale_next_id_token_file(store.as_ref(), 0).await;
+        let reader = store.open_index_file(&token_file_path(0)).await.unwrap();
+        let tokens = TokenSet::load(reader, TokenSetFormat::Fst).await.unwrap();
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens.next_id(), 2);
+    }
+
+    // A stale next_id loaded from disk must not leak an out-of-range token id into a merge.
+    #[tokio::test]
+    async fn test_merge_with_stale_next_id_token_file_does_not_panic() {
+        let index_dir = TempDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            index_dir.obj_path(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        write_stale_next_id_token_file(store.as_ref(), 0).await;
+        let reader = store.open_index_file(&token_file_path(0)).await.unwrap();
+        let tokens = TokenSet::load(reader, TokenSetFormat::Fst)
+            .await
+            .unwrap()
+            .into_mutable();
+
+        let mut first = InnerBuilder::new(0, false, TokenSetFormat::Fst);
+        first.set_tokens(tokens);
+        first
+            .posting_lists
+            .resize_with(first.tokens.len(), || PostingListBuilder::new(false));
+        let doc = first.docs.append(10, 1);
+        first.posting_lists[0].add(doc, PositionRecorder::Count(1));
+        first.posting_lists[1].add(doc, PositionRecorder::Count(1));
+
+        let mut second = InnerBuilder::new(1, false, TokenSetFormat::Fst);
+        let zeta = second.tokens.add("zeta".to_owned());
+        second
+            .posting_lists
+            .resize_with(second.tokens.len(), || PostingListBuilder::new(false));
+        let second_doc = second.docs.append(20, 1);
+        second.posting_lists[zeta as usize].add(second_doc, PositionRecorder::Count(1));
+
+        first.merge_from(second).unwrap();
+        assert_eq!(first.tokens.len(), 3);
+        assert_eq!(first.posting_lists.len(), 3);
+        let zeta_id = first.tokens.get("zeta").expect("zeta should be merged in");
+        assert!((zeta_id as usize) < first.posting_lists.len());
+    }
+
     #[tokio::test]
     async fn test_update_index_returns_worker_error_when_workers_exit_during_dispatch() {
         let num_batches = (*LANCE_FTS_NUM_SHARDS * 2 + 1) as u64;

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1620,15 +1620,13 @@ impl TokenSet {
         let map = fst::Map::new(bytes.to_vec())
             .map_err(|e| Error::index(format!("failed to load fst tokens: {}", e)))?;
 
-        let next_id_col = batch[TOKEN_NEXT_ID_COL].as_primitive::<datatypes::UInt32Type>();
         let total_length_col =
             batch[TOKEN_TOTAL_LENGTH_COL].as_primitive::<datatypes::UInt64Type>();
 
-        let next_id = next_id_col
-            .values()
-            .first()
-            .copied()
-            .ok_or(Error::index("token next id column is empty".to_owned()))?;
+        // Token ids are dense `[0, len)`, so `next_id` must equal the token count. Recompute
+        // it instead of trusting the persisted value, which writers before #7115 could leave
+        // stale. Mirrors `load_arrow`.
+        let next_id = map.len() as u32;
 
         let total_length = total_length_col
             .values()


### PR DESCRIPTION
Token ids in a TokenSet are dense [0, len), so next_id must equal the token count. load_fst restored next_id verbatim from the persisted _token_next_id column, so a stale value written by a binary built before #7115 -- whose remap dropped tokens without lowering next_id -- survived the reload. A later segment merge then minted an out-of-range token id and panicked in InnerBuilder::merge_from at self.posting_lists[new_token_id].

Recompute next_id from map.len() (O(1)) instead, mirroring load_arrow, which already does this. Heals existing indexes on read with no migration; writers and file schema are unchanged.

Complements 12f529f9 (#7115), which reset next_id after remap in memory but did not heal values already persisted by writers built before it.
