### PR TITLE
feat: configure blob inline threshold per column

### DIFF
--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -95,6 +95,16 @@ Note:
 - By default, external blob URIs must map to a registered non-dataset-root base path.
 - If you need to reference external objects outside those bases, set
   `allow_external_blob_outside_bases=True` when writing.
+- Blob v2 storage layout thresholds can be configured per column with
+  `blob_field(..., inline_size_threshold=..., dedicated_size_threshold=...)`.
+  The inline threshold controls when values move from the data file to packed
+  `.blob` sidecar storage. The dedicated threshold controls when values move
+  from packed sidecar storage to a dedicated `.blob` file. The dedicated
+  threshold is checked first. For existing columns, these thresholds are stored
+  in the dataset schema; appends that explicitly provide different threshold
+  metadata for the same column are rejected.
+- `blob_pack_file_size_threshold` is a write option for rolling packed `.blob`
+  sidecar files. It does not control inline-vs-packed placement.
 
 ### Example: packed external blobs (single container file)
 

--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+import ctypes
 import io
 from dataclasses import dataclass
 from typing import IO, Any, Iterator, Optional, Union
@@ -8,6 +9,12 @@ from typing import IO, Any, Iterator, Optional, Union
 import pyarrow as pa
 
 from .lance import LanceBlobFile
+
+_BLOB_INLINE_SIZE_THRESHOLD_META_KEY = b"lance-encoding:blob-inline-size-threshold"
+_BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY = (
+    b"lance-encoding:blob-dedicated-size-threshold"
+)
+_MAX_RUST_USIZE = ctypes.c_size_t(-1).value
 
 
 @dataclass(frozen=True)
@@ -190,9 +197,63 @@ def blob_array(values: list[Any]) -> BlobArray:
     return BlobArray.from_pylist(values)
 
 
-def blob_field(name: str, *, nullable: bool = True) -> pa.Field:
-    """Construct an Arrow field for a Lance blob column."""
-    return pa.field(name, BlobType(), nullable=nullable)
+def _validate_threshold(name: str, value: Optional[int], *, allow_zero: bool) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an int, got {type(value).__name__}")
+    if allow_zero:
+        if value < 0:
+            raise ValueError(f"{name} must be non-negative")
+    elif value <= 0:
+        raise ValueError(f"{name} must be positive")
+    if value > _MAX_RUST_USIZE:
+        raise OverflowError(f"{name} must fit in a Rust usize")
+
+
+def blob_field(
+    name: str,
+    *,
+    nullable: bool = True,
+    inline_size_threshold: Optional[int] = None,
+    dedicated_size_threshold: Optional[int] = None,
+) -> pa.Field:
+    """
+    Construct an Arrow field for a Lance blob column.
+
+    Parameters
+    ----------
+    name : str
+        Field name.
+    nullable : bool, default True
+        Whether the blob column accepts null values.
+    inline_size_threshold : optional, int
+        Maximum payload size in bytes to keep inline in the data file before
+        using packed blob storage.
+    dedicated_size_threshold : optional, int
+        Maximum payload size in bytes to store in packed blob storage before
+        using dedicated blob storage. This threshold is checked before
+        ``inline_size_threshold``.
+    """
+    _validate_threshold("inline_size_threshold", inline_size_threshold, allow_zero=True)
+    _validate_threshold(
+        "dedicated_size_threshold", dedicated_size_threshold, allow_zero=False
+    )
+
+    field = pa.field(name, BlobType(), nullable=nullable)
+    if inline_size_threshold is None and dedicated_size_threshold is None:
+        return field
+
+    metadata = dict(field.metadata or {})
+    if inline_size_threshold is not None:
+        metadata[_BLOB_INLINE_SIZE_THRESHOLD_META_KEY] = str(
+            inline_size_threshold
+        ).encode()
+    if dedicated_size_threshold is not None:
+        metadata[_BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY] = str(
+            dedicated_size_threshold
+        ).encode()
+    return field.with_metadata(metadata)
 
 
 class BlobIterator:

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -583,6 +583,160 @@ def test_blob_extension_write_inline(tmp_path):
         assert f.read() == b"foo"
 
 
