### PR TITLE
fix: support file-less fragments

### DIFF
--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1511,6 +1511,8 @@ impl FileFragment {
             data_file.validate(&self.dataset.data_file_dir(data_file)?)?;
         }
 
+        // File-less fragments only have a trustworthy cached row count when the
+        // manifest records the writer version; reject legacy manifests instead.
         if self.metadata.files.is_empty() && self.dataset.manifest.writer_version.is_none() {
             return Err(Error::corrupt_file(
                 self.dataset.base.clone(),
@@ -1576,6 +1578,8 @@ impl FileFragment {
             }
             *first_length
         } else {
+            // No data file was opened to measure the length, so a file-less
+            // fragment can only be validated using its persisted physical_rows.
             self.metadata.physical_rows.ok_or_else(|| {
                 Error::corrupt_file(
                     self.dataset.base.clone(),

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1439,7 +1439,8 @@ impl FileFragment {
     /// * All referenced data files exist and have the same length.
     /// * Field ids are distinct between data files.
     /// * The deletion file exists and has row offsets in the correct range.
-    /// * [`Fragment::physical_rows`], when present, matches the data-file length.
+    /// * [`Fragment::physical_rows`], when present, matches the data-file length for
+    ///   manifests with writer-version metadata; legacy cached counts are ignored.
     /// * [`DeletionFile::num_deleted_rows`], when present, matches the deletion-vector length.
     ///
     /// File-less fragments are accepted when the dataset manifest contains
@@ -1557,7 +1558,8 @@ impl FileFragment {
                     ));
                 }
             }
-            if let Some(physical_rows) = self.metadata.physical_rows
+            if self.dataset.manifest.writer_version.is_some()
+                && let Some(physical_rows) = self.metadata.physical_rows
                 && physical_rows != *first_length
             {
                 let path = self
@@ -5589,6 +5591,31 @@ mod tests {
             fragment.metadata.deletion_file.unwrap().num_deleted_rows,
             Some(13)
         );
+    }
+
+    #[tokio::test]
+    async fn test_fragment_validate_ignores_legacy_physical_rows() {
+        let test_dir = TempStrDir::default();
+        let mut dataset = create_dataset(&test_dir, LanceFileVersion::Legacy).await;
+        assert!(dataset.manifest.writer_version.is_some());
+
+        let actual_physical_rows = dataset.get_fragments()[0].physical_rows().await.unwrap();
+        let incorrect_physical_rows = actual_physical_rows + 1;
+        Arc::make_mut(&mut Arc::make_mut(&mut dataset.manifest).fragments)[0].physical_rows =
+            Some(incorrect_physical_rows);
+
+        let fragment = dataset.get_fragments().remove(0);
+        let err = fragment.validate().await.unwrap_err();
+        assert!(matches!(err, Error::CorruptFile { .. }));
+        assert_error_contains(err, "Fragment metadata has incorrect physical_rows");
+
+        Arc::make_mut(&mut dataset.manifest).writer_version = None;
+        let fragment = dataset.get_fragments().remove(0);
+        assert_eq!(
+            fragment.physical_rows().await.unwrap(),
+            actual_physical_rows
+        );
+        fragment.validate().await.unwrap();
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1366,21 +1366,40 @@ impl FileFragment {
         Ok(num_physical_rows - num_deleted_rows)
     }
 
-    /// Get the number of physical rows in the fragment. This includes deleted rows.
+    /// Get the number of physical rows in this [`FileFragment`].
     ///
-    /// If there are no deleted rows, this is equal to the number of rows in the
-    /// fragment.
+    /// Physical rows include deleted rows. If there are no deleted rows, this is
+    /// equal to the number of logical rows in the fragment.
+    ///
+    /// When the dataset manifest contains writer-version metadata, this method
+    /// trusts [`Fragment::physical_rows`] when it is present. This includes
+    /// file-less fragments, which can represent rows whose columns are all null.
+    /// Use [`Self::metadata`] to inspect the persisted [`Fragment`] metadata.
+    ///
+    /// Legacy manifests without writer-version metadata may contain an incorrect
+    /// cached count, so this method ignores it and reads the count from a data
+    /// file. If such a fragment has no data files, this method returns
+    /// [`Error::NotFound`]. See [`Self::validate`] for the corresponding metadata
+    /// checks.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use lance::{Dataset, Result};
+    /// # async fn example(dataset: &Dataset) -> Result<()> {
+    /// for fragment in dataset.get_fragments() {
+    ///     let physical_rows = fragment.physical_rows().await?;
+    ///     if fragment.num_data_files() == 0 {
+    ///         assert_eq!(fragment.metadata().physical_rows, Some(physical_rows));
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn physical_rows(&self) -> Result<usize> {
-        if self.metadata.files.is_empty() {
-            return Err(Error::not_found(format!(
-                "Fragment {} does not contain any data",
-                self.id()
-            )));
-        };
-
         // Early versions that did not write the writer version also could write
-        // incorrect `physical_row` values. So if we don't have a writer version,
-        // we should not used the cached value. On write, we update the values
+        // incorrect `physical_rows` values. So if we don't have a writer version,
+        // we should not use the cached value. On write, we update the values
         // in the manifest, fixing the issue for future reads.
         // See: https://github.com/lance-format/lance/issues/1531
         if self.dataset.manifest.writer_version.is_some()
@@ -1388,6 +1407,14 @@ impl FileFragment {
         {
             return Ok(physical_rows);
         }
+
+        // File-less fragments can occur; guard before indexing files[0] to avoid a panic.
+        if self.metadata.files.is_empty() {
+            return Err(Error::not_found(format!(
+                "Fragment {} does not contain any data",
+                self.id()
+            )));
+        };
 
         // Just open any file. All of them should have same size.
         let some_file = &self.metadata.files[0];
@@ -1404,16 +1431,39 @@ impl FileFragment {
         Ok(reader.len() as usize)
     }
 
-    /// Validate the fragment
+    /// Validate this [`FileFragment`] and its persisted [`Fragment`] metadata.
     ///
     /// Verifies:
-    /// * All field ids in the fragment are distinct
-    /// * Within each data file, field ids are in increasing order
-    /// * All data files exist and have the same length
+    /// * All field ids in the fragment are distinct.
+    /// * Within each data file, field ids are in increasing order.
+    /// * All referenced data files exist and have the same length.
     /// * Field ids are distinct between data files.
-    /// * Deletion file exists and has rowids in the correct range
-    /// * `Fragment.physical_rows` matches length of file
-    /// * `DeletionFile.num_deleted_rows` matches length of deletion vector
+    /// * The deletion file exists and has row offsets in the correct range.
+    /// * [`Fragment::physical_rows`], when present, matches the data-file length.
+    /// * [`DeletionFile::num_deleted_rows`], when present, matches the deletion-vector length.
+    ///
+    /// File-less fragments are accepted when the dataset manifest contains
+    /// writer-version metadata, [`Fragment::physical_rows`] is present, and the
+    /// remaining metadata is valid. The cached count supplies the expected length
+    /// for deletion metadata validation. A missing count returns
+    /// [`Error::CorruptFile`].
+    ///
+    /// For legacy manifests without writer-version metadata, a file-less fragment
+    /// returns [`Error::CorruptFile`] even when [`Fragment::physical_rows`] is
+    /// present, because the cached count cannot be trusted. See
+    /// [`Self::physical_rows`] for the corresponding row-count lookup behavior.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use lance::{Dataset, Result};
+    /// # async fn example(dataset: &Dataset) -> Result<()> {
+    /// for fragment in dataset.get_fragments() {
+    ///     fragment.validate().await?;
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn validate(&self) -> Result<()> {
         let mut seen_fields = HashSet::new();
         for data_file in &self.metadata.files {
@@ -1445,9 +1495,9 @@ impl FileFragment {
             }
         }
 
-        if self.metadata.files.iter().any(|f| f.is_legacy_file())
-            != self.metadata.files.iter().all(|f| f.is_legacy_file())
-        {
+        let has_legacy_files = self.metadata.files.iter().any(|f| f.is_legacy_file());
+        let has_non_legacy_files = self.metadata.files.iter().any(|f| !f.is_legacy_file());
+        if has_legacy_files && has_non_legacy_files {
             return Err(Error::corrupt_file(
                 self.dataset
                     .data_file_dir(&self.metadata.files[0])?
@@ -1458,6 +1508,17 @@ impl FileFragment {
 
         for data_file in &self.metadata.files {
             data_file.validate(&self.dataset.data_file_dir(data_file)?)?;
+        }
+
+        if self.metadata.files.is_empty() && self.dataset.manifest.writer_version.is_none() {
+            return Err(Error::corrupt_file(
+                self.dataset.base.clone(),
+                format!(
+                    "Fragment {} does not contain any data files; physical_rows={:?} cannot be trusted because manifest.writer_version is missing",
+                    self.id(),
+                    self.metadata.physical_rows
+                ),
+            ));
         }
 
         let get_lengths = self.metadata.files.iter().map(|data_file| async move {
@@ -1480,35 +1541,49 @@ impl FileFragment {
         let (get_lengths, deletion_vector) = join!(get_lengths, deletion_vector);
 
         let get_lengths = get_lengths?;
-        let expected_length = get_lengths.first().unwrap_or(&0);
-        for (length, data_file) in get_lengths.iter().zip(self.metadata.files.iter()) {
-            if length != expected_length {
+        let expected_length = if let Some(first_length) = get_lengths.first() {
+            for (length, data_file) in get_lengths.iter().zip(self.metadata.files.iter()) {
+                if length != first_length {
+                    let path = self
+                        .dataset
+                        .data_file_dir(data_file)?
+                        .join(data_file.path.as_str());
+                    return Err(Error::corrupt_file(
+                        path,
+                        format!(
+                            "data file has incorrect length. Expected: {} Got: {}",
+                            first_length, length
+                        ),
+                    ));
+                }
+            }
+            if let Some(physical_rows) = self.metadata.physical_rows
+                && physical_rows != *first_length
+            {
                 let path = self
                     .dataset
-                    .data_file_dir(data_file)?
-                    .join(data_file.path.as_str());
+                    .data_file_dir(&self.metadata.files[0])?
+                    .join(self.metadata.files[0].path.as_str());
                 return Err(Error::corrupt_file(
                     path,
                     format!(
-                        "data file has incorrect length. Expected: {} Got: {}",
-                        expected_length, length
+                        "Fragment metadata has incorrect physical_rows. Actual: {} Metadata: {}",
+                        first_length, physical_rows
                     ),
                 ));
             }
-        }
-        if let Some(physical_rows) = self.metadata.physical_rows
-            && physical_rows != *expected_length
-        {
-            return Err(Error::corrupt_file(
-                self.dataset
-                    .data_file_dir(&self.metadata.files[0])?
-                    .join(self.metadata.files[0].path.as_str()),
-                format!(
-                    "Fragment metadata has incorrect physical_rows. Actual: {} Metadata: {}",
-                    expected_length, physical_rows
-                ),
-            ));
-        }
+            *first_length
+        } else {
+            self.metadata.physical_rows.ok_or_else(|| {
+                Error::corrupt_file(
+                    self.dataset.base.clone(),
+                    format!(
+                        "Fragment {} does not contain any data files and is missing physical_rows",
+                        self.id()
+                    ),
+                )
+            })?
+        };
 
         if let Some(deletion_vector) = deletion_vector? {
             if let Some(num_deletions) = self
@@ -1534,7 +1609,7 @@ impl FileFragment {
             }
 
             for offset in deletion_vector.iter() {
-                if offset >= *expected_length as u32 {
+                if offset >= expected_length as u32 {
                     let deletion_file_meta = self.metadata.deletion_file.as_ref().unwrap();
                     return Err(Error::corrupt_file(
                         deletion_file_path(
@@ -3184,6 +3259,13 @@ mod tests {
             .unwrap();
 
         Dataset::open(test_uri).await.unwrap()
+    }
+
+    fn assert_error_contains(err: Error, expected: &str) {
+        assert!(
+            err.to_string().contains(expected),
+            "expected error to contain {expected:?}, got {err:?}"
+        );
     }
 
     async fn create_dataset_v2(test_uri: &str) -> Dataset {
@@ -5506,6 +5588,117 @@ mod tests {
         assert_eq!(
             fragment.metadata.deletion_file.unwrap().num_deleted_rows,
             Some(13)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_file_less_fragment_physical_rows_uses_cached_value() {
+        let test_dir = TempStrDir::default();
+        let mut dataset = create_dataset(&test_dir, LanceFileVersion::Stable).await;
+        assert!(dataset.manifest.writer_version.is_some());
+
+        let fragment = FileFragment::new(
+            Arc::new(dataset.clone()),
+            Fragment::new(99).with_physical_rows(7),
+        );
+        assert_eq!(fragment.physical_rows().await.unwrap(), 7);
+
+        Arc::make_mut(&mut dataset.manifest).writer_version = None;
+        let fragment =
+            FileFragment::new(Arc::new(dataset), Fragment::new(99).with_physical_rows(7));
+        let err = fragment.physical_rows().await.unwrap_err();
+        assert!(matches!(err, Error::NotFound { .. }));
+        assert_error_contains(err, "Fragment 99 does not contain any data");
+
+        let err = fragment.validate().await.unwrap_err();
+        assert!(matches!(err, Error::CorruptFile { .. }));
+        assert_error_contains(
+            err,
+            "physical_rows=Some(7) cannot be trusted because manifest.writer_version is missing",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_file_less_fragment_validate_requires_physical_rows() {
+        let test_dir = TempStrDir::default();
+        let dataset = Arc::new(create_dataset(&test_dir, LanceFileVersion::Stable).await);
+        let fragment = FileFragment::new(dataset, Fragment::new(99));
+
+        let err = fragment.validate().await.unwrap_err();
+        assert!(matches!(err, Error::CorruptFile { .. }));
+        assert_error_contains(
+            err,
+            "Fragment 99 does not contain any data files and is missing physical_rows",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_file_less_fragment_validate_checks_deletion_metadata() {
+        let test_dir = TempStrDir::default();
+        let dataset = Arc::new(create_dataset(&test_dir, LanceFileVersion::Stable).await);
+
+        let deletion_vector = DeletionVector::from_iter([2, 9]);
+        let deletion_file = write_deletion_file(
+            &dataset.base,
+            99,
+            dataset.version().version,
+            &deletion_vector,
+            &dataset.object_store,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let mut metadata = Fragment::new(99).with_physical_rows(10);
+        metadata.deletion_file = Some(deletion_file.clone());
+        FileFragment::new(dataset.clone(), metadata)
+            .validate()
+            .await
+            .unwrap();
+
+        let mut metadata = Fragment::new(99).with_physical_rows(10);
+        metadata.deletion_file = Some(DeletionFile {
+            num_deleted_rows: Some(3),
+            ..deletion_file
+        });
+        let err = FileFragment::new(dataset, metadata)
+            .validate()
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::CorruptFile { .. }));
+        assert_error_contains(
+            err,
+            "deletion vector length does not match metadata. Metadata: 3 Deletion vector: 2",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_file_less_fragment_validate_rejects_out_of_range_deletions() {
+        let test_dir = TempStrDir::default();
+        let dataset = Arc::new(create_dataset(&test_dir, LanceFileVersion::Stable).await);
+
+        let deletion_vector = DeletionVector::from_iter([2, 10]);
+        let deletion_file = write_deletion_file(
+            &dataset.base,
+            99,
+            dataset.version().version,
+            &deletion_vector,
+            &dataset.object_store,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let mut metadata = Fragment::new(99).with_physical_rows(10);
+        metadata.deletion_file = Some(deletion_file);
+        let err = FileFragment::new(dataset, metadata)
+            .validate()
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::CorruptFile { .. }));
+        assert_error_contains(
+            err,
+            "deletion vector contains an offset that is out of range. Offset: 10 Fragment length: 10",
         );
     }
 

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -126,7 +126,7 @@ pub mod remapping;
 
 use crate::index::frag_reuse::build_new_frag_reuse_index;
 use crate::io::deletion::read_dataset_deletion_file;
-use binary_copy::rewrite_files_binary_copy;
+use binary_copy::{binary_copy_schema_mapping, rewrite_files_binary_copy};
 pub use remapping::{IgnoreRemap, IndexRemapper, IndexRemapperOptions, RemappedIndex};
 
 /// Controls how data is rewritten during compaction.
@@ -494,10 +494,12 @@ impl CompactionOptions {
 /// - Compaction mode is not `Reencode`
 /// - Dataset storage format is non-legacy
 /// - Fragment list is non-empty
+/// - Every fragment has at least one data file
 /// - All data files share identical Lance file versions
 /// - No fragment has a deletion file
-///   TODO: Need to support schema evolution case like add column and drop column
-/// - All data files share identical schema mappings (`fields`, `column_indices`)
+/// - No fragment has data overlays
+/// - Every data file's field-to-column mapping exactly matches the current schema
+/// - Every data file has the current schema's expected physical-column count
 /// - Input data files must not contain extra global buffers (beyond schema / file descriptor)
 async fn can_use_binary_copy(
     dataset: &Dataset,
@@ -556,23 +558,30 @@ async fn can_use_binary_copy_impl(
         .data_storage_format
         .lance_file_version()?
         .resolve();
+    let expected_schema_mapping =
+        binary_copy_schema_mapping(dataset.schema(), storage_file_version);
 
-    if fragments[0].files.is_empty() {
+    if let Some(fragment) = fragments.iter().find(|fragment| fragment.files.is_empty()) {
         log::debug!(
             "Binary copy disabled: fragment {} has no data files",
-            fragments[0].id
+            fragment.id
         );
         return Ok(false);
     }
-    let ref_fields = &fragments[0].files[0].fields;
-    let ref_cols = &fragments[0].files[0].column_indices;
-    let mut is_same_version = true;
 
     for fragment in fragments {
         if fragment.deletion_file.is_some() {
             log::debug!(
                 "Binary copy disabled: fragment {} has a deletion file",
                 fragment.id
+            );
+            return Ok(false);
+        }
+        if !fragment.overlays.is_empty() {
+            log::debug!(
+                "Binary copy disabled: fragment {} has {} data overlays",
+                fragment.id,
+                fragment.overlays.len()
             );
             return Ok(false);
         }
@@ -586,9 +595,23 @@ async fn can_use_binary_copy_impl(
             .is_ok_and(|v| v == storage_file_version);
 
             if !version_ok {
-                is_same_version = false;
+                log::debug!(
+                    "Binary copy disabled: data file '{}' in fragment {} does not use dataset file version {}",
+                    data_file.path,
+                    fragment.id,
+                    storage_file_version
+                );
+                return Ok(false);
             }
-            if data_file.fields != *ref_fields || data_file.column_indices != *ref_cols {
+            if data_file.fields.as_ref() != expected_schema_mapping.field_ids.as_ref()
+                || data_file.column_indices.as_ref()
+                    != expected_schema_mapping.column_indices.as_ref()
+            {
+                log::debug!(
+                    "Binary copy disabled: data file '{}' in fragment {} does not exactly represent the current schema",
+                    data_file.path,
+                    fragment.id
+                );
                 return Ok(false);
             }
 
@@ -609,6 +632,16 @@ async fn can_use_binary_copy_impl(
                 .open_file_with_priority(&full_path, 0, &data_file.file_size_bytes)
                 .await?;
             let file_meta = LFReader::read_all_metadata(&file_scheduler).await?;
+            if file_meta.column_infos.len() != expected_schema_mapping.physical_column_count {
+                log::debug!(
+                    "Binary copy disabled: data file '{}' in fragment {} has {} physical columns, expected {} for the current schema",
+                    data_file.path,
+                    fragment.id,
+                    file_meta.column_infos.len(),
+                    expected_schema_mapping.physical_column_count
+                );
+                return Ok(false);
+            }
             // Binary copy only preserves page and column-buffer bytes. The output file's footer
             // (including global buffers) is re-generated, not copied from inputs.
             //
@@ -622,11 +655,6 @@ async fn can_use_binary_copy_impl(
                 return Ok(false);
             }
         }
-    }
-
-    if !is_same_version {
-        log::debug!("Binary copy disabled: data files use different file versions");
-        return Ok(false);
     }
 
     Ok(true)

--- a/rust/lance/src/dataset/optimize/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/binary_copy.rs
@@ -6,7 +6,7 @@ use crate::Result;
 use crate::dataset::DATA_DIR;
 use crate::dataset::WriteParams;
 use crate::dataset::fragment::write::generate_random_filename;
-use crate::datatypes::Schema;
+use crate::datatypes::{Field, Schema};
 use lance_arrow::DataTypeExt;
 use lance_core::Error;
 use lance_encoding::decoder::{ColumnInfo, PageEncoding, PageInfo as DecPageInfo};
@@ -65,26 +65,82 @@ async fn init_writer_if_necessary(
     Ok(false)
 }
 
-/// v2_0 vs v2_1+ field-to-column index mapping
-///  - v2_1+ stores only leaf columns; non-leaf fields get `-1` in the mapping
-///  - v2_0 includes structural headers as columns; non-leaf fields map to a concrete index
-fn compute_field_column_indices(
+/// The exact field-to-column mapping a file written from the current schema uses.
+///
+/// V2.0 gives ordinary structural fields their own header column, while V2.1+
+/// stores only leaf columns. Packed structs and blobs are opaque single columns
+/// in every non-legacy version.
+#[derive(Debug)]
+pub(super) struct BinaryCopySchemaMapping {
+    pub(super) field_ids: Arc<[i32]>,
+    pub(super) column_indices: Arc<[i32]>,
+    pub(super) physical_column_count: usize,
+    is_non_leaf_column: Arc<[bool]>,
+}
+
+pub(super) fn binary_copy_schema_mapping(
     schema: &Schema,
-    full_field_ids_len: usize,
     version: LanceFileVersion,
-) -> Vec<i32> {
-    let is_structural = version >= LanceFileVersion::V2_1;
-    let mut field_column_indices: Vec<i32> = Vec::with_capacity(full_field_ids_len);
-    let mut curr_col_idx: i32 = 0;
-    for field in schema.fields_pre_order() {
-        if field.is_packed_struct() || field.is_leaf() || !is_structural {
-            field_column_indices.push(curr_col_idx);
-            curr_col_idx += 1;
-        } else {
-            field_column_indices.push(-1);
+) -> BinaryCopySchemaMapping {
+    fn append_field(
+        field: &Field,
+        is_structural: bool,
+        field_ids: &mut Vec<i32>,
+        column_indices: &mut Vec<i32>,
+        is_non_leaf_column: &mut Vec<bool>,
+        next_column_index: &mut i32,
+    ) {
+        let is_opaque = field.is_packed_struct() || field.is_blob();
+        let contributes_column = is_opaque || field.is_leaf() || !is_structural;
+        if contributes_column {
+            field_ids.push(field.id);
+            column_indices.push(*next_column_index);
+            is_non_leaf_column.push(
+                !is_structural
+                    && field.data_type().is_struct()
+                    && !field.is_packed_struct()
+                    && !field.is_blob(),
+            );
+            *next_column_index += 1;
+        }
+
+        if !is_opaque {
+            for child in &field.children {
+                append_field(
+                    child,
+                    is_structural,
+                    field_ids,
+                    column_indices,
+                    is_non_leaf_column,
+                    next_column_index,
+                );
+            }
         }
     }
-    field_column_indices
+
+    let field_count = schema.fields_pre_order().count();
+    let mut field_ids = Vec::with_capacity(field_count);
+    let mut column_indices = Vec::with_capacity(field_count);
+    let mut is_non_leaf_column = Vec::with_capacity(field_count);
+    let mut next_column_index = 0;
+    let is_structural = version >= LanceFileVersion::V2_1;
+    for field in &schema.fields {
+        append_field(
+            field,
+            is_structural,
+            &mut field_ids,
+            &mut column_indices,
+            &mut is_non_leaf_column,
+            &mut next_column_index,
+        );
+    }
+
+    BinaryCopySchemaMapping {
+        physical_column_count: field_ids.len(),
+        field_ids: field_ids.into(),
+        column_indices: column_indices.into(),
+        is_non_leaf_column: is_non_leaf_column.into(),
+    }
 }
 
 /// Finalize the current output file and return it as a single [Fragment].
@@ -99,7 +155,7 @@ fn compute_field_column_indices(
 #[allow(clippy::too_many_arguments)]
 async fn finalize_current_output_file(
     schema: &Schema,
-    full_field_ids: &[i32],
+    schema_mapping: &BinaryCopySchemaMapping,
     current_writer: &mut Option<Box<dyn Writer>>,
     current_filename: &mut Option<String>,
     current_page_table: &[ColumnInfo],
@@ -136,10 +192,9 @@ async fn finalize_current_output_file(
     // Register the newly closed output file as a fragment data file
     let (maj, min) = version.to_numbers();
     let mut fragment = Fragment::new(0);
-    let field_column_indices = compute_field_column_indices(schema, full_field_ids.len(), version);
     let mut data_file = DataFile::new_unstarted(current_filename.take().unwrap(), maj, min);
-    data_file.fields = full_field_ids.to_vec().into();
-    data_file.column_indices = field_column_indices.into();
+    data_file.fields = schema_mapping.field_ids.clone();
+    data_file.column_indices = schema_mapping.column_indices.clone();
     fragment.files.push(data_file);
     fragment.physical_rows = Some(total_rows_in_current as usize);
     Ok(fragment)
@@ -190,7 +245,6 @@ pub async fn rewrite_files_binary_copy(
     // - Optionally carries forward stable row ids and persists them inline in fragment metadata
     // Merge small Lance files into larger ones by page-level binary copy.
     let schema = dataset.schema().clone();
-    let full_field_ids = schema.field_ids();
 
     // The previous checks have ensured that the file versions of all files are consistent.
     let version = LanceFileVersion::try_from_major_minor(
@@ -199,35 +253,9 @@ pub async fn rewrite_files_binary_copy(
     )
     .unwrap()
     .resolve();
-    // v2.0 and v2.1+ handle structural headers differently during file writing:
-    // - v2_0 materializes ALL fields in pre-order traversal (leaf fields + non-leaf struct headers),
-    //   which means the ColumnInfo set includes all fields in pre-order traversal.
-    // - v2_1+ materializes fields that are either leaf columns OR packed structs. Non-leaf structural
-    //   headers (unpacked structs with children) are not stored as columns.
-    //   As a result, the ColumnInfo set contains leaf fields and packed structs.
-    // To correctly align copy layout, we derive `column_count` by version:
-    // - v2_0: use total number of fields in pre-order (leaf + non-leaf headers)
-    // - v2_1+: use only the number of leaf fields plus packed structs
-    let column_count = if version == LanceFileVersion::V2_0 {
-        schema.fields_pre_order().count()
-    } else {
-        schema
-            .fields_pre_order()
-            .filter(|f| f.is_packed_struct() || f.is_leaf())
-            .count()
-    };
-
-    // v2_0 compatibility: build a map to identify non-leaf structural header columns
-    // - In v2_0 these headers exist as columns and must have a single page
-    // - In v2_1+ these headers are not stored as columns and this map is unused
-    let mut is_non_leaf_column: Vec<bool> = vec![false; column_count];
-    if version == LanceFileVersion::V2_0 {
-        for (col_idx, field) in schema.fields_pre_order().enumerate() {
-            // Only mark non-packed Struct fields (lists remain as leaf data carriers)
-            let is_non_leaf = field.data_type().is_struct() && !field.is_packed_struct();
-            is_non_leaf_column[col_idx] = is_non_leaf;
-        }
-    }
+    let schema_mapping = binary_copy_schema_mapping(&schema, version);
+    let column_count = schema_mapping.physical_column_count;
+    let is_non_leaf_column = schema_mapping.is_non_leaf_column.clone();
 
     let mut out: Vec<Fragment> = Vec::new();
     let mut current_writer: Option<Box<dyn Writer>> = None;
@@ -459,7 +487,7 @@ pub async fn rewrite_files_binary_copy(
             if total_rows_in_current >= max_rows_per_file {
                 let fragment_out = finalize_current_output_file(
                     &schema,
-                    &full_field_ids,
+                    &schema_mapping,
                     &mut current_writer,
                     &mut current_filename,
                     &current_page_table,
@@ -492,7 +520,7 @@ pub async fn rewrite_files_binary_copy(
         init_writer_if_necessary(dataset, &mut current_writer, &mut current_filename).await?;
         let frag = finalize_current_output_file(
             &schema,
-            &full_field_ids,
+            &schema_mapping,
             &mut current_writer,
             &mut current_filename,
             &current_page_table,

--- a/rust/lance/src/dataset/optimize/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/binary_copy.rs
@@ -161,7 +161,6 @@ async fn finalize_current_output_file(
     current_page_table: &[ColumnInfo],
     col_pages: &mut [Vec<DecPageInfo>],
     col_buffers: &mut [Vec<(u64, u64)>],
-    is_non_leaf_column: &[bool],
     total_rows_in_current: u64,
     version: LanceFileVersion,
 ) -> Result<Fragment> {
@@ -170,7 +169,11 @@ async fn finalize_current_output_file(
         let mut pages_vec = std::mem::take(&mut col_pages[i]);
         // For v2_0 struct headers, force a single page and set num_rows to total
         if version == LanceFileVersion::V2_0
-            && is_non_leaf_column.get(i).copied().unwrap_or(false)
+            && schema_mapping
+                .is_non_leaf_column
+                .get(i)
+                .copied()
+                .unwrap_or(false)
             && !pages_vec.is_empty()
         {
             pages_vec[0].num_rows = total_rows_in_current;
@@ -255,7 +258,6 @@ pub async fn rewrite_files_binary_copy(
     .resolve();
     let schema_mapping = binary_copy_schema_mapping(&schema, version);
     let column_count = schema_mapping.physical_column_count;
-    let is_non_leaf_column = schema_mapping.is_non_leaf_column.clone();
 
     let mut out: Vec<Fragment> = Vec::new();
     let mut current_writer: Option<Box<dyn Writer>> = None;
@@ -322,7 +324,11 @@ pub async fn rewrite_files_binary_copy(
                 // - During finalization we also normalize the single remaining page’s `num_rows` to the
                 //   total number of rows in the output file and reset `priority` to 0.
                 // - For v2_1+ this logic does not apply because non-leaf headers are not stored as columns.
-                let is_non_leaf = col_idx < is_non_leaf_column.len() && is_non_leaf_column[col_idx];
+                let is_non_leaf = schema_mapping
+                    .is_non_leaf_column
+                    .get(col_idx)
+                    .copied()
+                    .unwrap_or(false);
                 if is_non_leaf && !col_pages[col_idx].is_empty() {
                     continue;
                 }
@@ -493,7 +499,6 @@ pub async fn rewrite_files_binary_copy(
                     &current_page_table,
                     &mut col_pages,
                     &mut col_buffers,
-                    &is_non_leaf_column,
                     total_rows_in_current,
                     version,
                 )
@@ -526,7 +531,6 @@ pub async fn rewrite_files_binary_copy(
             &current_page_table,
             &mut col_pages,
             &mut col_buffers,
-            &is_non_leaf_column,
             total_rows_in_current,
             version,
         )

--- a/rust/lance/src/dataset/optimize/tests/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/tests/binary_copy.rs
@@ -2,6 +2,26 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use super::*;
+use crate::dataset::NewColumnTransform;
+
+async fn write_two_column_schema_evolution_dataset(uri: &str) -> Dataset {
+    let batch =
+        arrow_array::record_batch!(("a", Int32, [1, 2, 3, 4]), ("b", Int32, [10, 20, 30, 40]))
+            .unwrap();
+    let schema = batch.schema();
+    Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        uri,
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            max_rows_per_group: 2,
+            data_storage_version: Some(LanceFileVersion::Stable),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap()
+}
 
 #[tokio::test]
 async fn test_binary_copy_merge_small_files() {
@@ -579,6 +599,286 @@ async fn test_binary_copy_fallback_to_common_compaction() {
 
     let after = dataset.scan().try_into_batch().await.unwrap();
     assert_eq!(before, after);
+}
+
+#[tokio::test]
+async fn test_try_binary_copy_falls_back_for_file_less_fragment() {
+    for enable_stable_row_ids in [false, true] {
+        do_try_binary_copy_falls_back_for_file_less_fragment(enable_stable_row_ids).await;
+    }
+}
+
+async fn do_try_binary_copy_falls_back_for_file_less_fragment(enable_stable_row_ids: bool) {
+    let test_dir = TempStrDir::default();
+    let initial_batch =
+        arrow_array::record_batch!(("a", Int32, [1, 2]), ("b", Int32, [Some(10), Some(20)]))
+            .unwrap();
+    let initial_schema = initial_batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(initial_batch)], initial_schema),
+        &test_dir,
+        Some(WriteParams {
+            enable_stable_row_ids,
+            data_storage_version: Some(LanceFileVersion::Stable),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let append_batch = arrow_array::record_batch!(("a", Int32, [3, 4])).unwrap();
+    let append_schema = append_batch.schema();
+    dataset
+        .append(
+            RecordBatchIterator::new(vec![Ok(append_batch)], append_schema),
+            Some(WriteParams {
+                enable_stable_row_ids,
+                data_storage_version: Some(LanceFileVersion::Stable),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+    dataset.drop_columns(&["a"]).await.unwrap();
+
+    let fragments: Vec<Fragment> = dataset
+        .get_fragments()
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    assert_eq!(fragments.len(), 2);
+    assert!(!fragments[0].files.is_empty());
+    assert!(fragments[1].files.is_empty());
+
+    let before = dataset.scan().try_into_batch().await.unwrap();
+    let expected =
+        arrow_array::record_batch!(("b", Int32, [Some(10), Some(20), None, None])).unwrap();
+    assert_eq!(before, expected);
+    let row_ids_before = if enable_stable_row_ids {
+        Some(dataset.scan().with_row_id().try_into_batch().await.unwrap())
+    } else {
+        None
+    };
+
+    let options = CompactionOptions {
+        target_rows_per_fragment: 100_000,
+        compaction_mode: Some(CompactionMode::TryBinaryCopy),
+        ..Default::default()
+    };
+    assert!(!can_use_binary_copy(&dataset, &options, &fragments).await);
+
+    compact_files(&mut dataset, options, None).await.unwrap();
+
+    let after = dataset.scan().try_into_batch().await.unwrap();
+    assert_eq!(after, expected);
+    if let Some(row_ids_before) = row_ids_before {
+        let row_ids_after = dataset.scan().with_row_id().try_into_batch().await.unwrap();
+        assert_eq!(row_ids_after, row_ids_before);
+    }
+}
+
+#[tokio::test]
+async fn test_try_binary_copy_falls_back_after_all_null_column_addition() {
+    let test_dir = TempStrDir::default();
+    let batch = arrow_array::record_batch!(("a", Int32, [1, 2, 3, 4])).unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        &test_dir,
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            max_rows_per_group: 2,
+            data_storage_version: Some(LanceFileVersion::Stable),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    dataset
+        .add_columns(
+            NewColumnTransform::AllNulls(Arc::new(Schema::new(vec![Field::new(
+                "nulls",
+                DataType::Int32,
+                true,
+            )]))),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let fragments: Vec<Fragment> = dataset
+        .get_fragments()
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    assert_eq!(fragments.len(), 2);
+    assert!(fragments.iter().all(|fragment| fragment.files.len() == 1));
+    assert!(
+        fragments
+            .iter()
+            .flat_map(|fragment| &fragment.files)
+            .all(|file| file.fields.len() == 1)
+    );
+
+    let expected = arrow_array::record_batch!(
+        ("a", Int32, [1, 2, 3, 4]),
+        (
+            "nulls",
+            Int32,
+            [None::<i32>, None::<i32>, None::<i32>, None::<i32>]
+        )
+    )
+    .unwrap();
+    assert_eq!(dataset.scan().try_into_batch().await.unwrap(), expected);
+
+    let options = CompactionOptions {
+        target_rows_per_fragment: 100,
+        compaction_mode: Some(CompactionMode::TryBinaryCopy),
+        ..Default::default()
+    };
+    assert!(!can_use_binary_copy(&dataset, &options, &fragments).await);
+
+    compact_files(&mut dataset, options, None).await.unwrap();
+
+    assert_eq!(dataset.scan().try_into_batch().await.unwrap(), expected);
+    assert_eq!(dataset.get_fragments().len(), 1);
+}
+
+#[tokio::test]
+async fn test_try_binary_copy_falls_back_after_physical_column_drop() {
+    let test_dir = TempStrDir::default();
+    let mut dataset = write_two_column_schema_evolution_dataset(&test_dir).await;
+    dataset.drop_columns(&["a"]).await.unwrap();
+
+    let fragments: Vec<Fragment> = dataset
+        .get_fragments()
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    assert_eq!(fragments.len(), 2);
+    assert!(fragments.iter().all(|fragment| !fragment.files.is_empty()));
+
+    let expected = arrow_array::record_batch!(("b", Int32, [10, 20, 30, 40])).unwrap();
+    assert_eq!(dataset.scan().try_into_batch().await.unwrap(), expected);
+
+    let force_options = CompactionOptions {
+        target_rows_per_fragment: 100,
+        compaction_mode: Some(CompactionMode::ForceBinaryCopy),
+        ..Default::default()
+    };
+    let error = compact_files(&mut dataset, force_options, None)
+        .await
+        .unwrap_err();
+    assert!(matches!(&error, Error::NotSupported { .. }));
+    assert!(error.to_string().contains("binary copy is not supported"));
+
+    let options = CompactionOptions {
+        target_rows_per_fragment: 100,
+        compaction_mode: Some(CompactionMode::TryBinaryCopy),
+        ..Default::default()
+    };
+    assert!(!can_use_binary_copy(&dataset, &options, &fragments).await);
+
+    compact_files(&mut dataset, options, None).await.unwrap();
+
+    assert_eq!(dataset.scan().try_into_batch().await.unwrap(), expected);
+    assert_eq!(dataset.get_fragments().len(), 1);
+}
+
+#[tokio::test]
+async fn test_try_binary_copy_rejects_same_count_schema_replacement() {
+    let test_dir = TempStrDir::default();
+    let mut dataset = write_two_column_schema_evolution_dataset(&test_dir).await;
+    dataset.drop_columns(&["a"]).await.unwrap();
+    dataset
+        .add_columns(
+            NewColumnTransform::AllNulls(Arc::new(Schema::new(vec![Field::new(
+                "c",
+                DataType::Int32,
+                true,
+            )]))),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let fragments: Vec<Fragment> = dataset
+        .get_fragments()
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    let current_field_ids = dataset.schema().field_ids();
+    for file in fragments.iter().flat_map(|fragment| &fragment.files) {
+        assert_eq!(file.fields.len(), current_field_ids.len());
+        assert_ne!(file.fields.as_ref(), current_field_ids.as_slice());
+    }
+
+    let expected = arrow_array::record_batch!(
+        ("b", Int32, [10, 20, 30, 40]),
+        (
+            "c",
+            Int32,
+            [None::<i32>, None::<i32>, None::<i32>, None::<i32>]
+        )
+    )
+    .unwrap();
+    assert_eq!(dataset.scan().try_into_batch().await.unwrap(), expected);
+
+    let options = CompactionOptions {
+        target_rows_per_fragment: 100,
+        compaction_mode: Some(CompactionMode::TryBinaryCopy),
+        ..Default::default()
+    };
+    assert!(!can_use_binary_copy(&dataset, &options, &fragments).await);
+
+    compact_files(&mut dataset, options, None).await.unwrap();
+
+    assert_eq!(dataset.scan().try_into_batch().await.unwrap(), expected);
+    assert_eq!(dataset.get_fragments().len(), 1);
+}
+
+#[tokio::test]
+async fn test_try_binary_copy_materializes_data_overlay() {
+    let test_dir = TempStrDir::default();
+    let dataset = create_base_dataset(&test_dir).await;
+    let mut dataset = commit_overlay(
+        dataset,
+        0,
+        &[1],
+        OverlayCoverage::dense(bitmap([1, 4])),
+        vec![i32_array([Some(111), None])],
+    )
+    .await;
+
+    let fragments: Vec<Fragment> = dataset
+        .get_fragments()
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    assert_eq!(fragments[0].overlays.len(), 1);
+    let before = id_val_map(&dataset).await;
+    assert_eq!(before.get(&1), Some(&Some(111)));
+    assert_eq!(before.get(&4), Some(&None));
+
+    let options = CompactionOptions {
+        target_rows_per_fragment: 100,
+        compaction_mode: Some(CompactionMode::TryBinaryCopy),
+        ..Default::default()
+    };
+    assert!(!can_use_binary_copy(&dataset, &options, &fragments).await);
+
+    compact_files(&mut dataset, options, None).await.unwrap();
+
+    assert_eq!(id_val_map(&dataset).await, before);
+    assert!(
+        dataset
+            .get_fragments()
+            .iter()
+            .all(|fragment| fragment.metadata().overlays.is_empty())
+    );
 }
 
 #[tokio::test]

--- a/rust/lance/src/dataset/optimize/tests/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/tests/binary_copy.rs
@@ -601,11 +601,14 @@ async fn test_binary_copy_fallback_to_common_compaction() {
     assert_eq!(before, after);
 }
 
+#[rstest]
+#[case::unstable_row_ids(false)]
+#[case::stable_row_ids(true)]
 #[tokio::test]
-async fn test_try_binary_copy_falls_back_for_file_less_fragment() {
-    for enable_stable_row_ids in [false, true] {
-        do_try_binary_copy_falls_back_for_file_less_fragment(enable_stable_row_ids).await;
-    }
+async fn test_try_binary_copy_falls_back_for_file_less_fragment(
+    #[case] enable_stable_row_ids: bool,
+) {
+    do_try_binary_copy_falls_back_for_file_less_fragment(enable_stable_row_ids).await;
 }
 
 async fn do_try_binary_copy_falls_back_for_file_less_fragment(enable_stable_row_ids: bool) {

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -959,9 +959,9 @@ pub fn exclude(source: &Schema, other: &Schema, version: &LanceFileVersion) -> R
 mod test {
     use std::{collections::HashMap, fs, num::NonZero, path::Path as StdPath, sync::Mutex};
 
-    use crate::dataset::WriteParams;
+    use crate::dataset::{WriteMode, WriteParams};
     use arrow_array::{
-        ArrayRef, Int32Array, ListArray, RecordBatchIterator, StringArray, StructArray,
+        ArrayRef, Int32Array, Int64Array, ListArray, RecordBatchIterator, StringArray, StructArray,
     };
 
     use super::*;
@@ -2234,6 +2234,260 @@ mod test {
             matches!(err, Error::InvalidInput { .. }),
             "unexpected error: {err}"
         );
+
+        Ok(())
+    }
+
+    async fn dataset_with_all_null_column(
+        test_uri: &str,
+        num_rows: usize,
+        max_rows_per_file: Option<usize>,
+        max_rows_per_group: Option<usize>,
+    ) -> Result<Dataset> {
+        let batch = arrow_array::record_batch!((
+            "id",
+            Int64,
+            (1..=num_rows).map(|value| value as i64).collect::<Vec<_>>()
+        ))?;
+        let schema = batch.schema();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let mut write_params = WriteParams {
+            data_storage_version: Some(LanceFileVersion::Stable),
+            ..Default::default()
+        };
+        if let Some(max_rows_per_file) = max_rows_per_file {
+            write_params.max_rows_per_file = max_rows_per_file;
+        }
+        if let Some(max_rows_per_group) = max_rows_per_group {
+            write_params.max_rows_per_group = max_rows_per_group;
+        }
+
+        let mut dataset = Dataset::write(reader, test_uri, Some(write_params)).await?;
+
+        dataset
+            .add_columns(
+                NewColumnTransform::AllNulls(Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                    "x",
+                    DataType::Int64,
+                    true,
+                )]))),
+                None,
+                None,
+            )
+            .await?;
+
+        Ok(dataset)
+    }
+
+    fn assert_file_less_fragments(
+        dataset: &Dataset,
+        num_rows: usize,
+        expected_fragment_rows: &[usize],
+    ) {
+        let fragments = dataset.get_fragments();
+        assert_eq!(fragments.len(), expected_fragment_rows.len());
+        let mut total_physical_rows = 0;
+        for (fragment, expected_rows) in fragments.iter().zip(expected_fragment_rows) {
+            assert!(
+                fragment.metadata.files.is_empty(),
+                "fragment {} should not contain data files",
+                fragment.id()
+            );
+            assert_eq!(fragment.metadata.physical_rows, Some(*expected_rows));
+            total_physical_rows += expected_rows;
+        }
+        assert_eq!(total_physical_rows, num_rows);
+    }
+
+    async fn dataset_with_only_all_null_column(
+        test_uri: &str,
+        num_rows: usize,
+        max_rows_per_file: Option<usize>,
+        max_rows_per_group: Option<usize>,
+        expected_fragment_rows: &[usize],
+    ) -> Result<Dataset> {
+        let mut dataset =
+            dataset_with_all_null_column(test_uri, num_rows, max_rows_per_file, max_rows_per_group)
+                .await?;
+
+        dataset.drop_columns(&["id"]).await?;
+
+        let dataset = Dataset::open(test_uri).await?;
+        assert_file_less_fragments(&dataset, num_rows, expected_fragment_rows);
+        dataset.validate().await?;
+
+        Ok(dataset)
+    }
+
+    #[rstest]
+    #[case::single_fragment(9, None, None, &[9])]
+    #[case::multi_fragment(100, Some(50), Some(25), &[50, 50])]
+    #[tokio::test]
+    async fn test_scan_all_null_column_after_dropping_only_physical_column(
+        #[case] num_rows: usize,
+        #[case] max_rows_per_file: Option<usize>,
+        #[case] max_rows_per_group: Option<usize>,
+        #[case] expected_fragment_rows: &[usize],
+    ) -> Result<()> {
+        let test_dir = TempStrDir::default();
+        let dataset = dataset_with_only_all_null_column(
+            &test_dir,
+            num_rows,
+            max_rows_per_file,
+            max_rows_per_group,
+            expected_fragment_rows,
+        )
+        .await?;
+
+        assert_eq!(dataset.count_rows(None).await?, num_rows);
+
+        let data = dataset.scan().try_into_batch().await?;
+
+        let expected_schema = ArrowSchema::new(vec![ArrowField::new("x", DataType::Int64, true)]);
+        assert_eq!(data.schema().as_ref(), &expected_schema);
+        assert_eq!(data.num_rows(), num_rows);
+
+        let x = data["x"].as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(x.len(), num_rows);
+        assert_eq!(x.null_count(), num_rows);
+
+        let mut scanner = dataset.scan();
+        scanner.limit(Some(3), Some(2))?;
+        let limited = scanner.try_into_batch().await?;
+        assert_eq!(limited.num_rows(), 3);
+        let x = limited["x"].as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(x.null_count(), 3);
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::single_fragment(9, None, None, &[9])]
+    #[case::multi_fragment(100, Some(50), Some(25), &[50, 50])]
+    #[tokio::test]
+    async fn test_append_readded_column_after_dropping_only_physical_column(
+        #[case] num_existing_rows: usize,
+        #[case] max_rows_per_file: Option<usize>,
+        #[case] max_rows_per_group: Option<usize>,
+        #[case] expected_fragment_rows: &[usize],
+    ) -> Result<()> {
+        let test_dir = TempStrDir::default();
+        let mut dataset = dataset_with_only_all_null_column(
+            &test_dir,
+            num_existing_rows,
+            max_rows_per_file,
+            max_rows_per_group,
+            expected_fragment_rows,
+        )
+        .await?;
+
+        dataset
+            .add_columns(
+                NewColumnTransform::AllNulls(Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                    "id",
+                    DataType::Int64,
+                    true,
+                )]))),
+                None,
+                None,
+            )
+            .await?;
+
+        let append_batch =
+            arrow_array::record_batch!(("x", Int64, [None::<i64>]), ("id", Int64, [Some(42_i64)]))?;
+        let append_schema = append_batch.schema();
+        dataset
+            .append(
+                RecordBatchIterator::new(vec![Ok(append_batch)], append_schema),
+                Some(WriteParams {
+                    mode: WriteMode::Append,
+                    ..Default::default()
+                }),
+            )
+            .await?;
+
+        let data = dataset.scan().try_into_batch().await?;
+
+        let expected_schema = ArrowSchema::new(vec![
+            ArrowField::new("x", DataType::Int64, true),
+            ArrowField::new("id", DataType::Int64, true),
+        ]);
+        assert_eq!(data.schema().as_ref(), &expected_schema);
+        assert_eq!(data.num_rows(), num_existing_rows + 1);
+
+        let x = data["x"].as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(x.len(), num_existing_rows + 1);
+        assert_eq!(x.null_count(), num_existing_rows + 1);
+
+        let id = data["id"].as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(id.len(), num_existing_rows + 1);
+        for row_idx in 0..num_existing_rows {
+            assert!(id.is_null(row_idx));
+        }
+        assert_eq!(id.value(num_existing_rows), 42);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_file_less_fragment_with_deletions_after_dropping_only_physical_column_single_fragment()
+    -> Result<()> {
+        let num_rows = 9;
+        let expected_fragment_rows = &[9];
+        let test_dir = TempStrDir::default();
+        let mut dataset = dataset_with_all_null_column(&test_dir, num_rows, None, None).await?;
+
+        let delete_result = dataset.delete("id = 3").await?;
+        assert_eq!(delete_result.num_deleted_rows, 1);
+
+        dataset.drop_columns(&["id"]).await?;
+
+        let dataset = Dataset::open(&test_dir).await?;
+        assert_file_less_fragments(&dataset, num_rows, expected_fragment_rows);
+        dataset.validate().await?;
+
+        let data = dataset.scan().try_into_batch().await?;
+        assert_eq!(data.num_rows(), num_rows - 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_scan_file_less_fragments_with_deletions_after_dropping_only_physical_column()
+    -> Result<()> {
+        let num_rows = 100;
+        let expected_fragment_rows = &[50, 50];
+        let test_dir = TempStrDir::default();
+        let mut dataset =
+            dataset_with_all_null_column(&test_dir, num_rows, Some(50), Some(25)).await?;
+
+        let delete_result = dataset.delete("id = 10 OR id = 60").await?;
+        assert_eq!(delete_result.num_deleted_rows, 2);
+        assert_eq!(dataset.count_deleted_rows().await?, 2);
+
+        dataset.drop_columns(&["id"]).await?;
+
+        let dataset = Dataset::open(&test_dir).await?;
+        assert_file_less_fragments(&dataset, num_rows, expected_fragment_rows);
+        assert_eq!(dataset.count_rows(None).await?, num_rows - 2);
+
+        let fragments = dataset.get_fragments();
+        assert!(
+            fragments
+                .iter()
+                .all(|fragment| fragment.metadata.deletion_file.is_some())
+        );
+        dataset.validate().await?;
+
+        let data = dataset.scan().try_into_batch().await?;
+
+        let expected_schema = ArrowSchema::new(vec![ArrowField::new("x", DataType::Int64, true)]);
+        assert_eq!(data.schema().as_ref(), &expected_schema);
+        assert_eq!(data.num_rows(), num_rows - 2);
+
+        let x = data["x"].as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(x.len(), num_rows - 2);
+        assert_eq!(x.null_count(), num_rows - 2);
 
         Ok(())
     }


### PR DESCRIPTION
Closes #7236
## Problem

A dataset can become unreadable after schema evolution when:

1. It starts with a physical column.
2. A nullable all-null column is added through schema evolution.
3. The original physical column is dropped.
4. The dataset is scanned.

At that point, the remaining visible column is valid and row-bearing, but the affected fragments may have `files = []`. Scans should still return the preserved row count with null values for the remaining column.

## Root cause
`Operation::Project` can create fragments without visible data files while preserving `physical_rows`.

Some fragment paths still treated file-less fragments as invalid before trusting modern `Fragment.physical_rows`, so scans and validation could fail with errors like `Fragment 0 does not contain any data`.

Deletion-vector validation also needed to use `physical_rows` as the fragment length when no data files are present.

## Solution
Trust `Fragment.physical_rows` for modern manifests before rejecting file-less fragments, and allow validation to use that metadata as the fragment length when data files are absent.

This lets scans synthesize all-null arrays for schema-evolution columns even after the only physical column has been dropped.

## Changes
- Update `FileFragment::physical_rows()` to return cached `physical_rows` for modern file-less fragments.
- Update fragment validation to allow file-less fragments when `physical_rows` is present.
- Keep rejecting file-less fragments that do not have `physical_rows`.
- Validate deletion-vector metadata and bounds against `physical_rows` for file-less fragments.
- Add regressions for:
  - scanning an all-null column after dropping the only physical column;
  - single-fragment and multi-fragment datasets;
  - appending after re-adding a dropped column;
  - file-less fragments with deletion vectors.