### PR TITLE
perf(index): cache small-index posting, doc, and vector-probe reads

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -2048,7 +2048,7 @@ impl PostingListReader {
         match &self.metadata {
             PostingMetadata::LegacyV1 { .. } => Ok(self.posting_len(token_id)),
             PostingMetadata::V2 { metadata } => {
-                if let Some(metadata) = metadata.get() {
+                if let Some(metadata) = self.small_index_bulk_metadata(metadata).await? {
                     return Ok(metadata.lengths[token_id as usize] as usize);
                 }
                 let token_id = token_id as usize;
@@ -2060,6 +2060,25 @@ impl PostingListReader {
                 Ok(len as usize)
             }
         }
+    }
+
+    /// For small token sets, bulk-load (and afterwards serve) the v2 posting
+    /// metadata instead of the per-token single-row path. The single-row
+    /// reads are never cached, so every query pays one tiny ranged GET per
+    /// term per partition — for a small index (e.g. a mem_wal flushed
+    /// generation) the entire metadata costs one read of comparable latency
+    /// and the index object itself is cached. Large indexes keep the O(1)
+    /// single-row behavior. Returns the loaded metadata when (now) resident.
+    async fn small_index_bulk_metadata<'a>(
+        &self,
+        metadata: &'a tokio::sync::OnceCell<LoadedPostingMetadata>,
+    ) -> Result<Option<&'a LoadedPostingMetadata>> {
+        // 8 bytes/token (u32 length + f32 max_score): 256Ki tokens ≈ 2 MiB.
+        const BULK_LOAD_MAX_TOKENS: usize = 256 * 1024;
+        if metadata.get().is_none() && self.reader.num_rows() <= BULK_LOAD_MAX_TOKENS {
+            self.ensure_metadata_loaded().await?;
+        }
+        Ok(metadata.get())
     }
 
     /// Async access to a single token's `(max_score, length)` pair. Mirrors
