### PR TITLE
feat(index): support xabi scalar index plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4512,6 +4512,7 @@ dependencies = [
  "lance-encoding",
  "lance-file",
  "lance-index",
+ "lance-index-plugin-abi",
  "lance-io",
  "lance-linalg",
  "lance-namespace",
@@ -4557,6 +4558,7 @@ dependencies = [
  "tracking-allocator",
  "url",
  "uuid",
+ "xabi",
 ]
 
 [[package]]
@@ -4919,6 +4921,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-index-plugin-abi"
+version = "8.0.0-beta.9"
+dependencies = [
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-trait",
+ "futures",
+ "xabi",
+ "xabi-assert",
+]
+
+[[package]]
 name = "lance-io"
 version = "8.0.0-beta.9"
 dependencies = [
@@ -5260,6 +5275,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if 1.0.4",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -10257,6 +10282,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502d74af326b336ce3d0bb4f90a181bedc1a79de6eeccf51983339b5395e8aca"
+dependencies = [
+ "libloading",
+ "xabi-macros",
+]
+
+[[package]]
+name = "xabi-assert"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd399017ed5d647c7ed3612b0bc0b47eb5a5b7be315c89c2c4af462cdfd606e"
+dependencies = [
+ "xabi",
+]
+
+[[package]]
+name = "xabi-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9ded715a3002053fea77d239272e8bc8bbafd89dbdc8e0f1c8c21c2b3fc239"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "rust/lance-file",
     "rust/lance-geo",
     "rust/lance-index",
+    "rust/lance-index-plugin-abi",
     "rust/lance-io",
     "rust/lance-linalg",
     "rust/lance-namespace",
@@ -26,7 +27,11 @@ members = [
     "rust/arrow-scalar",
     "rust/arrow-stats",
 ]
-exclude = ["python", "java/lance-jni"]
+exclude = [
+    "python",
+    "java/lance-jni",
+    "rust/lance/tests/xabi_plugins/mock_btree",
+]
 # Python package needs to be built by maturin.
 resolver = "3"
 
@@ -67,6 +72,7 @@ lance-encoding = { version = "=8.0.0-beta.9", path = "./rust/lance-encoding" }
 lance-file = { version = "=8.0.0-beta.9", path = "./rust/lance-file" }
 lance-geo = { version = "=8.0.0-beta.9", path = "./rust/lance-geo" }
 lance-index = { version = "=8.0.0-beta.9", path = "./rust/lance-index" }
+lance-index-plugin-abi = { version = "=8.0.0-beta.9", path = "./rust/lance-index-plugin-abi" }
 lance-io = { version = "=8.0.0-beta.9", path = "./rust/lance-io", default-features = false }
 lance-linalg = { version = "=8.0.0-beta.9", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=8.0.0-beta.9", path = "./rust/lance-namespace" }
@@ -208,6 +214,7 @@ url = "2.5.7"
 uuid = { version = "1.2", features = ["v4", "serde"] }
 wiremock = "0.6"
 pretty_assertions = "1.4.0"
+xabi = "0.1.0"
 
 [profile.bench]
 opt-level = 3

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
  "core_extensions",
  "crossbeam-channel",
  "generational-arena",
- "libloading",
+ "libloading 0.7.4",
  "lock_api",
  "parking_lot",
  "paste",
@@ -4157,6 +4157,7 @@ dependencies = [
  "lance-encoding",
  "lance-file",
  "lance-index",
+ "lance-index-plugin-abi",
  "lance-io",
  "lance-linalg",
  "lance-namespace",
@@ -4185,6 +4186,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "xabi",
 ]
 
 [[package]]
@@ -4483,6 +4485,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lance-index-plugin-abi"
+version = "8.0.0-beta.9"
+dependencies = [
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-trait",
+ "futures",
+ "xabi",
+]
+
+[[package]]
 name = "lance-io"
 version = "8.0.0-beta.9"
 dependencies = [
@@ -4752,6 +4766,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if 1.0.4",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if 1.0.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -9207,6 +9231,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502d74af326b336ce3d0bb4f90a181bedc1a79de6eeccf51983339b5395e8aca"
+dependencies = [
+ "libloading 0.8.9",
+ "xabi-macros",
+]
+
+[[package]]
+name = "xabi-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9ded715a3002053fea77d239272e8bc8bbafd89dbdc8e0f1c8c21c2b3fc239"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/python/python/tests/test_memory_leaks.py
+++ b/python/python/tests/test_memory_leaks.py
@@ -101,7 +101,7 @@ def probe_index_statistics_no_leak(dataset_path: str) -> None:
             d.stats.index_stats(idx.name)
 
     assert_noleaks(
-        access_index_stats, iterations=1000, threshold_mb=2.0, check_interval=25
+        access_index_stats, iterations=1000, threshold_mb=3.0, check_interval=25
     )
 
 

--- a/rust/lance-index-plugin-abi/Cargo.toml
+++ b/rust/lance-index-plugin-abi/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "lance-index-plugin-abi"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Stable ABI contracts for Lance index plugins"
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+arrow-array.workspace = true
+arrow-ipc.workspace = true
+arrow-schema.workspace = true
+async-trait.workspace = true
+futures.workspace = true
+xabi.workspace = true
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+xabi-assert = "0.1.0"

--- a/rust/lance-index-plugin-abi/src/lib.rs
+++ b/rust/lance-index-plugin-abi/src/lib.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stable xabi contracts for Lance index plugins.
+//!
+//! This crate is the ABI boundary between Lance and dynamically loaded index
+//! plugins. It intentionally avoids depending on Lance internals. Data crosses
+//! the boundary as xabi data, Arrow IPC record batches, and Substrait bytes.
+
+use std::io::Cursor;
+
+use arrow_array::RecordBatch;
+use arrow_ipc::reader::StreamReader;
+use arrow_ipc::writer::StreamWriter;
+use arrow_schema::SchemaRef;
+
+pub const SCALAR_PLUGIN_TRAIT_ID: &str = "lance.scalar-index-plugin";
+pub const SCALAR_INDEX_TRAIT_ID: &str = "lance.scalar-index";
+pub const INDEX_STORE_TRAIT_ID: &str = "lance.index-store";
+pub const TRAINING_DATA_TRAIT_ID: &str = "lance.training-data";
+pub const BUILD_PROGRESS_TRAIT_ID: &str = "lance.index-build-progress";
+pub const ABI_VERSION: u32 = 1;
+
+pub const ORDERING_NONE: u32 = 0;
+pub const ORDERING_VALUES: u32 = 1;
+pub const ORDERING_ADDRESSES: u32 = 2;
+
+pub const EXACTNESS_EXACT: u32 = 0;
+pub const EXACTNESS_AT_MOST: u32 = 1;
+pub const EXACTNESS_AT_LEAST: u32 = 2;
+
+pub const UPDATE_REQUIRES_OLD_DATA: u32 = 0;
+pub const UPDATE_ONLY_NEW_DATA: u32 = 1;
+
+#[xabi::data]
+#[derive(Debug, Clone, Copy)]
+pub struct TrainingCriteriaAbi {
+    pub ordering: u32,
+    pub needs_row_ids: u8,
+    pub needs_row_addrs: u8,
+}
+
+#[xabi::data]
+#[derive(Debug, Clone, Copy)]
+pub struct UpdateCriteriaAbi {
+    pub mode: u32,
+    pub data_criteria: TrainingCriteriaAbi,
+}
+
+#[xabi::data]
+#[derive(Debug, Clone)]
+pub struct TrainingPlanAbi {
+    pub criteria: TrainingCriteriaAbi,
+}
+
+#[xabi::data]
+#[derive(Debug, Clone)]
+pub struct CreatedIndexAbi {
+    pub details_type_url: String,
+    pub details: Vec<u8>,
+    pub index_version: u32,
+}
+
+#[xabi::data]
+#[derive(Debug, Clone)]
+pub struct QueryPlanAbi {
+    pub accepted: u8,
+    pub query: Vec<u8>,
+    pub needs_recheck: u8,
+}
+
+#[xabi::data]
+#[derive(Debug, Clone)]
+pub struct SearchOutputAbi {
+    pub exactness: u32,
+    pub row_ids_le: Vec<u8>,
+    pub null_row_ids_le: Vec<u8>,
+}
+
+#[xabi::data]
+#[derive(Clone)]
+pub struct TrainInputAbi {
+    pub params_json: String,
+    pub fragment_ids_le: Vec<u8>,
+    pub data: BorrowedLanceTrainingDataAbi,
+    pub store: BorrowedLanceIndexStoreAbi,
+    pub progress: BorrowedLanceIndexBuildProgressAbi,
+}
+
+unsafe impl Send for TrainInputAbi {}
+unsafe impl Sync for TrainInputAbi {}
+
+#[xabi::data]
+#[derive(Debug, Clone)]
+pub struct SubstraitQueryAbi {
+    pub version: String,
+    pub schema_ipc: Vec<u8>,
+    pub expr_bytes: Vec<u8>,
+    pub host_query_json: String,
+}
+
+#[xabi::data]
+#[derive(Clone)]
+pub struct RemapInputAbi {
+    pub mappings_le: Vec<u8>,
+    pub mapped_row_ids_le: Vec<u8>,
+    pub has_mapped_row_id: Vec<u8>,
+    pub store: BorrowedLanceIndexStoreAbi,
+}
+
+unsafe impl Send for RemapInputAbi {}
+unsafe impl Sync for RemapInputAbi {}
+
+#[xabi::data]
+#[derive(Clone)]
+pub struct UpdateInputAbi {
+    pub new_data: BorrowedLanceTrainingDataAbi,
+    pub store: BorrowedLanceIndexStoreAbi,
+}
+
+unsafe impl Send for UpdateInputAbi {}
+unsafe impl Sync for UpdateInputAbi {}
+
+#[xabi::xabi(id = TRAINING_DATA_TRAIT_ID, version = ABI_VERSION)]
+pub trait LanceTrainingDataAbi {
+    async fn next_batch_ipc(&self) -> xabi::Result<Option<Vec<u8>>>;
+}
+
+#[xabi::xabi(id = INDEX_STORE_TRAIT_ID, version = ABI_VERSION)]
+pub trait LanceIndexStoreAbi {
+    async fn write_record_batches(&self, name: &str, batches_ipc: &[u8]) -> xabi::Result<Vec<u8>>;
+
+    async fn read_record_batches(&self, name: &str) -> xabi::Result<Vec<u8>>;
+}
+
+#[xabi::xabi(id = BUILD_PROGRESS_TRAIT_ID, version = ABI_VERSION)]
+pub trait LanceIndexBuildProgressAbi {
+    async fn stage_start(&self, name: &str, total: u64, unit: &str) -> xabi::Result<()>;
+
+    async fn stage_progress(&self, name: &str, amount: u64) -> xabi::Result<()>;
+
+    async fn stage_complete(&self, name: &str) -> xabi::Result<()>;
+}
+
+#[xabi::xabi(id = SCALAR_INDEX_TRAIT_ID, version = ABI_VERSION)]
+pub trait LanceScalarIndexAbi {
+    async fn prewarm(&self) -> xabi::Result<()>;
+
+    fn statistics(&self) -> xabi::Result<String>;
+
+    async fn calculate_included_frags(&self) -> xabi::Result<Vec<u8>>;
+
+    async fn search(&self, query: &[u8]) -> xabi::Result<SearchOutputAbi>;
+
+    fn can_remap(&self) -> bool;
+
+    async fn remap(&self, input: RemapInputAbi) -> xabi::Result<CreatedIndexAbi>;
+
+    async fn update(&self, input: UpdateInputAbi) -> xabi::Result<CreatedIndexAbi>;
+
+    fn update_criteria(&self) -> xabi::Result<UpdateCriteriaAbi>;
+
+    fn derive_index_params_json(&self) -> xabi::Result<String>;
+}
+
+#[xabi::xabi(id = SCALAR_PLUGIN_TRAIT_ID, version = ABI_VERSION)]
+pub trait LanceScalarIndexPluginAbi {
+    fn name(&self) -> String;
+
+    fn version(&self) -> u32;
+
+    fn details_type_url(&self) -> String;
+
+    fn provides_exact_answer(&self) -> bool;
+
+    fn new_training_plan(
+        &self,
+        params_json: &str,
+        field_json: &str,
+    ) -> xabi::Result<TrainingPlanAbi>;
+
+    async fn train_index(&self, input: TrainInputAbi) -> xabi::Result<CreatedIndexAbi>;
+
+    async fn load_index(
+        &self,
+        details: &[u8],
+        store: BorrowedLanceIndexStoreAbi,
+    ) -> xabi::Result<impl LanceScalarIndexAbi + 'static>;
+
+    fn plan_query(&self, details: &[u8], query: SubstraitQueryAbi) -> xabi::Result<QueryPlanAbi>;
+
+    async fn load_statistics(&self, details: &[u8]) -> xabi::Result<Option<String>>;
+
+    fn details_as_json(&self, details: &[u8]) -> xabi::Result<String>;
+}
+
+pub use XabiV1BorrowedTraitLanceIndexBuildProgressAbi as BorrowedLanceIndexBuildProgressAbi;
+pub use XabiV1BorrowedTraitLanceIndexStoreAbi as BorrowedLanceIndexStoreAbi;
+pub use XabiV1BorrowedTraitLanceTrainingDataAbi as BorrowedLanceTrainingDataAbi;
+pub use XabiV1HandleTraitLanceScalarIndexAbi as XabiLanceScalarIndexHandle;
+pub use XabiV1HandleTraitLanceScalarIndexPluginAbi as XabiLanceScalarIndexPluginHandle;
+pub use XabiV1OwnedTraitLanceIndexBuildProgressAbi as OwnedLanceIndexBuildProgressAbi;
+pub use XabiV1OwnedTraitLanceIndexStoreAbi as OwnedLanceIndexStoreAbi;
+pub use XabiV1OwnedTraitLanceTrainingDataAbi as OwnedLanceTrainingDataAbi;
+
+pub fn record_batch_to_ipc(batch: &RecordBatch) -> xabi::Result<Vec<u8>> {
+    record_batches_to_ipc(batch.schema(), std::slice::from_ref(batch))
+}
+
+pub fn record_batches_to_ipc(schema: SchemaRef, batches: &[RecordBatch]) -> xabi::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut out, schema.as_ref())
+            .map_err(|err| xabi::Error::Export(err.to_string()))?;
+        for batch in batches {
+            writer
+                .write(batch)
+                .map_err(|err| xabi::Error::Export(err.to_string()))?;
+        }
+        writer
+            .finish()
+            .map_err(|err| xabi::Error::Export(err.to_string()))?;
+    }
+    Ok(out)
+}
+
+pub fn ipc_to_record_batches(bytes: &[u8]) -> xabi::Result<Vec<RecordBatch>> {
+    let reader = StreamReader::try_new(Cursor::new(bytes), None)
+        .map_err(|err| xabi::Error::Export(err.to_string()))?;
+    reader
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| xabi::Error::Export(err.to_string()))
+}
+
+pub fn u32s_to_le_bytes(values: &[u32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(values.len() * 4);
+    for value in values {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+    bytes
+}
+
+pub fn le_bytes_to_u32s(bytes: &[u8]) -> xabi::Result<Vec<u32>> {
+    if !bytes.len().is_multiple_of(4) {
+        return Err(xabi::Error::Export(format!(
+            "u32 byte payload length {} is not divisible by 4",
+            bytes.len()
+        )));
+    }
+    Ok(bytes
+        .chunks_exact(4)
+        .map(|chunk| u32::from_le_bytes(chunk.try_into().expect("chunk has length 4")))
+        .collect())
+}
+
+pub fn u64s_to_le_bytes(values: &[u64]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(values.len() * 8);
+    for value in values {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+    bytes
+}
+
+pub fn le_bytes_to_u64s(bytes: &[u8]) -> xabi::Result<Vec<u64>> {
+    if !bytes.len().is_multiple_of(8) {
+        return Err(xabi::Error::Export(format!(
+            "u64 byte payload length {} is not divisible by 8",
+            bytes.len()
+        )));
+    }
+    Ok(bytes
+        .chunks_exact(8)
+        .map(|chunk| u64::from_le_bytes(chunk.try_into().expect("chunk has length 8")))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xabi_layout_snapshots() {
+        xabi_assert::assert_abi!(XabiV1AbiTraitLanceTrainingDataAbi);
+        xabi_assert::assert_abi!(XabiV1AbiTraitLanceIndexStoreAbi);
+        xabi_assert::assert_abi!(XabiV1AbiTraitLanceIndexBuildProgressAbi);
+        xabi_assert::assert_abi!(XabiV1AbiTraitLanceScalarIndexAbi);
+        xabi_assert::assert_abi!(XabiV1AbiTraitLanceScalarIndexPluginAbi);
+    }
+}

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-build-progress/aarch64-apple-darwin.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-build-progress/aarch64-apple-darwin.txt
@@ -1,0 +1,136 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-apple-darwin
+
+contract lance.index-build-progress
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexBuildProgressAbi)
+  field.stage_start offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, XabiStr, *mut XabiFuture) -> i32
+  field.stage_progress offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.stage_complete offset=64 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  full_size=72
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-build-progress/aarch64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-build-progress/aarch64-unknown-linux-gnu.txt
@@ -1,0 +1,136 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-unknown-linux-gnu
+
+contract lance.index-build-progress
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexBuildProgressAbi)
+  field.stage_start offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, XabiStr, *mut XabiFuture) -> i32
+  field.stage_progress offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.stage_complete offset=64 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  full_size=72
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-build-progress/x86_64-pc-windows-msvc.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-build-progress/x86_64-pc-windows-msvc.txt
@@ -1,0 +1,136 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-pc-windows-msvc
+
+contract lance.index-build-progress
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexBuildProgressAbi)
+  field.stage_start offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, XabiStr, *mut XabiFuture) -> i32
+  field.stage_progress offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.stage_complete offset=64 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  full_size=72
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-build-progress/x86_64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-build-progress/x86_64-unknown-linux-gnu.txt
@@ -1,0 +1,136 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-unknown-linux-gnu
+
+contract lance.index-build-progress
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexBuildProgressAbi)
+  field.stage_start offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, XabiStr, *mut XabiFuture) -> i32
+  field.stage_progress offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.stage_complete offset=64 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  full_size=72
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-store/aarch64-apple-darwin.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-store/aarch64-apple-darwin.txt
@@ -1,0 +1,135 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-apple-darwin
+
+contract lance.index-store
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-store/aarch64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-store/aarch64-unknown-linux-gnu.txt
@@ -1,0 +1,135 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-unknown-linux-gnu
+
+contract lance.index-store
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-store/x86_64-pc-windows-msvc.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-store/x86_64-pc-windows-msvc.txt
@@ -1,0 +1,135 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-pc-windows-msvc
+
+contract lance.index-store
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-store/x86_64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.index-store/x86_64-unknown-linux-gnu.txt
@@ -1,0 +1,135 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-unknown-linux-gnu
+
+contract lance.index-store
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index-plugin/aarch64-apple-darwin.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index-plugin/aarch64-apple-darwin.txt
@@ -1,0 +1,382 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-apple-darwin
+
+contract lance.scalar-index-plugin
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1DataCreatedIndexAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.details_type_url offset=16 type=XabiOwnedBytes
+  field.details offset=40 type=XabiOwnedBytes
+  field.index_version offset=64 type=u32
+
+type lance_index_plugin_abi::XabiV1DataQueryPlanAbi
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.accepted offset=12 type=u8
+  field.query offset=16 type=XabiOwnedBytes
+  field.needs_recheck offset=40 type=u8
+
+type lance_index_plugin_abi::XabiV1DataRemapInputAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mappings_le offset=16 type=XabiOwnedBytes
+  field.mapped_row_ids_le offset=40 type=XabiOwnedBytes
+  field.has_mapped_row_id offset=64 type=XabiOwnedBytes
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1DataSearchOutputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exactness offset=12 type=u32
+  field.row_ids_le offset=16 type=XabiOwnedBytes
+  field.null_row_ids_le offset=40 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataSubstraitQueryAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.version offset=16 type=XabiOwnedBytes
+  field.schema_ipc offset=40 type=XabiOwnedBytes
+  field.expr_bytes offset=64 type=XabiOwnedBytes
+  field.host_query_json offset=88 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataTrainInputAbi
+  stability=prefix
+  size=136
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.params_json offset=16 type=XabiOwnedBytes
+  field.fragment_ids_le offset=40 type=XabiOwnedBytes
+  field.data offset=64 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+  field.progress offset=112 type=XabiV1RefTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1DataTrainingCriteriaAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.ordering offset=12 type=u32
+  field.needs_row_ids offset=16 type=u8
+  field.needs_row_addrs offset=17 type=u8
+
+type lance_index_plugin_abi::XabiV1DataTrainingPlanAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateCriteriaAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mode offset=12 type=u32
+  field.data_criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateInputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.new_data offset=16 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=40 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexBuildProgressAbi)
+  field.stage_start offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, XabiStr, *mut XabiFuture) -> i32
+  field.stage_progress offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.stage_complete offset=64 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  stability=prefix
+  size=120
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexAbi)
+  field.prewarm offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.statistics offset=56 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.calculate_included_frags offset=64 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.search offset=72 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.can_remap offset=80 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.remap offset=88 type=unsafe extern "C" fn(*mut c_void, *const <RemapInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update offset=96 type=unsafe extern "C" fn(*mut c_void, *const <UpdateInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update_criteria offset=104 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.derive_index_params_json offset=112 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=128
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexPluginAbi)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.version offset=56 type=unsafe extern "C" fn(*mut c_void) -> u32
+  field.details_type_url offset=64 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.provides_exact_answer offset=72 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.new_training_plan offset=80 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiStr, *mut XabiOwnedBytes) -> i32
+  field.train_index offset=88 type=unsafe extern "C" fn(*mut c_void, *const <TrainInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.load_index offset=96 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *const <BorrowedLanceIndexStoreAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.plan_query offset=104 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *const <SubstraitQueryAbi as XabiType>::Wire, *mut XabiOwnedBytes) -> i32
+  field.load_statistics offset=112 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.details_as_json offset=120 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  full_size=72
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  full_size=120
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexPluginAbi
+  full_size=128
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index-plugin/aarch64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index-plugin/aarch64-unknown-linux-gnu.txt
@@ -1,0 +1,382 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-unknown-linux-gnu
+
+contract lance.scalar-index-plugin
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1DataCreatedIndexAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.details_type_url offset=16 type=XabiOwnedBytes
+  field.details offset=40 type=XabiOwnedBytes
+  field.index_version offset=64 type=u32
+
+type lance_index_plugin_abi::XabiV1DataQueryPlanAbi
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.accepted offset=12 type=u8
+  field.query offset=16 type=XabiOwnedBytes
+  field.needs_recheck offset=40 type=u8
+
+type lance_index_plugin_abi::XabiV1DataRemapInputAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mappings_le offset=16 type=XabiOwnedBytes
+  field.mapped_row_ids_le offset=40 type=XabiOwnedBytes
+  field.has_mapped_row_id offset=64 type=XabiOwnedBytes
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1DataSearchOutputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exactness offset=12 type=u32
+  field.row_ids_le offset=16 type=XabiOwnedBytes
+  field.null_row_ids_le offset=40 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataSubstraitQueryAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.version offset=16 type=XabiOwnedBytes
+  field.schema_ipc offset=40 type=XabiOwnedBytes
+  field.expr_bytes offset=64 type=XabiOwnedBytes
+  field.host_query_json offset=88 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataTrainInputAbi
+  stability=prefix
+  size=136
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.params_json offset=16 type=XabiOwnedBytes
+  field.fragment_ids_le offset=40 type=XabiOwnedBytes
+  field.data offset=64 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+  field.progress offset=112 type=XabiV1RefTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1DataTrainingCriteriaAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.ordering offset=12 type=u32
+  field.needs_row_ids offset=16 type=u8
+  field.needs_row_addrs offset=17 type=u8
+
+type lance_index_plugin_abi::XabiV1DataTrainingPlanAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateCriteriaAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mode offset=12 type=u32
+  field.data_criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateInputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.new_data offset=16 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=40 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexBuildProgressAbi)
+  field.stage_start offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, XabiStr, *mut XabiFuture) -> i32
+  field.stage_progress offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.stage_complete offset=64 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  stability=prefix
+  size=120
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexAbi)
+  field.prewarm offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.statistics offset=56 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.calculate_included_frags offset=64 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.search offset=72 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.can_remap offset=80 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.remap offset=88 type=unsafe extern "C" fn(*mut c_void, *const <RemapInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update offset=96 type=unsafe extern "C" fn(*mut c_void, *const <UpdateInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update_criteria offset=104 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.derive_index_params_json offset=112 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=128
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexPluginAbi)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.version offset=56 type=unsafe extern "C" fn(*mut c_void) -> u32
+  field.details_type_url offset=64 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.provides_exact_answer offset=72 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.new_training_plan offset=80 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiStr, *mut XabiOwnedBytes) -> i32
+  field.train_index offset=88 type=unsafe extern "C" fn(*mut c_void, *const <TrainInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.load_index offset=96 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *const <BorrowedLanceIndexStoreAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.plan_query offset=104 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *const <SubstraitQueryAbi as XabiType>::Wire, *mut XabiOwnedBytes) -> i32
+  field.load_statistics offset=112 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.details_as_json offset=120 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  full_size=72
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  full_size=120
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexPluginAbi
+  full_size=128
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index-plugin/x86_64-pc-windows-msvc.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index-plugin/x86_64-pc-windows-msvc.txt
@@ -1,0 +1,382 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-pc-windows-msvc
+
+contract lance.scalar-index-plugin
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1DataCreatedIndexAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.details_type_url offset=16 type=XabiOwnedBytes
+  field.details offset=40 type=XabiOwnedBytes
+  field.index_version offset=64 type=u32
+
+type lance_index_plugin_abi::XabiV1DataQueryPlanAbi
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.accepted offset=12 type=u8
+  field.query offset=16 type=XabiOwnedBytes
+  field.needs_recheck offset=40 type=u8
+
+type lance_index_plugin_abi::XabiV1DataRemapInputAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mappings_le offset=16 type=XabiOwnedBytes
+  field.mapped_row_ids_le offset=40 type=XabiOwnedBytes
+  field.has_mapped_row_id offset=64 type=XabiOwnedBytes
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1DataSearchOutputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exactness offset=12 type=u32
+  field.row_ids_le offset=16 type=XabiOwnedBytes
+  field.null_row_ids_le offset=40 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataSubstraitQueryAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.version offset=16 type=XabiOwnedBytes
+  field.schema_ipc offset=40 type=XabiOwnedBytes
+  field.expr_bytes offset=64 type=XabiOwnedBytes
+  field.host_query_json offset=88 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataTrainInputAbi
+  stability=prefix
+  size=136
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.params_json offset=16 type=XabiOwnedBytes
+  field.fragment_ids_le offset=40 type=XabiOwnedBytes
+  field.data offset=64 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+  field.progress offset=112 type=XabiV1RefTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1DataTrainingCriteriaAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.ordering offset=12 type=u32
+  field.needs_row_ids offset=16 type=u8
+  field.needs_row_addrs offset=17 type=u8
+
+type lance_index_plugin_abi::XabiV1DataTrainingPlanAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateCriteriaAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mode offset=12 type=u32
+  field.data_criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateInputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.new_data offset=16 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=40 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexBuildProgressAbi)
+  field.stage_start offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, XabiStr, *mut XabiFuture) -> i32
+  field.stage_progress offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.stage_complete offset=64 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  stability=prefix
+  size=120
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexAbi)
+  field.prewarm offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.statistics offset=56 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.calculate_included_frags offset=64 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.search offset=72 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.can_remap offset=80 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.remap offset=88 type=unsafe extern "C" fn(*mut c_void, *const <RemapInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update offset=96 type=unsafe extern "C" fn(*mut c_void, *const <UpdateInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update_criteria offset=104 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.derive_index_params_json offset=112 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=128
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexPluginAbi)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.version offset=56 type=unsafe extern "C" fn(*mut c_void) -> u32
+  field.details_type_url offset=64 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.provides_exact_answer offset=72 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.new_training_plan offset=80 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiStr, *mut XabiOwnedBytes) -> i32
+  field.train_index offset=88 type=unsafe extern "C" fn(*mut c_void, *const <TrainInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.load_index offset=96 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *const <BorrowedLanceIndexStoreAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.plan_query offset=104 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *const <SubstraitQueryAbi as XabiType>::Wire, *mut XabiOwnedBytes) -> i32
+  field.load_statistics offset=112 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.details_as_json offset=120 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  full_size=72
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  full_size=120
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexPluginAbi
+  full_size=128
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index-plugin/x86_64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index-plugin/x86_64-unknown-linux-gnu.txt
@@ -1,0 +1,382 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-unknown-linux-gnu
+
+contract lance.scalar-index-plugin
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1DataCreatedIndexAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.details_type_url offset=16 type=XabiOwnedBytes
+  field.details offset=40 type=XabiOwnedBytes
+  field.index_version offset=64 type=u32
+
+type lance_index_plugin_abi::XabiV1DataQueryPlanAbi
+  stability=prefix
+  size=48
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.accepted offset=12 type=u8
+  field.query offset=16 type=XabiOwnedBytes
+  field.needs_recheck offset=40 type=u8
+
+type lance_index_plugin_abi::XabiV1DataRemapInputAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mappings_le offset=16 type=XabiOwnedBytes
+  field.mapped_row_ids_le offset=40 type=XabiOwnedBytes
+  field.has_mapped_row_id offset=64 type=XabiOwnedBytes
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1DataSearchOutputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exactness offset=12 type=u32
+  field.row_ids_le offset=16 type=XabiOwnedBytes
+  field.null_row_ids_le offset=40 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataSubstraitQueryAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.version offset=16 type=XabiOwnedBytes
+  field.schema_ipc offset=40 type=XabiOwnedBytes
+  field.expr_bytes offset=64 type=XabiOwnedBytes
+  field.host_query_json offset=88 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataTrainInputAbi
+  stability=prefix
+  size=136
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.params_json offset=16 type=XabiOwnedBytes
+  field.fragment_ids_le offset=40 type=XabiOwnedBytes
+  field.data offset=64 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+  field.progress offset=112 type=XabiV1RefTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1DataTrainingCriteriaAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.ordering offset=12 type=u32
+  field.needs_row_ids offset=16 type=u8
+  field.needs_row_addrs offset=17 type=u8
+
+type lance_index_plugin_abi::XabiV1DataTrainingPlanAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateCriteriaAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mode offset=12 type=u32
+  field.data_criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateInputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.new_data offset=16 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=40 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexBuildProgressAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexPluginAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexBuildProgressAbi)
+  field.stage_start offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, XabiStr, *mut XabiFuture) -> i32
+  field.stage_progress offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *const <u64 as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.stage_complete offset=64 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  stability=prefix
+  size=120
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexAbi)
+  field.prewarm offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.statistics offset=56 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.calculate_included_frags offset=64 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.search offset=72 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.can_remap offset=80 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.remap offset=88 type=unsafe extern "C" fn(*mut c_void, *const <RemapInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update offset=96 type=unsafe extern "C" fn(*mut c_void, *const <UpdateInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update_criteria offset=104 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.derive_index_params_json offset=112 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexPluginAbi
+  stability=prefix
+  size=128
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexPluginAbi)
+  field.name offset=48 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.version offset=56 type=unsafe extern "C" fn(*mut c_void) -> u32
+  field.details_type_url offset=64 type=unsafe extern "C" fn(*mut c_void) -> XabiOwnedBytes
+  field.provides_exact_answer offset=72 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.new_training_plan offset=80 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiStr, *mut XabiOwnedBytes) -> i32
+  field.train_index offset=88 type=unsafe extern "C" fn(*mut c_void, *const <TrainInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.load_index offset=96 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *const <BorrowedLanceIndexStoreAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.plan_query offset=104 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *const <SubstraitQueryAbi as XabiType>::Wire, *mut XabiOwnedBytes) -> i32
+  field.load_statistics offset=112 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.details_as_json offset=120 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexBuildProgressAbi
+  full_size=72
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  full_size=120
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexPluginAbi
+  full_size=128
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index/aarch64-apple-darwin.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index/aarch64-apple-darwin.txt
@@ -1,0 +1,266 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-apple-darwin
+
+contract lance.scalar-index
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1DataCreatedIndexAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.details_type_url offset=16 type=XabiOwnedBytes
+  field.details offset=40 type=XabiOwnedBytes
+  field.index_version offset=64 type=u32
+
+type lance_index_plugin_abi::XabiV1DataRemapInputAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mappings_le offset=16 type=XabiOwnedBytes
+  field.mapped_row_ids_le offset=40 type=XabiOwnedBytes
+  field.has_mapped_row_id offset=64 type=XabiOwnedBytes
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1DataSearchOutputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exactness offset=12 type=u32
+  field.row_ids_le offset=16 type=XabiOwnedBytes
+  field.null_row_ids_le offset=40 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataTrainingCriteriaAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.ordering offset=12 type=u32
+  field.needs_row_ids offset=16 type=u8
+  field.needs_row_addrs offset=17 type=u8
+
+type lance_index_plugin_abi::XabiV1DataUpdateCriteriaAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mode offset=12 type=u32
+  field.data_criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateInputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.new_data offset=16 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=40 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  stability=prefix
+  size=120
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexAbi)
+  field.prewarm offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.statistics offset=56 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.calculate_included_frags offset=64 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.search offset=72 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.can_remap offset=80 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.remap offset=88 type=unsafe extern "C" fn(*mut c_void, *const <RemapInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update offset=96 type=unsafe extern "C" fn(*mut c_void, *const <UpdateInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update_criteria offset=104 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.derive_index_params_json offset=112 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  full_size=120
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index/aarch64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index/aarch64-unknown-linux-gnu.txt
@@ -1,0 +1,266 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-unknown-linux-gnu
+
+contract lance.scalar-index
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1DataCreatedIndexAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.details_type_url offset=16 type=XabiOwnedBytes
+  field.details offset=40 type=XabiOwnedBytes
+  field.index_version offset=64 type=u32
+
+type lance_index_plugin_abi::XabiV1DataRemapInputAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mappings_le offset=16 type=XabiOwnedBytes
+  field.mapped_row_ids_le offset=40 type=XabiOwnedBytes
+  field.has_mapped_row_id offset=64 type=XabiOwnedBytes
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1DataSearchOutputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exactness offset=12 type=u32
+  field.row_ids_le offset=16 type=XabiOwnedBytes
+  field.null_row_ids_le offset=40 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataTrainingCriteriaAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.ordering offset=12 type=u32
+  field.needs_row_ids offset=16 type=u8
+  field.needs_row_addrs offset=17 type=u8
+
+type lance_index_plugin_abi::XabiV1DataUpdateCriteriaAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mode offset=12 type=u32
+  field.data_criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateInputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.new_data offset=16 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=40 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  stability=prefix
+  size=120
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexAbi)
+  field.prewarm offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.statistics offset=56 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.calculate_included_frags offset=64 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.search offset=72 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.can_remap offset=80 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.remap offset=88 type=unsafe extern "C" fn(*mut c_void, *const <RemapInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update offset=96 type=unsafe extern "C" fn(*mut c_void, *const <UpdateInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update_criteria offset=104 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.derive_index_params_json offset=112 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  full_size=120
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index/x86_64-pc-windows-msvc.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index/x86_64-pc-windows-msvc.txt
@@ -1,0 +1,266 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-pc-windows-msvc
+
+contract lance.scalar-index
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1DataCreatedIndexAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.details_type_url offset=16 type=XabiOwnedBytes
+  field.details offset=40 type=XabiOwnedBytes
+  field.index_version offset=64 type=u32
+
+type lance_index_plugin_abi::XabiV1DataRemapInputAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mappings_le offset=16 type=XabiOwnedBytes
+  field.mapped_row_ids_le offset=40 type=XabiOwnedBytes
+  field.has_mapped_row_id offset=64 type=XabiOwnedBytes
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1DataSearchOutputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exactness offset=12 type=u32
+  field.row_ids_le offset=16 type=XabiOwnedBytes
+  field.null_row_ids_le offset=40 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataTrainingCriteriaAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.ordering offset=12 type=u32
+  field.needs_row_ids offset=16 type=u8
+  field.needs_row_addrs offset=17 type=u8
+
+type lance_index_plugin_abi::XabiV1DataUpdateCriteriaAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mode offset=12 type=u32
+  field.data_criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateInputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.new_data offset=16 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=40 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  stability=prefix
+  size=120
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexAbi)
+  field.prewarm offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.statistics offset=56 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.calculate_included_frags offset=64 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.search offset=72 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.can_remap offset=80 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.remap offset=88 type=unsafe extern "C" fn(*mut c_void, *const <RemapInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update offset=96 type=unsafe extern "C" fn(*mut c_void, *const <UpdateInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update_criteria offset=104 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.derive_index_params_json offset=112 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  full_size=120
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index/x86_64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.scalar-index/x86_64-unknown-linux-gnu.txt
@@ -1,0 +1,266 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-unknown-linux-gnu
+
+contract lance.scalar-index
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1DataCreatedIndexAbi
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.details_type_url offset=16 type=XabiOwnedBytes
+  field.details offset=40 type=XabiOwnedBytes
+  field.index_version offset=64 type=u32
+
+type lance_index_plugin_abi::XabiV1DataRemapInputAbi
+  stability=prefix
+  size=112
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mappings_le offset=16 type=XabiOwnedBytes
+  field.mapped_row_ids_le offset=40 type=XabiOwnedBytes
+  field.has_mapped_row_id offset=64 type=XabiOwnedBytes
+  field.store offset=88 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1DataSearchOutputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exactness offset=12 type=u32
+  field.row_ids_le offset=16 type=XabiOwnedBytes
+  field.null_row_ids_le offset=40 type=XabiOwnedBytes
+
+type lance_index_plugin_abi::XabiV1DataTrainingCriteriaAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.ordering offset=12 type=u32
+  field.needs_row_ids offset=16 type=u8
+  field.needs_row_addrs offset=17 type=u8
+
+type lance_index_plugin_abi::XabiV1DataUpdateCriteriaAbi
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.mode offset=12 type=u32
+  field.data_criteria offset=16 type=XabiV1DataTrainingCriteriaAbi
+
+type lance_index_plugin_abi::XabiV1DataUpdateInputAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.new_data offset=16 type=XabiV1RefTraitLanceTrainingDataAbi
+  field.store offset=40 type=XabiV1RefTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceIndexStoreAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceIndexStoreAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceScalarIndexAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceScalarIndexAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  stability=prefix
+  size=64
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceIndexStoreAbi)
+  field.write_record_batches offset=48 type=unsafe extern "C" fn(*mut c_void, XabiStr, XabiBytes, *mut XabiFuture) -> i32
+  field.read_record_batches offset=56 type=unsafe extern "C" fn(*mut c_void, XabiStr, *mut XabiFuture) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  stability=prefix
+  size=120
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceScalarIndexAbi)
+  field.prewarm offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.statistics offset=56 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.calculate_included_frags offset=64 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+  field.search offset=72 type=unsafe extern "C" fn(*mut c_void, XabiBytes, *mut XabiFuture) -> i32
+  field.can_remap offset=80 type=unsafe extern "C" fn(*mut c_void) -> u8
+  field.remap offset=88 type=unsafe extern "C" fn(*mut c_void, *const <RemapInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update offset=96 type=unsafe extern "C" fn(*mut c_void, *const <UpdateInputAbi as XabiType>::Wire, *mut XabiFuture) -> i32
+  field.update_criteria offset=104 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+  field.derive_index_params_json offset=112 type=unsafe extern "C" fn(*mut c_void, *mut XabiOwnedBytes) -> i32
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceIndexStoreAbi
+  full_size=64
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceScalarIndexAbi
+  full_size=120
+  min_size=48
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.training-data/aarch64-apple-darwin.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.training-data/aarch64-apple-darwin.txt
@@ -1,0 +1,134 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-apple-darwin
+
+contract lance.training-data
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.training-data/aarch64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.training-data/aarch64-unknown-linux-gnu.txt
@@ -1,0 +1,134 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=aarch64-unknown-linux-gnu
+
+contract lance.training-data
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.training-data/x86_64-pc-windows-msvc.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.training-data/x86_64-pc-windows-msvc.txt
@@ -1,0 +1,134 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-pc-windows-msvc
+
+contract lance.training-data
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index-plugin-abi/xabi/snapshots/lance.training-data/x86_64-unknown-linux-gnu.txt
+++ b/rust/lance-index-plugin-abi/xabi/snapshots/lance.training-data/x86_64-unknown-linux-gnu.txt
@@ -1,0 +1,134 @@
+format=xabi-contract-snapshot-v1
+package=lance-index-plugin-abi
+target=x86_64-unknown-linux-gnu
+
+contract lance.training-data
+  abi_version=1
+  rust_trait=lance_index_plugin_abi::LanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1OwnedRefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*mut XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1RefTraitLanceTrainingDataAbi
+  stability=prefix
+  size=24
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.vtable offset=16 type=*const XabiV1VtableTraitLanceTrainingDataAbi
+
+type lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.capabilities offset=16 type=u64
+  field.instance offset=24 type=*mut c_void
+  field.destroy offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=40 type=unsafe extern "C" fn(*mut XabiV1VtableTraitLanceTrainingDataAbi)
+  field.next_batch_ipc offset=48 type=unsafe extern "C" fn(*mut c_void, *mut XabiFuture) -> i32
+
+type xabi::XabiBytes
+  stability=fixed
+  size=16
+  align=8
+  field.0 offset=0 type=XabiSlice<u8>
+
+type xabi::XabiErrorWire
+  stability=prefix
+  size=16
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.kind offset=12 type=u32
+
+type xabi::XabiExport
+  stability=prefix
+  size=72
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.abi_id offset=16 type=XabiStr
+  field.name offset=32 type=XabiStr
+  field.contract_version offset=48 type=u32
+  field.export_version offset=52 type=u32
+  field.capabilities offset=56 type=u64
+  field.make offset=64 type=unsafe extern "C" fn() -> *mut c_void
+
+type xabi::XabiFuture
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.poll offset=24 type=unsafe extern "C" fn(*mut c_void, *const XabiWaker, *mut XabiResult) -> i32
+  field.release offset=32 type=unsafe extern "C" fn(*mut c_void)
+
+type xabi::XabiManifest
+  stability=prefix
+  size=32
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.exports offset=16 type=XabiSlice<XabiExport>
+
+type xabi::XabiOption
+  stability=prefix
+  size=40
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.is_some offset=12 type=u8
+  field.payload offset=16 type=XabiOwnedBytes
+
+type xabi::XabiOwnedBytes
+  stability=fixed
+  size=24
+  align=8
+  field.ptr offset=0 type=*mut u8
+  field.len offset=8 type=usize
+  field.free offset=16 type=unsafe extern "C" fn(*mut u8, usize)
+
+type xabi::XabiResult
+  stability=fixed
+  size=32
+  align=8
+  field.code offset=0 type=i32
+  field.payload offset=8 type=XabiOwnedBytes
+
+type xabi::XabiSlice<u8>
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiStr
+  stability=fixed
+  size=16
+  align=8
+  field.ptr offset=0 type=*const u8
+  field.len offset=8 type=usize
+
+type xabi::XabiWaker
+  stability=prefix
+  size=56
+  align=8
+  field.size offset=0 type=usize
+  field.abi_version offset=8 type=u32
+  field.instance offset=16 type=*mut c_void
+  field.clone offset=24 type=unsafe extern "C" fn(*mut c_void) -> XabiWaker
+  field.wake offset=32 type=unsafe extern "C" fn(*mut c_void)
+  field.wake_by_ref offset=40 type=unsafe extern "C" fn(*mut c_void)
+  field.release offset=48 type=unsafe extern "C" fn(*mut c_void)
+
+vtable lance_index_plugin_abi::XabiV1VtableTraitLanceTrainingDataAbi
+  full_size=56
+  min_size=48

--- a/rust/lance-index/src/registry.rs
+++ b/rust/lance-index/src/registry.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 use lance_core::{Error, Result};
 
@@ -33,7 +36,7 @@ pub fn display_type_from_url(type_url: &str) -> &str {
 
 /// A registry of index plugins
 pub struct IndexPluginRegistry {
-    plugins: HashMap<String, Box<dyn ScalarIndexPlugin>>,
+    plugins: RwLock<HashMap<String, Arc<dyn ScalarIndexPlugin>>>,
 }
 
 impl IndexPluginRegistry {
@@ -67,18 +70,76 @@ impl IndexPluginRegistry {
         DetailsType: prost::Message + prost::Name,
         PluginType: ScalarIndexPlugin + std::default::Default + 'static,
     >(
-        &mut self,
+        &self,
     ) {
         let plugin_name = self.get_plugin_name_from_details_name(DetailsType::NAME);
         self.plugins
-            .insert(plugin_name, Box::new(PluginType::default()));
+            .write()
+            .expect("index plugin registry lock is poisoned")
+            .insert(plugin_name, Arc::new(PluginType::default()));
+    }
+
+    /// Adds an already-created scalar index plugin under a runtime name.
+    pub fn add_runtime_plugin(
+        &self,
+        name: String,
+        plugin: Arc<dyn ScalarIndexPlugin>,
+    ) -> Result<()> {
+        let plugin_name = Self::normalize_plugin_name(&name);
+        let mut plugins = self
+            .plugins
+            .write()
+            .expect("index plugin registry lock is poisoned");
+        if plugins.contains_key(&plugin_name) {
+            return Err(Error::invalid_input(format!(
+                "scalar index plugin '{name}' is already registered"
+            )));
+        }
+        plugins.insert(plugin_name, plugin);
+        Ok(())
+    }
+
+    /// Adds an alias for a runtime scalar index plugin based on its details type URL.
+    ///
+    /// This lets dynamically registered plugins use their own persisted
+    /// `prost_types::Any::type_url` while still being resolved by manifest
+    /// metadata during dataset open and index description.
+    pub fn add_runtime_plugin_for_details(
+        &self,
+        details_type_url: &str,
+        plugin: Arc<dyn ScalarIndexPlugin>,
+    ) -> Result<()> {
+        let details_name = details_type_url
+            .split('.')
+            .next_back()
+            .unwrap_or(details_type_url);
+        let plugin_name = self.get_plugin_name_from_details_name(details_name);
+        let mut plugins = self
+            .plugins
+            .write()
+            .expect("index plugin registry lock is poisoned");
+        match plugins.get(&plugin_name) {
+            Some(existing) if Arc::ptr_eq(existing, &plugin) => Ok(()),
+            Some(_) => Err(Error::invalid_input(format!(
+                "scalar index plugin alias '{plugin_name}' is already registered"
+            ))),
+            None => {
+                plugins.insert(plugin_name, plugin);
+                Ok(())
+            }
+        }
+    }
+
+    /// Create an empty registry.
+    pub fn empty() -> Arc<Self> {
+        Arc::new(Self {
+            plugins: RwLock::new(HashMap::new()),
+        })
     }
 
     /// Create a registry with the default plugins
     pub fn with_default_plugins() -> Arc<Self> {
-        let mut registry = Self {
-            plugins: HashMap::new(),
-        };
+        let registry = Self::empty();
         registry.add_plugin::<pbold::BTreeIndexDetails, BTreeIndexPlugin>();
         registry.add_plugin::<pbold::BitmapIndexDetails, BitmapIndexPlugin>();
         registry.add_plugin::<pbold::LabelListIndexDetails, LabelListIndexPlugin>();
@@ -91,8 +152,12 @@ impl IndexPluginRegistry {
         #[cfg(feature = "geo")]
         registry.add_plugin::<pb::RTreeIndexDetails, RTreeIndexPlugin>();
 
-        let registry = Arc::new(registry);
-        for plugin in registry.plugins.values() {
+        for plugin in registry
+            .plugins
+            .read()
+            .expect("index plugin registry lock is poisoned")
+            .values()
+        {
             plugin.attach_registry(registry.clone());
         }
 
@@ -100,11 +165,13 @@ impl IndexPluginRegistry {
     }
 
     /// Get an index plugin suitable for training an index with the given parameters
-    pub fn get_plugin_by_name(&self, name: &str) -> Result<&dyn ScalarIndexPlugin> {
+    pub fn get_plugin_by_name(&self, name: &str) -> Result<Arc<dyn ScalarIndexPlugin>> {
         let plugin_name = Self::normalize_plugin_name(name);
         self.plugins
+            .read()
+            .expect("index plugin registry lock is poisoned")
             .get(&plugin_name)
-            .map(|plugin| plugin.as_ref())
+            .cloned()
             .ok_or_else(|| {
                 let hint = if plugin_name == "rtree" {
                     ". The 'rtree' index requires the `geo` feature. \
@@ -121,7 +188,7 @@ impl IndexPluginRegistry {
     pub fn get_plugin_by_details(
         &self,
         details: &prost_types::Any,
-    ) -> Result<&dyn ScalarIndexPlugin> {
+    ) -> Result<Arc<dyn ScalarIndexPlugin>> {
         let details_name = details.type_url.split('.').next_back().unwrap();
         let plugin_name = self.get_plugin_name_from_details_name(details_name);
         self.get_plugin_by_name(&plugin_name)

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -1787,6 +1787,10 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
             Ok(None)
         }
     }
+
+    fn supports_load_statistics(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -205,6 +205,12 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
         Ok(None)
     }
 
+    /// Returns true if [`load_statistics`](Self::load_statistics) may return
+    /// statistics without opening the index.
+    fn supports_load_statistics(&self) -> bool {
+        false
+    }
+
     /// Optional hook that plugins can use if they need to be aware of the registry
     fn attach_registry(&self, _registry: Arc<IndexPluginRegistry>) {}
 

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -28,6 +28,7 @@ lance-file = { workspace = true }
 lance-io = { workspace = true }
 lance-linalg = { workspace = true }
 lance-index = { workspace = true }
+lance-index-plugin-abi = { workspace = true }
 lance-namespace = { workspace = true }
 lance-select = { workspace = true }
 lance-tokenizer = { workspace = true }
@@ -97,6 +98,7 @@ async_cell = "0.2.2"
 semver.workspace = true
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
+xabi.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -664,7 +664,7 @@ impl Dataset {
                 .into_iter()
                 .map(IndexMetadata::try_from)
                 .collect::<Result<Vec<_>>>()?;
-            retain_supported_indices(&mut indices);
+            retain_supported_indices(&mut indices, session.scalar_index_plugins().as_ref());
             let ds_index_cache = session.index_cache.for_dataset(uri);
             let metadata_key = crate::session::index_caches::IndexMetadataKey {
                 version: manifest_location.version,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -688,6 +688,7 @@ struct IndexDescriptionImpl {
     /// persisted in the manifest. Such indices are still described on a
     /// best-effort basis rather than rejected.
     details: Option<IndexDetails>,
+    scalar_index_plugins: Arc<lance_index::registry::IndexPluginRegistry>,
     rows_indexed: u64,
 }
 
@@ -748,7 +749,7 @@ impl IndexDescriptionImpl {
                     // is registered, so a known type URL is never reported as the
                     // opaque "Unknown".
                     details
-                        .get_plugin()
+                        .get_plugin(dataset.session.scalar_index_plugins().as_ref())
                         .map(|p| p.name().to_string())
                         .unwrap_or_else(|_| {
                             display_type_from_url(details.0.type_url.as_str()).to_string()
@@ -805,6 +806,7 @@ impl IndexDescriptionImpl {
             index_type,
             segments,
             details,
+            scalar_index_plugins: dataset.session.scalar_index_plugins(),
             rows_indexed,
         })
     }
@@ -854,7 +856,7 @@ impl IndexDescription for IndexDescriptionImpl {
         if details.is_vector() {
             vector_details_as_json(&details.0)
         } else {
-            let plugin = details.get_plugin()?;
+            let plugin = details.get_plugin(self.scalar_index_plugins.as_ref())?;
             plugin.details_as_json(&details.0).map(|v| v.to_string())
         }
     }
@@ -1028,7 +1030,14 @@ impl DatasetIndexExt for Dataset {
                     .iter()
                     .filter_map(|id| self.schema().field_by_id(*id))
                     .collect::<Vec<_>>();
-                match index_matches_criteria(idx, &criteria, &fields, false, self.schema()) {
+                match index_matches_criteria(
+                    idx,
+                    &criteria,
+                    &fields,
+                    false,
+                    self.schema(),
+                    self.session.scalar_index_plugins().as_ref(),
+                ) {
                     Ok(matched) => matched,
                     Err(err) => {
                         log::warn!("Could not describe index {}: {}", idx.name, err);
@@ -1069,7 +1078,10 @@ impl DatasetIndexExt for Dataset {
                     &self.manifest,
                 )
                 .await?;
-                retain_supported_indices(&mut loaded_indices);
+                retain_supported_indices(
+                    &mut loaded_indices,
+                    self.session.scalar_index_plugins().as_ref(),
+                );
                 let loaded_indices = Arc::new(loaded_indices);
                 self.index_cache
                     .insert_with_key(&metadata_key, loaded_indices.clone())
@@ -1327,6 +1339,7 @@ impl DatasetIndexExt for Dataset {
                         &[field],
                         has_multiple,
                         self.schema(),
+                        self.session.scalar_index_plugins().as_ref(),
                     )?
                 {
                     let non_empty = idx.fragment_bitmap.as_ref().is_some_and(|bitmap| {
@@ -1630,7 +1643,8 @@ async fn collect_regular_indices_statistics(
         }
 
         let index_details_wrapper = scalar::IndexDetails(index_details.clone());
-        if let Ok(plugin) = index_details_wrapper.get_plugin()
+        if let Ok(plugin) =
+            index_details_wrapper.get_plugin(ds.session.scalar_index_plugins().as_ref())
             && let Some(stats) = plugin
                 .load_statistics(index_store.clone(), index_details.as_ref())
                 .await?
@@ -1699,14 +1713,17 @@ async fn gather_fragment_statistics(
     )))
 }
 
-pub(crate) fn retain_supported_indices(indices: &mut Vec<IndexMetadata>) {
+pub(crate) fn retain_supported_indices(
+    indices: &mut Vec<IndexMetadata>,
+    registry: &lance_index::registry::IndexPluginRegistry,
+) {
     indices.retain(|idx| {
         let max_supported_version = idx
             .index_details
             .as_ref()
             .map(|details| {
                 IndexDetails(details.clone())
-                    .index_version()
+                    .index_version(registry)
                     // If we don't know how to read the index, it isn't supported
                     .unwrap_or(i32::MAX as u32)
             })
@@ -2337,19 +2354,20 @@ impl DatasetIndexInternalExt for Dataset {
                 continue;
             }
 
-            let plugin = match index_details.get_plugin() {
-                Ok(plugin) => plugin,
-                Err(e) => {
-                    log::warn!(
-                        "Skipping index '{}' on column '{}': {}. \
+            let plugin =
+                match index_details.get_plugin(self.session.scalar_index_plugins().as_ref()) {
+                    Ok(plugin) => plugin,
+                    Err(e) => {
+                        log::warn!(
+                            "Skipping index '{}' on column '{}': {}. \
                          Queries on this column will fall back to a full scan.",
-                        index.name,
-                        field_path,
-                        e
-                    );
-                    continue;
-                }
-            };
+                            index.name,
+                            field_path,
+                            e
+                        );
+                        continue;
+                    }
+                };
             let query_parser = plugin.new_query_parser(index.name.clone(), &index_details.0);
 
             if let Some(query_parser) = query_parser {

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1636,7 +1636,6 @@ async fn collect_regular_indices_statistics(
     let mut index_uri: Option<String> = None;
 
     for meta in metadatas.iter() {
-        let index_store = Arc::new(LanceIndexStore::from_dataset_for_existing(ds, meta).await?);
         let index_details = scalar::fetch_index_details(ds, field_path, meta).await?;
         if index_uri.is_none() {
             index_uri = Some(index_details.type_url.clone());
@@ -1645,12 +1644,16 @@ async fn collect_regular_indices_statistics(
         let index_details_wrapper = scalar::IndexDetails(index_details.clone());
         if let Ok(plugin) =
             index_details_wrapper.get_plugin(ds.session.scalar_index_plugins().as_ref())
-            && let Some(stats) = plugin
-                .load_statistics(index_store.clone(), index_details.as_ref())
-                .await?
+            && plugin.supports_load_statistics()
         {
-            indices_stats.push(stats);
-            continue;
+            let index_store = Arc::new(LanceIndexStore::from_dataset_for_existing(ds, meta).await?);
+            if let Some(stats) = plugin
+                .load_statistics(index_store, index_details.as_ref())
+                .await?
+            {
+                indices_stats.push(stats);
+                continue;
+            }
         }
 
         let index = ds

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -12,7 +12,7 @@ pub(crate) mod zonemap;
 
 pub use inverted::{load_segment_details, load_segments};
 
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use uuid::Uuid;
 
@@ -37,7 +37,6 @@ use lance_index::pbold::{
     BTreeIndexDetails, BitmapIndexDetails, InvertedIndexDetails, LabelListIndexDetails,
 };
 use lance_index::progress::IndexBuildProgress;
-use lance_index::registry::IndexPluginRegistry;
 use lance_index::scalar::IndexStore;
 use lance_index::scalar::inverted::METADATA_FILE;
 use lance_index::scalar::label_list::{
@@ -232,10 +231,6 @@ pub(crate) async fn load_training_data(
     }
 }
 
-// TODO: Allow users to register their own plugins
-static SCALAR_INDEX_PLUGIN_REGISTRY: LazyLock<Arc<IndexPluginRegistry>> =
-    LazyLock::new(IndexPluginRegistry::with_default_plugins);
-
 pub struct IndexDetails(pub Arc<prost_types::Any>);
 
 impl IndexDetails {
@@ -251,12 +246,18 @@ impl IndexDetails {
     }
 
     /// Returns the plugin for the index
-    pub fn get_plugin(&self) -> Result<&dyn ScalarIndexPlugin> {
-        SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_details(self.0.as_ref())
+    pub fn get_plugin(
+        &self,
+        registry: &lance_index::registry::IndexPluginRegistry,
+    ) -> Result<Arc<dyn ScalarIndexPlugin>> {
+        registry.get_plugin_by_details(self.0.as_ref())
     }
 
     /// Returns the index version
-    pub fn index_version(&self) -> Result<u32> {
+    pub fn index_version(
+        &self,
+        registry: &lance_index::registry::IndexPluginRegistry,
+    ) -> Result<u32> {
         if self.is_vector() {
             // VectorIndexDetails currently does not include the concrete vector
             // subtype (IVF_PQ / IVF_RQ / ...), so compatibility filtering cannot
@@ -265,7 +266,7 @@ impl IndexDetails {
             // ignore newer indices based on their own lower bound.
             Ok(IndexType::max_vector_version())
         } else {
-            self.get_plugin().map(|p| p.version())
+            self.get_plugin(registry).map(|p| p.version())
         }
     }
 }
@@ -293,7 +294,10 @@ pub(super) async fn build_scalar_index(
 
     let index_store = LanceIndexStore::from_dataset_for_new(dataset, &uuid)?;
 
-    let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
+    let plugin = dataset
+        .session
+        .scalar_index_plugins()
+        .get_plugin_by_name(&params.index_type)?;
     let training_request =
         plugin.new_training_request(params.params.as_deref().unwrap_or("{}"), &field)?;
 
@@ -350,7 +354,10 @@ pub(super) async fn build_bitmap_index_segment(
     let field: arrow_schema::Field = field.into();
 
     let params = ScalarIndexParams::for_builtin(BuiltinIndexType::Bitmap);
-    let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
+    let plugin = dataset
+        .session
+        .scalar_index_plugins()
+        .get_plugin_by_name(&params.index_type)?;
     let training_request =
         plugin.new_training_request(params.params.as_deref().unwrap_or("{}"), &field)?;
     let criteria = training_request.criteria();
@@ -438,7 +445,10 @@ pub async fn open_scalar_index(
     let index_store = Arc::new(LanceIndexStore::from_dataset_for_existing(dataset, index).await?);
 
     let index_details = fetch_index_details(dataset, column, index).await?;
-    let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_details(index_details.as_ref())?;
+    let plugin = dataset
+        .session
+        .scalar_index_plugins()
+        .get_plugin_by_details(index_details.as_ref())?;
 
     let frag_reuse_index = dataset.open_frag_reuse_index(metrics).await?;
 
@@ -537,6 +547,7 @@ pub fn index_matches_criteria(
     fields: &[&Field],
     has_multiple_indices: bool,
     schema: &lance_core::datatypes::Schema,
+    registry: &lance_index::registry::IndexPluginRegistry,
 ) -> Result<bool> {
     if let Some(name) = &criteria.has_name
         && &index.name != name
@@ -589,7 +600,7 @@ pub fn index_matches_criteria(
         // We should not use FTS / NGram indices for exact equality queries
         // (i.e. merge insert with a join on the indexed column)
         if criteria.must_support_exact_equality {
-            let plugin = index_details.get_plugin()?;
+            let plugin = index_details.get_plugin(registry)?;
             if !plugin.provides_exact_answer() {
                 return Ok(false);
             }
@@ -734,10 +745,26 @@ mod tests {
             metadata: Default::default(),
         };
         // Vector indices should now match basic criteria
-        let result = index_matches_criteria(&index1, &criteria, &[&field], true, &schema).unwrap();
+        let result = index_matches_criteria(
+            &index1,
+            &criteria,
+            &[&field],
+            true,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
 
-        let result = index_matches_criteria(&index1, &criteria, &[&field], false, &schema).unwrap();
+        let result = index_matches_criteria(
+            &index1,
+            &criteria,
+            &[&field],
+            false,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
     }
 
@@ -759,12 +786,26 @@ mod tests {
             fields: vec![field.clone()],
             metadata: Default::default(),
         };
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], true, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            true,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
 
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], false, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            false,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
 
         // test for_column
@@ -774,13 +815,27 @@ mod tests {
             for_column: Some("mycol"),
             has_name: None,
         };
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], false, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            false,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
 
         criteria.for_column = Some("mycol2");
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], false, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            false,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(!result);
 
         // test has_name
@@ -790,19 +845,47 @@ mod tests {
             for_column: None,
             has_name: Some("btree_index"),
         };
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], true, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            true,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], false, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            false,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
 
         criteria.has_name = Some("btree_index2");
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], true, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            true,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(!result);
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], false, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            false,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(!result);
 
         // test supports_exact_equality
@@ -812,18 +895,39 @@ mod tests {
             for_column: None,
             has_name: None,
         };
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], false, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            false,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
 
         criteria.must_support_fts = true;
-        let result =
-            index_matches_criteria(&inverted_index, &criteria, &[&field], false, &schema).unwrap();
+        let result = index_matches_criteria(
+            &inverted_index,
+            &criteria,
+            &[&field],
+            false,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(!result);
 
         criteria.must_support_fts = false;
-        let result =
-            index_matches_criteria(&ngram_index, &criteria, &[&field], true, &schema).unwrap();
+        let result = index_matches_criteria(
+            &ngram_index,
+            &criteria,
+            &[&field],
+            true,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(!result);
 
         // test multiple indices
@@ -833,18 +937,39 @@ mod tests {
             for_column: None,
             has_name: None,
         };
-        let result =
-            index_matches_criteria(&btree_index, &criteria, &[&field], true, &schema).unwrap();
+        let result = index_matches_criteria(
+            &btree_index,
+            &criteria,
+            &[&field],
+            true,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
 
         criteria.must_support_fts = true;
-        let result =
-            index_matches_criteria(&inverted_index, &criteria, &[&field], true, &schema).unwrap();
+        let result = index_matches_criteria(
+            &inverted_index,
+            &criteria,
+            &[&field],
+            true,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
 
         criteria.must_support_fts = false;
-        let result =
-            index_matches_criteria(&ngram_index, &criteria, &[&field], true, &schema).unwrap();
+        let result = index_matches_criteria(
+            &ngram_index,
+            &criteria,
+            &[&field],
+            true,
+            &schema,
+            lance_index::registry::IndexPluginRegistry::with_default_plugins().as_ref(),
+        )
+        .unwrap();
         assert!(result);
     }
 

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -8,6 +8,7 @@ use lance_core::cache::{CacheBackend, LanceCache};
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::{Error, Result};
 use lance_index::IndexType;
+use lance_index::registry::IndexPluginRegistry;
 use lance_io::object_store::ObjectStoreRegistry;
 
 use crate::dataset::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
@@ -19,6 +20,7 @@ use self::index_extension::IndexExtension;
 pub(crate) mod caches;
 pub mod index_caches;
 pub(crate) mod index_extension;
+pub mod xabi_index_plugin;
 
 /// A user session holds the runtime state for a [`crate::Dataset`]
 ///
@@ -52,6 +54,8 @@ pub struct Session {
 
     pub(crate) index_extensions: HashMap<(IndexType, String), Arc<dyn IndexExtension>>,
 
+    pub(crate) scalar_index_plugins: Arc<IndexPluginRegistry>,
+
     store_registry: Arc<ObjectStoreRegistry>,
 }
 
@@ -83,6 +87,7 @@ impl std::fmt::Debug for Session {
                 "index_extensions",
                 &self.index_extensions.keys().collect::<Vec<_>>(),
             )
+            .field("scalar_index_plugins", &"IndexPluginRegistry")
             .finish()
     }
 }
@@ -106,6 +111,7 @@ impl Session {
             index_cache: GlobalIndexCache(LanceCache::with_capacity(index_cache_size)),
             metadata_cache: GlobalMetadataCache(LanceCache::with_capacity(metadata_cache_size)),
             index_extensions: HashMap::new(),
+            scalar_index_plugins: IndexPluginRegistry::with_default_plugins(),
             store_registry,
         }
     }
@@ -123,6 +129,7 @@ impl Session {
             index_cache: GlobalIndexCache(LanceCache::with_backend(index_cache_backend)),
             metadata_cache: GlobalMetadataCache(LanceCache::with_capacity(metadata_cache_size)),
             index_extensions: HashMap::new(),
+            scalar_index_plugins: IndexPluginRegistry::with_default_plugins(),
             store_registry,
         }
     }
@@ -171,6 +178,25 @@ impl Session {
         Ok(())
     }
 
+    /// Register scalar index plugins from a trusted xabi dynamic library.
+    ///
+    /// # Safety
+    ///
+    /// Loading a plugin library runs native code in the current process. The
+    /// caller must trust `path` and ensure it was built against a compatible
+    /// Lance index plugin ABI.
+    pub unsafe fn register_xabi_index_plugin_library(
+        &mut self,
+        path: impl AsRef<std::path::Path>,
+    ) -> Result<Vec<String>> {
+        unsafe {
+            xabi_index_plugin::register_xabi_scalar_index_plugin_library(
+                self.scalar_index_plugins.clone(),
+                path,
+            )
+        }
+    }
+
     /// Return the current size of the session in bytes
     ///
     /// Keep in mind that this is not trivial to compute, as we will need to walk the caches
@@ -193,6 +219,11 @@ impl Session {
     /// Get the object store registry.
     pub fn store_registry(&self) -> Arc<ObjectStoreRegistry> {
         self.store_registry.clone()
+    }
+
+    /// Get the scalar index plugin registry.
+    pub fn scalar_index_plugins(&self) -> Arc<IndexPluginRegistry> {
+        self.scalar_index_plugins.clone()
     }
 
     /// Get a reference to the raw metadata cache (for use in index reconstruction).

--- a/rust/lance/src/session/xabi_index_plugin.rs
+++ b/rust/lance/src/session/xabi_index_plugin.rs
@@ -1,0 +1,947 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow_schema::Field;
+use async_trait::async_trait;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::prelude::Column;
+use datafusion::scalar::ScalarValue;
+use datafusion_expr::expr::InList;
+use datafusion_expr::{Between, BinaryExpr, Expr, Operator};
+use futures::StreamExt;
+use lance_core::cache::LanceCache;
+use lance_core::deepsize::{Context, DeepSizeOf};
+use lance_core::{Error, Result};
+use lance_index::metrics::MetricsCollector;
+use lance_index::progress::IndexBuildProgress;
+use lance_index::registry::IndexPluginRegistry;
+use lance_index::scalar::expression::{
+    IndexedExpression, ScalarIndexExpr, ScalarIndexSearch, ScalarQueryParser,
+};
+use lance_index::scalar::registry::{
+    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+};
+use lance_index::scalar::{
+    AnyQuery, CreatedIndex, IndexStore, OldIndexDataFilter, ScalarIndex, ScalarIndexParams,
+    SearchResult, UpdateCriteria,
+};
+use lance_index::{Index, IndexType};
+use lance_index_plugin_abi::{
+    ABI_VERSION, EXACTNESS_AT_LEAST, EXACTNESS_AT_MOST, EXACTNESS_EXACT,
+    LanceIndexBuildProgressAbi, LanceIndexStoreAbi, LanceTrainingDataAbi, ORDERING_ADDRESSES,
+    ORDERING_NONE, ORDERING_VALUES, OwnedLanceIndexBuildProgressAbi, OwnedLanceIndexStoreAbi,
+    OwnedLanceTrainingDataAbi, QueryPlanAbi, SubstraitQueryAbi, TrainInputAbi,
+    UPDATE_ONLY_NEW_DATA, UPDATE_REQUIRES_OLD_DATA, XabiLanceScalarIndexHandle,
+    XabiLanceScalarIndexPluginHandle, ipc_to_record_batches, le_bytes_to_u32s, le_bytes_to_u64s,
+    record_batch_to_ipc, record_batches_to_ipc, u32s_to_le_bytes, u64s_to_le_bytes,
+};
+use lance_select::RowAddrTreeMap;
+use prost_types::Any as ProstAny;
+use roaring::RoaringBitmap;
+use serde_json::json;
+
+use tokio::sync::Mutex;
+
+#[derive(Debug)]
+pub struct XabiScalarIndexPlugin {
+    handle: Arc<XabiLanceScalarIndexPluginHandle>,
+    name: String,
+    version: u32,
+    provides_exact_answer: bool,
+}
+
+impl XabiScalarIndexPlugin {
+    fn new(
+        handle: XabiLanceScalarIndexPluginHandle,
+        name: String,
+        version: u32,
+        provides_exact_answer: bool,
+    ) -> Self {
+        Self {
+            handle: Arc::new(handle),
+            name,
+            version,
+            provides_exact_answer,
+        }
+    }
+}
+
+struct XabiTrainingRequest {
+    criteria: TrainingCriteria,
+}
+
+impl TrainingRequest for XabiTrainingRequest {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn criteria(&self) -> &TrainingCriteria {
+        &self.criteria
+    }
+}
+
+/// Register every Lance scalar-index export from a trusted xabi module.
+///
+/// # Safety
+///
+/// `path` must point to trusted native code that follows the Lance index plugin
+/// ABI. Loading an arbitrary dynamic library runs code in the current process.
+pub unsafe fn register_xabi_scalar_index_plugin_library(
+    registry: Arc<IndexPluginRegistry>,
+    path: impl AsRef<Path>,
+) -> Result<Vec<String>> {
+    let module = unsafe { xabi::Module::load(path) }.map_err(xabi_to_lance)?;
+    let mut registered = Vec::new();
+    for (_export_name, handle) in
+        XabiLanceScalarIndexPluginHandle::xabi_load_all(&module).map_err(xabi_to_lance)?
+    {
+        let name = handle.name().map_err(xabi_to_lance)?;
+        let version = handle.version().map_err(xabi_to_lance)?;
+        let provides_exact_answer = handle.provides_exact_answer().map_err(xabi_to_lance)?;
+        let details_type_url = handle.details_type_url().map_err(xabi_to_lance)?;
+        let plugin = Arc::new(XabiScalarIndexPlugin::new(
+            handle,
+            name.clone(),
+            version,
+            provides_exact_answer,
+        ));
+        plugin.attach_registry(registry.clone());
+        registry.add_runtime_plugin(name.clone(), plugin.clone())?;
+        registry.add_runtime_plugin_for_details(&details_type_url, plugin)?;
+        registered.push(name);
+    }
+    Ok(registered)
+}
+
+fn xabi_to_lance(err: impl std::fmt::Display) -> Error {
+    Error::index(format!("xabi index plugin error: {err}"))
+}
+
+fn block_on_xabi<F: std::future::Future>(future: F) -> F::Output {
+    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
+}
+
+fn training_ordering_from_abi(ordering: u32) -> Result<TrainingOrdering> {
+    match ordering {
+        ORDERING_NONE => Ok(TrainingOrdering::None),
+        ORDERING_VALUES => Ok(TrainingOrdering::Values),
+        ORDERING_ADDRESSES => Ok(TrainingOrdering::Addresses),
+        other => Err(Error::invalid_input(format!(
+            "unknown xabi training ordering {other}"
+        ))),
+    }
+}
+
+fn training_criteria_from_abi(
+    criteria: lance_index_plugin_abi::TrainingCriteriaAbi,
+) -> Result<TrainingCriteria> {
+    let ordering = training_ordering_from_abi(criteria.ordering)?;
+    let needs_row_ids = criteria.needs_row_ids != 0;
+    let needs_row_addrs = criteria.needs_row_addrs != 0;
+    let mut criteria = TrainingCriteria::new(ordering);
+    if needs_row_ids {
+        criteria = criteria.with_row_id();
+    }
+    if needs_row_addrs {
+        criteria = criteria.with_row_addr();
+    }
+    Ok(criteria)
+}
+
+fn update_criteria_from_abi(
+    criteria: lance_index_plugin_abi::UpdateCriteriaAbi,
+) -> Result<UpdateCriteria> {
+    let data_criteria = training_criteria_from_abi(criteria.data_criteria)?;
+    match criteria.mode {
+        UPDATE_REQUIRES_OLD_DATA => Ok(UpdateCriteria::requires_old_data(data_criteria)),
+        UPDATE_ONLY_NEW_DATA => Ok(UpdateCriteria::only_new_data(data_criteria)),
+        other => Err(Error::invalid_input(format!(
+            "unknown xabi update criteria mode {other}"
+        ))),
+    }
+}
+
+fn created_index_from_abi(created: lance_index_plugin_abi::CreatedIndexAbi) -> CreatedIndex {
+    CreatedIndex {
+        index_details: ProstAny {
+            type_url: created.details_type_url,
+            value: created.details,
+        },
+        index_version: created.index_version,
+        files: Vec::new(),
+    }
+}
+
+fn row_addr_map(row_ids: Vec<u64>) -> RowAddrTreeMap {
+    let mut map = RowAddrTreeMap::new();
+    for row_id in row_ids {
+        map.insert(row_id);
+    }
+    map
+}
+
+fn search_result_from_abi(output: lance_index_plugin_abi::SearchOutputAbi) -> Result<SearchResult> {
+    let row_ids = row_addr_map(le_bytes_to_u64s(&output.row_ids_le).map_err(xabi_to_lance)?);
+    let null_row_ids =
+        row_addr_map(le_bytes_to_u64s(&output.null_row_ids_le).map_err(xabi_to_lance)?);
+    let result = match output.exactness {
+        EXACTNESS_EXACT => SearchResult::exact(row_ids),
+        EXACTNESS_AT_MOST => SearchResult::at_most(row_ids),
+        EXACTNESS_AT_LEAST => SearchResult::at_least(row_ids),
+        other => {
+            return Err(Error::invalid_input(format!(
+                "unknown xabi search exactness {other}"
+            )));
+        }
+    };
+    Ok(result.with_nulls(null_row_ids))
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for XabiScalarIndexPlugin {
+    fn new_training_request(
+        &self,
+        params: &str,
+        field: &Field,
+    ) -> Result<Box<dyn TrainingRequest>> {
+        let field_json = format!("{field:?}");
+        let plan = self
+            .handle
+            .new_training_plan(params, &field_json)
+            .map_err(xabi_to_lance)?;
+        Ok(Box::new(XabiTrainingRequest {
+            criteria: training_criteria_from_abi(plan.criteria)?,
+        }))
+    }
+
+    async fn train_index(
+        &self,
+        data: SendableRecordBatchStream,
+        index_store: &dyn IndexStore,
+        request: Box<dyn TrainingRequest>,
+        fragment_ids: Option<Vec<u32>>,
+        progress: Arc<dyn IndexBuildProgress>,
+    ) -> Result<CreatedIndex> {
+        let data = OwnedLanceTrainingDataAbi::new(HostTrainingData::new(data));
+        let store = OwnedLanceIndexStoreAbi::new(HostIndexStore::new(index_store.clone_arc()));
+        let progress = OwnedLanceIndexBuildProgressAbi::new(HostIndexBuildProgress::new(progress));
+        let input = TrainInputAbi::new(
+            "{}".to_string(),
+            u32s_to_le_bytes(&fragment_ids.unwrap_or_default()),
+            data.xabi_borrow(),
+            store.xabi_borrow(),
+            progress.xabi_borrow(),
+        );
+        let created = block_on_xabi(self.handle.train_index(input)).map_err(xabi_to_lance)?;
+        let mut created = created_index_from_abi(created);
+        created.files = index_store.list_files_with_sizes().await?;
+        let _ = request;
+        Ok(created)
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn provides_exact_answer(&self) -> bool {
+        self.provides_exact_answer
+    }
+
+    fn version(&self) -> u32 {
+        self.version
+    }
+
+    fn new_query_parser(
+        &self,
+        index_name: String,
+        index_details: &ProstAny,
+    ) -> Option<Box<dyn ScalarQueryParser>> {
+        Some(Box::new(XabiScalarQueryParser {
+            handle: self.handle.clone(),
+            index_name,
+            index_type: self.name.clone(),
+            details: index_details.value.clone(),
+        }))
+    }
+
+    async fn load_index(
+        &self,
+        index_store: Arc<dyn IndexStore>,
+        index_details: &ProstAny,
+        _frag_reuse_index: Option<Arc<lance_index::frag_reuse::FragReuseIndex>>,
+        _cache: &LanceCache,
+    ) -> Result<Arc<dyn ScalarIndex>> {
+        let store = OwnedLanceIndexStoreAbi::new(HostIndexStore::new(index_store));
+        let handle = block_on_xabi(
+            self.handle
+                .load_index(&index_details.value, store.xabi_borrow()),
+        )
+        .map_err(xabi_to_lance)?;
+        let can_remap = handle.can_remap().map_err(xabi_to_lance)?;
+        Ok(Arc::new(XabiScalarIndex {
+            handle: Arc::new(handle),
+            index_type: self.name.clone(),
+            can_remap,
+        }))
+    }
+
+    async fn load_statistics(
+        &self,
+        _index_store: Arc<dyn IndexStore>,
+        index_details: &ProstAny,
+    ) -> Result<Option<serde_json::Value>> {
+        block_on_xabi(self.handle.load_statistics(&index_details.value))
+            .map_err(xabi_to_lance)?
+            .map(|json| serde_json::from_str(&json).map_err(Error::from))
+            .transpose()
+    }
+
+    fn details_as_json(&self, details: &ProstAny) -> Result<serde_json::Value> {
+        let json = self
+            .handle
+            .details_as_json(&details.value)
+            .map_err(xabi_to_lance)?;
+        serde_json::from_str(&json).map_err(Error::from)
+    }
+}
+
+#[derive(Debug)]
+struct XabiScalarQuery {
+    query: Vec<u8>,
+    display: String,
+}
+
+impl AnyQuery for XabiScalarQuery {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn format(&self, _col: &str) -> String {
+        self.display.clone()
+    }
+
+    fn to_expr(&self, _col: String) -> Expr {
+        Expr::Literal(ScalarValue::Boolean(Some(true)), None)
+    }
+
+    fn dyn_eq(&self, other: &dyn AnyQuery) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self.query == other.query)
+    }
+}
+
+struct XabiScalarQueryParser {
+    handle: Arc<XabiLanceScalarIndexPluginHandle>,
+    index_name: String,
+    index_type: String,
+    details: Vec<u8>,
+}
+
+fn bound_value(bound: &std::ops::Bound<ScalarValue>) -> Option<&ScalarValue> {
+    match bound {
+        std::ops::Bound::Included(value) | std::ops::Bound::Excluded(value) => Some(value),
+        std::ops::Bound::Unbounded => None,
+    }
+}
+
+impl Debug for XabiScalarQueryParser {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("XabiScalarQueryParser")
+            .field("index_name", &self.index_name)
+            .field("index_type", &self.index_type)
+            .finish()
+    }
+}
+
+impl XabiScalarQueryParser {
+    fn column_expr(column: &str) -> Expr {
+        Expr::Column(Column::from_name(column))
+    }
+
+    #[cfg(feature = "substrait")]
+    fn encode_substrait(expr: Expr, schema: arrow_schema::Schema) -> (Vec<u8>, Vec<u8>) {
+        let schema = Arc::new(schema);
+        let schema_ipc = record_batches_to_ipc(schema.clone(), &[]).unwrap_or_default();
+        let state = datafusion::execution::context::SessionContext::new().state();
+        let expr_bytes =
+            lance_datafusion::substrait::encode_substrait(expr, schema, &state).unwrap_or_default();
+        (schema_ipc, expr_bytes)
+    }
+
+    #[cfg(not(feature = "substrait"))]
+    fn encode_substrait(_expr: Expr, _schema: arrow_schema::Schema) -> (Vec<u8>, Vec<u8>) {
+        (Vec::new(), Vec::new())
+    }
+
+    fn plan(
+        &self,
+        column: &str,
+        host_query_json: serde_json::Value,
+        substrait: Option<(Expr, arrow_schema::Schema)>,
+    ) -> Option<IndexedExpression> {
+        let (schema_ipc, expr_bytes) = substrait
+            .map(|(expr, schema)| Self::encode_substrait(expr, schema))
+            .unwrap_or_default();
+        let query = SubstraitQueryAbi::new(
+            ABI_VERSION.to_string(),
+            schema_ipc,
+            expr_bytes,
+            host_query_json.to_string(),
+        );
+        let QueryPlanAbi {
+            accepted: _,
+            query,
+            needs_recheck,
+        } = self
+            .handle
+            .plan_query(&self.details, query)
+            .ok()
+            .filter(|plan| plan.accepted != 0)?;
+        Some(IndexedExpression {
+            scalar_query: Some(ScalarIndexExpr::Query(ScalarIndexSearch {
+                column: column.to_string(),
+                index_name: self.index_name.clone(),
+                index_type: self.index_type.clone(),
+                query: Arc::new(XabiScalarQuery {
+                    query,
+                    display: host_query_json.to_string(),
+                }),
+                needs_recheck: needs_recheck != 0,
+                fragment_bitmap: None,
+            })),
+            refine_expr: None,
+        })
+    }
+}
+
+impl ScalarQueryParser for XabiScalarQueryParser {
+    fn visit_between(
+        &self,
+        column: &str,
+        low: &std::ops::Bound<ScalarValue>,
+        high: &std::ops::Bound<ScalarValue>,
+    ) -> Option<IndexedExpression> {
+        self.plan(
+            column,
+            json!({
+                "op": "between",
+                "low": format!("{low:?}"),
+                "high": format!("{high:?}"),
+            }),
+            match (bound_value(low), bound_value(high)) {
+                (Some(low), Some(high)) => Some((
+                    Expr::Between(Between::new(
+                        Box::new(Self::column_expr(column)),
+                        false,
+                        Box::new(Expr::Literal(low.clone(), None)),
+                        Box::new(Expr::Literal(high.clone(), None)),
+                    )),
+                    arrow_schema::Schema::new(vec![Field::new(column, low.data_type(), true)]),
+                )),
+                _ => None,
+            },
+        )
+    }
+
+    fn visit_in_list(&self, column: &str, in_list: &[ScalarValue]) -> Option<IndexedExpression> {
+        let substrait = in_list.first().map(|value| {
+            (
+                Expr::InList(InList::new(
+                    Box::new(Self::column_expr(column)),
+                    in_list
+                        .iter()
+                        .cloned()
+                        .map(|value| Expr::Literal(value, None))
+                        .collect(),
+                    false,
+                )),
+                arrow_schema::Schema::new(vec![Field::new(column, value.data_type(), true)]),
+            )
+        });
+        self.plan(
+            column,
+            json!({
+                "op": "in",
+                "values": in_list.iter().map(|v| v.to_string()).collect::<Vec<_>>(),
+            }),
+            substrait,
+        )
+    }
+
+    fn visit_is_bool(&self, column: &str, value: bool) -> Option<IndexedExpression> {
+        self.plan(
+            column,
+            json!({"op": "eq", "value": value}),
+            Some((
+                Expr::BinaryExpr(BinaryExpr::new(
+                    Box::new(Self::column_expr(column)),
+                    Operator::Eq,
+                    Box::new(Expr::Literal(ScalarValue::Boolean(Some(value)), None)),
+                )),
+                arrow_schema::Schema::new(vec![Field::new(
+                    column,
+                    arrow_schema::DataType::Boolean,
+                    true,
+                )]),
+            )),
+        )
+    }
+
+    fn visit_is_null(&self, column: &str) -> Option<IndexedExpression> {
+        self.plan(
+            column,
+            json!({"op": "is_null"}),
+            Some((
+                Expr::IsNull(Box::new(Self::column_expr(column))),
+                arrow_schema::Schema::new(vec![Field::new(
+                    column,
+                    arrow_schema::DataType::Null,
+                    true,
+                )]),
+            )),
+        )
+    }
+
+    fn visit_comparison(
+        &self,
+        column: &str,
+        value: &ScalarValue,
+        op: &Operator,
+    ) -> Option<IndexedExpression> {
+        self.plan(
+            column,
+            json!({
+                "op": op.to_string(),
+                "value": value.to_string(),
+            }),
+            Some((
+                Expr::BinaryExpr(BinaryExpr::new(
+                    Box::new(Self::column_expr(column)),
+                    *op,
+                    Box::new(Expr::Literal(value.clone(), None)),
+                )),
+                arrow_schema::Schema::new(vec![Field::new(column, value.data_type(), true)]),
+            )),
+        )
+    }
+
+    fn visit_scalar_function(
+        &self,
+        _column: &str,
+        _data_type: &arrow_schema::DataType,
+        _func: &datafusion_expr::ScalarUDF,
+        _args: &[Expr],
+    ) -> Option<IndexedExpression> {
+        None
+    }
+}
+
+#[derive(Debug)]
+struct XabiScalarIndex {
+    handle: Arc<XabiLanceScalarIndexHandle>,
+    index_type: String,
+    can_remap: bool,
+}
+
+impl DeepSizeOf for XabiScalarIndex {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        0
+    }
+}
+
+#[async_trait]
+impl Index for XabiScalarIndex {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn lance_index::vector::VectorIndex>> {
+        Err(Error::invalid_input(
+            "xabi scalar index cannot be used as a vector index",
+        ))
+    }
+
+    async fn prewarm(&self) -> Result<()> {
+        block_on_xabi(self.handle.prewarm()).map_err(xabi_to_lance)
+    }
+
+    fn statistics(&self) -> Result<serde_json::Value> {
+        let json = self.handle.statistics().map_err(xabi_to_lance)?;
+        serde_json::from_str(&json).map_err(Error::from)
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::Scalar
+    }
+
+    async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+        let bytes = self.handle.calculate_included_frags();
+        let bytes = block_on_xabi(bytes).map_err(xabi_to_lance)?;
+        Ok(le_bytes_to_u32s(&bytes)
+            .map_err(xabi_to_lance)?
+            .into_iter()
+            .collect())
+    }
+}
+
+#[async_trait]
+impl ScalarIndex for XabiScalarIndex {
+    async fn search(
+        &self,
+        query: &dyn AnyQuery,
+        _metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
+        let query = query
+            .as_any()
+            .downcast_ref::<XabiScalarQuery>()
+            .ok_or_else(|| {
+                Error::invalid_input("xabi scalar index received an incompatible query")
+            })?;
+        let output = block_on_xabi(self.handle.search(&query.query)).map_err(xabi_to_lance)?;
+        search_result_from_abi(output)
+    }
+
+    fn can_remap(&self) -> bool {
+        self.can_remap
+    }
+
+    async fn remap(
+        &self,
+        mapping: &HashMap<u64, Option<u64>>,
+        dest_store: &dyn IndexStore,
+    ) -> Result<CreatedIndex> {
+        let mappings = mapping.keys().copied().collect::<Vec<_>>();
+        let mapped_row_ids = mapping
+            .values()
+            .map(|value| value.unwrap_or_default())
+            .collect::<Vec<_>>();
+        let has_mapped_row_id = mapping
+            .values()
+            .map(|value| u8::from(value.is_some()))
+            .collect::<Vec<_>>();
+        let store = OwnedLanceIndexStoreAbi::new(HostIndexStore::new(dest_store.clone_arc()));
+        let input = lance_index_plugin_abi::RemapInputAbi::new(
+            u64s_to_le_bytes(&mappings),
+            u64s_to_le_bytes(&mapped_row_ids),
+            has_mapped_row_id,
+            store.xabi_borrow(),
+        );
+        let created = block_on_xabi(self.handle.remap(input)).map_err(xabi_to_lance)?;
+        let mut created = created_index_from_abi(created);
+        created.files = dest_store.list_files_with_sizes().await?;
+        Ok(created)
+    }
+
+    async fn update(
+        &self,
+        new_data: SendableRecordBatchStream,
+        dest_store: &dyn IndexStore,
+        _old_data_filter: Option<OldIndexDataFilter>,
+    ) -> Result<CreatedIndex> {
+        let data = OwnedLanceTrainingDataAbi::new(HostTrainingData::new(new_data));
+        let store = OwnedLanceIndexStoreAbi::new(HostIndexStore::new(dest_store.clone_arc()));
+        let input =
+            lance_index_plugin_abi::UpdateInputAbi::new(data.xabi_borrow(), store.xabi_borrow());
+        let created = block_on_xabi(self.handle.update(input)).map_err(xabi_to_lance)?;
+        let mut created = created_index_from_abi(created);
+        created.files = dest_store.list_files_with_sizes().await?;
+        Ok(created)
+    }
+
+    fn update_criteria(&self) -> UpdateCriteria {
+        self.handle
+            .update_criteria()
+            .map_err(xabi_to_lance)
+            .and_then(update_criteria_from_abi)
+            .unwrap_or_else(|_| {
+                UpdateCriteria::only_new_data(TrainingCriteria::new(TrainingOrdering::None))
+            })
+    }
+
+    fn derive_index_params(&self) -> Result<ScalarIndexParams> {
+        let params_json = self
+            .handle
+            .derive_index_params_json()
+            .map_err(xabi_to_lance)?;
+        let value = serde_json::from_str::<serde_json::Value>(&params_json)?;
+        let mut params = ScalarIndexParams::new(
+            value
+                .get("index_type")
+                .and_then(|value| value.as_str())
+                .unwrap_or(&self.index_type)
+                .to_string(),
+        );
+        if let Some(plugin_params) = value.get("params") {
+            params.params = Some(plugin_params.to_string());
+        }
+        Ok(params)
+    }
+}
+
+struct HostTrainingData {
+    inner: Mutex<SendableRecordBatchStream>,
+}
+
+impl HostTrainingData {
+    fn new(inner: SendableRecordBatchStream) -> Self {
+        Self {
+            inner: Mutex::new(inner),
+        }
+    }
+}
+
+impl LanceTrainingDataAbi for HostTrainingData {
+    async fn next_batch_ipc(&self) -> xabi::Result<Option<Vec<u8>>> {
+        let mut stream = self.inner.lock().await;
+        match stream.next().await {
+            Some(Ok(batch)) => record_batch_to_ipc(&batch).map(Some),
+            Some(Err(err)) => Err(xabi::Error::Export(err.to_string())),
+            None => Ok(None),
+        }
+    }
+}
+
+struct HostIndexStore {
+    inner: Arc<dyn IndexStore>,
+}
+
+impl HostIndexStore {
+    fn new(inner: Arc<dyn IndexStore>) -> Self {
+        Self { inner }
+    }
+}
+
+impl LanceIndexStoreAbi for HostIndexStore {
+    async fn write_record_batches(&self, name: &str, batches_ipc: &[u8]) -> xabi::Result<Vec<u8>> {
+        let batches = ipc_to_record_batches(batches_ipc)?;
+        let Some(first) = batches.first() else {
+            return Err(xabi::Error::Export(
+                "write_record_batches requires at least one batch".to_string(),
+            ));
+        };
+        let mut writer = self
+            .inner
+            .new_index_file(name, first.schema())
+            .await
+            .map_err(|err| xabi::Error::Export(err.to_string()))?;
+        for batch in batches {
+            writer
+                .write_record_batch(batch)
+                .await
+                .map_err(|err| xabi::Error::Export(err.to_string()))?;
+        }
+        let file = writer
+            .finish()
+            .await
+            .map_err(|err| xabi::Error::Export(err.to_string()))?;
+        serde_json::to_vec(&json!({
+            "path": file.path,
+            "size_bytes": file.size_bytes,
+        }))
+        .map_err(|err| xabi::Error::Export(err.to_string()))
+    }
+
+    async fn read_record_batches(&self, name: &str) -> xabi::Result<Vec<u8>> {
+        let reader = self
+            .inner
+            .open_index_file(name)
+            .await
+            .map_err(|err| xabi::Error::Export(err.to_string()))?;
+        let batch = reader
+            .read_range(0..reader.num_rows(), None)
+            .await
+            .map_err(|err| xabi::Error::Export(err.to_string()))?;
+        record_batches_to_ipc(batch.schema(), &[batch])
+    }
+}
+
+struct HostIndexBuildProgress {
+    inner: Arc<dyn IndexBuildProgress>,
+}
+
+impl HostIndexBuildProgress {
+    fn new(inner: Arc<dyn IndexBuildProgress>) -> Self {
+        Self { inner }
+    }
+}
+
+impl LanceIndexBuildProgressAbi for HostIndexBuildProgress {
+    async fn stage_start(&self, name: &str, total: u64, unit: &str) -> xabi::Result<()> {
+        self.inner
+            .stage_start(name, Some(total), unit)
+            .await
+            .map_err(|err| xabi::Error::Export(err.to_string()))
+    }
+
+    async fn stage_progress(&self, name: &str, amount: u64) -> xabi::Result<()> {
+        self.inner
+            .stage_progress(name, amount)
+            .await
+            .map_err(|err| xabi::Error::Export(err.to_string()))
+    }
+
+    async fn stage_complete(&self, name: &str) -> xabi::Result<()> {
+        self.inner
+            .stage_complete(name)
+            .await
+            .map_err(|err| xabi::Error::Export(err.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+    use std::sync::Arc;
+
+    use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator};
+    use arrow_schema::{DataType, Field, Schema};
+    use lance_index::scalar::ScalarIndexParams;
+
+    use crate::Dataset;
+    use crate::dataset::builder::DatasetBuilder;
+    use crate::index::DatasetIndexExt;
+    use crate::session::Session;
+
+    fn mock_btree_plugin_path() -> std::path::PathBuf {
+        if let Some(path) = std::env::var_os("LANCE_XABI_MOCK_BTREE_PLUGIN") {
+            return path.into();
+        }
+
+        let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("lance crate should be under rust/lance");
+        let manifest_path = workspace
+            .join("rust")
+            .join("lance")
+            .join("tests")
+            .join("xabi_plugins")
+            .join("mock_btree")
+            .join("Cargo.toml");
+        let target_dir = workspace.join("target").join("xabi-mock-btree-test");
+        let status = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()))
+            .current_dir(workspace)
+            .args([
+                "build",
+                "--manifest-path",
+                manifest_path.to_str().unwrap(),
+                "--target-dir",
+            ])
+            .arg(&target_dir)
+            .status()
+            .expect("failed to build mock xabi btree plugin");
+        assert!(status.success(), "failed to build mock xabi btree plugin");
+
+        let library_name = if cfg!(target_os = "windows") {
+            "lance_index_plugin_mock_btree.dll"
+        } else if cfg!(target_os = "macos") {
+            "liblance_index_plugin_mock_btree.dylib"
+        } else {
+            "liblance_index_plugin_mock_btree.so"
+        };
+        target_dir.join("debug").join(library_name)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_xabi_mock_btree_scalar_index_end_to_end() {
+        let plugin_path = mock_btree_plugin_path();
+        assert!(
+            plugin_path.exists(),
+            "mock xabi btree plugin does not exist at {}",
+            plugin_path.display()
+        );
+
+        let mut session = Session::default();
+        let registered = unsafe {
+            session
+                .register_xabi_index_plugin_library(&plugin_path)
+                .unwrap()
+        };
+        assert_eq!(registered, vec!["mock-btree".to_string()]);
+        let session = Arc::new(session);
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let uri = tempdir.path().to_str().unwrap().to_string();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Int32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![10, 20, 10, 30, 10])),
+            ],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        Dataset::write(reader, &uri, None).await.unwrap();
+
+        let mut dataset = DatasetBuilder::from_uri(&uri)
+            .with_session(session.clone())
+            .load()
+            .await
+            .unwrap();
+        let params = ScalarIndexParams::new("mock-btree".to_string());
+        dataset
+            .create_index(
+                &["value"],
+                lance_index::IndexType::Scalar,
+                Some("value_mock_btree_idx".to_string()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let dataset = DatasetBuilder::from_uri(&uri)
+            .with_session(session)
+            .load()
+            .await
+            .unwrap();
+        let filtered = dataset
+            .scan()
+            .filter("value = 10")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let ids = filtered["id"]
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .values();
+        assert_eq!(ids, &[1, 3, 5]);
+
+        let descriptions = dataset.describe_indices(None).await.unwrap();
+        assert_eq!(descriptions.len(), 1);
+        let description = &descriptions[0];
+        assert_eq!(description.name(), "value_mock_btree_idx");
+        assert_eq!(description.index_type(), "mock-btree");
+        assert_eq!(
+            description.type_url(),
+            "type.googleapis.com/lance.index.plugin.MockBTreeIndexDetails"
+        );
+
+        let stats: serde_json::Value = serde_json::from_str(
+            &dataset
+                .index_statistics("value_mock_btree_idx")
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(stats["indices"][0]["plugin"], "mock-btree");
+    }
+}

--- a/rust/lance/src/session/xabi_index_plugin.rs
+++ b/rust/lance/src/session/xabi_index_plugin.rs
@@ -302,6 +302,10 @@ impl ScalarIndexPlugin for XabiScalarIndexPlugin {
             .transpose()
     }
 
+    fn supports_load_statistics(&self) -> bool {
+        true
+    }
+
     fn details_as_json(&self, details: &ProstAny) -> Result<serde_json::Value> {
         let json = self
             .handle

--- a/rust/lance/tests/xabi_plugins/mock_btree/.gitignore
+++ b/rust/lance/tests/xabi_plugins/mock_btree/.gitignore
@@ -1,0 +1,1 @@
+/Cargo.lock

--- a/rust/lance/tests/xabi_plugins/mock_btree/Cargo.toml
+++ b/rust/lance/tests/xabi_plugins/mock_btree/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "lance-index-plugin-mock-btree"
+version = "0.0.0"
+edition = "2024"
+publish = false
+description = "Mock xabi BTree scalar index plugin for Lance tests"
+license = "Apache-2.0"
+rust-version = "1.91.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+arrow-array = "58.0.0"
+arrow-schema = "58.0.0"
+lance-index-plugin-abi = { path = "../../../../lance-index-plugin-abi" }
+serde_json = "1"
+xabi = "0.1.0"
+
+[workspace]

--- a/rust/lance/tests/xabi_plugins/mock_btree/src/lib.rs
+++ b/rust/lance/tests/xabi_plugins/mock_btree/src/lib.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use arrow_array::{Array, Int32Array, RecordBatch, UInt64Array};
+use arrow_schema::{DataType, Field, Schema};
+use lance_index_plugin_abi::{
+    CreatedIndexAbi, EXACTNESS_EXACT, LanceScalarIndexAbi, LanceScalarIndexPluginAbi,
+    ORDERING_VALUES, QueryPlanAbi, SearchOutputAbi, SubstraitQueryAbi, TrainInputAbi,
+    TrainingCriteriaAbi, TrainingPlanAbi, UPDATE_ONLY_NEW_DATA, UpdateCriteriaAbi,
+    ipc_to_record_batches, record_batches_to_ipc, u32s_to_le_bytes, u64s_to_le_bytes,
+};
+use serde_json::Value;
+
+const PLUGIN_NAME: &str = "mock-btree";
+const DETAILS_TYPE_URL: &str = "type.googleapis.com/lance.index.plugin.MockBTreeIndexDetails";
+const INDEX_FILE: &str = "mock_btree.lance";
+
+#[derive(Default)]
+struct MockBTreePlugin;
+
+struct MockBTreeIndex {
+    rows: Vec<(i32, u64)>,
+}
+
+impl MockBTreeIndex {
+    async fn load(store: lance_index_plugin_abi::BorrowedLanceIndexStoreAbi) -> xabi::Result<Self> {
+        let bytes = store
+            .read_record_batches(INDEX_FILE)
+            .await
+            .map_err(xabi_call_to_error)?;
+        let rows = rows_from_batches(&ipc_to_record_batches(&bytes)?)?;
+        Ok(Self { rows })
+    }
+}
+
+impl MockBTreePlugin {
+    fn name(&self) -> String {
+        PLUGIN_NAME.to_string()
+    }
+
+    fn version(&self) -> u32 {
+        1
+    }
+
+    fn details_type_url(&self) -> String {
+        DETAILS_TYPE_URL.to_string()
+    }
+
+    fn provides_exact_answer(&self) -> bool {
+        true
+    }
+
+    fn new_training_plan(
+        &self,
+        _params_json: &str,
+        _field_json: &str,
+    ) -> xabi::Result<TrainingPlanAbi> {
+        Ok(TrainingPlanAbi::new(TrainingCriteriaAbi::new(
+            ORDERING_VALUES,
+            1,
+            0,
+        )))
+    }
+
+    async fn train_index(&self, input: TrainInputAbi) -> xabi::Result<CreatedIndexAbi> {
+        let mut rows = Vec::new();
+        while let Some(batch_ipc) = input
+            .data
+            .next_batch_ipc()
+            .await
+            .map_err(xabi_call_to_error)?
+        {
+            rows.extend(rows_from_batches(&ipc_to_record_batches(&batch_ipc)?)?);
+        }
+        rows.sort_unstable_by_key(|(value, row_id)| (*value, *row_id));
+
+        let batch = batch_from_rows(&rows)?;
+        let bytes = record_batches_to_ipc(batch.schema(), &[batch])?;
+        input
+            .store
+            .write_record_batches(INDEX_FILE, &bytes)
+            .await
+            .map_err(xabi_call_to_error)?;
+
+        Ok(CreatedIndexAbi::new(
+            DETAILS_TYPE_URL.to_string(),
+            b"mock-btree-v1".to_vec(),
+            1,
+        ))
+    }
+
+    async fn load_index(
+        &self,
+        _details: &[u8],
+        store: lance_index_plugin_abi::BorrowedLanceIndexStoreAbi,
+    ) -> xabi::Result<impl LanceScalarIndexAbi + 'static> {
+        MockBTreeIndex::load(store).await
+    }
+
+    fn plan_query(&self, _details: &[u8], query: SubstraitQueryAbi) -> xabi::Result<QueryPlanAbi> {
+        let host_query: Value = serde_json::from_str(&query.host_query_json)
+            .map_err(|err| xabi::Error::Export(err.to_string()))?;
+        let accepted = matches!(
+            host_query.get("op").and_then(Value::as_str),
+            Some("=") | Some("Eq")
+        );
+        if accepted && (query.schema_ipc.is_empty() || query.expr_bytes.is_empty()) {
+            return Err(xabi::Error::Export(
+                "accepted mock-btree queries must include Substrait payload".to_string(),
+            ));
+        }
+        Ok(QueryPlanAbi::new(
+            u8::from(accepted),
+            query.host_query_json.into_bytes(),
+            0,
+        ))
+    }
+
+    async fn load_statistics(&self, _details: &[u8]) -> xabi::Result<Option<String>> {
+        Ok(Some(r#"{"plugin":"mock-btree"}"#.to_string()))
+    }
+
+    fn details_as_json(&self, details: &[u8]) -> xabi::Result<String> {
+        Ok(format!(
+            r#"{{"plugin":"mock-btree","details_size":{}}}"#,
+            details.len()
+        ))
+    }
+}
+
+impl LanceScalarIndexAbi for MockBTreeIndex {
+    async fn prewarm(&self) -> xabi::Result<()> {
+        Ok(())
+    }
+
+    fn statistics(&self) -> xabi::Result<String> {
+        Ok(format!(r#"{{"rows":{}}}"#, self.rows.len()))
+    }
+
+    async fn calculate_included_frags(&self) -> xabi::Result<Vec<u8>> {
+        let mut fragments = self
+            .rows
+            .iter()
+            .map(|(_, row_id)| (*row_id >> 32) as u32)
+            .collect::<Vec<_>>();
+        fragments.sort_unstable();
+        fragments.dedup();
+        Ok(u32s_to_le_bytes(&fragments))
+    }
+
+    async fn search(&self, query: &[u8]) -> xabi::Result<SearchOutputAbi> {
+        let query: Value =
+            serde_json::from_slice(query).map_err(|err| xabi::Error::Export(err.to_string()))?;
+        let needle = query
+            .get("value")
+            .and_then(Value::as_str)
+            .ok_or_else(|| xabi::Error::Export("query is missing string value".to_string()))?
+            .parse::<i32>()
+            .map_err(|err| xabi::Error::Export(err.to_string()))?;
+        let row_ids = self
+            .rows
+            .iter()
+            .filter_map(|(value, row_id)| (*value == needle).then_some(*row_id))
+            .collect::<Vec<_>>();
+        Ok(SearchOutputAbi::new(
+            EXACTNESS_EXACT,
+            u64s_to_le_bytes(&row_ids),
+            Vec::new(),
+        ))
+    }
+
+    fn can_remap(&self) -> bool {
+        false
+    }
+
+    async fn remap(
+        &self,
+        _input: lance_index_plugin_abi::RemapInputAbi,
+    ) -> xabi::Result<CreatedIndexAbi> {
+        Err(xabi::Error::Export(
+            "mock-btree remap is not implemented".to_string(),
+        ))
+    }
+
+    async fn update(
+        &self,
+        _input: lance_index_plugin_abi::UpdateInputAbi,
+    ) -> xabi::Result<CreatedIndexAbi> {
+        Err(xabi::Error::Export(
+            "mock-btree update is not implemented".to_string(),
+        ))
+    }
+
+    fn update_criteria(&self) -> xabi::Result<UpdateCriteriaAbi> {
+        Ok(UpdateCriteriaAbi::new(
+            UPDATE_ONLY_NEW_DATA,
+            TrainingCriteriaAbi::new(ORDERING_VALUES, 1, 0),
+        ))
+    }
+
+    fn derive_index_params_json(&self) -> xabi::Result<String> {
+        Ok(r#"{"index_type":"mock-btree"}"#.to_string())
+    }
+}
+
+fn rows_from_batches(batches: &[RecordBatch]) -> xabi::Result<Vec<(i32, u64)>> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let values = batch
+            .column_by_name("value")
+            .ok_or_else(|| {
+                xabi::Error::Export("training batch is missing value column".to_string())
+            })?
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .ok_or_else(|| xabi::Error::Export("value column must be Int32".to_string()))?;
+        let row_ids = batch
+            .column_by_name("_rowid")
+            .ok_or_else(|| {
+                xabi::Error::Export("training batch is missing _rowid column".to_string())
+            })?
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| xabi::Error::Export("_rowid column must be UInt64".to_string()))?;
+        for row_idx in 0..batch.num_rows() {
+            if values.is_null(row_idx) || row_ids.is_null(row_idx) {
+                continue;
+            }
+            rows.push((values.value(row_idx), row_ids.value(row_idx)));
+        }
+    }
+    Ok(rows)
+}
+
+fn batch_from_rows(rows: &[(i32, u64)]) -> xabi::Result<RecordBatch> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("value", DataType::Int32, true),
+        Field::new("_rowid", DataType::UInt64, true),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from_iter_values(
+                rows.iter().map(|(value, _)| *value),
+            )),
+            Arc::new(UInt64Array::from_iter_values(
+                rows.iter().map(|(_, row_id)| *row_id),
+            )),
+        ],
+    )
+    .map_err(|err| xabi::Error::Export(err.to_string()))
+}
+
+fn xabi_call_to_error(err: impl std::fmt::Display) -> xabi::Error {
+    xabi::Error::Export(err.to_string())
+}
+
+#[xabi::module]
+mod exports {
+    use super::*;
+
+    #[xabi::xabi(name = "mock-btree", version = 1)]
+    impl LanceScalarIndexPluginAbi for MockBTreePlugin {
+        fn name(&self) -> String {
+            MockBTreePlugin::name(self)
+        }
+
+        fn version(&self) -> u32 {
+            MockBTreePlugin::version(self)
+        }
+
+        fn details_type_url(&self) -> String {
+            MockBTreePlugin::details_type_url(self)
+        }
+
+        fn provides_exact_answer(&self) -> bool {
+            MockBTreePlugin::provides_exact_answer(self)
+        }
+
+        fn new_training_plan(
+            &self,
+            params_json: &str,
+            field_json: &str,
+        ) -> xabi::Result<TrainingPlanAbi> {
+            MockBTreePlugin::new_training_plan(self, params_json, field_json)
+        }
+
+        async fn train_index(&self, input: TrainInputAbi) -> xabi::Result<CreatedIndexAbi> {
+            MockBTreePlugin::train_index(self, input).await
+        }
+
+        async fn load_index(
+            &self,
+            details: &[u8],
+            store: lance_index_plugin_abi::BorrowedLanceIndexStoreAbi,
+        ) -> xabi::Result<impl LanceScalarIndexAbi + 'static> {
+            MockBTreePlugin::load_index(self, details, store).await
+        }
+
+        fn plan_query(
+            &self,
+            details: &[u8],
+            query: SubstraitQueryAbi,
+        ) -> xabi::Result<QueryPlanAbi> {
+            MockBTreePlugin::plan_query(self, details, query)
+        }
+
+        async fn load_statistics(&self, details: &[u8]) -> xabi::Result<Option<String>> {
+            MockBTreePlugin::load_statistics(self, details).await
+        }
+
+        fn details_as_json(&self, details: &[u8]) -> xabi::Result<String> {
+            MockBTreePlugin::details_as_json(self, details)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds scalar index plugin support on top of `xabi`, allowing Lance to load session-scoped index implementations from dynamic libraries without making plugins depend on Lance internals.

`xabi` is used as the stable ABI layer between Lance and plugins. In this model, `#[xabi::data]` defines versioned wire data types, and `#[xabi::xabi]` defines trait contracts that are lowered into C-compatible vtables, handles, borrowed references, futures, and owned byte buffers. Lance and a plugin communicate through those generated ABI contracts instead of Rust trait objects from the same crate build. Larger payloads stay format-oriented: Arrow data crosses the boundary as Arrow IPC, and query expressions cross as Substrait bytes plus host-side JSON context.

The Lance session now owns plugin registrations and exposes scalar index integration through the existing index registry. A fixture mock btree plugin lives outside the workspace as a test-only xabi dynamic library, so the end-to-end dynamic loading path is covered without adding another published crate.

## Reviewing the ABI

The concrete ABI should be reviewed in these files:

- `rust/lance-index-plugin-abi/src/lib.rs`
  - Contract IDs and `ABI_VERSION`
  - `#[xabi::data]` request/response structs
  - `#[xabi::xabi]` traits for plugin, index, training data, index store, and build progress
  - Arrow IPC and little-endian encoding helpers used at the boundary

- `rust/lance-index-plugin-abi/xabi/snapshots/lance.*/*.txt`
  - Generated xabi layout snapshots for each public contract
  - Concrete field offsets, sizes, alignments, vtable sizes, and contract IDs for supported targets

The host-side adapter is in `rust/lance/src/session/xabi_index_plugin.rs`, and the test plugin implementation is in `rust/lance/tests/xabi_plugins/mock_btree/src/lib.rs`.

## ABI stability

The ABI stability story is intentionally centered on xabi rather than Lance internals:

- Public contracts use stable `lance.*` contract IDs and an explicit `ABI_VERSION`.
- xabi data layouts include size and ABI version fields, allowing prefix-compatible extension.
- xabi vtables track minimum and full sizes so older/newer sides can validate available methods.
- Boundary validation checks ABI version, vtable size, null pointers, and field availability before use.
- `xabi-assert` snapshots lock the generated ABI layout; intentional ABI changes require updating the snapshots.
- The ABI crate avoids depending on Lance internals, so plugins bind to stable wire contracts instead of private Rust types.