### PR TITLE
perf(fts): stream prewarm posting lists in chunks

### DIFF
--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -256,6 +256,11 @@ pub trait IndexReader: Send + Sync {
     fn num_rows(&self) -> usize;
     /// Return the metadata of the file
     fn schema(&self) -> &lance_core::datatypes::Schema;
+    /// Best-effort on-disk byte size of the file when the reader already knows it
+    /// without extra I/O, else `None`. Used to size prewarm chunks.
+    fn file_size_bytes(&self) -> Option<u64> {
+        None
+    }
 }
 
 /// Trait abstracting I/O away from index logic

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1023,6 +1023,52 @@ impl Index for InvertedIndex {
     }
 }
 
+/// Target on-disk size of one prewarm chunk; a partition is streamed in chunks of
+/// ~this size so its peak resident set is one chunk, not the whole `invert.lance`.
+const PREWARM_CHUNK_TARGET_BYTES: u64 = 32 << 20;
+
+/// Cap on token rows per chunk, bounding the built `Vec` when posting lists are tiny.
+const PREWARM_MAX_CHUNK_TOKENS: usize = 4096;
+
+/// Floor on token rows per chunk, so a partition always makes progress.
+const PREWARM_MIN_CHUNK_TOKENS: usize = 1;
+
+/// Token rows per chunk: byte target / average bytes-per-token, clamped to `[MIN, MAX]`.
+fn prewarm_chunk_tokens(token_count: usize, file_size_bytes: u64) -> usize {
+    if token_count == 0 {
+        return PREWARM_MIN_CHUNK_TOKENS;
+    }
+    let bytes_per_token = (file_size_bytes / token_count as u64).max(1); // >= 1: no div-by-zero
+    let by_bytes = (PREWARM_CHUNK_TARGET_BYTES / bytes_per_token) as usize;
+    by_bytes.clamp(PREWARM_MIN_CHUNK_TOKENS, PREWARM_MAX_CHUNK_TOKENS)
+}
+
+/// Snap a chunk's exclusive token end back to a posting-group boundary so no group
+/// straddles chunks. Returns the largest group boundary in `(tok_start, desired_end]`,
+/// or the next boundary past an oversized group so it runs as one solo chunk.
+fn group_aligned_chunk_end(
+    starts: &[u32],
+    token_count: usize,
+    tok_start: usize,
+    desired_end: usize,
+) -> usize {
+    let fit = starts
+        .iter()
+        .map(|&s| s as usize)
+        .chain(std::iter::once(token_count))
+        .filter(|&b| b > tok_start && b <= desired_end)
+        .max();
+    if let Some(end) = fit {
+        return end;
+    }
+    // Oversized group: extend to its end so it runs as one chunk.
+    starts
+        .iter()
+        .map(|&s| s as usize)
+        .find(|&b| b > tok_start)
+        .unwrap_or(token_count)
+}
+
 impl InvertedIndex {
     pub async fn prewarm_with_options(&self, options: &FtsPrewarmOptions) -> Result<()> {
         let with_position = options.with_position;
@@ -2286,50 +2332,84 @@ impl PostingListReader {
         )
     }
 
-    fn build_prewarm_posting_lists(
-        batch: RecordBatch,
-        offsets: Option<Vec<usize>>,
-        max_scores: Option<Vec<f32>>,
-        lengths: Option<Vec<u32>>,
-        posting_tail_codec: PostingTailCodec,
-        positions_layout: PositionsLayout,
+    /// Build posting lists for one chunk's token range from `chunk_batch`, rebasing
+    /// global offsets to chunk-local rows. Returns `(global token_id, PostingList)`
+    /// pairs identical to the whole-file path, only bounded to one chunk.
+    fn build_prewarm_posting_lists_chunk(
+        chunk_batch: RecordBatch,
+        chunk: PrewarmChunk<'_>,
+        ctx: &PrewarmBuildCtx<'_>,
     ) -> Result<Vec<(u32, PostingList)>> {
-        let token_count = if let Some(offsets) = offsets.as_ref() {
-            offsets.len()
-        } else if let Some(lengths) = lengths.as_ref() {
-            lengths.len()
-        } else {
-            batch.num_rows()
-        };
-
-        let mut posting_lists = Vec::with_capacity(token_count);
-        for token_id in 0..token_count {
-            let batch = if let Some(offsets) = offsets.as_ref() {
-                let start = offsets[token_id];
-                let end = if token_id + 1 < offsets.len() {
-                    offsets[token_id + 1]
+        let mut posting_lists = Vec::with_capacity(chunk.token_count);
+        for local in 0..chunk.token_count {
+            let global = chunk.tok_start + local;
+            let row_batch = if let Some(chunk_offsets) = chunk.offsets {
+                // Legacy v1: rebase global offsets to chunk row 0; the last token
+                // ends at `chunk.end_row` (no trailing sentinel in chunk_offsets).
+                let base = chunk_offsets[0];
+                let start = chunk_offsets[local] - base;
+                let end = if local + 1 < chunk_offsets.len() {
+                    chunk_offsets[local + 1] - base
                 } else {
-                    batch.num_rows()
+                    chunk.end_row - base
                 };
-                batch.slice(start, end - start)
+                chunk_batch.slice(start, end - start)
             } else {
-                batch.slice(token_id, 1)
+                // V2: one posting row per token; row `local` within the chunk.
+                chunk_batch.slice(local, 1)
             };
-            let batch = batch.shrink_to_fit()?;
+            let row_batch = row_batch.shrink_to_fit()?;
             let posting_list = Self::posting_list_from_batch_parts(
-                &batch,
-                max_scores.as_ref().map(|scores| scores[token_id]),
-                lengths.as_ref().map(|lengths| lengths[token_id]),
-                posting_tail_codec,
-                positions_layout,
+                &row_batch,
+                ctx.max_scores.map(|scores| scores[global]),
+                ctx.lengths.map(|lengths| lengths[global]),
+                ctx.posting_tail_codec,
+                ctx.positions_layout,
             )?;
-            posting_lists.push((token_id as u32, posting_list));
+            posting_lists.push((global as u32, posting_list));
         }
 
         Ok(posting_lists)
     }
 
+    /// Read the posting rows for token ids `[tok_start, tok_end)` into one RecordBatch.
+    /// For v2 the token range is the row range; for v1 it's derived from the offsets.
+    async fn read_chunk_batch(
+        &self,
+        tok_start: usize,
+        tok_end: usize,
+        with_position: bool,
+    ) -> Result<RecordBatch> {
+        let columns = self.posting_columns(with_position);
+        let row_range = match &self.metadata {
+            PostingMetadata::LegacyV1 { offsets, .. } => {
+                let start = offsets[tok_start];
+                let end = offsets
+                    .get(tok_end)
+                    .copied()
+                    .unwrap_or_else(|| self.reader.num_rows());
+                start..end
+            }
+            PostingMetadata::V2 { .. } => tok_start..tok_end,
+        };
+        let batch = self.reader.read_range(row_range, Some(&columns)).await?;
+        Ok(batch)
+    }
+
     async fn prewarm_posting_lists(&self, with_position: bool) -> Result<()> {
+        self.prewarm_posting_lists_chunked(with_position, None)
+            .await?;
+        Ok(())
+    }
+
+    /// Stream the partition's posting lists into the cache in bounded token-row chunks
+    /// (read -> build -> insert -> drop), so peak resident set is ~one chunk. Returns
+    /// the chunk count (tests assert it split). `chunk_tokens_override` is test-only.
+    async fn prewarm_posting_lists_chunked(
+        &self,
+        with_position: bool,
+        chunk_tokens_override: Option<usize>,
+    ) -> Result<usize> {
         if with_position && !self.has_positions() {
             return Err(Error::invalid_input(
                 "cannot prewarm positions for an inverted index that was built without positions; recreate the index with with_position=true".to_owned(),
@@ -2341,34 +2421,124 @@ impl PostingListReader {
         // OnceCells.
         self.ensure_metadata_loaded().await?;
 
-        let read_batch_start = Instant::now();
-        let batch = self.read_batch(with_position).await?;
-        let read_batch_elapsed = read_batch_start.elapsed();
+        let state = self.chunk_build_state();
+        // With grouping the cache stores one entry per group, so a group's posting
+        // lists must all be resident at once: align chunk boundaries to whole
+        // groups. Without grouping, chunks are plain token ranges.
+        let group_starts = self.group_starts.clone();
+        let token_count = self.len();
+        let chunk_tokens = chunk_tokens_override
+            .unwrap_or_else(|| prewarm_chunk_tokens(token_count, self.posting_data_size_bytes()))
+            .max(1);
 
-        let (legacy_layout, offsets, max_scores, lengths) = match &self.metadata {
+        let mut chunk_count = 0usize;
+        let read_build_start = Instant::now();
+        let mut tok_start = 0usize;
+        while tok_start < token_count {
+            let mut tok_end = (tok_start + chunk_tokens).min(token_count);
+            // `tok_start` is always a group boundary; snap `tok_end` back to one too.
+            if let Some(starts) = group_starts.as_ref() {
+                tok_end = group_aligned_chunk_end(starts, token_count, tok_start, tok_end);
+            }
+            chunk_count += 1;
+
+            let posting_lists = self
+                .build_chunk_postings(tok_start, tok_end, with_position, &state)
+                .await?;
+            self.publish_chunk_postings(
+                posting_lists,
+                group_starts.as_deref(),
+                tok_start,
+                tok_end,
+                token_count,
+                with_position,
+            )
+            .await;
+
+            tok_start = tok_end;
+        }
+        let read_build_elapsed = read_build_start.elapsed();
+
+        info!(
+            legacy_layout = self.is_legacy_layout(),
+            with_position,
+            token_count,
+            chunk_count,
+            chunk_tokens,
+            read_build_ms = read_build_elapsed.as_secs_f64() * 1000.0,
+            "posting list prewarm timing"
+        );
+
+        Ok(chunk_count)
+    }
+
+    /// Loop-invariant inputs shared by every chunk build: the metadata vecs
+    /// (`Arc`d so chunks share them without re-cloning) plus codec/layout.
+    fn chunk_build_state(&self) -> ChunkBuildState {
+        let (offsets, max_scores, lengths) = match &self.metadata {
             PostingMetadata::LegacyV1 {
                 offsets,
                 max_scores,
-            } => (true, Some(offsets.clone()), max_scores.clone(), None),
+            } => (Some(offsets.clone()), max_scores.clone(), None),
             PostingMetadata::V2 { metadata } => (
-                false,
                 None,
                 metadata.get().map(|loaded| loaded.max_scores.clone()),
                 metadata.get().map(|loaded| loaded.lengths.clone()),
             ),
         };
-        let posting_tail_codec = self.posting_tail_codec;
-        let positions_layout = self.positions_layout;
-        let populate_start = Instant::now();
+        ChunkBuildState {
+            offsets: offsets.map(Arc::new),
+            max_scores: max_scores.map(Arc::new),
+            lengths: lengths.map(Arc::new),
+            posting_tail_codec: self.posting_tail_codec,
+            positions_layout: self.positions_layout,
+        }
+    }
+
+    /// Read one token-row chunk and build its posting lists off the runtime thread.
+    /// The large batch is dropped inside the blocking task once built, bounding
+    /// resident memory to one chunk.
+    async fn build_chunk_postings(
+        &self,
+        tok_start: usize,
+        tok_end: usize,
+        with_position: bool,
+        state: &ChunkBuildState,
+    ) -> Result<Vec<(u32, PostingList)>> {
+        let chunk_token_count = tok_end - tok_start;
+        let chunk_batch = self
+            .read_chunk_batch(tok_start, tok_end, with_position)
+            .await?;
+
+        let (chunk_offsets, chunk_end_row) = match state.offsets.as_ref() {
+            Some(offsets) => {
+                let end_row = offsets
+                    .get(tok_end)
+                    .copied()
+                    .unwrap_or_else(|| self.reader.num_rows());
+                (Some(offsets[tok_start..tok_end].to_vec()), end_row)
+            }
+            // V2 doesn't use chunk_end_row (one row per token); pass tok_end.
+            None => (None, tok_end),
+        };
+        let max_scores = state.max_scores.clone();
+        let lengths = state.lengths.clone();
+        let posting_tail_codec = state.posting_tail_codec;
+        let positions_layout = state.positions_layout;
         let posting_lists = spawn_blocking(move || {
-            Self::build_prewarm_posting_lists(
-                batch,
-                offsets,
-                max_scores,
-                lengths,
+            let ctx = PrewarmBuildCtx {
+                max_scores: max_scores.as_deref().map(|v| v.as_slice()),
+                lengths: lengths.as_deref().map(|v| v.as_slice()),
                 posting_tail_codec,
                 positions_layout,
-            )
+            };
+            let chunk = PrewarmChunk {
+                tok_start,
+                token_count: chunk_token_count,
+                offsets: chunk_offsets.as_deref(),
+                end_row: chunk_end_row,
+            };
+            Self::build_prewarm_posting_lists_chunk(chunk_batch, chunk, &ctx)
         })
         .await
         .map_err(|err| {
@@ -2376,60 +2546,95 @@ impl PostingListReader {
                 "Failed to build prewarm posting lists in blocking task: {err}"
             ))
         })??;
-        // Strip positions into their own per-token cache entries first
-        // (unchanged); the posting cache holds positions-free lists.
-        let mut postings_by_token = Vec::with_capacity(posting_lists.len());
-        for (token_id, mut posting_list) in posting_lists {
-            if with_position && let Some(positions) = posting_list.take_positions() {
-                self.index_cache
-                    .insert_with_key(&PositionKey { token_id }, Arc::new(Positions(positions)))
-                    .await;
-            }
-            debug_assert_eq!(token_id as usize, postings_by_token.len());
-            postings_by_token.push(posting_list);
-        }
-        // Populate the same cache keys the read path uses: grouped entries when
-        // grouping is active (issue #7040), per-token entries otherwise.
-        match self.group_starts.as_ref() {
+        // The chunk yields its token range as contiguous ascending ids from
+        // `tok_start`; the group publish path relies on this to index the lists.
+        debug_assert_eq!(posting_lists.len(), chunk_token_count);
+        debug_assert!(
+            posting_lists
+                .iter()
+                .enumerate()
+                .all(|(i, (token_id, _))| *token_id as usize == tok_start + i)
+        );
+        Ok(posting_lists)
+    }
+
+    /// Strip positions into their own per-token cache entries (the posting cache
+    /// holds positions-free lists), then populate the same cache keys the read
+    /// path uses: grouped entries when grouping is active, per-token entries
+    /// otherwise. Called once per chunk; the chunk's lists drop on return.
+    async fn publish_chunk_postings(
+        &self,
+        posting_lists: Vec<(u32, PostingList)>,
+        group_starts: Option<&[u32]>,
+        tok_start: usize,
+        tok_end: usize,
+        token_count: usize,
+        with_position: bool,
+    ) {
+        match group_starts {
             Some(starts) => {
-                // The read path derives the last group's `end` from `self.len()`;
-                // match it here so both produce identical `PostingListGroupKey`s.
-                debug_assert_eq!(postings_by_token.len(), self.len());
+                let mut chunk_postings = Vec::with_capacity(posting_lists.len());
+                for (token_id, mut posting_list) in posting_lists {
+                    self.cache_positions(&mut posting_list, token_id, with_position)
+                        .await;
+                    chunk_postings.push(posting_list);
+                }
+                // Chunk is group-aligned, so every group starting in it also ends
+                // in it; `chunk_postings[i]` is token `tok_start + i`. The last
+                // group's `end` derives from `token_count`, matching the read path
+                // so both produce identical `PostingListGroupKey`s.
                 for (k, &start) in starts.iter().enumerate() {
-                    let end = starts.get(k + 1).copied().unwrap_or(self.len() as u32);
-                    let group = PostingListGroup::new(
-                        postings_by_token[start as usize..end as usize].to_vec(),
-                    );
+                    let start_usize = start as usize;
+                    if start_usize < tok_start || start_usize >= tok_end {
+                        continue;
+                    }
+                    let end = starts.get(k + 1).copied().unwrap_or(token_count as u32);
+                    let lo = start_usize - tok_start;
+                    let hi = end as usize - tok_start;
+                    let group = PostingListGroup::new(chunk_postings[lo..hi].to_vec());
                     self.index_cache
                         .insert_with_key(&PostingListGroupKey { start, end }, Arc::new(group))
                         .await;
                 }
             }
             None => {
-                for (token_id, posting_list) in postings_by_token.into_iter().enumerate() {
+                for (token_id, mut posting_list) in posting_lists {
+                    self.cache_positions(&mut posting_list, token_id, with_position)
+                        .await;
                     self.index_cache
-                        .insert_with_key(
-                            &PostingListKey {
-                                token_id: token_id as u32,
-                            },
-                            Arc::new(posting_list),
-                        )
+                        .insert_with_key(&PostingListKey { token_id }, Arc::new(posting_list))
                         .await;
                 }
             }
         }
-        let populate_elapsed = populate_start.elapsed();
+    }
 
-        info!(
-            legacy_layout,
-            with_position,
-            token_count = self.len(),
-            read_batch_ms = read_batch_elapsed.as_secs_f64() * 1000.0,
-            post_read_loop_ms = populate_elapsed.as_secs_f64() * 1000.0,
-            "posting list prewarm timing"
-        );
+    /// Move a posting list's positions (when present and requested) into the
+    /// dedicated per-token position cache, leaving the posting list positions-free.
+    async fn cache_positions(
+        &self,
+        posting_list: &mut PostingList,
+        token_id: u32,
+        with_position: bool,
+    ) {
+        if with_position && let Some(positions) = posting_list.take_positions() {
+            self.index_cache
+                .insert_with_key(&PositionKey { token_id }, Arc::new(Positions(positions)))
+                .await;
+        }
+    }
 
-        Ok(())
+    /// Cheap `invert.lance` size estimate (file length from object metadata, no
+    /// data read), used only to size prewarm chunks. Falls back to a row-count
+    /// proxy when the reader can't surface the length (legacy v1).
+    pub(crate) fn posting_data_size_bytes(&self) -> u64 {
+        if let Some(size) = self.reader.file_size_bytes() {
+            return size;
+        }
+        // Fallback proxy for readers that don't cache their file length: just needs
+        // to be monotonic in partition size.
+        const ESTIMATED_BYTES_PER_ROW: u64 = 16;
+        (self.reader.num_rows() as u64).saturating_mul(ESTIMATED_BYTES_PER_ROW)
     }
 
     pub(crate) async fn read_batch(&self, with_position: bool) -> Result<RecordBatch> {
@@ -2569,6 +2774,38 @@ impl PostingListReader {
         }
         base_columns
     }
+}
+
+/// Loop-invariant state for [`InvertedPartition::build_chunk_postings`]. The
+/// metadata vecs are `Arc`d so each chunk's blocking build shares them cheaply.
+struct ChunkBuildState {
+    offsets: Option<Arc<Vec<usize>>>,
+    max_scores: Option<Arc<Vec<f32>>>,
+    lengths: Option<Arc<Vec<u32>>>,
+    posting_tail_codec: PostingTailCodec,
+    positions_layout: PositionsLayout,
+}
+
+/// Chunk-invariant inputs to [`InvertedPartition::build_prewarm_posting_lists_chunk`]:
+/// the per-partition codec/layout and the (shared, whole-partition) metadata
+/// slices indexed by global token id. These don't change across chunks.
+struct PrewarmBuildCtx<'a> {
+    max_scores: Option<&'a [f32]>,
+    lengths: Option<&'a [u32]>,
+    posting_tail_codec: PostingTailCodec,
+    positions_layout: PositionsLayout,
+}
+
+/// Per-chunk inputs to [`InvertedPartition::build_prewarm_posting_lists_chunk`]:
+/// the token sub-range `[tok_start, tok_start + token_count)` and, for legacy
+/// v1, the rebased offset slice plus the chunk's end row.
+struct PrewarmChunk<'a> {
+    tok_start: usize,
+    token_count: usize,
+    /// Legacy v1 only: `offsets[tok_start..tok_start+token_count]` (no sentinel).
+    offsets: Option<&'a [usize]>,
+    /// Legacy v1 only: global row at which this chunk's posting rows end.
+    end_row: usize,
 }
 
 /// New type just to allow Positions implement DeepSizeOf so it can be put
@@ -5835,6 +6072,253 @@ mod tests {
         );
     }
 
+    /// Prewarming a large partition in multiple chunks must end up holding exactly the
+    /// same per-token posting lists (doc ids and frequencies) as the whole-file path.
+    /// Parametrized over layout: the legacy-v1 chunk path rebases global offsets to
+    /// chunk-local rows, which the v2 one-row-per-token path never exercises.
+    #[rstest::rstest]
+    #[case::v1(InvertedListFormatVersion::V1)]
+    #[case::v2(InvertedListFormatVersion::V2)]
+    #[tokio::test]
+    async fn test_prewarm_streams_in_chunks_preserves_content(
+        #[case] format_version: InvertedListFormatVersion,
+    ) {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        // One partition with many tokens (so it spans many chunks) and several
+        // docs per token (so each token is more than one posting row).
+        const NUM_TOKENS: u32 = 20;
+        const DOCS_PER_TOKEN: u32 = 3;
+        let posting_tail_codec = format_version.posting_tail_codec();
+        let mut builder = InnerBuilder::new_with_format_version(
+            0,
+            false,
+            TokenSetFormat::default(),
+            format_version,
+        );
+        // Small groups so the partition spans several; chunks snap to whole groups,
+        // so several groups are needed to stream in more than one chunk.
+        builder.group_config = PostingGroupConfig {
+            target_bytes: 4096,
+            max_tokens: 4,
+        };
+        // expected[token] = [(doc_id, frequency)] in stored (doc-id) order.
+        let mut expected: Vec<Vec<(u32, u32)>> = Vec::new();
+        let mut doc_id = 0u64;
+        for t in 0..NUM_TOKENS {
+            builder.tokens.add(format!("tok_{t:03}"));
+            let mut posting =
+                PostingListBuilder::new_with_posting_tail_codec(false, posting_tail_codec);
+            let mut docs = Vec::new();
+            for _ in 0..DOCS_PER_TOKEN {
+                posting.add(doc_id as u32, PositionRecorder::Count(1));
+                builder.docs.append(doc_id, 1);
+                docs.push((doc_id as u32, 1));
+                doc_id += 1;
+            }
+            expected.push(docs);
+            builder.posting_lists.push(posting);
+        }
+        builder.write(store.as_ref()).await.unwrap();
+
+        let metadata = std::collections::HashMap::from_iter(vec![
+            (
+                "partitions".to_owned(),
+                serde_json::to_string(&vec![0u64]).unwrap(),
+            ),
+            (
+                "params".to_owned(),
+                serde_json::to_string(&InvertedIndexParams::default()).unwrap(),
+            ),
+            (
+                TOKEN_SET_FORMAT_KEY.to_owned(),
+                TokenSetFormat::default().to_string(),
+            ),
+            (
+                POSTING_TAIL_CODEC_KEY.to_owned(),
+                posting_tail_codec.as_str().to_owned(),
+            ),
+        ]);
+        let mut writer = store
+            .new_index_file(METADATA_FILE, Arc::new(arrow_schema::Schema::empty()))
+            .await
+            .unwrap();
+        writer.finish_with_metadata(metadata).await.unwrap();
+
+        let cache = Arc::new(LanceCache::with_capacity(1 << 20));
+        let index = InvertedIndex::load(store.clone(), None, cache.as_ref())
+            .await
+            .unwrap();
+        let inverted_list = &index.partitions[0].inverted_list;
+        assert_eq!(inverted_list.len(), NUM_TOKENS as usize);
+
+        // Force a small chunk so the partition deterministically splits; with
+        // CHUNK_TOKENS < NUM_TOKENS each chunk is bounded below the whole partition.
+        const CHUNK_TOKENS: usize = 6;
+        let chunk_count = inverted_list
+            .prewarm_posting_lists_chunked(false, Some(CHUNK_TOKENS))
+            .await
+            .unwrap();
+
+        // (1) The partition was streamed in multiple chunks. The exact count is
+        // group-alignment-dependent (chunks snap to whole groups), so just
+        // require more than one.
+        assert!(
+            chunk_count > 1,
+            "single partition must be streamed in more than one chunk, got {chunk_count}"
+        );
+
+        // (2) Correctness: every token's posting list round-trips with exactly
+        // the doc ids and frequencies of the whole-file path.
+        for token_id in 0..NUM_TOKENS {
+            let actual = inverted_list
+                .posting_list(token_id, false, &NoOpMetricsCollector)
+                .await
+                .unwrap()
+                .iter()
+                .map(|(doc_id, freq, _positions)| (doc_id as u32, freq))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                actual, expected[token_id as usize],
+                "token {token_id} posting list mismatch after chunked prewarm"
+            );
+        }
+    }
+
+    /// With positions, the chunked prewarm must strip positions into their own
+    /// per-token cache entries (leaving the posting cache positions-free) and still
+    /// round-trip exact doc ids, frequencies, and positions across chunk boundaries.
+    #[tokio::test]
+    async fn test_prewarm_streams_in_chunks_with_positions() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let format_version = InvertedListFormatVersion::V2;
+        let posting_tail_codec = format_version.posting_tail_codec();
+        const NUM_TOKENS: u32 = 16;
+        const DOCS_PER_TOKEN: u32 = 3;
+        let mut builder = InnerBuilder::new_with_format_version(
+            0,
+            true,
+            TokenSetFormat::default(),
+            format_version,
+        );
+        builder.group_config = PostingGroupConfig {
+            target_bytes: 4096,
+            max_tokens: 4,
+        };
+        // expected[token] = [(doc_id, frequency, positions)].
+        let mut expected: Vec<Vec<(u32, u32, Vec<u32>)>> = Vec::new();
+        let mut doc_id = 0u64;
+        for t in 0..NUM_TOKENS {
+            builder.tokens.add(format!("tok_{t:03}"));
+            let mut posting =
+                PostingListBuilder::new_with_posting_tail_codec(true, posting_tail_codec);
+            let mut docs = Vec::new();
+            for _ in 0..DOCS_PER_TOKEN {
+                let positions = vec![t % 3, t % 3 + 2, t % 3 + 5];
+                posting.add(
+                    doc_id as u32,
+                    PositionRecorder::Position(positions.clone().into()),
+                );
+                builder.docs.append(doc_id, positions.len() as u32);
+                docs.push((doc_id as u32, positions.len() as u32, positions));
+                doc_id += 1;
+            }
+            expected.push(docs);
+            builder.posting_lists.push(posting);
+        }
+        builder.write(store.as_ref()).await.unwrap();
+
+        let metadata = std::collections::HashMap::from_iter(vec![
+            (
+                "partitions".to_owned(),
+                serde_json::to_string(&vec![0u64]).unwrap(),
+            ),
+            (
+                "params".to_owned(),
+                serde_json::to_string(&InvertedIndexParams::default().with_position(true)).unwrap(),
+            ),
+            (
+                TOKEN_SET_FORMAT_KEY.to_owned(),
+                TokenSetFormat::default().to_string(),
+            ),
+            (
+                POSTING_TAIL_CODEC_KEY.to_owned(),
+                posting_tail_codec.as_str().to_owned(),
+            ),
+            (
+                POSITIONS_LAYOUT_KEY.to_owned(),
+                POSITIONS_LAYOUT_SHARED_STREAM_V2.to_owned(),
+            ),
+            (
+                POSITIONS_CODEC_KEY.to_owned(),
+                PositionStreamCodec::PackedDelta.as_str().to_owned(),
+            ),
+        ]);
+        let mut writer = store
+            .new_index_file(METADATA_FILE, Arc::new(arrow_schema::Schema::empty()))
+            .await
+            .unwrap();
+        writer.finish_with_metadata(metadata).await.unwrap();
+
+        let cache = Arc::new(LanceCache::with_capacity(1 << 20));
+        let index = InvertedIndex::load(store.clone(), None, cache.as_ref())
+            .await
+            .unwrap();
+        let inverted_list = &index.partitions[0].inverted_list;
+
+        const CHUNK_TOKENS: usize = 5;
+        let chunk_count = inverted_list
+            .prewarm_posting_lists_chunked(true, Some(CHUNK_TOKENS))
+            .await
+            .unwrap();
+        assert!(
+            chunk_count > 1,
+            "partition must be streamed in more than one chunk, got {chunk_count}"
+        );
+
+        for token_id in 0..NUM_TOKENS {
+            // The prewarmed posting cache entry is positions-free.
+            let (start, end) = inverted_list.group_range_for_token(token_id).unwrap();
+            let group = inverted_list
+                .index_cache
+                .get_with_key(&PostingListGroupKey { start, end })
+                .await
+                .unwrap();
+            let slot = (token_id - start) as usize;
+            assert!(
+                !group.get(slot).unwrap().has_position(),
+                "token {token_id} posting cache entry must be positions-free after prewarm"
+            );
+
+            // Full content (doc ids, frequencies, positions) round-trips; the
+            // positions come from the dedicated per-token cache prewarm populated.
+            let actual = inverted_list
+                .posting_list(token_id, true, &NoOpMetricsCollector)
+                .await
+                .unwrap()
+                .iter()
+                .map(|(doc_id, freq, positions)| {
+                    (doc_id as u32, freq, positions.unwrap().collect::<Vec<_>>())
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                actual, expected[token_id as usize],
+                "token {token_id} posting list / positions mismatch after chunked prewarm"
+            );
+        }
+    }
+
     /// IO accounting for the IO-counting stats test below: tracks bytes
     /// pulled from the posting file so we can assert that the stats path is
     /// O(1) in num_unique_tokens.
@@ -6753,6 +7237,90 @@ mod tests {
             .unwrap();
 
         assert_eq!(row_ids, vec![100]);
+    }
+
+    /// Build a multi-partition inverted index in `store` with `num_partitions`
+    /// partitions, each carrying a handful of tokens/docs.
+    async fn build_multi_partition_index(
+        store: &Arc<LanceIndexStore>,
+        num_partitions: u64,
+    ) -> (Arc<InvertedIndex>, Arc<LanceCache>) {
+        for id in 0..num_partitions {
+            let mut builder = InnerBuilder::new_with_format_version(
+                id,
+                false,
+                TokenSetFormat::default(),
+                InvertedListFormatVersion::V1,
+            );
+            // A few distinct tokens per partition so each posting file has real
+            // content to read and materialize during prewarm.
+            for t in 0..4u32 {
+                builder.tokens.add(format!("tok_{id}_{t}"));
+                let mut posting = PostingListBuilder::new_with_posting_tail_codec(
+                    false,
+                    PostingTailCodec::Fixed32,
+                );
+                let base = id * 1000 + t as u64 * 10;
+                for d in 0..5u32 {
+                    posting.add(d, PositionRecorder::Count(1));
+                    builder.docs.append(base + d as u64, 4);
+                }
+                builder.posting_lists.push(posting);
+            }
+            builder.write(store.as_ref()).await.unwrap();
+        }
+
+        let partition_ids: Vec<u64> = (0..num_partitions).collect();
+        let metadata = std::collections::HashMap::from_iter(vec![
+            (
+                "partitions".to_owned(),
+                serde_json::to_string(&partition_ids).unwrap(),
+            ),
+            (
+                "params".to_owned(),
+                serde_json::to_string(&InvertedIndexParams::default()).unwrap(),
+            ),
+            (
+                TOKEN_SET_FORMAT_KEY.to_owned(),
+                TokenSetFormat::default().to_string(),
+            ),
+        ]);
+        let mut writer = store
+            .new_index_file(METADATA_FILE, Arc::new(arrow_schema::Schema::empty()))
+            .await
+            .unwrap();
+        writer.finish_with_metadata(metadata).await.unwrap();
+
+        // Keep the cache alive and return it: the partition readers hold only a
+        // WeakLanceCache, so the prewarmed entries vanish if this Arc is dropped.
+        let cache = Arc::new(LanceCache::with_capacity(1 << 20));
+        let index = InvertedIndex::load(store.clone(), None, cache.as_ref())
+            .await
+            .unwrap();
+        (index, cache)
+    }
+
+    /// The prewarm cost estimate must come from cheap object metadata (the
+    /// posting file length) without reading the posting data, and must be
+    /// monotonic in the partition's content.
+    #[tokio::test]
+    async fn test_posting_data_size_bytes_uses_file_length() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let (index, _cache) = build_multi_partition_index(&store, 3).await;
+        for part in &index.partitions {
+            // File length is reported by object metadata at open time; it must be
+            // non-trivial for a partition that actually holds postings.
+            let est = part.inverted_list.posting_data_size_bytes();
+            assert!(
+                est > 0,
+                "expected a non-zero posting-data size estimate, got {est}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -370,6 +370,12 @@ impl IndexReader for current_reader::FileReader {
     fn schema(&self) -> &lance_core::datatypes::Schema {
         Self::schema(self)
     }
+
+    fn file_size_bytes(&self) -> Option<u64> {
+        // The manifest records each index file's size and passes it to the reader
+        // at open, so it's already in metadata here (no extra I/O).
+        Some(self.metadata().file_size())
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
Stream each inverted-index partition's posting lists in bounded token-row chunks (read -> build -> insert -> drop) so prewarm's peak resident set is ~one chunk rather than the whole invert.lance, instead of loading whole positional posting segments at once. The chunk target is a fixed 32 MiB.

ENT-1663