### PR TITLE
feat: shard directory namespace manifest

### DIFF
--- a/rust/lance-namespace-impls/BENCHMARK.md
+++ b/rust/lance-namespace-impls/BENCHMARK.md
@@ -1,10 +1,12 @@
 # `__manifest` commit benchmark
 
-Measures how fast the copy-on-write directory catalog commits `__manifest` mutations as
-the manifest scales, with the inline scalar indices on or off.
+Measures how fast the directory catalog commits `__manifest` mutations as the
+manifest scales, with copy-on-write and optional fragment sharding.
 
-The catalog commits every mutation by rewriting the whole `__manifest` (copy-on-write)
-and atomically writing a new manifest version. This benchmark characterises:
+Without sharding, the catalog commits every mutation by rewriting the whole
+`__manifest` (copy-on-write) and atomically writing a new manifest version. With
+`--manifest-shard-count`, the catalog keeps one physical `__manifest` fragment per
+shard and rewrites only the target fragment. This benchmark characterises:
 
 - **Continuous commit** — a single process commits `N` times into a manifest already
   holding `rows` entries (per-commit latency + throughput).
@@ -15,23 +17,33 @@ and atomically writing a new manifest version. This benchmark characterises:
 
 ```
 manifest_bench seed-large --root <uri> --count <rows> --inline-optimization <true|false> \
-    [--storage-option aws_region=us-east-1]
+    [--manifest-shard-count <shards>] [--storage-option aws_region=us-east-1]
 manifest_bench run --root <uri> --operation write-create-namespace \
-    --concurrency 1 --operations 100 --initial-entries <rows> --inline-optimization <bool>   # continuous
+    --concurrency 1 --operations 100 --initial-entries <rows> --inline-optimization <bool> \
+    [--manifest-shard-count <shards>]   # continuous
 manifest_bench run --root <uri> --operation write-create-namespace \
-    --concurrency 50 --duration-secs 30 --initial-entries <rows> --inline-optimization <bool> # concurrent
+    --concurrency 50 --duration-secs 30 --initial-entries <rows> --inline-optimization <bool> \
+    [--manifest-shard-count <shards>]   # concurrent
 ```
 
 - `seed-large` bootstraps a manifest to `count` rows by writing the Lance dataset
   directly (O(rows) once) and then triggering one CoW rewrite so the on-disk state
   matches the steady catalog form (single fragment; inline indices when enabled).
+  With `--manifest-shard-count`, it writes exactly one fragment per shard; when inline
+  indices are enabled, the setup rewrite is routed through a single shard so the shard
+  layout is preserved while the full inline index section is built.
 - `run` spawns `--concurrency` worker subprocesses. With `--operations` it runs a fixed
   commit budget (continuous); with `--duration-secs` each worker commits until the
   deadline (steady TPS). It prints one JSON `BenchResult` per concurrency level with
-  throughput and p50/p90/p99 latency.
+  throughput, p50/p90/p99 latency, and `manifest_shard_count`.
 - The committed operation (`--operation`) defaults to `write-create-namespace`, the
   cheapest pure-`__manifest` mutation (no table data). `write-create-table` /
   `write-declare-table` are also available.
+- Sharding reduces the amount of data rewritten per commit. It does not remove the
+  single-version commit serialization point, so high-concurrency runs still contend on
+  the `__manifest` dataset version. When inline optimization is enabled, sharded
+  rewrites rebuild the inline scalar index section with row addresses across all
+  manifest fragments.
 
 S3 requires the default `dir-aws` feature (on by default) and AWS credentials in the
 environment; pass `--storage-option aws_region=<region>`.
@@ -48,9 +60,12 @@ S3_BASE=s3://<bucket>/manifest-cow-bench/$(date -u +%Y%m%dT%H%M%SZ) \
   rust/lance-namespace-impls/benches/manifest_commit_sweep.sh
 ```
 
+Set `MANIFEST_SHARD_COUNT=1000` to run the same panel against a sharded
+`__manifest`. Leave it unset or set it to `0` for the copy-on-write baseline.
+
 Default panel (override via env): `SIZES="1000 2000 5000 10000 20000 50000 100000 200000
 500000 1000000"`, `CONCURRENCY="10 20 50 100 120 150 200"`, `INLINE_VARIANTS="true false"`,
