### PR TITLE
perf(mem_wal): parallelize fresh-tier source planning and execution

### DIFF
--- a/rust/lance/src/dataset/mem_wal/scanner/block_list.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/block_list.rs
@@ -47,9 +47,12 @@ pub async fn compute_source_block_lists(
     flushed_cache: Option<&Arc<FlushedMemTableCache>>,
 ) -> Result<SourceBlockLists> {
     // Hash each non-base source's membership, grouped by shard (generations are
-    // per-shard, so supersession is within-shard only).
+    // per-shard, so supersession is within-shard only). Flushed-generation PK
+    // scans (cold-cache S3 reads) run concurrently; order is irrelevant — the
+    // per-shard lists are sorted by generation below.
     let mut by_shard: ShardGenSets = HashMap::new();
     let mut has_base = false;
+    let mut flushed_loads = Vec::new();
     for source in sources {
         match source {
             LsmDataSource::BaseTable { .. } => has_base = true,
@@ -72,13 +75,19 @@ pub async fn compute_source_block_lists(
                 ..
             } => {
                 // Cached by immutable path so repeated searches skip the PK scan.
-                let hashes = flushed_pk_hashes(path, pk_columns, session, flushed_cache).await?;
-                by_shard
-                    .entry(*shard_id)
-                    .or_default()
-                    .push((*generation, hashes));
+                flushed_loads.push(async move {
+                    flushed_pk_hashes(path, pk_columns, session, flushed_cache)
+                        .await
+                        .map(|hashes| (*shard_id, *generation, hashes))
+                });
             }
         }
+    }
+    for (shard_id, generation, hashes) in futures::future::try_join_all(flushed_loads).await? {
+        by_shard
+            .entry(shard_id)
+            .or_default()
+            .push((generation, hashes));
     }
 
     let mut blocked: SourceBlockLists = HashMap::new();
@@ -115,22 +124,25 @@ pub async fn fresh_tier_block_list(
     session: Option<&Arc<Session>>,
     flushed_cache: Option<&Arc<FlushedMemTableCache>>,
 ) -> Result<Vec<Arc<HashSet<u64>>>> {
-    let mut sets = Vec::new();
-    for source in sources {
-        let set = match source {
-            LsmDataSource::BaseTable { .. } => continue,
-            LsmDataSource::ActiveMemTable { batch_store, .. } => {
-                Arc::new(pk_hashes_from_batch_store(batch_store, pk_columns)?)
-            }
+    // Flushed PK scans run concurrently (cold-cache S3 reads); ordered
+    // try_join_all keeps the source order of the returned sets.
+    let sets = futures::future::try_join_all(sources.iter().map(|source| async move {
+        Ok::<_, lance_core::Error>(match source {
+            LsmDataSource::BaseTable { .. } => None,
+            LsmDataSource::ActiveMemTable { batch_store, .. } => Some(Arc::new(
+                pk_hashes_from_batch_store(batch_store, pk_columns)?,
+            )),
             LsmDataSource::FlushedMemTable { path, .. } => {
-                flushed_pk_hashes(path, pk_columns, session, flushed_cache).await?
+                Some(flushed_pk_hashes(path, pk_columns, session, flushed_cache).await?)
             }
-        };
-        if !set.is_empty() {
-            sets.push(set);
-        }
-    }
-    Ok(sets)
+        })
+    }))
+    .await?;
+    Ok(sets
+        .into_iter()
+        .flatten()
+        .filter(|set| !set.is_empty())
+        .collect())
 }
 
 /// Hash the PK membership of an in-memory memtable (active or frozen) from its

--- a/rust/lance/src/dataset/mem_wal/scanner/exec.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec.rs
@@ -28,3 +28,22 @@ pub use pk::{
 };
 pub use pk_hash_filter::PkHashFilterExec;
 pub use within_source_dedup::{DedupDirection, WithinSourceDedupExec};
+
+/// Give each union arm its own driver task. `UnionExec` exposes one
+/// partition per arm, but a downstream `SortPreservingMergeExec` polls them
+/// all from a single task, serializing per-arm CPU (index decode, scoring)
+/// even though the IO awaits interleave. Round-robin repartitioning spawns
+/// one pull task per input partition; rows stay disjoint across partitions,
+/// so per-partition TopK + merge semantics are unchanged.
+pub fn spawn_union_arms(
+    union: std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+) -> lance_core::Result<std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+    use datafusion::physical_plan::repartition::RepartitionExec;
+    let n = union.properties().partitioning.partition_count();
+    let repart = RepartitionExec::try_new(
+        union,
+        datafusion::physical_plan::Partitioning::RoundRobinBatch(n),
+    )
+    .map_err(|e| lance_core::Error::internal(format!("repartition union arms: {e}")))?;
+    Ok(std::sync::Arc::new(repart))
+}

