### PR TITLE
perf(vector): vectorize RaBitQ top-k lower-bound pruning scan

### DIFF
--- a/rust/lance-index/benches/rq.rs
+++ b/rust/lance-index/benches/rq.rs
@@ -512,9 +512,138 @@ fn ex_bulk_paths(c: &mut Criterion) {
     }
 }
 
+/// Top-k accumulation through the gated raw-query multi-bit path: binary
+/// FastScan, the per-row lower-bound pruning scan, and the exact rerank of
+/// the surviving rows. Error factors are present so the gating is enabled.
+fn heap_topk(c: &mut Criterion) {
+    use arrow_array::{ArrayRef, FixedSizeListArray, Float32Array, UInt8Array, UInt64Array};
+    use lance_arrow::FixedSizeListArrayExt;
+    use lance_index::vector::ApproxMode;
+    use lance_index::vector::bq::transform::{
+        ERROR_FACTORS_COLUMN, EX_ADD_FACTORS_COLUMN, EX_SCALE_FACTORS_COLUMN,
+    };
+    use lance_index::vector::storage::DistanceCalculatorOptions;
+    use std::collections::BinaryHeap;
+    use std::sync::Arc;
+
+    const TOPK_DIM: usize = 1536;
+    const TOPK_ROWS: usize = 4096;
+    const TOPK_K: usize = 10;
+    const NUM_BITS: u8 = 5;
+    let ex_bits = NUM_BITS - 1;
+
+    let mut rng = SmallRng::seed_from_u64(99);
+    let rq = RabitQuantizer::new_with_rotation::<Float32Type>(
+        NUM_BITS,
+        TOPK_DIM as i32,
+        RQRotationType::Fast,
+    );
+    let metadata = rq.metadata(None);
+
+    let code_len = TOPK_DIM / 8;
+    let binary_codes = (0..TOPK_ROWS * code_len)
+        .map(|_| rng.random())
+        .collect::<Vec<u8>>();
+    let ex_code_len = blocked_ex_code_bytes(TOPK_DIM, ex_bits);
+    let ex_codes = (0..TOPK_ROWS * ex_code_len)
+        .map(|_| rng.random())
+        .collect::<Vec<u8>>();
+    // Factor magnitudes chosen so the lower bounds spread mostly with the add
+    // factors; once the heap is full the threshold prunes the vast majority
+    // of rows, like a production multi-partition scan.
+    let mut rand_factors = |low: f32, high: f32| {
+        Arc::new(Float32Array::from(
+            (0..TOPK_ROWS)
+                .map(|_| rng.random_range(low..high))
+                .collect::<Vec<_>>(),
+        )) as ArrayRef
+    };
+    let batch = arrow_array::RecordBatch::try_from_iter(vec![
+        (
+            ROW_ID,
+            Arc::new(UInt64Array::from_iter_values(0..TOPK_ROWS as u64)) as ArrayRef,
+        ),
+        (
+            RABIT_CODE_COLUMN,
+            Arc::new(
+                FixedSizeListArray::try_new_from_values(
+                    UInt8Array::from(binary_codes),
+                    code_len as i32,
+                )
+                .unwrap(),
+            ) as ArrayRef,
+        ),
+        (ADD_FACTORS_COLUMN, rand_factors(0.0, 1.0)),
+        (SCALE_FACTORS_COLUMN, rand_factors(0.0005, 0.0015)),
+        (ERROR_FACTORS_COLUMN, rand_factors(0.0, 0.01)),
+        (
+            RABIT_BLOCKED_EX_CODE_COLUMN,
+            Arc::new(
+                FixedSizeListArray::try_new_from_values(
+                    UInt8Array::from(ex_codes),
+                    ex_code_len as i32,
+                )
+                .unwrap(),
+            ) as ArrayRef,
+        ),
+        (EX_ADD_FACTORS_COLUMN, rand_factors(0.0, 1.0)),
+        (EX_SCALE_FACTORS_COLUMN, rand_factors(0.00003, 0.0001)),
+    ])
+    .unwrap();
+    let storage =
+        RabitQuantizationStorage::try_from_batch(batch, &metadata, DistanceType::L2, None).unwrap();
+    let query: ArrayRef = Arc::new(Float32Array::from(
+        (0..TOPK_DIM)
+            .map(|_| rng.random_range(-1.0f32..1.0))
+            .collect::<Vec<_>>(),
+    ));
+
+    for (label, approx_mode) in [
+        ("normal", ApproxMode::Normal),
+        ("accurate", ApproxMode::Accurate),
+    ] {
+        let mut f32_scratch = Vec::new();
+        let calc = storage.dist_calculator_with_scratch(
+            query.clone(),
+            1.0,
+            None,
+            &mut f32_scratch,
+            DistanceCalculatorOptions { approx_mode },
+        );
+        let mut heap = BinaryHeap::with_capacity(TOPK_K + 1);
+        let mut dists = Vec::new();
+        let mut u16_scratch = Vec::new();
+        let mut u8_scratch = Vec::new();
+        let mut u32_scratch = Vec::new();
+        c.bench_function(
+            format!(
+                "RQ heap topk ({label}): num_bits={NUM_BITS}, DIM={TOPK_DIM}, rows={TOPK_ROWS}, k={TOPK_K}"
+            )
+            .as_str(),
+            |b| {
+                b.iter(|| {
+                    heap.clear();
+                    calc.accumulate_topk_with_scratch(
+                        TOPK_K,
+                        None,
+                        None,
+                        |id| id as u64,
+                        &mut heap,
+                        &mut dists,
+                        &mut u16_scratch,
+                        &mut u8_scratch,
+                        &mut u32_scratch,
+                    );
+                    black_box(heap.len())
+                })
+            },
+        );
+    }
+}
+
 criterion_group!(
     name=benches;
     config = Criterion::default().measurement_time(Duration::from_secs(10));
-    targets = construct_dist_table, compute_distances, ex_dot_kernels, ex_code_storage_load, ex_bulk_paths);
+    targets = construct_dist_table, compute_distances, ex_dot_kernels, ex_code_storage_load, ex_bulk_paths, heap_topk);
 
 criterion_main!(benches);

--- a/rust/lance-index/src/vector/bq.rs
+++ b/rust/lance-index/src/vector/bq.rs
@@ -20,6 +20,7 @@ use crate::vector::quantizer::QuantizerBuildParams;
 pub mod builder;
 pub(crate) mod dist_table_quant;
 pub mod ex_dot;
+pub mod prune;
 pub mod rotation;
 pub mod storage;
 pub mod transform;

