### PR TITLE
perf(vector): vectorize RaBitQ dist table quantization

### DIFF
--- a/rust/lance-index/src/vector/bq.rs
+++ b/rust/lance-index/src/vector/bq.rs
@@ -18,6 +18,7 @@ use crate::vector::bq::storage::RabitQuantizationMetadata;
 use crate::vector::quantizer::QuantizerBuildParams;
 
 pub mod builder;
+pub(crate) mod dist_table_quant;
 pub mod ex_dot;
 pub mod rotation;
 pub mod storage;

--- a/rust/lance-index/src/vector/bq/dist_table_quant.rs
+++ b/rust/lance-index/src/vector/bq/dist_table_quant.rs
@@ -18,12 +18,14 @@
 //! and the `qmin == qmax` early-out are arithmetically identical either way.
 //!
 //! Quantization rounds half-to-even so that the scalar fallback and the SIMD
-//! kernels agree bit-exactly; the SIMD paths round with explicit static
-//! rounding rather than the dynamic MXCSR mode, so the result is independent
-//! of any rounding mode native code may have installed. Relative to the
-//! pre-SIMD implementation (`f32::round`, half-away-from-zero) this can move a
-//! LUT entry by 1 on exact .5 ties, which is within the table's inherent
-//! quantization error.
+//! kernels agree bit-exactly. All paths round with fixed-mode rounding,
+//! independent of the dynamic MXCSR rounding mode native code may have
+//! installed: the SIMD kernels use the converts' static rounding and the
+//! scalar path (also the SIMD tails) rounds via `f32::floor` rather than
+//! `f32::round_ties_even`, which can lower to an MXCSR-honoring instruction on
+//! x86. Relative to the pre-SIMD implementation (`f32::round`,
+//! half-away-from-zero) this can move a LUT entry by 1 on exact .5 ties, which
+//! is within the table's inherent quantization error.
 
 use std::mem::MaybeUninit;
 use std::sync::LazyLock;
@@ -228,17 +230,34 @@ fn min_max_fold(values: &[f32]) -> (f32, f32) {
     (min, max)
 }
 
+/// Round `x` to the nearest integer, ties to even — the same rule the SIMD
+/// converts use. Built from `f32::floor`, which is a fixed-mode rounding on
+/// every target, so (unlike `f32::round_ties_even`, which can lower to an
+/// MXCSR-honoring instruction on x86) the result is independent of the
+/// dynamic rounding mode. `x` is a non-negative quantization product, so only
+/// the upward tie case is reachable, but the form is written for any finite
+/// `x` whose floor fits in `i64`. Branchless to keep the aarch64 quantize
+/// loop (which has no dedicated SIMD kernel) autovectorizable.
+#[inline(always)]
+fn round_ties_even_fixed(x: f32) -> f32 {
+    let lower = x.floor();
+    let frac = x - lower;
+    let lower_is_odd = (lower as i64 & 1) != 0;
+    let round_up = frac > 0.5 || (frac == 0.5 && lower_is_odd);
+    lower + f32::from(round_up)
+}
+
 fn quantize_u8_scalar(values: &[f32], qmin: f32, factor: f32, out: &mut [MaybeUninit<u8>]) {
     debug_assert_eq!(values.len(), out.len());
     for (quantized, &d) in out.iter_mut().zip(values) {
-        quantized.write(((d - qmin) * factor).round_ties_even() as u8);
+        quantized.write(round_ties_even_fixed((d - qmin) * factor) as u8);
     }
 }
 
 fn quantize_u16_scalar(values: &[f32], qmin: f32, factor: f32, out: &mut [MaybeUninit<u16>]) {
     debug_assert_eq!(values.len(), out.len());
     for (quantized, &d) in out.iter_mut().zip(values) {
-        quantized.write(((d - qmin) * factor).round_ties_even() as u16);
+        quantized.write(round_ties_even_fixed((d - qmin) * factor) as u16);
     }
 }
 