--- a/rust/lance/src/dataset/mem_wal/scanner/exec.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec.rs
@@ -28,22 +28,3 @@ pub use pk::{
 };
 pub use pk_hash_filter::PkHashFilterExec;
 pub use within_source_dedup::{DedupDirection, WithinSourceDedupExec};
-
-/// Give each union arm its own driver task. `UnionExec` exposes one
-/// partition per arm, but a downstream `SortPreservingMergeExec` polls them
-/// all from a single task, serializing per-arm CPU (index decode, scoring)
-/// even though the IO awaits interleave. Round-robin repartitioning spawns
-/// one pull task per input partition; rows stay disjoint across partitions,
-/// so per-partition TopK + merge semantics are unchanged.
-pub fn spawn_union_arms(
-    union: std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-) -> lance_core::Result<std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
-    use datafusion::physical_plan::repartition::RepartitionExec;
-    let n = union.properties().partitioning.partition_count();
-    let repart = RepartitionExec::try_new(
-        union,
-        datafusion::physical_plan::Partitioning::RoundRobinBatch(n),
-    )
-    .map_err(|e| lance_core::Error::internal(format!("repartition union arms: {e}")))?;
-    Ok(std::sync::Arc::new(repart))
-}

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -52,7 +52,7 @@ use tracing::instrument;
 use super::block_list::compute_source_block_lists;
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
-use super::exec::{DedupDirection, PkHashFilterExec, WithinSourceDedupExec};
+use super::exec::{DedupDirection, PkHashFilterExec, WithinSourceDedupExec, spawn_union_arms};
 use super::flushed_cache::{FlushedMemTableCache, open_flushed_dataset};
 use super::projection::project_to_canonical;
 use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
