### PR TITLE
test(compat): search maintenance-op sequences between two arbitrary refs

### DIFF
--- a/.github/workflows/compat-pair.yml
+++ b/.github/workflows/compat-pair.yml
@@ -1,0 +1,158 @@
+# Cross-version index compatibility suite between two refs.
+#
+# Each ref (version, commit sha, branch, or tag) is provisioned by the compat framework:
+# a published release installs a wheel, anything else is built from a worktree via maturin.
+# The suite ages an index under the writer ref and exercises it under the reader, searching
+# maintenance-op sequences and asserting the reader neither panics nor disagrees with a
+# full scan.
+#
+# Triggers:
+#   - workflow_dispatch: run one explicit writer -> reader pair on demand.
+#   - pull_request: age indexes under the latest release of each of the two previous
+#     majors and exercise them under the PR head, so a change that breaks reading older
+#     indexes fails the PR.
+name: Compat (index ref pair)
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_ref:
+        description: "Writer ref (version / sha / branch). Blank = 2nd most recent release."
+        required: false
+        default: ""
+      to_ref:
+        description: "Reader ref (version / sha / branch). Blank = most recent release."
+        required: false
+        default: ""
+      kinds:
+        description: "Comma-separated index kinds (INVERTED,BTREE,...) or 'all'."
+        required: false
+        default: "all"
+      max_length:
+        description: "Max maintenance-op sequence length to search (deeper = slower)."
+        required: false
+        default: "5"
+  pull_request:
+    # Only changes that can alter index format or its readers need the cross-version check.
+    paths:
+      - "rust/lance-index/**"
+      - "rust/lance/**"
+      - "python/**"
+      - ".github/workflows/compat-pair.yml"
+
+# Each run builds refs from source, so supersede an in-flight run for the same PR/ref
+# rather than letting expensive builds pile up on rapid pushes.
+concurrency:
+  group: compat-pair-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Resolve the writer -> reader pairs to run. For a PR this is the latest minor/patch
+  # release of each of the two previous majors (e.g. 6.0.1, not 6.0.0) aged into the PR
+  # head; for a manual run it is the single pair from the inputs (blank inputs fall
+  # through to the suite's own defaults).
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - run: pip install pytest packaging
+      - id: gen
+        env:
+          EVENT: ${{ github.event_name }}
+          IN_FROM: ${{ inputs.from_ref }}
+          IN_TO: ${{ inputs.to_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+
+          sys.path.insert(0, "python/tests")
+          from compat.compat_decorator import pylance_stable_versions
+
+          if os.environ["EVENT"] == "pull_request":
+              # Latest minor/patch release within each of the two most recent majors --
+              # e.g. 6.0.1, not 6.0.0 -- aged into the PR head. Iterating ascending means
+              # the last version stored per major is that major's newest release.
+              latest_by_major = {}
+              for v in pylance_stable_versions():
+                  latest_by_major[v.major] = v
+              refs = [str(latest_by_major[m]) for m in sorted(latest_by_major)[-2:]]
+              head = os.environ["HEAD_SHA"]
+              include = [{"from_ref": ref, "to_ref": head} for ref in refs]
+          else:
+              # Single explicit pair; blanks fall through to the suite defaults.
+              include = [
+                  {"from_ref": os.environ.get("IN_FROM", ""),
+                   "to_ref": os.environ.get("IN_TO", "")}
+              ]
+
+          matrix = {"include": include}
+          print(json.dumps(matrix, indent=2))
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"matrix={json.dumps(matrix)}\n")
+          PY
+
+  compat-pair:
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix) }}
+    defaults:
+      run:
+        working-directory: python
+    env:
+      # PRs cover all kinds; a manual run honors its input (expanded below). Length 5 is
+      # the shallowest depth that reaches the ENT-1662 sequence.
+      COMPAT_MAX_LENGTH: ${{ inputs.max_length || '5' }}
+    steps:
+      # Full history so arbitrary refs (and the PR head) can be checked out for builds.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      # Toolchain for the build-from-source provisioning path (refs without a wheel).
+      - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+      - name: Install build deps
+        run: |
+          sudo apt update
+          sudo apt install -y protobuf-compiler libssl-dev
+      - name: Install host deps
+        run: pip install pytest pytest-xdist pyarrow packaging maturin
+      - name: Resolve kinds
+        id: kinds
+        env:
+          KINDS_IN: ${{ inputs.kinds }}
+        run: |
+          if [ -z "$KINDS_IN" ] || [ "$KINDS_IN" = "all" ]; then
+            echo "value=INVERTED,BTREE,BITMAP,LABEL_LIST,NGRAM,ZONEMAP,BLOOMFILTER" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=$KINDS_IN" >> "$GITHUB_OUTPUT"
+          fi
+      # Run the kind x shard cases in parallel. Each scenario writes a small dataset to
+      # disk and the reader spends most of its time in short subprocess round-trips, so the
+      # work is largely I/O-bound -- oversubscribe (4x cores) so a worker waiting on disk or
+      # the sub-venv pipe overlaps another's compute. Venvs live in a shared cache and are
+      # created under a lock, so workers build each ref once.
+      - name: Run compat suite (${{ matrix.from_ref }} -> ${{ matrix.to_ref }})
+        env:
+          COMPAT_FROM_REF: ${{ matrix.from_ref }}
+          COMPAT_TO_REF: ${{ matrix.to_ref }}
+          COMPAT_KINDS: ${{ steps.kinds.outputs.value }}
+        run: |
+          python -m pytest python/tests/compat/test_index_sequence.py \
+            --run-compat -n "$(( $(nproc) * 4 ))" -v --no-header

