### PR TITLE
fix: evaluate all list-element docs in FTS prefilter walk-the-allowlist branch

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -37,7 +37,7 @@ use datafusion::physical_plan::metrics::Time;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use fst::{Automaton, IntoStreamer, Streamer};
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt, stream};
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use lance_arrow::{RecordBatchExt, iter_str_array};
 use lance_core::cache::{CacheCodec, CacheKey, LanceCache, WeakLanceCache};
 use lance_core::deepsize::DeepSizeOf;
@@ -4615,18 +4615,25 @@ impl DocSet {
         self.row_ids[doc_id as usize]
     }
 
-    pub fn doc_id(&self, row_id: u64) -> Option<u64> {
+    /// Resolve a `row_id` to every `doc_id` it owns.
+    ///
+    /// A scalar column maps each row to a single document, but a
+    /// `list<string>` column indexes every element as its own document, so a
+    /// single `row_id` can own several `doc_id`s sharing that key in `inv`.
+    /// The prefilter path (`flat_search`) walks an allow-list of row_ids and
+    /// must evaluate *all* of a row's documents; resolving to one `doc_id`
+    /// silently drops matches at non-last list positions (lancedb#3352).
+    pub fn doc_ids(&self, row_id: u64) -> impl Iterator<Item = u64> + '_ {
         if self.inv.is_empty() {
-            // in legacy format, the row id is doc id
-            match self.row_ids.binary_search(&row_id) {
-                Ok(_) => Some(row_id),
-                Err(_) => None,
-            }
+            // in legacy format, the row id is doc id (one document per row)
+            let found = self.row_ids.binary_search(&row_id).is_ok();
+            Either::Left(found.then_some(row_id).into_iter())
         } else {
-            match self.inv.binary_search_by_key(&row_id, |x| x.0) {
-                Ok(idx) => Some(self.inv[idx].1 as u64),
-                Err(_) => None,
-            }
+            // `inv` is sorted by row_id, so the entries sharing this key form a
+            // contiguous run; yield the doc_id of each.
+            let lo = self.inv.partition_point(|entry| entry.0 < row_id);
+            let hi = self.inv.partition_point(|entry| entry.0 <= row_id);
+            Either::Right(self.inv[lo..hi].iter().map(|entry| entry.1 as u64))
         }
     }
     pub fn total_tokens_num(&self) -> u64 {

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -2273,14 +2273,15 @@ mod tests {
             )
             .unwrap();
 
-        let matched = result
-            .into_iter()
-            .map(|doc| match doc.addr {
-                CandidateAddr::RowId(r) => r,
-                CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(matched, vec![100]);
+        // flat_search resolves the prefilter against the DocSet, so the single
+        // match comes back as a concrete RowId(100) rather than a deferred
+        // Pending addr. Asserting on the whole result avoids a never-taken
+        // match arm that would otherwise read as uncovered.
+        let addrs = result.into_iter().map(|doc| doc.addr).collect::<Vec<_>>();
+        assert!(
+            matches!(addrs.as_slice(), [CandidateAddr::RowId(100)]),
+            "expected exactly row 100, got {addrs:?}"
+        );
     }
 
     #[test]

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -819,11 +819,16 @@ impl<'a, S: Scorer> Wand<'a, S> {
         }
 
         // we need to map the row ids to doc ids, and sort them,
-        // because WAND PostingIterator can't go back to the previous doc id
+        // because WAND PostingIterator can't go back to the previous doc id.
+        // A list column maps one row id to several doc ids, so expand every
+        // document the row owns — keying on a single doc id would drop matches
+        // at non-last list positions (lancedb#3352).
         let doc_ids = row_ids
-            .filter_map(|row_addr| {
+            .flat_map(|row_addr| {
                 let row_id: u64 = row_addr.into();
-                self.docs.doc_id(row_id).map(|doc_id| (doc_id, row_id))
+                self.docs
+                    .doc_ids(row_id)
+                    .map(move |doc_id| (doc_id, row_id))
             })
             .sorted_unstable()
             .collect::<Vec<_>>();
@@ -2209,6 +2214,73 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(matched, vec![2]);
+    }
+
+    #[test]
+    fn test_doc_ids_resolves_every_document_a_row_owns() {
+        // A list<string> column indexes each element as its own document, so
+        // one row id owns several doc ids. row 100 -> {0, 1}, row 101 -> {2}.
+        let row_id_col = arrow_array::UInt64Array::from(vec![100_u64, 100, 101]);
+        let num_tokens_col = arrow_array::UInt32Array::from(vec![1_u32, 1, 1]);
+        let docs = DocSet::from_columns(&row_id_col, &num_tokens_col, false, None).unwrap();
+
+        assert_eq!(docs.doc_ids(100).collect::<Vec<_>>(), vec![0, 1]);
+        assert_eq!(docs.doc_ids(101).collect::<Vec<_>>(), vec![2]);
+        assert!(docs.doc_ids(999).next().is_none());
+
+        // legacy shape (row id == doc id) still resolves to a single document.
+        let mut legacy = DocSet::default();
+        legacy.append(7, 1);
+        assert_eq!(legacy.doc_ids(7).collect::<Vec<_>>(), vec![7]);
+        assert!(legacy.doc_ids(8).next().is_none());
+    }
+
+    #[rstest]
+    fn test_flat_search_finds_list_row_with_match_at_non_last_position(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        // row 100 owns two element-documents (doc 0, doc 1) that share its row
+        // id; row 101 owns doc 2. The query term lives only in doc 0 — the
+        // *non-last* element of row 100. Resolving the row to a single doc id
+        // would evaluate doc 1, miss the term, and drop the row (lancedb#3352).
+        let row_id_col = arrow_array::UInt64Array::from(vec![100_u64, 100, 101]);
+        let num_tokens_col = arrow_array::UInt32Array::from(vec![1_u32, 1, 1]);
+        let docs = DocSet::from_columns(&row_id_col, &num_tokens_col, false, None).unwrap();
+
+        let posting = PostingIterator::with_query_weight(
+            String::from("needle"),
+            0,
+            0,
+            1.0,
+            generate_posting_list(vec![0], 1.0, None, is_compressed),
+            docs.len(),
+        );
+
+        let mut wand = Wand::new(
+            Operator::Or,
+            vec![posting].into_iter(),
+            &docs,
+            InverseDocLengthScorer,
+        );
+        wand.threshold = 0.5;
+
+        let selected = vec![RowAddress::from(100_u64)];
+        let result = wand
+            .flat_search(
+                &FtsSearchParams::default(),
+                Box::new(selected.into_iter()),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        let matched = result
+            .into_iter()
+            .map(|doc| match doc.addr {
+                CandidateAddr::RowId(r) => r,
+                CandidateAddr::Pending(_) => panic!("row_id should be set in this path"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(matched, vec![100]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

FTS `search()` combined with a `where(...)` prefilter on a `list<string>` / `large_list<large_string>` column silently drops matches when the query token sits at any position **other than the last** in a row's list. `.postfilter()` (FTS first, then filter) returns the correct rows.

Reported as lancedb#3352 with a runnable Python repro. The plan is `MatchQuery > ScalarIndexQuery`, and the bug only surfaces when the planner picks the small-allowlist prefilter path (`index_comparisons ≈ allowlist size`):

| Target row `keywords` | prefilter (default) | postfilter |
|---|---|---|
| `["needle", "synonym"]` | **0 rows (bug)** | 2 rows |
| `["synonym", "needle"]` | 2 rows | 2 rows |

## Root cause

A list column indexes every element as its own document, so one `row_id` owns several `doc_id`s: `DocSet.inv` (a `Vec<(row_id, doc_id)>` sorted by `row_id`) holds multiple entries per row.

`DocSet::doc_id(row_id)` resolved a row to a **single** `doc_id` via `binary_search_by_key`, and its only caller is `Wand::flat_search`: the walk-the-allowlist prefilter branch. It therefore evaluated just one of the row's
documents against the posting lists; when the query token lived in any other element, the row became a false negative.

The regular WAND path is forward-driven (document -> `row_id`, with a per-document mask check), so it was always correct, only `flat_search` was affected, which is why the bug is specific to the prefilter branch.

## Fix

- Replace `DocSet::doc_id` with `DocSet::doc_ids(row_id) -> impl Iterator`, which yields every `doc_id` in the contiguous equal-key run in `inv` (the legacy `row_id == doc_id` shape still resolves to a single document).
- `flat_search` now expands each allow-listed `row_id` to **all** of its documents (`flat_map` over `doc_ids`) before sorting into doc-id order.

This brings `flat_search` to parity with the WAND path, so it introduces no new duplicate-row behaviour: only documents actually present in the posting lists score.

## Tests

- `test_doc_ids_resolves_every_document_a_row_owns`: unit coverage of the multi-valued resolution (list shape, legacy shape, and a missing row).
- `test_flat_search_finds_list_row_with_match_at_non_last_position` (rstest, compressed + plain): reproduces the bug; it fails on the previous single-`doc_id` resolution and passes with the fix.

All 143 `scalar::inverted` tests pass; `cargo fmt --all --check` and `cargo clippy -p lance-index --tests -- -D warnings` are clean.

Closes lancedb#3352