### PR TITLE
fix(index): share FTS position stream offsets

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -2947,10 +2947,9 @@ impl DeepSizeOf for CompressedPositionStorage {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct SharedPositionStream {
     codec: PositionStreamCodec,
-    block_offsets: Vec<u32>,
-    // Stored as `Bytes` so that the cache deserialization path can hand
-    // ownership of an IPC-decoded slice in without copying. Cloning the
-    // stream is then an `Arc` bump rather than an O(N) buffer copy.
+    block_offsets: Arc<[u32]>,
+    // Stored with shared ownership so cache hits can clone position streams
+    // without copying either offsets or bytes.
     bytes: bytes::Bytes,
 }
 
@@ -2958,7 +2957,7 @@ impl SharedPositionStream {
     pub fn new(codec: PositionStreamCodec, block_offsets: Vec<u32>, bytes: bytes::Bytes) -> Self {
         Self {
             codec,
-            block_offsets,
+            block_offsets: Arc::from(block_offsets.into_boxed_slice()),
             bytes,
         }
     }
@@ -2991,11 +2990,11 @@ impl SharedPositionStream {
     }
 
     pub fn block_offsets(&self) -> &[u32] {
-        &self.block_offsets
+        self.block_offsets.as_ref()
     }
 
     pub fn size(&self) -> usize {
-        self.block_offsets.capacity() * std::mem::size_of::<u32>() + self.bytes.len()
+        self.block_offsets.len() * std::mem::size_of::<u32>() + self.bytes.len()
     }
 }
 
@@ -5473,6 +5472,21 @@ mod tests {
                 (2_u32, 1_u32, Some(vec![3_u32])),
             ]
         );
+    }
+
+    #[test]
+    fn test_shared_position_stream_clone_shares_block_offsets() {
+        let stream = SharedPositionStream::new(
+            PositionStreamCodec::PackedDelta,
+            vec![0_u32, 4, 11],
+            bytes::Bytes::from_static(b"shared position bytes"),
+        );
+        let original_offsets = stream.block_offsets().as_ptr();
+
+        let cloned = stream.clone();
+
+        assert_eq!(cloned.block_offsets(), stream.block_offsets());
+        assert_eq!(cloned.block_offsets().as_ptr(), original_offsets);
     }
 
     #[test]


### PR DESCRIPTION
## Bug Fix

### What is the bug?
FTS phrase-query position cache hits clone `SharedPositionStream`. The stream already used shared `Bytes` for the compressed position payload, but `block_offsets` was stored as `Vec<u32>`, so each clone copied one offset per compressed position block.

### What issues or incorrect behavior does the bug cause?
For large shared-position streams, repeated cache-hit clones can add avoidable O(N) CPU and memory traffic even when the position data itself is cached.

### How does this PR fix the problem?
`SharedPositionStream` now stores `block_offsets` as `Arc<[u32]>`, keeping the existing `block_offsets() -> &[u32]` API while making clones share the offset allocation. A regression test verifies that cloned streams point at the same offsets allocation.

## Validation

- `cargo test -p lance-index scalar::inverted::index::tests::test_shared_position_stream_clone_shares_block_offsets`
- `cargo test -p lance-index shared_position`
- `cargo test -p lance-index shared_stream`
- `cargo test -p lance-index scalar::inverted::cache_codec::tests`
- `cargo test -p lance-index`
- `cargo fmt --all`
- `cargo clippy --all --tests --benches -- -D warnings`
- `git diff --check`