--- a/.github/workflows/compat-pair.yml
+++ b/.github/workflows/compat-pair.yml
@@ -1,16 +1,12 @@
-# Cross-version index compatibility suite between two refs.
+# On-demand cross-version index compatibility run between two arbitrary refs.
 #
-# Each ref (version, commit sha, branch, or tag) is provisioned by the compat framework:
-# a published release installs a wheel, anything else is built from a worktree via maturin.
-# The suite ages an index under the writer ref and exercises it under the reader, searching
-# maintenance-op sequences and asserting the reader neither panics nor disagrees with a
-# full scan.
-#
-# Triggers:
-#   - workflow_dispatch: run one explicit writer -> reader pair on demand.
-#   - pull_request: age indexes under the latest release of each of the two previous
-#     majors and exercise them under the PR head, so a change that breaks reading older
-#     indexes fails the PR.
+# The PR path lives in python.yml (compat-sequence job), which ages the two previous
+# majors into the PR head reusing the prebuilt wheel. This workflow is the manual escape
+# hatch for any other pairing: each ref (version, sha, branch, or tag) is provisioned by
+# the framework -- a published release installs a wheel, anything else is built from a
+# worktree via maturin -- so two arbitrary refs can be compared even when neither has a
+# published wheel. The suite ages an index under the writer ref and exercises it under the
+# reader, searching maintenance-op sequences for panics or correctness divergence.
 name: Compat (index ref pair)
 
 on:
@@ -32,92 +28,20 @@ on:
         description: "Max maintenance-op sequence length to search (deeper = slower)."
         required: false
         default: "5"
-  pull_request:
-    # Only changes that can alter index format or its readers need the cross-version check.
-    paths:
-      - "rust/lance-index/**"
-      - "rust/lance/**"
-      - "python/**"
-      - ".github/workflows/compat-pair.yml"
-
-# Each run builds refs from source, so supersede an in-flight run for the same PR/ref
-# rather than letting expensive builds pile up on rapid pushes.
-concurrency:
-  group: compat-pair-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 jobs:
-  # Resolve the writer -> reader pairs to run. For a PR this is the latest minor/patch
-  # release of each of the two previous majors (e.g. 6.0.1, not 6.0.0) aged into the PR
-  # head; for a manual run it is the single pair from the inputs (blank inputs fall
-  # through to the suite's own defaults).
-  resolve:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.gen.outputs.matrix }}
-    defaults:
-      run:
-        working-directory: python
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.11"
-      - run: pip install pytest packaging
-      - id: gen
-        env:
-          EVENT: ${{ github.event_name }}
-          IN_FROM: ${{ inputs.from_ref }}
-          IN_TO: ${{ inputs.to_ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          import sys
-
-          sys.path.insert(0, "python/tests")
-          from compat.compat_decorator import pylance_stable_versions
-
-          if os.environ["EVENT"] == "pull_request":
-              # Latest minor/patch release within each of the two most recent majors --
-              # e.g. 6.0.1, not 6.0.0 -- aged into the PR head. Iterating ascending means
-              # the last version stored per major is that major's newest release.
-              latest_by_major = {}
-              for v in pylance_stable_versions():
-                  latest_by_major[v.major] = v
-              refs = [str(latest_by_major[m]) for m in sorted(latest_by_major)[-2:]]
-              head = os.environ["HEAD_SHA"]
-              include = [{"from_ref": ref, "to_ref": head} for ref in refs]
-          else:
-              # Single explicit pair; blanks fall through to the suite defaults.
-              include = [
-                  {"from_ref": os.environ.get("IN_FROM", ""),
-                   "to_ref": os.environ.get("IN_TO", "")}
-              ]
-
-          matrix = {"include": include}
-          print(json.dumps(matrix, indent=2))
-          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
-              out.write(f"matrix={json.dumps(matrix)}\n")
-          PY
-
   compat-pair:
-    needs: resolve
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.resolve.outputs.matrix) }}
     defaults:
       run:
         working-directory: python
     env:
-      # PRs cover all kinds; a manual run honors its input (expanded below). Length 5 is
-      # the shallowest depth that reaches the ENT-1662 sequence.
+      COMPAT_FROM_REF: ${{ inputs.from_ref }}
+      COMPAT_TO_REF: ${{ inputs.to_ref }}
       COMPAT_MAX_LENGTH: ${{ inputs.max_length || '5' }}
     steps:
-      # Full history so arbitrary refs (and the PR head) can be checked out for builds.
+      # Full history so arbitrary refs can be checked out for builds.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
@@ -143,15 +67,11 @@ jobs:
           else
             echo "value=$KINDS_IN" >> "$GITHUB_OUTPUT"
           fi
-      # Run the kind x shard cases in parallel. Each scenario writes a small dataset to
-      # disk and the reader spends most of its time in short subprocess round-trips, so the
-      # work is largely I/O-bound -- oversubscribe (4x cores) so a worker waiting on disk or
-      # the sub-venv pipe overlaps another's compute. Venvs live in a shared cache and are
-      # created under a lock, so workers build each ref once.
-      - name: Run compat suite (${{ matrix.from_ref }} -> ${{ matrix.to_ref }})
+      # Oversubscribe (4x cores): each scenario writes a small dataset to disk and the
+      # reader spends most of its time in short subprocess round-trips, so a worker waiting
+      # on disk or the sub-venv pipe overlaps another's compute.
+      - name: Run compat suite (${{ inputs.from_ref }} -> ${{ inputs.to_ref }})
         env:
-          COMPAT_FROM_REF: ${{ matrix.from_ref }}
-          COMPAT_TO_REF: ${{ matrix.to_ref }}
           COMPAT_KINDS: ${{ steps.kinds.outputs.value }}
         run: |
           python -m pytest python/tests/compat/test_index_sequence.py \

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -162,6 +162,65 @@ jobs:
         env:
           COMPAT_TEMP_VENV: 1
 
+  # Cross-version index maintenance-sequence search (see tests/compat/compat_sequence.py).
+  # Ages an index under the latest release of each of the two previous majors and exercises
+  # it under this commit, searching op sequences for panics or correctness divergence. The
+  # reader (HEAD) reuses the wheel the `linux` job already built rather than recompiling.
+  # Post-merge only: the search is slower than the rest of the suite, so it runs on pushes
+  # to main/release rather than blocking every PR (same gating as rust-benchmark).
+  compat-sequence:
+    needs: linux
+    if: github.event_name != 'pull_request'
+    timeout-minutes: 60
+    runs-on: ubuntu-24.04
+    name: Index Sequence Compat
+    defaults:
+      run:
+        shell: bash
+        working-directory: python
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: 3.13
+      - name: Download wheels
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: linux-wheels
+          path: python/wheels
+      - name: Install host deps
+        run: pip install pytest pytest-xdist pyarrow packaging
+      # Age under each of the two previous majors (writer wheels from PyPI) and read under
+      # this commit's prebuilt wheel. Length 5 is the shallowest depth that reaches the
+      # ENT-1662 sequence; -n oversubscribes cores since the work is I/O-bound.
+      - name: Run sequence search (previous two majors -> HEAD)
+        env:
+          COMPAT_MAX_LENGTH: "5"
+          COMPAT_TO_REF: HEAD
+          COMPAT_PREBUILT_REF: HEAD
+        run: |
+          set -euo pipefail
+          wheel=$(ls "$PWD"/wheels/pylance-*.whl | head -1)
+          refs=$(PYTHONPATH=python/tests python -c "
+          from compat.compat_decorator import pylance_stable_versions
+          latest = {}
+          for v in pylance_stable_versions():
+              latest[v.major] = v
+          print(' '.join(str(latest[m]) for m in sorted(latest)[-2:]))
+          ")
+          echo "reader wheel: $wheel"
+          echo "writer refs : $refs"
+          status=0
+          for from_ref in $refs; do
+            echo "::group::$from_ref -> HEAD"
+            COMPAT_FROM_REF="$from_ref" COMPAT_PREBUILT_WHEEL="$wheel" \
+              python -m pytest python/tests/compat/test_index_sequence.py \
+                --run-compat -n "$(( $(nproc) * 4 ))" -v --no-header || status=1
+            echo "::endgroup::"
+          done
+          exit $status
+
   linux-arm:
     timeout-minutes: 45
     runs-on: ubuntu-24.04-arm64-4x

--- a/python/python/tests/compat/compat_sequence.py
+++ b/python/python/tests/compat/compat_sequence.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Cross-version index maintenance-sequence search.
+
+Runs on the same per-ref venv substrate as the rest of this package: venv_factory
+(venv_manager.py) provisions one venv per ref, so the *setup* half of a sequence runs
+under `from_ref` and the *exercise* half under `to_ref` (the version split). After each
+run an oracle checks that the reader did not panic and that an index query agrees with a
+full (unindexed) scan. This *discovers* cross-version regressions (e.g. ENT-1662)
+without hand-coding the triggering sequence.
+
+The scenario is parameterized by index *kind* so every scalar index type gets the same
+aged-lifecycle, cross-version treatment. The oracle runs the same predicate twice --
+normally and with use_scalar_index=False (lance ignores the index) -- and requires
+the results to match. If the two query plans are identical the index wasn't used, so the
+comparison is skipped rather than failed (uninformative, not a regression). FTS has no
+"ignore the index" mode to diff against, so its oracle reconstructs ground truth from a
+full scan: tokenize every live row, then require an FTS search for a spread of sampled
+terms to return exactly the rows that contain them. The FTS scenarios run under both
+on-disk format versions (LANCE_FTS_FORMAT_VERSION 1 and 2), which take different merge
+paths.
+
+The op vocabulary and bounds are deliberately small so the search is runnable; this is
+exhaustive over the maintenance-lifecycle grammar up to the configured lengths, not over
+every op permutation.
+"""
+
+import itertools
+import os
+import shutil
+from pathlib import Path
+
+ROWS_PER_WRITE = 200
+
+SETUP_TAIL_OPS = ["D", "C", "W"]
+EXERCISE_OPS = ["W", "D", "C", "Oa", "Om", "Od"]
+
+OP_NAMES = {
+    "W": "write rows",
+    "I": "create index",
+    "D": "delete rows",
+    "C": "compact",
+    "Oa": "optimize (append)",
+    "Om": "optimize (merge)",
+    "Od": "optimize",
+}
+
+
+def describe(kind, from_ref, to_ref, setup_ops, exercise_ops, fts_version=None):
+    """A plain-English description of a scenario for failure output."""
+    writer = ", then ".join(OP_NAMES[o] for o in ["W", "I", *setup_ops])
+    reader = ", then ".join(OP_NAMES[o] for o in exercise_ops)
+    tag = f" (fts fmt v{fts_version})" if fts_version is not None else ""
+    return f"{kind}{tag} ({from_ref} -> {to_ref}): writer [{writer}]; reader [{reader}]"
+
+
+# Index kinds covered by the maintenance-sequence search.
+SCALAR_KINDS = ["BTREE", "BITMAP", "LABEL_LIST", "NGRAM", "ZONEMAP", "BLOOMFILTER"]
+ALL_KINDS = ["INVERTED", *SCALAR_KINDS]
+
+
+class IndexScenario:
+    """A picklable, kind-parameterized scenario run across a version split."""
+
+    def __init__(self, kind, path, setup_ops, exercise_ops):
+        self.kind = kind
+        self.path = str(path)
+        self.setup_ops = list(setup_ops)
+        self.exercise_ops = list(exercise_ops)
+        self.next_idx = 0
+
+    # --- in-venv helpers (only lance + pyarrow available) ---
+    def _open(self):
+        import lance
+
+        session = lance.Session(index_cache_size_bytes=0, metadata_cache_size_bytes=0)
+        return lance.dataset(self.path, session=session)
+
+    def _batch(self, a, b):
+        import pyarrow as pa
+
+        idx = list(range(a, b))
+        if self.kind == "INVERTED":
+            # Each row's text mixes tokens of different frequency: a unique term, a
+            # mid-frequency bucket (~1/7 of rows), and one shared by every row. Sampling
+            # across that spread exercises postings of varied length.
+            return pa.table(
+                {"idx": idx, "key": [f"term{i} bucket{i % 7} shared" for i in idx]}
+            )
+        if self.kind == "LABEL_LIST":
+            return pa.table({"idx": idx, "key": [[f"l{i % 8}"] for i in idx]})
+        if self.kind == "NGRAM":
+            return pa.table({"idx": idx, "key": [f"w{i % 50}x" for i in idx]})
+        # BTREE / BITMAP / ZONEMAP / BLOOMFILTER: integer column
+        card = 8 if self.kind == "BITMAP" else 50
+        key = [i if self.kind == "ZONEMAP" else i % card for i in idx]
+        return pa.table({"idx": idx, "key": key})
+
+    def _index_type(self):
+        return "INVERTED" if self.kind == "INVERTED" else self.kind
+
+    def _oracle_pred(self):
+        if self.kind == "LABEL_LIST":
+            return "array_has_any(key, ['l3'])"
+        if self.kind == "NGRAM":
+            return "contains(key, 'w3x')"
+        if self.kind == "ZONEMAP":
+            return "key >= 100 AND key < 300"
+        return "key == 3"  # BTREE / BITMAP / BLOOMFILTER
+
+    # --- ops ---
+    def _op_W(self):
+        import lance
+
+        a, b = self.next_idx, self.next_idx + ROWS_PER_WRITE
+        self.next_idx = b
+        tbl = self._batch(a, b)
+        if not os.path.exists(self.path):
+            lance.write_dataset(tbl, self.path)  # single fragment
+        else:
+            self._open().insert(tbl)
+
+    def _op_I(self):
+        kwargs = {"with_position": True} if self.kind == "INVERTED" else {}
+        self._open().create_scalar_index("key", self._index_type(), **kwargs)
+
+    def _op_D(self):
+        # Partial-range delete inside the id space so compaction rewrites and remaps the
+        # index per-row.
+        if self.next_idx == 0:
+            return
+        lo, hi = self.next_idx // 4, self.next_idx // 2
+        if hi > lo:
+            self._open().delete(f"idx >= {lo} AND idx < {hi}")
+
+    def _op_C(self):
+        self._open().optimize.compact_files()
+
+    def _op_Oa(self):
+        self._open().optimize.optimize_indices(num_indices_to_merge=0)
+
+    def _op_Om(self):
+        self._open().optimize.optimize_indices(num_indices_to_merge=10)
+
+    def _op_Od(self):
+        self._open().optimize.optimize_indices()
+
+    def _run(self, ops):
+        for op in ops:
+            getattr(self, f"_op_{op}")()
+
+    # --- methods invoked across the version split ---
+    def setup(self):
+        shutil.rmtree(self.path, ignore_errors=True)
+        self.next_idx = 0
+        self._run(["W", "I"] + self.setup_ops)
+        return self.next_idx
+
+    def exercise_and_check(self):
+        self._run(self.exercise_ops)
+        ds = self._open()
+        if self.kind == "INVERTED":
+            # Differential oracle: rebuild the token -> rows map from a full (unindexed)
+            # scan, then require an FTS search for a spread of sampled terms to return
+            # exactly those rows. Catches a merge that drops or misassigns postings, not
+            # just a row-count drift. (Tokens here are alphanumeric and space-separated,
+            # so a whitespace split reproduces lance's tokenization.)
+            rows = ds.to_table(columns=["idx", "key"])
+            idxs = rows.column("idx").to_pylist()
+            texts = rows.column("key").to_pylist()
+            truth = {}
+            for i, text in zip(idxs, texts):
+                for tok in text.split():
+                    truth.setdefault(tok, set()).add(i)
+            if not truth:
+                return  # everything deleted; nothing to search
+            vocab = sorted(truth)
+            # A spread across the vocabulary plus the most common term.
+            sample = set(vocab[:: max(1, len(vocab) // 6)])
+            sample.add(max(truth, key=lambda t: len(truth[t])))
+            for term in sorted(sample):
+                hit = ds.to_table(full_text_query={"query": term, "columns": ["key"]})
+                got = set(hit.column("idx").to_pylist())
+                want = truth[term]
+                assert got == want, (
+                    f"FTS('{term}'): index returned {len(got)} rows, corpus has "
+                    f"{len(want)} (missing {sorted(want - got)[:5]}, "
+                    f"extra {sorted(got - want)[:5]})"
+                )
+            return
+        # Same column/predicate, index on vs forced off: use_scalar_index=False makes
+        # lance ignore the index, so the plans differ iff the index is used. If they are
+        # identical the index wasn't consulted here (the planner chose a scan after
+        # deletes), so the comparison is vacuous -- skip rather than compare two scans.
+        pred = self._oracle_pred()
+        plan_index = ds.scanner(filter=pred).explain_plan(True)
+        plan_scan = ds.scanner(filter=pred, use_scalar_index=False).explain_plan(True)
+        if plan_index == plan_scan:
+            return
+        got = ds.to_table(filter=pred).num_rows
+        expected = ds.to_table(filter=pred, use_scalar_index=False).num_rows
+        assert got == expected, (
+            f"{self.kind}: index gave {got} rows, full scan {expected}, for '{pred}'"
+        )
+
+
+def generate(max_length):
+    """Yield every (setup_ops, exercise_ops) whose combined length is 1..max_length,
+    breadth-first by total length (shorter first). `max_length` is the number of
+    maintenance ops after the implicit write + create-index, split between the writer
+    (setup) and reader (exercise) at every position. The order is neutral, so finding a
+    bug is a real search, not a sorted shortcut. The space grows fast with max_length,
+    so deeper bugs (ENT-1662 needs length 5) cost more to reach."""
+    for total in range(1, max_length + 1):
+        for setup_len in range(total):  # exercise gets total - setup_len >= 1
+            for s in itertools.product(SETUP_TAIL_OPS, repeat=setup_len):
+                for e in itertools.product(EXERCISE_OPS, repeat=total - setup_len):
+                    yield list(s), list(e)
+
+
+def search(
+    venv_factory,
+    from_ref,
+    to_ref,
+    base_path,
+    kind,
+    max_length=4,
+    shard=0,
+    num_shards=1,
+    stop_on_first=True,
+    fts_version=None,
+):
+    """Search index-maintenance sequences up to `max_length` ops for one `kind`, across
+    (from_ref -> to_ref). Runs only scenarios in this shard (i % num_shards == shard) so
+    the space can be split across parallel workers. For INVERTED, `fts_version` ("1" or
+    "2") pins the on-disk FTS format (LANCE_FTS_FORMAT_VERSION) on both sides; both are
+    Fst token sets and exercise distinct merge paths. Returns failures; stops on the
+    first when `stop_on_first`."""
+    from_venv = venv_factory.get_venv(from_ref)
+    to_venv = venv_factory.get_venv(to_ref)
+    env = {}
+    if kind == "INVERTED" and fts_version is not None:
+        env["LANCE_FTS_FORMAT_VERSION"] = str(fts_version)
+    base = Path(base_path)
+    failures = []
+    # Each setup's aged dataset is built once under from_ref and snapshotted; every
+    # exercise for that setup runs on a *copy* of it (a dir copy is far cheaper
+    # than rebuilding the index). Cached per shard, keyed by the setup ops.
+    snapshots = {}  # tuple(setup) -> (snapshot_path, next_idx), or None if setup failed
+    try:
+        for i, (setup_tail, exercise) in enumerate(generate(max_length)):
+            if i % num_shards != shard:
+                continue
+            key = tuple(setup_tail)
+            if key not in snapshots:
+                snap = base / f"snap_{kind}_{len(snapshots)}"
+                shutil.rmtree(snap, ignore_errors=True)
+                builder = IndexScenario(kind, snap, setup_tail, [])
+                try:
+                    next_idx = from_venv.execute_method(builder, "setup", env)
+                    snapshots[key] = (snap, next_idx)
+                except Exception as e:
+                    label = describe(
+                        kind, from_ref, to_ref, setup_tail, [], fts_version
+                    )
+                    err = str(e).strip()
+                    failures.append({"run": i, "sequence": label, "error": err})
+                    print(f"FAIL (setup): {label}\n    {err}")
+                    snapshots[key] = None
+                    shutil.rmtree(snap, ignore_errors=True)
+                    if stop_on_first:
+                        break
+            entry = snapshots[key]
+            if entry is None:
+                continue  # setup failed; skip its exercises
+            snap, next_idx = entry
+            ex_path = base / f"ex_{kind}_{i}"
+            shutil.rmtree(ex_path, ignore_errors=True)
+            shutil.copytree(snap, ex_path)
+            scenario = IndexScenario(kind, ex_path, setup_tail, exercise)
+            scenario.next_idx = next_idx
+            label = describe(kind, from_ref, to_ref, setup_tail, exercise, fts_version)
+            try:
+                to_venv.execute_method(scenario, "exercise_and_check", env)
+            except Exception as e:
+                error = str(e).strip()
+                failures.append({"run": i, "sequence": label, "error": error})
+                print(f"FAIL: {label}\n    {error}")
+                if stop_on_first:
+                    break
+            else:
+                print(f"ok  : {label}")
+            finally:
+                shutil.rmtree(ex_path, ignore_errors=True)
+    finally:
+        for entry in snapshots.values():
+            if entry is not None:
+                shutil.rmtree(entry[0], ignore_errors=True)
+    return failures

--- a/python/python/tests/compat/compat_sequence.py
+++ b/python/python/tests/compat/compat_sequence.py
@@ -266,7 +266,6 @@ def search(
                     )
                     err = str(e).strip()
                     failures.append({"run": i, "sequence": label, "error": err})
-                    print(f"FAIL (setup): {label}\n    {err}")
                     snapshots[key] = None
                     shutil.rmtree(snap, ignore_errors=True)
                     if stop_on_first:
@@ -286,11 +285,8 @@ def search(
             except Exception as e:
                 error = str(e).strip()
                 failures.append({"run": i, "sequence": label, "error": error})
-                print(f"FAIL: {label}\n    {error}")
                 if stop_on_first:
                     break
-            else:
-                print(f"ok  : {label}")
             finally:
                 shutil.rmtree(ex_path, ignore_errors=True)
     finally:

--- a/python/python/tests/compat/test_index_sequence.py
+++ b/python/python/tests/compat/test_index_sequence.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Cross-version index maintenance-sequence search, wired as a compat test.
+
+For each index kind, generate maintenance-op sequences from a small grammar, run the
+setup half under an older writer ref and the exercise half under a newer reader, and
+check after each that the reader did not panic and that an index query matches a full
+scan. Discovers cross-version regressions (e.g. ENT-1662, under INVERTED) with no
+hand-coded sequence.
+
+Refs and max length are environment-driven so the suite can run between two refs
+(versions, commits, or branches): COMPAT_FROM_REF / COMPAT_TO_REF / COMPAT_MAX_LENGTH /
+COMPAT_KINDS (comma-separated subset of kinds) / COMPAT_SHARDS (split each kind's search
+into this many cases so pytest-xdist (`-n auto`) parallelizes them across cores).
+"""
+
+import os
+
+import pytest
+
+from .compat_decorator import pylance_stable_versions
+from .compat_sequence import ALL_KINDS, search
+
+
+def _default_refs():
+    """The two most recent published stable releases (older -> newer)."""
+    versions = pylance_stable_versions()
+    if len(versions) >= 2:
+        return str(versions[-2]), str(versions[-1])
+    return "6.0.1", "7.0.0"  # fallback if PyPI is unreachable
+
+
+_default_from, _default_to = _default_refs()
+FROM_REF = os.environ.get("COMPAT_FROM_REF") or _default_from
+TO_REF = os.environ.get("COMPAT_TO_REF") or _default_to
+MAX_LENGTH = int(os.environ.get("COMPAT_MAX_LENGTH", "4"))
+KINDS = os.environ.get("COMPAT_KINDS", ",".join(ALL_KINDS)).split(",")
+# Many small shards (default 4x cores) so xdist's dynamic scheduler keeps every worker
+# busy and an oversubscribed `-n` has work to overlap.
+NUM_SHARDS = int(os.environ.get("COMPAT_SHARDS", str((os.cpu_count() or 1) * 4)))
+
+
+def _cases():
+    """(kind, fts_version) cases. FTS runs under both on-disk formats (v1, v2); the
+    scalar kinds are format-agnostic and run once."""
+    cases = []
+    for kind in KINDS:
+        if kind == "INVERTED":
+            cases.extend([("INVERTED", "1"), ("INVERTED", "2")])
+        else:
+            cases.append((kind, None))
+    return cases
+
+
+CASES = _cases()
+CASE_IDS = [k if v is None else f"{k}-fmtv{v}" for k, v in CASES]
+
+
+@pytest.mark.compat
+@pytest.mark.parametrize("kind,fts_version", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("shard", range(NUM_SHARDS))
+def test_index_maintenance_sequence_search(
+    venv_factory, tmp_path, kind, fts_version, shard
+):
+    failures = search(
+        venv_factory,
+        FROM_REF,
+        TO_REF,
+        tmp_path,
+        kind,
+        max_length=MAX_LENGTH,
+        shard=shard,
+        num_shards=NUM_SHARDS,
+        fts_version=fts_version,
+    )
+    # First line is the failure itself so it shows in pytest's bottom summary; the rest
+    # (if more than one) appears in the failure body.
+    assert not failures, "\n".join(
+        f"{f['sequence']}  ==>  {f['error']}" for f in failures
+    )

--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -8,15 +8,38 @@ Manages creation and execution of test code in isolated virtual environments
 with specific Lance versions installed.
 """
 
+import contextlib
 import os
 import pickle
+import re
+import shutil
 import struct
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Optional
 
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX
+    fcntl = None
+
+
+@contextlib.contextmanager
+def _venv_lock(lock_path: Path):
+    """Hold an exclusive lock so parallel workers don't race creating the same venv."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "w") as handle:
+        if fcntl is not None:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(handle, fcntl.LOCK_UN)
+
 
 NAMESPACE_0_6_DEPENDENCY = "lance-namespace<0.7"
 NAMESPACE_0_7_DEPENDENCY = "lance-namespace>=0.7.2,<0.8"
@@ -29,6 +52,26 @@ def _lance_namespace_dependency(pylance_version: str) -> str:
     if Version(pylance_version) >= Version("6.0.0b0"):
         return NAMESPACE_0_7_DEPENDENCY
     return NAMESPACE_0_6_DEPENDENCY
+
+
+def _is_release_version(ref: str) -> bool:
+    """A ref is treated as a published release (install a wheel) if it parses as a
+    version; anything else (commit sha, branch, tag) is built from source."""
+    try:
+        Version(ref)
+        return True
+    except InvalidVersion:
+        return False
+
+
+def _repo_root() -> Path:
+    """Lance source checkout holding this test file (used to build refs from source)."""
+    # .../python/python/tests/compat/venv_manager.py -> repo root is parents[4]
+    return Path(__file__).resolve().parents[4]
+
+
+def _safe(ref: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "_", ref)
 
 
 class VenvExecutor:
@@ -52,6 +95,8 @@ class VenvExecutor:
         self.persistent = persistent
         self._created = False
         self._subprocess: Optional[subprocess.Popen] = None
+        self._stderr_path: Optional[Path] = None
+        self._stderr_file = None
 
     @property
     def python_path(self) -> Path:
@@ -59,54 +104,50 @@ class VenvExecutor:
             return self.venv_path / "Scripts" / "python.exe"
         return self.venv_path / "bin" / "python"
 
-    def _validate_venv(self) -> bool:
-        """Check if existing venv is valid and has correct Lance version."""
-        if not self.venv_path.exists():
-            return False
+    @property
+    def _marker_path(self) -> Path:
+        return self.venv_path / ".compat_ref"
 
+    def _validate_venv(self) -> bool:
+        """A cached venv is reusable if it exists and its recorded ref matches. A marker
+        file is used (not `pip show`) so source-built commit refs also validate."""
         if not self.python_path.exists():
             return False
-
-        # Check if pylance is installed with correct version
         try:
-            result = subprocess.run(
-                [str(self.python_path), "-m", "pip", "show", "pylance"],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            if result.returncode != 0:
-                return False
-
-            # Parse version from output
-            for line in result.stdout.splitlines():
-                if line.startswith("Version:"):
-                    installed_version = line.split(":", 1)[1].strip()
-                    return installed_version == self.version
-
-        except Exception:
+            return self._marker_path.read_text().strip() == self.version
+        except OSError:
             return False
-
-        return False
 
     def create(self):
         """Create the virtual environment and install the specified Lance version."""
         if self._created:
             return
-
-        # Check if persistent venv already exists and is valid
         if self.persistent and self._validate_venv():
             self._created = True
             return
 
-        # Create virtual environment
-        subprocess.run(
-            [sys.executable, "-m", "venv", str(self.venv_path)],
-            check=True,
-            capture_output=True,
-        )
+        # Lock so parallel workers don't build the same venv at once; re-check in the
+        # lock since another worker may have just finished it.
+        with _venv_lock(self.venv_path.parent / f".lock_{_safe(self.version)}"):
+            if not self._validate_venv():
+                if self.venv_path.exists():
+                    shutil.rmtree(self.venv_path)  # drop any partial build
+                subprocess.run(
+                    [sys.executable, "-m", "venv", str(self.venv_path)],
+                    check=True,
+                    capture_output=True,
+                )
+                # Release wheel when the ref is a published version; otherwise build the
+                # ref (commit/branch/tag) from source -- so two arbitrary refs can be
+                # compared and only the ones without a wheel pay a build.
+                if _is_release_version(self.version):
+                    self._install_release_wheel()
+                else:
+                    self._build_from_source()
+                self._marker_path.write_text(self.version)
+        self._created = True
 
-        # Install specific pylance version and pytest
+    def _install_release_wheel(self):
         subprocess.run(
             [
                 str(self.python_path),
@@ -131,7 +172,55 @@ class VenvExecutor:
             capture_output=True,
         )
 
-        self._created = True
+    def _build_from_source(self):
+        """Build a wheel for an arbitrary git ref via a worktree + maturin, then install
+        it. The worktree/build is cached by ref so it is paid at most once."""
+        py = str(self.python_path)
+        src = self.venv_path.parent / f"src_{_safe(self.version)}"
+        if not src.exists():
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(_repo_root()),
+                    "worktree",
+                    "add",
+                    "--detach",
+                    str(src),
+                    self.version,
+                ],
+                check=True,
+                capture_output=True,
+            )
+        subprocess.run(
+            [py, "-m", "pip", "install", "--quiet", "maturin", "pytest", "pyarrow"],
+            check=True,
+            capture_output=True,
+        )
+        wheels = src / "target" / "compat-wheels"
+        subprocess.run(
+            [
+                py,
+                "-m",
+                "maturin",
+                "build",
+                "--release",
+                "--interpreter",
+                py,
+                "-m",
+                str(src / "python" / "Cargo.toml"),
+                "--out",
+                str(wheels),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        wheel = next(wheels.glob("pylance-*.whl"))
+        subprocess.run(
+            [py, "-m", "pip", "install", "--quiet", str(wheel)],
+            check=True,
+            capture_output=True,
+        )
 
     def _ensure_subprocess(self):
         """Ensure the persistent subprocess is running."""
@@ -147,13 +236,34 @@ class VenvExecutor:
         tests_dir = Path(__file__).parent.parent
         env["PYTHONPATH"] = str(tests_dir)
 
+        # Capture stderr to a file so a Rust panic (which crashes the runner) can be
+        # surfaced in the error instead of an opaque "broken pipe".
+        self._stderr_path = self.venv_path / ".runner_stderr.log"
+        self._stderr_file = open(self._stderr_path, "w")
         self._subprocess = subprocess.Popen(
             [str(self.python_path), "-u", str(runner_script)],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=None,  # Inherit stderr to see timing messages
+            stderr=self._stderr_file,
             env=env,
         )
+
+    def _last_panic(self) -> str:
+        """Pull the panic message from the runner's captured stderr, if any."""
+        try:
+            text = self._stderr_path.read_text()
+        except (OSError, AttributeError):
+            return ""
+        lines = text.splitlines()
+        for i, line in enumerate(lines):
+            if "panicked at" in line:
+                # Compact the long path to just "builder.rs:962:57"
+                loc = line.split("panicked at", 1)[1].strip().rstrip(":")
+                loc = loc.rsplit("/", 1)[-1]
+                msg = lines[i + 1].strip() if i + 1 < len(lines) else ""
+                return f"panic at {loc}: {msg}" if msg else f"panic at {loc}"
+        tail = [line.strip() for line in lines if line.strip()]
+        return tail[-1] if tail else ""
 
     def _send_message(self, obj: Any):
         """Send a length-prefixed pickled message to subprocess."""
@@ -165,18 +275,19 @@ class VenvExecutor:
 
     def _receive_message(self) -> Any:
         """Receive a length-prefixed pickled message from subprocess."""
-        # Read 4-byte length header
+        # Short reads mean the subprocess closed stdout (usually a crash); raise
+        # EOFError so the caller can surface the panic from captured stderr.
         length_bytes = self._subprocess.stdout.read(4)
         if len(length_bytes) < 4:
-            raise RuntimeError("Failed to read message length from subprocess")
+            raise EOFError("subprocess closed stdout before sending a message length")
 
         length = struct.unpack(">I", length_bytes)[0]
 
         # Read message data
         data = self._subprocess.stdout.read(length)
         if len(data) < length:
-            raise RuntimeError(
-                f"Incomplete message: expected {length} bytes, got {len(data)}"
+            raise EOFError(
+                f"incomplete message: expected {length} bytes, got {len(data)}"
             )
 
         return pickle.loads(data)
@@ -234,11 +345,15 @@ class VenvExecutor:
                 raise RuntimeError(error_msg)
 
         except (BrokenPipeError, EOFError, struct.error) as e:
-            # Subprocess died or communication failed
-            raise RuntimeError(
-                f"Communication with venv subprocess failed (Lance {self.version}):\n"
-                f"Error: {e}"
-            )
+            # Subprocess died (usually a Rust panic); flush it, then surface that.
+            if self._subprocess is not None:
+                try:
+                    self._subprocess.wait(timeout=2)
+                except Exception:
+                    pass
+            panic = self._last_panic()
+            detail = panic or f"subprocess communication failed: {e}"
+            raise RuntimeError(f"Lance {self.version}: {detail}")
 
     def cleanup(self):
         """Remove the virtual environment directory and terminate subprocess."""
@@ -295,7 +410,7 @@ class VenvFactory:
             Executor for the specified version
         """
         if version not in self.venvs:
-            venv_path = self.base_path / f"venv_{version}"
+            venv_path = self.base_path / f"venv_{_safe(version)}"
             executor = VenvExecutor(version, venv_path, persistent=self.persistent)
             executor.create()
             self.venvs[version] = executor

--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -9,6 +9,7 @@ with specific Lance versions installed.
 """
 
 import contextlib
+import glob
 import os
 import pickle
 import re
@@ -62,6 +63,27 @@ def _is_release_version(ref: str) -> bool:
         return True
     except InvalidVersion:
         return False
+
+
+def _prebuilt_wheel_for(ref: str) -> Optional[str]:
+    """A prebuilt wheel to install for `ref` instead of building it from source.
+
+    When CI has already built a ref (e.g. the PR head, built once by the Python build
+    job), COMPAT_PREBUILT_REF names that ref and COMPAT_PREBUILT_WHEEL points at the
+    wheel (a path or glob). Lets the PR workflow reuse that wheel rather than rebuilding
+    the reader. Returns None when no prebuilt wheel applies to `ref`.
+    """
+    if os.environ.get("COMPAT_PREBUILT_REF") != ref:
+        return None
+    pattern = os.environ.get("COMPAT_PREBUILT_WHEEL")
+    if not pattern:
+        return None
+    matches = sorted(glob.glob(pattern))
+    if not matches:
+        raise FileNotFoundError(
+            f"COMPAT_PREBUILT_WHEEL={pattern!r} matched no wheel for ref {ref!r}"
+        )
+    return matches[0]
 
 
 def _repo_root() -> Path:
@@ -137,15 +159,26 @@ class VenvExecutor:
                     check=True,
                     capture_output=True,
                 )
-                # Release wheel when the ref is a published version; otherwise build the
-                # ref (commit/branch/tag) from source -- so two arbitrary refs can be
-                # compared and only the ones without a wheel pay a build.
-                if _is_release_version(self.version):
+                # Prefer a wheel CI already built for this ref; else a published
+                # release installs its wheel; else build the ref (commit/branch/tag)
+                # from source -- so two arbitrary refs can be compared and only the
+                # ones without a wheel pay a build.
+                prebuilt = _prebuilt_wheel_for(self.version)
+                if prebuilt is not None:
+                    self._install_wheel(prebuilt)
+                elif _is_release_version(self.version):
                     self._install_release_wheel()
                 else:
                     self._build_from_source()
                 self._marker_path.write_text(self.version)
         self._created = True
+
+    def _install_wheel(self, wheel: str):
+        subprocess.run(
+            [str(self.python_path), "-m", "pip", "install", "--quiet", wheel, "pytest"],
+            check=True,
+            capture_output=True,
+        )
 
     def _install_release_wheel(self):
         subprocess.run(


### PR DESCRIPTION
Adds a cross-version index compat capability: take two arbitrary refs (version, sha, branch, or tag), age an index under the first, exercise it under the second, and search maintenance-op sequences for panics or correctness divergence -- without hand-coding the failing sequence. This is the test that would have caught ENT-1662 (FTS `load_fst` stale `next_id` panic, fixed in #7200).

## What's here

- `venv_manager.py`: a venv per ref -- published releases install the wheel, anything else builds from a git worktree via maturin. Cached and lock-guarded so parallel workers build each ref once. Sub-venv Rust panics are surfaced as the failure.
- `compat_sequence.py`: breadth-first search over op sequences (write/delete/compact/optimize) up to a max length, for INVERTED + BTREE, BITMAP, LABEL_LIST, NGRAM, ZONEMAP, BLOOMFILTER. Non-vacuous oracle per kind (FTS count for INVERTED; index-vs-`use_scalar_index=False` for scalar). Setups built once and snapshotted for speed.
- `test_fts_sequence.py`: env-driven entry, parallel via xdist sharding. Failures print the plain-English sequence and real error. Default refs are the two most recent stable releases.
- `.github/workflows/compat-pair.yml`: on a pull request, ages indexes under the latest release of each of the two previous majors and exercises them under the PR head; `workflow_dispatch` runs one explicit ref pair on demand.

## Test

`pytest python/tests/compat/test_fts_sequence.py --run-compat -n 128` reproduces ENT-1662 and runs all scalar kinds green. JSON is the one index kind not yet covered by the sequence search.