### PR TITLE
fix: serve remapped row addresses from vector indexes during the FRI window

### DIFF
--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -221,7 +221,7 @@ impl ProductQuantizationStorage {
                 "Row ID column not found from PQ storage".to_string(),
             ));
         };
-        let row_ids: Arc<UInt64Array> = row_ids
+        let mut row_ids: Arc<UInt64Array> = row_ids
             .as_primitive_opt::<UInt64Type>()
             .ok_or(Error::index(
                 "Row ID column is not of type UInt64".to_string(),
@@ -293,6 +293,8 @@ impl ProductQuantizationStorage {
                 .as_primitive::<UInt8Type>()
                 .clone()
                 .into();
+            // Refresh from the remapped batch; the binding above is pre-remap.
+            row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().clone().into();
         }
 
         let distance_type = match distance_type {

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1891,9 +1891,18 @@ impl DatasetIndexInternalExt for Dataset {
         if let Some(entry) = self.index_cache.get_with_key(&state_key).await {
             log::debug!("Found IvfIndexState in cache uuid: {}", uuid);
             let partition_cache = self.index_cache.with_key_prefix(&state_key.key());
+            // Re-open the FRI (cheap; cached) and thread it in: the cached state
+            // can't carry it, so without this the reconstruct path skips
+            // auto-remap and serves stale addresses after deferred compaction.
+            let frag_reuse_index = self.open_frag_reuse_index(metrics).await?;
             return entry
                 .0
-                .reconstruct(object_store, self.metadata_cache.as_ref(), partition_cache)
+                .reconstruct(
+                    object_store,
+                    self.metadata_cache.as_ref(),
+                    partition_cache,
+                    frag_reuse_index,
+                )
                 .await;
         }
 
@@ -7652,6 +7661,134 @@ mod tests {
 
             // Validate files are populated after remap
             assert_all_indices_have_files(&dataset, "after remap").await;
+        }
+    }
+
+    /// Regression test: vector search must return remapped row addresses
+    /// during the FRI window (after a deferred-remap compaction, before any
+    /// physical remap). Covers two historical bugs:
+    /// 1. `IvfIndexState::reconstruct` (index state-cache hit) dropped the
+    ///    frag reuse index, so partitions loaded through reconstruction
+    ///    served stale pre-compaction addresses.
+    /// 2. `ProductQuantizationStorage::new` refreshed the remapped batch and
+    ///    codes but kept the pre-remap `row_ids` binding, so PQ searches
+    ///    returned stale addresses even on a cold open.
+    /// Searching twice on the same handle exercises both the cold-open and
+    /// the state-cache reconstruct paths.
+    #[tokio::test]
+    async fn test_vector_search_during_fri_window() {
+        use arrow_array::types::UInt64Type;
+        use futures::TryStreamExt;
+
+        async fn knn_ids(dataset: &Dataset) -> Vec<u64> {
+            let q = Float32Array::from(vec![0.5f32; 32]);
+            let batches: Vec<RecordBatch> = dataset
+                .scan()
+                .nearest("vec_col", &q, 10)
+                .unwrap()
+                .with_row_id()
+                .project(&["vec_col"])
+                .unwrap()
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect()
+                .await
+                .unwrap();
+            let mut ids: Vec<u64> = batches
+                .iter()
+                .flat_map(|b| {
+                    b["_rowid"]
+                        .as_primitive::<UInt64Type>()
+                        .values()
+                        .iter()
+                        .copied()
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+            ids.sort_unstable();
+            ids
+        }
+
+        for use_pq in [false, true] {
+            let test_dir = TempStrDir::default();
+            let data = gen_batch()
+                .col(
+                    "vec_col",
+                    array::rand_vec::<Float32Type>(Dimension::from(32)),
+                )
+                .into_reader_rows(RowCount::from(1000), BatchCount::from(1));
+            let mut dataset = Dataset::write(
+                data,
+                test_dir.as_str(),
+                Some(WriteParams {
+                    max_rows_per_file: 100,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+
+            let params = if use_pq {
+                VectorIndexParams::ivf_pq(4, 8, 4, MetricType::L2, 50)
+            } else {
+                VectorIndexParams::ivf_flat(4, MetricType::L2)
+            };
+            dataset
+                .create_index(
+                    &["vec_col"],
+                    IndexType::Vector,
+                    Some("vec_idx".to_string()),
+                    &params,
+                    false,
+                )
+                .await
+                .unwrap();
+
+            let dataset = Dataset::open(test_dir.as_str()).await.unwrap();
+            let before = knn_ids(&dataset).await;
+            assert_eq!(before.len(), 10);
+
+            let mut dataset = Dataset::open(test_dir.as_str()).await.unwrap();
+            compact_files(
+                &mut dataset,
+                CompactionOptions {
+                    target_rows_per_fragment: 1000,
+                    defer_index_remap: true,
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+            // Old fragments are gone post-compaction, so any stale address fails the take.
+            let dataset = Dataset::open(test_dir.as_str()).await.unwrap();
+            let expected: Vec<u64> = {
+                let fri = dataset
+                    .open_frag_reuse_index(&NoOpMetricsCollector)
+                    .await
+                    .unwrap()
+                    .expect("deferred compaction must write a frag reuse index");
+                let mut ids: Vec<u64> = before
+                    .iter()
+                    .filter_map(|id| fri.remap_row_id(*id))
+                    .collect();
+                ids.sort_unstable();
+                ids
+            };
+            // Cold open path (PQ row_ids bug).
+            let first = knn_ids(&dataset).await;
+            assert_eq!(
+                first, expected,
+                "use_pq={use_pq}: first search during FRI window must return remapped addresses"
+            );
+            // State-cache reconstruct path (dropped-FRI bug).
+            let second = knn_ids(&dataset).await;
+            assert_eq!(
+                second, expected,
+                "use_pq={use_pq}: search through the reconstructed index must return remapped addresses"
+            );
         }
     }
 

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -253,6 +253,7 @@ pub(crate) trait IvfStateEntry: DeepSizeOf + Send + Sync + 'static {
         object_store: Arc<ObjectStore>,
         file_metadata_cache: &'a LanceCache,
         index_cache: LanceCache,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> BoxFuture<'a, Result<Arc<dyn VectorIndex>>>;
 }
 
@@ -435,6 +436,7 @@ impl<Q: Quantization + 'static> IvfStateEntry for IvfIndexState<Q> {
         object_store: Arc<ObjectStore>,
         file_metadata_cache: &'a LanceCache,
         index_cache: LanceCache,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> BoxFuture<'a, Result<Arc<dyn VectorIndex>>> {
         Box::pin(async move {
             match self.sub_index_type {
@@ -444,6 +446,7 @@ impl<Q: Quantization + 'static> IvfStateEntry for IvfIndexState<Q> {
                         object_store,
                         file_metadata_cache,
                         index_cache,
+                        frag_reuse_index,
                     )
                     .await
                 }
@@ -453,6 +456,7 @@ impl<Q: Quantization + 'static> IvfStateEntry for IvfIndexState<Q> {
                         object_store,
                         file_metadata_cache,
                         index_cache,
+                        frag_reuse_index,
                     )
                     .await
                 }
@@ -1857,6 +1861,7 @@ async fn reconstruct_typed<S: IvfSubIndex + 'static, Q: Quantization + 'static>(
     object_store: Arc<ObjectStore>,
     file_metadata_cache: &LanceCache,
     index_cache: LanceCache,
+    frag_reuse_index: Option<Arc<FragReuseIndex>>,
 ) -> Result<Arc<dyn VectorIndex>> {
     let io_parallelism = object_store.io_parallelism();
 
@@ -1912,7 +1917,7 @@ async fn reconstruct_typed<S: IvfSubIndex + 'static, Q: Quantization + 'static>(
         state.aux_ivf.clone(),
         state.metadata.clone(),
         state.distance_type,
-        None,
+        frag_reuse_index.clone(),
     );
     let rq_search_cache = IVFIndex::<S, Q>::rq_search_cache_from_state(state, &storage)?;
 


### PR DESCRIPTION
## Problem

After a deferred-remap compaction (`defer_index_remap=true`), vector searches can return stale pre-compaction row addresses, failing the subsequent take with `fragment id N does not exist in the dataset` (or silently reading wrong rows). Scalar/FTS indexes auto-remap through the FRI at load (#3971); vector indexes did not, due to two bugs:

**1. `IvfIndexState::reconstruct` drops the frag reuse index.** The state cache key is FRI-aware, but `reconstruct_typed` hardcoded `None` into `IvfQuantizationStorage::from_cached`, so any index opened through the state-cache hit path loaded partitions without auto-remap.
Fix: thread `Option<Arc<FragReuseIndex>>` through `reconstruct` → `reconstruct_typed` → `from_cached`; the call site re-opens the FRI (cached under `FragReuseIndexKey`).

**2. `ProductQuantizationStorage::new` keeps the pre-remap `row_ids`.** The remap branch rebuilds the batch and refreshes `pq_code`, but `row_ids` kept the binding extracted before the remap, so `row_ids()` served stale addresses paired with remapped codes — even on a cold open.
Fix: refresh `row_ids` from the remapped batch.

## Test

`test_vector_search_during_fri_window`: IVF_FLAT and IVF_PQ, KNN before → deferred compaction → KNN twice on the same handle (cold open, then state-cache reconstruct), asserting results equal the FRI-translated pre-compaction results. Fails without the fixes.

No existing test covered this intersection — FRI active + stable row ids off + a query through the index: `test_binary_copy_*` defers remap but only asserts a full `scan()`, and `do_binary_copy_preserves_stable_row_ids` queries the index but with `enable_stable_row_ids: true` (so `needs_remapping == false`, no FRI).

## Note

IVF_HNSW_SQ is also fixed (its row ids come from the SQ storage, now FRI-applied on both paths). Its physical remap separately rebuilds the graph (#4941) — benign approximate top-k drift, not stale addresses.
