### PR TITLE
build(deps): pin time to 0.3.47 to avoid aws-smithy-types E0119

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,6 +2719,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
+ "powerfmt",
  "serde_core",
 ]
 
@@ -8840,11 +8841,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.48"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1aa89044e7786ffb2ec017acb22cb7de5b0be46d0f21aea2b224b8561e5db2"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -8854,15 +8856,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.28"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3bfe86347f0cc659f586f01e26303ccd32418f26f30c7b0309b3ca3a07d695"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -2586,6 +2586,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
+ "powerfmt",
  "serde_core",
 ]
 
@@ -7939,11 +7940,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.48"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1aa89044e7786ffb2ec017acb22cb7de5b0be46d0f21aea2b224b8561e5db2"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -7953,15 +7955,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.28"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3bfe86347f0cc659f586f01e26303ccd32418f26f30c7b0309b3ca3a07d695"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Context

`time 0.3.48` (published 2026-06-12) added a `From` impl on an associated type that rustc's coherence checker treats as conflicting with any crate carrying a generic blanket `From<T>` impl. For us that is `aws-smithy-types` `1.4.5`'s `impl<T> From<T> for CanDisable<T>`, which fails to compile with `E0119`:

```
error[E0119]: conflicting implementations of trait `From<...HourBase>`
  --> aws-smithy-types-1.4.5/src/timeout.rs:49
49 | impl<T> From<T> for CanDisable<T> {
  = note: conflicting implementation in crate `time`
```

This is an ecosystem-wide break tracked upstream in time-rs/time#783. The maintainer has acknowledged it and a patch is pending.

For lance it takes down every Rust and Python build job. `main` has been red since the first CI run after the upstream release, with no code change in between: CI re-resolved the newly published `time` at build time, and the
subsequent beta release baked `0.3.48` into the committed lockfiles. It blocks all open PRs, not just one (#7254 rebases on top once this lands).

## Change

Pin `time` to the last good release, `0.3.47`, via `cargo update -p time --precise 0.3.47` (the workaround recommended in time-rs/time#783). Applied to both lockfiles:

- `Cargo.lock` (root workspace)
- `python/Cargo.lock` (the `python/` crate is excluded from the root workspace
  and carries its own lock, so the Python wheel and lint jobs need the pin too)

Lockfile only, no manifest or source change. Downgrades `time` (0.3.48 to 0.3.47), `time-core`, and `time-macros`. Nothing requires `>= 0.3.48` (it is hours old), so the pin is safe.

## Test plan

- `cargo check -p aws-smithy-types --locked` compiles clean in both the root and `python/` workspaces (was `E0119`).
- Locked CI jobs are green again (clippy, MSRV, rustdoc, and the rest).

## Note on build-no-lock

`build-no-lock` stays red by design and is non-blocking. It removes `Cargo.lock` and re-resolves against the latest crates, so it re-pulls the broken `time 0.3.48` regardless of this pin. It is the canary for exactly this
kind of upstream break, and `main` currently merges with it red (#7234 merged today with it failing).

## Follow-up

Remove the pin once upstream resolves the conflict, tracked in time-rs/time#783:

- the fix in time-rs/time#784 ships (expected as `time 0.3.49`), bump to it, or
- `0.3.48` is yanked (requested in the issue), in which case a fresh resolve returns to `0.3.47` on its own and `build-no-lock` self-heals.