+def test_blob_field_threshold_metadata():
+    field = lance.blob_field(
+        "blob",
+        inline_size_threshold=16 * 1024,
+        dedicated_size_threshold=2 * 1024 * 1024,
+    )
+
+    assert field.metadata[b"lance-encoding:blob-inline-size-threshold"] == b"16384"
+    assert field.metadata[b"lance-encoding:blob-dedicated-size-threshold"] == b"2097152"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "message"),
+    [
+        pytest.param(
+            {"inline_size_threshold": -1},
+            ValueError,
+            "inline_size_threshold must be non-negative",
+            id="negative_inline",
+        ),
+        pytest.param(
+            {"dedicated_size_threshold": 0},
+            ValueError,
+            "dedicated_size_threshold must be positive",
+            id="zero_dedicated",
+        ),
+        pytest.param(
+            {"dedicated_size_threshold": -1},
+            ValueError,
+            "dedicated_size_threshold must be positive",
+            id="negative_dedicated",
+        ),
+        pytest.param(
+            {"inline_size_threshold": True},
+            TypeError,
+            "inline_size_threshold must be an int",
+            id="bool_inline",
+        ),
+        pytest.param(
+            {"dedicated_size_threshold": True},
+            TypeError,
+            "dedicated_size_threshold must be an int",
+            id="bool_dedicated",
+        ),
+        pytest.param(
+            {"inline_size_threshold": 1.5},
+            TypeError,
+            "inline_size_threshold must be an int",
+            id="float_inline",
+        ),
+        pytest.param(
+            {"inline_size_threshold": 2**100},
+            OverflowError,
+            "inline_size_threshold must fit in a Rust usize",
+            id="overflow_inline",
+        ),
+        pytest.param(
+            {"dedicated_size_threshold": 2**100},
+            OverflowError,
+            "dedicated_size_threshold must fit in a Rust usize",
+            id="overflow_dedicated",
+        ),
+    ],
+)
+def test_blob_field_rejects_invalid_thresholds(kwargs, error, message):
+    with pytest.raises(error, match=message):
+        lance.blob_field("blob", **kwargs)
+
+
+def test_blob_extension_inline_threshold_per_column(tmp_path):
+    payload = b"x" * 2048
+    schema = pa.schema(
+        [
+            lance.blob_field("inline_blob", inline_size_threshold=4096),
+            lance.blob_field("packed_blob", inline_size_threshold=1024),
+        ]
+    )
+    table = pa.table(
+        {
+            "inline_blob": lance.blob_array([payload]),
+            "packed_blob": lance.blob_array([payload]),
+        },
+        schema=schema,
+    )
+    ds = lance.write_dataset(
+        table,
+        tmp_path / "test_ds_v2_inline_threshold_per_column",
+        data_storage_version="2.2",
+    )
+
+    desc = ds.to_table(columns=["inline_blob", "packed_blob"])
+    assert desc.column("inline_blob").chunk(0).field("kind").to_pylist() == [0]
+    assert desc.column("packed_blob").chunk(0).field("kind").to_pylist() == [1]
+
+
+def test_blob_extension_threshold_metadata_persists_after_reopen(tmp_path):
+    dataset_path = tmp_path / "test_ds_v2_threshold_metadata_persists"
+    schema = pa.schema([lance.blob_field("blob", inline_size_threshold=1024)])
+    table = pa.table({"blob": lance.blob_array([b"x"])}, schema=schema)
+
+    lance.write_dataset(table, dataset_path, data_storage_version="2.2")
+    reopened = lance.dataset(dataset_path)
+
+    assert (
+        reopened.schema.field("blob").metadata[
+            b"lance-encoding:blob-inline-size-threshold"
+        ]
+        == b"1024"
+    )
+
+
+def test_blob_extension_append_rejects_explicit_threshold_mismatch(tmp_path):
+    dataset_path = tmp_path / "test_ds_v2_append_threshold_mismatch"
+    initial_schema = pa.schema([lance.blob_field("blob", inline_size_threshold=4096)])
+    initial = pa.table(
+        {"blob": lance.blob_array([b"x" * 2048])},
+        schema=initial_schema,
+    )
+    lance.write_dataset(initial, dataset_path, data_storage_version="2.2")
+
+    append_schema = pa.schema([lance.blob_field("blob", inline_size_threshold=1024)])
+    append = pa.table(
+        {"blob": lance.blob_array([b"x" * 2048])},
+        schema=append_schema,
+    )
+
+    with pytest.raises(
+        OSError, match="Cannot append data with blob threshold metadata"
+    ):
+        lance.write_dataset(append, dataset_path, mode="append")
+
+
+def test_blob_extension_dedicated_threshold_precedes_inline_threshold(tmp_path):
+    payload = b"x" * 2048
+    schema = pa.schema(
+        [
+            lance.blob_field(
+                "blob",
+                inline_size_threshold=4096,
+                dedicated_size_threshold=1024,
+            )
+        ]
+    )
+    table = pa.table({"blob": lance.blob_array([payload])}, schema=schema)
+    ds = lance.write_dataset(
+        table,
+        tmp_path / "test_ds_v2_dedicated_precedes_inline",
+        data_storage_version="2.2",
+    )
+
+    desc = ds.to_table(columns=["blob"]).column("blob").chunk(0)
+    assert desc.field("kind").to_pylist() == [2]
+
+
 def test_blob_extension_write_external(tmp_path):
     blob_path = tmp_path / "external_blob.bin"
     blob_path.write_bytes(b"hello")

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -52,6 +52,8 @@ pub const BLOB_V2_EXT_NAME: &str = "lance.blob.v2";
 /// Metadata key for overriding the dedicated blob size threshold (in bytes)
 pub const BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY: &str =
     "lance-encoding:blob-dedicated-size-threshold";
+/// Metadata key for overriding the inline blob size threshold (in bytes)
+pub const BLOB_INLINE_SIZE_THRESHOLD_META_KEY: &str = "lance-encoding:blob-inline-size-threshold";
 
 type Result<T> = std::result::Result<T, ArrowError>;
 

--- a/rust/lance/src/blob.rs
+++ b/rust/lance/src/blob.rs
@@ -7,12 +7,16 @@
 //! tagged with `ARROW:extension:name = "lance.blob.v2"`. This module offers a
 //! type-safe builder to construct that struct without manually wiring metadata
 
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use arrow_array::{ArrayRef, StructArray, builder::LargeBinaryBuilder, builder::StringBuilder};
 use arrow_buffer::NullBufferBuilder;
 use arrow_schema::{DataType, Field};
-use lance_arrow::{ARROW_EXT_NAME_KEY, BLOB_V2_EXT_NAME};
+use lance_arrow::{
+    ARROW_EXT_NAME_KEY, BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
+    BLOB_INLINE_SIZE_THRESHOLD_META_KEY, BLOB_V2_EXT_NAME,
+};
 
 use crate::{Error, Result};
 
