### PR TITLE
fix(fsst): grow decode buffer to prevent out-of-bounds write

### DIFF
--- a/rust/compression/fsst/src/fsst.rs
+++ b/rust/compression/fsst/src/fsst.rs
@@ -812,6 +812,19 @@ fn decompress_bulk<T: OffsetSizeTrait>(
 ) -> io::Result<()> {
     let symbols = decoder.symbols;
     let lens = decoder.lens;
+
+    // A code byte can decode to an 8-byte symbol and the loop below writes 8 bytes
+    // at a time via raw pointers, so size the buffer for the worst case (it is
+    // shrunk to the real size at the end).
+    let max_decoded = compressed_strs
+        .len()
+        .saturating_mul(MAX_SYMBOL_LENGTH)
+        .saturating_add(MAX_SYMBOL_LENGTH);
+    let needed = out_pos.saturating_add(max_decoded);
+    if out.len() < needed {
+        out.resize(needed, 0);
+    }
+
     let mut decompress = |mut in_curr: usize, in_end: usize, out_curr: &mut usize| {
         // Do SIMD operation here by 4 bytes
         while in_curr + 4 <= in_end {

--- a/rust/compression/fsst/tests/buffer_bound.rs
+++ b/rust/compression/fsst/tests/buffer_bound.rs
@@ -1,0 +1,54 @@
+// Regression test for the out-of-bounds write when data compresses better than
+// 3:1 (a code byte can expand to an 8-byte symbol, but decompress only required a
+// 3x output buffer).
+use arrow_array::StringArray;
+use fsst::fsst::{FSST_SYMBOL_TABLE_SIZE, compress, decompress};
+
+#[test]
+fn decompress_high_ratio_into_documented_minimum_buffer() {
+    // >= 32 KiB so the encoder turns on; very repetitive so it compresses ~8:1.
+    let row = "a".repeat(64);
+    let rows: Vec<&str> = (0..2000).map(|_| row.as_str()).collect();
+    let array = StringArray::from(rows);
+    let in_data = array.value_data();
+    let in_offsets = array.value_offsets();
+
+    let mut comp_buf: Vec<u8> = vec![0; in_data.len()];
+    let mut comp_offsets: Vec<i32> = vec![0; in_offsets.len()];
+    let mut symbol_table = [0u8; FSST_SYMBOL_TABLE_SIZE];
+    compress(
+        symbol_table.as_mut(),
+        in_data,
+        in_offsets,
+        &mut comp_buf,
+        &mut comp_offsets,
+    )
+    .unwrap();
+
+    // The input compresses much better than 3:1.
+    assert!(
+        in_data.len() > 3 * comp_buf.len(),
+        "expected >3:1 ratio, got {} -> {}",
+        in_data.len(),
+        comp_buf.len()
+    );
+
+    // Allocate exactly the documented minimum (3x the compressed input).
+    let mut dec_buf: Vec<u8> = vec![0; 3 * comp_buf.len()];
+    let mut dec_offsets: Vec<i32> = vec![0; comp_offsets.len()];
+    decompress(
+        &symbol_table,
+        &comp_buf,
+        &comp_offsets,
+        &mut dec_buf,
+        &mut dec_offsets,
+    )
+    .unwrap();
+
+    // Round-trips correctly.
+    for i in 1..dec_offsets.len() {
+        let got = &dec_buf[dec_offsets[i - 1] as usize..dec_offsets[i] as usize];
+        let want = &in_data[in_offsets[i - 1] as usize..in_offsets[i] as usize];
+        assert_eq!(got, want, "mismatch on row {i}");
+    }
+}


### PR DESCRIPTION
## Summary

`fsst::fsst::decompress` only required a `3 * input` output buffer, but an FSST code byte can decode to an 8-byte symbol and the decode loop writes 8 bytes at a time through raw pointers. On data that compresses better than 3:1, honoring the documented minimum overran the buffer (a heap out-of-bounds write, observed as a segfault).

This sizes the output buffer for the worst case before decoding, then shrinks it to the real length at the end. The change is internal to the decode path and does not change results for callers that already pass a large enough buffer (in-tree callers pass `8 * input`).

Closes #7266. Related: #2606.

## Test

Added `rust/compression/fsst/tests/buffer_bound.rs`: it compresses an ~8:1 input and decompresses into the documented 3x buffer. This segfaulted before the change and round-trips correctly after. `cargo test -p fsst` and `cargo clippy -p fsst --tests` pass.