@@ -2077,7 +2096,7 @@ impl PostingListReader {
                 Ok((max_scores.as_ref().map(|m| m[token_id as usize]), None))
             }
             PostingMetadata::V2 { metadata } => {
-                if let Some(loaded) = metadata.get() {
+                if let Some(loaded) = self.small_index_bulk_metadata(metadata).await? {
                     return Ok((
                         Some(loaded.max_scores[token_id as usize]),
                         Some(loaded.lengths[token_id as usize]),
@@ -6524,15 +6543,15 @@ mod tests {
     ///
     /// * `InvertedIndex::load` does not touch the posting file at all
     ///   (`InvertedPartition::load` only needs the token file and docs file).
-    /// * `bm25_stats_for_terms(["t0"])` reads exactly one row from the
-    ///   posting file (the single LENGTH_COL entry for token 0) regardless
-    ///   of how many unique tokens the partition has.
+    /// * the first `bm25_stats_for_terms` call issues exactly one
+    ///   `read_range` against the posting file — for a small (≤
+    ///   `BULK_LOAD_MAX_TOKENS`) index that is the one-time bulk metadata
+    ///   load — and subsequent stats calls read nothing at all.
     ///
-    /// Before this refactor, `PostingListReader::try_new` did
-    /// `read_range(0..num_rows, [MAX_SCORE_COL, LENGTH_COL])`, so the
-    /// `metadata_rows_read` figure scaled linearly with `num_tokens` even
-    /// when nobody asked for those stats. The cases below exercise that
-    /// scaling explicitly.
+    /// Before the lazy refactor, `PostingListReader::try_new` did
+    /// `read_range(0..num_rows, [MAX_SCORE_COL, LENGTH_COL])` at *open*
+    /// time, even when nobody asked for stats. Large indexes (above the
+    /// bulk threshold) keep the uncached single-row-per-term path.
     #[rstest::rstest]
     #[case::tokens_10(10)]
     #[case::tokens_100(100)]
@@ -6564,18 +6583,30 @@ mod tests {
         assert_eq!(num_docs, num_tokens);
         assert_eq!(dfs, vec![1]);
 
-        // Stats must pull a constant number of metadata rows from the posting
-        // file regardless of how many tokens the partition has. One term, one
-        // partition, one row.
+        // Small index: the first stats lookup pays exactly one read_range
+        // (the bulk metadata load), never per-term call scaling.
         assert_eq!(
-            counter.metadata_rows_read(),
+            counter.read_range_calls(),
             1,
-            "stats path should read exactly 1 metadata row per (term, partition); \
-             got {} (read_range_calls={}, rows_read={}, num_tokens={})",
-            counter.metadata_rows_read(),
+            "first stats lookup should issue exactly one posting-file read \
+             (the small-index bulk metadata load); got {} calls \
+             (rows_read={}, num_tokens={})",
             counter.read_range_calls(),
             counter.rows_read(),
             num_tokens,
+        );
+
+        // Every later lookup is served from the loaded metadata: zero reads.
+        let (_, _, dfs) = index
+            .bm25_stats_for_terms(&[format!("t{}", num_tokens - 1)])
+            .await
+            .unwrap();
+        assert_eq!(dfs, vec![1]);
+        assert_eq!(
+            counter.read_range_calls(),
+            1,
+            "subsequent stats lookups must be served from the bulk-loaded \
+             metadata without touching the posting file",
         );
     }
 

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -331,7 +331,13 @@ impl DeferredDocSet {
         {
             return Ok(doc_ids.iter().map(|&d| full.row_id(d)).collect());
         }
-        if let Some(arr) = self.row_ids_col.get() {
+        // Small partition: load (and cache) the whole ROW_ID column instead
+        // of targeted reads — the targeted path is never cached, so every
+        // query re-pays its IO. 256Ki docs = 2 MiB, one read of comparable
+        // latency to a single targeted read.
+        const BULK_LOAD_MAX_DOCS: usize = 256 * 1024;
+        if self.row_ids_col.get().is_some() || self.num_rows <= BULK_LOAD_MAX_DOCS {
+            let arr = self.row_ids_column().await?;
             return Ok(doc_ids.iter().map(|&d| arr.value(d as usize)).collect());
         }
         let ranges: Vec<std::ops::Range<usize>> = doc_ids

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1837,14 +1837,28 @@ impl DatasetIndexInternalExt for Dataset {
             // If we have file metadata, check if INDEX_FILE_NAME is in the list
             files.iter().any(|f| f.path == INDEX_FILE_NAME)
         } else {
-            // Fall back to file existence check for older indices without file metadata
-            let index_dir = self.indice_files_dir(&index_meta)?;
-            let index_file = index_dir
-                .clone()
-                .join(uuid.to_string())
-                .join(INDEX_FILE_NAME);
-            let object_store = self.object_store_for_index(&index_meta).await?;
-            object_store.exists(&index_file).await?
+            // Fall back to file existence check for older indices without file
+            // metadata. Memoized per uuid: index files are immutable, and
+            // without the memo every generic open re-pays a HEAD request.
+            let probe_key = crate::session::index_caches::IsVectorIndexProbeKey { uuid };
+            if let Some(probe) = self.index_cache.get_with_key(&probe_key).await {
+                probe.0
+            } else {
+                let index_dir = self.indice_files_dir(&index_meta)?;
+                let index_file = index_dir
+                    .clone()
+                    .join(uuid.to_string())
+                    .join(INDEX_FILE_NAME);
+                let object_store = self.object_store_for_index(&index_meta).await?;
+                let is_vector = object_store.exists(&index_file).await?;
+                self.index_cache
+                    .insert_with_key(
+                        &probe_key,
+                        Arc::new(crate::session::index_caches::IsVectorIndexProbe(is_vector)),
+                    )
+                    .await;
+                is_vector
+            }
         };
 
         if is_vector_index {

--- a/rust/lance/src/session/index_caches.rs
+++ b/rust/lance/src/session/index_caches.rs
@@ -145,3 +145,33 @@ impl CacheKey for ScalarIndexDetailsKey<'_> {
         "ScalarIndexDetails"
     }
 }
+
+/// Cached result of the "is this a vector index?" file-existence probe.
+///
+/// Indexes without `files` metadata (e.g. mem_wal flushed-generation
+/// indexes) force a HEAD on `index.idx` to classify them; without this
+/// memo the probe re-runs on every query that opens the index generically.
+pub struct IsVectorIndexProbe(pub bool);
+
+impl DeepSizeOf for IsVectorIndexProbe {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        0
+    }
+}
+
+#[derive(Debug)]
+pub struct IsVectorIndexProbeKey<'a> {
+    pub uuid: &'a Uuid,
+}
+
+impl CacheKey for IsVectorIndexProbeKey<'_> {
+    type ValueType = IsVectorIndexProbe;
+
+    fn key(&self) -> Cow<'_, str> {
+        Cow::Owned(format!("is-vector-probe/{}", self.uuid))
+    }
+
+    fn type_name() -> &'static str {
+        "IsVectorIndexProbe"
+    }
+}


### PR DESCRIPTION
## Summary

Querying a small full-text index (e.g. a mem_wal flushed-generation index) re-paid object-store IO on every query for metadata that is never cached. Three uncached read paths, each fixed for small indexes while leaving large-index behavior unchanged:

1. **Posting metadata** — `posting_len_for_token` / `posting_metadata_for_token` issued one tiny single-row `read_range` against the posting file per term per partition, never cached. For a small index (≤256Ki tokens) bulk-load the whole posting metadata once into the existing `OnceCell` (`small_index_bulk_metadata`); large indexes keep the O(1) single-row path.
2. **Doc row-ids** — `DeferredDocSet::resolve_row_ids` did targeted (uncached) row-id reads on every query. For a small partition (≤256Ki docs) load and cache the whole `ROW_ID` column instead.
3. **Vector-index probe** — the "is this a vector index?" file-existence check for indexes without `files` metadata issued a HEAD per generic open. Memoize per uuid in the session index cache (`IsVectorIndexProbeKey`).

## Changes
- `lance-index/.../inverted/index.rs`: `small_index_bulk_metadata` + updated `test_bm25_stats_for_terms_is_lazy`.
- `lance-index/.../inverted/lazy_docset.rs`: small-partition row-id column caching in `resolve_row_ids`.
- `lance/src/index.rs`: memoized `is_vector_index` existence probe.
- `lance/src/session/index_caches.rs`: `IsVectorIndexProbe` cache key.

## Validation
`cargo test -p lance-index test_bm25_stats_for_terms_is_lazy` passes (asserts the first stats lookup issues exactly one posting read and subsequent lookups issue none). Validated end-to-end against a WAL FTS benchmark: a warm query dropped from re-reading per-term posting offsets + doc row-ids + the vector probe each query to zero such reads (all served from cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)