### PR TITLE
fix: reject nested legacy blobs in v2.2

### DIFF
--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -992,13 +992,10 @@ pub async fn write_fragments_internal(
     }
 
     if storage_version >= LanceFileVersion::V2_2
-        && schema
-            .fields
-            .iter()
-            .any(|f| f.metadata.contains_key(BLOB_META_KEY))
+        && let Some(blob_field_path) = legacy_blob_field_path(&schema)
     {
         return Err(Error::invalid_input(format!(
-            "Legacy blob columns (field metadata key {BLOB_META_KEY:?}) are not supported for file version >= 2.2. Use the blob v2 extension type (ARROW:extension:name = \"lance.blob.v2\") and the new blob APIs (e.g. lance::blob::blob_field / lance::blob::BlobArrayBuilder)."
+            "Legacy blob columns (field metadata key {BLOB_META_KEY:?}) are not supported for file version >= 2.2. Found legacy blob field: {blob_field_path}. Use the blob v2 extension type (ARROW:extension:name = \"lance.blob.v2\") and the new blob APIs (e.g. lance::blob::blob_field / lance::blob::BlobArrayBuilder)."
         )));
     }
 
@@ -1015,6 +1012,17 @@ pub async fn write_fragments_internal(
     .await?;
 
     Ok((fragments, schema))
+}
+
+fn legacy_blob_field_path(schema: &Schema) -> Option<String> {
+    schema
+        .fields_pre_order()
+        .find(|field| field.metadata.contains_key(BLOB_META_KEY))
+        .map(|field| {
+            schema
+                .field_path(field.id)
+                .unwrap_or_else(|_| field.name.clone())
+        })
 }
 
 #[async_trait::async_trait]

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -442,7 +442,7 @@ struct WriteContext<'a> {
 mod test {
     use std::collections::HashMap;
 
-    use arrow_array::{BinaryArray, Int32Array, RecordBatchReader, StructArray};
+    use arrow_array::{ArrayRef, BinaryArray, Int32Array, RecordBatchReader, StructArray};
     use arrow_schema::{ArrowError, DataType, Field, Schema};
     use lance_arrow::BLOB_META_KEY;
 
@@ -553,6 +553,41 @@ mod test {
             Error::InvalidInput { source, .. } => {
                 let message = source.to_string();
                 assert!(message.contains("Legacy blob columns"));
+                assert!(message.contains("lance.blob.v2"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_v2_2_dataset_rejects_nested_legacy_blob_schema() {
+        let image_field = Field::new("image_bytes", DataType::Binary, true).with_metadata(
+            HashMap::from([(BLOB_META_KEY.to_string(), "true".to_string())]),
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "summary_image_nested",
+            DataType::Struct(vec![image_field.clone()].into()),
+            true,
+        )]));
+        let image_values: ArrayRef = Arc::new(BinaryArray::from(vec![Some(b"abc".as_slice())]));
+        let nested_values = StructArray::from(vec![(Arc::new(image_field), image_values)]);
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(nested_values)]).unwrap();
+
+        let dataset = InsertBuilder::new("memory://forced-nested-blob-v2")
+            .with_params(&WriteParams {
+                mode: WriteMode::Create,
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                ..Default::default()
+            })
+            .execute_stream(RecordBatchIterator::new(vec![Ok(batch)], schema.clone()))
+            .await;
+
+        let err = dataset.unwrap_err();
+        match err {
+            Error::InvalidInput { source, .. } => {
+                let message = source.to_string();
+                assert!(message.contains("Legacy blob columns"));
+                assert!(message.contains("summary_image_nested.image_bytes"));
                 assert!(message.contains("lance.blob.v2"));
             }
             other => panic!("unexpected error: {other:?}"),


### PR DESCRIPTION
This closes a v2.2 write-path hole where legacy blob metadata was rejected only on top-level fields. A nested field such as `summary_image_nested.image_bytes` could still carry `lance-encoding:blob` into a v2.2 dataset manifest.

The write guard now scans the full Lance schema preorder and reports the offending field path. This keeps v2.2 dataset creation from silently preserving BlobV1 columns while leaving valid `lance.blob.v2` inputs untouched.
