### PR TITLE
feat(index): expose per-query I/O metrics on ANN operators

### DIFF
--- a/rust/lance-core/src/utils.rs
+++ b/rust/lance-core/src/utils.rs
@@ -12,6 +12,7 @@ pub mod cpu;
 pub mod deletion;
 pub mod futures;
 pub mod hash;
+pub mod io_stats;
 pub mod parse;
 pub mod path;
 pub mod tempfile;

--- a/rust/lance-core/src/utils/io_stats.rs
+++ b/rust/lance-core/src/utils/io_stats.rs
@@ -10,6 +10,18 @@ use std::ops::Range;
 /// another.  It lets a caller attach a lightweight counter to a file reader and
 /// measure the exact bytes/IOPS performed for a bounded scope (e.g. a single
 /// query); see `lance_io::scheduler::IoStats` for the concrete implementation.
+///
+/// # When to use this
+///
+/// Lance also exposes two *process-wide, cumulative* I/O accounting facilities:
+/// the global scheduler counters (`lance_io::scheduler::iops_counter` /
+/// `bytes_read_counter`) and the object-store `IOTracker` wrapper used in tests.
+/// Both aggregate every read in the process and cannot attribute I/O to a single
+/// bounded scope.  Prefer an `IoStatsRecorder` when you need the *exact* I/O of
+/// one operation (e.g. a single query): attach it to a reader with
+/// `with_io_stats`, then read the snapshot when the scope ends.  It re-uses the
+/// reader's cached metadata, so measuring costs no extra file opens and does not
+/// disturb the global counters.
 pub trait IoStatsRecorder: std::fmt::Debug + Send + Sync {
     /// Record one completed request, given the byte ranges as actually
     /// submitted to storage (i.e. after any coalescing/splitting), so the

--- a/rust/lance-core/src/utils/io_stats.rs
+++ b/rust/lance-core/src/utils/io_stats.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::ops::Range;
+
+/// A sink that records I/O requests as they are submitted to storage.
+///
+/// This lives in `lance-core` so that the encoding layer (`lance-encoding`) and
+/// the I/O layer (`lance-io`) can both refer to it without depending on one
+/// another.  It lets a caller attach a lightweight counter to a file reader and
+/// measure the exact bytes/IOPS performed for a bounded scope (e.g. a single
+/// query); see `lance_io::scheduler::IoStats` for the concrete implementation.
+pub trait IoStatsRecorder: std::fmt::Debug + Send + Sync {
+    /// Record one completed request, given the byte ranges as actually
+    /// submitted to storage (i.e. after any coalescing/splitting), so the
+    /// counts reflect physical I/O.
+    fn record_request(&self, ranges: &[Range<u64>]);
+}

--- a/rust/lance-encoding/src/lib.rs
+++ b/rust/lance-encoding/src/lib.rs
@@ -86,6 +86,22 @@ pub trait EncodingsIo: std::fmt::Debug + Send + Sync {
     fn with_bypass_backpressure(&self) -> Option<Arc<dyn EncodingsIo>> {
         None
     }
+
+    /// Returns a version of this I/O service that additionally records the I/O it
+    /// performs into `stats`, on top of any global accounting.  This is the seam
+    /// used to measure exact per-scope (e.g. per-query) I/O without re-opening
+    /// files: wrap a reader's I/O service, perform the reads, then inspect the
+    /// recorder.
+    ///
+    /// Returns `None` if this implementation does not support per-scope I/O
+    /// statistics (e.g. in-memory or test schedulers), in which case the caller
+    /// should fall back to using self (and no statistics are recorded).
+    fn with_io_stats(
+        &self,
+        _stats: Arc<dyn lance_core::utils::io_stats::IoStatsRecorder>,
+    ) -> Option<Arc<dyn EncodingsIo>> {
+        None
+    }
 }
 
 /// An implementation of EncodingsIo that serves data from an in-memory buffer

--- a/rust/lance-file/src/io.rs
+++ b/rust/lance-file/src/io.rs
@@ -38,6 +38,16 @@ impl EncodingsIo for LanceEncodingsIo {
         }))
     }
 
+    fn with_io_stats(
+        &self,
+        stats: Arc<dyn lance_core::utils::io_stats::IoStatsRecorder>,
+    ) -> Option<Arc<dyn EncodingsIo>> {
+        Some(Arc::new(Self {
+            scheduler: self.scheduler.with_io_stats(stats),
+            read_chunk_size: self.read_chunk_size,
+        }))
+    }
+
     fn submit_request(
         &self,
         ranges: Vec<std::ops::Range<u64>>,

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -470,6 +470,23 @@ impl FileReader {
         }
     }
 