@@ -21,9 +25,71 @@ use crate::{Error, Result};
 /// Blob v2 expects a column shaped as `Struct<data: LargeBinary?, uri: Utf8?>` and
 /// tagged with `ARROW:extension:name = "lance.blob.v2"`.
 pub fn blob_field(name: &str, nullable: bool) -> Field {
-    let metadata = [(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string())]
+    blob_field_with_options(name, nullable, BlobFieldOptions::default())
+}
+
+/// Options for constructing a blob v2 field.
+#[derive(Clone, Debug, Default)]
+pub struct BlobFieldOptions {
+    /// Maximum payload size to keep inline in the data file before using packed blob storage.
+    pub inline_size_threshold: Option<usize>,
+    /// Maximum payload size to store in packed blob storage before using dedicated blob storage.
+    ///
+    /// A zero threshold is invalid because dedicated blob storage is selected when
+    /// the payload size is greater than this value.
+    pub dedicated_size_threshold: Option<NonZeroUsize>,
+}
+
+impl BlobFieldOptions {
+    /// Set the maximum payload size to keep inline in the data file.
+    pub fn with_inline_size_threshold(mut self, threshold: usize) -> Self {
+        self.inline_size_threshold = Some(threshold);
+        self
+    }
+
+    /// Set the maximum payload size to store in packed blob storage.
+    pub fn with_dedicated_size_threshold(mut self, threshold: NonZeroUsize) -> Self {
+        self.dedicated_size_threshold = Some(threshold);
+        self
+    }
+}
+
+/// Construct the Arrow field for a blob v2 column with storage layout options.
+///
+/// Blob v2 expects a column shaped as `Struct<data: LargeBinary?, uri: Utf8?>` and
+/// tagged with `ARROW:extension:name = "lance.blob.v2"`.
+///
+/// ```
+/// # use lance::{BlobFieldOptions, blob_field_with_options};
+/// let field = blob_field_with_options(
+///     "blob",
+///     true,
+///     BlobFieldOptions::default().with_inline_size_threshold(16 * 1024),
+/// );
+/// assert_eq!(
+///     field
+///         .metadata()
+///         .get("lance-encoding:blob-inline-size-threshold")
+///         .map(String::as_str),
+///     Some("16384"),
+/// );
+/// ```
+pub fn blob_field_with_options(name: &str, nullable: bool, options: BlobFieldOptions) -> Field {
+    let mut metadata = [(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string())]
         .into_iter()
-        .collect();
+        .collect::<std::collections::HashMap<_, _>>();
+    if let Some(threshold) = options.inline_size_threshold {
+        metadata.insert(
+            BLOB_INLINE_SIZE_THRESHOLD_META_KEY.to_string(),
+            threshold.to_string(),
+        );
+    }
+    if let Some(threshold) = options.dedicated_size_threshold {
+        metadata.insert(
+            BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY.to_string(),
+            threshold.get().to_string(),
+        );
+    }
     Field::new(
         name,
         DataType::Struct(
@@ -142,6 +208,8 @@ impl BlobArrayBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use super::*;
     use arrow_array::Array;
     use arrow_array::cast::AsArray;
@@ -153,6 +221,31 @@ mod tests {
         assert_eq!(
             field.metadata().get(ARROW_EXT_NAME_KEY).unwrap(),
             BLOB_V2_EXT_NAME
+        );
+    }
+
+    #[test]
+    fn test_field_metadata_with_options() {
+        let field = blob_field_with_options(
+            "blob",
+            true,
+            BlobFieldOptions::default()
+                .with_inline_size_threshold(16 * 1024)
+                .with_dedicated_size_threshold(NonZeroUsize::new(2 * 1024 * 1024).unwrap()),
+        );
+        assert_eq!(
+            field
+                .metadata()
+                .get(BLOB_INLINE_SIZE_THRESHOLD_META_KEY)
+                .unwrap(),
+            "16384"
+        );
+        assert_eq!(
+            field
+                .metadata()
+                .get(BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY)
+                .unwrap(),
+            "2097152"
         );
     }
 

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -19,7 +19,9 @@ use arrow_schema::DataType as ArrowDataType;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt, TryStreamExt, stream};
-use lance_arrow::{BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, FieldExt};
+use lance_arrow::{
+    BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, BLOB_INLINE_SIZE_THRESHOLD_META_KEY, FieldExt,
+};
 use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
 use lance_io::scheduler::{FileScheduler, ScanScheduler, SchedulerConfig};
 use object_store::path::Path;
@@ -206,6 +208,7 @@ pub struct BlobPreprocessor {
     local_counter: u32,
     pack_writer: PackWriter,
     blob_v2_cols: Vec<bool>,
+    inline_thresholds: Vec<usize>,
     dedicated_thresholds: Vec<usize>,
     writer_metadata: Vec<HashMap<String, String>>,
     external_base_resolver: Option<Arc<ExternalBaseResolver>>,
@@ -325,6 +328,10 @@ impl BlobPreprocessor {
         let arrow_schema = arrow_schema::Schema::from(schema);
         let fields = arrow_schema.fields();
         let blob_v2_cols = fields.iter().map(|field| field.is_blob_v2()).collect();
+        let inline_thresholds = fields
+            .iter()
+            .map(|field| inline_threshold_from_metadata(field.as_ref()))
+            .collect();
         let dedicated_thresholds = fields
             .iter()
             .map(|field| dedicated_threshold_from_metadata(field.as_ref()))
@@ -341,6 +348,7 @@ impl BlobPreprocessor {
             local_counter: 1,
             pack_writer,
             blob_v2_cols,
+            inline_thresholds,
             dedicated_thresholds,
             writer_metadata,
             external_base_resolver,
@@ -523,6 +531,7 @@ impl BlobPreprocessor {
                 let data_len = if has_data { data_col.value(i).len() } else { 0 };
 
                 let dedicated_threshold = self.dedicated_thresholds[idx];
+                let inline_threshold = self.inline_thresholds[idx];
                 if has_data && data_len > dedicated_threshold {
                     let blob_id = self.next_blob_id();
                     self.write_dedicated(blob_id, BlobWriteSource::Bytes(data_col.value(i)))
@@ -537,7 +546,7 @@ impl BlobPreprocessor {
                     continue;
                 }
 
-                if has_data && data_len > INLINE_MAX {
+                if has_data && data_len > inline_threshold {
                     let (pack_blob_id, position) = self
                         .write_packed(BlobWriteSource::Bytes(data_col.value(i)))
                         .await?;
@@ -586,7 +595,7 @@ impl BlobPreprocessor {
                             continue;
                         }
 
-                        if data_len > INLINE_MAX as u64 {
+                        if data_len > inline_threshold as u64 {
                             let (pack_blob_id, position) = self
                                 .write_packed(BlobWriteSource::External(&source))
                                 .await?;
@@ -700,13 +709,20 @@ impl BlobPreprocessor {
     }
 }
 
+fn inline_threshold_from_metadata(field: &arrow_schema::Field) -> usize {
+    field
+        .metadata()
+        .get(BLOB_INLINE_SIZE_THRESHOLD_META_KEY)
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(INLINE_MAX)
+}
+
 fn dedicated_threshold_from_metadata(field: &arrow_schema::Field) -> usize {
     field
         .metadata()
         .get(BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY)
-        .and_then(|value| value.parse::<i64>().ok())
+        .and_then(|value| value.parse::<usize>().ok())
         .filter(|value| *value > 0)
-        .and_then(|value| usize::try_from(value).ok())
         .unwrap_or(DEDICATED_THRESHOLD)
 }
 
@@ -2111,7 +2127,8 @@ mod tests {
     use chrono::Utc;
     use futures::{StreamExt, TryStreamExt, future::try_join_all};
     use lance_arrow::{
-        ARROW_EXT_NAME_KEY, BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, BLOB_V2_EXT_NAME, DataTypeExt,
+        ARROW_EXT_NAME_KEY, BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
+        BLOB_INLINE_SIZE_THRESHOLD_META_KEY, BLOB_V2_EXT_NAME, DataTypeExt,
     };
     use lance_core::datatypes::BlobKind;
     use lance_io::object_store::{
@@ -2142,7 +2159,7 @@ mod tests {
     use crate::{
         Dataset,
         blob::{BlobArrayBuilder, blob_field},
-        dataset::{ExternalBlobMode, WriteParams},
+        dataset::{ExternalBlobMode, WriteMode, WriteParams},
         utils::test::TestDatasetGenerator,
     };
 
@@ -3622,6 +3639,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_blob_v2_external_ingest_respects_inline_threshold() {
+        let dataset_dir = TempDir::default();
+        let external_dir = TempDir::default();
+        let external_path = external_dir.std_path().join("external.bin");
+        let payload = vec![0x5A; 2048];
+        std::fs::write(&external_path, &payload).unwrap();
+        let external_uri = format!("file://{}", external_path.display());
+
+        let mut blob_builder = BlobArrayBuilder::new(1);
+        blob_builder.push_uri(external_uri).unwrap();
+        let blob_array: arrow_array::ArrayRef = blob_builder.finish().unwrap();
+
+        let mut field = blob_field("blob", true);
+        let mut metadata = field.metadata().clone();
+        metadata.insert(
+            BLOB_INLINE_SIZE_THRESHOLD_META_KEY.to_string(),
+            "1024".to_string(),
+        );
+        field = field.with_metadata(metadata);
+        let schema = Arc::new(Schema::new(vec![field]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![blob_array]).unwrap();
+        let reader = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+
+        let dataset = Arc::new(
+            Dataset::write(
+                reader,
+                &dataset_dir.path_str(),
+                Some(WriteParams {
+                    data_storage_version: Some(LanceFileVersion::V2_2),
+                    external_blob_mode: ExternalBlobMode::Ingest,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+
+        let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
+        assert_eq!(blobs.len(), 1);
+        assert_eq!(blobs[0].kind(), BlobKind::Packed);
+        assert_eq!(blobs[0].read().await.unwrap().as_ref(), payload.as_slice());
+    }
+
+    #[tokio::test]
     async fn test_blob_v2_external_ingest_dedicated() {
         let dataset_dir = TempDir::default();
         let external_dir = TempDir::default();
@@ -3713,7 +3774,10 @@ mod tests {
         );
     }
 
-    async fn preprocess_kind_with_schema_metadata(metadata_value: &str, data_len: usize) -> u8 {
+    async fn preprocess_kind_with_blob_metadata(
+        metadata_entries: Vec<(&'static str, String)>,
+        data_len: usize,
+    ) -> u8 {
         let (object_store, base_path) = ObjectStore::from_uri_and_params(
             Arc::new(ObjectStoreRegistry::default()),
             "memory://blob_preprocessor",
@@ -3726,10 +3790,9 @@ mod tests {
 
         let mut field = blob_field("blob", true);
         let mut metadata = field.metadata().clone();
-        metadata.insert(
-            BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY.to_string(),
-            metadata_value.to_string(),
-        );
+        for (key, value) in metadata_entries {
+            metadata.insert(key.to_string(), value);
+        }
         field = field.with_metadata(metadata);
 
         let writer_arrow_schema = Schema::new(vec![field.clone()]);
@@ -3772,21 +3835,242 @@ mod tests {
 
     #[tokio::test]
     async fn test_blob_v2_dedicated_threshold_ignores_non_positive_metadata() {
-        let kind = preprocess_kind_with_schema_metadata("0", 256 * 1024).await;
+        let kind = preprocess_kind_with_blob_metadata(
+            vec![(BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, "0".to_string())],
+            256 * 1024,
+        )
+        .await;
         assert_eq!(kind, lance_core::datatypes::BlobKind::Packed as u8);
     }
 
     #[tokio::test]
     async fn test_blob_v2_dedicated_threshold_respects_smaller_metadata() {
-        let kind = preprocess_kind_with_schema_metadata("131072", 256 * 1024).await;
+        let kind = preprocess_kind_with_blob_metadata(
+            vec![(BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, "131072".to_string())],
+            256 * 1024,
+        )
+        .await;
         assert_eq!(kind, lance_core::datatypes::BlobKind::Dedicated as u8);
     }
 
     #[tokio::test]
     async fn test_blob_v2_dedicated_threshold_respects_larger_metadata() {
-        let kind =
-            preprocess_kind_with_schema_metadata("8388608", super::DEDICATED_THRESHOLD + 1024)
-                .await;
+        let kind = preprocess_kind_with_blob_metadata(
+            vec![(
+                BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
+                "8388608".to_string(),
+            )],
+            super::DEDICATED_THRESHOLD + 1024,
+        )
+        .await;
         assert_eq!(kind, lance_core::datatypes::BlobKind::Packed as u8);
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_inline_threshold_respects_smaller_metadata() {
+        let kind = preprocess_kind_with_blob_metadata(
+            vec![(BLOB_INLINE_SIZE_THRESHOLD_META_KEY, "1024".to_string())],
+            2048,
+        )
+        .await;
+        assert_eq!(kind, lance_core::datatypes::BlobKind::Packed as u8);
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_inline_threshold_respects_larger_metadata() {
+        let kind = preprocess_kind_with_blob_metadata(
+            vec![(
+                BLOB_INLINE_SIZE_THRESHOLD_META_KEY,
+                (super::INLINE_MAX + 8192).to_string(),
+            )],
+            super::INLINE_MAX + 4096,
+        )
+        .await;
+        assert_eq!(kind, lance_core::datatypes::BlobKind::Inline as u8);
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_inline_threshold_uses_strict_greater_than() {
+        let kind = preprocess_kind_with_blob_metadata(
+            vec![(BLOB_INLINE_SIZE_THRESHOLD_META_KEY, "1024".to_string())],
+            1024,
+        )
+        .await;
+        assert_eq!(kind, lance_core::datatypes::BlobKind::Inline as u8);
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_dedicated_threshold_uses_strict_greater_than() {
+        let kind = preprocess_kind_with_blob_metadata(
+            vec![
+                (BLOB_INLINE_SIZE_THRESHOLD_META_KEY, "2048".to_string()),
+                (BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, "1024".to_string()),
+            ],
+            1024,
+        )
+        .await;
+        assert_eq!(kind, lance_core::datatypes::BlobKind::Inline as u8);
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_inline_threshold_does_not_override_dedicated_threshold() {
+        let kind = preprocess_kind_with_blob_metadata(
+            vec![
+                (BLOB_INLINE_SIZE_THRESHOLD_META_KEY, "8192".to_string()),
+                (BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, "4096".to_string()),
+            ],
+            6144,
+        )
+        .await;
+        assert_eq!(kind, lance_core::datatypes::BlobKind::Dedicated as u8);
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_inline_threshold_is_per_column() {
+        let (object_store, base_path) = ObjectStore::from_uri_and_params(
+            Arc::new(ObjectStoreRegistry::default()),
+            "memory://blob_preprocessor",
+            &ObjectStoreParams::default(),
+        )
+        .await
+        .unwrap();
+        let object_store = object_store.as_ref().clone();
+        let data_dir = base_path.clone().join("data");
+
+        let mut inline_field = blob_field("inline_blob", true);
+        let mut inline_metadata = inline_field.metadata().clone();
+        inline_metadata.insert(
+            BLOB_INLINE_SIZE_THRESHOLD_META_KEY.to_string(),
+            "4096".to_string(),
+        );
+        inline_field = inline_field.with_metadata(inline_metadata);
+
+        let mut packed_field = blob_field("packed_blob", true);
+        let mut packed_metadata = packed_field.metadata().clone();
+        packed_metadata.insert(
+            BLOB_INLINE_SIZE_THRESHOLD_META_KEY.to_string(),
+            "1024".to_string(),
+        );
+        packed_field = packed_field.with_metadata(packed_metadata);
+
+        let writer_arrow_schema = Schema::new(vec![inline_field.clone(), packed_field.clone()]);
+        let writer_schema = lance_core::datatypes::Schema::try_from(&writer_arrow_schema).unwrap();
+
+        let mut preprocessor = super::BlobPreprocessor::new(
+            object_store.clone(),
+            data_dir,
+            "data_file_key".to_string(),
+            &writer_schema,
+            None,
+            false,
+            ExternalBlobMode::Reference,
+            Arc::new(ObjectStoreRegistry::default()),
+            ObjectStoreParams::default(),
+            None,
+        );
+
+        let mut inline_builder = BlobArrayBuilder::new(1);
+        inline_builder.push_bytes(vec![0u8; 2048]).unwrap();
+        let inline_array: arrow_array::ArrayRef = inline_builder.finish().unwrap();
+
+        let mut packed_builder = BlobArrayBuilder::new(1);
+        packed_builder.push_bytes(vec![0u8; 2048]).unwrap();
+        let packed_array: arrow_array::ArrayRef = packed_builder.finish().unwrap();
+
+        let batch_schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "inline_blob",
+                inline_field.data_type().clone(),
+                inline_field.is_nullable(),
+            ),
+            Field::new(
+                "packed_blob",
+                packed_field.data_type().clone(),
+                packed_field.is_nullable(),
+            ),
+        ]));
+        let batch = RecordBatch::try_new(batch_schema, vec![inline_array, packed_array]).unwrap();
+
+        let out = preprocessor.preprocess_batch(&batch).await.unwrap();
+        let inline_kind = out
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow_array::StructArray>()
+            .unwrap()
+            .column_by_name("kind")
+            .unwrap()
+            .as_primitive::<arrow::datatypes::UInt8Type>()
+            .value(0);
+        let packed_kind = out
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow_array::StructArray>()
+            .unwrap()
+            .column_by_name("kind")
+            .unwrap()
+            .as_primitive::<arrow::datatypes::UInt8Type>()
+            .value(0);
+
+        assert_eq!(inline_kind, lance_core::datatypes::BlobKind::Inline as u8);
+        assert_eq!(packed_kind, lance_core::datatypes::BlobKind::Packed as u8);
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_append_rejects_explicit_inline_threshold_mismatch() {
+        let dataset_dir = TempDir::default();
+        let payload = vec![0u8; 2048];
+
+        let schema = Arc::new(Schema::new(vec![blob_field("blob", true)]));
+        let mut initial_builder = BlobArrayBuilder::new(1);
+        initial_builder.push_bytes(payload.clone()).unwrap();
+        let initial_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(initial_builder.finish().unwrap()) as ArrayRef],
+        )
+        .unwrap();
+        let initial_reader = RecordBatchIterator::new(vec![Ok(initial_batch)], schema);
+        let dataset = Dataset::write(
+            initial_reader,
+            &dataset_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let mut append_field = blob_field("blob", true);
+        let mut append_metadata = append_field.metadata().clone();
+        append_metadata.insert(
+            BLOB_INLINE_SIZE_THRESHOLD_META_KEY.to_string(),
+            "1024".to_string(),
+        );
+        append_field = append_field.with_metadata(append_metadata);
+        let append_schema = Arc::new(Schema::new(vec![append_field]));
+        let mut append_builder = BlobArrayBuilder::new(1);
+        append_builder.push_bytes(payload).unwrap();
+        let append_batch = RecordBatch::try_new(
+            append_schema.clone(),
+            vec![Arc::new(append_builder.finish().unwrap()) as ArrayRef],
+        )
+        .unwrap();
+        let append_reader = RecordBatchIterator::new(vec![Ok(append_batch)], append_schema);
+
+        let result = Dataset::write(
+            append_reader,
+            Arc::new(dataset),
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("append with explicit blob threshold mismatch should fail");
+        };
+        let message = err.to_string();
+        assert!(message.contains("Cannot append data with blob threshold metadata"));
+        assert!(message.contains(BLOB_INLINE_SIZE_THRESHOLD_META_KEY));
     }
 }

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -42,6 +42,58 @@ use lance_io::utils::CachedFileSize;
 const INLINE_MAX: usize = 64 * 1024; // 64KB inline cutoff
 const DEDICATED_THRESHOLD: usize = 4 * 1024 * 1024; // 4MB dedicated cutoff
 const PACK_FILE_MAX_SIZE: usize = 1024 * 1024 * 1024; // 1GiB per .pack sidecar
+
+pub(super) fn blob_inline_threshold_from_metadata(
+    metadata: &HashMap<String, String>,
+    field_name: &str,
+) -> Result<usize> {
+    blob_threshold_from_metadata(
+        metadata,
+        field_name,
+        BLOB_INLINE_SIZE_THRESHOLD_META_KEY,
+        INLINE_MAX,
+        true,
+    )
+}
+
+pub(super) fn blob_dedicated_threshold_from_metadata(
+    metadata: &HashMap<String, String>,
+    field_name: &str,
+) -> Result<usize> {
+    blob_threshold_from_metadata(
+        metadata,
+        field_name,
+        BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
+        DEDICATED_THRESHOLD,
+        false,
+    )
+}
+
+fn blob_threshold_from_metadata(
+    metadata: &HashMap<String, String>,
+    field_name: &str,
+    key: &str,
+    default_value: usize,
+    allow_zero: bool,
+) -> Result<usize> {
+    let Some(value) = metadata.get(key) else {
+        return Ok(default_value);
+    };
+    let threshold = value.parse::<usize>().map_err(|_| {
+        Error::invalid_input(format!(
+            "Invalid blob threshold metadata {key}={value:?} for field '{field_name}'; \
+             expected a non-negative integer that fits in usize"
+        ))
+    })?;
+    if !allow_zero && threshold == 0 {
+        return Err(Error::invalid_input(format!(
+            "Invalid blob threshold metadata {key}={value:?} for field '{field_name}'; \
+             expected a positive integer"
+        )));
+    }
+    Ok(threshold)
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct ResolvedExternalBase {
     pub base_id: u32,
@@ -316,7 +368,7 @@ impl BlobPreprocessor {
         source_store_registry: Arc<ObjectStoreRegistry>,
         source_store_params: ObjectStoreParams,
         pack_file_size_threshold: Option<usize>,
-    ) -> Self {
+    ) -> Result<Self> {
         let mut pack_writer = PackWriter::new(
             object_store.clone(),
             data_dir.clone(),
@@ -327,20 +379,37 @@ impl BlobPreprocessor {
         }
         let arrow_schema = arrow_schema::Schema::from(schema);
         let fields = arrow_schema.fields();
-        let blob_v2_cols = fields.iter().map(|field| field.is_blob_v2()).collect();
+        let blob_v2_cols = fields
+            .iter()
+            .map(|field| field.is_blob_v2())
+            .collect::<Vec<_>>();
         let inline_thresholds = fields
             .iter()
-            .map(|field| inline_threshold_from_metadata(field.as_ref()))
-            .collect();
+            .zip(blob_v2_cols.iter())
+            .map(|(field, is_blob_v2)| {
+                if *is_blob_v2 {
+                    blob_inline_threshold_from_metadata(field.metadata(), field.name())
+                } else {
+                    Ok(INLINE_MAX)
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
         let dedicated_thresholds = fields
             .iter()
-            .map(|field| dedicated_threshold_from_metadata(field.as_ref()))
-            .collect();
+            .zip(blob_v2_cols.iter())
+            .map(|(field, is_blob_v2)| {
+                if *is_blob_v2 {
+                    blob_dedicated_threshold_from_metadata(field.metadata(), field.name())
+                } else {
+                    Ok(DEDICATED_THRESHOLD)
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
         let writer_metadata = fields
             .iter()
             .map(|field| field.metadata().clone())
             .collect();
-        Self {
+        Ok(Self {
             object_store,
             data_dir,
             data_file_key,
@@ -356,7 +425,7 @@ impl BlobPreprocessor {
             external_blob_mode,
             source_store_registry,
             source_store_params,
-        }
+        })
     }
 
     fn next_blob_id(&mut self) -> u32 {
@@ -707,23 +776,6 @@ impl BlobPreprocessor {
     pub(crate) async fn finish(&mut self) -> Result<()> {
         self.pack_writer.finish().await
     }
-}
-
-fn inline_threshold_from_metadata(field: &arrow_schema::Field) -> usize {
-    field
-        .metadata()
-        .get(BLOB_INLINE_SIZE_THRESHOLD_META_KEY)
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(INLINE_MAX)
-}
-
-fn dedicated_threshold_from_metadata(field: &arrow_schema::Field) -> usize {
-    field
-        .metadata()
-        .get(BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY)
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(DEDICATED_THRESHOLD)
 }
 
 pub async fn preprocess_blob_batches(
@@ -3774,10 +3826,10 @@ mod tests {
         );
     }
 
-    async fn preprocess_kind_with_blob_metadata(
+    async fn try_preprocess_kind_with_blob_metadata(
         metadata_entries: Vec<(&'static str, String)>,
         data_len: usize,
-    ) -> u8 {
+    ) -> Result<u8> {
         let (object_store, base_path) = ObjectStore::from_uri_and_params(
             Arc::new(ObjectStoreRegistry::default()),
             "memory://blob_preprocessor",
@@ -3809,7 +3861,7 @@ mod tests {
             Arc::new(ObjectStoreRegistry::default()),
             ObjectStoreParams::default(),
             None,
-        );
+        )?;
 
         let mut blob_builder = BlobArrayBuilder::new(1);
         blob_builder.push_bytes(vec![0u8; data_len]).unwrap();
@@ -3820,27 +3872,93 @@ mod tests {
         let batch_schema = Arc::new(Schema::new(vec![field_without_metadata]));
         let batch = RecordBatch::try_new(batch_schema, vec![blob_array]).unwrap();
 
-        let out = preprocessor.preprocess_batch(&batch).await.unwrap();
+        let out = preprocessor.preprocess_batch(&batch).await?;
         let struct_arr = out
             .column(0)
             .as_any()
             .downcast_ref::<arrow_array::StructArray>()
             .unwrap();
-        struct_arr
+        Ok(struct_arr
             .column_by_name("kind")
             .unwrap()
             .as_primitive::<arrow::datatypes::UInt8Type>()
-            .value(0)
+            .value(0))
+    }
+
+    async fn preprocess_kind_with_blob_metadata(
+        metadata_entries: Vec<(&'static str, String)>,
+        data_len: usize,
+    ) -> u8 {
+        try_preprocess_kind_with_blob_metadata(metadata_entries, data_len)
+            .await
+            .unwrap()
     }
 
     #[tokio::test]
-    async fn test_blob_v2_dedicated_threshold_ignores_non_positive_metadata() {
-        let kind = preprocess_kind_with_blob_metadata(
+    async fn test_blob_v2_dedicated_threshold_rejects_non_positive_metadata() {
+        let err = try_preprocess_kind_with_blob_metadata(
             vec![(BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, "0".to_string())],
             256 * 1024,
         )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("expected a positive integer"));
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_inline_threshold_rejects_invalid_metadata() {
+        let err = try_preprocess_kind_with_blob_metadata(
+            vec![(
+                BLOB_INLINE_SIZE_THRESHOLD_META_KEY,
+                "not-a-number".to_string(),
+            )],
+            256 * 1024,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("expected a non-negative integer that fits in usize")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_write_rejects_invalid_inline_threshold_metadata() {
+        let dataset_dir = TempDir::default();
+        let mut field = blob_field("blob", true);
+        let mut metadata = field.metadata().clone();
+        metadata.insert(
+            BLOB_INLINE_SIZE_THRESHOLD_META_KEY.to_string(),
+            "not-a-number".to_string(),
+        );
+        field = field.with_metadata(metadata);
+        let schema = Arc::new(Schema::new(vec![field]));
+
+        let mut blob_builder = BlobArrayBuilder::new(1);
+        blob_builder.push_bytes(vec![0u8; 256]).unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(blob_builder.finish().unwrap()) as ArrayRef],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+
+        let result = Dataset::write(
+            reader,
+            &dataset_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                ..Default::default()
+            }),
+        )
         .await;
-        assert_eq!(kind, lance_core::datatypes::BlobKind::Packed as u8);
+        let Err(err) = result else {
+            panic!("write with invalid blob threshold metadata should fail");
+        };
+        assert!(
+            err.to_string()
+                .contains("expected a non-negative integer that fits in usize")
+        );
     }
 
     #[tokio::test]
@@ -3967,7 +4085,8 @@ mod tests {
             Arc::new(ObjectStoreRegistry::default()),
             ObjectStoreParams::default(),
             None,
-        );
+        )
+        .unwrap();
 
         let mut inline_builder = BlobArrayBuilder::new(1);
         inline_builder.push_bytes(vec![0u8; 2048]).unwrap();
@@ -4072,5 +4191,60 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("Cannot append data with blob threshold metadata"));
         assert!(message.contains(BLOB_INLINE_SIZE_THRESHOLD_META_KEY));
+    }
+
+    #[tokio::test]
+    async fn test_blob_v2_append_accepts_explicit_default_inline_threshold() {
+        let dataset_dir = TempDir::default();
+        let payload = vec![0u8; 2048];
+
+        let schema = Arc::new(Schema::new(vec![blob_field("blob", true)]));
+        let mut initial_builder = BlobArrayBuilder::new(1);
+        initial_builder.push_bytes(payload.clone()).unwrap();
+        let initial_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(initial_builder.finish().unwrap()) as ArrayRef],
+        )
+        .unwrap();
+        let initial_reader = RecordBatchIterator::new(vec![Ok(initial_batch)], schema);
+        let dataset = Dataset::write(
+            initial_reader,
+            &dataset_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let mut append_field = blob_field("blob", true);
+        let mut append_metadata = append_field.metadata().clone();
+        append_metadata.insert(
+            BLOB_INLINE_SIZE_THRESHOLD_META_KEY.to_string(),
+            super::INLINE_MAX.to_string(),
+        );
+        append_field = append_field.with_metadata(append_metadata);
+        let append_schema = Arc::new(Schema::new(vec![append_field]));
+        let mut append_builder = BlobArrayBuilder::new(1);
+        append_builder.push_bytes(payload).unwrap();
+        let append_batch = RecordBatch::try_new(
+            append_schema.clone(),
+            vec![Arc::new(append_builder.finish().unwrap()) as ArrayRef],
+        )
+        .unwrap();
+        let append_reader = RecordBatchIterator::new(vec![Ok(append_batch)], append_schema);
+
+        let dataset = Dataset::write(
+            append_reader,
+            Arc::new(dataset),
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.count_rows(None).await.unwrap(), 2);
     }
 }

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -4194,6 +4194,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_blob_v2_append_rejects_threshold_mismatch_with_non_blob_input_extension() {
+        let dataset_dir = TempDir::default();
+        let payload = vec![0u8; 2048];
+
+        let schema = Arc::new(Schema::new(vec![blob_field("blob", true)]));
+        let mut initial_builder = BlobArrayBuilder::new(1);
+        initial_builder.push_bytes(payload.clone()).unwrap();
+        let initial_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(initial_builder.finish().unwrap()) as ArrayRef],
+        )
+        .unwrap();
+        let initial_reader = RecordBatchIterator::new(vec![Ok(initial_batch)], schema);
+        let dataset = Dataset::write(
+            initial_reader,
+            &dataset_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let mut append_field = blob_field("blob", true);
+        let mut append_metadata = append_field.metadata().clone();
+        append_metadata.insert(
+            ARROW_EXT_NAME_KEY.to_string(),
+            "some.other.extension".to_string(),
+        );
+        append_metadata.insert(
+            BLOB_INLINE_SIZE_THRESHOLD_META_KEY.to_string(),
+            "1024".to_string(),
+        );
+        append_field = append_field.with_metadata(append_metadata);
+        let append_schema = Arc::new(Schema::new(vec![append_field]));
+        let mut append_builder = BlobArrayBuilder::new(1);
+        append_builder.push_bytes(payload).unwrap();
+        let append_batch = RecordBatch::try_new(
+            append_schema.clone(),
+            vec![Arc::new(append_builder.finish().unwrap()) as ArrayRef],
+        )
+        .unwrap();
+        let append_reader = RecordBatchIterator::new(vec![Ok(append_batch)], append_schema);
+
+        let result = Dataset::write(
+            append_reader,
+            Arc::new(dataset),
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("append with ignored blob threshold metadata should fail");
+        };
+        let message = err.to_string();
+        assert!(message.contains("Cannot append data with blob threshold metadata"));
+        assert!(message.contains(BLOB_INLINE_SIZE_THRESHOLD_META_KEY));
+    }
+
+    #[tokio::test]
     async fn test_blob_v2_append_accepts_explicit_default_inline_threshold() {
         let dataset_dir = TempDir::default();
         let payload = vec![0u8; 2048];

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -7,7 +7,8 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::{Stream, StreamExt, TryStreamExt};
 use lance_arrow::{
-    BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, BLOB_INLINE_SIZE_THRESHOLD_META_KEY, BLOB_META_KEY,
+    ARROW_EXT_NAME_KEY, BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
+    BLOB_INLINE_SIZE_THRESHOLD_META_KEY, BLOB_META_KEY, BLOB_V2_EXT_NAME,
 };
 use lance_core::datatypes::{
     NullabilityComparison, OnMissing, OnTypeMismatch, SchemaCompareOptions,
@@ -37,7 +38,9 @@ use tracing::{info, instrument};
 
 use crate::Dataset;
 use crate::dataset::blob::{
-    BlobPreprocessor, ExternalBaseCandidate, ExternalBaseResolver, preprocess_blob_batches,
+    BlobPreprocessor, ExternalBaseCandidate, ExternalBaseResolver,
+    blob_dedicated_threshold_from_metadata, blob_inline_threshold_from_metadata,
+    preprocess_blob_batches,
 };
 use crate::session::Session;
 
@@ -180,26 +183,58 @@ fn validate_blob_threshold_metadata_for_append(
         let Some(dataset_field) = dataset_schema.field(&input_field.name) else {
             continue;
         };
+        let is_blob_v2_field = input_field
+            .metadata
+            .get(ARROW_EXT_NAME_KEY)
+            .or_else(|| dataset_field.metadata.get(ARROW_EXT_NAME_KEY))
+            .is_some_and(|extension_name| extension_name == BLOB_V2_EXT_NAME);
+        if !is_blob_v2_field {
+            continue;
+        }
 
-        for key in [
-            BLOB_INLINE_SIZE_THRESHOLD_META_KEY,
-            BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
-        ] {
-            let Some(input_value) = input_field.metadata.get(key) else {
-                continue;
-            };
+        let has_inline_threshold = input_field
+            .metadata
+            .contains_key(BLOB_INLINE_SIZE_THRESHOLD_META_KEY);
+        let has_dedicated_threshold = input_field
+            .metadata
+            .contains_key(BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY);
+        if !has_inline_threshold && !has_dedicated_threshold {
+            continue;
+        }
 
-            if dataset_field.metadata.get(key) != Some(input_value) {
-                let dataset_value = dataset_field
-                    .metadata
-                    .get(key)
-                    .map(String::as_str)
-                    .unwrap_or("<unset>");
+        if has_inline_threshold {
+            let input_inline_threshold =
+                blob_inline_threshold_from_metadata(&input_field.metadata, &input_field.name)?;
+            let dataset_inline_threshold =
+                blob_inline_threshold_from_metadata(&dataset_field.metadata, &dataset_field.name)?;
+            if input_inline_threshold != dataset_inline_threshold {
                 return Err(Error::invalid_input(format!(
-                    "Cannot append data with blob threshold metadata {key}={input_value:?} \
-                     for field '{}'; the dataset schema has {key}={dataset_value:?}. \
-                     Blob thresholds for existing columns are stored in the dataset schema.",
-                    input_field.name
+                    "Cannot append data with blob threshold metadata {}={} for field '{}'; \
+                     the dataset schema has effective value {}. Blob thresholds for existing \
+                     columns are stored in the dataset schema.",
+                    BLOB_INLINE_SIZE_THRESHOLD_META_KEY,
+                    input_inline_threshold,
+                    input_field.name,
+                    dataset_inline_threshold,
+                )));
+            }
+        }
+        if has_dedicated_threshold {
+            let input_dedicated_threshold =
+                blob_dedicated_threshold_from_metadata(&input_field.metadata, &input_field.name)?;
+            let dataset_dedicated_threshold = blob_dedicated_threshold_from_metadata(
+                &dataset_field.metadata,
+                &dataset_field.name,
+            )?;
+            if input_dedicated_threshold != dataset_dedicated_threshold {
+                return Err(Error::invalid_input(format!(
+                    "Cannot append data with blob threshold metadata {}={} for field '{}'; \
+                     the dataset schema has effective value {}. Blob thresholds for existing \
+                     columns are stored in the dataset schema.",
+                    BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
+                    input_dedicated_threshold,
+                    input_field.name,
+                    dataset_dedicated_threshold,
                 )));
             }
         }
@@ -1296,7 +1331,7 @@ async fn open_writer_with_options(
                 source_store_registry,
                 source_store_params,
                 blob_pack_file_size_threshold,
-            ))
+            )?)
         } else {
             None
         };

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -183,12 +183,15 @@ fn validate_blob_threshold_metadata_for_append(
         let Some(dataset_field) = dataset_schema.field(&input_field.name) else {
             continue;
         };
-        let is_blob_v2_field = input_field
+        let input_is_blob_v2 = input_field
             .metadata
             .get(ARROW_EXT_NAME_KEY)
-            .or_else(|| dataset_field.metadata.get(ARROW_EXT_NAME_KEY))
             .is_some_and(|extension_name| extension_name == BLOB_V2_EXT_NAME);
-        if !is_blob_v2_field {
+        let dataset_is_blob_v2 = dataset_field
+            .metadata
+            .get(ARROW_EXT_NAME_KEY)
+            .is_some_and(|extension_name| extension_name == BLOB_V2_EXT_NAME);
+        if !input_is_blob_v2 && !dataset_is_blob_v2 {
             continue;
         }
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -6,7 +6,9 @@ use chrono::TimeDelta;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::{Stream, StreamExt, TryStreamExt};
-use lance_arrow::BLOB_META_KEY;
+use lance_arrow::{
+    BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY, BLOB_INLINE_SIZE_THRESHOLD_META_KEY, BLOB_META_KEY,
+};
 use lance_core::datatypes::{
     NullabilityComparison, OnMissing, OnTypeMismatch, SchemaCompareOptions,
 };
@@ -165,6 +167,42 @@ fn validate_external_blob_write_params(params: &WriteParams) -> Result<()> {
         return Err(Error::invalid_input(
             "allow_external_blob_outside_bases only applies when external_blob_mode=\"reference\"",
         ));
+    }
+
+    Ok(())
+}
+
+fn validate_blob_threshold_metadata_for_append(
+    input_schema: &Schema,
+    dataset_schema: &Schema,
+) -> Result<()> {
+    for input_field in &input_schema.fields {
+        let Some(dataset_field) = dataset_schema.field(&input_field.name) else {
+            continue;
+        };
+
+        for key in [
+            BLOB_INLINE_SIZE_THRESHOLD_META_KEY,
+            BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
+        ] {
+            let Some(input_value) = input_field.metadata.get(key) else {
+                continue;
+            };
+
+            if dataset_field.metadata.get(key) != Some(input_value) {
+                let dataset_value = dataset_field
+                    .metadata
+                    .get(key)
+                    .map(String::as_str)
+                    .unwrap_or("<unset>");
+                return Err(Error::invalid_input(format!(
+                    "Cannot append data with blob threshold metadata {key}={input_value:?} \
+                     for field '{}'; the dataset schema has {key}={dataset_value:?}. \
+                     Blob thresholds for existing columns are stored in the dataset schema.",
+                    input_field.name
+                )));
+            }
+        }
     }
 
     Ok(())
@@ -953,6 +991,7 @@ pub async fn write_fragments_internal(
                         ..Default::default()
                     },
                 )?;
+                validate_blob_threshold_metadata_for_append(&converted_schema, dataset.schema())?;
                 let write_schema = dataset.schema().project_by_schema(
                     &converted_schema,
                     OnMissing::Error,

--- a/rust/lance/src/lib.rs
+++ b/rust/lance/src/lib.rs
@@ -90,7 +90,7 @@ pub mod pb {
     include!(concat!(env!("OUT_DIR"), "/lance.pb.rs"));
 }
 
-pub use blob::{BlobArrayBuilder, blob_field};
+pub use blob::{BlobArrayBuilder, BlobFieldOptions, blob_field, blob_field_with_options};
 pub use dataset::Dataset;
 use lance_index::vector::DIST_COL;
 


### PR DESCRIPTION
This adds per-column blob v2 inline threshold metadata so callers can choose when a blob column moves from inline data-file storage to packed sidecar storage, without changing the existing packed sidecar rolling option.

The threshold is stored on the blob field metadata, matching the existing dedicated blob threshold model. Existing blob columns keep their policy in the dataset schema; appends that explicitly provide different threshold metadata are rejected instead of silently ignoring the input schema. The Python and Rust helpers validate threshold values at the API boundary so invalid values do not silently fall back to defaults.

Closes #7268.
