### PR TITLE
feat(index): support distributed LabelList scalar index builds

### DIFF
--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -486,6 +486,75 @@ async fn write_label_list_bitmap_index(
     .await
 }
 
+/// Merge multiple LabelList index segments into a single index.
+///
+/// A [`LabelListIndex`] is a [`BitmapIndex`] over the unnested list values plus a
+/// separate `list_nulls` row set. Because distributed segments cover disjoint rows
+/// (distinct fragments), merging is a cheap union of the underlying bitmap states
+/// and of the `list_nulls` sets — no re-scan of source data is required. This
+/// mirrors [`crate::scalar::bitmap::merge_bitmap_indices`] but also carries the
+/// per-segment `list_nulls`.
+pub async fn merge_label_list_indices(
+    source_indices: &[Arc<LabelListIndex>],
+    dest_store: &dyn IndexStore,
+    progress: Arc<dyn crate::progress::IndexBuildProgress>,
+) -> Result<CreatedIndex> {
+    if source_indices.is_empty() {
+        return Err(Error::invalid_input(
+            "LabelList segment merge requires at least one source segment".to_string(),
+        ));
+    }
+
+    let value_type = source_indices[0].values_index.value_type().clone();
+    let mut merged_state = HashMap::<ScalarValue, RowAddrTreeMap>::new();
+    let mut merged_nulls = RowAddrTreeMap::new();
+
+    progress
+        .stage_start(
+            "merge_label_list_segments",
+            Some(source_indices.len() as u64),
+            "segments",
+        )
+        .await?;
+    for (idx, source_index) in source_indices.iter().enumerate() {
+        if source_index.values_index.value_type() != &value_type {
+            return Err(Error::invalid_input(format!(
+                "LabelList segment has value type {:?}, expected {:?}",
+                source_index.values_index.value_type(),
+                value_type
+            )));
+        }
+
+        let state = source_index.values_index.load_bitmap_index_state().await?;
+        for (key, bitmap) in state {
+            merged_state
+                .entry(key)
+                .and_modify(|existing| *existing |= &bitmap)
+                .or_insert(bitmap);
+        }
+        merged_nulls |= source_index.list_nulls.as_ref();
+        progress
+            .stage_progress("merge_label_list_segments", (idx + 1) as u64)
+            .await?;
+    }
+    progress.stage_complete("merge_label_list_segments").await?;
+
+    progress
+        .stage_start("write_label_list_index", Some(1), "files")
+        .await?;
+    let file =
+        write_label_list_bitmap_index(merged_state, dest_store, &value_type, &merged_nulls).await?;
+    progress.stage_progress("write_label_list_index", 1).await?;
+    progress.stage_complete("write_label_list_index").await?;
+
+    Ok(CreatedIndex {
+        index_details: prost_types::Any::from_msg(&pbold::LabelListIndexDetails::default())
+            .unwrap(),
+        index_version: LABEL_LIST_INDEX_VERSION,
+        files: vec![file],
+    })
+}
+
 /// The serializable state of a [`LabelListIndex`].
 ///
 /// `LabelListIndex` is a thin wrapper around a [`BitmapIndex`] plus a separate
@@ -634,15 +703,13 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
         data: SendableRecordBatchStream,
         index_store: &dyn IndexStore,
         _request: Box<dyn TrainingRequest>,
