### PR TITLE
perf(index): set ivf_rq target partition size to 4096

### DIFF
--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -312,6 +312,7 @@ impl IndexType {
             Self::IvfFlat => 4096,
             Self::IvfSq => 8192,
             Self::IvfPq => 8192,
+            Self::IvfRq => 4096,
             Self::IvfHnswFlat => 1 << 20,
             Self::IvfHnswSq => 1 << 20,
             Self::IvfHnswPq => 1 << 20,
@@ -380,6 +381,11 @@ mod tests {
     #[test]
     fn test_max_vector_version_tracks_highest_supported() {
         assert_eq!(IndexType::max_vector_version(), IVF_RQ_INDEX_VERSION);
+    }
+
+    #[test]
+    fn test_ivf_rq_target_partition_size() {
+        assert_eq!(IndexType::IvfRq.target_partition_size(), 4096);
     }
 
     #[test]


### PR DESCRIPTION
## Performance Improvement

### What is the performance issue or bottleneck?

IVF_RQ currently falls through to the generic vector index target partition size of 8192. Recent IVF_RQ tuning indicates a smaller default partition target is preferred for this index type.

### How does this PR improve performance?

This PR gives `IndexType::IvfRq` an explicit `target_partition_size()` default of 4096. IVF_RQ index creation paths that do not set `target_partition_size` will now derive the number of IVF partitions from 4096 instead of the generic fallback.

It also adds a focused unit test so the IVF_RQ default cannot silently fall back to 8192 again.

### Benchmark or measurement results

No new benchmark run in this PR. This only changes the configured default and protects it with a unit test.

## Verification

- `cargo fmt --all`
- `cargo test -p lance-index test_ivf_rq_target_partition_size`
- `cargo clippy --all --tests --benches -- -D warnings`