### PR TITLE
test(python): use non-deprecated params in search benchmark fixtures

### DIFF
--- a/python/python/benchmarks/test_search.py
+++ b/python/python/benchmarks/test_search.py
@@ -78,10 +78,12 @@ def create_base_dataset(data_dir: Path) -> lance.LanceDataset:
         rows_remaining -= next_batch_length
         table = create_table(next_batch_length, offset)
         if offset == 0:
-            dataset = lance.write_dataset(table, tmp_path, use_legacy_format=False)
+            dataset = lance.write_dataset(
+                table, tmp_path, data_storage_version="stable"
+            )
         else:
             dataset = lance.write_dataset(
-                table, tmp_path, mode="append", use_legacy_format=False
+                table, tmp_path, mode="append", data_storage_version="stable"
             )
         offset += next_batch_length
 
@@ -98,7 +100,7 @@ def create_base_dataset(data_dir: Path) -> lance.LanceDataset:
     dataset.create_scalar_index("category", "BITMAP")
     dataset.create_scalar_index("genres", "LABEL_LIST")
 
-    return lance.dataset(tmp_path, index_cache_size=64 * 1024)
+    return lance.dataset(tmp_path, index_cache_size_bytes=512 * 1024 * 1024)
 
 
 def create_delete_dataset(data_dir):
@@ -113,7 +115,7 @@ def create_delete_dataset(data_dir):
     dataset = lance.dataset(tmp_path)
     dataset.delete("filterable % 2 != 0")
 
-    return lance.dataset(tmp_path, index_cache_size=64 * 1024)
+    return lance.dataset(tmp_path, index_cache_size_bytes=512 * 1024 * 1024)
 
 
 def create_new_rows_dataset(data_dir):
@@ -129,7 +131,7 @@ def create_new_rows_dataset(data_dir):
     table = create_table(NEW_ROWS, offset=NUM_ROWS)
     dataset = lance.write_dataset(table, tmp_path, mode="append")
 
-    return lance.dataset(tmp_path, index_cache_size=64 * 1024)
+    return lance.dataset(tmp_path, index_cache_size_bytes=512 * 1024 * 1024)
 
 
 class Datasets(NamedTuple):


### PR DESCRIPTION
## Problem

The dataset fixtures in `python/benchmarks/test_search.py` pass deprecated parameters to the dataset APIs:

- `lance.write_dataset(..., use_legacy_format=False)`
- `lance.dataset(..., index_cache_size=64 * 1024)`

The test config sets `filterwarnings = ['error::DeprecationWarning', ...]`, so these emit `DeprecationWarning` **as errors during fixture setup**. As a result every benchmark in `test_search.py` errors out before running:

```
DeprecationWarning: use_legacy_format is deprecated, use data_storage_version instead
DeprecationWarning: The 'index_cache_size' parameter is deprecated. Use 'index_cache_size_bytes' instead.
```

## Fix

Switch to the current parameters:

- `use_legacy_format=False` → `data_storage_version="stable"` (the exact mapping the deprecation shim applies).
- `index_cache_size=64 * 1024` → `index_cache_size_bytes=512 * 1024 * 1024` (512 MiB comfortably caches these 100k-row IVF_PQ indices).

## Verification

```
$ uv run --group benchmarks pytest python/benchmarks/test_search.py::test_ann_no_refine --benchmark-only
test_ann_no_refine[clean]               541.48 us   1813 ops
test_ann_no_refine[with_delete_files]   770.46 us   1285 ops
test_ann_no_refine[with_new_rows]      2843.17 us    349 ops
3 passed
```

`ruff check` / `ruff format --check` clean.