### PR TITLE
feat: bump lance-namespace-reqwest-client to 0.8.6 (source_task_size)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5063,9 +5063,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d287494559c22838ce34e51ea0fa29dc780d5be8283de5ab33e9395623000c8"
+checksum = "ba3f0a235e3ed5f8805205649ccc7d7d0f3df23ce1294242c9265ad488d7f19d"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ lance-linalg = { version = "=8.0.0-beta.13", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=8.0.0-beta.13", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=8.0.0-beta.13", path = "./rust/lance-namespace-impls" }
 lance-namespace-datafusion = { version = "=7.0.0-beta.9", path = "./rust/lance-namespace-datafusion" }
-lance-namespace-reqwest-client = "0.8.4"
+lance-namespace-reqwest-client = "0.8.6"
 lance-select = { version = "=8.0.0-beta.13", path = "./rust/lance-select" }
 lance-tokenizer = { version = "=8.0.0-beta.13", path = "./rust/lance-tokenizer" }
 lance-table = { version = "=8.0.0-beta.13", path = "./rust/lance-table" }


### PR DESCRIPTION
## Context

Linear: [GEN-476](https://linear.app/lancedb/issue/GEN-476)

lance-namespace [0.8.6](https://github.com/lance-format/lance-namespace/releases) added an optional `source_task_size` field to `RefreshMaterializedViewRequest` (chunker materialized-view refresh work-item size, bounds per-actor memory). The reqwest client in this repo was pinned at `0.8.4`, so the field was dropped when `RestNamespace` deserialized the request — never reaching the server.

## Change

Bumps `lance-namespace-reqwest-client` `0.8.4` → `0.8.6` (workspace `Cargo.toml` + `Cargo.lock`). Additive and **code-free**: the PyO3 binding (`python/src/namespace.rs`) `depythonize`s the typed `RefreshMaterializedViewRequest`, so the new field flows automatically once the crate carries it.

## Test plan

- `cargo update -p lance-namespace-reqwest-client` → `v0.8.6`
- `cargo check -p lance-namespace` → clean (builds against reqwest-client 0.8.6)
- *(Local full build of the AWS-credential-vendor path hits a pre-existing `aws-smithy-types` E0119 under rustc 1.91, unrelated to this bump — CI's pinned toolchain builds it.)*

## Follow-up

Publish a pylance beta from this so geneva can pin `lance-namespace>=0.8.6` + the new pylance and have `source_task_size` transit `db://` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)