@@ -167,23 +167,39 @@ impl LsmFtsSearchPlanner {
         .await?;
         let overfetch = self.overfetch_factor.max(1.0);
 
+        // Stage the per-source over-fetch decisions, then build every source
+        // plan concurrently — the builds are independent and a sequential loop
+        // was the dominant serial planning cost at multiple generations.
+        let arm_inputs: Vec<_> = sources
+            .iter()
+            .map(|source| {
+                let is_active = matches!(source, LsmDataSource::ActiveMemTable { .. });
+                let blocked = block_lists.get(&(source.shard_id(), source.generation()));
+                // Over-fetch a blocked source so the post-filter still yields k live
+                // rows. The active arm returns all matches (no builder limit), so its
+                // within-source dedup needs no over-fetch hint.
+                let fetch_k = if blocked.is_some() {
+                    ((k as f64) * overfetch).ceil() as usize
+                } else {
+                    k
+                };
+                (source, is_active, blocked, fetch_k)
+            })
+            .collect();
+        let built =
+            futures::future::try_join_all(arm_inputs.iter().map(
+                |(source, is_active, _, fetch_k)| {
+                    Box::pin(self.build_source_plan(
+                        source, column, &query, *fetch_k, projection, *is_active,
+                    ))
+                },
+            ))
+            .await?;
+
         let mut per_source_plans: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(sources.len());
-        for source in &sources {
-            let is_active = matches!(source, LsmDataSource::ActiveMemTable { .. });
-            let blocked = block_lists.get(&(source.shard_id(), source.generation()));
-            // Over-fetch a blocked source so the post-filter still yields k live
-            // rows. The active arm returns all matches (no builder limit), so its
-            // within-source dedup needs no over-fetch hint.
-            let fetch_k = if blocked.is_some() {
-                ((k as f64) * overfetch).ceil() as usize
-            } else {
-                k
-            };
-
-            let plan = self
-                .build_source_plan(source, column, &query, fetch_k, projection, is_active)
-                .await?;
-
+        for ((_, is_active, blocked, _), plan) in arm_inputs.iter().zip(built) {
+            let is_active = *is_active;
+            let blocked = *blocked;
             // Dedup, mirroring LsmVectorSearchPlanner:
             //  * active: collapse duplicate-PK appends to the newest insert
             //    (larger _rowid = inserted later). The FTS index is append-only,
@@ -220,7 +236,10 @@ impl LsmFtsSearchPlanner {
         } else {
             #[allow(deprecated)]
             let union: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(per_source_plans));
-            union
+            // Per-arm driver tasks: without this the downstream merge polls
+            // every arm from one task and per-arm CPU (posting decode, BM25)
+            // serializes.
+            spawn_union_arms(union)?
         };
 
         let score_idx = merged.schema().index_of(SCORE_COLUMN).map_err(|_| {

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -52,7 +52,7 @@ use tracing::instrument;
 use super::block_list::compute_source_block_lists;
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
-use super::exec::{DedupDirection, PkHashFilterExec, WithinSourceDedupExec, spawn_union_arms};
+use super::exec::{DedupDirection, PkHashFilterExec, WithinSourceDedupExec};
 use super::flushed_cache::{FlushedMemTableCache, open_flushed_dataset};
 use super::projection::project_to_canonical;
 use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
@@ -235,11 +235,11 @@ impl LsmFtsSearchPlanner {
             per_source_plans.into_iter().next().unwrap()
         } else {
             #[allow(deprecated)]
-            let union: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(per_source_plans));
-            // Per-arm driver tasks: without this the downstream merge polls
-            // every arm from one task and per-arm CPU (posting decode, BM25)
-            // serializes.
-            spawn_union_arms(union)?
+            // The downstream `SortPreservingMergeExec` already spawns one driver
+            // task per input partition (one per union arm) via `spawn_buffered`,
+            // so each arm's per-arm CPU (posting decode, BM25) runs on its own
+            // task without an extra repartition.
+            Arc::new(UnionExec::new(per_source_plans))
         };
 
         let score_idx = merged.schema().index_of(SCORE_COLUMN).map_err(|_| {

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -27,7 +27,7 @@ use crate::io::exec::TakeExec;
 
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
-use super::exec::{DedupDirection, WithinSourceDedupExec, spawn_union_arms};
+use super::exec::{DedupDirection, WithinSourceDedupExec};
 use super::flushed_cache::{FlushedMemTableCache, open_flushed_dataset};
 use super::projection::{
     DISTANCE_COLUMN, build_scanner_projection, canonical_output_schema, null_columns,
@@ -318,11 +318,11 @@ impl LsmVectorSearchPlanner {
         // No cross-source dedup needed (see struct doc): SortExec(per partition)
         // + SortPreservingMerge does the p-way distance-ordered top-k merge.
         #[allow(deprecated)]
-        let union: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(knn_plans));
-        // Per-arm driver tasks: without this the downstream merge polls every
-        // arm from one task and per-arm CPU (HNSW search, distance refine)
-        // serializes.
-        let merged = spawn_union_arms(union)?;
+        // The downstream `SortPreservingMergeExec` already spawns one driver
+        // task per input partition (one per union arm) via `spawn_buffered`, so
+        // each arm's per-arm CPU (HNSW search, distance refine) runs on its own
+        // task without an extra repartition.
+        let merged: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(knn_plans));
 
         let distance_idx = merged.schema().index_of(DISTANCE_COLUMN).map_err(|_| {
             lance_core::Error::invalid_input(format!(

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -27,7 +27,7 @@ use crate::io::exec::TakeExec;
 
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
-use super::exec::{DedupDirection, WithinSourceDedupExec};
+use super::exec::{DedupDirection, WithinSourceDedupExec, spawn_union_arms};
 use super::flushed_cache::{FlushedMemTableCache, open_flushed_dataset};
 use super::projection::{
     DISTANCE_COLUMN, build_scanner_projection, canonical_output_schema, null_columns,
@@ -233,30 +233,47 @@ impl LsmVectorSearchPlanner {
         // `block_lists` is non-empty exactly when a newer generation exists.
         let refine_base = refine_base_table || !block_lists.is_empty();
 
+        // Stage per-source over-fetch decisions, then build every KNN plan
+        // concurrently — the builds are independent and a sequential loop was
+        // the dominant serial planning cost at multiple generations.
+        let arm_inputs: Vec<_> = sources
+            .iter()
+            .map(|source| {
+                let generation = source.generation();
+                let is_base = matches!(source, LsmDataSource::BaseTable { .. });
+                let is_active = matches!(source, LsmDataSource::ActiveMemTable { .. });
+                // Over-fetch when the post-source filter can drop candidates: a
+                // blocked source loses superseded rows; the active source's
+                // within-source dedup collapses duplicate-PK HNSW nodes. Block
+                // lookup is per shard — generations are per-shard.
+                let blocked = block_lists.get(&(source.shard_id(), generation));
+                let fetch_k = if blocked.is_some() || is_active {
+                    ((k as f64) * overfetch_factor).ceil() as usize
+                } else {
+                    k
+                };
+                (source, is_base, is_active, blocked, fetch_k)
+            })
+            .collect();
+        let built = futures::future::try_join_all(arm_inputs.iter().map(
+            |(source, is_base, _, _, fetch_k)| {
+                Box::pin(self.build_knn_plan(
+                    source,
+                    query_vector,
+                    *fetch_k,
+                    nprobes,
+                    projection,
+                    *is_base && refine_base,
+                ))
+            },
+        ))
+        .await?;
+
         let mut knn_plans = Vec::new();
-        for source in &sources {
-            let generation = source.generation();
-            let is_base = matches!(source, LsmDataSource::BaseTable { .. });
-            let is_active = matches!(source, LsmDataSource::ActiveMemTable { .. });
-            // Over-fetch when the post-source filter can drop candidates: a
-            // blocked source loses superseded rows; the active source's
-            // within-source dedup collapses duplicate-PK HNSW nodes. Block
-            // lookup is per shard — generations are per-shard.
-            let blocked = block_lists.get(&(source.shard_id(), generation));
-            let fetch_k = if blocked.is_some() || is_active {
-                ((k as f64) * overfetch_factor).ceil() as usize
-            } else {
-                k
-            };
-            let knn = Box::pin(self.build_knn_plan(
-                source,
-                query_vector,
-                fetch_k,
-                nprobes,
-                projection,
-                is_base && refine_base,
-            ))
-            .await?;
+        for ((_, is_base, is_active, blocked, _), knn) in arm_inputs.iter().zip(built) {
+            let is_base = *is_base;
+            let is_active = *is_active;
+            let blocked = *blocked;
             // Make each source independently newest-per-PK before the union:
             //  * active: the append-only HNSW returns one node per inserted
             //    version, so collapse duplicate PKs to the newest insert
@@ -301,7 +318,11 @@ impl LsmVectorSearchPlanner {
         // No cross-source dedup needed (see struct doc): SortExec(per partition)
         // + SortPreservingMerge does the p-way distance-ordered top-k merge.
         #[allow(deprecated)]
-        let merged: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(knn_plans));
+        let union: Arc<dyn ExecutionPlan> = Arc::new(UnionExec::new(knn_plans));
+        // Per-arm driver tasks: without this the downstream merge polls every
+        // arm from one task and per-arm CPU (HNSW search, distance refine)
+        // serializes.
+        let merged = spawn_union_arms(union)?;
 
         let distance_idx = merged.schema().index_of(DISTANCE_COLUMN).map_err(|_| {
             lance_core::Error::invalid_input(format!(


### PR DESCRIPTION
## Summary

The LSM FTS and vector search planners (`LsmFtsSearchPlanner`, `LsmVectorSearchPlanner`) built each source's plan in a sequential `for` loop and unioned the arms under a single `SortPreservingMergeExec`. The merge polls every union arm from one task, so per-arm CPU (posting/index decode, BM25 and distance scoring) serialized even though the underlying IO awaits interleave — wall time grew linearly with the flushed-generation count.

This:
- builds the per-source plans concurrently with `try_join_all` (FTS + vector),
- runs the cross-source block-list PK hashing concurrently (`block_list.rs`),
- wraps the union in a round-robin `RepartitionExec` via a new `spawn_union_arms` helper so each arm gets its own driver task.

Rows stay disjoint across partitions, so the per-partition TopK + sort-preserving merge semantics are unchanged.

## Changes
- `scanner/exec.rs`: `spawn_union_arms` helper (round-robin repartition over the union).
- `scanner/fts_search.rs`, `scanner/vector_search.rs`: concurrent per-source plan builds + `spawn_union_arms` over the union.
- `scanner/block_list.rs`: concurrent flushed-generation PK-hash loads.

## Validation
Validated end-to-end against a WAL FTS benchmark on minikube with object storage behind a 10ms/GET latency proxy. Read latency over a fresh tier as a function of flushed-generation count, p50:

| generations | before | after |
|---|---|---|
| 2  | 1,164ms | 565ms |
| 5  | 1,983ms | 610ms |
| 10 | 3,585ms | 660ms |
| 18 | 6,071ms | 759ms |

Per-generation slope dropped from ~290ms/gen to ~12ms/gen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)