### PR TITLE
fix: remap index data when its fragment bitmap was already coverage-remapped

### DIFF
--- a/rust/lance/src/dataset/index/frag_reuse.rs
+++ b/rust/lance/src/dataset/index/frag_reuse.rs
@@ -243,4 +243,91 @@ mod tests {
             Err(Error::RetryableCommitConflict { .. })
         ));
     }
+
+    /// With more than one index on the table, remapping every index must catch
+    /// all of them up so the reuse index can be trimmed.
+    ///
+    /// Regression: `remap_column_index` used to decide whether to remap an
+    /// index's data from the presence of the old fragments in its fragment
+    /// bitmap. But `load_indices` coverage-remaps the bitmap onto the new
+    /// fragments in memory, and remapping the *first* index commits a manifest
+    /// that persists that cleaned bitmap for the others — so remapping the
+    /// remaining indexes became a silent no-op (their data was never remapped
+    /// and their `dataset_version` never advanced), and the reuse index could
+    /// never be trimmed.
+    #[tokio::test]
+    async fn test_cleanup_frag_reuse_index_multiple_indices() {
+        let mut dataset = lance_datagen::gen_batch()
+            .col("i", lance_datagen::array::step::<Int32Type>())
+            .col("j", lance_datagen::array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(6), FragmentRowCount::from(1000))
+            .await
+            .unwrap();
+
+        for col in ["i", "j"] {
+            dataset
+                .create_index(
+                    &[col],
+                    IndexType::Scalar,
+                    Some(format!("{col}_idx")),
+                    &ScalarIndexParams::default(),
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        compact_files(
+            &mut dataset,
+            CompactionOptions {
+                target_rows_per_fragment: 2_000,
+                defer_index_remap: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        let frag_reuse_index_meta = dataset
+            .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+            .await
+            .unwrap()
+            .expect("Fragment reuse index must be available");
+        let frag_reuse_details = load_frag_reuse_index_details(&dataset, &frag_reuse_index_meta)
+            .await
+            .unwrap();
+        assert_eq!(frag_reuse_details.versions.len(), 1);
+
+        for col in ["i", "j"] {
+            remapping::remap_column_index(&mut dataset, &[col], Some(format!("{col}_idx")))
+                .await
+                .unwrap();
+        }
+
+        // Every index must now be caught up (data remapped, version advanced).
+        let indices = dataset.load_indices().await.unwrap();
+        for col in ["i", "j"] {
+            let index = indices
+                .iter()
+                .find(|idx| idx.name == format!("{col}_idx"))
+                .unwrap();
+            assert!(
+                is_index_remap_caught_up(&frag_reuse_details.versions[0], index).unwrap(),
+                "index {col}_idx was not caught up after remap"
+            );
+        }
+
+        // ... so the reuse index trims down to zero versions.
+        cleanup_frag_reuse_index(&mut dataset).await.unwrap();
+        let frag_reuse_index_meta = dataset
+            .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+            .await
+            .unwrap()
+            .expect("Fragment reuse index must be available");
+        let frag_reuse_details = load_frag_reuse_index_details(&dataset, &frag_reuse_index_meta)
+            .await
+            .unwrap();
+        assert_eq!(frag_reuse_details.versions.len(), 0);
+    }
 }

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -235,6 +235,13 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
         .find(|idx| idx.uuid == curr_index_id)
         .unwrap();
 
+        // Whether the index data predates this reuse version, i.e. its stored
+        // row addresses still point at the compacted-away fragments. The
+        // fragment bitmap alone cannot tell us this: `load_indices`
+        // coverage-remaps the bitmap onto the new fragments in memory, and a
+        // later commit can persist that cleaned bitmap to disk without the index
+        // data ever being remapped (e.g. while remapping a *sibling* index).
+        let data_predates_version = curr_index_meta.dataset_version < version.dataset_version;
         let maybe_index_bitmap = curr_index_meta.fragment_bitmap.clone();
         let (should_remap, bitmap_after_remap) = match maybe_index_bitmap {
             Some(mut index_frag_bitmap) => {
@@ -260,6 +267,19 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                         }
                         index_frag_bitmap
                             .extend(group.new_frags.clone().into_iter().map(|f| f.id as u32));
+                        should_remap = true;
+                    } else if data_predates_version
+                        && group
+                            .new_frags
+                            .iter()
+                            .any(|new_frag| index_frag_bitmap.contains(new_frag.id as u32))
+                    {
+                        // The bitmap was already coverage-remapped onto this
+                        // group's new fragments and persisted before the data was
+                        // remapped, so the old fragments are gone from the bitmap
+                        // but the index data still needs remapping. Without this
+                        // the data remap is silently skipped and the reuse index
+                        // can never be trimmed.
                         should_remap = true;
                     }
                 }


### PR DESCRIPTION
## Summary

`remap_column_index` can silently skip remapping an index's data after a deferred compaction, which leaves the index permanently dependent on the fragment-reuse index and prevents that reuse index from ever being trimmed (it grows without bound). This happens whenever the index's `fragment_bitmap` has already been coverage-remapped onto the new fragments before the data remap runs — most reliably when a table carries **more than one index**.

The fix makes `remap_index` decide whether to remap an index's *data* from whether that data predates the reuse version, instead of inferring it from the current state of the fragment bitmap (which can be cleaned independently of the data).

## Background

With `defer_index_remap: true`, compaction rewrites fragments but does **not** rewrite index data inline. Instead it records a fragment-reuse index (FRI) holding, per compaction, the old→new row-address map. Two remaps then happen at different times:

- **Coverage remap** — `load_indices` (`rust/lance/src/index.rs`) applies `FragReuseIndex::remap_fragment_bitmap` to every index's `fragment_bitmap` in memory, swapping the compacted-away fragment ids for the new ones, so queries route correctly.
- **Data remap** — `remap_column_index` / `remap_index` (`rust/lance/src/dataset/optimize/remapping.rs`) actually rewrites the row addresses stored *inside* the index, and advances the index's `dataset_version`. Until this runs, the index data still holds the old addresses and relies on FRI auto-remap-at-load for correctness.

`cleanup_frag_reuse_index` can only trim a reuse version once **every** index is "caught up" with it (`is_index_remap_caught_up`), which requires both that the index no longer references the version's old fragments **and** that `index.dataset_version >= reuse_version.dataset_version`.

## The bug

After a deferred compaction, remapping the indexes one by one leaves some of them un-remapped, and the reuse index never trims.

Reproduced deterministically with two scalar indexes on one table (see the added test). Observed state after compaction + remapping both indexes:

| index | `dataset_version` | `fragment_bitmap` |
|---|---|---|
| FRI version | 4 | — |
| first index remapped | 6 (advanced ✓) | `[10]` |
| second index | 2 (**stale**) | `[10]` |
| third index | 3 (**stale**) | `[10]` |

The second/third indexes' bitmaps are already clean (`[10]`, no old fragments), but their data was never remapped and their `dataset_version` never advanced — so `is_index_remap_caught_up` returns false on the `dataset_version < reuse_version.dataset_version` check, and the reuse version is retained forever.

## Root cause

The deferred-compaction commit itself does **not** coverage-remap the on-disk bitmaps (with stable row ids disabled, `Operation::Rewrite` takes the `handle_rewrite_indices` path with an empty `rewritten_indices`, leaving bitmaps untouched). The cleaned bitmap is introduced later, by the **remap path itself**:

1. `remap_index` begins with `dataset.load_indices()`, which returns every index's bitmap **coverage-remapped in memory** onto the new fragments.
2. When it commits the **first** index's remap, the new manifest is built from that coverage-remapped in-memory index list — so the cleaned bitmap is **persisted to disk for the other, not-yet-remapped indexes**, without their data being remapped or their `dataset_version` being advanced.
3. `remap_index` for those remaining indexes computes `should_remap` from `old_frag_in_index > 0`. The old fragments are already gone from the persisted bitmap, so `should_remap` is `false` → the data remap is skipped → the index keeps its stale addresses and stale `dataset_version` → the reuse index can never be trimmed.

In short: the fragment bitmap is an unreliable signal for "has this index's data been remapped?", because coverage remap and data remap are decoupled and the cleaned bitmap can be persisted before the data remap happens.

### Why not "fix" the trim check instead?

The `dataset_version` guard in `is_index_remap_caught_up` is correct and protective: an index whose bitmap is coverage-remapped but whose **data** still holds old addresses genuinely still needs the reuse index for auto-remap-at-load. Advancing `dataset_version` (or trimming) on the strength of a coverage remap alone would discard the reuse index while the data is still stale → **incorrect query results**. So the data remap must actually run; the fix belongs in `remap_index`.

## The fix

`rust/lance/src/dataset/optimize/remapping.rs`, in `remap_index`: when a rewrite group's **old** fragments are already gone from the bitmap but its **new** fragments are present, and the index data still predates the reuse version (`index.dataset_version < version.dataset_version`), set `should_remap = true` anyway. The bitmap is already correct in that case, so only the data is remapped; `dataset_version` then advances and the reuse index can trim.

The existing "old fragments present" path is left byte-for-byte unchanged, so the normal (non-pre-cleaned) case — including chained single-index bitmap remapping — behaves exactly as before.

```rust
let data_predates_version = curr_index_meta.dataset_version < version.dataset_version;
// ... existing per-group loop ...
if old_frag_in_index > 0 {
    // unchanged: rewrite the bitmap and remap the data
} else if data_predates_version
    && group.new_frags.iter().any(|f| index_frag_bitmap.contains(f.id as u32))
{
    // bitmap already coverage-remapped + persisted before the data remap:
    // remap the data anyway (bitmap is already correct)
    should_remap = true;
}
```

## Testing

- **New regression test** `test_cleanup_frag_reuse_index_multiple_indices` (`rust/lance/src/dataset/index/frag_reuse.rs`): two scalar indexes on one table, deferred compaction, remap both, then assert each index is caught up and the reuse index trims to zero versions. **Fails on `main`** (`index j_idx was not caught up after remap`), passes with this change.
- Existing suites green with the fix: `frag_reuse` (incl. the single-index `test_cleanup_frag_reuse_index`), `remap` (incl. `test_remap_index_after_compaction`, which exercises chained single-index bitmap remapping), and `compaction`.
- `cargo fmt` + `cargo clippy` clean.

## Scope / risk

- ~20 lines, one new `else if` branch; no public API change.
- The change only ever *enables* a data remap that should have happened; it cannot skip one the old code performed (the new branch is additive to the existing `should_remap` conditions).