@@ -340,7 +359,7 @@ mod x86 {
     /// Load 16 floats and affine-quantize them into `i32` lanes, rounding to
     /// nearest-even with static rounding (`_MM_FROUND_TO_NEAREST_INT`) so the
     /// result does not depend on the dynamic MXCSR rounding mode and matches
-    /// the scalar `round_ties_even`.
+    /// the scalar [`super::round_ties_even_fixed`].
     #[inline]
     #[target_feature(enable = "avx512f")]
     unsafe fn quantize16_epi32(src: *const f32, min: __m512, factor: __m512) -> __m512i {
@@ -422,7 +441,8 @@ mod x86 {
     /// embedded-rounding convert, so round to nearest-even explicitly with
     /// `_mm256_round_ps` (which ignores MXCSR); the subsequent convert then
     /// sees an integral value, so its dynamic rounding mode cannot change the
-    /// result, keeping it bit-identical to the scalar `round_ties_even`.
+    /// result, keeping it bit-identical to the scalar
+    /// [`super::round_ties_even_fixed`].
     #[inline]
     #[target_feature(enable = "avx2")]
     unsafe fn quantize8_epi32(src: *const f32, min: __m256, factor: __m256) -> __m256i {
@@ -831,22 +851,19 @@ mod tests {
         assert_eq!(quantized, vec![0; 64]);
     }
 
-    /// The SIMD quantizers must round with static nearest-even independent of
-    /// the dynamic MXCSR rounding mode. Run them with MXCSR forced to
-    /// round-toward-zero and require they still match the nearest-even
+    /// Every quantizer — scalar, AVX2, AVX-512, including the SIMD kernels'
+    /// scalar tails — must round with fixed nearest-even, independent of the
+    /// dynamic MXCSR rounding mode. Run each with MXCSR forced to
+    /// round-toward-zero and require it still matches the nearest-even
     /// reference (computed under the default mode). `factor == 0.5` puts odd
     /// integers on exact .5 ties, where truncation (1.5 -> 1) and nearest-even
-    /// (1.5 -> 2) disagree, so a kernel that honored MXCSR would fail here.
-    ///
-    /// The scalar fallback is intentionally excluded: `f32::round_ties_even`
-    /// can itself lower to an MXCSR-honoring instruction on x86, which is
-    /// precisely the hazard the SIMD kernels avoid with static rounding. The
-    /// scalar path is only reached when no SIMD is available and only matters
-    /// under the default rounding mode that lance runs in.
+    /// (1.5 -> 2) disagree, so a path that honored MXCSR would fail. The
+    /// length (511) is deliberately not a multiple of the SIMD step so the
+    /// kernels' scalar tails are exercised too.
     #[cfg(target_arch = "x86_64")]
     #[test]
     #[allow(deprecated)] // _mm_getcsr/_mm_setcsr: no stable non-asm replacement.
-    fn test_simd_rounding_ignores_mxcsr() {
+    fn test_quantize_rounding_ignores_mxcsr() {
         use std::arch::x86_64::{_MM_ROUND_MASK, _MM_ROUND_TOWARD_ZERO, _mm_getcsr, _mm_setcsr};
 
         let values = (0..=510).map(|v| v as f32).collect::<Vec<_>>();
@@ -856,12 +873,7 @@ mod tests {
         let factor_u8 = u8::MAX as f32 / 510.0;
         let factor_u16 = u16::MAX as f32 / 510.0;
 
-        let mut simd_kernels_tested = 0usize;
         for (name, _, quantize_u8_fn, quantize_u16_fn) in available_kernels() {
-            if name == "scalar" {
-                continue;
-            }
-            simd_kernels_tested += 1;
             let mut out_u8 = Vec::with_capacity(values.len());
             let mut out_u16 = Vec::with_capacity(values.len());
             // SAFETY: SSE is baseline on x86_64. MXCSR is restored before any
@@ -891,10 +903,6 @@ mod tests {
                 "kernel={name} under truncating MXCSR"
             );
         }
-        assert!(
-            simd_kernels_tested > 0 || !std::arch::is_x86_feature_detected!("avx2"),
-            "AVX2 detected but no SIMD kernel was exercised"
-        );
     }
 
     /// The scratch buffer must be fully overwritten across reuses with

--- a/rust/lance-index/src/vector/bq/dist_table_quant.rs
+++ b/rust/lance-index/src/vector/bq/dist_table_quant.rs
@@ -42,13 +42,18 @@ pub fn quantize_dist_table_into(
 ) -> (f32, f32) {
     debug_assert!(!dist_table.is_empty(), "dist table must be non-empty");
     let (qmin, qmax) = min_max(dist_table);
-    // this happens if the query is all zeros
-    if qmin == qmax {
+    let range = qmax - qmin;
+    let factor = u8::MAX as f32 / range;
+    // A zero range happens if the query is all zeros. A non-finite `range`
+    // or `factor` (table spread overflowing f32 or below ~255/f32::MAX)
+    // would produce NaN/inf products on which the kernels' saturating
+    // narrows disagree. Either way the table carries no information at u8
+    // resolution: emit a zeroed LUT that callers reconstruct from `min`.
+    if !range.is_finite() || !factor.is_finite() {
         quantized_dist_table.clear();
         quantized_dist_table.resize(dist_table.len(), 0);
         return (qmin, qmax);
     }
-    let factor = u8::MAX as f32 / (qmax - qmin);
     quantized_dist_table.clear();
     quantized_dist_table.reserve(dist_table.len());
     quantize_u8(
@@ -72,12 +77,15 @@ pub fn quantize_dist_table_u16_into(
 ) -> (f32, f32) {
     debug_assert!(!dist_table.is_empty(), "dist table must be non-empty");
     let (qmin, qmax) = min_max(dist_table);
-    if qmin == qmax {
+    let range = qmax - qmin;
+    let factor = u16::MAX as f32 / range;
+    // See quantize_dist_table_into: degenerate ranges collapse to a zeroed
+    // LUT to keep all kernels bit-exact.
+    if !range.is_finite() || !factor.is_finite() {
         quantized_dist_table.clear();
         quantized_dist_table.resize(dist_table.len(), 0);
         return (qmin, qmax);
     }
-    let factor = u16::MAX as f32 / (qmax - qmin);
     quantized_dist_table.clear();
     quantized_dist_table.reserve(dist_table.len());
     quantize_u16(
@@ -485,10 +493,11 @@ mod tests {
 
     fn reference_u8(values: &[f32]) -> (Vec<u8>, f32, f32) {
         let (qmin, qmax) = reference_min_max(values);
-        if qmin == qmax {
+        let range = qmax - qmin;
+        let factor = u8::MAX as f32 / range;
+        if !range.is_finite() || !factor.is_finite() {
             return (vec![0; values.len()], qmin, qmax);
         }
-        let factor = u8::MAX as f32 / (qmax - qmin);
         let quantized = values
             .iter()
             .map(|&d| ((d - qmin) * factor).round_ties_even() as u8)
@@ -498,10 +507,11 @@ mod tests {
 
     fn reference_u16(values: &[f32]) -> (Vec<u16>, f32, f32) {
         let (qmin, qmax) = reference_min_max(values);
-        if qmin == qmax {
+        let range = qmax - qmin;
+        let factor = u16::MAX as f32 / range;
+        if !range.is_finite() || !factor.is_finite() {
             return (vec![0; values.len()], qmin, qmax);
         }
-        let factor = u16::MAX as f32 / (qmax - qmin);
         let quantized = values
             .iter()
             .map(|&d| ((d - qmin) * factor).round_ties_even() as u16)
@@ -554,31 +564,36 @@ mod tests {
                 "kernel={name} len={}",
                 values.len()
             );
-            if qmin == qmax {
-                continue;
+
+            // The public entry points never hand a degenerate factor to the
+            // quantize kernels; mirror that here.
+            let factor_u8 = u8::MAX as f32 / (qmax - qmin);
+            if (qmax - qmin).is_finite() && factor_u8.is_finite() {
+                let mut out_u8 = Vec::with_capacity(values.len());
+                quantize_u8_fn(
+                    values,
+                    qmin,
+                    factor_u8,
+                    &mut out_u8.spare_capacity_mut()[..values.len()],
+                );
+                // SAFETY: the kernel initialized every element.
+                unsafe { out_u8.set_len(values.len()) };
+                assert_eq!(out_u8, expected_u8, "kernel={name} len={}", values.len());
             }
 
-            let mut out_u8 = Vec::with_capacity(values.len());
-            quantize_u8_fn(
-                values,
-                qmin,
-                u8::MAX as f32 / (qmax - qmin),
-                &mut out_u8.spare_capacity_mut()[..values.len()],
-            );
-            // SAFETY: the kernel initialized every element.
-            unsafe { out_u8.set_len(values.len()) };
-            assert_eq!(out_u8, expected_u8, "kernel={name} len={}", values.len());
-
-            let mut out_u16 = Vec::with_capacity(values.len());
-            quantize_u16_fn(
-                values,
-                qmin,
-                u16::MAX as f32 / (qmax - qmin),
-                &mut out_u16.spare_capacity_mut()[..values.len()],
-            );
-            // SAFETY: the kernel initialized every element.
-            unsafe { out_u16.set_len(values.len()) };
-            assert_eq!(out_u16, expected_u16, "kernel={name} len={}", values.len());
+            let factor_u16 = u16::MAX as f32 / (qmax - qmin);
+            if (qmax - qmin).is_finite() && factor_u16.is_finite() {
+                let mut out_u16 = Vec::with_capacity(values.len());
+                quantize_u16_fn(
+                    values,
+                    qmin,
+                    factor_u16,
+                    &mut out_u16.spare_capacity_mut()[..values.len()],
+                );
+                // SAFETY: the kernel initialized every element.
+                unsafe { out_u16.set_len(values.len()) };
+                assert_eq!(out_u16, expected_u16, "kernel={name} len={}", values.len());
+            }
         }
 
         // The public entry points exercise the dispatched kernels plus the
@@ -662,6 +677,40 @@ mod tests {
         let (qmin, qmax) = quantize_dist_table_u16_into(&values, &mut quantized);
         assert_eq!((qmin, qmax), (value, value));
         assert_eq!(quantized, vec![0; 100]);
+    }
+
+    /// Degenerate finite ranges make `factor` (or `range` itself) non-finite
+    /// and must collapse to a zeroed LUT on every kernel: NaN/inf products
+    /// would otherwise hit the saturating narrows, which disagree across
+    /// scalar, AVX2, and AVX-512.
+    #[test]
+    fn test_degenerate_range_zeroes_table() {
+        // factor = 255 / 1e-38 overflows to +inf.
+        let mut tiny_range = vec![0.0f32; 32];
+        tiny_range[1] = 1e-38;
+        // qmax - qmin overflows to +inf, so factor is 0 and products are NaN.
+        let mut huge_range = vec![0.0f32; 32];
+        huge_range[0] = -2e38;
+        huge_range[1] = 2e38;
+        // factor = 65535 / 1e-35 overflows only in the u16 variant; the u8
+        // variant still quantizes normally.
+        let mut u16_only = vec![0.0f32; 32];
+        u16_only[1] = 1e-35;
+
+        for values in [&tiny_range, &huge_range, &u16_only] {
+            check_against_reference(values);
+        }
+        let mut quantized_u8 = Vec::new();
+        let (qmin, qmax) = quantize_dist_table_into(&tiny_range, &mut quantized_u8);
+        assert_eq!((qmin, qmax), (0.0, 1e-38));
+        assert_eq!(quantized_u8, vec![0; 32]);
+        quantize_dist_table_into(&huge_range, &mut quantized_u8);
+        assert_eq!(quantized_u8, vec![0; 32]);
+        let mut quantized_u16 = Vec::new();
+        quantize_dist_table_u16_into(&u16_only, &mut quantized_u16);
+        assert_eq!(quantized_u16, vec![0; 32]);
+        quantize_dist_table_into(&u16_only, &mut quantized_u8);
+        assert_eq!(quantized_u8[1], u8::MAX);
     }
 
     /// `-0.0 == 0.0` must keep taking the all-equal early-out even though

--- a/rust/lance-index/src/vector/bq/dist_table_quant.rs
+++ b/rust/lance-index/src/vector/bq/dist_table_quant.rs
@@ -1,0 +1,696 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! SIMD kernels for quantizing the RaBitQ FastScan distance table.
+//!
+//! Once per (query, probed partition) the `dim * 4`-entry `f32` distance
+//! table is quantized into `u8` (fast/normal approx modes) or `u16`
+//! (accurate mode) FastScan LUT entries: a min/max pass over the table
+//! followed by an affine quantize-and-narrow pass. Both passes are branchy
+//! in scalar form, so they get the same runtime-dispatch treatment as
+//! [`super::ex_dot`]: explicit AVX-512/AVX2 kernels on x86_64 and a portable
+//! fold elsewhere that LLVM auto-vectorizes (NEON is part of the aarch64
+//! baseline).
+//!
+//! Table values are sums of rotated-query components: always finite, never
+//! NaN, so lanewise IEEE `min`/`max` matches `total_cmp` ordering. The only
+//! divergence is the sign of zero, which callers cannot observe: `d - qmin`
+//! and the `qmin == qmax` early-out are arithmetically identical either way.
+//!
+//! Quantization rounds half-to-even (the SSE/AVX default rounding mode)
+//! rather than `f32::round`'s half-away-from-zero so that the scalar
+//! fallback and the SIMD kernels agree bit-exactly; relative to the pre-SIMD
+//! implementation this can move a LUT entry by 1 on exact .5 ties, which is
+//! within the table's inherent quantization error.
+
+use std::mem::MaybeUninit;
+use std::sync::LazyLock;
+
+type MinMaxFn = fn(&[f32]) -> (f32, f32);
+type QuantizeU8Fn = fn(&[f32], f32, f32, &mut [MaybeUninit<u8>]);
+type QuantizeU16Fn = fn(&[f32], f32, f32, &mut [MaybeUninit<u16>]);
+
+/// Quantize `dist_table` into `u8` FastScan LUT entries in the caller-owned
+/// scratch buffer, returning the table's `(min, max)`.
+///
+/// An all-equal table (e.g. from an all-zero query) produces a zeroed LUT;
+/// callers reconstruct distances from `min` alone. `dist_table` must be
+/// non-empty and all values finite.
+pub fn quantize_dist_table_into(
+    dist_table: &[f32],
+    quantized_dist_table: &mut Vec<u8>,
+) -> (f32, f32) {
+    debug_assert!(!dist_table.is_empty(), "dist table must be non-empty");
+    let (qmin, qmax) = min_max(dist_table);
+    // this happens if the query is all zeros
+    if qmin == qmax {
+        quantized_dist_table.clear();
+        quantized_dist_table.resize(dist_table.len(), 0);
+        return (qmin, qmax);
+    }
+    let factor = u8::MAX as f32 / (qmax - qmin);
+    quantized_dist_table.clear();
+    quantized_dist_table.reserve(dist_table.len());
+    quantize_u8(
+        dist_table,
+        qmin,
+        factor,
+        &mut quantized_dist_table.spare_capacity_mut()[..dist_table.len()],
+    );
+    // SAFETY: the kernel initialized every element in the reserved range.
+    unsafe {
+        quantized_dist_table.set_len(dist_table.len());
+    }
+    (qmin, qmax)
+}
+
+/// `u16` variant of [`quantize_dist_table_into`] for the accurate approx
+/// mode.
+pub fn quantize_dist_table_u16_into(
+    dist_table: &[f32],
+    quantized_dist_table: &mut Vec<u16>,
+) -> (f32, f32) {
+    debug_assert!(!dist_table.is_empty(), "dist table must be non-empty");
+    let (qmin, qmax) = min_max(dist_table);
+    if qmin == qmax {
+        quantized_dist_table.clear();
+        quantized_dist_table.resize(dist_table.len(), 0);
+        return (qmin, qmax);
+    }
+    let factor = u16::MAX as f32 / (qmax - qmin);
+    quantized_dist_table.clear();
+    quantized_dist_table.reserve(dist_table.len());
+    quantize_u16(
+        dist_table,
+        qmin,
+        factor,
+        &mut quantized_dist_table.spare_capacity_mut()[..dist_table.len()],
+    );
+    // SAFETY: the kernel initialized every element in the reserved range.
+    unsafe {
+        quantized_dist_table.set_len(dist_table.len());
+    }
+    (qmin, qmax)
+}
+
+fn min_max(values: &[f32]) -> (f32, f32) {
+    static KERNEL: LazyLock<MinMaxFn> = LazyLock::new(select_min_max);
+    KERNEL(values)
+}
+
+fn quantize_u8(values: &[f32], qmin: f32, factor: f32, out: &mut [MaybeUninit<u8>]) {
+    static KERNEL: LazyLock<QuantizeU8Fn> = LazyLock::new(select_quantize_u8);
+    KERNEL(values, qmin, factor, out)
+}
+
+fn quantize_u16(values: &[f32], qmin: f32, factor: f32, out: &mut [MaybeUninit<u16>]) {
+    static KERNEL: LazyLock<QuantizeU16Fn> = LazyLock::new(select_quantize_u16);
+    KERNEL(values, qmin, factor, out)
+}
+
+fn select_min_max() -> MinMaxFn {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx512f") {
+            return x86::min_max_avx512_dispatch;
+        }
+        if std::arch::is_x86_feature_detected!("avx2") {
+            return x86::min_max_avx2_dispatch;
+        }
+    }
+    min_max_fold
+}
+
+fn select_quantize_u8() -> QuantizeU8Fn {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx512f") {
+            return x86::quantize_u8_avx512_dispatch;
+        }
+        if std::arch::is_x86_feature_detected!("avx2") {
+            return x86::quantize_u8_avx2_dispatch;
+        }
+    }
+    quantize_u8_scalar
+}
+
+fn select_quantize_u16() -> QuantizeU16Fn {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx512f") {
+            return x86::quantize_u16_avx512_dispatch;
+        }
+        if std::arch::is_x86_feature_detected!("avx2") {
+            return x86::quantize_u16_avx2_dispatch;
+        }
+    }
+    quantize_u16_scalar
+}
+
+const FOLD_LANES: usize = 16;
+
+/// Portable 16-lane min/max fold; the scalar fallback and the aarch64 path.
+/// The `if` comparisons (rather than `f32::min`/`max`, which carry NaN
+/// bookkeeping) lower to lanewise min/max instructions on targets with
+/// baseline SIMD.
+fn min_max_fold(values: &[f32]) -> (f32, f32) {
+    let mut mins = [f32::INFINITY; FOLD_LANES];
+    let mut maxs = [f32::NEG_INFINITY; FOLD_LANES];
+    let mut chunks = values.chunks_exact(FOLD_LANES);
+    for chunk in &mut chunks {
+        let chunk: &[f32; FOLD_LANES] = chunk.try_into().expect("chunks_exact length");
+        for (i, &v) in chunk.iter().enumerate() {
+            mins[i] = if v < mins[i] { v } else { mins[i] };
+            maxs[i] = if v > maxs[i] { v } else { maxs[i] };
+        }
+    }
+    let mut min = f32::INFINITY;
+    let mut max = f32::NEG_INFINITY;
+    for v in mins {
+        min = if v < min { v } else { min };
+    }
+    for v in maxs {
+        max = if v > max { v } else { max };
+    }
+    for &v in chunks.remainder() {
+        min = if v < min { v } else { min };
+        max = if v > max { v } else { max };
+    }
+    (min, max)
+}
+
+fn quantize_u8_scalar(values: &[f32], qmin: f32, factor: f32, out: &mut [MaybeUninit<u8>]) {
+    debug_assert_eq!(values.len(), out.len());
+    for (quantized, &d) in out.iter_mut().zip(values) {
+        quantized.write(((d - qmin) * factor).round_ties_even() as u8);
+    }
+}
+
+fn quantize_u16_scalar(values: &[f32], qmin: f32, factor: f32, out: &mut [MaybeUninit<u16>]) {
+    debug_assert_eq!(values.len(), out.len());
+    for (quantized, &d) in out.iter_mut().zip(values) {
+        quantized.write(((d - qmin) * factor).round_ties_even() as u16);
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+mod x86 {
+    use std::arch::x86_64::*;
+    use std::mem::MaybeUninit;
+
+    use super::{quantize_u8_scalar, quantize_u16_scalar};
+
+    pub(super) fn min_max_avx512_dispatch(values: &[f32]) -> (f32, f32) {
+        // SAFETY: only selected when AVX-512F was detected.
+        unsafe { min_max_avx512(values) }
+    }
+
+    #[target_feature(enable = "avx512f")]
+    unsafe fn min_max_avx512(values: &[f32]) -> (f32, f32) {
+        // Two accumulators per direction break the lanewise min/max latency
+        // chain; they are reduced once at the end.
+        let mut min0 = _mm512_set1_ps(f32::INFINITY);
+        let mut min1 = min0;
+        let mut max0 = _mm512_set1_ps(f32::NEG_INFINITY);
+        let mut max1 = max0;
+        let mut chunks = values.chunks_exact(32);
+        for chunk in &mut chunks {
+            // SAFETY: the chunk holds 32 consecutive floats.
+            let (v0, v1) = unsafe {
+                (
+                    _mm512_loadu_ps(chunk.as_ptr()),
+                    _mm512_loadu_ps(chunk.as_ptr().add(16)),
+                )
+            };
+            min0 = _mm512_min_ps(min0, v0);
+            max0 = _mm512_max_ps(max0, v0);
+            min1 = _mm512_min_ps(min1, v1);
+            max1 = _mm512_max_ps(max1, v1);
+        }
+        let mut min = _mm512_reduce_min_ps(_mm512_min_ps(min0, min1));
+        let mut max = _mm512_reduce_max_ps(_mm512_max_ps(max0, max1));
+        for &v in chunks.remainder() {
+            min = if v < min { v } else { min };
+            max = if v > max { v } else { max };
+        }
+        (min, max)
+    }
+
+    pub(super) fn min_max_avx2_dispatch(values: &[f32]) -> (f32, f32) {
+        // SAFETY: only selected when AVX2 was detected.
+        unsafe { min_max_avx2(values) }
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn min_max_avx2(values: &[f32]) -> (f32, f32) {
+        let mut min0 = _mm256_set1_ps(f32::INFINITY);
+        let mut min1 = min0;
+        let mut max0 = _mm256_set1_ps(f32::NEG_INFINITY);
+        let mut max1 = max0;
+        let mut chunks = values.chunks_exact(16);
+        for chunk in &mut chunks {
+            // SAFETY: the chunk holds 16 consecutive floats.
+            let (v0, v1) = unsafe {
+                (
+                    _mm256_loadu_ps(chunk.as_ptr()),
+                    _mm256_loadu_ps(chunk.as_ptr().add(8)),
+                )
+            };
+            min0 = _mm256_min_ps(min0, v0);
+            max0 = _mm256_max_ps(max0, v0);
+            min1 = _mm256_min_ps(min1, v1);
+            max1 = _mm256_max_ps(max1, v1);
+        }
+        let mut min = reduce_min_avx2(_mm256_min_ps(min0, min1));
+        let mut max = reduce_max_avx2(_mm256_max_ps(max0, max1));
+        for &v in chunks.remainder() {
+            min = if v < min { v } else { min };
+            max = if v > max { v } else { max };
+        }
+        (min, max)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    fn reduce_min_avx2(v: __m256) -> f32 {
+        let halves = _mm_min_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps::<1>(v));
+        let pairs = _mm_min_ps(halves, _mm_movehl_ps(halves, halves));
+        let single = _mm_min_ss(pairs, _mm_shuffle_ps::<0b01>(pairs, pairs));
+        _mm_cvtss_f32(single)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    fn reduce_max_avx2(v: __m256) -> f32 {
+        let halves = _mm_max_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps::<1>(v));
+        let pairs = _mm_max_ps(halves, _mm_movehl_ps(halves, halves));
+        let single = _mm_max_ss(pairs, _mm_shuffle_ps::<0b01>(pairs, pairs));
+        _mm_cvtss_f32(single)
+    }
+
+    /// Load 16 floats and affine-quantize them into `i32` lanes; the convert
+    /// rounds to nearest-even (the MXCSR default).
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn quantize16_epi32(src: *const f32, min: __m512, factor: __m512) -> __m512i {
+        // SAFETY: the caller guarantees 16 floats are readable at `src`.
+        let v = unsafe { _mm512_loadu_ps(src) };
+        _mm512_cvtps_epi32(_mm512_mul_ps(_mm512_sub_ps(v, min), factor))
+    }
+
+    pub(super) fn quantize_u8_avx512_dispatch(
+        values: &[f32],
+        qmin: f32,
+        factor: f32,
+        out: &mut [MaybeUninit<u8>],
+    ) {
+        // SAFETY: only selected when AVX-512F was detected.
+        unsafe { quantize_u8_avx512(values, qmin, factor, out) }
+    }
+
+    #[target_feature(enable = "avx512f")]
+    unsafe fn quantize_u8_avx512(
+        values: &[f32],
+        qmin: f32,
+        factor: f32,
+        out: &mut [MaybeUninit<u8>],
+    ) {
+        debug_assert_eq!(values.len(), out.len());
+        let min = _mm512_set1_ps(qmin);
+        let factor_v = _mm512_set1_ps(factor);
+        let full = values.len() - values.len() % 16;
+        let src = values.as_ptr();
+        let dst = out.as_mut_ptr().cast::<u8>();
+        for i in (0..full).step_by(16) {
+            // SAFETY: `i + 16 <= values.len() == out.len()`.
+            unsafe {
+                let q = quantize16_epi32(src.add(i), min, factor_v);
+                // Unsigned-saturating i32 -> u8 narrow: lanes are in
+                // [0, 255] plus float epsilon, which saturation clips.
+                _mm_storeu_si128(dst.add(i).cast(), _mm512_cvtusepi32_epi8(q));
+            }
+        }
+        quantize_u8_scalar(&values[full..], qmin, factor, &mut out[full..]);
+    }
+
+    pub(super) fn quantize_u16_avx512_dispatch(
+        values: &[f32],
+        qmin: f32,
+        factor: f32,
+        out: &mut [MaybeUninit<u16>],
+    ) {
+        // SAFETY: only selected when AVX-512F was detected.
+        unsafe { quantize_u16_avx512(values, qmin, factor, out) }
+    }
+
+    #[target_feature(enable = "avx512f")]
+    unsafe fn quantize_u16_avx512(
+        values: &[f32],
+        qmin: f32,
+        factor: f32,
+        out: &mut [MaybeUninit<u16>],
+    ) {
+        debug_assert_eq!(values.len(), out.len());
+        let min = _mm512_set1_ps(qmin);
+        let factor_v = _mm512_set1_ps(factor);
+        let full = values.len() - values.len() % 16;
+        let src = values.as_ptr();
+        let dst = out.as_mut_ptr().cast::<u16>();
+        for i in (0..full).step_by(16) {
+            // SAFETY: `i + 16 <= values.len() == out.len()`.
+            unsafe {
+                let q = quantize16_epi32(src.add(i), min, factor_v);
+                _mm256_storeu_si256(dst.add(i).cast(), _mm512_cvtusepi32_epi16(q));
+            }
+        }
+        quantize_u16_scalar(&values[full..], qmin, factor, &mut out[full..]);
+    }
+
+    /// Load 8 floats and affine-quantize them into `i32` lanes; the convert
+    /// rounds to nearest-even (the MXCSR default).
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn quantize8_epi32(src: *const f32, min: __m256, factor: __m256) -> __m256i {
+        // SAFETY: the caller guarantees 8 floats are readable at `src`.
+        let v = unsafe { _mm256_loadu_ps(src) };
+        _mm256_cvtps_epi32(_mm256_mul_ps(_mm256_sub_ps(v, min), factor))
+    }
+
+    pub(super) fn quantize_u8_avx2_dispatch(
+        values: &[f32],
+        qmin: f32,
+        factor: f32,
+        out: &mut [MaybeUninit<u8>],
+    ) {
+        // SAFETY: only selected when AVX2 was detected.
+        unsafe { quantize_u8_avx2(values, qmin, factor, out) }
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn quantize_u8_avx2(
+        values: &[f32],
+        qmin: f32,
+        factor: f32,
+        out: &mut [MaybeUninit<u8>],
+    ) {
+        debug_assert_eq!(values.len(), out.len());
+        let min = _mm256_set1_ps(qmin);
+        let factor_v = _mm256_set1_ps(factor);
+        // The 32->16 and 16->8 packs interleave the two 128-bit lanes; this
+        // permutation of 32-bit groups restores natural order.
+        let restore = _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7);
+        let full = values.len() - values.len() % 32;
+        let src = values.as_ptr();
+        let dst = out.as_mut_ptr().cast::<u8>();
+        for i in (0..full).step_by(32) {
+            // SAFETY: `i + 32 <= values.len() == out.len()`.
+            unsafe {
+                let q0 = quantize8_epi32(src.add(i), min, factor_v);
+                let q1 = quantize8_epi32(src.add(i + 8), min, factor_v);
+                let q2 = quantize8_epi32(src.add(i + 16), min, factor_v);
+                let q3 = quantize8_epi32(src.add(i + 24), min, factor_v);
+                // Unsigned-saturating i32 -> u16 -> u8 narrows: lanes are in
+                // [0, 255] plus float epsilon, which saturation clips.
+                let lo = _mm256_packus_epi32(q0, q1);
+                let hi = _mm256_packus_epi32(q2, q3);
+                let bytes = _mm256_permutevar8x32_epi32(_mm256_packus_epi16(lo, hi), restore);
+                _mm256_storeu_si256(dst.add(i).cast(), bytes);
+            }
+        }
+        quantize_u8_scalar(&values[full..], qmin, factor, &mut out[full..]);
+    }
+
+    pub(super) fn quantize_u16_avx2_dispatch(
+        values: &[f32],
+        qmin: f32,
+        factor: f32,
+        out: &mut [MaybeUninit<u16>],
+    ) {
+        // SAFETY: only selected when AVX2 was detected.
+        unsafe { quantize_u16_avx2(values, qmin, factor, out) }
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn quantize_u16_avx2(
+        values: &[f32],
+        qmin: f32,
+        factor: f32,
+        out: &mut [MaybeUninit<u16>],
+    ) {
+        debug_assert_eq!(values.len(), out.len());
+        let min = _mm256_set1_ps(qmin);
+        let factor_v = _mm256_set1_ps(factor);
+        let full = values.len() - values.len() % 16;
+        let src = values.as_ptr();
+        let dst = out.as_mut_ptr().cast::<u16>();
+        for i in (0..full).step_by(16) {
+            // SAFETY: `i + 16 <= values.len() == out.len()`.
+            unsafe {
+                let q0 = quantize8_epi32(src.add(i), min, factor_v);
+                let q1 = quantize8_epi32(src.add(i + 8), min, factor_v);
+                // The pack interleaves the 128-bit lanes as
+                // [q0_lo, q1_lo, q0_hi, q1_hi]; the 64-bit-lane permute
+                // restores [q0_lo, q0_hi, q1_lo, q1_hi].
+                let packed = _mm256_packus_epi32(q0, q1);
+                let words = _mm256_permute4x64_epi64::<0b11_01_10_00>(packed);
+                _mm256_storeu_si256(dst.add(i).cast(), words);
+            }
+        }
+        quantize_u16_scalar(&values[full..], qmin, factor, &mut out[full..]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+    use rstest::rstest;
+
+    /// Straightforward scalar reference implementing the documented
+    /// semantics: `total_cmp` min/max plus nearest-even rounding.
+    fn reference_min_max(values: &[f32]) -> (f32, f32) {
+        let min = values
+            .iter()
+            .cloned()
+            .min_by(|a, b| a.total_cmp(b))
+            .unwrap();
+        let max = values
+            .iter()
+            .cloned()
+            .max_by(|a, b| a.total_cmp(b))
+            .unwrap();
+        (min, max)
+    }
+
+    fn reference_u8(values: &[f32]) -> (Vec<u8>, f32, f32) {
+        let (qmin, qmax) = reference_min_max(values);
+        if qmin == qmax {
+            return (vec![0; values.len()], qmin, qmax);
+        }
+        let factor = u8::MAX as f32 / (qmax - qmin);
+        let quantized = values
+            .iter()
+            .map(|&d| ((d - qmin) * factor).round_ties_even() as u8)
+            .collect();
+        (quantized, qmin, qmax)
+    }
+
+    fn reference_u16(values: &[f32]) -> (Vec<u16>, f32, f32) {
+        let (qmin, qmax) = reference_min_max(values);
+        if qmin == qmax {
+            return (vec![0; values.len()], qmin, qmax);
+        }
+        let factor = u16::MAX as f32 / (qmax - qmin);
+        let quantized = values
+            .iter()
+            .map(|&d| ((d - qmin) * factor).round_ties_even() as u16)
+            .collect();
+        (quantized, qmin, qmax)
+    }
+
+    fn available_kernels() -> Vec<(&'static str, MinMaxFn, QuantizeU8Fn, QuantizeU16Fn)> {
+        // `mut` is only exercised on x86_64 where extra kernels may be pushed.
+        #[allow(unused_mut)]
+        let mut kernels = vec![(
+            "scalar",
+            min_max_fold as MinMaxFn,
+            quantize_u8_scalar as QuantizeU8Fn,
+            quantize_u16_scalar as QuantizeU16Fn,
+        )];
+        #[cfg(target_arch = "x86_64")]
+        {
+            if std::arch::is_x86_feature_detected!("avx2") {
+                kernels.push((
+                    "avx2",
+                    x86::min_max_avx2_dispatch,
+                    x86::quantize_u8_avx2_dispatch,
+                    x86::quantize_u16_avx2_dispatch,
+                ));
+            }
+            if std::arch::is_x86_feature_detected!("avx512f") {
+                kernels.push((
+                    "avx512",
+                    x86::min_max_avx512_dispatch,
+                    x86::quantize_u8_avx512_dispatch,
+                    x86::quantize_u16_avx512_dispatch,
+                ));
+            }
+        }
+        kernels
+    }
+
+    /// Every available kernel must agree bit-exactly with the reference on
+    /// the given input.
+    fn check_against_reference(values: &[f32]) {
+        let (expected_u8, expected_min, expected_max) = reference_u8(values);
+        let (expected_u16, ..) = reference_u16(values);
+
+        for (name, min_max_fn, quantize_u8_fn, quantize_u16_fn) in available_kernels() {
+            let (qmin, qmax) = min_max_fn(values);
+            assert_eq!(
+                (qmin, qmax),
+                (expected_min, expected_max),
+                "kernel={name} len={}",
+                values.len()
+            );
+            if qmin == qmax {
+                continue;
+            }
+
+            let mut out_u8 = Vec::with_capacity(values.len());
+            quantize_u8_fn(
+                values,
+                qmin,
+                u8::MAX as f32 / (qmax - qmin),
+                &mut out_u8.spare_capacity_mut()[..values.len()],
+            );
+            // SAFETY: the kernel initialized every element.
+            unsafe { out_u8.set_len(values.len()) };
+            assert_eq!(out_u8, expected_u8, "kernel={name} len={}", values.len());
+
+            let mut out_u16 = Vec::with_capacity(values.len());
+            quantize_u16_fn(
+                values,
+                qmin,
+                u16::MAX as f32 / (qmax - qmin),
+                &mut out_u16.spare_capacity_mut()[..values.len()],
+            );
+            // SAFETY: the kernel initialized every element.
+            unsafe { out_u16.set_len(values.len()) };
+            assert_eq!(out_u16, expected_u16, "kernel={name} len={}", values.len());
+        }
+
+        // The public entry points exercise the dispatched kernels plus the
+        // scratch-buffer handling.
+        let mut out_u8 = Vec::new();
+        assert_eq!(
+            quantize_dist_table_into(values, &mut out_u8),
+            (expected_min, expected_max)
+        );
+        assert_eq!(out_u8, expected_u8);
+        let mut out_u16 = Vec::new();
+        assert_eq!(
+            quantize_dist_table_u16_into(values, &mut out_u16),
+            (expected_min, expected_max)
+        );
+        assert_eq!(out_u16, expected_u16);
+    }
+
+    #[rstest]
+    fn test_quantize_matches_reference(
+        #[values(1, 2, 15, 16, 17, 31, 32, 33, 63, 64, 100, 6144, 6160)] len: usize,
+        #[values(1.0, 1e-3, 1e4)] scale: f32,
+    ) {
+        let mut rng = SmallRng::seed_from_u64(42 + len as u64);
+        let values = (0..len)
+            .map(|_| rng.random_range(-scale..scale))
+            .collect::<Vec<_>>();
+        check_against_reference(&values);
+    }
+
+    /// Integer tables with range 510 (resp. 131070) make `factor` exactly
+    /// 0.5, so odd values land on exact .5 ties; all kernels must round them
+    /// to even and agree with each other.
+    #[test]
+    fn test_exact_half_ties_round_to_even() {
+        let values = (0..=510).map(|v| v as f32).collect::<Vec<_>>();
+        check_against_reference(&values);
+        let mut quantized = Vec::new();
+        let (qmin, qmax) = quantize_dist_table_into(&values, &mut quantized);
+        assert_eq!((qmin, qmax), (0.0, 510.0));
+        // Spot-check nearest-even: 0.5 -> 0, 1.5 -> 2, 127.5 -> 128,
+        // 254.5 -> 254.
+        assert_eq!(&quantized[..6], &[0, 0, 1, 2, 2, 2]);
+        assert_eq!(quantized[255], 128);
+        assert_eq!(quantized[509], 254);
+        assert_eq!(quantized[510], 255);
+
+        // Integers up to 131070 are exactly representable in f32.
+        let values = (0..=510).map(|v| (v * 257) as f32).collect::<Vec<_>>();
+        check_against_reference(&values);
+        let mut quantized = Vec::new();
+        let (qmin, qmax) = quantize_dist_table_u16_into(&values, &mut quantized);
+        assert_eq!((qmin, qmax), (0.0, 131070.0));
+        // value * 0.5 = 128.5 -> 128, 385.5 -> 386 under nearest-even.
+        assert_eq!(&quantized[..4], &[0, 128, 257, 386]);
+        assert_eq!(quantized[510], u16::MAX);
+    }
+
+    #[test]
+    fn test_negative_and_mixed_sign_values() {
+        let mut rng = SmallRng::seed_from_u64(7);
+        let values = (0..1000)
+            .map(|_| rng.random_range(-100.0f32..-1.0))
+            .collect::<Vec<_>>();
+        check_against_reference(&values);
+        let values = (0..999)
+            .map(|i| (i as f32 - 499.5) * 0.75)
+            .collect::<Vec<_>>();
+        check_against_reference(&values);
+    }
+
+    #[rstest]
+    fn test_all_equal_input_zeroes_table(#[values(0.0, -7.25, 3.5)] value: f32) {
+        let values = vec![value; 100];
+        check_against_reference(&values);
+        let mut quantized = vec![1u8; 5];
+        let (qmin, qmax) = quantize_dist_table_into(&values, &mut quantized);
+        assert_eq!((qmin, qmax), (value, value));
+        assert_eq!(quantized, vec![0; 100]);
+        let mut quantized = vec![1u16; 5];
+        let (qmin, qmax) = quantize_dist_table_u16_into(&values, &mut quantized);
+        assert_eq!((qmin, qmax), (value, value));
+        assert_eq!(quantized, vec![0; 100]);
+    }
+
+    /// `-0.0 == 0.0` must keep taking the all-equal early-out even though
+    /// SIMD min/max may pick either sign for the extremes.
+    #[test]
+    fn test_signed_zero_mix_zeroes_table() {
+        let mut values = vec![0.0f32; 64];
+        values.iter_mut().step_by(2).for_each(|v| *v = -0.0);
+        let mut quantized = Vec::new();
+        let (qmin, qmax) = quantize_dist_table_into(&values, &mut quantized);
+        assert_eq!(qmin, qmax);
+        assert_eq!(quantized, vec![0; 64]);
+    }
+
+    /// The scratch buffer must be fully overwritten across reuses with
+    /// different lengths.
+    #[test]
+    fn test_scratch_buffer_reuse() {
+        let mut rng = SmallRng::seed_from_u64(11);
+        let mut scratch_u8 = vec![7u8; 500];
+        let mut scratch_u16 = vec![7u16; 500];
+        for len in [48, 512, 16] {
+            let values = (0..len)
+                .map(|_| rng.random_range(-1.0f32..1.0))
+                .collect::<Vec<_>>();
+            quantize_dist_table_into(&values, &mut scratch_u8);
+            assert_eq!(scratch_u8, reference_u8(&values).0);
+            quantize_dist_table_u16_into(&values, &mut scratch_u16);
+            assert_eq!(scratch_u16, reference_u16(&values).0);
+        }
+    }
+}

--- a/rust/lance-index/src/vector/bq/dist_table_quant.rs
+++ b/rust/lance-index/src/vector/bq/dist_table_quant.rs
@@ -831,13 +831,18 @@ mod tests {
         assert_eq!(quantized, vec![0; 64]);
     }
 
-    /// The SIMD quantizers must round with static nearest-even regardless of
+    /// The SIMD quantizers must round with static nearest-even independent of
     /// the dynamic MXCSR rounding mode. Run them with MXCSR forced to
-    /// round-toward-zero and require they still match the scalar reference
-    /// (whose `round_ties_even` is unaffected by MXCSR). `factor == 0.5` puts
-    /// odd integers on exact .5 ties, where truncation (e.g. 1.5 -> 1) and
-    /// nearest-even (1.5 -> 2) disagree, so a kernel that honored MXCSR would
-    /// fail here.
+    /// round-toward-zero and require they still match the nearest-even
+    /// reference (computed under the default mode). `factor == 0.5` puts odd
+    /// integers on exact .5 ties, where truncation (1.5 -> 1) and nearest-even
+    /// (1.5 -> 2) disagree, so a kernel that honored MXCSR would fail here.
+    ///
+    /// The scalar fallback is intentionally excluded: `f32::round_ties_even`
+    /// can itself lower to an MXCSR-honoring instruction on x86, which is
+    /// precisely the hazard the SIMD kernels avoid with static rounding. The
+    /// scalar path is only reached when no SIMD is available and only matters
+    /// under the default rounding mode that lance runs in.
     #[cfg(target_arch = "x86_64")]
     #[test]
     #[allow(deprecated)] // _mm_getcsr/_mm_setcsr: no stable non-asm replacement.
@@ -845,12 +850,18 @@ mod tests {
         use std::arch::x86_64::{_MM_ROUND_MASK, _MM_ROUND_TOWARD_ZERO, _mm_getcsr, _mm_setcsr};
 
         let values = (0..=510).map(|v| v as f32).collect::<Vec<_>>();
+        // Computed under the default (nearest-even) rounding mode.
         let (_, expected_u8) = reference_u8(&values);
         let (_, expected_u16) = reference_u16(&values);
         let factor_u8 = u8::MAX as f32 / 510.0;
         let factor_u16 = u16::MAX as f32 / 510.0;
 
+        let mut simd_kernels_tested = 0usize;
         for (name, _, quantize_u8_fn, quantize_u16_fn) in available_kernels() {
+            if name == "scalar" {
+                continue;
+            }
+            simd_kernels_tested += 1;
             let mut out_u8 = Vec::with_capacity(values.len());
             let mut out_u16 = Vec::with_capacity(values.len());
             // SAFETY: SSE is baseline on x86_64. MXCSR is restored before any
@@ -880,6 +891,10 @@ mod tests {
                 "kernel={name} under truncating MXCSR"
             );
         }
+        assert!(
+            simd_kernels_tested > 0 || !std::arch::is_x86_feature_detected!("avx2"),
+            "AVX2 detected but no SIMD kernel was exercised"
+        );
     }
 
     /// The scratch buffer must be fully overwritten across reuses with

--- a/rust/lance-index/src/vector/bq/dist_table_quant.rs
+++ b/rust/lance-index/src/vector/bq/dist_table_quant.rs
@@ -17,42 +17,64 @@
 //! divergence is the sign of zero, which callers cannot observe: `d - qmin`
 //! and the `qmin == qmax` early-out are arithmetically identical either way.
 //!
-//! Quantization rounds half-to-even (the SSE/AVX default rounding mode)
-//! rather than `f32::round`'s half-away-from-zero so that the scalar
-//! fallback and the SIMD kernels agree bit-exactly; relative to the pre-SIMD
-//! implementation this can move a LUT entry by 1 on exact .5 ties, which is
-//! within the table's inherent quantization error.
+//! Quantization rounds half-to-even so that the scalar fallback and the SIMD
+//! kernels agree bit-exactly; the SIMD paths round with explicit static
+//! rounding rather than the dynamic MXCSR mode, so the result is independent
+//! of any rounding mode native code may have installed. Relative to the
+//! pre-SIMD implementation (`f32::round`, half-away-from-zero) this can move a
+//! LUT entry by 1 on exact .5 ties, which is within the table's inherent
+//! quantization error.
 
 use std::mem::MaybeUninit;
 use std::sync::LazyLock;
+
+use super::storage::SEGMENT_NUM_CODES;
 
 type MinMaxFn = fn(&[f32]) -> (f32, f32);
 type QuantizeU8Fn = fn(&[f32], f32, f32, &mut [MaybeUninit<u8>]);
 type QuantizeU16Fn = fn(&[f32], f32, f32, &mut [MaybeUninit<u16>]);
 
+/// How the caller reconstructs binary inner-product distances from the
+/// FastScan accumulator sums computed against the quantized LUT.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DistTableDequant {
+    /// Reconstruct each distance with the affine map
+    /// `q_sum * (qmax - qmin) / SCALE + num_tables * qmin`. Returned whenever
+    /// that map is finite, including a zero/sub-resolution range — then the
+    /// LUT is zeroed and every distance collapses to the constant
+    /// `num_tables * qmin`.
+    Affine { qmin: f32, qmax: f32 },
+    /// `num_tables * {qmin, qmax, qmax - qmin}` overflowed f32, so the affine
+    /// reconstruction would yield NaN/inf. The LUT is zeroed; the caller must
+    /// compute exact distances directly from the f32 table.
+    Exact,
+}
+
 /// Quantize `dist_table` into `u8` FastScan LUT entries in the caller-owned
-/// scratch buffer, returning the table's `(min, max)`.
-///
-/// An all-equal table (e.g. from an all-zero query) produces a zeroed LUT;
-/// callers reconstruct distances from `min` alone. `dist_table` must be
-/// non-empty and all values finite.
+/// scratch buffer, returning how the caller must dequantize the FastScan
+/// sums (see [`DistTableDequant`]). `dist_table` must be non-empty and all
+/// values finite.
 pub fn quantize_dist_table_into(
     dist_table: &[f32],
     quantized_dist_table: &mut Vec<u8>,
-) -> (f32, f32) {
+) -> DistTableDequant {
     debug_assert!(!dist_table.is_empty(), "dist table must be non-empty");
     let (qmin, qmax) = min_max(dist_table);
-    let range = qmax - qmin;
-    let factor = u8::MAX as f32 / range;
-    // A zero range happens if the query is all zeros. A non-finite `range`
-    // or `factor` (table spread overflowing f32 or below ~255/f32::MAX)
-    // would produce NaN/inf products on which the kernels' saturating
-    // narrows disagree. Either way the table carries no information at u8
-    // resolution: emit a zeroed LUT that callers reconstruct from `min`.
-    if !range.is_finite() || !factor.is_finite() {
+    if dequant_overflows(dist_table.len(), qmin, qmax) {
+        // The caller's affine reconstruction would be non-finite; it computes
+        // exact distances and ignores the LUT, but keep the buffer valid.
         quantized_dist_table.clear();
         quantized_dist_table.resize(dist_table.len(), 0);
-        return (qmin, qmax);
+        return DistTableDequant::Exact;
+    }
+    let factor = u8::MAX as f32 / (qmax - qmin);
+    if !factor.is_finite() {
+        // Zero or sub-u8-resolution range (e.g. an all-zeros query): the LUT
+        // carries no information, but the finite affine map sends every sum
+        // to the constant `num_tables * qmin`.
+        quantized_dist_table.clear();
+        quantized_dist_table.resize(dist_table.len(), 0);
+        return DistTableDequant::Affine { qmin, qmax };
     }
     quantized_dist_table.clear();
     quantized_dist_table.reserve(dist_table.len());
@@ -66,7 +88,7 @@ pub fn quantize_dist_table_into(
     unsafe {
         quantized_dist_table.set_len(dist_table.len());
     }
-    (qmin, qmax)
+    DistTableDequant::Affine { qmin, qmax }
 }
 
 /// `u16` variant of [`quantize_dist_table_into`] for the accurate approx
@@ -74,17 +96,19 @@ pub fn quantize_dist_table_into(
 pub fn quantize_dist_table_u16_into(
     dist_table: &[f32],
     quantized_dist_table: &mut Vec<u16>,
-) -> (f32, f32) {
+) -> DistTableDequant {
     debug_assert!(!dist_table.is_empty(), "dist table must be non-empty");
     let (qmin, qmax) = min_max(dist_table);
-    let range = qmax - qmin;
-    let factor = u16::MAX as f32 / range;
-    // See quantize_dist_table_into: degenerate ranges collapse to a zeroed
-    // LUT to keep all kernels bit-exact.
-    if !range.is_finite() || !factor.is_finite() {
+    if dequant_overflows(dist_table.len(), qmin, qmax) {
         quantized_dist_table.clear();
         quantized_dist_table.resize(dist_table.len(), 0);
-        return (qmin, qmax);
+        return DistTableDequant::Exact;
+    }
+    let factor = u16::MAX as f32 / (qmax - qmin);
+    if !factor.is_finite() {
+        quantized_dist_table.clear();
+        quantized_dist_table.resize(dist_table.len(), 0);
+        return DistTableDequant::Affine { qmin, qmax };
     }
     quantized_dist_table.clear();
     quantized_dist_table.reserve(dist_table.len());
@@ -98,7 +122,24 @@ pub fn quantize_dist_table_u16_into(
     unsafe {
         quantized_dist_table.set_len(dist_table.len());
     }
-    (qmin, qmax)
+    DistTableDequant::Affine { qmin, qmax }
+}
+
+/// Whether the caller's affine dequantization
+/// `q_sum * (qmax - qmin) / SCALE + num_tables * qmin` would overflow `f32`
+/// for some row. Each row's reconstructed binary IP lies in
+/// `[num_tables * qmin, num_tables * qmax]` and its quantized term is at most
+/// `num_tables * (qmax - qmin)`, so if any of those is non-finite the table
+/// must fall back to exact distances. The bound is scale-independent — the
+/// `1 / SCALE` factor and the `q_sum <= num_tables * SCALE` range cancel.
+/// Real dist tables are bounded sums of rotated-query components and never
+/// approach this; the guard exists so a pathological query degrades to exact
+/// distances instead of producing NaN.
+fn dequant_overflows(table_len: usize, qmin: f32, qmax: f32) -> bool {
+    let num_tables = (table_len / SEGMENT_NUM_CODES) as f32;
+    !(num_tables * qmin).is_finite()
+        || !(num_tables * qmax).is_finite()
+        || !(num_tables * (qmax - qmin)).is_finite()
 }
 
 fn min_max(values: &[f32]) -> (f32, f32) {
@@ -296,14 +337,17 @@ mod x86 {
         _mm_cvtss_f32(single)
     }
 
-    /// Load 16 floats and affine-quantize them into `i32` lanes; the convert
-    /// rounds to nearest-even (the MXCSR default).
+    /// Load 16 floats and affine-quantize them into `i32` lanes, rounding to
+    /// nearest-even with static rounding (`_MM_FROUND_TO_NEAREST_INT`) so the
+    /// result does not depend on the dynamic MXCSR rounding mode and matches
+    /// the scalar `round_ties_even`.
     #[inline]
     #[target_feature(enable = "avx512f")]
     unsafe fn quantize16_epi32(src: *const f32, min: __m512, factor: __m512) -> __m512i {
         // SAFETY: the caller guarantees 16 floats are readable at `src`.
         let v = unsafe { _mm512_loadu_ps(src) };
-        _mm512_cvtps_epi32(_mm512_mul_ps(_mm512_sub_ps(v, min), factor))
+        let scaled = _mm512_mul_ps(_mm512_sub_ps(v, min), factor);
+        _mm512_cvt_roundps_epi32::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(scaled)
     }
 
     pub(super) fn quantize_u8_avx512_dispatch(
@@ -374,14 +418,19 @@ mod x86 {
         quantize_u16_scalar(&values[full..], qmin, factor, &mut out[full..]);
     }
 
-    /// Load 8 floats and affine-quantize them into `i32` lanes; the convert
-    /// rounds to nearest-even (the MXCSR default).
+    /// Load 8 floats and affine-quantize them into `i32` lanes. AVX2 has no
+    /// embedded-rounding convert, so round to nearest-even explicitly with
+    /// `_mm256_round_ps` (which ignores MXCSR); the subsequent convert then
+    /// sees an integral value, so its dynamic rounding mode cannot change the
+    /// result, keeping it bit-identical to the scalar `round_ties_even`.
     #[inline]
     #[target_feature(enable = "avx2")]
     unsafe fn quantize8_epi32(src: *const f32, min: __m256, factor: __m256) -> __m256i {
         // SAFETY: the caller guarantees 8 floats are readable at `src`.
         let v = unsafe { _mm256_loadu_ps(src) };
-        _mm256_cvtps_epi32(_mm256_mul_ps(_mm256_sub_ps(v, min), factor))
+        let scaled = _mm256_mul_ps(_mm256_sub_ps(v, min), factor);
+        let rounded = _mm256_round_ps::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(scaled);
+        _mm256_cvtps_epi32(rounded)
     }
 
     pub(super) fn quantize_u8_avx2_dispatch(
@@ -491,32 +540,42 @@ mod tests {
         (min, max)
     }
 
-    fn reference_u8(values: &[f32]) -> (Vec<u8>, f32, f32) {
+    fn reference_u8(values: &[f32]) -> (DistTableDequant, Vec<u8>) {
         let (qmin, qmax) = reference_min_max(values);
-        let range = qmax - qmin;
-        let factor = u8::MAX as f32 / range;
-        if !range.is_finite() || !factor.is_finite() {
-            return (vec![0; values.len()], qmin, qmax);
+        if dequant_overflows(values.len(), qmin, qmax) {
+            return (DistTableDequant::Exact, vec![0; values.len()]);
+        }
+        let factor = u8::MAX as f32 / (qmax - qmin);
+        if !factor.is_finite() {
+            return (
+                DistTableDequant::Affine { qmin, qmax },
+                vec![0; values.len()],
+            );
         }
         let quantized = values
             .iter()
             .map(|&d| ((d - qmin) * factor).round_ties_even() as u8)
             .collect();
-        (quantized, qmin, qmax)
+        (DistTableDequant::Affine { qmin, qmax }, quantized)
     }
 
-    fn reference_u16(values: &[f32]) -> (Vec<u16>, f32, f32) {
+    fn reference_u16(values: &[f32]) -> (DistTableDequant, Vec<u16>) {
         let (qmin, qmax) = reference_min_max(values);
-        let range = qmax - qmin;
-        let factor = u16::MAX as f32 / range;
-        if !range.is_finite() || !factor.is_finite() {
-            return (vec![0; values.len()], qmin, qmax);
+        if dequant_overflows(values.len(), qmin, qmax) {
+            return (DistTableDequant::Exact, vec![0; values.len()]);
+        }
+        let factor = u16::MAX as f32 / (qmax - qmin);
+        if !factor.is_finite() {
+            return (
+                DistTableDequant::Affine { qmin, qmax },
+                vec![0; values.len()],
+            );
         }
         let quantized = values
             .iter()
             .map(|&d| ((d - qmin) * factor).round_ties_even() as u16)
             .collect();
-        (quantized, qmin, qmax)
+        (DistTableDequant::Affine { qmin, qmax }, quantized)
     }
 
     fn available_kernels() -> Vec<(&'static str, MinMaxFn, QuantizeU8Fn, QuantizeU16Fn)> {
@@ -553,8 +612,9 @@ mod tests {
     /// Every available kernel must agree bit-exactly with the reference on
     /// the given input.
     fn check_against_reference(values: &[f32]) {
-        let (expected_u8, expected_min, expected_max) = reference_u8(values);
-        let (expected_u16, ..) = reference_u16(values);
+        let (expected_dequant_u8, expected_u8) = reference_u8(values);
+        let (expected_dequant_u16, expected_u16) = reference_u16(values);
+        let (expected_min, expected_max) = reference_min_max(values);
 
         for (name, min_max_fn, quantize_u8_fn, quantize_u16_fn) in available_kernels() {
             let (qmin, qmax) = min_max_fn(values);
@@ -565,10 +625,11 @@ mod tests {
                 values.len()
             );
 
-            // The public entry points never hand a degenerate factor to the
-            // quantize kernels; mirror that here.
+            // The quantize kernels are only invoked on the populated path, so
+            // mirror that guard before exercising them directly.
+            let overflows = dequant_overflows(values.len(), qmin, qmax);
             let factor_u8 = u8::MAX as f32 / (qmax - qmin);
-            if (qmax - qmin).is_finite() && factor_u8.is_finite() {
+            if !overflows && factor_u8.is_finite() {
                 let mut out_u8 = Vec::with_capacity(values.len());
                 quantize_u8_fn(
                     values,
@@ -582,7 +643,7 @@ mod tests {
             }
 
             let factor_u16 = u16::MAX as f32 / (qmax - qmin);
-            if (qmax - qmin).is_finite() && factor_u16.is_finite() {
+            if !overflows && factor_u16.is_finite() {
                 let mut out_u16 = Vec::with_capacity(values.len());
                 quantize_u16_fn(
                     values,
@@ -596,20 +657,24 @@ mod tests {
             }
         }
 
-        // The public entry points exercise the dispatched kernels plus the
-        // scratch-buffer handling.
+        // The public entry points exercise the dispatched kernels, the
+        // dequantization classification, and the scratch-buffer handling.
         let mut out_u8 = Vec::new();
         assert_eq!(
             quantize_dist_table_into(values, &mut out_u8),
-            (expected_min, expected_max)
+            expected_dequant_u8,
+            "len={}",
+            values.len()
         );
-        assert_eq!(out_u8, expected_u8);
+        assert_eq!(out_u8, expected_u8, "len={}", values.len());
         let mut out_u16 = Vec::new();
         assert_eq!(
             quantize_dist_table_u16_into(values, &mut out_u16),
-            (expected_min, expected_max)
+            expected_dequant_u16,
+            "len={}",
+            values.len()
         );
-        assert_eq!(out_u16, expected_u16);
+        assert_eq!(out_u16, expected_u16, "len={}", values.len());
     }
 
     #[rstest]
@@ -632,8 +697,13 @@ mod tests {
         let values = (0..=510).map(|v| v as f32).collect::<Vec<_>>();
         check_against_reference(&values);
         let mut quantized = Vec::new();
-        let (qmin, qmax) = quantize_dist_table_into(&values, &mut quantized);
-        assert_eq!((qmin, qmax), (0.0, 510.0));
+        assert_eq!(
+            quantize_dist_table_into(&values, &mut quantized),
+            DistTableDequant::Affine {
+                qmin: 0.0,
+                qmax: 510.0
+            }
+        );
         // Spot-check nearest-even: 0.5 -> 0, 1.5 -> 2, 127.5 -> 128,
         // 254.5 -> 254.
         assert_eq!(&quantized[..6], &[0, 0, 1, 2, 2, 2]);
@@ -645,8 +715,13 @@ mod tests {
         let values = (0..=510).map(|v| (v * 257) as f32).collect::<Vec<_>>();
         check_against_reference(&values);
         let mut quantized = Vec::new();
-        let (qmin, qmax) = quantize_dist_table_u16_into(&values, &mut quantized);
-        assert_eq!((qmin, qmax), (0.0, 131070.0));
+        assert_eq!(
+            quantize_dist_table_u16_into(&values, &mut quantized),
+            DistTableDequant::Affine {
+                qmin: 0.0,
+                qmax: 131070.0
+            }
+        );
         // value * 0.5 = 128.5 -> 128, 385.5 -> 386 under nearest-even.
         assert_eq!(&quantized[..4], &[0, 128, 257, 386]);
         assert_eq!(quantized[510], u16::MAX);
@@ -669,26 +744,34 @@ mod tests {
     fn test_all_equal_input_zeroes_table(#[values(0.0, -7.25, 3.5)] value: f32) {
         let values = vec![value; 100];
         check_against_reference(&values);
+        // Zero range: a zeroed LUT plus the finite affine map (every sum maps
+        // to `num_tables * value`).
+        let expected = DistTableDequant::Affine {
+            qmin: value,
+            qmax: value,
+        };
         let mut quantized = vec![1u8; 5];
-        let (qmin, qmax) = quantize_dist_table_into(&values, &mut quantized);
-        assert_eq!((qmin, qmax), (value, value));
+        assert_eq!(quantize_dist_table_into(&values, &mut quantized), expected);
         assert_eq!(quantized, vec![0; 100]);
         let mut quantized = vec![1u16; 5];
-        let (qmin, qmax) = quantize_dist_table_u16_into(&values, &mut quantized);
-        assert_eq!((qmin, qmax), (value, value));
+        assert_eq!(
+            quantize_dist_table_u16_into(&values, &mut quantized),
+            expected
+        );
         assert_eq!(quantized, vec![0; 100]);
     }
 
-    /// Degenerate finite ranges make `factor` (or `range` itself) non-finite
-    /// and must collapse to a zeroed LUT on every kernel: NaN/inf products
-    /// would otherwise hit the saturating narrows, which disagree across
-    /// scalar, AVX2, and AVX-512.
+    /// A finite sub-resolution range zeroes the LUT but still dequantizes
+    /// with the finite affine map (`Affine`), whereas a range whose
+    /// `num_tables`-scaled reconstruction overflows must signal `Exact` so the
+    /// caller computes exact distances instead of `0 * inf = NaN`.
     #[test]
-    fn test_degenerate_range_zeroes_table() {
-        // factor = 255 / 1e-38 overflows to +inf.
+    fn test_degenerate_range_classification() {
+        // factor = 255 / 1e-38 overflows to +inf, but the reconstruction
+        // (num_tables * {0, 1e-38}) stays finite -> Affine, zeroed LUT.
         let mut tiny_range = vec![0.0f32; 32];
         tiny_range[1] = 1e-38;
-        // qmax - qmin overflows to +inf, so factor is 0 and products are NaN.
+        // num_tables * (2e38 - (-2e38)) overflows f32 -> Exact.
         let mut huge_range = vec![0.0f32; 32];
         huge_range[0] = -2e38;
         huge_range[1] = 2e38;
@@ -701,28 +784,102 @@ mod tests {
             check_against_reference(values);
         }
         let mut quantized_u8 = Vec::new();
-        let (qmin, qmax) = quantize_dist_table_into(&tiny_range, &mut quantized_u8);
-        assert_eq!((qmin, qmax), (0.0, 1e-38));
+        assert_eq!(
+            quantize_dist_table_into(&tiny_range, &mut quantized_u8),
+            DistTableDequant::Affine {
+                qmin: 0.0,
+                qmax: 1e-38
+            }
+        );
         assert_eq!(quantized_u8, vec![0; 32]);
-        quantize_dist_table_into(&huge_range, &mut quantized_u8);
+        assert_eq!(
+            quantize_dist_table_into(&huge_range, &mut quantized_u8),
+            DistTableDequant::Exact
+        );
         assert_eq!(quantized_u8, vec![0; 32]);
         let mut quantized_u16 = Vec::new();
-        quantize_dist_table_u16_into(&u16_only, &mut quantized_u16);
+        assert_eq!(
+            quantize_dist_table_u16_into(&u16_only, &mut quantized_u16),
+            DistTableDequant::Affine {
+                qmin: 0.0,
+                qmax: 1e-35
+            }
+        );
         assert_eq!(quantized_u16, vec![0; 32]);
-        quantize_dist_table_into(&u16_only, &mut quantized_u8);
+        assert_eq!(
+            quantize_dist_table_into(&u16_only, &mut quantized_u8),
+            DistTableDequant::Affine {
+                qmin: 0.0,
+                qmax: 1e-35
+            }
+        );
         assert_eq!(quantized_u8[1], u8::MAX);
     }
 
-    /// `-0.0 == 0.0` must keep taking the all-equal early-out even though
-    /// SIMD min/max may pick either sign for the extremes.
+    /// `-0.0 == 0.0` must keep taking the zero-range path (zeroed LUT,
+    /// `Affine`) even though SIMD min/max may pick either sign for the
+    /// extremes.
     #[test]
     fn test_signed_zero_mix_zeroes_table() {
         let mut values = vec![0.0f32; 64];
         values.iter_mut().step_by(2).for_each(|v| *v = -0.0);
         let mut quantized = Vec::new();
-        let (qmin, qmax) = quantize_dist_table_into(&values, &mut quantized);
-        assert_eq!(qmin, qmax);
+        match quantize_dist_table_into(&values, &mut quantized) {
+            DistTableDequant::Affine { qmin, qmax } => assert_eq!(qmin, qmax),
+            other => panic!("expected Affine, got {other:?}"),
+        }
         assert_eq!(quantized, vec![0; 64]);
+    }
+
+    /// The SIMD quantizers must round with static nearest-even regardless of
+    /// the dynamic MXCSR rounding mode. Run them with MXCSR forced to
+    /// round-toward-zero and require they still match the scalar reference
+    /// (whose `round_ties_even` is unaffected by MXCSR). `factor == 0.5` puts
+    /// odd integers on exact .5 ties, where truncation (e.g. 1.5 -> 1) and
+    /// nearest-even (1.5 -> 2) disagree, so a kernel that honored MXCSR would
+    /// fail here.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    #[allow(deprecated)] // _mm_getcsr/_mm_setcsr: no stable non-asm replacement.
+    fn test_simd_rounding_ignores_mxcsr() {
+        use std::arch::x86_64::{_MM_ROUND_MASK, _MM_ROUND_TOWARD_ZERO, _mm_getcsr, _mm_setcsr};
+
+        let values = (0..=510).map(|v| v as f32).collect::<Vec<_>>();
+        let (_, expected_u8) = reference_u8(&values);
+        let (_, expected_u16) = reference_u16(&values);
+        let factor_u8 = u8::MAX as f32 / 510.0;
+        let factor_u16 = u16::MAX as f32 / 510.0;
+
+        for (name, _, quantize_u8_fn, quantize_u16_fn) in available_kernels() {
+            let mut out_u8 = Vec::with_capacity(values.len());
+            let mut out_u16 = Vec::with_capacity(values.len());
+            // SAFETY: SSE is baseline on x86_64. MXCSR is restored before any
+            // assertion so a failure cannot leak the truncating mode.
+            let saved = unsafe { _mm_getcsr() };
+            unsafe {
+                _mm_setcsr((saved & !_MM_ROUND_MASK) | _MM_ROUND_TOWARD_ZERO);
+                quantize_u8_fn(
+                    &values,
+                    0.0,
+                    factor_u8,
+                    &mut out_u8.spare_capacity_mut()[..values.len()],
+                );
+                quantize_u16_fn(
+                    &values,
+                    0.0,
+                    factor_u16,
+                    &mut out_u16.spare_capacity_mut()[..values.len()],
+                );
+                _mm_setcsr(saved);
+                out_u8.set_len(values.len());
+                out_u16.set_len(values.len());
+            }
+            assert_eq!(out_u8, expected_u8, "kernel={name} under truncating MXCSR");
+            assert_eq!(
+                out_u16, expected_u16,
+                "kernel={name} under truncating MXCSR"
+            );
+        }
     }
 
     /// The scratch buffer must be fully overwritten across reuses with
@@ -737,9 +894,9 @@ mod tests {
                 .map(|_| rng.random_range(-1.0f32..1.0))
                 .collect::<Vec<_>>();
             quantize_dist_table_into(&values, &mut scratch_u8);
-            assert_eq!(scratch_u8, reference_u8(&values).0);
+            assert_eq!(scratch_u8, reference_u8(&values).1);
             quantize_dist_table_u16_into(&values, &mut scratch_u16);
-            assert_eq!(scratch_u16, reference_u16(&values).0);
+            assert_eq!(scratch_u16, reference_u16(&values).1);
         }
     }
 }

--- a/rust/lance-index/src/vector/bq/dist_table_quant.rs
+++ b/rust/lance-index/src/vector/bq/dist_table_quant.rs
@@ -231,20 +231,30 @@ fn min_max_fold(values: &[f32]) -> (f32, f32) {
 }
 
 /// Round `x` to the nearest integer, ties to even — the same rule the SIMD
-/// converts use. Built from `f32::floor`, which is a fixed-mode rounding on
-/// every target, so (unlike `f32::round_ties_even`, which can lower to an
-/// MXCSR-honoring instruction on x86) the result is independent of the
-/// dynamic rounding mode. `x` is a non-negative quantization product, so only
-/// the upward tie case is reachable, but the form is written for any finite
-/// `x` whose floor fits in `i64`. Branchless to keep the aarch64 quantize
-/// loop (which has no dedicated SIMD kernel) autovectorizable.
+/// converts use — with fixed-mode operations only, so the result never
+/// depends on the dynamic rounding mode native code may have installed.
+///
+/// On x86, `f32::round_ties_even` can lower to an MXCSR-honoring instruction
+/// (outside an SSE4.1 context), so nearest-even is built from `f32::floor`,
+/// which is always fixed-mode. `x` is a non-negative quantization product, so
+/// only the upward tie case is reachable, but the form is correct for any
+/// finite `x` whose floor fits in `i64`. Elsewhere (e.g. aarch64) the standard
+/// `round_ties_even` is already a fixed-mode instruction (`frintn`) that the
+/// quantize loop — which has no dedicated SIMD kernel there — vectorizes, so
+/// it is kept.
 #[inline(always)]
 fn round_ties_even_fixed(x: f32) -> f32 {
-    let lower = x.floor();
-    let frac = x - lower;
-    let lower_is_odd = (lower as i64 & 1) != 0;
-    let round_up = frac > 0.5 || (frac == 0.5 && lower_is_odd);
-    lower + f32::from(round_up)
+    #[cfg(target_arch = "x86_64")]
+    {
+        let lower = x.floor();
+        let frac = x - lower;
+        let round_up = frac > 0.5 || (frac == 0.5 && (lower as i64 & 1) != 0);
+        lower + f32::from(round_up)
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        x.round_ties_even()
+    }
 }
 
 fn quantize_u8_scalar(values: &[f32], qmin: f32, factor: f32, out: &mut [MaybeUninit<u8>]) {

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 use crate::frag_reuse::FragReuseIndex;
 use crate::pb;
 use crate::vector::ApproxMode;
+use crate::vector::bq::dist_table_quant::{quantize_dist_table_into, quantize_dist_table_u16_into};
 use crate::vector::bq::ex_dot::{
     EX_DOT_BLOCK_DIMS, ExDotFn, blocked_ex_code_bytes, ex_dot_kernel, pad_query_into,
     padded_query_len, repack_sequential_row, sequential_matches_blocked,
@@ -1343,68 +1344,6 @@ where
         // where lowbit(0b1010) = 0b10, LOWBIT_IDX[0b1010] = LOWBIT_IDX[0b10] = 1.
         dist_table[j] = dist_table[j - lowbit(j)] + sub_vec[LOWBIT_IDX[j]].as_();
     })
-}
-
-// Quantize the distance table into a caller-owned buffer.
-#[inline]
-fn quantize_dist_table_into(dist_table: &[f32], quantized_dist_table: &mut Vec<u8>) -> (f32, f32) {
-    let (qmin, qmax) = dist_table
-        .iter()
-        .cloned()
-        .minmax_by(|a, b| a.total_cmp(b))
-        .into_option()
-        .unwrap();
-    // this happens if the query is all zeros
-    if qmin == qmax {
-        quantized_dist_table.clear();
-        quantized_dist_table.resize(dist_table.len(), 0);
-        return (qmin, qmax);
-    }
-    let factor = 255.0 / (qmax - qmin);
-    quantized_dist_table.clear();
-    quantized_dist_table.reserve(dist_table.len());
-    let spare = quantized_dist_table.spare_capacity_mut();
-    for (quantized, &d) in spare[..dist_table.len()].iter_mut().zip(dist_table.iter()) {
-        quantized.write(((d - qmin) * factor).round() as u8);
-    }
-    // SAFETY: every element in the reserved range was initialized in the loop above.
-    unsafe {
-        quantized_dist_table.set_len(dist_table.len());
-    }
-
-    (qmin, qmax)
-}
-
-#[inline]
-fn quantize_dist_table_u16_into(
-    dist_table: &[f32],
-    quantized_dist_table: &mut Vec<u16>,
-) -> (f32, f32) {
-    let (qmin, qmax) = dist_table
-        .iter()
-        .cloned()
-        .minmax_by(|a, b| a.total_cmp(b))
-        .into_option()
-        .unwrap();
-    if qmin == qmax {
-        quantized_dist_table.clear();
-        quantized_dist_table.resize(dist_table.len(), 0);
-        return (qmin, qmax);
-    }
-
-    let factor = u16::MAX as f32 / (qmax - qmin);
-    quantized_dist_table.clear();
-    quantized_dist_table.reserve(dist_table.len());
-    let spare = quantized_dist_table.spare_capacity_mut();
-    for (quantized, &d) in spare[..dist_table.len()].iter_mut().zip(dist_table.iter()) {
-        quantized.write(((d - qmin) * factor).round() as u16);
-    }
-    // SAFETY: every element in the reserved range was initialized in the loop above.
-    unsafe {
-        quantized_dist_table.set_len(dist_table.len());
-    }
-
-    (qmin, qmax)
 }
 
 /// Build the u8 FastScan LUT for the ex codes directly from the rotated

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -41,7 +41,9 @@ use serde::{Deserialize, Serialize};
 use crate::frag_reuse::FragReuseIndex;
 use crate::pb;
 use crate::vector::ApproxMode;
-use crate::vector::bq::dist_table_quant::{quantize_dist_table_into, quantize_dist_table_u16_into};
+use crate::vector::bq::dist_table_quant::{
+    DistTableDequant, quantize_dist_table_into, quantize_dist_table_u16_into,
+};
 use crate::vector::bq::ex_dot::{
     EX_DOT_BLOCK_DIMS, ExDotFn, blocked_ex_code_bytes, ex_dot_kernel, pad_query_into,
     padded_query_len, repack_sequential_row, sequential_matches_blocked,
@@ -898,6 +900,22 @@ impl<'a> RabitDistCalculator<'a> {
         )
     }
 
+    /// Fill `dists[0..n]` with exact per-row binary distances computed
+    /// directly from the f32 dist table — the fallback when the quantized
+    /// reconstruction scale would be non-finite ([`DistTableDequant::Exact`]).
+    #[allow(clippy::uninit_vec)]
+    fn fill_exact_binary_distances(&self, n: usize, code_len: usize, dists: &mut Vec<f32>) {
+        dists.clear();
+        dists.reserve(n);
+        // SAFETY: the loop initializes every element in [0, n).
+        unsafe {
+            dists.set_len(n);
+        }
+        dists.iter_mut().enumerate().for_each(|(id, dist)| {
+            *dist = compute_single_rq_distance(self.codes, id, n, code_len, &self.dist_table);
+        });
+    }
+
     #[allow(clippy::uninit_vec)]
     fn binary_distances_with_scratch(
         &self,
@@ -919,7 +937,16 @@ impl<'a> RabitDistCalculator<'a> {
             );
         }
 
-        let (qmin, qmax) = quantize_dist_table_into(&self.dist_table, quantized_dists_table);
+        let (qmin, qmax) = match quantize_dist_table_into(&self.dist_table, quantized_dists_table) {
+            DistTableDequant::Affine { qmin, qmax } => (qmin, qmax),
+            DistTableDequant::Exact => {
+                // The affine reconstruction would be non-finite; compute every
+                // binary distance exactly and report no SIMD rows so the
+                // ex-rerank caller takes the per-row path for all of them.
+                self.fill_exact_binary_distances(n, code_len, dists);
+                return 0;
+            }
+        };
         let remainder = n % BATCH_SIZE;
         let simd_len = n - remainder;
         quantized_dists.clear();
@@ -979,7 +1006,16 @@ impl<'a> RabitDistCalculator<'a> {
         hacc_dist_table: &mut Vec<u8>,
         quantized_dists: &mut Vec<u32>,
     ) -> usize {
-        let (qmin, qmax) = quantize_dist_table_u16_into(&self.dist_table, quantized_dist_table);
+        let (qmin, qmax) =
+            match quantize_dist_table_u16_into(&self.dist_table, quantized_dist_table) {
+                DistTableDequant::Affine { qmin, qmax } => (qmin, qmax),
+                DistTableDequant::Exact => {
+                    // See binary_distances_with_scratch: non-finite affine
+                    // scale falls back to exact per-row distances.
+                    self.fill_exact_binary_distances(n, code_len, dists);
+                    return 0;
+                }
+            };
         simd::dist_table::transfer_4bit_dist_table_u16(quantized_dist_table, hacc_dist_table);
         let remainder = n % BATCH_SIZE;
         let simd_len = n - remainder;
@@ -2490,6 +2526,7 @@ mod tests {
     use arrow_array::{ArrayRef, Float32Array, Float64Array, UInt64Array};
     use lance_core::ROW_ID;
     use lance_linalg::distance::DistanceType;
+    use rstest::rstest;
 
     use crate::vector::bq::{RQRotationType, builder::RabitQuantizer};
     use crate::vector::quantizer::{Quantization, QuantizerStorage};
@@ -3483,6 +3520,97 @@ mod tests {
             // Gated indexes (with error factors) skip the FastScan artifacts
             // and score the bulk path with the exact kernels.
             assert_raw_query_multi_bit_distance_all_uses_fastscan(num_bits, false, true);
+        }
+    }
+
+    /// A dist table whose `num_tables`-scaled reconstruction overflows `f32`
+    /// must fall back to exact distances rather than the affine dequant's
+    /// `0 * inf = NaN`. Covers both the u8 (Normal) and u16 (Accurate) LUT
+    /// paths end-to-end through `distance_all`, asserting the result is
+    /// NaN-free and bit-identical to the always-exact per-row computation.
+    #[rstest]
+    fn test_degenerate_dist_table_falls_back_to_exact_distances(
+        #[values(ApproxMode::Normal, ApproxMode::Accurate)] approx_mode: ApproxMode,
+    ) {
+        let code_dim = 8usize;
+        let num_rows = BATCH_SIZE + 5;
+        let num_bits = 3;
+        let ex_bits = rabit_ex_bits(num_bits).unwrap();
+        let identity = Float32Array::from_iter_values(
+            (0..code_dim)
+                .flat_map(|row| (0..code_dim).map(move |col| if row == col { 1.0 } else { 0.0 })),
+        );
+        let rotate_mat =
+            FixedSizeListArray::try_new_from_values(identity, code_dim as i32).unwrap();
+        let metadata = RabitQuantizationMetadata {
+            rotate_mat: Some(rotate_mat),
+            rotate_mat_position: None,
+            fast_rotation_signs: None,
+            rotation_type: RQRotationType::Matrix,
+            code_dim: code_dim as u32,
+            num_bits,
+            packed: false,
+            query_estimator: RabitQueryEstimator::RawQuery,
+        };
+        let codes = FixedSizeListArray::try_new_from_values(
+            UInt8Array::from_iter_values((0..num_rows).map(|idx| (idx * 19) as u8)),
+            rabit_binary_code_bytes(code_dim) as i32,
+        )
+        .unwrap();
+        let ex_codes = make_test_ex_codes(num_rows, code_dim, num_bits);
+        let batch = make_test_batch_with_ex(codes, ex_codes);
+        let storage =
+            RabitQuantizationStorage::try_from_batch(batch, &metadata, DistanceType::L2, None)
+                .unwrap();
+        let query = Arc::new(Float32Array::from(vec![1.0; code_dim])) as ArrayRef;
+
+        let mut calc = storage.dist_calculator(query, 4.0);
+        calc.approx_mode = approx_mode;
+        // num_tables = (code_dim * 4) / SEGMENT_NUM_CODES = 2; the extrema sum
+        // (qmax - qmin = 4e38) overflows when scaled by num_tables, so the
+        // quantizer returns `Exact`. Per-row sums stay finite (each row reads
+        // one entry per segment), so the exact path is well-defined.
+        let mut degenerate = vec![0.0f32; code_dim * 4];
+        degenerate[0] = -2e38;
+        degenerate[1] = 2e38;
+        calc.dist_table = Cow::Owned(degenerate);
+
+        let code_len = rabit_binary_code_bytes(code_dim);
+        let ex_codes = calc.ex_codes.unwrap();
+        let ex_add_factors = calc.ex_add_factors.unwrap();
+        let ex_scale_factors = calc.ex_scale_factors.unwrap();
+        let expected = (0..num_rows)
+            .map(|id| {
+                let binary_ip = compute_single_rq_distance(
+                    calc.codes,
+                    id,
+                    num_rows,
+                    code_len,
+                    &calc.dist_table,
+                );
+                calc.raw_query_multi_bit_exact_distance(
+                    id,
+                    binary_ip,
+                    ex_bits,
+                    ex_codes,
+                    ex_add_factors,
+                    ex_scale_factors,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let actual = calc.distance_all(0);
+        assert_eq!(actual.len(), num_rows);
+        for id in 0..num_rows {
+            assert!(
+                !actual[id].is_nan(),
+                "approx_mode={approx_mode:?} id={id}: degenerate table produced NaN"
+            );
+            assert_eq!(
+                actual[id].to_bits(),
+                expected[id].to_bits(),
+                "approx_mode={approx_mode:?} id={id}: distance_all must match the exact path"
+            );
         }
     }
 


### PR DESCRIPTION
## What

`quantize_dist_table_into` / `quantize_dist_table_u16_into` quantize the per-(query, partition)
`dim * 4`-entry f32 FastScan distance table into u8 (fast/normal approx modes) or u16 (accurate
mode) LUT entries. Both were scalar: `itertools::minmax_by(total_cmp)` for the min/max pass
(branchy pairwise compares that never vectorize; `minmax_impl` alone is 6.0-6.6% of query time in
cpu-clock profiles of IVF_RQ on dbpedia-openai-1M, dim=1536, num_bits=5, nprobes=24) plus a
scalar quantize-write loop.

This moves them into a dedicated module `vector/bq/dist_table_quant.rs` with the same
runtime-dispatch treatment as the ex-dot kernels (#7205):

- min/max: two-accumulator 16-lane AVX-512 / 8-lane AVX2 folds; elsewhere a portable 16-lane
  fold that LLVM auto-vectorizes (NEON is part of the aarch64 baseline).
- quantize: `(d - qmin) * factor`, `cvtps_epi32` (nearest-even, MXCSR default), then
  unsigned-saturating narrows (`vpmovusdb`/`vpmovusdw` on AVX-512; `packus` + lane-restore
  permutes on AVX2); scalar fallback uses `round_ties_even`.

## Numeric semantics

- Rounding changes from `f32::round` (half away from zero) to half-to-even so the scalar
  fallback and all SIMD paths are bit-exact with each other. Relative to the old code this can
  move a LUT entry by 1 only on exact .5 ties, within the table's inherent quantization error.
- SIMD min/max vs `total_cmp` differs only on NaN (inputs are finite sums of rotated-query
  components) and the sign of zero, which callers cannot observe (`d - qmin` and the
  `qmin == qmax` early-out are unchanged either way).
- Degenerate ranges (table spread below ~`255/f32::MAX`, which overflows `factor` to inf, or
  above `f32::MAX`) now collapse to the zeroed-LUT early-out. Previously these produced garbage
  (NaN -> 0 casts); the SIMD narrows would additionally disagree across kernels on the NaN
  products, so the early-out keeps every path deterministic and bit-exact.

## Benchmarks

GCP c4-standard-16 (AVX-512), `taskset -c 4`, criterion baseline = main (b6a99cda9),
`cargo bench -p lance-index --bench rq`:

| bench (DIM=1536, rows=16384)        | before    | after     | change |
|-------------------------------------|-----------|-----------|--------|
| binary-only distance_all num_bits=3 | 130.89 us | 117.31 us | -10.3% |
| binary-only distance_all num_bits=5 | 127.69 us | 110.43 us | -13.6% |
| binary-only distance_all num_bits=9 | 127.91 us | 106.43 us | -16.4% |
| full distance_all num_bits=3        | 413.89 us | 399.48 us | -3.9%  |

The untouched `RQ bulk ex kernel loop` control group moved within +-3% between runs, so the
binary-only wins are far above the machine noise floor. Full-path results for num_bits=5/9 are
within that noise envelope (the binary stage is a small share of those).

On Apple M-series (NEON: portable min/max fold + autovectorized scalar quantize), the same
paired criterion run improves binary-only distance_all by -24% / -13% / -8% (num_bits=3/5/9);
the Mac's run-to-run noise is larger than the pinned GCP runs but all three move well past it.

## Tests

- New differential tests run every available kernel (scalar, AVX2, AVX-512 when detected)
  against a straightforward `total_cmp` + `round_ties_even` reference and require bit-exact
  agreement: random inputs (lengths 1..6160 including non-multiples of 16/32, scales
  1e-3..1e4), exact .5 ties (integer tables constructed so `factor == 0.5`), all-equal inputs,
  signed-zero mixes, degenerate ranges, and scratch-buffer reuse.
- `cargo test -p lance-index --lib vector::bq`: 207 pass on aarch64 (scalar + NEON dispatch)
  and on AVX-512/AVX2 hardware (GCP c4, both debug and release).
- `cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