+    /// Returns a clone of this reader whose I/O is additionally recorded into
+    /// `stats`, on top of the scheduler's global accounting.
+    ///
+    /// All cached metadata is shared with `self`, so no file is re-opened and
+    /// only a few `Arc` clones are performed.  If the underlying I/O service
+    /// does not support per-scope statistics (e.g. an in-memory scheduler), the
+    /// returned reader is an ordinary, uninstrumented clone.
+    pub fn with_io_stats(
+        &self,
+        stats: Arc<dyn lance_core::utils::io_stats::IoStatsRecorder>,
+    ) -> Self {
+        match self.scheduler.with_io_stats(stats) {
+            Some(scheduler) => self.with_scheduler(scheduler),
+            None => self.clone(),
+        }
+    }
+
     pub fn num_rows(&self) -> u64 {
         self.num_rows
     }

--- a/rust/lance-index/src/metrics.rs
+++ b/rust/lance-index/src/metrics.rs
@@ -43,6 +43,19 @@ pub trait MetricsCollector: Send + Sync {
     ///
     /// The goal is to provide some visibility into the compute cost of the search
     fn record_comparisons(&self, num_comparisons: usize);
+
+    /// Returns an optional sink for recording exact I/O statistics (bytes read,
+    /// IOPS, and requests) performed on behalf of this collector.
+    ///
+    /// Index implementations that read from a
+    /// [`lance_io::scheduler::ScanScheduler`] can attach the returned handle to
+    /// their file readers so the I/O performed for a single query is measured
+    /// and attributed here.  The default returns `None`, meaning the caller does
+    /// not want I/O measured (and index implementations should then take their
+    /// normal, uninstrumented read path).
+    fn io_stats(&self) -> Option<lance_io::scheduler::IoStats> {
+        None
+    }
 }
 
 /// A no-op metrics collector that does nothing

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -419,6 +419,14 @@ pub trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
 
     /// the index type of this vector index.
     fn sub_index_type(&self) -> (SubIndexType, QuantizationType);
+
+    /// The cumulative I/O performed while opening this index (file footers, IVF
+    /// centroids, quantization metadata).  This is a one-time cost; it is
+    /// reported once, on the query that actually opens the index, and is `None`
+    /// for index implementations that do not track it.
+    fn open_io_stats(&self) -> Option<lance_io::scheduler::ScanStats> {
+        None
+    }
 }
 
 // it can be an IVF index or a partition of IVF index

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -622,10 +622,6 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
         self.ivf.num_partitions()
     }
 
-    pub async fn load_partition(&self, part_id: usize) -> Result<Q::Storage> {
-        self.load_partition_with_io_stats(part_id, None).await
-    }
-
     /// Load a partition's quantization storage, optionally measuring the exact
     /// I/O it performs into `io_stats`.
     ///
@@ -633,7 +629,7 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
     /// scheduler also records into the sink (a cheap clone that shares all
     /// cached metadata, so no file is re-opened).  When `None`, the normal
     /// uninstrumented reader is used.