-        fragment_ids: Option<Vec<u32>>,
+        // Training over a fragment subset is supported for distributed builds: the
+        // provided `data` stream is already scoped to those fragments, so a partial
+        // index covering exactly those rows is produced. Segments are recombined by
+        // `merge_label_list_indices`.
+        _fragment_ids: Option<Vec<u32>>,
         _progress: Arc<dyn crate::progress::IndexBuildProgress>,
     ) -> Result<CreatedIndex> {
-        if fragment_ids.is_some() {
-            return Err(Error::invalid_input_source(
-                "LabelList index does not support fragment training".into(),
-            ));
-        }
-
         let schema = data.schema();
         let field = schema
             .column_with_name(VALUE_COLUMN_NAME)

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -28,7 +28,10 @@ use lance_select::{NullableRowAddrSet, RowAddrTreeMap, RowSetOps};
 use roaring::RoaringBitmap;
 use tracing::instrument;
 
-use super::{AnyQuery, IndexFile, IndexStore, LabelListQuery, ScalarIndex, bitmap::BitmapIndex};
+use super::{
+    AnyQuery, IndexFile, IndexStore, LabelListQuery, OldIndexDataFilter, ScalarIndex,
+    bitmap::BitmapIndex,
+};
 use super::{BuiltinIndexType, SargableQuery, ScalarIndexParams};
 use super::{MetricsCollector, SearchResult};
 use crate::frag_reuse::FragReuseIndex;
@@ -493,10 +496,12 @@ async fn write_label_list_bitmap_index(
 /// (distinct fragments), merging is a cheap union of the underlying bitmap states
 /// and of the `list_nulls` sets — no re-scan of source data is required. This
 /// mirrors [`crate::scalar::bitmap::merge_bitmap_indices`] but also carries the
-/// per-segment `list_nulls`.
+/// per-segment `list_nulls`. When `old_data_filter` is provided, rows from
+/// retired fragments are removed from both the value bitmaps and `list_nulls`.
 pub async fn merge_label_list_indices(
     source_indices: &[Arc<LabelListIndex>],
     dest_store: &dyn IndexStore,
+    old_data_filter: Option<OldIndexDataFilter>,
     progress: Arc<dyn crate::progress::IndexBuildProgress>,
 ) -> Result<CreatedIndex> {
     if source_indices.is_empty() {
@@ -526,13 +531,23 @@ pub async fn merge_label_list_indices(
         }
 
         let state = source_index.values_index.load_bitmap_index_state().await?;
-        for (key, bitmap) in state {
+        for (key, mut bitmap) in state {
+            if let Some(filter) = old_data_filter.as_ref() {
+                filter.retain_old_rows(&mut bitmap);
+            }
+            if bitmap.is_empty() {
+                continue;
+            }
             merged_state
                 .entry(key)
                 .and_modify(|existing| *existing |= &bitmap)
                 .or_insert(bitmap);
         }
-        merged_nulls |= source_index.list_nulls.as_ref();
+        let mut list_nulls = source_index.list_nulls.as_ref().clone();
+        if let Some(filter) = old_data_filter.as_ref() {
+            filter.retain_old_rows(&mut list_nulls);
+        }
+        merged_nulls |= &list_nulls;
         progress
             .stage_progress("merge_label_list_segments", (idx + 1) as u64)
             .await?;

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -292,6 +292,13 @@ fn segment_has_fmindex_details(segment: &IndexMetadata) -> bool {
         .is_some_and(|details| details.type_url.ends_with("FMIndexDetails"))
 }
 
+fn segment_has_label_list_details(segment: &IndexMetadata) -> bool {
+    segment
+        .index_details
+        .as_ref()
+        .is_some_and(|details| details.type_url.ends_with("LabelListIndexDetails"))
+}
+
 // Cache keys for different index types
 #[derive(Debug, Clone)]
 pub(crate) struct LegacyVectorIndexCacheKey<'a> {
@@ -1149,7 +1156,14 @@ impl DatasetIndexExt for Dataset {
         let all_btree = source_segments.iter().all(segment_has_btree_details);
         let all_fmindex = source_segments.iter().all(segment_has_fmindex_details);
         let all_zonemap = source_segments.iter().all(segment_has_zonemap_details);
-        if !all_vector && !all_inverted && !all_bitmap && !all_btree && !all_fmindex && !all_zonemap
+        let all_label_list = source_segments.iter().all(segment_has_label_list_details);
+        if !all_vector
+            && !all_inverted
+            && !all_bitmap
+            && !all_btree
+            && !all_fmindex
+            && !all_zonemap
+            && !all_label_list
         {
             return Err(Error::invalid_input(
                 "merge_existing_index_segments requires all segments to have the same supported index type"
@@ -1170,6 +1184,8 @@ impl DatasetIndexExt for Dataset {
             crate::index::scalar::fmindex::merge_segments(self, source_segments).await?
         } else if all_bitmap {
             crate::index::scalar::bitmap::merge_segments(self, source_segments).await?
+        } else if all_label_list {
+            crate::index::scalar::label_list::merge_segments(self, source_segments).await?
         } else if all_zonemap {
             crate::index::scalar::zonemap::merge_segments(self, source_segments).await?
         } else {

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -2271,6 +2271,112 @@ mod tests {
         );
     }
 
+    // Distributed LabelList build: one segment per fragment via
+    // `execute_uncommitted`, then `merge_existing_index_segments` consolidates them
+    // into a single canonical segment that answers `array_has_any` across all rows.
+    #[tokio::test]
+    async fn test_label_list_merge_existing_index_segments() {
+        use lance_index::scalar::{LabelListQuery, SearchResult};
+
+        // Open `segment` and count rows whose `labels` list contains `label`.
+        async fn count_has_any(dataset: &Dataset, segment: &IndexMetadata, label: i64) -> usize {
+            let field_path = dataset.schema().field_path(segment.fields[0]).unwrap();
+            let index = crate::index::scalar::open_scalar_index(
+                dataset,
+                &field_path,
+                segment,
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+            let query = LabelListQuery::HasAnyLabel(vec![ScalarValue::Int64(Some(label))]);
+            match index.search(&query, &NoOpMetricsCollector).await.unwrap() {
+                SearchResult::Exact(row_addrs) => {
+                    row_addrs.true_rows().row_addrs().unwrap().count()
+                }
+                other => panic!("expected exact result, got {other:?}"),
+            }
+        }
+
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+
+        // 4000 rows across two 2000-row fragments; each `labels` list cycles over 1..=5.
+        let mut dataset = gen_batch()
+            .col(
+                "labels",
+                lance_datagen::array::rand_list_any(
+                    lance_datagen::array::cycle::<arrow::datatypes::Int64Type>(vec![1, 2, 3, 4, 5]),
+                    false,
+                ),
+            )
+            .into_dataset(
+                &dataset_uri,
+                FragmentCount::from(2),
+                FragmentRowCount::from(2000),
+            )
+            .await
+            .unwrap();
+
+        // Ground truth via a full scan before any index exists.
+        let expected = dataset
+            .scan()
+            .project(&["labels"])
+            .unwrap()
+            .filter("array_has_any(labels, [3])")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows();
+        assert!(
+            expected > 0,
+            "test dataset must contain at least one row whose labels include 3"
+        );
+
+        // One LabelList segment per fragment, committed as a multi-segment index.
+        let params =
+            ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::LabelList);
+        let mut staged = Vec::new();
+        for fragment in dataset.get_fragments() {
+            staged.push(
+                CreateIndexBuilder::new(&mut dataset, &["labels"], IndexType::LabelList, &params)
+                    .name("labels_idx".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap(),
+            );
+        }
+        dataset
+            .commit_existing_index_segments("labels_idx", "labels", staged)
+            .await
+            .unwrap();
+
+        // Merge the two per-fragment segments into a single segment covering both.
+        let merged = dataset
+            .merge_existing_index_segments(
+                dataset.load_indices_by_name("labels_idx").await.unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            merged.fragment_bitmap.as_ref().unwrap(),
+            &roaring::RoaringBitmap::from_iter([0u32, 1])
+        );
+        assert!(
+            merged
+                .index_details
+                .as_ref()
+                .unwrap()
+                .type_url
+                .ends_with("LabelListIndexDetails")
+        );
+        // The merged segment returns every row whose labels include 3 across both
+        // fragments — i.e. the per-fragment bitmaps and null sets were unioned.
+        assert_eq!(count_has_any(&dataset, &merged, 3).await, expected);
+    }
+
     #[tokio::test]
     async fn test_commit_existing_index_supports_local_hnsw_segments() {
         let tmpdir = TempStrDir::default();

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -847,9 +847,9 @@ mod tests {
     use crate::dataset::{WriteMode, WriteParams};
     use crate::index::{DatasetIndexExt, IndexSegment};
     use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
-    use arrow::datatypes::{Float32Type, Int32Type};
+    use arrow::datatypes::{Float32Type, Int32Type, Int64Type};
     use arrow_array::cast::AsArray;
-    use arrow_array::{FixedSizeListArray, RecordBatchIterator};
+    use arrow_array::{Array, FixedSizeListArray, ListArray, RecordBatchIterator};
     use arrow_array::{Int32Array, RecordBatch, StringArray};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use datafusion::common::ScalarValue;
@@ -2375,6 +2375,207 @@ mod tests {
         // The merged segment returns every row whose labels include 3 across both
         // fragments — i.e. the per-fragment bitmaps and null sets were unioned.
         assert_eq!(count_has_any(&dataset, &merged, 3).await, expected);
+    }
+
+    fn label_list_batch(labels: Vec<Option<Vec<Option<i64>>>>) -> (Arc<ArrowSchema>, RecordBatch) {
+        let labels = ListArray::from_iter_primitive::<Int64Type, _, _>(labels);
+        let row_count = labels.len();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int32, false),
+            ArrowField::new("labels", labels.data_type().clone(), true),
+        ]));
+        let ids = Int32Array::from_iter_values((0..row_count).map(|id| id as i32));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(ids), Arc::new(labels)]).unwrap();
+        (schema, batch)
+    }
+
+    #[tokio::test]
+    async fn test_label_list_merge_existing_index_segments_drops_retired_fragments() {
+        use lance_index::scalar::{LabelListQuery, SearchResult};
+
+        async fn search_counts(
+            dataset: &Dataset,
+            segment: &IndexMetadata,
+            label: i64,
+        ) -> (usize, usize) {
+            let field_path = dataset.schema().field_path(segment.fields[0]).unwrap();
+            let index = crate::index::scalar::open_scalar_index(
+                dataset,
+                &field_path,
+                segment,
+                &NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+            let query = LabelListQuery::HasAnyLabel(vec![ScalarValue::Int64(Some(label))]);
+            match index.search(&query, &NoOpMetricsCollector).await.unwrap() {
+                SearchResult::Exact(row_addrs) => (
+                    row_addrs.true_rows().row_addrs().unwrap().count(),
+                    row_addrs.null_rows().row_addrs().unwrap().count(),
+                ),
+                other => panic!("expected exact result, got {other:?}"),
+            }
+        }
+
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let (schema, batch) = label_list_batch(vec![
+            Some(vec![Some(1)]),
+            None,
+            Some(vec![Some(1)]),
+            Some(vec![Some(1)]),
+            Some(vec![Some(2)]),
+            Some(vec![Some(2)]),
+            Some(vec![Some(2)]),
+            Some(vec![Some(2)]),
+        ]);
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let mut dataset = Dataset::write(
+            reader,
+            &dataset_uri,
+            Some(WriteParams {
+                max_rows_per_file: 4,
+                mode: WriteMode::Overwrite,
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let params =
+            ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::LabelList);
+        let mut staged = Vec::new();
+        for fragment in dataset.get_fragments() {
+            staged.push(
+                CreateIndexBuilder::new(&mut dataset, &["labels"], IndexType::LabelList, &params)
+                    .name("labels_retired_idx".to_string())
+                    .fragments(vec![fragment.id() as u32])
+                    .execute_uncommitted()
+                    .await
+                    .unwrap(),
+            );
+        }
+        dataset
+            .commit_existing_index_segments("labels_retired_idx", "labels", staged)
+            .await
+            .unwrap();
+
+        dataset.delete("id < 4").await.unwrap();
+        crate::dataset::optimize::compact_files(
+            &mut dataset,
+            crate::dataset::optimize::CompactionOptions {
+                target_rows_per_fragment: 4,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(
+            !dataset.fragment_bitmap.contains(0),
+            "compaction should retire fragment 0"
+        );
+
+        let merged = dataset
+            .merge_existing_index_segments(
+                dataset
+                    .load_indices_by_name("labels_retired_idx")
+                    .await
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let coverage = merged.fragment_bitmap.as_ref().unwrap();
+        assert!(!coverage.contains(0), "must drop retired frag 0");
+        assert!(coverage.contains(1), "must keep live indexed frag 1");
+
+        let (retired_true, _) = search_counts(&dataset, &merged, 1).await;
+        assert_eq!(
+            retired_true, 0,
+            "must filter value bitmaps from retired fragments"
+        );
+
+        let (live_true, null_rows) = search_counts(&dataset, &merged, 2).await;
+        assert_eq!(live_true, 4, "must keep live fragment rows");
+        assert_eq!(
+            null_rows, 0,
+            "must filter list_nulls from retired fragments"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_label_list_merge_rejects_nullable_segment_missing_null_metadata() {
+        use crate::dataset::index::LanceIndexStoreExt;
+        use lance_index::scalar::IndexStore;
+        use lance_index::scalar::label_list::{
+            BITMAP_LOOKUP_NAME, LABEL_LIST_NULLS_METADATA_KEY, LABEL_LIST_NULLS_MIN_VERSION,
+        };
+        use lance_index::scalar::lance_format::LanceIndexStore;
+
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let (schema, batch) = label_list_batch(vec![
+            Some(vec![Some(1)]),
+            None,
+            Some(vec![Some(2)]),
+            Some(vec![Some(3)]),
+        ]);
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let mut dataset = Dataset::write(
+            reader,
+            &dataset_uri,
+            Some(WriteParams {
+                mode: WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let params =
+            ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::LabelList);
+        let segment =
+            CreateIndexBuilder::new(&mut dataset, &["labels"], IndexType::LabelList, &params)
+                .name("labels_legacy_idx".to_string())
+                .execute_uncommitted()
+                .await
+                .unwrap();
+
+        let source_store = LanceIndexStore::from_dataset_for_existing(&dataset, &segment)
+            .await
+            .unwrap();
+        let reader = source_store
+            .open_index_file(BITMAP_LOOKUP_NAME)
+            .await
+            .unwrap();
+        let batch = reader.read_range(0..reader.num_rows(), None).await.unwrap();
+        let source_schema: ArrowSchema = reader.schema().into();
+        let schema_without_metadata = Arc::new(ArrowSchema::new(source_schema.fields().clone()));
+
+        let legacy_uuid = Uuid::new_v4();
+        let legacy_store = LanceIndexStore::from_dataset_for_new(&dataset, &legacy_uuid).unwrap();
+        let mut writer = legacy_store
+            .new_index_file(BITMAP_LOOKUP_NAME, schema_without_metadata)
+            .await
+            .unwrap();
+        writer.write_record_batch(batch).await.unwrap();
+        let legacy_file = writer.finish().await.unwrap();
+
+        let mut legacy_segment = segment.clone();
+        legacy_segment.uuid = legacy_uuid;
+        legacy_segment.index_version = LABEL_LIST_NULLS_MIN_VERSION;
+        legacy_segment.files = Some(vec![legacy_file]);
+
+        let err = dataset
+            .merge_existing_index_segments(vec![legacy_segment])
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains(LABEL_LIST_NULLS_METADATA_KEY),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -8,6 +8,7 @@ pub(crate) mod bitmap;
 pub(crate) mod btree;
 pub(crate) mod fmindex;
 pub(crate) mod inverted;
+pub(crate) mod label_list;
 pub(crate) mod zonemap;
 
 pub use inverted::{load_segment_details, load_segments};

--- a/rust/lance/src/index/scalar/label_list.rs
+++ b/rust/lance/src/index/scalar/label_list.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use lance_index::metrics::NoOpMetricsCollector;
+use lance_index::scalar::label_list::LabelListIndex;
+use lance_index::scalar::lance_format::LanceIndexStore;
+use lance_table::format::IndexMetadata;
+use roaring::RoaringBitmap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::{Dataset, Error, Result, dataset::index::LanceIndexStoreExt};
+
+/// Merge one caller-defined group of source LabelList segments into a single segment.
+///
+/// A LabelList index is a bitmap over the unnested list values plus a `list_nulls`
+/// row set, so segments are recombined by unioning the underlying bitmap states and
+/// null sets (see [`lance_index::scalar::label_list::merge_label_list_indices`])
+/// rather than rebuilding from source text.
+pub(in crate::index) async fn merge_segments(
+    dataset: &Dataset,
+    segments: Vec<IndexMetadata>,
+) -> Result<IndexMetadata> {
+    if segments.is_empty() {
+        return Err(Error::index("No segment metadata was provided".to_string()));
+    }
+
+    let field_id = *segments[0].fields.first().ok_or_else(|| {
+        Error::invalid_input(format!(
+            "CreateIndex: segment {} is missing field ids",
+            segments[0].uuid
+        ))
+    })?;
+    let field_path = dataset.schema().field_path(field_id)?;
+
+    let mut source_indices = Vec::with_capacity(segments.len());
+    let mut fragment_bitmap = RoaringBitmap::new();
+    for segment in &segments {
+        fragment_bitmap |= segment.fragment_bitmap.as_ref().cloned().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "CreateIndex: segment {} is missing fragment coverage",
+                segment.uuid
+            ))
+        })?;
+        let scalar_index =
+            super::open_scalar_index(dataset, &field_path, segment, &NoOpMetricsCollector).await?;
+        let label_list_index = scalar_index
+            .as_any()
+            .downcast_ref::<LabelListIndex>()
+            .ok_or_else(|| {
+                Error::index(format!(
+                    "merge_existing_index_segments: expected label list segment {}, got {:?}",
+                    segment.uuid,
+                    scalar_index.index_type()
+                ))
+            })?;
+        source_indices.push(Arc::new(label_list_index.clone()));
+    }
+
+    let new_uuid = Uuid::new_v4();
+    let new_store = LanceIndexStore::from_dataset_for_new(dataset, &new_uuid)?;
+    let created_index = lance_index::scalar::label_list::merge_label_list_indices(
+        &source_indices,
+        &new_store,
+        lance_index::progress::noop_progress(),
+    )
+    .await?;
+
+    Ok(IndexMetadata {
+        uuid: new_uuid,
+        fields: vec![field_id],
+        dataset_version: dataset.manifest.version,
+        fragment_bitmap: Some(fragment_bitmap),
+        index_details: Some(Arc::new(created_index.index_details)),
+        index_version: created_index.index_version as i32,
+        created_at: Some(chrono::Utc::now()),
+        base_id: None,
+        files: Some(created_index.files),
+        ..segments[0].clone()
+    })
+}

--- a/rust/lance/src/index/scalar/label_list.rs
+++ b/rust/lance/src/index/scalar/label_list.rs
@@ -2,7 +2,10 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use lance_index::metrics::NoOpMetricsCollector;
-use lance_index::scalar::label_list::LabelListIndex;
+use lance_index::scalar::IndexStore;
+use lance_index::scalar::label_list::{
+    BITMAP_LOOKUP_NAME, LABEL_LIST_NULLS_METADATA_KEY, LABEL_LIST_NULLS_MIN_VERSION, LabelListIndex,
+};
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_table::format::IndexMetadata;
 use roaring::RoaringBitmap;
@@ -10,6 +13,45 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::{Dataset, Error, Result, dataset::index::LanceIndexStoreExt};
+
+async fn validate_nullable_segment_for_merge(
+    dataset: &Dataset,
+    field_id: i32,
+    segment: &IndexMetadata,
+) -> Result<()> {
+    let field = dataset.schema().field_by_id(field_id).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "merge_existing_index_segments: field id {} does not exist",
+            field_id
+        ))
+    })?;
+
+    if !field.nullable {
+        return Ok(());
+    }
+
+    if segment.index_version < LABEL_LIST_NULLS_MIN_VERSION {
+        return Err(Error::invalid_input(format!(
+            "Cannot merge nullable LabelList segment {} because it was created before list-null metadata was required. Rebuild the segment instead.",
+            segment.uuid
+        )));
+    }
+
+    let index_store = LanceIndexStore::from_dataset_for_existing(dataset, segment).await?;
+    let reader = index_store.open_index_file(BITMAP_LOOKUP_NAME).await?;
+    if !reader
+        .schema()
+        .metadata
+        .contains_key(LABEL_LIST_NULLS_METADATA_KEY)
+    {
+        return Err(Error::invalid_input(format!(
+            "Cannot merge nullable LabelList segment {} because it is missing required metadata key {}. Rebuild the segment instead.",
+            segment.uuid, LABEL_LIST_NULLS_METADATA_KEY
+        )));
+    }
+
+    Ok(())
+}
 
 /// Merge one caller-defined group of source LabelList segments into a single segment.
 ///
@@ -33,15 +75,39 @@ pub(in crate::index) async fn merge_segments(
     })?;
     let field_path = dataset.schema().field_path(field_id)?;
 
-    let mut source_indices = Vec::with_capacity(segments.len());
-    let mut fragment_bitmap = RoaringBitmap::new();
+    let dataset_fragments = dataset.fragment_bitmap.as_ref();
+    let mut effective_old_frags = RoaringBitmap::new();
+    let mut deleted_old_frags = RoaringBitmap::new();
     for segment in &segments {
-        fragment_bitmap |= segment.fragment_bitmap.as_ref().cloned().ok_or_else(|| {
-            Error::invalid_input(format!(
+        if segment.fragment_bitmap.is_none() {
+            return Err(Error::invalid_input(format!(
                 "CreateIndex: segment {} is missing fragment coverage",
                 segment.uuid
-            ))
-        })?;
+            )));
+        }
+        if let Some(effective) = segment.effective_fragment_bitmap(dataset_fragments) {
+            effective_old_frags |= effective;
+        }
+        if let Some(deleted) = segment.deleted_fragment_bitmap(dataset_fragments) {
+            deleted_old_frags |= deleted;
+        }
+    }
+
+    let fragment_bitmap = effective_old_frags.clone();
+    let old_data_filter = if deleted_old_frags.is_empty() {
+        None
+    } else {
+        crate::index::append::build_old_data_filter(
+            dataset,
+            &effective_old_frags,
+            &deleted_old_frags,
+        )
+        .await?
+    };
+
+    let mut source_indices = Vec::with_capacity(segments.len());
+    for segment in &segments {
+        validate_nullable_segment_for_merge(dataset, field_id, segment).await?;
         let scalar_index =
             super::open_scalar_index(dataset, &field_path, segment, &NoOpMetricsCollector).await?;
         let label_list_index = scalar_index
@@ -62,6 +128,7 @@ pub(in crate::index) async fn merge_segments(
     let created_index = lance_index::scalar::label_list::merge_label_list_indices(
         &source_indices,
         &new_store,
+        old_data_filter,
         lance_index::progress::noop_progress(),
     )
     .await?;


### PR DESCRIPTION
## Summary

`LabelListIndexPlugin::train_index` unconditionally rejected fragment-scoped
training (`fragment_ids.is_some()`), so a LabelList index could not be built
through the distributed / segmented path (per-fragment `execute_uncommitted` +
`merge_existing_index_segments`) the way BTree, Inverted, Bitmap, and FM already
are. This makes LabelList a first-class distributed scalar index.

## Changes

- `lance-index/src/scalar/label_list.rs`: `train_index` ignores `fragment_ids` and
  builds over the already fragment-scoped stream (mirrors `FMIndexPlugin`); a partial
  index over a fragment subset is correct since it covers exactly those rows. Add
  `merge_label_list_indices`, which unions the per-segment bitmap states and the
  `list_nulls` row sets. LabelList wraps a `BitmapIndex` plus a null-row set and
  distributed segments cover disjoint rows, so this is a cheap union (the same
  operation `LabelListIndex::update` performs) — no source re-scan. Mirrors
  `merge_bitmap_indices` but also carries `list_nulls`.
- `lance/src/index/scalar/label_list.rs` (new): `merge_segments` opens each source
  segment as a `LabelListIndex` and calls `merge_label_list_indices` (mirrors
  `scalar/bitmap.rs`).
- `lance/src/index.rs`: `merge_existing_index_segments` routes `all_label_list`
  segments (details `LabelListIndexDetails`) to the new merge; add
  `segment_has_label_list_details`.
- `lance/src/index/scalar.rs`: declare the `label_list` module.

Covered by `test_label_list_merge_existing_index_segments`: one LabelList segment per
fragment, merged via `merge_existing_index_segments`, answers `array_has_any` across
both fragments with the same row count as a pre-index full scan.