-`CONT_OPS=100`, `CONC_DURATION_SECS=30`. Results land in `$OUT_DIR` (default
+`CONT_OPS=100`, `CONC_DURATION_SECS=30`, `MANIFEST_SHARD_COUNT=0`. Results land in `$OUT_DIR` (default
 `~/manifest_cow_bench_<RUN_ID>`).
 
 ## Representative results

--- a/rust/lance-namespace-impls/benches/manifest_commit_sweep.sh
+++ b/rust/lance-namespace-impls/benches/manifest_commit_sweep.sh
@@ -18,7 +18,7 @@
 #
 # Env knobs (defaults match the requested panel):
 #   SIZES, CONCURRENCY, INLINE_VARIANTS, CONT_OPS, CONC_DURATION_SECS,
-#   AWS_REGION, OUT_DIR, BIN
+#   MANIFEST_SHARD_COUNT, AWS_REGION, OUT_DIR, BIN
 #
 # Resilient by design: a single failed run is logged and skipped rather than aborting
 # the sweep, and re-running fills the gaps (completed runs are detected and skipped).
@@ -41,7 +41,14 @@ CONCURRENCY=(${CONCURRENCY:-10 20 50 100 120 150 200})
 INLINE_VARIANTS=(${INLINE_VARIANTS:-true false})
 CONT_OPS="${CONT_OPS:-100}"
 CONC_DURATION_SECS="${CONC_DURATION_SECS:-30}"
+MANIFEST_SHARD_COUNT="${MANIFEST_SHARD_COUNT:-0}"
 STORAGE_OPT=(--storage-option "aws_region=${AWS_REGION}")
+SHARD_ARGS=()
+SHARD_TAG=""
+if [[ "$MANIFEST_SHARD_COUNT" -gt 0 ]]; then
+  SHARD_ARGS=(--manifest-shard-count "$MANIFEST_SHARD_COUNT")
+  SHARD_TAG="_shards_${MANIFEST_SHARD_COUNT}"
+fi
 
 log() { printf '%s %s\n' "$(date -u +%H:%M:%S)" "$*" | tee -a "$PROGRESS"; }
 
@@ -66,17 +73,21 @@ clear_stragglers() { pkill -f 'examples/manifest_bench worker' 2>/dev/null || tr
 
 for inline in "${INLINE_VARIANTS[@]}"; do
   for rows in "${SIZES[@]}"; do
-    golden="${S3_BASE}/golden/inline_${inline}_rows_${rows}"
-    boot_tag="boot_inline_${inline}_rows_${rows}"
+    golden="${S3_BASE}/golden/inline_${inline}_rows_${rows}${SHARD_TAG}"
+    boot_tag="boot_inline_${inline}_rows_${rows}${SHARD_TAG}"
+    VARIANT_ARGS=()
+    if [[ "$MANIFEST_SHARD_COUNT" -gt 0 ]]; then
+      VARIANT_ARGS=(--variant "sharded_${MANIFEST_SHARD_COUNT}_inline_${inline}")
+    fi
 
     if ! done_already "$boot_tag"; then
-      log "BOOTSTRAP inline=$inline rows=$rows -> $golden"
+      log "BOOTSTRAP inline=$inline rows=$rows shards=$MANIFEST_SHARD_COUNT -> $golden"
       s3_rm "$golden"
       if "$BIN" seed-large --root "$golden" --count "$rows" \
-          --inline-optimization "$inline" "${STORAGE_OPT[@]}"; then
+          --inline-optimization "$inline" "${SHARD_ARGS[@]}" "${STORAGE_OPT[@]}"; then
         echo "{\"bench_tag\":\"$boot_tag\"}" >> "$RESULTS"
       else
-        log "BOOTSTRAP FAILED inline=$inline rows=$rows (skipping this size)"
+        log "BOOTSTRAP FAILED inline=$inline rows=$rows shards=$MANIFEST_SHARD_COUNT (skipping this size)"
         continue
       fi
     else
@@ -84,15 +95,15 @@ for inline in "${INLINE_VARIANTS[@]}"; do
     fi
 
     # ---- Continuous: single process, CONT_OPS commits ----
-    cont_tag="cont_inline_${inline}_rows_${rows}"
+    cont_tag="cont_inline_${inline}_rows_${rows}${SHARD_TAG}"
     if ! done_already "$cont_tag"; then
       run_prefix="${S3_BASE}/run/${cont_tag}"
-      log "CONTINUOUS inline=$inline rows=$rows ops=$CONT_OPS"
+      log "CONTINUOUS inline=$inline rows=$rows shards=$MANIFEST_SHARD_COUNT ops=$CONT_OPS"
       clear_stragglers
       s3_copy "$golden" "$run_prefix"
       timeout "$RUN_TIMEOUT" "$BIN" run --root "$run_prefix" --operation write-create-namespace \
         --concurrency 1 --operations "$CONT_OPS" --initial-entries "$rows" \
-        --inline-optimization "$inline" "${STORAGE_OPT[@]}" \
+        --inline-optimization "$inline" "${SHARD_ARGS[@]}" "${VARIANT_ARGS[@]}" "${STORAGE_OPT[@]}" \
         2>>"$PROGRESS" | while read -r line; do record "$cont_tag" <<<"$line"; done
       s3_rm "$run_prefix"
     else
@@ -101,15 +112,15 @@ for inline in "${INLINE_VARIANTS[@]}"; do
 
     # ---- Concurrent: C processes, steady TPS over CONC_DURATION_SECS ----
     for c in "${CONCURRENCY[@]}"; do
-      conc_tag="conc_inline_${inline}_rows_${rows}_c_${c}"
+      conc_tag="conc_inline_${inline}_rows_${rows}_c_${c}${SHARD_TAG}"
       if done_already "$conc_tag"; then log "skip concurrent $conc_tag (done)"; continue; fi
       run_prefix="${S3_BASE}/run/${conc_tag}"
-      log "CONCURRENT inline=$inline rows=$rows c=$c dur=${CONC_DURATION_SECS}s"
+      log "CONCURRENT inline=$inline rows=$rows shards=$MANIFEST_SHARD_COUNT c=$c dur=${CONC_DURATION_SECS}s"
       clear_stragglers
       s3_copy "$golden" "$run_prefix"
       timeout "$RUN_TIMEOUT" "$BIN" run --root "$run_prefix" --operation write-create-namespace \
         --concurrency "$c" --duration-secs "$CONC_DURATION_SECS" --initial-entries "$rows" \
-        --inline-optimization "$inline" "${STORAGE_OPT[@]}" \
+        --inline-optimization "$inline" "${SHARD_ARGS[@]}" "${VARIANT_ARGS[@]}" "${STORAGE_OPT[@]}" \
         2>>"$PROGRESS" | while read -r line; do record "$conc_tag" <<<"$line"; done
       s3_rm "$run_prefix"
     done
@@ -129,6 +140,7 @@ with open(sys.argv[1]) as f:
         mode = "continuous" if d["duration_secs"] == 0 else "concurrent"
         rows.append({
             "mode": mode, "variant": d["variant"], "initial_entries": d["initial_entries"],
+            "manifest_shard_count": d.get("manifest_shard_count", 0),
             "concurrency": d["concurrency"], "duration_secs": d["duration_secs"],
             "ops": d["total_operations"], "errors": d["errors"],
             "tps": round(d["throughput_ops_per_sec"], 3),

--- a/rust/lance-namespace-impls/examples/manifest_bench.rs
+++ b/rust/lance-namespace-impls/examples/manifest_bench.rs
@@ -18,6 +18,10 @@
 //!   manifest_bench seed-large --root s3://bucket/bench/p --count 100000 \
 //!     --inline-optimization true --storage-option aws_region=us-east-1
 //!
+//!   # Bootstrap 100k rows into a 1000-fragment sharded __manifest
+//!   manifest_bench seed-large --root s3://bucket/bench/p --count 100000 \
+//!     --manifest-shard-count 1000 --storage-option aws_region=us-east-1
+//!
 //!   # Continuous: 100 commits, single process
 //!   manifest_bench run --root s3://bucket/bench/p --operation write-create-namespace \
 //!     --concurrency 1 --operations 100 --initial-entries 100000 --inline-optimization true
@@ -63,6 +67,7 @@ struct BenchResult {
     operation: String,
     concurrency: usize,
     initial_entries: usize,
+    manifest_shard_count: usize,
     duration_secs: u64,
     total_operations: usize,
     total_duration_ms: f64,
@@ -90,6 +95,7 @@ fn compute_result(
     operation: &str,
     concurrency: usize,
     initial_entries: usize,
+    manifest_shard_count: usize,
     duration_secs: u64,
     wall_duration: Duration,
     mut latencies: Vec<f64>,
@@ -108,6 +114,7 @@ fn compute_result(
         operation: operation.to_string(),
         concurrency,
         initial_entries,
+        manifest_shard_count,
         duration_secs,
         total_operations: total,
         total_duration_ms: total_ms,
@@ -174,61 +181,84 @@ fn manifest_schema() -> Arc<ArrowSchema> {
     ]))
 }
 
-async fn build_namespace(
-    root: &str,
-    inline_optimization: bool,
-    storage_options: &HashMap<String, String>,
-) -> Box<dyn LanceNamespace> {
-    let mut properties = HashMap::new();
-    properties.insert("root".to_string(), root.to_string());
-    properties.insert("dir_listing_enabled".to_string(), "false".to_string());
-    properties.insert(
-        "inline_optimization_enabled".to_string(),
-        inline_optimization.to_string(),
-    );
-    for (k, v) in storage_options {
-        properties.insert(format!("storage.{}", k), v.clone());
-    }
-    let builder = DirectoryNamespaceBuilder::from_properties(properties, None)
-        .expect("Failed to create namespace builder from properties");
-    Box::new(builder.build().await.expect("Failed to build namespace"))
+const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
+
+#[derive(Clone)]
+struct ManifestSeedRow {
+    object_id: String,
+    object_type: String,
+    location: Option<String>,
+    metadata: Option<String>,
 }
 
-// ──────────────────── seed-large mode ────────────────────
-// Bootstrap a `__manifest` with N rows by writing the Lance dataset directly (fast,
-// O(N) once), then trigger a single CoW rewrite via the namespace so the on-disk state
-// matches what the catalog produces (single fragment + inline indices when enabled).
+fn stable_hash(value: &str) -> u64 {
+    value
+        .as_bytes()
+        .iter()
+        .fold(FNV_OFFSET_BASIS, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(FNV_PRIME)
+        })
+}
 
-const SEED_LARGE_BATCH_SIZE: usize = 50_000;
+fn shard_index_for_key(shard_count: usize, key: &str) -> usize {
+    (stable_hash(key) % shard_count as u64) as usize
+}
 
-fn generate_manifest_batch(start_idx: usize, batch_size: usize, total_count: usize) -> RecordBatch {
+fn shard_marker_object_id(shard_index: usize, marker_index: usize) -> String {
+    format!(
+        "__manifest_shard_marker_{:06}_{:06}",
+        shard_index, marker_index
+    )
+}
+
+fn shard_marker_row(shard_index: usize, marker_index: usize) -> ManifestSeedRow {
+    ManifestSeedRow {
+        object_id: shard_marker_object_id(shard_index, marker_index),
+        object_type: "shard_marker".to_string(),
+        location: None,
+        metadata: None,
+    }
+}
+
+fn generate_manifest_seed_row(row_index: usize, total_count: usize) -> ManifestSeedRow {
     let ns_count = total_count / 3;
-    let actual_size = batch_size.min(total_count - start_idx);
-
-    let mut object_ids = Vec::with_capacity(actual_size);
-    let mut object_types = Vec::with_capacity(actual_size);
-    let mut locations: Vec<Option<String>> = Vec::with_capacity(actual_size);
-    let mut metadatas: Vec<Option<String>> = Vec::with_capacity(actual_size);
-
-    for i in start_idx..start_idx + actual_size {
-        if i < ns_count {
-            object_ids.push(format!("ns_{}", i));
-            object_types.push("namespace".to_string());
-            locations.push(None);
-            metadatas.push(None);
-        } else {
-            let table_idx = i - ns_count;
-            object_ids.push(format!("table_{}", table_idx));
-            object_types.push("table".to_string());
-            locations.push(Some(format!("table_{}", table_idx)));
-            metadatas.push(Some(r#"{"bench":"true"}"#.to_string()));
+    if row_index < ns_count {
+        ManifestSeedRow {
+            object_id: format!("ns_{}", row_index),
+            object_type: "namespace".to_string(),
+            location: None,
+            metadata: None,
         }
+    } else {
+        let table_idx = row_index - ns_count;
+        ManifestSeedRow {
+            object_id: format!("table_{}", table_idx),
+            object_type: "table".to_string(),
+            location: Some(format!("table_{}", table_idx)),
+            metadata: Some(r#"{"bench":"true"}"#.to_string()),
+        }
+    }
+}
+
+fn manifest_batch_from_rows(rows: Vec<ManifestSeedRow>) -> RecordBatch {
+    let row_count = rows.len();
+    let mut object_ids = Vec::with_capacity(row_count);
+    let mut object_types = Vec::with_capacity(row_count);
+    let mut locations: Vec<Option<String>> = Vec::with_capacity(row_count);
+    let mut metadatas: Vec<Option<String>> = Vec::with_capacity(row_count);
+
+    for row in rows {
+        object_ids.push(row.object_id);
+        object_types.push(row.object_type);
+        locations.push(row.location);
+        metadatas.push(row.metadata);
     }
 
     // base_objects is null for every bootstrapped row.
     let mut base_objects_builder = ListBuilder::new(StringBuilder::new())
         .with_field(Arc::new(Field::new("object_id", DataType::Utf8, true)));
-    for _ in 0..actual_size {
+    for _ in 0..row_count {
         base_objects_builder.append_null();
     }
 
@@ -249,27 +279,117 @@ fn generate_manifest_batch(start_idx: usize, batch_size: usize, total_count: usi
     .expect("Failed to create manifest batch")
 }
 
+async fn build_namespace(
+    root: &str,
+    inline_optimization: bool,
+    manifest_shard_count: usize,
+    storage_options: &HashMap<String, String>,
+) -> Box<dyn LanceNamespace> {
+    let mut properties = HashMap::new();
+    properties.insert("root".to_string(), root.to_string());
+    properties.insert("dir_listing_enabled".to_string(), "false".to_string());
+    properties.insert(
+        "inline_optimization_enabled".to_string(),
+        inline_optimization.to_string(),
+    );
+    if manifest_shard_count > 0 {
+        properties.insert(
+            "manifest_shard_count".to_string(),
+            manifest_shard_count.to_string(),
+        );
+    }
+    for (k, v) in storage_options {
+        properties.insert(format!("storage.{}", k), v.clone());
+    }
+    let builder = DirectoryNamespaceBuilder::from_properties(properties, None)
+        .expect("Failed to create namespace builder from properties");
+    Box::new(builder.build().await.expect("Failed to build namespace"))
+}
+
+// ──────────────────── seed-large mode ────────────────────
+// Bootstrap a `__manifest` with N rows by writing the Lance dataset directly (fast,
+// O(N) once), then trigger a single CoW rewrite via the namespace so the on-disk state
+// matches what the catalog produces (single fragment + inline indices when enabled).
+
+const SEED_LARGE_BATCH_SIZE: usize = 50_000;
+
+fn generate_manifest_batch(start_idx: usize, batch_size: usize, total_count: usize) -> RecordBatch {
+    let actual_size = batch_size.min(total_count - start_idx);
+    let rows = (start_idx..start_idx + actual_size)
+        .map(|row_index| generate_manifest_seed_row(row_index, total_count))
+        .collect();
+    manifest_batch_from_rows(rows)
+}
+
+fn generate_sharded_manifest_batches(
+    count: usize,
+    shard_count: usize,
+) -> (Vec<RecordBatch>, usize) {
+    let mut grouped = vec![Vec::<ManifestSeedRow>::new(); shard_count];
+    for row_index in 0..count {
+        let row = generate_manifest_seed_row(row_index, count);
+        let shard_index = shard_index_for_key(shard_count, &row.object_id);
+        grouped[shard_index].push(row);
+    }
+
+    let rows_per_fragment = grouped.iter().map(|rows| rows.len() + 1).max().unwrap_or(1);
+
+    let batches = grouped
+        .into_iter()
+        .enumerate()
+        .map(|(shard_index, rows)| {
+            let mut shard_rows = Vec::with_capacity(rows_per_fragment);
+            shard_rows.push(shard_marker_row(shard_index, 0));
+            shard_rows.extend(rows);
+            while shard_rows.len() < rows_per_fragment {
+                shard_rows.push(shard_marker_row(shard_index, shard_rows.len()));
+            }
+            manifest_batch_from_rows(shard_rows)
+        })
+        .collect();
+
+    (batches, rows_per_fragment)
+}
+
 async fn seed_large(
     root: &str,
     count: usize,
     inline_optimization: bool,
+    manifest_shard_count: usize,
     storage_options: &HashMap<String, String>,
 ) {
     let manifest_uri = format!("{}/{}", root, "__manifest");
-    eprintln!("Seed-large: writing {} rows to {}", count, manifest_uri);
+    eprintln!(
+        "Seed-large: writing {} rows to {} (manifest_shard_count={})",
+        count, manifest_uri, manifest_shard_count
+    );
 
     let schema = manifest_schema();
-    let mut batches = Vec::new();
-    let mut offset = 0;
-    while offset < count {
-        let batch_size = SEED_LARGE_BATCH_SIZE.min(count - offset);
-        batches.push(generate_manifest_batch(offset, batch_size, count));
-        offset += batch_size;
-    }
-    eprintln!("  generated {} batches", batches.len());
+    let (batches, max_rows_per_file) = if manifest_shard_count > 0 {
+        let (batches, rows_per_fragment) =
+            generate_sharded_manifest_batches(count, manifest_shard_count);
+        eprintln!(
+            "  generated {} shard batches with {} rows per fragment",
+            batches.len(),
+            rows_per_fragment
+        );
+        (batches, rows_per_fragment)
+    } else {
+        let mut batches = Vec::new();
+        let mut offset = 0;
+        while offset < count {
+            let batch_size = SEED_LARGE_BATCH_SIZE.min(count - offset);
+            batches.push(generate_manifest_batch(offset, batch_size, count));
+            offset += batch_size;
+        }
+        eprintln!("  generated {} batches", batches.len());
+        (batches, WriteParams::default().max_rows_per_file)
+    };
 
     let mut write_params = WriteParams {
         mode: WriteMode::Create,
+        max_rows_per_file,
+        max_bytes_per_file: usize::MAX,
         ..WriteParams::default()
     };
     if !storage_options.is_empty() {
@@ -292,13 +412,13 @@ async fn seed_large(
         .expect("Failed to write manifest dataset");
     eprintln!("  wrote Lance dataset");
 
-    // Trigger one CoW rewrite so the manifest is in steady catalog form (single
-    // fragment; inline indices when enabled). For the no-index variant the first real
-    // commit performs this rewrite instead.
+    // Trigger one catalog rewrite so the manifest is in steady catalog form with
+    // inline indices when enabled. Sharded manifests route this through a single
+    // shard rewrite so the fragment layout is preserved.
     if inline_optimization {
         eprintln!("  triggering initial CoW rewrite to build indices...");
         let start = Instant::now();
-        let ns = build_namespace(root, true, storage_options).await;
+        let ns = build_namespace(root, true, manifest_shard_count, storage_options).await;
         let mut req = CreateNamespaceRequest::new();
         req.id = Some(vec!["__seed_trigger__".to_string()]);
         ns.create_namespace(req)
@@ -308,6 +428,15 @@ async fn seed_large(
             "  CoW rewrite with index build took {:.1}s",
             start.elapsed().as_secs_f64()
         );
+    } else if manifest_shard_count > 0 {
+        let ns = build_namespace(
+            root,
+            inline_optimization,
+            manifest_shard_count,
+            storage_options,
+        )
+        .await;
+        drop(ns);
     }
 
     let ns_count = count / 3;
@@ -331,9 +460,16 @@ async fn worker(
     worker_id: usize,
     table_count: usize,
     inline_optimization: bool,
+    manifest_shard_count: usize,
     storage_options: &HashMap<String, String>,
 ) {
-    let ns = build_namespace(root, inline_optimization, storage_options).await;
+    let ns = build_namespace(
+        root,
+        inline_optimization,
+        manifest_shard_count,
+        storage_options,
+    )
+    .await;
     let ipc_data = Bytes::from(create_test_ipc_data());
 
     if operation.starts_with("warm-read") {
@@ -454,6 +590,7 @@ fn run_workers(
     warmup: usize,
     table_count: usize,
     initial_entries: usize,
+    manifest_shard_count: usize,
     inline_optimization: bool,
     variant: &str,
     storage_options: &HashMap<String, String>,
@@ -471,6 +608,7 @@ fn run_workers(
             operation,
             concurrency,
             initial_entries,
+            manifest_shard_count,
             duration_secs,
             Duration::ZERO,
             vec![],
@@ -498,7 +636,9 @@ fn run_workers(
                 .arg("--table-count")
                 .arg(table_count.to_string())
                 .arg("--inline-optimization")
-                .arg(inline_optimization.to_string());
+                .arg(inline_optimization.to_string())
+                .arg("--manifest-shard-count")
+                .arg(manifest_shard_count.to_string());
             for (k, v) in storage_options {
                 cmd.arg("--storage-option").arg(format!("{}={}", k, v));
             }
@@ -534,6 +674,7 @@ fn run_workers(
         operation,
         concurrency,
         initial_entries,
+        manifest_shard_count,
         duration_secs,
         wall_start.elapsed(),
         all_latencies,
@@ -568,6 +709,7 @@ async fn main() {
     let mut table_count: usize = 667;
     let mut initial_entries: usize = 0;
     let mut inline_optimization = true;
+    let mut manifest_shard_count: usize = 0;
     let mut variant = String::new();
     let mut storage_options: HashMap<String, String> = HashMap::new();
 
@@ -618,6 +760,10 @@ async fn main() {
                 inline_optimization = args[i + 1].parse().unwrap();
                 i += 2;
             }
+            "--manifest-shard-count" => {
+                manifest_shard_count = args[i + 1].parse().unwrap();
+                i += 2;
+            }
             "--variant" => {
                 variant = args[i + 1].clone();
                 i += 2;
@@ -636,7 +782,9 @@ async fn main() {
     }
 
     if variant.is_empty() {
-        variant = if inline_optimization {
+        variant = if manifest_shard_count > 0 {
+            format!("sharded_{}", manifest_shard_count)
+        } else if inline_optimization {
             "inline_index".to_string()
         } else {
             "no_index".to_string()
@@ -645,7 +793,14 @@ async fn main() {
 
     match mode {
         "seed-large" => {
-            seed_large(&root, count, inline_optimization, &storage_options).await;
+            seed_large(
+                &root,
+                count,
+                inline_optimization,
+                manifest_shard_count,
+                &storage_options,
+            )
+            .await;
         }
         "worker" => {
             worker(
@@ -657,6 +812,7 @@ async fn main() {
                 worker_id,
                 table_count,
                 inline_optimization,
+                manifest_shard_count,
                 &storage_options,
             )
             .await;
@@ -674,8 +830,15 @@ async fn main() {
 
             eprintln!("=== Manifest commit benchmark ===");
             eprintln!(
-                "variant={} op={} root={} initial_entries={} concurrency={:?} operations={} duration_secs={}",
-                variant, op, root, initial_entries, concurrency_list, operations, duration_secs
+                "variant={} op={} root={} initial_entries={} manifest_shard_count={} concurrency={:?} operations={} duration_secs={}",
+                variant,
+                op,
+                root,
+                initial_entries,
+                manifest_shard_count,
+                concurrency_list,
+                operations,
+                duration_secs
             );
 
             for &concurrency in &concurrency_list {
@@ -689,6 +852,7 @@ async fn main() {
                     warmup,
                     table_count,
                     initial_entries,
+                    manifest_shard_count,
                     inline_optimization,
                     &variant,
                     &storage_options,

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -194,6 +194,9 @@ pub struct DirectoryNamespaceBuilder {
     manifest_enabled: bool,
     dir_listing_enabled: bool,
     inline_optimization_enabled: bool,
+    /// Number of manifest fragments used as shards. Zero keeps the default
+    /// single-fragment `__manifest` layout.
+    manifest_shard_count: usize,
     table_version_tracking_enabled: bool,
     /// When true, table versions are stored in the `__manifest` table instead of
     /// relying on Lance's native version management.
@@ -229,6 +232,7 @@ impl std::fmt::Debug for DirectoryNamespaceBuilder {
                 "inline_optimization_enabled",
                 &self.inline_optimization_enabled,
             )
+            .field("manifest_shard_count", &self.manifest_shard_count)
             .field(
                 "table_version_tracking_enabled",
                 &self.table_version_tracking_enabled,
@@ -272,6 +276,7 @@ impl DirectoryNamespaceBuilder {
             manifest_enabled: true,
             dir_listing_enabled: true, // Default to enabled for backwards compatibility
             inline_optimization_enabled: true,
+            manifest_shard_count: 0,
             table_version_tracking_enabled: false, // Default to disabled
             table_version_storage_enabled: false,  // Default to disabled
             dir_listing_to_manifest_migration_enabled: false, // Default to disabled
@@ -322,6 +327,16 @@ impl DirectoryNamespaceBuilder {
         self
     }
 
+    /// Configure the number of fragments in the `__manifest` table.
+    ///
+    /// A value of 0 keeps the default single-fragment layout. Values greater
+    /// than 0 create or open a sharded `__manifest` with exactly that many
+    /// fragments.
+    pub fn manifest_shard_count(mut self, shard_count: usize) -> Self {
+        self.manifest_shard_count = shard_count;
+        self
+    }
+
     /// Enable or disable table version tracking through the namespace.
     ///
     /// When enabled, `describe_table` returns `managed_versioning: true` to indicate
@@ -355,6 +370,7 @@ impl DirectoryNamespaceBuilder {
     /// - `manifest_enabled`: Enable manifest-based table tracking (optional, default: true)
     /// - `dir_listing_enabled`: Enable directory listing for table discovery (optional, default: true)
     /// - `inline_optimization_enabled`: Enable replacement indices on __manifest rewrites (optional, default: true)
+    /// - `manifest_shard_count`: Number of __manifest fragments to use as shards (optional, default: 0)
     /// - `storage.*`: Storage options (optional, prefix will be stripped)
     ///
     /// Credential vendor properties (prefixed with `credential_vendor.`, prefix is stripped):
@@ -458,6 +474,21 @@ impl DirectoryNamespaceBuilder {
             .and_then(|v| v.parse::<bool>().ok())
             .unwrap_or(true);
 
+        let manifest_shard_count = properties
+            .get("manifest_shard_count")
+            .map(|value| {
+                value.parse::<usize>().map_err(|e| {
+                    lance_core::Error::from(NamespaceError::InvalidInput {
+                        message: format!(
+                            "manifest_shard_count must be a non-negative integer, got '{}': {}",
+                            value, e
+                        ),
+                    })
+                })
+            })
+            .transpose()?
+            .unwrap_or(0);
+
         // Extract table_version_tracking_enabled (default: false)
         let table_version_tracking_enabled = properties
             .get("table_version_tracking_enabled")
@@ -515,6 +546,7 @@ impl DirectoryNamespaceBuilder {
             manifest_enabled,
             dir_listing_enabled,
             inline_optimization_enabled,
+            manifest_shard_count,
             table_version_tracking_enabled,
             table_version_storage_enabled,
             dir_listing_to_manifest_migration_enabled,
@@ -700,6 +732,12 @@ impl DirectoryNamespaceBuilder {
             }
             .into());
         }
+        if self.manifest_shard_count > 0 && !self.manifest_enabled {
+            return Err(NamespaceError::InvalidInput {
+                message: "manifest_shard_count requires manifest_enabled=true".to_string(),
+            }
+            .into());
+        }
 
         let (object_store, base_path) =
             Self::initialize_object_store(&self.root, &self.storage_options, &self.session).await?;
@@ -715,10 +753,12 @@ impl DirectoryNamespaceBuilder {
                 self.inline_optimization_enabled,
                 self.commit_retries,
                 self.table_version_storage_enabled,
+                (self.manifest_shard_count > 0).then_some(self.manifest_shard_count),
             )
             .await
             {
                 Ok(ns) => Some(Arc::new(ns)),
+                Err(e) if self.manifest_shard_count > 0 => return Err(e),
                 Err(e) => {
                     // Failed to initialize manifest namespace, fall back to directory listing only
                     log::warn!(
@@ -4652,6 +4692,7 @@ mod tests {
         QueryTableRequestColumns,
     };
     use lance_namespace::schema::convert_json_arrow_schema;
+    use std::collections::BTreeMap;
     use std::io::Cursor;
     use std::sync::{
         Arc,
@@ -4680,6 +4721,29 @@ mod tests {
             .await
             .unwrap();
         (namespace, temp_dir)
+    }
+
+    async fn open_manifest_dataset(root: &str) -> Dataset {
+        Dataset::open(&format!("{}/__manifest", root))
+            .await
+            .unwrap()
+    }
+
+    fn manifest_fragment_files(dataset: &Dataset) -> BTreeMap<u64, Vec<String>> {
+        dataset
+            .manifest()
+            .fragments
+            .iter()
+            .map(|fragment| {
+                let mut files = fragment
+                    .files
+                    .iter()
+                    .map(|file| file.path.clone())
+                    .collect::<Vec<_>>();
+                files.sort();
+                (fragment.id, files)
+            })
+            .collect()
     }
 
     #[derive(Debug)]
@@ -7429,6 +7493,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_from_properties_manifest_shard_count() {
+        let temp_dir = TempStdDir::default();
+
+        let mut properties = HashMap::new();
+        properties.insert("root".to_string(), temp_dir.to_str().unwrap().to_string());
+        properties.insert("manifest_shard_count".to_string(), "4".to_string());
+
+        let builder = DirectoryNamespaceBuilder::from_properties(properties, None).unwrap();
+        assert_eq!(builder.manifest_shard_count, 4);
+
+        let mut invalid_properties = HashMap::new();
+        invalid_properties.insert("root".to_string(), temp_dir.to_str().unwrap().to_string());
+        invalid_properties.insert(
+            "manifest_shard_count".to_string(),
+            "not-a-number".to_string(),
+        );
+        let err = DirectoryNamespaceBuilder::from_properties(invalid_properties, None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("manifest_shard_count must be a non-negative integer")
+        );
+
+        let err = DirectoryNamespaceBuilder::new(temp_dir.to_str().unwrap())
+            .manifest_enabled(false)
+            .manifest_shard_count(4)
+            .build()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("manifest_shard_count requires manifest_enabled=true")
+        );
+    }
+
+    #[tokio::test]
     async fn test_from_properties_with_storage_options() {
         let temp_dir = TempStdDir::default();
 
@@ -9084,6 +9183,127 @@ mod tests {
                 .unwrap()
                 .tables
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sharded_manifest_namespace_and_table_operations() {
+        use lance_namespace::models::{
+            DeclareTableRequest, DescribeTableRequest, ListNamespacesRequest, ListTablesRequest,
+            TableExistsRequest,
+        };
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let shard_count = 4;
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .manifest_shard_count(shard_count)
+            .build()
+            .await
+            .unwrap();
+
+        let manifest_before = open_manifest_dataset(temp_path).await;
+        assert_eq!(manifest_before.count_fragments(), shard_count);
+        assert_eq!(manifest_before.count_rows(None).await.unwrap(), shard_count);
+        let files_before = manifest_fragment_files(&manifest_before);
+
+        let mut create_ns_req = CreateNamespaceRequest::new();
+        create_ns_req.id = Some(vec!["team_a".to_string()]);
+        namespace.create_namespace(create_ns_req).await.unwrap();
+
+        let manifest_after = open_manifest_dataset(temp_path).await;
+        assert_eq!(manifest_after.count_fragments(), shard_count);
+        assert_eq!(
+            manifest_after.count_rows(None).await.unwrap(),
+            shard_count + 1
+        );
+        let files_after = manifest_fragment_files(&manifest_after);
+        assert_eq!(
+            files_before.keys().collect::<Vec<_>>(),
+            files_after.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            files_before
+                .iter()
+                .filter(|(fragment_id, files)| files_after.get(fragment_id) != Some(files))
+                .count(),
+            1
+        );
+
+        let mut list_ns_req = ListNamespacesRequest::new();
+        list_ns_req.id = Some(vec![]);
+        assert_eq!(
+            namespace
+                .list_namespaces(list_ns_req)
+                .await
+                .unwrap()
+                .namespaces,
+            vec!["team_a".to_string()]
+        );
+
+        let mut declare_req = DeclareTableRequest::new();
+        declare_req.id = Some(vec!["team_a".to_string(), "events".to_string()]);
+        declare_req.properties = Some(HashMap::from([(
+            "owner".to_string(),
+            "analytics".to_string(),
+        )]));
+        namespace.declare_table(declare_req).await.unwrap();
+
+        let mut exists_req = TableExistsRequest::new();
+        exists_req.id = Some(vec!["team_a".to_string(), "events".to_string()]);
+        namespace.table_exists(exists_req).await.unwrap();
+
+        let mut describe_req = DescribeTableRequest::new();
+        describe_req.id = Some(vec!["team_a".to_string(), "events".to_string()]);
+        describe_req.check_declared = Some(true);
+        let describe_response = namespace.describe_table(describe_req).await.unwrap();
+        assert_eq!(describe_response.is_only_declared, Some(true));
+        assert_eq!(
+            describe_response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get("owner")),
+            Some(&"analytics".to_string())
+        );
+
+        let mut list_tables_req = ListTablesRequest::new();
+        list_tables_req.id = Some(vec!["team_a".to_string()]);
+        assert_eq!(
+            namespace.list_tables(list_tables_req).await.unwrap().tables,
+            vec!["events".to_string()]
+        );
+
+        assert!(
+            !std::path::Path::new(temp_path)
+                .join("__manifest_shard_000000")
+                .exists()
+        );
+
+        let reopened = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+        let mut create_ns_req = CreateNamespaceRequest::new();
+        create_ns_req.id = Some(vec!["team_b".to_string()]);
+        reopened.create_namespace(create_ns_req).await.unwrap();
+        let manifest_after_reopen = open_manifest_dataset(temp_path).await;
+        assert_eq!(manifest_after_reopen.count_fragments(), shard_count);
+
+        let err = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .manifest_shard_count(shard_count + 1)
+            .build()
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("manifest_shard_count=4 but requested 5")
         );
     }
 
@@ -11297,6 +11517,22 @@ mod tests {
             )
         }
 
+        async fn create_sharded_managed_namespace(
+            temp_path: &str,
+            shard_count: usize,
+        ) -> Arc<DirectoryNamespace> {
+            Arc::new(
+                DirectoryNamespaceBuilder::new(temp_path)
+                    .table_version_tracking_enabled(true)
+                    .table_version_storage_enabled(true)
+                    .manifest_enabled(true)
+                    .manifest_shard_count(shard_count)
+                    .build()
+                    .await
+                    .unwrap(),
+            )
+        }
+
         /// Helper to create a table and get its staging manifest path
         async fn create_table_and_get_staging(
             namespace: Arc<dyn LanceNamespace>,
@@ -11423,6 +11659,36 @@ mod tests {
             );
             let (ver, _path) = &versions[0];
             assert_eq!(*ver, 2, "Recorded version should be 2");
+        }
+
+        #[tokio::test]
+        async fn test_sharded_create_table_version_records_in_manifest() {
+            let temp_dir = TempStrDir::default();
+            let temp_path: &str = &temp_dir;
+
+            let namespace = create_sharded_managed_namespace(temp_path, 4).await;
+            let ns: Arc<dyn LanceNamespace> = namespace.clone();
+
+            let (table_id, staging_path) =
+                create_table_and_get_staging(ns.clone(), "table_managed_sharded").await;
+
+            let mut create_req = CreateTableVersionRequest::new(2, staging_path.to_string());
+            create_req.id = Some(table_id.clone());
+            create_req.naming_scheme = Some("V2".to_string());
+            namespace.create_table_version(create_req).await.unwrap();
+
+            let manifest = open_manifest_dataset(temp_path).await;
+            assert_eq!(manifest.count_fragments(), 4);
+
+            let manifest_ns = namespace.manifest_ns.as_ref().unwrap();
+            let table_id_str = manifest::ManifestNamespace::str_object_id(&table_id);
+            let versions = manifest_ns
+                .query_table_versions(&table_id_str, false, None)
+                .await
+                .unwrap();
+
+            assert_eq!(versions.len(), 1);
+            assert_eq!(versions[0].0, 2);
         }
     }
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -26,10 +26,12 @@ use lance::dataset::transaction::{Operation, Transaction};
 use lance::dataset::{
     InsertBuilder, ReadParams, WhenMatched, WriteMode, WriteParams, builder::DatasetBuilder,
 };
+use lance::index::DatasetIndexExt;
 use lance::session::Session;
 use lance::{Dataset, dataset::scanner::Scanner};
 use lance_core::Error as LanceError;
 use lance_core::datatypes::LANCE_UNENFORCED_PRIMARY_KEY_POSITION;
+use lance_core::utils::address::RowAddress;
 use lance_core::{Error, ROW_ID, Result};
 use lance_index::progress::noop_progress;
 use lance_index::registry::IndexPluginRegistry;
@@ -88,6 +90,8 @@ const BASE_OBJECTS_INDEX_NAME: &str = "base_objects_label_list";
 // commit retry budget so multi-process namespace writes can make progress.
 const DEFAULT_MANIFEST_REWRITE_COMMIT_RETRIES: u32 = 20;
 const MANIFEST_INDEX_BATCH_SIZE: usize = 8192;
+const MANIFEST_FRAGMENT_SHARD_MARKER_ROWS_PER_FILE: usize = 1;
+const MANIFEST_SHARD_COUNT_PROPERTY: &str = "manifest_shard_count";
 
 /// Object types that can be stored in the manifest
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,6 +99,7 @@ pub enum ObjectType {
     Namespace,
     Table,
     TableVersion,
+    ShardMarker,
 }
 
 impl ObjectType {
@@ -103,6 +108,7 @@ impl ObjectType {
             Self::Namespace => "namespace",
             Self::Table => "table",
             Self::TableVersion => "table_version",
+            Self::ShardMarker => "shard_marker",
         }
     }
 
@@ -111,6 +117,7 @@ impl ObjectType {
             "namespace" => Ok(Self::Namespace),
             "table" => Ok(Self::Table),
             "table_version" => Ok(Self::TableVersion),
+            "shard_marker" => Ok(Self::ShardMarker),
             _ => Err(NamespaceError::Internal {
                 message: format!("Invalid object type: {}", s),
             }
@@ -173,7 +180,7 @@ pub struct TableInfo {
 pub struct ManifestEntry {
     /// The unique object identifier (e.g., table name or version object_id)
     pub object_id: String,
-    /// The type of the object (Namespace, Table, or TableVersion)
+    /// The type of the object (Namespace, Table, TableVersion, or ShardMarker)
     pub object_type: ObjectType,
     /// The storage location (e.g., directory name for tables)
     pub location: Option<String>,
@@ -233,35 +240,52 @@ struct ManifestOutputRow<'a> {
     base_objects: Option<&'a [String]>,
 }
 
-#[derive(Default)]
 struct ManifestIndexAccumulator {
     object_ids: BTreeMap<Arc<str>, u64>,
-    object_types: BTreeMap<&'static str, RoaringBitmap>,
+    object_types: BTreeMap<&'static str, Vec<u64>>,
     base_objects_values: Vec<Option<Vec<String>>>,
     base_objects_row_ids: Vec<u64>,
+    fragment_id: u32,
     row_count: u64,
 }
 
 impl ManifestIndexAccumulator {
+    fn new(fragment_id: u32) -> Self {
+        Self {
+            object_ids: BTreeMap::new(),
+            object_types: BTreeMap::new(),
+            base_objects_values: Vec::new(),
+            base_objects_row_ids: Vec::new(),
+            fragment_id,
+            row_count: 0,
+        }
+    }
+
     fn next_row_id(&self) -> Result<u64> {
         if self.row_count >= u64::from(u32::MAX) {
             return Err(NamespaceError::Internal {
                 message: format!(
-                    "Manifest rewrite exceeded maximum single-fragment row count: {}",
-                    self.row_count
+                    "Manifest rewrite exceeded maximum row count for fragment {}: {}",
+                    self.fragment_id, self.row_count
                 ),
             }
             .into());
         }
-        Ok(self.row_count)
+        Ok(RowAddress::new_from_parts(self.fragment_id, self.row_count as u32).into())
     }
 
     fn push(&mut self, row: &ManifestOutputRow<'_>) -> Result<u64> {
         let row_id = self.next_row_id()?;
-        if self
-            .object_ids
-            .insert(Arc::<str>::from(row.object_id), row_id)
-            .is_some()
+        self.push_row_id(row, row_id)?;
+        Ok(row_id)
+    }
+
+    fn push_row_id(&mut self, row: &ManifestOutputRow<'_>, row_id: u64) -> Result<()> {
+        if row.object_type != ObjectType::ShardMarker
+            && self
+                .object_ids
+                .insert(Arc::<str>::from(row.object_id), row_id)
+                .is_some()
         {
             return Err(NamespaceError::Internal {
                 message: format!("Manifest contains duplicate object_id '{}'", row.object_id),
@@ -271,12 +295,18 @@ impl ManifestIndexAccumulator {
         self.object_types
             .entry(row.object_type.as_str())
             .or_default()
-            .insert(row_id as u32);
+            .push(row_id);
         self.base_objects_values
             .push(row.base_objects.map(|objects| objects.to_vec()));
         self.base_objects_row_ids.push(row_id);
         self.row_count += 1;
-        Ok(row_id)
+        Ok(())
+    }
+}
+
+impl Default for ManifestIndexAccumulator {
+    fn default() -> Self {
+        Self::new(0)
     }
 }
 
@@ -386,10 +416,10 @@ struct ManifestRewriteShared<M: ManifestStreamMutation> {
 }
 
 impl<M: ManifestStreamMutation> ManifestRewriteShared<M> {
-    fn new(mutation: M) -> Self {
+    fn new(mutation: M, fragment_id: u32) -> Self {
         Self {
             mutation,
-            index_data: Some(ManifestIndexAccumulator::default()),
+            index_data: Some(ManifestIndexAccumulator::new(fragment_id)),
             result: None,
             error: None,
         }
@@ -450,7 +480,9 @@ impl ManifestStreamMutation for UpsertManifestMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
-        if let Some(index) = self.entry_positions.get(&row.object_id).copied() {
+        if row.object_type != ObjectType::ShardMarker
+            && let Some(index) = self.entry_positions.get(&row.object_id).copied()
+        {
             match self.when_matched {
                 WhenMatched::Fail => {
                     return Err(NamespaceError::ConcurrentModification {
@@ -526,7 +558,7 @@ struct DeleteObjectMutation {
 }
 
 impl ManifestStreamMutation for DeleteObjectMutation {
-    type Output = ();
+    type Output = bool;
 
     fn process_existing_row(
         &mut self,
@@ -534,7 +566,7 @@ impl ManifestStreamMutation for DeleteObjectMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
-        if row.object_id == self.object_id {
+        if row.object_type != ObjectType::ShardMarker && row.object_id == self.object_id {
             self.deleted = true;
             return Ok(());
         }
@@ -561,9 +593,9 @@ impl ManifestStreamMutation for DeleteObjectMutation {
 
     fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
         if self.deleted {
-            CopyOnWriteMutation::updated(())
+            CopyOnWriteMutation::updated(true)
         } else {
-            CopyOnWriteMutation::unchanged(())
+            CopyOnWriteMutation::unchanged(false)
         }
     }
 
@@ -571,7 +603,7 @@ impl ManifestStreamMutation for DeleteObjectMutation {
         // If a concurrent writer already removed the object, the delete is satisfied.
         ConflictResolution::SucceedIfAbsent {
             object_id: self.object_id.clone(),
-            output: (),
+            output: true,
         }
     }
 }
@@ -580,6 +612,9 @@ enum DeleteTableVersionsTarget {
     ObjectIds(HashSet<String>),
     Ranges(Vec<DeleteTableVersionRangeTarget>),
 }
+
+type TableVersionRangeGroup = Vec<(String, Vec<(i64, i64)>)>;
+type TableVersionRangeGroupsByShard = HashMap<usize, TableVersionRangeGroup>;
 
 #[derive(Clone)]
 struct DeleteTableVersionRangeTarget {
@@ -819,6 +854,10 @@ pub struct ManifestNamespace {
     /// Number of retries for commit operations on the manifest table.
     /// If None, defaults to [`lance_table::io::commit::CommitConfig`] default (20).
     commit_retries: Option<u32>,
+    /// When set, the single `__manifest` table is partitioned into this many
+    /// Lance fragments and each manifest mutation rewrites only the routed
+    /// fragment.
+    manifest_fragment_shard_count: Option<usize>,
     /// Serialize manifest mutations within a single namespace instance so concurrent
     /// create/drop calls do not compete with each other on the same in-memory snapshot.
     manifest_mutation_lock: Arc<Mutex<()>>,
@@ -833,6 +872,10 @@ impl std::fmt::Debug for ManifestNamespace {
             .field(
                 "inline_optimization_enabled",
                 &self.inline_optimization_enabled,
+            )
+            .field(
+                "manifest_fragment_shard_count",
+                &self.manifest_fragment_shard_count,
             )
             .finish()
     }
@@ -909,14 +952,17 @@ impl ManifestNamespace {
         inline_optimization_enabled: bool,
         commit_retries: Option<u32>,
         table_version_storage_enabled: bool,
+        manifest_fragment_shard_count: Option<usize>,
     ) -> Result<Self> {
-        let manifest_dataset = Self::ensure_manifest_table_up_to_date(
-            &root,
-            &storage_options,
-            session.clone(),
-            table_version_storage_enabled,
-        )
-        .await?;
+        let (manifest_dataset, manifest_fragment_shard_count) =
+            Self::ensure_manifest_table_up_to_date(
+                &root,
+                &storage_options,
+                session.clone(),
+                table_version_storage_enabled,
+                manifest_fragment_shard_count,
+            )
+            .await?;
 
         Ok(Self {
             root,
@@ -928,6 +974,7 @@ impl ManifestNamespace {
             dir_listing_enabled,
             inline_optimization_enabled,
             commit_retries,
+            manifest_fragment_shard_count,
             manifest_mutation_lock: Arc::new(Mutex::new(())),
         })
     }
@@ -1002,6 +1049,146 @@ impl ManifestNamespace {
 
     fn build_version_object_id_prefix(table_object_id: &str) -> String {
         format!("{}{}", table_object_id, DELIMITER)
+    }
+
+    fn stable_hash(value: &str) -> u64 {
+        let mut hash = 0xcbf29ce484222325u64;
+        for byte in value.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        hash
+    }
+
+    fn table_version_table_id(version_object_id: &str) -> &str {
+        version_object_id
+            .rsplit_once(DELIMITER)
+            .map(|(table_id, _version)| table_id)
+            .unwrap_or(version_object_id)
+    }
+
+    fn table_version_table_id_if_version_object_id(object_id: &str) -> Option<&str> {
+        let (table_id, version) = object_id.rsplit_once(DELIMITER)?;
+        if version.len() == 20 && version.bytes().all(|byte| byte.is_ascii_digit()) {
+            Some(table_id)
+        } else {
+            None
+        }
+    }
+
+    fn shard_key_for_entry(entry: &ManifestEntry) -> &str {
+        match entry.object_type {
+            ObjectType::TableVersion => Self::table_version_table_id(&entry.object_id),
+            _ => &entry.object_id,
+        }
+    }
+
+    fn shard_index_for_key(shard_count: usize, key: &str) -> usize {
+        (Self::stable_hash(key) % shard_count as u64) as usize
+    }
+
+    fn shard_count(&self) -> Option<usize> {
+        self.manifest_fragment_shard_count
+    }
+
+    fn persisted_manifest_shard_count(dataset: &Dataset) -> Result<Option<usize>> {
+        let Some(value) = dataset.metadata().get(MANIFEST_SHARD_COUNT_PROPERTY) else {
+            return Ok(None);
+        };
+        let shard_count = value.parse::<usize>().map_err(|e| {
+            lance_core::Error::from(NamespaceError::InvalidInput {
+                message: format!(
+                    "Invalid persisted {} value '{}': {}",
+                    MANIFEST_SHARD_COUNT_PROPERTY, value, e
+                ),
+            })
+        })?;
+        if shard_count == 0 {
+            return Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "Invalid persisted {} value '0': shard count must be greater than 0",
+                    MANIFEST_SHARD_COUNT_PROPERTY
+                ),
+            }
+            .into());
+        }
+        Ok(Some(shard_count))
+    }
+
+    async fn persist_manifest_shard_count(dataset: &mut Dataset, shard_count: usize) -> Result<()> {
+        if dataset
+            .metadata()
+            .get(MANIFEST_SHARD_COUNT_PROPERTY)
+            .is_some_and(|value| value == &shard_count.to_string())
+        {
+            return Ok(());
+        }
+        dataset
+            .update_metadata([(
+                MANIFEST_SHARD_COUNT_PROPERTY.to_string(),
+                shard_count.to_string(),
+            )])
+            .await
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Failed to persist {}={} in __manifest metadata: {}",
+                        MANIFEST_SHARD_COUNT_PROPERTY, shard_count, e
+                    ),
+                })
+            })?;
+        Ok(())
+    }
+
+    async fn resolve_manifest_shard_count(
+        dataset: &mut Dataset,
+        requested_shard_count: Option<usize>,
+    ) -> Result<Option<usize>> {
+        let persisted_shard_count = Self::persisted_manifest_shard_count(dataset)?;
+        let effective_shard_count = match (requested_shard_count, persisted_shard_count) {
+            (Some(requested), Some(persisted)) if requested != persisted => {
+                return Err(NamespaceError::InvalidInput {
+                    message: format!(
+                        "Existing __manifest table has {}={} but requested {}",
+                        MANIFEST_SHARD_COUNT_PROPERTY, persisted, requested
+                    ),
+                }
+                .into());
+            }
+            (Some(requested), _) => Some(requested),
+            (None, Some(persisted)) => Some(persisted),
+            (None, None) => None,
+        };
+
+        if let Some(shard_count) = effective_shard_count {
+            let fragment_count = dataset.manifest().fragments.len();
+            if fragment_count != shard_count {
+                return Err(NamespaceError::InvalidInput {
+                    message: format!(
+                        "Existing __manifest table has {} fragments but {} is {}",
+                        fragment_count, MANIFEST_SHARD_COUNT_PROPERTY, shard_count
+                    ),
+                }
+                .into());
+            }
+            if persisted_shard_count != Some(shard_count) {
+                Self::persist_manifest_shard_count(dataset, shard_count).await?;
+            }
+        }
+
+        Ok(effective_shard_count)
+    }
+
+    fn delete_shard_indices_for_object_id(&self, object_id: &str) -> Option<Vec<usize>> {
+        let shard_count = self.shard_count()?;
+        let mut shard_indices = vec![Self::shard_index_for_key(shard_count, object_id)];
+        if let Some(table_id) = Self::table_version_table_id_if_version_object_id(object_id) {
+            let table_shard_index = Self::shard_index_for_key(shard_count, table_id);
+            if !shard_indices.contains(&table_shard_index) {
+                shard_indices.push(table_shard_index);
+            }
+        }
+        Some(shard_indices)
     }
 
     fn normalize_table_version_ranges(ranges: &[(i64, i64)]) -> Vec<(i64, i64)> {
@@ -1189,7 +1376,7 @@ impl ManifestNamespace {
     }
 
     fn object_type_index_stream(
-        object_types: BTreeMap<&'static str, RoaringBitmap>,
+        object_types: BTreeMap<&'static str, Vec<u64>>,
     ) -> SendableRecordBatchStream {
         let schema =
             Self::value_row_id_schema(Field::new(VALUE_COLUMN_NAME, DataType::Utf8, false));
@@ -1199,7 +1386,7 @@ impl ManifestNamespace {
             .map(|(value, bitmap)| {
                 (
                     value,
-                    Box::new(bitmap.into_iter()) as Box<dyn Iterator<Item = u32> + Send>,
+                    Box::new(bitmap.into_iter()) as Box<dyn Iterator<Item = u64> + Send>,
                 )
             })
             .collect::<Vec<_>>()
@@ -1218,7 +1405,7 @@ impl ManifestNamespace {
                     };
                     if let Some(row_id) = iter.next() {
                         values.push((*value).to_string());
-                        row_ids.push(u64::from(row_id));
+                        row_ids.push(row_id);
                     } else {
                         current = None;
                     }
@@ -1342,14 +1529,18 @@ impl ManifestNamespace {
     fn manifest_fragment_bitmap(manifest: &Manifest) -> Result<RoaringBitmap> {
         let mut bitmap = RoaringBitmap::new();
         for fragment in manifest.fragments.iter() {
-            let fragment_id = u32::try_from(fragment.id).map_err(|_| {
-                lance_core::Error::from(NamespaceError::Internal {
-                    message: format!("Manifest fragment id {} exceeds u32", fragment.id),
-                })
-            })?;
+            let fragment_id = Self::fragment_id_for_row_address(fragment.id)?;
             bitmap.insert(fragment_id);
         }
         Ok(bitmap)
+    }
+
+    fn fragment_id_for_row_address(fragment_id: u64) -> Result<u32> {
+        u32::try_from(fragment_id).map_err(|_| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Manifest fragment id {} exceeds u32", fragment_id),
+            })
+        })
     }
 
     fn manifest_from_overwrite_transaction(
@@ -1380,6 +1571,40 @@ impl ManifestNamespace {
         index_uuids: [Uuid; 3],
     ) -> Result<Vec<IndexMetadata>> {
         let fragment_bitmap = Self::manifest_fragment_bitmap(manifest)?;
+        Self::build_manifest_indices_for_bitmap(
+            dataset,
+            manifest,
+            index_data,
+            index_uuids,
+            fragment_bitmap,
+        )
+        .await
+    }
+
+    async fn build_manifest_indices_for_fragment(
+        dataset: &Dataset,
+        manifest: &Manifest,
+        index_data: ManifestIndexAccumulator,
+        index_uuids: [Uuid; 3],
+        fragment_id: u32,
+    ) -> Result<Vec<IndexMetadata>> {
+        Self::build_manifest_indices_for_bitmap(
+            dataset,
+            manifest,
+            index_data,
+            index_uuids,
+            RoaringBitmap::from_iter([fragment_id]),
+        )
+        .await
+    }
+
+    async fn build_manifest_indices_for_bitmap(
+        dataset: &Dataset,
+        manifest: &Manifest,
+        index_data: ManifestIndexAccumulator,
+        index_uuids: [Uuid; 3],
+        fragment_bitmap: RoaringBitmap,
+    ) -> Result<Vec<IndexMetadata>> {
         let schema = &manifest.schema;
         let ManifestIndexAccumulator {
             object_ids,
@@ -1455,6 +1680,111 @@ impl ManifestNamespace {
         ])
     }
 
+    fn is_manifest_index_name(name: &str) -> bool {
+        matches!(
+            name,
+            OBJECT_ID_INDEX_NAME | OBJECT_TYPE_INDEX_NAME | BASE_OBJECTS_INDEX_NAME
+        )
+    }
+
+    fn manifest_index_is_shard_local(index: &IndexMetadata) -> bool {
+        index
+            .fragment_bitmap
+            .as_ref()
+            .is_some_and(|fragment_bitmap| fragment_bitmap.len() == 1)
+    }
+
+    fn manifest_indices_are_shard_local(
+        manifest: &Manifest,
+        indices: &[IndexMetadata],
+    ) -> Result<bool> {
+        let expected_fragments = Self::manifest_fragment_bitmap(manifest)?;
+        for index_name in [
+            OBJECT_ID_INDEX_NAME,
+            OBJECT_TYPE_INDEX_NAME,
+            BASE_OBJECTS_INDEX_NAME,
+        ] {
+            let mut covered_fragments = RoaringBitmap::new();
+            let mut found = false;
+            for index in indices.iter().filter(|index| index.name == index_name) {
+                found = true;
+                let Some(fragment_bitmap) = index.fragment_bitmap.as_ref() else {
+                    return Ok(false);
+                };
+                if !Self::manifest_index_is_shard_local(index)
+                    || covered_fragments.intersection_len(fragment_bitmap) != 0
+                {
+                    return Ok(false);
+                }
+                covered_fragments |= fragment_bitmap.clone();
+            }
+            if !found || covered_fragments != expected_fragments {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn replace_manifest_index_segments(
+        existing_indices: Vec<IndexMetadata>,
+        fragment_id: u32,
+        replacement_indices: Vec<IndexMetadata>,
+    ) -> Vec<IndexMetadata> {
+        existing_indices
+            .into_iter()
+            .filter(|index| {
+                !Self::is_manifest_index_name(&index.name)
+                    || !index
+                        .fragment_bitmap
+                        .as_ref()
+                        .is_some_and(|fragment_bitmap| fragment_bitmap.contains(fragment_id))
+            })
+            .chain(replacement_indices)
+            .collect()
+    }
+
+    async fn build_all_manifest_shard_indices(
+        dataset: &Dataset,
+        manifest: &Manifest,
+        replaced_fragment_id: u32,
+        replaced_fragment_index_data: ManifestIndexAccumulator,
+        staged_index_uuids: &mut Vec<Uuid>,
+    ) -> Result<Vec<IndexMetadata>> {
+        let mut indices = Vec::new();
+        let mut replaced_fragment_index_data = Some(replaced_fragment_index_data);
+
+        for fragment in manifest.fragments.iter() {
+            let fragment_id = Self::fragment_id_for_row_address(fragment.id)?;
+            let index_data = if fragment_id == replaced_fragment_id {
+                replaced_fragment_index_data.take().ok_or_else(|| {
+                    lance_core::Error::from(NamespaceError::Internal {
+                        message: format!(
+                            "Missing replacement index data for manifest fragment {}",
+                            fragment_id
+                        ),
+                    })
+                })?
+            } else {
+                Self::collect_manifest_index_data_from_fragments(dataset, vec![fragment.clone()])
+                    .await?
+            };
+            let fragment_index_uuids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+            staged_index_uuids.extend(fragment_index_uuids.iter().copied());
+            indices.extend(
+                Self::build_manifest_indices_for_fragment(
+                    dataset,
+                    manifest,
+                    index_data,
+                    fragment_index_uuids,
+                    fragment_id,
+                )
+                .await?,
+            );
+        }
+
+        Ok(indices)
+    }
+
     async fn build_manifest_index(
         dataset: &Dataset,
         registry: Arc<IndexPluginRegistry>,
@@ -1497,10 +1827,54 @@ impl ManifestNamespace {
         ]))
     }
 
+    fn shard_marker_object_id(shard_index: usize) -> String {
+        format!("__manifest_shard_marker_{:06}", shard_index)
+    }
+
+    fn manifest_shard_marker_batch(
+        schema: Arc<ArrowSchema>,
+        shard_index: usize,
+    ) -> Result<RecordBatch> {
+        let base_objects = Self::base_objects_array(&[None]);
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Self::shard_marker_object_id(
+                    shard_index,
+                )])),
+                Arc::new(StringArray::from(vec![ObjectType::ShardMarker.as_str()])),
+                Arc::new(StringArray::from(vec![None::<String>])),
+                Arc::new(StringArray::from(vec![None::<String>])),
+                Arc::new(base_objects),
+            ],
+        )
+        .map_err(|e| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Failed to create manifest shard marker batch: {:?}", e),
+            })
+        })
+    }
+
     /// Get a scanner for the manifest dataset
     async fn manifest_scanner(&self) -> Result<Scanner> {
         let dataset_guard = self.manifest_dataset.get().await?;
         Ok(dataset_guard.scan())
+    }
+
+    async fn manifest_scanner_for_shard(&self, shard_index: usize) -> Result<Scanner> {
+        let dataset_guard = self.manifest_dataset.get().await?;
+        let fragment = Self::manifest_shard_fragment(&dataset_guard, shard_index)?;
+        let mut scanner = dataset_guard.scan();
+        scanner.with_fragments(vec![fragment]);
+        Ok(scanner)
+    }
+
+    async fn manifest_scanner_for_shard_key(&self, shard_key: &str) -> Result<Scanner> {
+        let Some(shard_count) = self.shard_count() else {
+            return self.manifest_scanner().await;
+        };
+        let shard_index = Self::shard_index_for_key(shard_count, shard_key);
+        self.manifest_scanner_for_shard(shard_index).await
     }
 
     /// Helper to execute a scanner and collect results into a Vec
@@ -1536,6 +1910,22 @@ impl ManifestNamespace {
             .ok_or_else(|| {
                 lance_core::Error::from(NamespaceError::Internal {
                     message: format!("Column '{}' is not a string array", column_name),
+                })
+            })
+    }
+
+    fn get_u64_column<'a>(batch: &'a RecordBatch, column_name: &str) -> Result<&'a UInt64Array> {
+        let column = batch.column_by_name(column_name).ok_or_else(|| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Column '{}' not found", column_name),
+            })
+        })?;
+        column
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!("Column '{}' is not a uint64 array", column_name),
                 })
             })
     }
@@ -1604,8 +1994,60 @@ impl ManifestNamespace {
         Ok(values)
     }
 
+    fn append_manifest_index_batch(
+        index_data: &mut ManifestIndexAccumulator,
+        batch: &RecordBatch,
+    ) -> Result<()> {
+        let object_ids = Self::get_string_column(batch, "object_id")?;
+        let object_types = Self::get_string_column(batch, "object_type")?;
+        let base_objects = Self::base_objects_column_values(batch)?;
+        let row_ids = Self::get_u64_column(batch, ROW_ID)?;
+
+        for (row, base_objects) in base_objects.into_iter().enumerate().take(batch.num_rows()) {
+            if row_ids.is_null(row) {
+                return Err(NamespaceError::Internal {
+                    message: format!("Manifest row id column has null at row {}", row),
+                }
+                .into());
+            }
+            let row_value = ManifestOutputRow {
+                object_id: Self::required_string_value(object_ids, row, "object_id")?,
+                object_type: ObjectType::parse(Self::required_string_value(
+                    object_types,
+                    row,
+                    "object_type",
+                )?)?,
+                location: None,
+                metadata: None,
+                base_objects: base_objects.as_deref(),
+            };
+            index_data.push_row_id(&row_value, row_ids.value(row))?;
+        }
+
+        Ok(())
+    }
+
     async fn manifest_projected_stream(dataset: &Dataset) -> Result<SendableRecordBatchStream> {
+        Self::manifest_projected_stream_for_fragments(dataset, None).await
+    }
+
+    async fn manifest_projected_stream_for_fragments(
+        dataset: &Dataset,
+        fragments: Option<Vec<Fragment>>,
+    ) -> Result<SendableRecordBatchStream> {
+        if fragments
+            .as_ref()
+            .is_some_and(|fragments| fragments.iter().all(|fragment| fragment.files.is_empty()))
+        {
+            return Ok(Box::pin(DatafusionRecordBatchStreamAdapter::new(
+                Self::manifest_schema(),
+                stream::empty(),
+            )));
+        }
         let mut scanner = dataset.scan();
+        if let Some(fragments) = fragments {
+            scanner.with_fragments(fragments);
+        }
         scanner
             .project(&[
                 "object_id",
@@ -1630,6 +2072,53 @@ impl ManifestNamespace {
             schema,
             stream.fuse(),
         )))
+    }
+
+    async fn collect_manifest_index_data_from_fragments(
+        dataset: &Dataset,
+        fragments: Vec<Fragment>,
+    ) -> Result<ManifestIndexAccumulator> {
+        let fragments = fragments
+            .into_iter()
+            .filter(|fragment| !fragment.files.is_empty())
+            .collect::<Vec<_>>();
+        let mut index_data = ManifestIndexAccumulator::default();
+        if fragments.is_empty() {
+            return Ok(index_data);
+        }
+
+        let mut scanner = dataset.scan();
+        scanner.with_fragments(fragments);
+        scanner
+            .project(&[
+                "object_id",
+                "object_type",
+                "location",
+                "metadata",
+                "base_objects",
+            ])
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!("Failed to project manifest columns: {:?}", e),
+                })
+            })?;
+        scanner.with_row_id();
+        let mut stream = scanner.try_into_stream().await.map_err(|e| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Failed to create manifest stream: {:?}", e),
+            })
+        })?;
+
+        while let Some(batch) = stream.next().await {
+            let batch = batch.map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!("Failed to read manifest index batch: {:?}", e),
+                })
+            })?;
+            Self::append_manifest_index_batch(&mut index_data, &batch)?;
+        }
+
+        Ok(index_data)
     }
 
     fn manifest_rewrite_commit_retries(&self) -> u32 {
@@ -1882,9 +2371,9 @@ impl ManifestNamespace {
     }
 
     /// Directly write the rewritten `__manifest` as a new version using the storage
-    /// backend's atomic put-if-not-exists. The overwrite transaction is embedded inline
+    /// backend's atomic put-if-not-exists. The transaction is embedded inline
     /// (no separate transaction file) and the commit handler writes the version hint.
-    async fn commit_manifest_overwrite(
+    async fn commit_manifest_transaction(
         &self,
         dataset: &Dataset,
         commit_handler: &dyn CommitHandler,
@@ -1997,12 +2486,15 @@ impl ManifestNamespace {
             let dataset = Arc::new(dataset_guard.clone());
             drop(dataset_guard);
             // Staged files, indices, the commit, and cleanup must all use the dataset's
-            // own object store (see `commit_manifest_overwrite`).
+            // own object store (see `commit_manifest_transaction`).
             let object_store = dataset.object_store(None).await?;
 
             let source = Self::manifest_projected_stream(&dataset).await?;
             let resolution = make_mutation().conflict_resolution();
-            let shared = Arc::new(StdMutex::new(ManifestRewriteShared::new(make_mutation())));
+            let shared = Arc::new(StdMutex::new(ManifestRewriteShared::new(
+                make_mutation(),
+                0,
+            )));
             let output_stream = Self::manifest_rewrite_output_stream(source, shared.clone());
             // Pin both limits so the overwrite never splits into multiple fragments: the
             // replacement indices map each row to address `(0 << 32) | offset`, valid only
@@ -2086,7 +2578,7 @@ impl ManifestNamespace {
             let staged_index_uuids: &[Uuid] = if build_indices { &index_uuids } else { &[] };
 
             let commit_result = self
-                .commit_manifest_overwrite(
+                .commit_manifest_transaction(
                     &dataset,
                     commit_handler.as_ref(),
                     &mut manifest,
@@ -2148,13 +2640,365 @@ impl ManifestNamespace {
         }
     }
 
-    /// Check if the manifest contains an object with the given ID
-    async fn manifest_contains_object(&self, object_id: &str) -> Result<bool> {
-        let escaped_id = object_id.replace('\'', "''");
-        let filter = format!("object_id = '{}'", escaped_id);
+    fn manifest_shard_fragment(dataset: &Dataset, shard_index: usize) -> Result<Fragment> {
+        let mut fragments = dataset.manifest().fragments.iter().collect::<Vec<_>>();
+        fragments.sort_by_key(|fragment| fragment.id);
+        fragments
+            .get(shard_index)
+            .map(|fragment| (*fragment).clone())
+            .ok_or_else(|| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!(
+                        "Manifest shard fragment {} is missing from __manifest",
+                        shard_index
+                    ),
+                })
+            })
+    }
 
-        let dataset_guard = self.manifest_dataset.get().await?;
-        let mut scanner = dataset_guard.scan();
+    fn staged_data_files(fragments: &[Fragment]) -> HashSet<String> {
+        fragments
+            .iter()
+            .flat_map(|fragment| fragment.files.iter())
+            .filter(|file| file.base_id.is_none())
+            .map(|file| file.path.clone())
+            .collect()
+    }
+
+    fn all_manifest_field_ids(dataset: &Dataset) -> Vec<u32> {
+        dataset
+            .schema()
+            .fields
+            .iter()
+            .map(|field| field.id as u32)
+            .collect()
+    }
+
+    fn manifest_with_replaced_fragment(
+        previous: &Manifest,
+        replacement_fragment: Fragment,
+    ) -> Result<Manifest> {
+        Self::manifest_with_replaced_fragments(previous, vec![replacement_fragment])
+    }
+
+    fn manifest_with_replaced_fragments(
+        previous: &Manifest,
+        replacement_fragments: Vec<Fragment>,
+    ) -> Result<Manifest> {
+        let mut replacements = HashMap::with_capacity(replacement_fragments.len());
+        for replacement_fragment in replacement_fragments {
+            if replacements
+                .insert(replacement_fragment.id, replacement_fragment)
+                .is_some()
+            {
+                return Err(NamespaceError::Internal {
+                    message: "Manifest shard replacement contained duplicate fragment ids"
+                        .to_string(),
+                }
+                .into());
+            }
+        }
+        let mut fragments = previous
+            .fragments
+            .iter()
+            .map(|fragment| {
+                if let Some(replacement_fragment) = replacements.remove(&fragment.id) {
+                    replacement_fragment
+                } else {
+                    fragment.clone()
+                }
+            })
+            .collect::<Vec<_>>();
+        if !replacements.is_empty() {
+            return Err(NamespaceError::Internal {
+                message: format!(
+                    "Manifest shard replacement fragments {:?} do not match existing fragments",
+                    replacements.keys().collect::<Vec<_>>()
+                ),
+            }
+            .into());
+        }
+        fragments.sort_by_key(|fragment| fragment.id);
+        Ok(Manifest::new_from_previous(
+            previous,
+            previous.schema.clone(),
+            Arc::new(fragments),
+        ))
+    }
+
+    async fn rewrite_manifest_shard<M, F>(
+        &self,
+        shard_index: usize,
+        operation: &str,
+        mut make_mutation: F,
+    ) -> Result<M::Output>
+    where
+        M: ManifestStreamMutation + 'static,
+        F: FnMut() -> M,
+    {
+        let _mutation_guard = self.manifest_mutation_lock.lock().await;
+        let max_retries = self.manifest_rewrite_commit_retries();
+        let mut retries = 0;
+        let build_indices = self.inline_optimization_enabled;
+        let commit_handler = self.manifest_commit_handler().await?;
+
+        loop {
+            let dataset_guard = self.manifest_dataset.get_refreshed().await?;
+            let dataset = Arc::new(dataset_guard.clone());
+            drop(dataset_guard);
+            let object_store = dataset.object_store(None).await?;
+
+            let old_fragment = Self::manifest_shard_fragment(&dataset, shard_index)?;
+            let shard_fragment_id = Self::fragment_id_for_row_address(old_fragment.id)?;
+            let source = Self::manifest_projected_stream_for_fragments(
+                &dataset,
+                Some(vec![old_fragment.clone()]),
+            )
+            .await?;
+            let resolution = make_mutation().conflict_resolution();
+            let shared = Arc::new(StdMutex::new(ManifestRewriteShared::new(
+                make_mutation(),
+                shard_fragment_id,
+            )));
+            let output_stream = Self::manifest_rewrite_output_stream(source, shared.clone());
+            let write_params = WriteParams {
+                mode: WriteMode::Append,
+                session: self.session.clone(),
+                max_rows_per_file: u32::MAX as usize,
+                max_bytes_per_file: usize::MAX,
+                skip_auto_cleanup: true,
+                ..WriteParams::default()
+            };
+
+            let append_transaction = match InsertBuilder::new(dataset.clone())
+                .with_params(&write_params)
+                .execute_uncommitted_stream(output_stream)
+                .await
+            {
+                Ok(transaction) => transaction,
+                Err(err) => {
+                    if let Some(stream_err) = Self::take_manifest_rewrite_error(&shared)? {
+                        return Err(stream_err);
+                    }
+                    return Err(convert_lance_commit_error(&err, operation, None));
+                }
+            };
+
+            let (mutation, shard_index_data) = Self::take_manifest_rewrite_result(&shared)?;
+            let Operation::Append { mut fragments } = append_transaction.operation else {
+                return Err(NamespaceError::Internal {
+                    message: "Manifest shard rewrite transaction is not an append".to_string(),
+                }
+                .into());
+            };
+            let staged_data_files = Self::staged_data_files(&fragments);
+
+            if !mutation.has_changes {
+                self.cleanup_staged_manifest_files(&object_store, &staged_data_files, &[])
+                    .await;
+                return Ok(mutation.result);
+            }
+
+            if fragments.len() != 1 {
+                self.cleanup_staged_manifest_files(&object_store, &staged_data_files, &[])
+                    .await;
+                return Err(NamespaceError::Internal {
+                    message: format!(
+                        "Manifest shard rewrite expected one replacement fragment, got {}",
+                        fragments.len()
+                    ),
+                }
+                .into());
+            }
+
+            let mut replacement_fragment = fragments.remove(0);
+            replacement_fragment.id = old_fragment.id;
+            let update = Operation::Update {
+                removed_fragment_ids: vec![],
+                updated_fragments: vec![replacement_fragment.clone()],
+                new_fragments: vec![],
+                fields_modified: Self::all_manifest_field_ids(&dataset),
+                merged_generations: vec![],
+                fields_for_preserving_frag_bitmap: vec![],
+                update_mode: None,
+                inserted_rows_filter: None,
+                updated_fragment_offsets: None,
+            };
+            let update_transaction =
+                Transaction::new_from_version(dataset.manifest().version, update);
+            let mut manifest = match Self::manifest_with_replaced_fragment(
+                dataset.manifest(),
+                replacement_fragment,
+            ) {
+                Ok(manifest) => manifest,
+                Err(err) => {
+                    self.cleanup_staged_manifest_files(&object_store, &staged_data_files, &[])
+                        .await;
+                    return Err(err);
+                }
+            };
+            let target_version = manifest.version;
+
+            let mut staged_index_uuids = Vec::new();
+            let indices = if build_indices {
+                let existing_indices = match dataset.load_indices().await {
+                    Ok(indices) => indices.as_ref().clone(),
+                    Err(err) => {
+                        self.cleanup_staged_manifest_files(&object_store, &staged_data_files, &[])
+                            .await;
+                        return Err(err);
+                    }
+                };
+                let shard_local_indices = match Self::manifest_indices_are_shard_local(
+                    dataset.manifest(),
+                    &existing_indices,
+                ) {
+                    Ok(shard_local_indices) => shard_local_indices,
+                    Err(err) => {
+                        self.cleanup_staged_manifest_files(&object_store, &staged_data_files, &[])
+                            .await;
+                        return Err(err);
+                    }
+                };
+                if shard_local_indices {
+                    let index_uuids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+                    staged_index_uuids.extend(index_uuids.iter().copied());
+                    let replacement_indices = match Self::build_manifest_indices_for_fragment(
+                        &dataset,
+                        &manifest,
+                        shard_index_data,
+                        index_uuids,
+                        shard_fragment_id,
+                    )
+                    .await
+                    {
+                        Ok(indices) => indices,
+                        Err(err) => {
+                            self.cleanup_staged_manifest_files(
+                                &object_store,
+                                &staged_data_files,
+                                &staged_index_uuids,
+                            )
+                            .await;
+                            return Err(err);
+                        }
+                    };
+                    Some(Self::replace_manifest_index_segments(
+                        existing_indices,
+                        shard_fragment_id,
+                        replacement_indices,
+                    ))
+                } else {
+                    let new_manifest_indices = match Self::build_all_manifest_shard_indices(
+                        &dataset,
+                        &manifest,
+                        shard_fragment_id,
+                        shard_index_data,
+                        &mut staged_index_uuids,
+                    )
+                    .await
+                    {
+                        Ok(indices) => indices,
+                        Err(err) => {
+                            self.cleanup_staged_manifest_files(
+                                &object_store,
+                                &staged_data_files,
+                                &staged_index_uuids,
+                            )
+                            .await;
+                            return Err(err);
+                        }
+                    };
+                    Some(
+                        existing_indices
+                            .into_iter()
+                            .filter(|index| !Self::is_manifest_index_name(&index.name))
+                            .chain(new_manifest_indices)
+                            .collect(),
+                    )
+                }
+            } else {
+                None
+            };
+            let staged_index_uuids: &[Uuid] = if build_indices {
+                &staged_index_uuids
+            } else {
+                &[]
+            };
+
+            let commit_result = self
+                .commit_manifest_transaction(
+                    &dataset,
+                    commit_handler.as_ref(),
+                    &mut manifest,
+                    indices,
+                    update_transaction,
+                )
+                .await;
+
+            match commit_result {
+                Ok(()) => {
+                    let _ = self.manifest_dataset.get_refreshed().await;
+                    return Ok(mutation.result);
+                }
+                Err(err) => {
+                    if self
+                        .manifest_commit_landed(&dataset, target_version, &staged_data_files)
+                        .await
+                    {
+                        let _ = self.manifest_dataset.get_refreshed().await;
+                        return Ok(mutation.result);
+                    }
+                    self.cleanup_staged_manifest_files(
+                        &object_store,
+                        &staged_data_files,
+                        staged_index_uuids,
+                    )
+                    .await;
+                    match err {
+                        CommitError::CommitConflict => {
+                            if let Some(output) =
+                                self.resolve_manifest_conflict(&resolution).await?
+                            {
+                                return Ok(output);
+                            }
+                            if retries >= max_retries {
+                                return Err(NamespaceError::ConcurrentModification {
+                                    message: format!(
+                                        "{}: still conflicting after {} retries",
+                                        operation, max_retries
+                                    ),
+                                }
+                                .into());
+                            }
+                            retries += 1;
+                            tokio::time::sleep(std::time::Duration::from_millis(
+                                10 * u64::from(retries),
+                            ))
+                            .await;
+                        }
+                        CommitError::OtherError(err) => {
+                            return Err(convert_lance_commit_error(&err, operation, None));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn manifest_contains_object_in_shard(
+        &self,
+        object_id: &str,
+        shard_key: &str,
+    ) -> Result<bool> {
+        let escaped_id = object_id.replace('\'', "''");
+        let filter = format!(
+            "object_id = '{}' AND object_type != '{}'",
+            escaped_id,
+            ObjectType::ShardMarker.as_str()
+        );
+
+        let mut scanner = self.manifest_scanner_for_shard_key(shard_key).await?;
 
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
@@ -2180,11 +3024,36 @@ impl ManifestNamespace {
         Ok(count > 0)
     }
 
+    /// Check if the manifest contains an object with the given ID
+    async fn manifest_contains_object(&self, object_id: &str) -> Result<bool> {
+        let Some(shard_count) = self.shard_count() else {
+            return self
+                .manifest_contains_object_in_shard(object_id, object_id)
+                .await;
+        };
+
+        if self
+            .manifest_contains_object_in_shard(object_id, object_id)
+            .await?
+        {
+            return Ok(true);
+        }
+        if let Some(table_id) = Self::table_version_table_id_if_version_object_id(object_id)
+            && Self::shard_index_for_key(shard_count, table_id)
+                != Self::shard_index_for_key(shard_count, object_id)
+        {
+            return self
+                .manifest_contains_object_in_shard(object_id, table_id)
+                .await;
+        }
+        Ok(false)
+    }
+
     /// Query the manifest for a table with the given object ID
     async fn query_manifest_for_table(&self, object_id: &str) -> Result<Option<TableInfo>> {
         let escaped_id = object_id.replace('\'', "''");
         let filter = format!("object_id = '{}' AND object_type = 'table'", escaped_id);
-        let mut scanner = self.manifest_scanner().await?;
+        let mut scanner = self.manifest_scanner_for_shard_key(object_id).await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
                 message: format!("Failed to filter: {:?}", e),
@@ -2393,6 +3262,51 @@ impl ManifestNamespace {
             return Ok(());
         }
 
+        if let Some(shard_count) = self.shard_count() {
+            let mut grouped: HashMap<usize, Vec<(usize, ManifestEntry)>> = HashMap::new();
+            for (entry_index, entry) in entries.into_iter().enumerate() {
+                let shard_index =
+                    Self::shard_index_for_key(shard_count, Self::shard_key_for_entry(&entry));
+                grouped
+                    .entry(shard_index)
+                    .or_default()
+                    .push((entry_index, entry));
+            }
+
+            if grouped.len() > 1 {
+                return Err(NamespaceError::Unsupported {
+                    message: "Sharded manifest mode does not support multi-shard batch upserts"
+                        .to_string(),
+                }
+                .into());
+            }
+
+            for (shard_index, grouped_entries) in grouped {
+                let group_base_objects = grouped_entries
+                    .iter()
+                    .any(|(entry_index, _entry)| *entry_index == 0)
+                    .then(|| base_objects.clone())
+                    .flatten();
+                let entries = grouped_entries
+                    .into_iter()
+                    .map(|(_entry_index, entry)| entry)
+                    .collect::<Vec<_>>();
+                self.rewrite_manifest_shard(
+                    shard_index,
+                    "Failed to overwrite manifest shard",
+                    || {
+                        UpsertManifestMutation::new(
+                            entries.clone(),
+                            group_base_objects.clone(),
+                            when_matched.clone(),
+                        )
+                    },
+                )
+                .await?;
+            }
+            return Ok(());
+        }
+
         self.rewrite_manifest("Failed to overwrite manifest", || {
             UpsertManifestMutation::new(entries.clone(), base_objects.clone(), when_matched.clone())
         })
@@ -2402,11 +3316,30 @@ impl ManifestNamespace {
     /// Delete an entry from the manifest table
     pub async fn delete_from_manifest(&self, object_id: &str) -> Result<()> {
         let object_id = object_id.to_string();
+        if let Some(shard_indices) = self.delete_shard_indices_for_object_id(&object_id) {
+            for shard_index in shard_indices {
+                let deleted = self
+                    .rewrite_manifest_shard(
+                        shard_index,
+                        "Failed to delete from manifest shard",
+                        || DeleteObjectMutation {
+                            object_id: object_id.clone(),
+                            deleted: false,
+                        },
+                    )
+                    .await?;
+                if deleted {
+                    return Ok(());
+                }
+            }
+            return Ok(());
+        }
         self.rewrite_manifest("Failed to delete from manifest", || DeleteObjectMutation {
             object_id: object_id.clone(),
             deleted: false,
         })
         .await
+        .map(|_| ())
     }
 
     /// Query the manifest for all versions of a table, sorted by version.
@@ -2430,7 +3363,7 @@ impl ManifestNamespace {
             "object_type = 'table_version' AND starts_with(object_id, '{}{}')",
             escaped_id, DELIMITER
         );
-        let mut scanner = self.manifest_scanner().await?;
+        let mut scanner = self.manifest_scanner_for_shard_key(object_id).await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
                 message: format!("Failed to filter: {:?}", e),
@@ -2498,7 +3431,9 @@ impl ManifestNamespace {
             "object_id = '{}' AND object_type = 'table_version'",
             escaped_id
         );
-        let mut scanner = self.manifest_scanner().await?;
+        let mut scanner = self
+            .manifest_scanner_for_shard_key(Self::table_version_table_id(version_object_id))
+            .await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
                 message: format!("Failed to filter: {:?}", e),
@@ -2545,6 +3480,61 @@ impl ManifestNamespace {
         &self,
         table_ranges: &[(String, Vec<(i64, i64)>)],
     ) -> Result<i64> {
+        if let Some(shard_count) = self.shard_count() {
+            let mut grouped: TableVersionRangeGroupsByShard = HashMap::new();
+            for (object_id, ranges) in table_ranges {
+                let shard_index = Self::shard_index_for_key(shard_count, object_id);
+                grouped
+                    .entry(shard_index)
+                    .or_default()
+                    .push((object_id.clone(), ranges.clone()));
+            }
+
+            let mut shard_inputs = grouped
+                .into_iter()
+                .filter_map(|(shard_index, table_ranges)| {
+                    let targets = table_ranges
+                        .iter()
+                        .filter_map(|(object_id, ranges)| {
+                            let ranges = Self::normalize_table_version_ranges(ranges);
+                            if ranges.is_empty() {
+                                None
+                            } else {
+                                Some(DeleteTableVersionRangeTarget {
+                                    object_id_prefix: Self::build_version_object_id_prefix(
+                                        object_id,
+                                    ),
+                                    ranges,
+                                })
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    (!targets.is_empty()).then_some((shard_index, targets))
+                })
+                .collect::<Vec<_>>();
+            if shard_inputs.len() > 1 {
+                return Err(NamespaceError::Unsupported {
+                    message:
+                        "Sharded manifest mode does not support multi-shard table version deletes"
+                            .to_string(),
+                }
+                .into());
+            }
+            if let Some((shard_index, targets)) = shard_inputs.pop() {
+                return self
+                    .rewrite_manifest_shard(
+                        shard_index,
+                        "Failed to delete table versions from manifest shard",
+                        || DeleteTableVersionsMutation {
+                            target: DeleteTableVersionsTarget::Ranges(targets.clone()),
+                            deleted_count: 0,
+                        },
+                    )
+                    .await;
+            }
+            return Ok(0);
+        }
+
         let targets = table_ranges
             .iter()
             .filter_map(|(object_id, ranges)| {
@@ -2585,6 +3575,45 @@ impl ManifestNamespace {
     ) -> Result<i64> {
         if object_ids.is_empty() {
             return Ok(0);
+        }
+
+        if let Some(shard_count) = self.shard_count() {
+            let mut grouped: HashMap<usize, Vec<String>> = HashMap::new();
+            for object_id in object_ids {
+                let shard_index =
+                    Self::shard_index_for_key(shard_count, Self::table_version_table_id(object_id));
+                grouped
+                    .entry(shard_index)
+                    .or_default()
+                    .push(object_id.clone());
+            }
+
+            let mut shard_inputs = grouped
+                .into_iter()
+                .map(|(shard_index, object_ids)| {
+                    (shard_index, object_ids.into_iter().collect::<HashSet<_>>())
+                })
+                .collect::<Vec<_>>();
+            if shard_inputs.len() > 1 {
+                return Err(NamespaceError::Unsupported {
+                    message:
+                        "Sharded manifest mode does not support multi-shard table version deletes"
+                            .to_string(),
+                }
+                .into());
+            }
+            if let Some((shard_index, object_ids)) = shard_inputs.pop() {
+                return self
+                    .rewrite_manifest_shard(
+                        shard_index,
+                        "Failed to delete table versions from manifest shard",
+                        || DeleteTableVersionsMutation {
+                            target: DeleteTableVersionsTarget::ObjectIds(object_ids.clone()),
+                            deleted_count: 0,
+                        },
+                    )
+                    .await;
+            }
         }
 
         let object_ids = object_ids.iter().cloned().collect::<HashSet<_>>();
@@ -2754,7 +3783,7 @@ impl ManifestNamespace {
     async fn query_manifest_for_namespace(&self, object_id: &str) -> Result<Option<NamespaceInfo>> {
         let escaped_id = object_id.replace('\'', "''");
         let filter = format!("object_id = '{}' AND object_type = 'namespace'", escaped_id);
-        let mut scanner = self.manifest_scanner().await?;
+        let mut scanner = self.manifest_scanner_for_shard_key(object_id).await?;
         scanner.filter(&filter).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
                 message: format!("Failed to filter: {:?}", e),
@@ -2831,7 +3860,15 @@ impl ManifestNamespace {
         storage_options: &Option<HashMap<String, String>>,
         session: Option<Arc<Session>>,
         table_version_storage_enabled: bool,
-    ) -> Result<DatasetConsistencyWrapper> {
+        manifest_fragment_shard_count: Option<usize>,
+    ) -> Result<(DatasetConsistencyWrapper, Option<usize>)> {
+        if matches!(manifest_fragment_shard_count, Some(0)) {
+            return Err(NamespaceError::InvalidInput {
+                message: "manifest_shard_count must be greater than 0".to_string(),
+            }
+            .into());
+        }
+
         let manifest_path = format!("{}/{}", root, MANIFEST_TABLE_NAME);
         log::debug!("Attempting to load manifest from {}", manifest_path);
         let store_options = ObjectStoreParams {
@@ -2906,12 +3943,29 @@ impl ManifestNamespace {
                 }
             }
 
-            Ok(DatasetConsistencyWrapper::new(dataset))
+            let effective_shard_count =
+                Self::resolve_manifest_shard_count(&mut dataset, manifest_fragment_shard_count)
+                    .await?;
+            Ok((
+                DatasetConsistencyWrapper::new(dataset),
+                effective_shard_count,
+            ))
         } else {
             log::info!("Creating new manifest table at {}", manifest_path);
             let schema = Self::manifest_schema();
-            let empty_batch = RecordBatch::new_empty(schema.clone());
-            let reader = RecordBatchIterator::new(vec![Ok(empty_batch)], schema.clone());
+            let batches = if let Some(shard_count) = manifest_fragment_shard_count {
+                let mut batches = Vec::with_capacity(shard_count);
+                for shard_index in 0..shard_count {
+                    batches.push(Self::manifest_shard_marker_batch(
+                        schema.clone(),
+                        shard_index,
+                    )?);
+                }
+                batches
+            } else {
+                vec![RecordBatch::new_empty(schema.clone())]
+            };
+            let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
 
             let store_params = ObjectStoreParams {
                 storage_options_accessor: storage_options.as_ref().map(|opts| {
@@ -2926,6 +3980,9 @@ impl ManifestNamespace {
             let write_params = WriteParams {
                 session: session.clone(),
                 store_params: Some(store_params),
+                max_rows_per_file: manifest_fragment_shard_count
+                    .map(|_| MANIFEST_FRAGMENT_SHARD_MARKER_ROWS_PER_FILE)
+                    .unwrap_or(WriteParams::default().max_rows_per_file),
                 ..Default::default()
             };
 
@@ -2934,14 +3991,22 @@ impl ManifestNamespace {
 
             // Handle race condition where another process created the manifest concurrently
             match dataset {
-                Ok(dataset) => {
+                Ok(mut dataset) => {
                     log::info!(
                         "Successfully created manifest table at {}, version={}, uri={}",
                         manifest_path,
                         dataset.version().version,
                         dataset.uri()
                     );
-                    Ok(DatasetConsistencyWrapper::new(dataset))
+                    let effective_shard_count = Self::resolve_manifest_shard_count(
+                        &mut dataset,
+                        manifest_fragment_shard_count,
+                    )
+                    .await?;
+                    Ok((
+                        DatasetConsistencyWrapper::new(dataset),
+                        effective_shard_count,
+                    ))
                 }
                 Err(ref e)
                     if matches!(
@@ -2972,7 +4037,7 @@ impl ManifestNamespace {
                         store_options: Some(recovery_store_options),
                         ..Default::default()
                     };
-                    let dataset = DatasetBuilder::from_uri(&manifest_path)
+                    let mut dataset = DatasetBuilder::from_uri(&manifest_path)
                         .with_read_params(recovery_read_params)
                         .load()
                         .await
@@ -2984,7 +4049,15 @@ impl ManifestNamespace {
                                 ),
                             })
                         })?;
-                    Ok(DatasetConsistencyWrapper::new(dataset))
+                    let effective_shard_count = Self::resolve_manifest_shard_count(
+                        &mut dataset,
+                        manifest_fragment_shard_count,
+                    )
+                    .await?;
+                    Ok((
+                        DatasetConsistencyWrapper::new(dataset),
+                        effective_shard_count,
+                    ))
                 }
                 Err(e) => Err(lance_core::Error::from(NamespaceError::Internal {
                     message: format!("Failed to create manifest dataset: {:?}", e),
@@ -4013,7 +5086,7 @@ mod tests {
     use bytes::Bytes;
     use futures::StreamExt;
     use lance::index::DatasetIndexExt;
-    use lance_core::utils::tempfile::TempStdDir;
+    use lance_core::utils::{address::RowAddress, tempfile::TempStdDir};
     use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
     use lance_namespace::LanceNamespace;
     use lance_namespace::models::{
@@ -4021,6 +5094,7 @@ mod tests {
         ListTablesRequest, TableExistsRequest,
     };
     use lance_table::format::Fragment;
+    use roaring::RoaringBitmap;
     use rstest::rstest;
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
@@ -4036,6 +5110,21 @@ mod tests {
         root: &str,
         inline_optimization_enabled: bool,
         commit_retries: Option<u32>,
+    ) -> ManifestNamespace {
+        create_manifest_namespace_with_shards(
+            root,
+            inline_optimization_enabled,
+            commit_retries,
+            None,
+        )
+        .await
+    }
+
+    async fn create_manifest_namespace_with_shards(
+        root: &str,
+        inline_optimization_enabled: bool,
+        commit_retries: Option<u32>,
+        manifest_fragment_shard_count: Option<usize>,
     ) -> ManifestNamespace {
         let (object_store, base_path) = ObjectStore::from_uri_and_params(
             Arc::new(ObjectStoreRegistry::default()),
@@ -4054,6 +5143,7 @@ mod tests {
             inline_optimization_enabled,
             commit_retries,
             false,
+            manifest_fragment_shard_count,
         )
         .await
         .unwrap()
@@ -4139,7 +5229,7 @@ mod tests {
     }
 
     impl ManifestStreamMutation for ConcurrentDeleteBeforeCommitMutation {
-        type Output = ();
+        type Output = bool;
 
         fn process_existing_row(
             &mut self,
@@ -4176,7 +5266,7 @@ mod tests {
         fn conflict_resolution(&self) -> ConflictResolution<Self::Output> {
             ConflictResolution::SucceedIfAbsent {
                 object_id: self.target.clone(),
-                output: (),
+                output: true,
             }
         }
     }
@@ -4410,6 +5500,121 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_manifest_index_accumulator_uses_fragment_row_addresses() {
+        let mut index_data = ManifestIndexAccumulator::new(7);
+        let row_id = index_data
+            .push(&ManifestOutputRow {
+                object_id: "table",
+                object_type: ObjectType::Table,
+                location: Some("table.lance"),
+                metadata: None,
+                base_objects: Some(&["base".to_string()]),
+            })
+            .unwrap();
+
+        assert_eq!(row_id, u64::from(RowAddress::new_from_parts(7, 0)));
+        assert_eq!(
+            index_data.object_ids.get("table").copied(),
+            Some(u64::from(RowAddress::new_from_parts(7, 0)))
+        );
+        assert_eq!(
+            index_data
+                .object_types
+                .get(ObjectType::Table.as_str())
+                .unwrap(),
+            &vec![u64::from(RowAddress::new_from_parts(7, 0))]
+        );
+        assert_eq!(
+            index_data.base_objects_row_ids,
+            vec![u64::from(RowAddress::new_from_parts(7, 0))]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sharded_manifest_rewrite_builds_shard_local_index_segments() {
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let shard_count = 4;
+        let manifest_ns =
+            create_manifest_namespace_with_shards(temp_path, true, None, Some(shard_count)).await;
+
+        let first_id = "table_a".to_string();
+        let first_shard = ManifestNamespace::shard_index_for_key(shard_count, &first_id);
+        let second_id = (0..)
+            .map(|index| format!("table_b_{}", index))
+            .find(|object_id| {
+                ManifestNamespace::shard_index_for_key(shard_count, object_id) != first_shard
+            })
+            .unwrap();
+
+        for object_id in [&first_id, &second_id] {
+            manifest_ns
+                .insert_into_manifest_with_metadata(
+                    vec![ManifestEntry {
+                        object_id: object_id.clone(),
+                        object_type: ObjectType::Table,
+                        location: Some(format!("{}.lance", object_id)),
+                        metadata: None,
+                    }],
+                    Some(vec!["base".to_string()]),
+                )
+                .await
+                .unwrap();
+        }
+
+        let dataset_guard = manifest_ns.manifest_dataset.get().await.unwrap();
+        let dataset_version = dataset_guard.version().version;
+        let expected_fragments = dataset_guard
+            .manifest()
+            .fragments
+            .iter()
+            .map(|fragment| fragment.id as u32)
+            .collect::<Vec<_>>();
+        assert_eq!(expected_fragments.len(), shard_count);
+
+        let indices = dataset_guard.load_indices().await.unwrap();
+        let names = indices
+            .iter()
+            .map(|index| index.name.as_str())
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            names,
+            HashSet::from([
+                OBJECT_ID_INDEX_NAME,
+                OBJECT_TYPE_INDEX_NAME,
+                BASE_OBJECTS_INDEX_NAME
+            ])
+        );
+        assert_eq!(indices.len(), shard_count * 3);
+        assert!(
+            indices
+                .iter()
+                .any(|index| index.dataset_version == dataset_version)
+        );
+
+        for index_name in [
+            OBJECT_ID_INDEX_NAME,
+            OBJECT_TYPE_INDEX_NAME,
+            BASE_OBJECTS_INDEX_NAME,
+        ] {
+            let mut covered_fragments = RoaringBitmap::new();
+            let mut segment_count = 0;
+            for index in indices.iter().filter(|index| index.name == index_name) {
+                let fragment_bitmap = index.fragment_bitmap.as_ref().unwrap();
+                assert_eq!(fragment_bitmap.len(), 1);
+                assert_eq!(covered_fragments.intersection_len(fragment_bitmap), 0);
+                covered_fragments |= fragment_bitmap.clone();
+                segment_count += 1;
+            }
+            assert_eq!(segment_count, shard_count);
+            assert_eq!(
+                covered_fragments.into_iter().collect::<Vec<_>>(),
+                expected_fragments
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_manifest_delete_table_versions_by_ranges() {
         let temp_dir = TempStdDir::default();
@@ -4492,6 +5697,141 @@ mod tests {
             .map(|(version, _)| version)
             .collect::<Vec<_>>();
         assert_eq!(remaining, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn test_sharded_manifest_rejects_multi_shard_insert_without_partial_write() {
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let shard_count = 4;
+        let manifest_ns =
+            create_manifest_namespace_with_shards(temp_path, false, None, Some(shard_count)).await;
+
+        let existing_id = "existing_table".to_string();
+        let existing_shard = ManifestNamespace::shard_index_for_key(shard_count, &existing_id);
+        let different_shard_id = (0..)
+            .map(|index| format!("new_table_{}", index))
+            .find(|object_id| {
+                ManifestNamespace::shard_index_for_key(shard_count, object_id) != existing_shard
+            })
+            .unwrap();
+
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: existing_id.clone(),
+                    object_type: ObjectType::Table,
+                    location: Some("existing_table.lance".to_string()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+        let version_before = manifest_ns
+            .manifest_dataset
+            .get()
+            .await
+            .unwrap()
+            .version()
+            .version;
+
+        let result = manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![
+                    ManifestEntry {
+                        object_id: different_shard_id.clone(),
+                        object_type: ObjectType::Table,
+                        location: Some("new_table.lance".to_string()),
+                        metadata: None,
+                    },
+                    ManifestEntry {
+                        object_id: existing_id.clone(),
+                        object_type: ObjectType::Table,
+                        location: Some("duplicate.lance".to_string()),
+                        metadata: None,
+                    },
+                ],
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("multi-shard"));
+        assert!(
+            !manifest_ns
+                .manifest_contains_object(&different_shard_id)
+                .await
+                .unwrap()
+        );
+        let dataset_after = manifest_ns.manifest_dataset.get_refreshed().await.unwrap();
+        assert_eq!(dataset_after.version().version, version_before);
+        assert_eq!(dataset_after.count_fragments(), shard_count);
+    }
+
+    #[tokio::test]
+    async fn test_sharded_manifest_marker_ids_do_not_conflict_with_user_objects() {
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let shard_count = 3;
+        let manifest_ns =
+            create_manifest_namespace_with_shards(temp_path, false, None, Some(shard_count)).await;
+        let marker_object_id = ManifestNamespace::shard_marker_object_id(2);
+        assert_eq!(
+            ManifestNamespace::shard_index_for_key(shard_count, &marker_object_id),
+            2
+        );
+
+        assert!(
+            !manifest_ns
+                .manifest_contains_object(&marker_object_id)
+                .await
+                .unwrap()
+        );
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: marker_object_id.clone(),
+                    object_type: ObjectType::Table,
+                    location: Some("marker_table.lance".to_string()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            manifest_ns
+                .manifest_contains_object(&marker_object_id)
+                .await
+                .unwrap()
+        );
+        assert!(
+            manifest_ns
+                .query_manifest_for_table(&marker_object_id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        manifest_ns
+            .delete_from_manifest(&marker_object_id)
+            .await
+            .unwrap();
+        assert!(
+            !manifest_ns
+                .manifest_contains_object(&marker_object_id)
+                .await
+                .unwrap()
+        );
+        assert!(
+            manifest_ns
+                .query_manifest_for_table(&marker_object_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -5548,20 +5548,42 @@ mod tests {
             })
             .unwrap();
 
-        for object_id in [&first_id, &second_id] {
-            manifest_ns
-                .insert_into_manifest_with_metadata(
-                    vec![ManifestEntry {
-                        object_id: object_id.clone(),
-                        object_type: ObjectType::Table,
-                        location: Some(format!("{}.lance", object_id)),
-                        metadata: None,
-                    }],
-                    Some(vec!["base".to_string()]),
-                )
-                .await
-                .unwrap();
-        }
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: first_id.clone(),
+                    object_type: ObjectType::Table,
+                    location: Some(format!("{}.lance", first_id)),
+                    metadata: None,
+                }],
+                Some(vec!["base".to_string()]),
+            )
+            .await
+            .unwrap();
+        let indices_after_first_insert = manifest_ns
+            .manifest_dataset
+            .get()
+            .await
+            .unwrap()
+            .load_indices()
+            .await
+            .unwrap()
+            .as_ref()
+            .clone();
+        assert_eq!(indices_after_first_insert.len(), shard_count * 3);
+
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: second_id.clone(),
+                    object_type: ObjectType::Table,
+                    location: Some(format!("{}.lance", second_id)),
+                    metadata: None,
+                }],
+                Some(vec!["base".to_string()]),
+            )
+            .await
+            .unwrap();
 
         let dataset_guard = manifest_ns.manifest_dataset.get().await.unwrap();
         let dataset_version = dataset_guard.version().version;
@@ -5574,6 +5596,41 @@ mod tests {
         assert_eq!(expected_fragments.len(), shard_count);
 
         let indices = dataset_guard.load_indices().await.unwrap();
+        let first_insert_uuids = indices_after_first_insert
+            .iter()
+            .map(|index| index.uuid)
+            .collect::<HashSet<_>>();
+        let retained_segment_count = indices
+            .iter()
+            .filter(|index| first_insert_uuids.contains(&index.uuid))
+            .count();
+        assert_eq!(retained_segment_count, (shard_count - 1) * 3);
+        let second_shard = ManifestNamespace::shard_index_for_key(shard_count, &second_id) as u32;
+        assert_eq!(
+            indices_after_first_insert
+                .iter()
+                .filter(|index| index
+                    .fragment_bitmap
+                    .as_ref()
+                    .unwrap()
+                    .contains(second_shard))
+                .count(),
+            3
+        );
+        assert_eq!(
+            indices
+                .iter()
+                .filter(|index| {
+                    index
+                        .fragment_bitmap
+                        .as_ref()
+                        .unwrap()
+                        .contains(second_shard)
+                        && !first_insert_uuids.contains(&index.uuid)
+                })
+                .count(),
+            3
+        );
         let names = indices
             .iter()
             .map(|index| index.name.as_str())

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2864,6 +2864,11 @@ impl Scanner {
         let mut read_options = FilteredReadOptions::basic_full_read(&self.dataset)
             .with_filter_plan(filter_plan.clone())
             .with_projection(projection);
+        let target_fragment_bitmap = fragments.as_ref().map(|fragments| {
+            Arc::new(RoaringBitmap::from_iter(
+                fragments.iter().map(|fragment| fragment.id as u32),
+            ))
+        });
 
         if let Some(fragments) = fragments {
             read_options = read_options.with_fragments(fragments);
@@ -2899,11 +2904,12 @@ impl Scanner {
 
         let result_format = self.index_expr_result_format();
         let index_input = filter_plan.index_query.clone().map(|index_query| {
-            Arc::new(ScalarIndexExec::new(
-                self.dataset.clone(),
-                index_query,
-                result_format,
-            )) as Arc<dyn ExecutionPlan>
+            let mut index_exec =
+                ScalarIndexExec::new(self.dataset.clone(), index_query, result_format);
+            if let Some(target_fragment_bitmap) = target_fragment_bitmap.clone() {
+                index_exec = index_exec.with_fragment_bitmap(target_fragment_bitmap);
+            }
+            Arc::new(index_exec) as Arc<dyn ExecutionPlan>
         });
 
         Ok(Arc::new(FilteredReadExec::try_new(

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -203,23 +203,32 @@ fn combine_search_results(results: Vec<SearchResult>) -> Result<SearchResult> {
     })
 }
 
-fn index_intersects_dataset(index: &IndexMetadata, dataset: &Dataset) -> bool {
+fn index_intersects_fragments(index: &IndexMetadata, fragment_bitmap: &RoaringBitmap) -> bool {
     index
         .fragment_bitmap
         .as_ref()
-        .is_some_and(|index_bitmap| index_bitmap.intersection_len(&dataset.fragment_bitmap) > 0)
+        .is_some_and(|index_bitmap| index_bitmap.intersection_len(fragment_bitmap) > 0)
 }
 
 async fn load_named_scalar_segments(
     dataset: &Dataset,
     column: &str,
     index_name: &str,
+    target_fragment_bitmap: Option<&RoaringBitmap>,
 ) -> Result<Vec<IndexMetadata>> {
+    let live_fragment_bitmap;
+    let fragment_bitmap = if let Some(target_fragment_bitmap) = target_fragment_bitmap {
+        live_fragment_bitmap = target_fragment_bitmap & dataset.fragment_bitmap.as_ref();
+        &live_fragment_bitmap
+    } else {
+        dataset.fragment_bitmap.as_ref()
+    };
+
     let usable_indices = dataset
         .load_indices_by_name(index_name)
         .await?
         .into_iter()
-        .filter(|index| index_intersects_dataset(index, dataset))
+        .filter(|index| index_intersects_fragments(index, fragment_bitmap))
         .collect::<Vec<_>>();
 
     let mut index_type_url = None::<String>;
@@ -268,7 +277,7 @@ pub async fn scalar_index_fragment_bitmap(
     column: &str,
     index_name: &str,
 ) -> Result<Option<RoaringBitmap>> {
-    let indices = load_named_scalar_segments(dataset, column, index_name).await?;
+    let indices = load_named_scalar_segments(dataset, column, index_name, None).await?;
     match indices.len() {
         0 => Ok(None),
         1 => Ok(indices
@@ -279,13 +288,48 @@ pub async fn scalar_index_fragment_bitmap(
     }
 }
 
+pub async fn scalar_index_fragment_bitmap_for_fragments(
+    dataset: &Dataset,
+    column: &str,
+    index_name: &str,
+    target_fragment_bitmap: &RoaringBitmap,
+) -> Result<Option<RoaringBitmap>> {
+    let indices =
+        load_named_scalar_segments(dataset, column, index_name, Some(target_fragment_bitmap))
+            .await?;
+    let Some(mut fragment_bitmap) = (match indices.len() {
+        0 => Ok(None),
+        1 => Ok(indices
+            .into_iter()
+            .next()
+            .and_then(|index| index.fragment_bitmap)),
+        _ => union_fragment_bitmaps(&indices, index_name).map(Some),
+    })?
+    else {
+        return Ok(None);
+    };
+    fragment_bitmap &= target_fragment_bitmap;
+    Ok(Some(fragment_bitmap))
+}
+
 pub async fn open_named_scalar_index(
     dataset: &Dataset,
     column: &str,
     index_name: &str,
     metrics: &dyn MetricsCollector,
 ) -> Result<Arc<dyn ScalarIndex>> {
-    let indices = load_named_scalar_segments(dataset, column, index_name).await?;
+    open_named_scalar_index_for_fragments(dataset, column, index_name, metrics, None).await
+}
+
+pub async fn open_named_scalar_index_for_fragments(
+    dataset: &Dataset,
+    column: &str,
+    index_name: &str,
+    metrics: &dyn MetricsCollector,
+    target_fragment_bitmap: Option<&RoaringBitmap>,
+) -> Result<Arc<dyn ScalarIndex>> {
+    let indices =
+        load_named_scalar_segments(dataset, column, index_name, target_fragment_bitmap).await?;
     match indices.len() {
         0 => Err(Error::internal(format!(
             "Scanner created plan for index query on index {} for column {} but no usable index exists with that name",
@@ -435,6 +479,33 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(combined_bitmap, dataset.fragment_bitmap.as_ref().clone());
+
+        let target_fragment_bitmap = RoaringBitmap::from_iter([fragments[2].id() as u32]);
+        let pruned = open_named_scalar_index_for_fragments(
+            &dataset,
+            "value",
+            "value_btree",
+            &NoOpMetricsCollector,
+            Some(&target_fragment_bitmap),
+        )
+        .await
+        .unwrap();
+        assert_eq!(pruned.index_type(), IndexType::BTree);
+        assert_eq!(
+            pruned.calculate_included_frags().await.unwrap(),
+            target_fragment_bitmap
+        );
+
+        let pruned_bitmap = scalar_index_fragment_bitmap_for_fragments(
+            &dataset,
+            "value",
+            "value_btree",
+            &target_fragment_bitmap,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(pruned_bitmap, target_fragment_bitmap);
     }
 
     #[tokio::test]

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -9,7 +9,10 @@ use crate::{
     dataset::rowids::load_row_id_sequences,
     index::{
         prefilter::DatasetPreFilter,
-        scalar_logical::{open_named_scalar_index, scalar_index_fragment_bitmap},
+        scalar_logical::{
+            open_named_scalar_index, open_named_scalar_index_for_fragments,
+            scalar_index_fragment_bitmap, scalar_index_fragment_bitmap_for_fragments,
+        },
     },
 };
 use arrow_array::{Array, RecordBatch, UInt64Array};
@@ -60,6 +63,30 @@ impl ScalarIndexLoader for Dataset {
     }
 }
 
+struct FragmentPrunedScalarIndexLoader {
+    dataset: Arc<Dataset>,
+    fragment_bitmap: Option<Arc<RoaringBitmap>>,
+}
+
+#[async_trait]
+impl ScalarIndexLoader for FragmentPrunedScalarIndexLoader {
+    async fn load_index(
+        &self,
+        column: &str,
+        index_name: &str,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<Arc<dyn ScalarIndex>> {
+        open_named_scalar_index_for_fragments(
+            &self.dataset,
+            column,
+            index_name,
+            metrics,
+            self.fragment_bitmap.as_deref(),
+        )
+        .await
+    }
+}
+
 /// An execution node that performs a scalar index search
 ///
 /// This does not actually scan any data.  We only look through the index to determine
@@ -74,6 +101,7 @@ pub struct ScalarIndexExec {
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     result_format: IndexExprResultWireFormat,
+    fragment_bitmap: Option<Arc<RoaringBitmap>>,
 }
 
 impl DisplayAs for ScalarIndexExec {
@@ -107,7 +135,13 @@ impl ScalarIndexExec {
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
             result_format,
+            fragment_bitmap: None,
         }
+    }
+
+    pub fn with_fragment_bitmap(mut self, fragment_bitmap: Arc<RoaringBitmap>) -> Self {
+        self.fragment_bitmap = Some(fragment_bitmap);
+        self
     }
 
     pub fn dataset(&self) -> &Arc<Dataset> {
@@ -129,29 +163,48 @@ impl ScalarIndexExec {
     pub async fn fragments_covered_by_index_query(
         index_expr: &ScalarIndexExpr,
         dataset: &Dataset,
+        target_fragment_bitmap: Option<&RoaringBitmap>,
     ) -> Result<RoaringBitmap> {
         match index_expr {
-            ScalarIndexExpr::And(lhs, rhs) => {
-                Ok(Self::fragments_covered_by_index_query(lhs, dataset).await?
-                    & Self::fragments_covered_by_index_query(rhs, dataset).await?)
-            }
-            ScalarIndexExpr::Or(lhs, rhs) => {
-                Ok(Self::fragments_covered_by_index_query(lhs, dataset).await?
-                    & Self::fragments_covered_by_index_query(rhs, dataset).await?)
-            }
+            ScalarIndexExpr::And(lhs, rhs) => Ok(Self::fragments_covered_by_index_query(
+                lhs,
+                dataset,
+                target_fragment_bitmap,
+            )
+            .await?
+                & Self::fragments_covered_by_index_query(rhs, dataset, target_fragment_bitmap)
+                    .await?),
+            ScalarIndexExpr::Or(lhs, rhs) => Ok(Self::fragments_covered_by_index_query(
+                lhs,
+                dataset,
+                target_fragment_bitmap,
+            )
+            .await?
+                & Self::fragments_covered_by_index_query(rhs, dataset, target_fragment_bitmap)
+                    .await?),
             ScalarIndexExpr::Not(expr) => {
-                Self::fragments_covered_by_index_query(expr, dataset).await
+                Self::fragments_covered_by_index_query(expr, dataset, target_fragment_bitmap).await
             }
-            ScalarIndexExpr::Query(search_key) => {
+            ScalarIndexExpr::Query(search_key) => if let Some(target_fragment_bitmap) =
+                target_fragment_bitmap
+            {
+                scalar_index_fragment_bitmap_for_fragments(
+                    dataset,
+                    &search_key.column,
+                    &search_key.index_name,
+                    target_fragment_bitmap,
+                )
+                .await?
+            } else {
                 scalar_index_fragment_bitmap(dataset, &search_key.column, &search_key.index_name)
                     .await?
-                    .ok_or_else(|| {
-                        Error::internal(format!(
-                            "Index not found even though it must have been found earlier: {}",
-                            search_key.index_name
-                        ))
-                    })
             }
+            .ok_or_else(|| {
+                Error::internal(format!(
+                    "Index not found even though it must have been found earlier: {}",
+                    search_key.index_name
+                ))
+            }),
         }
     }
 
@@ -160,15 +213,25 @@ impl ScalarIndexExec {
         dataset: Arc<Dataset>,
         plan_metrics: ExecutionPlanMetricsSet,
         result_format: IndexExprResultWireFormat,
+        fragment_bitmap: Option<Arc<RoaringBitmap>>,
     ) -> Result<RecordBatch> {
         let metrics = IndexMetrics::new(&plan_metrics, 0);
-        let query_result = {
+        let mut query_result = {
             let search_time = plan_metrics.new_time(SCALAR_INDEX_SEARCH_TIME_METRIC, 0);
             let _timer = search_time.timer();
-            expr.evaluate(dataset.as_ref(), &metrics).await?
+            let index_loader = FragmentPrunedScalarIndexLoader {
+                dataset: dataset.clone(),
+                fragment_bitmap: fragment_bitmap.clone(),
+            };
+            expr.evaluate(&index_loader, &metrics).await?
         };
-        let fragments_covered_by_result =
-            Self::fragments_covered_by_index_query(&expr, dataset.as_ref()).await?;
+        let fragments_covered_by_result = Self::fragments_covered_by_index_query(
+            &expr,
+            dataset.as_ref(),
+            fragment_bitmap.as_deref(),
+        )
+        .await?;
+        retain_index_result_fragments(&mut query_result, &fragments_covered_by_result);
         {
             let ser_time = plan_metrics.new_time(SCALAR_INDEX_SER_TIME_METRIC, 0);
             let _timer = ser_time.timer();
@@ -217,6 +280,7 @@ impl ExecutionPlan for ScalarIndexExec {
             self.dataset.clone(),
             self.metrics.clone(),
             self.result_format,
+            self.fragment_bitmap.clone(),
         );
         let stream = futures::stream::iter(vec![batch_fut])
             .then(|batch_fut| batch_fut.map_err(|err| err.into()))
@@ -250,6 +314,19 @@ impl ExecutionPlan for ScalarIndexExec {
 
     fn supports_limit_pushdown(&self) -> bool {
         false
+    }
+}
+
+fn retain_index_result_fragments(result: &mut IndexExprResult, fragment_bitmap: &RoaringBitmap) {
+    retain_mask_fragments(&mut result.lower, fragment_bitmap);
+    retain_mask_fragments(&mut result.upper, fragment_bitmap);
+}
+
+fn retain_mask_fragments(mask: &mut RowAddrMask, fragment_bitmap: &RoaringBitmap) {
+    match mask {
+        RowAddrMask::AllowList(rows) | RowAddrMask::BlockList(rows) => {
+            rows.retain_fragments(fragment_bitmap.iter());
+        }
     }
 }
 
@@ -855,6 +932,7 @@ mod tests {
         scalar::ScalarValue,
     };
     use futures::TryStreamExt;
+    use lance_core::utils::address::RowAddress;
     use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::gen_batch;
     use lance_index::{
@@ -864,7 +942,8 @@ mod tests {
             expression::{ScalarIndexExpr, ScalarIndexSearch},
         },
     };
-    use lance_select::result::IndexExprResultWireFormat;
+    use lance_select::{IndexExprResult, RowAddrMask, result::IndexExprResultWireFormat};
+    use roaring::RoaringBitmap;
 
     use crate::{
         Dataset,
@@ -1004,6 +1083,47 @@ mod tests {
         let schema = IndexExprResultWireFormat::TwoMask.schema().clone();
 
         verify(plan, schema).await;
+    }
+
+    #[tokio::test]
+    async fn test_scalar_index_exec_restricts_fragment_bitmap() {
+        let TestFixture {
+            dataset,
+            _tmp_dir_guard,
+        } = test_fixture().await;
+
+        let query = ScalarIndexExpr::Query(ScalarIndexSearch {
+            column: "ordered".to_string(),
+            index_name: "ordered_idx".to_string(),
+            index_type: "BTree".to_string(),
+            query: Arc::new(SargableQuery::Range(
+                Bound::Unbounded,
+                Bound::Excluded(ScalarValue::UInt64(Some(47))),
+            )),
+            needs_recheck: false,
+            fragment_bitmap: None,
+        });
+
+        let target_fragment = 2_u32;
+        let target_fragment_bitmap = Arc::new(RoaringBitmap::from_iter([target_fragment]));
+        let plan = ScalarIndexExec::new(dataset, query, IndexExprResultWireFormat::default())
+            .with_fragment_bitmap(target_fragment_bitmap.clone());
+
+        let stream = plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(batches.len(), 1);
+        let (result, fragments_covered) = IndexExprResult::deserialize(&batches[0]).unwrap();
+        assert_eq!(fragments_covered, target_fragment_bitmap.as_ref().clone());
+        assert!(result.is_exact());
+
+        let RowAddrMask::AllowList(rows) = result.upper else {
+            panic!("BTree range search should return an allow-list");
+        };
+        let row_addrs = unsafe { rows.into_addr_iter().collect::<Vec<_>>() };
+        let expected = (0..10)
+            .map(|row_offset| u64::from(RowAddress::new_from_parts(target_fragment, row_offset)))
+            .collect::<Vec<_>>();
+        assert_eq!(row_addrs, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `manifest_shard_count` support for directory namespace manifests
- shard `__manifest` into routed physical fragments while keeping the manifest schema unchanged
- extend the manifest benchmark harness and docs for sharded S3 runs

## Benchmark

- c7i.48xlarge, S3 us-east-1, `jack-devland-build`, `write-create-namespace`
- 1M inline continuous: 0.339 -> 2.859 ops/s (8.43x)
- 1M inline c=10: 0.324 -> 3.861 ops/s (11.92x)
- 1M no-index continuous: 0.490 -> 2.918 ops/s (5.96x)