-    pub async fn load_partition_with_io_stats(
+    pub async fn load_partition(
         &self,
         part_id: usize,
         io_stats: Option<IoStats>,

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -14,10 +14,12 @@ use lance_core::{Error, ROW_ID, Result};
 use lance_encoding::decoder::FilterExpression;
 use lance_file::reader::FileReader;
 use lance_io::ReadBatchParams;
+use lance_io::scheduler::IoStats;
 use lance_linalg::distance::DistanceType;
 use prost::Message;
 use std::{
     any::Any,
+    borrow::Cow,
     collections::BinaryHeap,
     mem::size_of,
     ops::{Deref, DerefMut},
@@ -621,14 +623,32 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
     }
 
     pub async fn load_partition(&self, part_id: usize) -> Result<Q::Storage> {
+        self.load_partition_with_io_stats(part_id, None).await
+    }
+
+    /// Load a partition's quantization storage, optionally measuring the exact
+    /// I/O it performs into `io_stats`.
+    ///
+    /// When `io_stats` is `Some`, the partition is read through a reader whose
+    /// scheduler also records into the sink (a cheap clone that shares all
+    /// cached metadata, so no file is re-opened).  When `None`, the normal
+    /// uninstrumented reader is used.
+    pub async fn load_partition_with_io_stats(
+        &self,
+        part_id: usize,
+        io_stats: Option<IoStats>,
+    ) -> Result<Q::Storage> {
         let range = self.ivf.row_range(part_id);
         let batch = if range.is_empty() {
             let schema = self.reader.schema();
             let arrow_schema = arrow_schema::Schema::from(schema.as_ref());
             RecordBatch::new_empty(Arc::new(arrow_schema))
         } else {
-            let batches = self
-                .reader
+            let reader = match &io_stats {
+                Some(io_stats) => Cow::Owned(self.reader.with_io_stats(io_stats.recorder())),
+                None => Cow::Borrowed(&self.reader),
+            };
+            let batches = reader
                 .read_stream(
                     ReadBatchParams::Range(range),
                     u32::MAX,

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::Notify;
 
+use lance_core::utils::io_stats::IoStatsRecorder;
 use lance_core::utils::parse::str_is_truthy;
 use lance_core::{Error, Result};
 
@@ -475,8 +476,25 @@ impl StatsCollector {
             Ordering::Relaxed,
         );
     }
+
+    /// Add already-aggregated counts (e.g. a snapshot captured from another
+    /// scheduler) into these counters.
+    fn add(&self, iops: u64, requests: u64, bytes_read: u64) {
+        self.iops.fetch_add(iops, Ordering::Relaxed);
+        self.requests.fetch_add(requests, Ordering::Relaxed);
+        self.bytes_read.fetch_add(bytes_read, Ordering::Relaxed);
+    }
 }
 
+impl IoStatsRecorder for StatsCollector {
+    fn record_request(&self, request: &[Range<u64>]) {
+        // Inherent methods take precedence in resolution, so this delegates to
+        // the inherent `record_request` above rather than recursing.
+        Self::record_request(self, request)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ScanStats {
     pub iops: u64,
     pub requests: u64,
@@ -490,6 +508,57 @@ impl ScanStats {
             requests: stats.requests(),
             bytes_read: stats.bytes_read(),
         }
+    }
+}
+
+/// A shareable, cloneable handle to a set of cumulative I/O counters.
+///
+/// All clones share the same underlying counters.  This serves two purposes:
+///
+/// 1. It backs each [`ScanScheduler`]'s own running totals.
+/// 2. It can be attached to an individual [`FileScheduler`] (via
+///    [`FileScheduler::with_io_stats`]) as a *secondary* sink, so a caller can
+///    measure the exact bytes/IOPS performed through that file handle for a
+///    bounded scope (e.g. a single query) without disturbing the scheduler's
+///    global totals.  Read the result back with [`IoStats::snapshot`].
+#[derive(Debug, Clone)]
+pub struct IoStats(Arc<StatsCollector>);
+
+impl IoStats {
+    pub fn new() -> Self {
+        Self(Arc::new(StatsCollector::new()))
+    }
+
+    /// Record a single completed request.  `request` holds the byte ranges as
+    /// actually submitted to storage (post coalescing/splitting), so the counts
+    /// reflect physical I/O.
+    pub fn record_request(&self, request: &[Range<u64>]) {
+        self.0.record_request(request);
+    }
+
+    /// Take an immutable snapshot of the current cumulative counters.
+    pub fn snapshot(&self) -> ScanStats {
+        ScanStats::new(self.0.as_ref())
+    }
+
+    /// Return this handle as a type-erased [`IoStatsRecorder`], suitable for
+    /// attaching to a file reader (e.g. `FileReader::with_io_stats`).  The
+    /// returned recorder shares the same underlying counters as `self`.
+    pub fn recorder(&self) -> Arc<dyn IoStatsRecorder> {
+        self.0.clone()
+    }
+
+    /// Add a snapshot of already-aggregated statistics into this sink.  Used to
+    /// fold in I/O measured on a separate scheduler (e.g. the one-time reads
+    /// performed while opening an index).
+    pub fn add_scan_stats(&self, stats: &ScanStats) {
+        self.0.add(stats.iops, stats.requests, stats.bytes_read);
+    }
+}
+
+impl Default for IoStats {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -509,7 +578,7 @@ enum IoQueueType {
 pub struct ScanScheduler {
     object_store: Arc<ObjectStore>,
     io_queue: IoQueueType,
-    stats: Arc<StatsCollector>,
+    stats: IoStats,
 }
 
 impl Debug for ScanScheduler {
@@ -606,7 +675,7 @@ impl ScanScheduler {
         Arc::new(Self {
             object_store,
             io_queue,
-            stats: Arc::new(StatsCollector::new()),
+            stats: IoStats::new(),
         })
     }
 
@@ -646,6 +715,7 @@ impl ScanScheduler {
             base_priority,
             max_iop_size,
             bypass_backpressure: false,
+            extra_stats: None,
         })
     }
 
@@ -791,7 +861,7 @@ impl ScanScheduler {
     }
 
     pub fn stats(&self) -> ScanStats {
-        ScanStats::new(self.stats.as_ref())
+        self.stats.snapshot()
     }
 
     #[cfg(test)]
@@ -829,6 +899,10 @@ pub struct FileScheduler {
     base_priority: u64,
     max_iop_size: u64,
     bypass_backpressure: bool,
+    /// Optional secondary statistics sink.  When set, every request submitted
+    /// through this handle is also recorded here, in addition to the
+    /// scheduler's global totals.  Used to measure per-scope I/O.
+    extra_stats: Option<Arc<dyn IoStatsRecorder>>,
 }
 
 fn is_close_together(range1: &Range<u64>, range2: &Range<u64>, block_size: u64) -> bool {
@@ -899,6 +973,9 @@ impl FileScheduler {
         }
 
         self.root.stats.record_request(&updated_requests);
+        if let Some(extra_stats) = &self.extra_stats {
+            extra_stats.record_request(&updated_requests);
+        }
 
         let bytes_vec_fut = self.root.submit_request(
             self.reader.clone(),
@@ -964,6 +1041,23 @@ impl FileScheduler {
             max_iop_size: self.max_iop_size,
             base_priority: priority,
             bypass_backpressure: self.bypass_backpressure,
+            extra_stats: self.extra_stats.clone(),
+        }
+    }
+
+    /// Returns a copy of this scheduler that additionally records the I/O it
+    /// performs into `stats`, on top of the scheduler's global statistics.
+    ///
+    /// This is the mechanism for measuring exact per-scope (e.g. per-query) I/O:
+    /// attach a recorder here (e.g. via [`IoStats::recorder`]), perform the reads
+    /// through the returned handle, then read the totals back with
+    /// [`IoStats::snapshot`].  The returned handle is cheap to create (a few
+    /// `Arc` clones) and reuses the same underlying reader, so it does not
+    /// re-open the file.
+    pub fn with_io_stats(&self, stats: Arc<dyn IoStatsRecorder>) -> Self {
+        Self {
+            extra_stats: Some(stats),
+            ..self.clone()
         }
     }
 
@@ -1181,6 +1275,59 @@ mod tests {
             );
         }
         assert_eq!(11, scheduler.stats().iops);
+    }
+
+    #[tokio::test]
+    async fn test_io_stats_sink() {
+        let tmp_file = TempObjFile::default();
+        let obj_store = Arc::new(ObjectStore::local());
+
+        const DATA_SIZE: u64 = 1024 * 1024;
+        let mut some_data = vec![0; DATA_SIZE as usize];
+        rand::rng().fill_bytes(&mut some_data);
+        obj_store.put(&tmp_file, &some_data).await.unwrap();
+
+        let scheduler = ScanScheduler::new(obj_store, SchedulerConfig::default_for_testing());
+
+        // Attach a per-scope sink to one file handle.
+        let sink = IoStats::new();
+        let file_scheduler = scheduler
+            .open_file(&tmp_file, &CachedFileSize::unknown())
+            .await
+            .unwrap()
+            .with_io_stats(sink.recorder());
+
+        // Three reads within 4KiB coalesce into a single physical IOP.  The sink
+        // and the scheduler's global totals must agree exactly, because both are
+        // recorded from the same post-coalescing request.
+        file_scheduler
+            .submit_request(vec![50_000..51_000, 52_000..53_000, 54_000..55_000], 0)
+            .await
+            .unwrap();
+
+        let global = scheduler.stats();
+        let scoped = sink.snapshot();
+        assert_eq!(1, scoped.iops);
+        assert_eq!(1, scoped.requests);
+        // Coalesced range 50_000..55_000 => 5000 physical bytes.
+        assert_eq!(5000, scoped.bytes_read);
+        assert_eq!(global.iops, scoped.iops);
+        assert_eq!(global.requests, scoped.requests);
+        assert_eq!(global.bytes_read, scoped.bytes_read);
+
+        // A sibling handle without the sink: the global totals advance but the
+        // sink stays put, proving per-scope isolation.
+        let other = scheduler
+            .open_file(&tmp_file, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+        other.submit_request(vec![0..1000], 0).await.unwrap();
+
+        let global_after = scheduler.stats();
+        let scoped_after = sink.snapshot();
+        assert_eq!(global.bytes_read + 1000, global_after.bytes_read);
+        assert_eq!(scoped.bytes_read, scoped_after.bytes_read);
+        assert_eq!(scoped.iops, scoped_after.iops);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -2158,6 +2158,15 @@ impl DatasetIndexInternalExt for Dataset {
         };
         let (index, ivf_entry) = result?;
         metrics.record_index_load();
+        // Attribute the one-time index-open I/O (file footers, IVF centroids,
+        // quantization metadata) to this query's metrics.  This runs only on a
+        // real open; cache hits return earlier, so a warm query reports zero
+        // index-open I/O.
+        if let Some(io_stats) = metrics.io_stats()
+            && let Some(open_stats) = index.open_io_stats()
+        {
+            io_stats.add_scan_stats(&open_stats);
+        }
         if let Some(ivf_entry) = ivf_entry {
             let state_key = IvfIndexStateCacheKey::new(uuid, frag_reuse_uuid.as_ref());
             self.index_cache

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -1045,7 +1045,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 continue;
             }
 
-            let part_storage = existing_index.load_partition_storage(part_id).await?;
+            let part_storage = existing_index.load_partition_storage(part_id, None).await?;
             let mut part_batches = part_storage.to_batches()?.collect::<Vec<_>>();
             // for PQ, the PQ codes are transposed, so we need to transpose them back
             match Q::quantization_type() {

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -6266,7 +6266,7 @@ mod tests {
         );
 
         // PQ code is on residual space
-        let pq_store = ivf_idx.load_partition_storage(0).await.unwrap();
+        let pq_store = ivf_idx.load_partition_storage(0, None).await.unwrap();
         pq_store
             .codebook()
             .values()

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1258,9 +1258,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         partition_id: usize,
         io_stats: Option<IoStats>,
     ) -> Result<Q::Storage> {
-        self.storage
-            .load_partition_with_io_stats(partition_id, io_stats)
-            .await
+        self.storage.load_partition(partition_id, io_stats).await
     }
 
     /// preprocess the query vector given the partition id.
@@ -2767,7 +2765,7 @@ mod tests {
     async fn load_partition_row_ids(index: &IvfPq, partition_idx: usize) -> Vec<u64> {
         index
             .storage
-            .load_partition(partition_idx)
+            .load_partition(partition_idx, None)
             .await
             .unwrap()
             .row_ids()

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -7,6 +7,7 @@ use std::io::Write as IoWrite;
 use std::marker::PhantomData;
 use std::{
     any::Any,
+    borrow::Cow,
     collections::{BinaryHeap, HashMap},
     sync::{Arc, Mutex},
 };
@@ -64,7 +65,7 @@ use lance_index::{
 };
 use lance_index::{INDEX_METADATA_SCHEMA_KEY, IndexMetadata};
 use lance_io::local::to_local_path;
-use lance_io::scheduler::SchedulerConfig;
+use lance_io::scheduler::{IoStats, ScanStats, SchedulerConfig};
 use lance_io::utils::CachedFileSize;
 use lance_io::{
     ReadBatchParams, object_store::ObjectStore, scheduler::ScanScheduler, traits::Reader,
@@ -614,6 +615,11 @@ pub struct IVFIndex<S: IvfSubIndex + 'static, Q: Quantization + 'static> {
     index_cache: WeakLanceCache,
 
     io_parallelism: usize,
+    /// Cumulative I/O performed while opening this index (file footers, IVF
+    /// centroids, quantization metadata).  Captured once in `try_new`; exposed
+    /// via [`VectorIndex::open_io_stats`] so the opening query can attribute the
+    /// one-time open cost to its plan metrics.
+    open_io_stats: ScanStats,
     scratch_pool: Arc<QueryScratchPool>,
     use_query_residual: bool,
     use_residual_scratch: bool,
@@ -1090,6 +1096,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         let use_residual_scratch = Self::use_residual_scratch(&ivf, use_query_residual);
         let rq_search_cache = Self::build_rq_search_cache(&ivf, &storage)?;
 
+        // The scheduler is freshly created above and, at this point, has served
+        // only the open-time reads (file footers, IVF centroids, quantization
+        // metadata) -- partition reads happen later, during queries.  So its
+        // cumulative stats are exactly the one-time index-open I/O.
+        let open_io_stats = scheduler.stats();
+
         Ok(Self {
             uri: to_local_path(&uri),
             index_path: uri.as_ref().to_string(),
@@ -1105,6 +1117,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             distance_type,
             index_cache: WeakLanceCache::from(&index_cache),
             io_parallelism,
+            open_io_stats,
             _marker: PhantomData,
         })
     }
@@ -1142,6 +1155,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             distance_type,
             index_cache: WeakLanceCache::from(&index_cache),
             io_parallelism,
+            // Reconstruction from cached state re-opens readers on its own path;
+            // the open-time I/O is not attributed here (it is a one-time cost,
+            // and the first open via `try_new` already accounts for it).
+            open_io_stats: ScanStats::default(),
             _marker: PhantomData,
         }
     }
@@ -1169,7 +1186,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
                 .get_or_insert_with_key(cache_key, || async {
                     info!(target: TRACE_IO_EVENTS, r#type=IO_TYPE_LOAD_VECTOR_PART, index_type="ivf", part_id=partition_id);
                     metrics.record_part_load();
-                    self.load_partition_entry(partition_id).await
+                    self.load_partition_entry(partition_id, metrics.io_stats())
+                        .await
                 })
                 .await?;
             Ok(entry as Arc<dyn VectorIndexCacheEntry>)
@@ -1179,11 +1197,18 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             }
             info!(target: TRACE_IO_EVENTS, r#type=IO_TYPE_LOAD_VECTOR_PART, index_type="ivf", part_id=partition_id);
             metrics.record_part_load();
-            Ok(Arc::new(self.load_partition_entry(partition_id).await?))
+            Ok(Arc::new(
+                self.load_partition_entry(partition_id, metrics.io_stats())
+                    .await?,
+            ))
         }
     }
 
-    async fn load_partition_entry(&self, partition_id: usize) -> Result<PartitionEntry<S, Q>> {
+    async fn load_partition_entry(
+        &self,
+        partition_id: usize,
+        io_stats: Option<IoStats>,
+    ) -> Result<PartitionEntry<S, Q>> {
         let schema = Arc::new(self.reader.schema().as_ref().into());
         let batch = match self.reader.metadata().num_rows {
             0 => RecordBatch::new_empty(schema),
@@ -1192,8 +1217,17 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
                 if row_range.is_empty() {
                     RecordBatch::new_empty(schema)
                 } else {
-                    let batches = self
-                        .reader
+                    // When I/O is being measured, read through a reader whose
+                    // scheduler also records into the per-query sink (a cheap
+                    // clone sharing all cached metadata, no file re-open).
+                    // Otherwise borrow the shared reader as-is, with no clone.
+                    let reader = match &io_stats {
+                        Some(io_stats) => {
+                            Cow::Owned(self.reader.with_io_stats(io_stats.recorder()))
+                        }
+                        None => Cow::Borrowed(&self.reader),
+                    };
+                    let batches = reader
                         .read_stream(
                             ReadBatchParams::Range(row_range),
                             u32::MAX,
@@ -1212,15 +1246,21 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             self.sub_index_metadata[partition_id].clone(),
         )?;
         let idx = S::load(batch)?;
-        let storage = self.load_partition_storage(partition_id).await?;
+        let storage = self.load_partition_storage(partition_id, io_stats).await?;
         Ok(PartitionEntry {
             index: idx,
             storage,
         })
     }
 
-    pub async fn load_partition_storage(&self, partition_id: usize) -> Result<Q::Storage> {
-        self.storage.load_partition(partition_id).await
+    pub async fn load_partition_storage(
+        &self,
+        partition_id: usize,
+        io_stats: Option<IoStats>,
+    ) -> Result<Q::Storage> {
+        self.storage
+            .load_partition_with_io_stats(partition_id, io_stats)
+            .await
     }
 
     /// preprocess the query vector given the partition id.
@@ -1799,6 +1839,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> VectorIndex for IVFInd
 
     fn metric_type(&self) -> DistanceType {
         self.distance_type
+    }
+
+    fn open_io_stats(&self) -> Option<ScanStats> {
+        Some(self.open_io_stats)
     }
 }
 

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -926,6 +926,9 @@ impl ExecutionPlan for ANNIvfPartitionExec {
             })
             .buffered(self.index_uuids.len().min(target_partitions).max(1))
             .finally(move || {
+                // Partition ranking reads centroids from memory, so this is
+                // typically zero; flushed for symmetry with ANNSubIndex.
+                metrics_clone.index_metrics.flush_io();
                 metrics_clone.baseline_metrics.done();
                 metrics_clone
                     .baseline_metrics
@@ -1627,6 +1630,9 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 // will not start until the early search is complete across all deltas.
                 .try_flatten_unordered(None)
                 .finally(move || {
+                    // Publish the exact index-file I/O measured for this query
+                    // (cache misses only) to the iops/requests/bytes_read gauges.
+                    metrics_clone.index_metrics.flush_io();
                     metrics_clone
                         .baseline_metrics
                         .elapsed_compute()
@@ -2917,6 +2923,128 @@ mod tests {
             assert!(*stats.all_counts.get(PARTITIONS_SEARCHED_METRIC).unwrap() < 100 * num_deltas);
         }
         assert_find_partitions_elapsed_recorded(&stats);
+    }
+
+    /// The ANN operators report the exact index-file I/O performed for a query
+    /// (bytes_read / iops), measured only on cache misses.  A cold search loads
+    /// partitions from storage and reports non-zero I/O; an immediately
+    /// following warm search serves every partition from the index cache and
+    /// reports zero -- which is the cache-effectiveness signal the metric adds.
+    #[tokio::test]
+    async fn test_io_metrics_cold_vs_warm() {
+        let fixture = NprobesTestFixture::new(100, 1).await;
+        let q = fixture.get_centroid(0);
+
+        let run = |holder: &StatsHolder| {
+            let setter = holder.get_setter();
+            async {
+                fixture
+                    .dataset
+                    .scan()
+                    .nearest("vector", q.as_ref(), 10)
+                    .unwrap()
+                    .minimum_nprobes(10)
+                    .scan_stats_callback(setter)
+                    .project(&Vec::<String>::new())
+                    .unwrap()
+                    .with_row_id()
+                    .try_into_batch()
+                    .await
+                    .unwrap()
+            }
+        };
+
+        // Cold: a freshly opened dataset has an empty index cache, so the
+        // sub-index search must read partitions (and their quantization storage)
+        // from disk.  Those reads flow through the per-query I/O sink.
+        let cold_holder = StatsHolder::default();
+        run(&cold_holder).await;
+        let cold = cold_holder.consume();
+        assert!(
+            cold.parts_loaded > 0,
+            "cold search should load partitions, got parts_loaded={}",
+            cold.parts_loaded
+        );
+        assert!(
+            cold.bytes_read > 0,
+            "cold search should report index-file I/O, got bytes_read={}",
+            cold.bytes_read
+        );
+        assert!(
+            cold.iops > 0,
+            "cold search should report index-file IOPS, got iops={}",
+            cold.iops
+        );
+
+        // Warm: the same query on the same dataset finds every partition it
+        // needs already cached, so no index-file I/O is performed.
+        let warm_holder = StatsHolder::default();
+        run(&warm_holder).await;
+        let warm = warm_holder.consume();
+        assert_eq!(
+            warm.parts_loaded, 0,
+            "warm search should not reload partitions, got parts_loaded={}",
+            warm.parts_loaded
+        );
+        assert_eq!(
+            warm.bytes_read, 0,
+            "warm search should report no index-file I/O, got bytes_read={}",
+            warm.bytes_read
+        );
+    }
+
+    /// The new I/O metrics must actually surface in `EXPLAIN ANALYZE` text on
+    /// the ANN operators: non-zero on a cold query (partition reads on
+    /// `ANNSubIndex`, index-open reads on `ANNIvfPartition`) and zero on a warm
+    /// query (everything served from the index cache).
+    #[tokio::test]
+    async fn test_io_metrics_visible_in_explain_analyze() {
+        // Returns the value of `metric=` from the analyzed-plan line for `node`.
+        fn node_metric<'a>(plan: &'a str, node: &str, metric: &str) -> &'a str {
+            let line = plan
+                .lines()
+                .find(|l| l.trim_start().starts_with(node))
+                .unwrap_or_else(|| panic!("plan missing node {node}:\n{plan}"));
+            let after = line
+                .split_once(&format!("{metric}="))
+                .unwrap_or_else(|| panic!("node {node} line missing {metric}=:\n{line}"))
+                .1;
+            after.split([',', ']']).next().unwrap().trim()
+        }
+
+        let fixture = NprobesTestFixture::new(100, 1).await;
+        let q = fixture.get_centroid(0);
+
+        // Cold: a freshly opened dataset must show real index-file I/O.
+        let cold = fixture
+            .dataset
+            .scan()
+            .nearest("vector", q.as_ref(), 10)
+            .unwrap()
+            .minimum_nprobes(10)
+            .analyze_plan()
+            .await
+            .unwrap();
+        // Sub-index partition reads.
+        assert_ne!(node_metric(&cold, "ANNSubIndex", "bytes_read"), "0");
+        assert_ne!(node_metric(&cold, "ANNSubIndex", "iops"), "0");
+        // Index-open reads (centroids/metadata) now attributed to the partition
+        // operator -- the value this part of the change adds.
+        assert_ne!(node_metric(&cold, "ANNIvfPartition", "bytes_read"), "0");
+        assert_ne!(node_metric(&cold, "ANNIvfPartition", "iops"), "0");
+
+        // Warm: same query, everything cache-resident -> zero index-file I/O.
+        let warm = fixture
+            .dataset
+            .scan()
+            .nearest("vector", q.as_ref(), 10)
+            .unwrap()
+            .minimum_nprobes(10)
+            .analyze_plan()
+            .await
+            .unwrap();
+        assert_eq!(node_metric(&warm, "ANNSubIndex", "bytes_read"), "0");
+        assert_eq!(node_metric(&warm, "ANNIvfPartition", "bytes_read"), "0");
     }
 
     #[rstest]

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -6,7 +6,7 @@ use lance_datafusion::utils::{
     IOPS_METRIC, PARTS_LOADED_METRIC, REQUESTS_METRIC,
 };
 use lance_index::metrics::MetricsCollector;
-use lance_io::scheduler::ScanScheduler;
+use lance_io::scheduler::{IoStats, ScanScheduler, ScanStats};
 use lance_table::format::IndexMetadata;
 use pin_project::pin_project;
 use std::future::Future;
@@ -502,12 +502,17 @@ impl IoMetrics {
     }
 
     pub fn record(&self, scan_scheduler: &ScanScheduler) {
-        let current_stats = scan_scheduler.stats();
+        self.record_stats(scan_scheduler.stats());
+    }
 
-        // Use set_max to ensure gauge always shows the highest value seen
-        self.iops.set_max(current_stats.iops as usize);
-        self.requests.set_max(current_stats.requests as usize);
-        self.bytes_read.set_max(current_stats.bytes_read as usize);
+    /// Record a snapshot of cumulative I/O statistics.
+    ///
+    /// Uses `set_max` because the underlying counters are cumulative; the gauge
+    /// always reflects the highest (i.e. final) value seen.
+    pub fn record_stats(&self, stats: ScanStats) {
+        self.iops.set_max(stats.iops as usize);
+        self.requests.set_max(stats.requests as usize);
+        self.bytes_read.set_max(stats.bytes_read as usize);
     }
 }
 
@@ -516,6 +521,12 @@ pub struct IndexMetrics {
     indices_loaded: Count,
     parts_loaded: Count,
     index_comparisons: Count,
+    /// Per-query sink that accumulates exact index-file I/O as partitions are
+    /// loaded from storage.  Shared by all clones of this `IndexMetrics`, so
+    /// concurrent partition loads all funnel into the same counters.  Published
+    /// to `io_metrics` for display via [`IndexMetrics::flush_io`].
+    io_stats: IoStats,
+    io_metrics: IoMetrics,
 }
 
 impl IndexMetrics {
@@ -524,7 +535,17 @@ impl IndexMetrics {
             indices_loaded: metrics.new_count(INDICES_LOADED_METRIC, partition),
             parts_loaded: metrics.new_count(PARTS_LOADED_METRIC, partition),
             index_comparisons: metrics.new_count(INDEX_COMPARISONS_METRIC, partition),
+            io_stats: IoStats::new(),
+            io_metrics: IoMetrics::new(metrics, partition),
         }
+    }
+
+    /// Publish the I/O accumulated in the per-query sink to the displayed
+    /// `iops`/`requests`/`bytes_read` metrics.  Call once when the operator's
+    /// stream finishes; the sink only accumulates on cache misses, so a fully
+    /// cache-resident query publishes zeros.
+    pub fn flush_io(&self) {
+        self.io_metrics.record_stats(self.io_stats.snapshot());
     }
 }
 
@@ -537,6 +558,9 @@ impl MetricsCollector for IndexMetrics {
     }
     fn record_comparisons(&self, num_comparisons: usize) {
         self.index_comparisons.add(num_comparisons);
+    }
+    fn io_stats(&self) -> Option<IoStats> {
+        Some(self.io_stats.clone())
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #7201. The vector-search operators `ANNSubIndex` and `ANNIvfPartition` only reported index metrics and registered no `IoMetrics`, so index-file I/O was invisible in `EXPLAIN ANALYZE`. This makes per-query `bytes_read` / `iops` / `requests` observable on both operators.

## Design

The ANN operators delegate reads to a cached, shared `IVFIndex` whose `ScanScheduler` is reused across queries, so the established "own a fresh scheduler and read its cumulative stats" pattern does not apply. A lightweight per-query sink (`IoStats`, backed by a new `IoStatsRecorder` trait in `lance-core`) rides on the already per-query `MetricsCollector` and is attached to the index / quantization-storage readers only on an actual cache-miss load, tapping the authoritative `FileScheduler` accounting point. Numbers are exact, correctly attributed, and ~0 on a warm cache. The one-time index-open I/O (file footers, IVF centroids, quantization metadata) is captured from the fresh `IVFIndex::try_new` scheduler and attributed to `ANNIvfPartition`.

Always on, consistent with the data-path operators; surfaces through the existing scan-statistics / EXPLAIN ANALYZE path with no DataFusion-layer change.

## Observability (EXPLAIN ANALYZE)

Cold query (empty index cache):
- `ANNSubIndex: ... parts_loaded=10, bytes_read=57.02 K, iops=40, requests=40`
- `ANNIvfPartition: ... bytes_read=8.11 K, iops=4, requests=4` (index-open I/O)

Warm query (partitions cached): both operators report `bytes_read=0, iops=0, requests=0`.

## Overhead

Adding metrics is observability, not a speedup. Measured via a same-binary A/B (feature on vs off, which isolates runtime cost from code-layout noise): `Ivf_PQ_NoCache` change `[-0.57%, -0.08%, +0.43%]`, p=0.76, "No change in performance detected".

## Tests

- `lance-io`: the per-query sink records identically to the scheduler and stays isolated from sibling file handles.
- `lance`: cold-vs-warm aggregate counts (`ExecutionSummaryCounts`); and an end-to-end `EXPLAIN ANALYZE` assertion that the metrics are non-zero (cold) and zero (warm) on both ANN operators.