--- a/rust/lance-index/src/vector/bq/prune.rs
+++ b/rust/lance-index/src/vector/bq/prune.rs
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! SIMD kernels for the RaBitQ top-k lower-bound pruning scan.
+//!
+//! Multi-bit IVF_RQ search gates the exact ex-code rerank with a per-row
+//! distance lower bound: after the binary FastScan fills the per-row binary
+//! inner products, every row of the partition is classified against the query
+//! upper bound and the current top-k heap threshold, and only the survivors
+//! (typically well under 1%) are reranked. The classification is the per-row
+//! formula of `RabitDistCalculator::raw_query_lower_bound`:
+//!
+//! ```text
+//! lower_bound = (binary_ip - 0.5 * sum_q) * scale_factor
+//!             + add_factor + query_factor
+//!             - error_factor * query_error
+//! ```
+//!
+//! These kernels evaluate the formula and both comparisons for
+//! [`PRUNE_LANES`] rows at a time, returning bit masks instead of values so
+//! the caller can skip whole groups (the overwhelmingly common case) and run
+//! the existing scalar rerank only for the surviving lanes.
+//!
+//! Correctness contract:
+//!
+//! - The lower bound is computed with exactly the operation order of the
+//!   scalar helper — multiplies and adds, never FMA. A fused multiply-add
+//!   rounds differently, which could prune a row the scalar code would have
+//!   kept; with bit-identical lower bounds the masks reproduce the scalar
+//!   `>=` decisions exactly, keeping heap contents and prune-stats counters
+//!   unchanged.
+//! - Comparisons use ordered-quiet GE predicates (`_CMP_GE_OQ`), matching
+//!   scalar `>=`: a NaN lower bound is never pruned and falls through to the
+//!   exact rerank.
+//! - The heap threshold may be a stale snapshot (it only ever tightens); the
+//!   caller re-checks surviving lanes against live values, so a stale
+//!   threshold can only over-select survivors, never wrongly prune.
+
+use std::sync::LazyLock;
+
+/// Rows classified per kernel invocation.
+pub const PRUNE_LANES: usize = 16;
+
+/// Per-query constants of the lower-bound formula, mirroring
+/// `RabitDistCalculator::raw_query_lower_bound` term by term.
+#[derive(Debug, Clone, Copy)]
+pub struct LowerBoundTerms {
+    /// `0.5 * sum_q`, subtracted from the binary inner product.
+    pub half_sum_q: f32,
+    pub query_factor: f32,
+    pub query_error: f32,
+}
+
+/// Classify [`PRUNE_LANES`] rows against the pruning bounds.
+///
+/// Arguments are the per-row binary inner products, scale factors, add
+/// factors, and error factors, followed by the formula constants, the query
+/// upper bound, and the heap threshold (`None` while the heap is not full,
+/// which disables the heap mask).
+///
+/// Returns `(pruned_upper_bound, pruned_heap)` masks: bit `i` of
+/// `pruned_upper_bound` is set when `lower_bound[i] >= upper_bound`, and bit
+/// `i` of `pruned_heap` is set when the row is not already pruned by the
+/// upper bound and `lower_bound[i] >= heap_threshold`. Surviving rows are the
+/// zero bits of the OR of both masks.
+pub type PruneMaskFn = fn(
+    &[f32; PRUNE_LANES],
+    &[f32; PRUNE_LANES],
+    &[f32; PRUNE_LANES],
+    &[f32; PRUNE_LANES],
+    LowerBoundTerms,
+    f32,
+    Option<f32>,
+) -> (u16, u16);
+
+/// Resolve the prune-mask kernel for the running CPU once; the result can be
+/// cached by the caller for per-partition use.
+pub fn prune_mask_kernel() -> PruneMaskFn {
+    static KERNEL: LazyLock<PruneMaskFn> = LazyLock::new(select_prune_mask_kernel);
+    *KERNEL
+}
+
+fn select_prune_mask_kernel() -> PruneMaskFn {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx512f") {
+            return x86::prune_masks_avx512_dispatch;
+        }
+        if std::arch::is_x86_feature_detected!("avx2") {
+            return x86::prune_masks_avx2_dispatch;
+        }
+    }
+    // On aarch64 the plain 16-wide loop auto-vectorizes to NEON (part of the
+    // baseline), so no dedicated kernel is needed.
+    prune_masks_portable
+}
+
+/// Portable implementation; also the reference for the SIMD kernels.
+fn prune_masks_portable(
+    dists: &[f32; PRUNE_LANES],
+    scale_factors: &[f32; PRUNE_LANES],
+    add_factors: &[f32; PRUNE_LANES],
+    error_factors: &[f32; PRUNE_LANES],
+    terms: LowerBoundTerms,
+    upper_bound: f32,
+    heap_threshold: Option<f32>,
+) -> (u16, u16) {
+    let mut lower_bounds = [0.0f32; PRUNE_LANES];
+    for lane in 0..PRUNE_LANES {
+        lower_bounds[lane] = ((dists[lane] - terms.half_sum_q) * scale_factors[lane]
+            + add_factors[lane]
+            + terms.query_factor)
+            - error_factors[lane] * terms.query_error;
+    }
+    let mut pruned_upper_bound = 0u16;
+    for (lane, lower_bound) in lower_bounds.iter().enumerate() {
+        pruned_upper_bound |= u16::from(*lower_bound >= upper_bound) << lane;
+    }
+    let mut pruned_heap = 0u16;
+    if let Some(threshold) = heap_threshold {
+        for (lane, lower_bound) in lower_bounds.iter().enumerate() {
+            pruned_heap |= u16::from(*lower_bound >= threshold) << lane;
+        }
+        pruned_heap &= !pruned_upper_bound;
+    }
+    (pruned_upper_bound, pruned_heap)
+}
+
+#[cfg(target_arch = "x86_64")]
+mod x86 {
+    use super::{LowerBoundTerms, PRUNE_LANES};
+    use std::arch::x86_64::*;
+
+    /// Lower bounds for 8 lanes with the scalar operation order (no FMA).
+    #[inline]
+    #[target_feature(enable = "avx")]
+    fn lower_bounds_avx(
+        dists: __m256,
+        scale_factors: __m256,
+        add_factors: __m256,
+        error_factors: __m256,
+        half_sum_q: __m256,
+        query_factor: __m256,
+        query_error: __m256,
+    ) -> __m256 {
+        let binary_distance = _mm256_add_ps(
+            _mm256_add_ps(
+                _mm256_mul_ps(_mm256_sub_ps(dists, half_sum_q), scale_factors),
+                add_factors,
+            ),
+            query_factor,
+        );
+        _mm256_sub_ps(binary_distance, _mm256_mul_ps(error_factors, query_error))
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx")]
+    fn ge_mask_avx(lower_bounds_lo: __m256, lower_bounds_hi: __m256, bound: f32) -> u16 {
+        let bound = _mm256_set1_ps(bound);
+        let lo = _mm256_movemask_ps(_mm256_cmp_ps::<_CMP_GE_OQ>(lower_bounds_lo, bound));
+        let hi = _mm256_movemask_ps(_mm256_cmp_ps::<_CMP_GE_OQ>(lower_bounds_hi, bound));
+        (lo | (hi << 8)) as u16
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn prune_masks_avx2(
+        dists: &[f32; PRUNE_LANES],
+        scale_factors: &[f32; PRUNE_LANES],
+        add_factors: &[f32; PRUNE_LANES],
+        error_factors: &[f32; PRUNE_LANES],
+        terms: LowerBoundTerms,
+        upper_bound: f32,
+        heap_threshold: Option<f32>,
+    ) -> (u16, u16) {
+        let half_sum_q = _mm256_set1_ps(terms.half_sum_q);
+        let query_factor = _mm256_set1_ps(terms.query_factor);
+        let query_error = _mm256_set1_ps(terms.query_error);
+        // SAFETY: the array references guarantee 16 readable floats each.
+        let lower_bounds_lo = unsafe {
+            lower_bounds_avx(
+                _mm256_loadu_ps(dists.as_ptr()),
+                _mm256_loadu_ps(scale_factors.as_ptr()),
+                _mm256_loadu_ps(add_factors.as_ptr()),
+                _mm256_loadu_ps(error_factors.as_ptr()),
+                half_sum_q,
+                query_factor,
+                query_error,
+            )
+        };
+        let lower_bounds_hi = unsafe {
+            lower_bounds_avx(
+                _mm256_loadu_ps(dists.as_ptr().add(8)),
+                _mm256_loadu_ps(scale_factors.as_ptr().add(8)),
+                _mm256_loadu_ps(add_factors.as_ptr().add(8)),
+                _mm256_loadu_ps(error_factors.as_ptr().add(8)),
+                half_sum_q,
+                query_factor,
+                query_error,
+            )
+        };
+        let pruned_upper_bound = ge_mask_avx(lower_bounds_lo, lower_bounds_hi, upper_bound);
+        let pruned_heap = match heap_threshold {
+            Some(threshold) => {
+                ge_mask_avx(lower_bounds_lo, lower_bounds_hi, threshold) & !pruned_upper_bound
+            }
+            None => 0,
+        };
+        (pruned_upper_bound, pruned_heap)
+    }
+
+    pub(super) fn prune_masks_avx2_dispatch(
+        dists: &[f32; PRUNE_LANES],
+        scale_factors: &[f32; PRUNE_LANES],
+        add_factors: &[f32; PRUNE_LANES],
+        error_factors: &[f32; PRUNE_LANES],
+        terms: LowerBoundTerms,
+        upper_bound: f32,
+        heap_threshold: Option<f32>,
+    ) -> (u16, u16) {
+        // SAFETY: only selected when AVX2 was detected.
+        unsafe {
+            prune_masks_avx2(
+                dists,
+                scale_factors,
+                add_factors,
+                error_factors,
+                terms,
+                upper_bound,
+                heap_threshold,
+            )
+        }
+    }
+
+    #[target_feature(enable = "avx512f")]
+    unsafe fn prune_masks_avx512(
+        dists: &[f32; PRUNE_LANES],
+        scale_factors: &[f32; PRUNE_LANES],
+        add_factors: &[f32; PRUNE_LANES],
+        error_factors: &[f32; PRUNE_LANES],
+        terms: LowerBoundTerms,
+        upper_bound: f32,
+        heap_threshold: Option<f32>,
+    ) -> (u16, u16) {
+        // SAFETY: the array references guarantee 16 readable floats each.
+        let (dists, scale_factors, add_factors, error_factors) = unsafe {
+            (
+                _mm512_loadu_ps(dists.as_ptr()),
+                _mm512_loadu_ps(scale_factors.as_ptr()),
+                _mm512_loadu_ps(add_factors.as_ptr()),
+                _mm512_loadu_ps(error_factors.as_ptr()),
+            )
+        };
+        let binary_distance = _mm512_add_ps(
+            _mm512_add_ps(
+                _mm512_mul_ps(
+                    _mm512_sub_ps(dists, _mm512_set1_ps(terms.half_sum_q)),
+                    scale_factors,
+                ),
+                add_factors,
+            ),
+            _mm512_set1_ps(terms.query_factor),
+        );
+        let lower_bounds = _mm512_sub_ps(
+            binary_distance,
+            _mm512_mul_ps(error_factors, _mm512_set1_ps(terms.query_error)),
+        );
+        let pruned_upper_bound =
+            _mm512_cmp_ps_mask::<_CMP_GE_OQ>(lower_bounds, _mm512_set1_ps(upper_bound));
+        let pruned_heap = match heap_threshold {
+            Some(threshold) => {
+                _mm512_cmp_ps_mask::<_CMP_GE_OQ>(lower_bounds, _mm512_set1_ps(threshold))
+                    & !pruned_upper_bound
+            }
+            None => 0,
+        };
+        (pruned_upper_bound, pruned_heap)
+    }
+
+    pub(super) fn prune_masks_avx512_dispatch(
+        dists: &[f32; PRUNE_LANES],
+        scale_factors: &[f32; PRUNE_LANES],
+        add_factors: &[f32; PRUNE_LANES],
+        error_factors: &[f32; PRUNE_LANES],
+        terms: LowerBoundTerms,
+        upper_bound: f32,
+        heap_threshold: Option<f32>,
+    ) -> (u16, u16) {
+        // SAFETY: only selected when AVX-512F was detected.
+        unsafe {
+            prune_masks_avx512(
+                dists,
+                scale_factors,
+                add_factors,
+                error_factors,
+                terms,
+                upper_bound,
+                heap_threshold,
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    fn available_kernels() -> Vec<(&'static str, PruneMaskFn)> {
+        // `mut` is only exercised on x86_64 where extra kernels may be pushed.
+        #[allow(unused_mut)]
+        let mut kernels = vec![
+            ("portable", prune_masks_portable as PruneMaskFn),
+            ("dispatched", prune_mask_kernel()),
+        ];
+        #[cfg(target_arch = "x86_64")]
+        {
+            if std::arch::is_x86_feature_detected!("avx2") {
+                kernels.push(("avx2", x86::prune_masks_avx2_dispatch));
+            }
+            if std::arch::is_x86_feature_detected!("avx512f") {
+                kernels.push(("avx512", x86::prune_masks_avx512_dispatch));
+            }
+        }
+        kernels
+    }
+
+    /// Per-lane reference mirroring `raw_query_lower_bound` and the scalar
+    /// pruning checks of the top-k scan.
+    fn reference_masks(
+        dists: &[f32; PRUNE_LANES],
+        scale_factors: &[f32; PRUNE_LANES],
+        add_factors: &[f32; PRUNE_LANES],
+        error_factors: &[f32; PRUNE_LANES],
+        terms: LowerBoundTerms,
+        upper_bound: f32,
+        heap_threshold: Option<f32>,
+    ) -> (u16, u16) {
+        let mut pruned_upper_bound = 0u16;
+        let mut pruned_heap = 0u16;
+        for lane in 0..PRUNE_LANES {
+            let lower_bound = (dists[lane] - terms.half_sum_q) * scale_factors[lane]
+                + add_factors[lane]
+                + terms.query_factor
+                - error_factors[lane] * terms.query_error;
+            if lower_bound >= upper_bound {
+                pruned_upper_bound |= 1 << lane;
+            } else if heap_threshold.is_some_and(|threshold| lower_bound >= threshold) {
+                pruned_heap |= 1 << lane;
+            }
+        }
+        (pruned_upper_bound, pruned_heap)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn assert_kernels_match_reference(
+        dists: &[f32; PRUNE_LANES],
+        scale_factors: &[f32; PRUNE_LANES],
+        add_factors: &[f32; PRUNE_LANES],
+        error_factors: &[f32; PRUNE_LANES],
+        terms: LowerBoundTerms,
+        upper_bound: f32,
+        heap_threshold: Option<f32>,
+        case: &str,
+    ) {
+        let expected = reference_masks(
+            dists,
+            scale_factors,
+            add_factors,
+            error_factors,
+            terms,
+            upper_bound,
+            heap_threshold,
+        );
+        for (name, kernel) in available_kernels() {
+            let actual = kernel(
+                dists,
+                scale_factors,
+                add_factors,
+                error_factors,
+                terms,
+                upper_bound,
+                heap_threshold,
+            );
+            assert_eq!(
+                actual, expected,
+                "kernel={name} case={case}: masks {actual:04x?} != {expected:04x?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_prune_masks_match_reference_on_random_inputs() {
+        let mut rng = SmallRng::seed_from_u64(42);
+        for round in 0..200 {
+            let mut dists = [0.0f32; PRUNE_LANES];
+            let mut scale_factors = [0.0f32; PRUNE_LANES];
+            let mut add_factors = [0.0f32; PRUNE_LANES];
+            let mut error_factors = [0.0f32; PRUNE_LANES];
+            for lane in 0..PRUNE_LANES {
+                dists[lane] = rng.random_range(-100.0f32..100.0);
+                scale_factors[lane] = rng.random_range(-2.0f32..2.0);
+                add_factors[lane] = rng.random_range(-10.0f32..10.0);
+                error_factors[lane] = rng.random_range(0.0f32..5.0);
+            }
+            let terms = LowerBoundTerms {
+                half_sum_q: rng.random_range(-50.0f32..50.0),
+                query_factor: rng.random_range(-10.0f32..10.0),
+                query_error: rng.random_range(0.0f32..2.0),
+            };
+            let upper_bound = rng.random_range(-50.0f32..50.0);
+            let heap_threshold = if round % 3 == 0 {
+                None
+            } else {
+                Some(rng.random_range(-50.0f32..50.0))
+            };
+            assert_kernels_match_reference(
+                &dists,
+                &scale_factors,
+                &add_factors,
+                &error_factors,
+                terms,
+                upper_bound,
+                heap_threshold,
+                &format!("random round {round}"),
+            );
+        }
+    }
+
+    #[test]
+    fn test_prune_masks_exact_boundaries() {
+        // With scale=1, err=0, half_sum_q=0, query_factor=0 the lower bound
+        // is the input itself, so bounds can be placed exactly on lanes.
+        let dists: [f32; PRUNE_LANES] = std::array::from_fn(|lane| lane as f32);
+        let scale_factors = [1.0f32; PRUNE_LANES];
+        let add_factors = [0.0f32; PRUNE_LANES];
+        let error_factors = [0.0f32; PRUNE_LANES];
+        let terms = LowerBoundTerms {
+            half_sum_q: 0.0,
+            query_factor: 0.0,
+            query_error: 1.0,
+        };
+        // Equality must prune (scalar uses `>=`): lanes 3.. hit the upper
+        // bound, lanes 1..3 hit only the heap threshold.
+        let (pruned_upper_bound, pruned_heap) = prune_masks_portable(
+            &dists,
+            &scale_factors,
+            &add_factors,
+            &error_factors,
+            terms,
+            3.0,
+            Some(1.0),
+        );
+        assert_eq!(pruned_upper_bound, 0xfff8);
+        assert_eq!(pruned_heap, 0x0006);
+        assert_kernels_match_reference(
+            &dists,
+            &scale_factors,
+            &add_factors,
+            &error_factors,
+            terms,
+            3.0,
+            Some(1.0),
+            "exact boundaries",
+        );
+        // No heap threshold: only the upper-bound mask is set.
+        assert_kernels_match_reference(
+            &dists,
+            &scale_factors,
+            &add_factors,
+            &error_factors,
+            terms,
+            3.0,
+            None,
+            "no heap threshold",
+        );
+    }
+
+    #[test]
+    fn test_prune_masks_nan_and_infinity_semantics() {
+        let mut dists = [0.0f32; PRUNE_LANES];
+        dists[0] = f32::NAN;
+        dists[1] = f32::INFINITY;
+        dists[2] = f32::NEG_INFINITY;
+        dists[3] = 1.0;
+        let mut scale_factors = [1.0f32; PRUNE_LANES];
+        scale_factors[4] = f32::NAN;
+        let add_factors = [0.0f32; PRUNE_LANES];
+        let mut error_factors = [0.0f32; PRUNE_LANES];
+        error_factors[5] = f32::INFINITY;
+        let terms = LowerBoundTerms {
+            half_sum_q: 0.0,
+            query_factor: 0.0,
+            query_error: 1.0,
+        };
+        for (upper_bound, heap_threshold) in [
+            (0.5, Some(0.0)),
+            (f32::INFINITY, Some(f32::NEG_INFINITY)),
+            (f32::NAN, Some(f32::NAN)),
+            (0.5, None),
+        ] {
+            assert_kernels_match_reference(
+                &dists,
+                &scale_factors,
+                &add_factors,
+                &error_factors,
+                terms,
+                upper_bound,
+                heap_threshold,
+                &format!("special values ub={upper_bound} thr={heap_threshold:?}"),
+            );
+        }
+        // NaN lower bounds (lane 0 via a NaN binary inner product, lane 4 via
+        // a NaN scale factor) must never be pruned by either mask.
+        let (pruned_upper_bound, pruned_heap) = prune_masks_portable(
+            &dists,
+            &scale_factors,
+            &add_factors,
+            &error_factors,
+            terms,
+            0.5,
+            Some(0.0),
+        );
+        assert_eq!(pruned_upper_bound & 0b1_0001, 0);
+        assert_eq!(pruned_heap & 0b1_0001, 0);
+    }
+}

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -17,7 +17,7 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, SchemaRef};
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
-use itertools::Itertools;
+use itertools::{Itertools, izip};
 use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray, RecordBatchExt};
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::{Error, ROW_ID, Result};
@@ -48,6 +48,7 @@ use crate::vector::bq::ex_dot::{
     EX_DOT_BLOCK_DIMS, ExDotFn, blocked_ex_code_bytes, ex_dot_kernel, pad_query_into,
     padded_query_len, repack_sequential_row, sequential_matches_blocked,
 };
+use crate::vector::bq::prune::{LowerBoundTerms, PRUNE_LANES, prune_mask_kernel};
 use crate::vector::bq::rotation::{apply_fast_rotation, apply_fast_rotation_in_place};
 use crate::vector::bq::transform::{
     ADD_FACTORS_COLUMN, ERROR_FACTORS_COLUMN, EX_ADD_FACTORS_COLUMN, EX_SCALE_FACTORS_COLUMN,
@@ -136,16 +137,28 @@ fn emit_rabit_prune_stats(message: &str) {
     );
 }
 
-fn record_rabit_prune_stats(
+/// Per-scan tallies of the raw-query lower-bound gating, reported through
+/// `record_rabit_prune_stats`.
+#[derive(Default)]
+struct RabitPruneCounters {
     candidates: usize,
     pruned_upper_bound: usize,
     pruned_heap: usize,
     exact: usize,
     exact_rejected: usize,
-) {
+}
+
+fn record_rabit_prune_stats(counters: &RabitPruneCounters) {
     if !rabit_prune_stats_enabled() {
         return;
     }
+    let RabitPruneCounters {
+        candidates,
+        pruned_upper_bound,
+        pruned_heap,
+        exact,
+        exact_rejected,
+    } = *counters;
 
     let stats = RABIT_PRUNE_STATS.get_or_init(RabitPruneStats::default);
     let calls = stats.calls.fetch_add(1, Ordering::Relaxed) + 1;
@@ -798,6 +811,20 @@ struct RabitDistCalculatorParts<'a> {
     approx_mode: ApproxMode,
 }
 
+/// Loop-invariant inputs of the raw-query multi-bit top-k scans: the row
+/// count, the resolved ex-code state for exact reranking, and the query
+/// bounds.
+struct RawQueryTopkContext<'a> {
+    n: usize,
+    k: usize,
+    ex_bits: u8,
+    ex_codes: &'a [u8],
+    ex_add_factors: &'a [f32],
+    ex_scale_factors: &'a [f32],
+    query_lower_bound: f32,
+    query_upper_bound: f32,
+}
+
 /// Pick the query slice the ex-dot kernels consume: the rotated query itself
 /// when the dim is block-aligned, otherwise a zero-padded copy.
 fn kernel_query<'a>(rotated_query: &'a [f32], padded: &'a [f32]) -> &'a [f32] {
@@ -1212,6 +1239,107 @@ impl<'a> RabitDistCalculator<'a> {
         full_dot * ex_scale_factors[id] + ex_add_factors[id] + self.query_factor
     }
 
+    /// Compute the binary inner products into `dists` and resolve the inputs
+    /// shared by the raw-query multi-bit top-k scans. Returns `None` when the
+    /// partition has no rows.
+    #[allow(clippy::too_many_arguments)]
+    fn raw_query_multi_bit_topk_context(
+        &self,
+        k: usize,
+        lower_bound: Option<f32>,
+        upper_bound: Option<f32>,
+        dists: &mut Vec<f32>,
+        quantized_dists: &mut Vec<u16>,
+        quantized_dists_table: &mut Vec<u8>,
+        hacc_quantized_dists: &mut Vec<u32>,
+    ) -> Option<RawQueryTopkContext<'_>> {
+        let code_len = rabit_binary_code_bytes(self.dim);
+        let n = self.codes.len() / code_len;
+        if n == 0 {
+            dists.clear();
+            quantized_dists.clear();
+            hacc_quantized_dists.clear();
+            return None;
+        }
+
+        self.binary_distances_with_scratch(
+            n,
+            code_len,
+            dists,
+            quantized_dists,
+            quantized_dists_table,
+            hacc_quantized_dists,
+        );
+
+        Some(RawQueryTopkContext {
+            n,
+            k,
+            ex_bits: self.num_bits - 1,
+            ex_codes: self
+                .ex_codes
+                .expect("raw-query multi-bit RQ requires ex codes"),
+            ex_add_factors: self
+                .ex_add_factors
+                .expect("raw-query multi-bit RQ requires ex add factors"),
+            ex_scale_factors: self
+                .ex_scale_factors
+                .expect("raw-query multi-bit RQ requires ex scale factors"),
+            query_lower_bound: lower_bound.unwrap_or(f32::MIN),
+            query_upper_bound: upper_bound.unwrap_or(f32::MAX),
+        })
+    }
+
+    /// Process one candidate row given its lower bound: the bound checks,
+    /// the exact rerank, and the heap update shared by the sparse scan and
+    /// the dense scan's surviving lanes and tail.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn accumulate_raw_query_multi_bit_row(
+        &self,
+        ctx: &RawQueryTopkContext<'_>,
+        id: usize,
+        row_id: u64,
+        binary_ip: f32,
+        raw_lower_bound: f32,
+        res: &mut BinaryHeap<OrderedNode<u64>>,
+        max_dist: &mut Option<OrderedFloat>,
+        counters: &mut RabitPruneCounters,
+    ) {
+        if raw_lower_bound >= ctx.query_upper_bound {
+            counters.pruned_upper_bound += 1;
+            return;
+        }
+        if res.len() >= ctx.k && max_dist.is_some_and(|max_dist| raw_lower_bound >= max_dist.0) {
+            counters.pruned_heap += 1;
+            return;
+        }
+
+        counters.exact += 1;
+        let dist = self.raw_query_multi_bit_exact_distance(
+            id,
+            binary_ip,
+            ctx.ex_bits,
+            ctx.ex_codes,
+            ctx.ex_add_factors,
+            ctx.ex_scale_factors,
+        );
+        if dist < ctx.query_lower_bound || dist >= ctx.query_upper_bound {
+            counters.exact_rejected += 1;
+            return;
+        }
+        let dist = OrderedFloat(dist);
+        if res.len() < ctx.k {
+            res.push(OrderedNode::new(row_id, dist));
+            if res.len() == ctx.k {
+                *max_dist = res.peek().map(|node| node.dist);
+            }
+        } else if max_dist.is_some_and(|max_dist| max_dist > dist) {
+            res.pop();
+            res.push(OrderedNode::new(row_id, dist));
+            *max_dist = res.peek().map(|node| node.dist);
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn accumulate_raw_query_multi_bit_topk_with_scratch(
         &self,
@@ -1225,92 +1353,151 @@ impl<'a> RabitDistCalculator<'a> {
         quantized_dists_table: &mut Vec<u8>,
         hacc_quantized_dists: &mut Vec<u32>,
     ) {
-        let code_len = rabit_binary_code_bytes(self.dim);
-        let n = self.codes.len() / code_len;
-        if n == 0 {
-            dists.clear();
-            quantized_dists.clear();
-            hacc_quantized_dists.clear();
-            return;
-        }
-
-        self.binary_distances_with_scratch(
-            n,
-            code_len,
+        let Some(ctx) = self.raw_query_multi_bit_topk_context(
+            k,
+            lower_bound,
+            upper_bound,
             dists,
             quantized_dists,
             quantized_dists_table,
             hacc_quantized_dists,
-        );
-
-        let ex_bits = self.num_bits - 1;
-        let ex_codes = self
-            .ex_codes
-            .expect("raw-query multi-bit RQ requires ex codes");
-        let ex_add_factors = self
-            .ex_add_factors
-            .expect("raw-query multi-bit RQ requires ex add factors");
-        let ex_scale_factors = self
-            .ex_scale_factors
-            .expect("raw-query multi-bit RQ requires ex scale factors");
-        let query_lower_bound = lower_bound.unwrap_or(f32::MIN);
-        let query_upper_bound = upper_bound.unwrap_or(f32::MAX);
+        ) else {
+            return;
+        };
         let mut max_dist = res.peek().map(|node| node.dist);
-        let mut candidates = 0;
-        let mut pruned_upper_bound = 0;
-        let mut pruned_heap = 0;
-        let mut exact = 0;
-        let mut exact_rejected = 0;
+        let mut counters = RabitPruneCounters::default();
 
         for (id, row_id) in row_ids {
             let Some(binary_ip) = dists.get(id).copied() else {
                 continue;
             };
-            candidates += 1;
+            counters.candidates += 1;
             let Some(raw_lower_bound) = self.raw_query_lower_bound(id, binary_ip) else {
                 continue;
             };
-            if raw_lower_bound >= query_upper_bound {
-                pruned_upper_bound += 1;
-                continue;
-            }
-            if res.len() >= k && max_dist.is_some_and(|max_dist| raw_lower_bound >= max_dist.0) {
-                pruned_heap += 1;
-                continue;
-            }
-
-            exact += 1;
-            let dist = self.raw_query_multi_bit_exact_distance(
+            self.accumulate_raw_query_multi_bit_row(
+                &ctx,
                 id,
+                row_id,
                 binary_ip,
-                ex_bits,
-                ex_codes,
-                ex_add_factors,
-                ex_scale_factors,
+                raw_lower_bound,
+                res,
+                &mut max_dist,
+                &mut counters,
             );
-            if dist < query_lower_bound || dist >= query_upper_bound {
-                exact_rejected += 1;
-                continue;
-            }
-            let dist = OrderedFloat(dist);
-            if res.len() < k {
-                res.push(OrderedNode::new(row_id, dist));
-                if res.len() == k {
-                    max_dist = res.peek().map(|node| node.dist);
-                }
-            } else if max_dist.is_some_and(|max_dist| max_dist > dist) {
-                res.pop();
-                res.push(OrderedNode::new(row_id, dist));
-                max_dist = res.peek().map(|node| node.dist);
+        }
+        record_rabit_prune_stats(&counters);
+    }
+
+    /// Top-k scan over all rows `0..n` in order: classify [`PRUNE_LANES`]
+    /// rows at a time with the SIMD lower-bound kernel and run the scalar
+    /// rerank only for the surviving lanes.
+    #[allow(clippy::too_many_arguments)]
+    fn accumulate_raw_query_multi_bit_topk_dense_with_scratch(
+        &self,
+        k: usize,
+        lower_bound: Option<f32>,
+        upper_bound: Option<f32>,
+        row_id: impl Fn(u32) -> u64,
+        res: &mut BinaryHeap<OrderedNode<u64>>,
+        dists: &mut Vec<f32>,
+        quantized_dists: &mut Vec<u16>,
+        quantized_dists_table: &mut Vec<u8>,
+        hacc_quantized_dists: &mut Vec<u32>,
+    ) {
+        let Some(ctx) = self.raw_query_multi_bit_topk_context(
+            k,
+            lower_bound,
+            upper_bound,
+            dists,
+            quantized_dists,
+            quantized_dists_table,
+            hacc_quantized_dists,
+        ) else {
+            return;
+        };
+        let dists = dists.as_slice();
+        debug_assert_eq!(dists.len(), ctx.n);
+        let scale_factors = &self.scale_factors[..ctx.n];
+        let add_factors = &self.add_factors[..ctx.n];
+        let error_factors = &self
+            .error_factors
+            .expect("raw-query lower-bound gating requires error factors")[..ctx.n];
+        // Same expression as `raw_query_lower_bound` with `error_factors`
+        // already resolved; the masks below match it bit for bit.
+        let lower_bound_of = |id: usize, binary_ip: f32| {
+            self.raw_query_binary_distance(id, binary_ip) - error_factors[id] * self.query_error
+        };
+        let terms = LowerBoundTerms {
+            half_sum_q: 0.5 * self.sum_q,
+            query_factor: self.query_factor,
+            query_error: self.query_error,
+        };
+        let prune_masks = prune_mask_kernel();
+        let mut max_dist = res.peek().map(|node| node.dist);
+        let mut counters = RabitPruneCounters::default();
+
+        let (dist_groups, dist_tail) = dists.as_chunks::<PRUNE_LANES>();
+        let (scale_groups, _) = scale_factors.as_chunks::<PRUNE_LANES>();
+        let (add_groups, _) = add_factors.as_chunks::<PRUNE_LANES>();
+        let (error_groups, _) = error_factors.as_chunks::<PRUNE_LANES>();
+        for (group, (dist16, scale16, add16, error16)) in
+            izip!(dist_groups, scale_groups, add_groups, error_groups).enumerate()
+        {
+            counters.candidates += PRUNE_LANES;
+            // The heap threshold only ever tightens, so this group-start
+            // snapshot can only over-select survivors (which the per-row
+            // processing below re-checks against live values), never prune a
+            // row the scalar scan would have kept.
+            let heap_threshold = (res.len() >= ctx.k)
+                .then(|| max_dist.map(|max_dist| max_dist.0))
+                .flatten();
+            let (pruned_upper_bound, pruned_heap) = prune_masks(
+                dist16,
+                scale16,
+                add16,
+                error16,
+                terms,
+                ctx.query_upper_bound,
+                heap_threshold,
+            );
+            counters.pruned_upper_bound += pruned_upper_bound.count_ones() as usize;
+            counters.pruned_heap += pruned_heap.count_ones() as usize;
+            let mut survivors = !(pruned_upper_bound | pruned_heap);
+            while survivors != 0 {
+                let lane = survivors.trailing_zeros() as usize;
+                survivors &= survivors - 1;
+                let id = group * PRUNE_LANES + lane;
+                let binary_ip = dists[id];
+                self.accumulate_raw_query_multi_bit_row(
+                    &ctx,
+                    id,
+                    row_id(id as u32),
+                    binary_ip,
+                    lower_bound_of(id, binary_ip),
+                    res,
+                    &mut max_dist,
+                    &mut counters,
+                );
             }
         }
-        record_rabit_prune_stats(
-            candidates,
-            pruned_upper_bound,
-            pruned_heap,
-            exact,
-            exact_rejected,
-        );
+
+        let tail_start = ctx.n - dist_tail.len();
+        for (offset, binary_ip) in dist_tail.iter().copied().enumerate() {
+            let id = tail_start + offset;
+            counters.candidates += 1;
+            self.accumulate_raw_query_multi_bit_row(
+                &ctx,
+                id,
+                row_id(id as u32),
+                binary_ip,
+                lower_bound_of(id, binary_ip),
+                res,
+                &mut max_dist,
+                &mut counters,
+            );
+        }
+        record_rabit_prune_stats(&counters);
     }
 
     fn raw_query_lower_bound_gating_disabled_reason(&self) -> Option<&'static str> {
@@ -1717,13 +1904,11 @@ impl DistCalculator for RabitDistCalculator<'_> {
             return;
         }
 
-        let code_len = rabit_binary_code_bytes(self.dim);
-        let n = self.codes.len() / code_len;
-        self.accumulate_raw_query_multi_bit_topk_with_scratch(
+        self.accumulate_raw_query_multi_bit_topk_dense_with_scratch(
             k,
             lower_bound,
             upper_bound,
-            (0..n).map(|id| (id, row_id(id as u32))),
+            row_id,
             res,
             dists,
             quantized_dists,
@@ -2526,6 +2711,8 @@ mod tests {
     use arrow_array::{ArrayRef, Float32Array, Float64Array, UInt64Array};
     use lance_core::ROW_ID;
     use lance_linalg::distance::DistanceType;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
     use rstest::rstest;
 
     use crate::vector::bq::{RQRotationType, builder::RabitQuantizer};
@@ -3738,6 +3925,200 @@ mod tests {
                 (actual_dist - expected_dist).abs() < 1e-5,
                 "actual={actual_dist}, expected={expected_dist}"
             );
+        }
+    }
+
+    /// Inputs crafted so the top-k scan outcomes are fully determined by the
+    /// factor columns: with zero scale factors, a zero query factor, and a
+    /// query error of one, the lower bound is
+    /// `add_factors[id] - error_factors[id]`, and with zero ex scale factors
+    /// the exact distance is `ex_add_factors[id]`, regardless of the random
+    /// codes and query.
+    struct CraftedTopkData {
+        codes: Vec<u8>,
+        ex_codes: Vec<u8>,
+        dist_table: Vec<f32>,
+        ex_query: Vec<f32>,
+        scale_factors: Vec<f32>,
+        add_factors: Vec<f32>,
+        error_factors: Vec<f32>,
+        ex_scale_factors: Vec<f32>,
+        ex_add_factors: Vec<f32>,
+    }
+
+    const CRAFTED_TOPK_DIM: usize = 64;
+    const CRAFTED_TOPK_NUM_BITS: u8 = 5;
+
+    impl CraftedTopkData {
+        fn new(
+            exact_dists: &[f32],
+            lower_bound_margins: &[f32],
+            error_factors: Vec<f32>,
+            rng: &mut SmallRng,
+        ) -> Self {
+            let n = exact_dists.len();
+            let code_len = rabit_binary_code_bytes(CRAFTED_TOPK_DIM);
+            let ex_code_len = blocked_ex_code_bytes(CRAFTED_TOPK_DIM, CRAFTED_TOPK_NUM_BITS - 1);
+            let add_factors = izip!(exact_dists, lower_bound_margins, &error_factors)
+                .map(|(dist, margin, error)| dist - margin + error)
+                .collect();
+            Self {
+                codes: (0..n * code_len).map(|_| rng.random()).collect(),
+                ex_codes: (0..n * ex_code_len).map(|_| rng.random()).collect(),
+                dist_table: (0..CRAFTED_TOPK_DIM * 4)
+                    .map(|_| rng.random_range(-1.0f32..1.0))
+                    .collect(),
+                ex_query: (0..CRAFTED_TOPK_DIM)
+                    .map(|_| rng.random_range(-1.0f32..1.0))
+                    .collect(),
+                scale_factors: vec![0.0; n],
+                add_factors,
+                error_factors,
+                ex_scale_factors: vec![0.0; n],
+                ex_add_factors: exact_dists.to_vec(),
+            }
+        }
+
+        fn calculator(&self, approx_mode: ApproxMode) -> RabitDistCalculator<'_> {
+            RabitDistCalculator::new(
+                CRAFTED_TOPK_DIM,
+                CRAFTED_TOPK_NUM_BITS,
+                RabitQueryEstimator::RawQuery,
+                Cow::Borrowed(self.dist_table.as_slice()),
+                Cow::Borrowed(self.ex_query.as_slice()),
+                0.7,
+                &self.codes,
+                Some(&self.ex_codes),
+                blocked_ex_code_bytes(CRAFTED_TOPK_DIM, CRAFTED_TOPK_NUM_BITS - 1),
+                &self.add_factors,
+                &self.scale_factors,
+                Some(&self.error_factors),
+                Some(&self.ex_add_factors),
+                Some(&self.ex_scale_factors),
+                None,
+                0.0,
+                1.0,
+                approx_mode,
+            )
+        }
+    }
+
+    fn canonical_heap_rows(heap: BinaryHeap<OrderedNode<u64>>) -> Vec<(u32, u64)> {
+        let mut rows = heap
+            .into_iter()
+            .map(|node| (node.dist.0.to_bits(), node.id))
+            .collect::<Vec<_>>();
+        rows.sort_unstable();
+        rows
+    }
+
+    /// The dense (SIMD-pruned) scan must reproduce the sparse scalar scan
+    /// exactly: identical heap contents including row ids, and the k smallest
+    /// in-bounds exact distances overall.
+    #[rstest]
+    fn test_raw_query_multi_bit_topk_dense_matches_sparse(
+        #[values(ApproxMode::Normal, ApproxMode::Accurate)] approx_mode: ApproxMode,
+        #[values("descending", "ascending", "random", "duplicates", "duplicate_ties")]
+        ordering: &str,
+    ) {
+        for n in [1usize, 15, 16, 17, 100, 4109] {
+            let mut rng = SmallRng::seed_from_u64(n as u64 * 31 + ordering.len() as u64);
+            let exact_dists: Vec<f32> = match ordering {
+                // Improving rows force constant heap updates.
+                "descending" => (0..n).map(|id| (n - id) as f32).collect(),
+                // Worsening rows force mass pruning, the common regime.
+                "ascending" => (0..n).map(|id| id as f32).collect(),
+                "random" => (0..n).map(|_| rng.random_range(0.0..n as f32)).collect(),
+                "duplicates" => (0..n).map(|id| (id % 7) as f32).collect(),
+                // Lower bound equals the distance, so heap-threshold and
+                // upper-bound comparisons hit exact `>=` ties.
+                "duplicate_ties" => (0..n).map(|id| (id % 5) as f32).collect(),
+                _ => unreachable!(),
+            };
+            let (margins, error_factors) = if ordering == "duplicate_ties" {
+                (vec![0.0; n], vec![0.0; n])
+            } else if ordering == "random" {
+                (
+                    (0..n).map(|_| rng.random_range(0.0f32..2.0)).collect(),
+                    (0..n).map(|_| rng.random_range(0.0f32..1.0)).collect(),
+                )
+            } else {
+                (
+                    vec![1.0; n],
+                    (0..n).map(|_| rng.random_range(0.0f32..1.0)).collect(),
+                )
+            };
+            let data = CraftedTopkData::new(&exact_dists, &margins, error_factors, &mut rng);
+            let calc = data.calculator(approx_mode);
+            assert!(
+                calc.raw_query_lower_bound_gating_disabled_reason()
+                    .is_none()
+            );
+
+            let max_dist = exact_dists.iter().fold(0.0f32, |acc, dist| acc.max(*dist));
+            for k in [1usize, 10, n + 7] {
+                for bounds in [(None, None), (Some(max_dist * 0.25), Some(max_dist * 0.7))] {
+                    let (lower_bound, upper_bound) = bounds;
+                    let mut dense_heap = BinaryHeap::new();
+                    let mut sparse_heap = BinaryHeap::new();
+                    let mut dists = Vec::new();
+                    let mut u16_scratch = Vec::new();
+                    let mut u8_scratch = Vec::new();
+                    let mut u32_scratch = Vec::new();
+                    // Two passes sharing the heap, as IVF partition probing
+                    // does: the second pass starts with a full, tight heap.
+                    for pass in 0..2u64 {
+                        let offset = pass * n as u64;
+                        calc.accumulate_topk_with_scratch(
+                            k,
+                            lower_bound,
+                            upper_bound,
+                            |id| id as u64 + offset,
+                            &mut dense_heap,
+                            &mut dists,
+                            &mut u16_scratch,
+                            &mut u8_scratch,
+                            &mut u32_scratch,
+                        );
+                        calc.accumulate_filtered_topk_with_scratch(
+                            k,
+                            lower_bound,
+                            upper_bound,
+                            (0..n as u32).map(|id| (id, id as u64 + offset)),
+                            |_| true,
+                            &mut sparse_heap,
+                            &mut dists,
+                            &mut u16_scratch,
+                            &mut u8_scratch,
+                            &mut u32_scratch,
+                        );
+                    }
+                    let dense = canonical_heap_rows(dense_heap);
+                    let sparse = canonical_heap_rows(sparse_heap);
+                    assert_eq!(
+                        dense, sparse,
+                        "ordering={ordering} n={n} k={k} bounds={bounds:?} mode={approx_mode:?}"
+                    );
+
+                    // The distance multiset must be the k smallest in-bounds
+                    // distances over both passes. Row ids are not compared:
+                    // evictions among tied maxima depend on heap layout.
+                    let query_lower_bound = lower_bound.unwrap_or(f32::MIN);
+                    let query_upper_bound = upper_bound.unwrap_or(f32::MAX);
+                    let mut expected = (0..2 * n)
+                        .map(|row| exact_dists[row % n])
+                        .filter(|dist| *dist >= query_lower_bound && *dist < query_upper_bound)
+                        .map(|dist| dist.to_bits())
+                        .collect::<Vec<_>>();
+                    expected.sort_unstable();
+                    expected.truncate(k);
+                    let actual = dense.iter().map(|(dist, _)| *dist).collect::<Vec<_>>();
+                    assert_eq!(
+                        actual, expected,
+                        "ordering={ordering} n={n} k={k} bounds={bounds:?} mode={approx_mode:?}"
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## What

The per-partition top-k scan of multi-bit IVF_RQ search (`accumulate_raw_query_multi_bit_topk_with_scratch`, Normal/Accurate modes) walked all `n` rows with a scalar lower-bound computation — per row: 4 bounds-checked loads, ~5 FLOPs, two compares, iterator and `Option` plumbing — even though ~99.9% of rows are pruned once the heap is tight. On dbpedia-openai-1M (1536d, num_bits=5, nprobes=24, k=10) this loop profiled at ~10–13% of query self time.

This PR vectorizes the classification:

- **Dense path** (`accumulate_topk_with_scratch`, rows `0..n`): new `bq::prune` kernels evaluate the lower bound and both pruning compares for 16 rows per call, returning bit masks. Mask-zero groups (the common case) are skipped whole; surviving lanes run the existing scalar rerank with live values. The `row_id` mapping is now only invoked for rows that reach the scalar tail, and no scratch buffer is needed — everything stays in registers.
- **Sparse path** (prefiltered `accumulate_filtered_topk_with_scratch`): unchanged scalar loop.

Kernels follow the `ex_dot` dispatch pattern: `#[target_feature]` AVX-512 and AVX2 implementations behind a `LazyLock` runtime-dispatched fn pointer, with a portable 16-wide fallback that LLVM auto-vectorizes (NEON is baseline on aarch64).

`accumulate_distances_into_heap` (Fast-mode bypass) is left as is: it has no factor arrays and would need a separate kernel shape, and Fast mode doesn't take the gated path.

## Correctness

The dense path is bit-identical to the scalar implementation, not just statistically equivalent:

- The kernels keep the scalar operation order (multiplies and adds, **no FMA**), so the lower bounds match `raw_query_lower_bound` bit for bit, and comparisons use ordered-quiet GE (`_CMP_GE_OQ`) matching scalar `>=` (a NaN lower bound is never pruned).
- The heap threshold snapshot taken at each 16-row group start can be stale, but the threshold only ever tightens, so the masks can only over-select survivors — and survivors are re-checked per row against live values.
- Heap contents, processing order, and the `LANCE_RQ_PRUNE_STATS` counters are unchanged.

## Tests

- `vector::bq::prune`: every available kernel (portable, AVX2, AVX-512, dispatched) against a per-lane scalar reference on random inputs, exact `>=` boundary ties, and NaN/±inf semantics.
- `test_raw_query_multi_bit_topk_dense_matches_sparse`: differential test of the dense path against the unchanged sparse scalar path with crafted factor columns controlling lower bounds and exact distances — n ∈ {1, 15, 16, 17, 100, 4109} × k ∈ {1, 10, n+7} × bounds, distance orderings descending (constant heap churn), ascending (mass pruning), random, duplicates, and exact ties, with a second pass on the shared heap (the carried tight-threshold regime). Asserts identical heap contents (row ids + distance bit patterns) and the k-smallest-distances reference.
- `cargo test -p lance-index --lib vector::bq` and `cargo test -p lance ivf_rq` pass on aarch64 (portable kernel) and on x86_64 with AVX-512 (GCP c4-standard-16).

## Benchmark

New `RQ heap topk` bench (binary FastScan + pruning scan + exact rerank; 4096 rows, k=10, DIM=1536, num_bits=5, error factors present so gating is enabled), GCP c4-standard-16 (AVX-512), pinned core:

| mode | before | after | change |
|---|---|---|---|
| normal | 70.7 µs | 64.9 µs | **−9.4%** (p = 0.00) |
| accurate | 93.4 µs | 87.9 µs | **−5.7%** (p = 0.00) |

The binary FastScan portion of the bench is unchanged; the delta is the pruning scan itself, matching the ~5–9% end-to-end win predicted from the profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
