### PR TITLE
feat: expose session cache key inventory

### DIFF
--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -22,6 +22,9 @@ use super::CacheCodec;
 /// A type-erased cache entry.
 pub type CacheEntry = Arc<dyn Any + Send + Sync>;
 
+/// Iterator over cache keys currently known to a backend.
+pub type CacheKeyIterator<'a> = Box<dyn Iterator<Item = InternalCacheKey> + Send + 'a>;
+
 /// Structured cache key passed to [`CacheBackend`] methods.
 ///
 /// CacheBackend impls receive these ready-made from [`LanceCache`](super::LanceCache)
@@ -115,6 +118,15 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
 
     /// Remove all entries.
     async fn clear(&self);
+
+    /// Return an iterator over cache keys currently known to this backend.
+    ///
+    /// Backends that cannot enumerate keys cheaply or accurately should return
+    /// `None`. An empty iterator means key inventory is supported and the
+    /// cache currently has no entries.
+    async fn keys(&self) -> Option<CacheKeyIterator<'_>> {
+        None
+    }
 
     /// Number of entries currently stored (may flush pending operations).
     async fn num_entries(&self) -> usize;

--- a/rust/lance-core/src/cache/mod.rs
+++ b/rust/lance-core/src/cache/mod.rs
@@ -49,7 +49,7 @@ pub mod backend;
 pub mod codec;
 mod moka;
 
-pub use backend::{CacheBackend, CacheEntry, InternalCacheKey};
+pub use backend::{CacheBackend, CacheEntry, CacheKeyIterator, InternalCacheKey};
 pub use codec::{CacheCodec, CacheCodecImpl};
 pub use moka::MokaCacheBackend;
 
@@ -243,6 +243,40 @@ impl LanceCache {
 
     pub async fn size_bytes(&self) -> usize {
         self.cache.size_bytes().await
+    }
+
+    /// Return an iterator over keys currently stored under this cache's prefix.
+    ///
+    /// Returns `None` when the backend does not support key inventory. The
+    /// iterator is intended for diagnostics and may be weakly consistent with
+    /// concurrent cache mutations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::{borrow::Cow, sync::Arc};
+    /// # use lance_core::cache::{CacheKey, LanceCache};
+    /// # struct MyKey;
+    /// # impl CacheKey for MyKey {
+    /// #     type ValueType = Vec<i32>;
+    /// #     fn key(&self) -> Cow<'_, str> { Cow::Borrowed("my-key") }
+    /// #     fn type_name() -> &'static str { "VecI32" }
+    /// # }
+    /// # async fn example() {
+    /// let cache = LanceCache::with_capacity(1024);
+    /// cache.insert_with_key(&MyKey, Arc::new(vec![1, 2, 3])).await;
+    ///
+    /// let mut keys = cache.keys().await.expect("Moka supports key inventory");
+    /// assert_eq!(keys.next().unwrap().key(), "my-key");
+    /// # }
+    /// ```
+    pub async fn keys(&self) -> Option<CacheKeyIterator<'_>> {
+        Some(Box::new(
+            self.cache
+                .keys()
+                .await?
+                .filter(|key| key.starts_with(&self.prefix)),
+        ))
     }
 
     // -- Sized insert/get (internal, shared by sized and unsized paths) --------
@@ -557,7 +591,7 @@ impl CacheStats {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{BTreeSet, HashMap};
     use std::marker::PhantomData;
 
     struct TestKey<T: 'static> {
@@ -607,6 +641,18 @@ mod tests {
         fn type_name() -> &'static str {
             std::any::type_name::<T>()
         }
+    }
+
+    fn key_fields(keys: &[InternalCacheKey]) -> BTreeSet<(String, String, &'static str)> {
+        keys.iter()
+            .map(|key| {
+                (
+                    key.prefix().to_string(),
+                    key.key().to_string(),
+                    key.type_name(),
+                )
+            })
+            .collect()
     }
 
     #[tokio::test]
@@ -716,6 +762,99 @@ mod tests {
                 .is_some()
         );
         assert_eq!(base.stats().await.hits, 1);
+    }
+
+    #[tokio::test]
+    async fn test_cache_keys_with_prefixes() {
+        let base = LanceCache::with_capacity(1000);
+        let prefixed = base.with_key_prefix("ns");
+        let nested = prefixed.with_key_prefix("index");
+        let other = base.with_key_prefix("ns-other");
+
+        base.insert_with_key(&TestKey::new("root"), Arc::new(vec![0]))
+            .await;
+        prefixed
+            .insert_with_key(&TestKey::new("child"), Arc::new(vec![1]))
+            .await;
+        nested
+            .insert_with_key(&TestKey::new("nested"), Arc::new(vec![2]))
+            .await;
+        other
+            .insert_with_key(&TestKey::new("other"), Arc::new(vec![3]))
+            .await;
+
+        let base_keys = base.keys().await.unwrap().collect::<Vec<_>>();
+        assert_eq!(
+            key_fields(&base_keys),
+            BTreeSet::from([
+                (
+                    "".to_string(),
+                    "root".to_string(),
+                    TestKey::<Vec<i32>>::type_name()
+                ),
+                (
+                    "ns/".to_string(),
+                    "child".to_string(),
+                    TestKey::<Vec<i32>>::type_name()
+                ),
+                (
+                    "ns/index/".to_string(),
+                    "nested".to_string(),
+                    TestKey::<Vec<i32>>::type_name()
+                ),
+                (
+                    "ns-other/".to_string(),
+                    "other".to_string(),
+                    TestKey::<Vec<i32>>::type_name()
+                ),
+            ])
+        );
+
+        let prefixed_keys = prefixed.keys().await.unwrap().collect::<Vec<_>>();
+        assert_eq!(
+            key_fields(&prefixed_keys),
+            BTreeSet::from([
+                (
+                    "ns/".to_string(),
+                    "child".to_string(),
+                    TestKey::<Vec<i32>>::type_name()
+                ),
+                (
+                    "ns/index/".to_string(),
+                    "nested".to_string(),
+                    TestKey::<Vec<i32>>::type_name()
+                ),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_keys_reflect_invalidation_and_clear() {
+        let base = LanceCache::with_capacity(1000);
+        let prefixed = base.with_key_prefix("ns");
+        let other = base.with_key_prefix("other");
+
+        prefixed
+            .insert_with_key(&TestKey::new("child"), Arc::new(vec![1]))
+            .await;
+        other
+            .insert_with_key(&TestKey::new("other"), Arc::new(vec![2]))
+            .await;
+        assert_eq!(base.keys().await.unwrap().count(), 2);
+
+        prefixed.invalidate_prefix("").await;
+        let keys = base.keys().await.unwrap().collect::<Vec<_>>();
+        assert_eq!(
+            key_fields(&keys),
+            BTreeSet::from([(
+                "other/".to_string(),
+                "other".to_string(),
+                TestKey::<Vec<i32>>::type_name()
+            )])
+        );
+
+        base.clear().await;
+        assert_eq!(base.keys().await.unwrap().count(), 0);
     }
 
     #[tokio::test]
@@ -833,6 +972,7 @@ mod tests {
                 .await
                 .is_none()
         );
+        assert!(cache.keys().await.is_none());
     }
 
     #[tokio::test]

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -11,7 +11,7 @@ use futures::Future;
 use crate::Result;
 
 use super::CacheCodec;
-use super::backend::{CacheBackend, CacheEntry, InternalCacheKey};
+use super::backend::{CacheBackend, CacheEntry, CacheKeyIterator, InternalCacheKey};
 
 /// Internal record stored in the moka cache.
 #[derive(Clone, Debug)]
@@ -121,6 +121,13 @@ impl CacheBackend for MokaCacheBackend {
     async fn clear(&self) {
         self.cache.invalidate_all();
         self.cache.run_pending_tasks().await;
+    }
+
+    async fn keys(&self) -> Option<CacheKeyIterator<'_>> {
+        self.cache.run_pending_tasks().await;
+        Some(Box::new(
+            self.cache.iter().map(|(key, _)| key.as_ref().clone()),
+        ))
     }
 
     async fn num_entries(&self) -> usize {

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use lance_core::cache::{CacheBackend, LanceCache};
+use lance_core::cache::{CacheBackend, CacheKeyIterator, LanceCache};
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::{Error, Result};
 use lance_index::IndexType;
@@ -209,6 +209,44 @@ impl Session {
     pub async fn index_cache_stats(&self) -> lance_core::cache::CacheStats {
         self.index_cache.0.stats().await
     }
+
+    /// Return an iterator over keys currently held by the index cache.
+    ///
+    /// Returns `None` when the index cache backend does not support key
+    /// inventory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lance::session::Session;
+    /// # async fn example() {
+    /// let session = Session::default();
+    /// let keys = session.index_cache_keys().await;
+    /// assert!(keys.is_some());
+    /// # }
+    /// ```
+    pub async fn index_cache_keys(&self) -> Option<CacheKeyIterator<'_>> {
+        self.index_cache.0.keys().await
+    }
+
+    /// Return an iterator over keys currently held by the metadata cache.
+    ///
+    /// Returns `None` when the metadata cache backend does not support key
+    /// inventory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use lance::session::Session;
+    /// # async fn example() {
+    /// let session = Session::default();
+    /// let keys = session.metadata_cache_keys().await;
+    /// assert!(keys.is_some());
+    /// # }
+    /// ```
+    pub async fn metadata_cache_keys(&self) -> Option<CacheKeyIterator<'_>> {
+        self.metadata_cache.0.keys().await
+    }
 }
 
 impl Default for Session {
@@ -224,9 +262,22 @@ impl Default for Session {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lance_core::cache::UnsizedCacheKey;
+    use lance_core::cache::{CacheKey, UnsizedCacheKey};
     use lance_index::vector::VectorIndex;
     use std::borrow::Cow;
+
+    struct TestKey(&'static str);
+    impl CacheKey for TestKey {
+        type ValueType = Vec<i32>;
+
+        fn key(&self) -> Cow<'_, str> {
+            Cow::Borrowed(self.0)
+        }
+
+        fn type_name() -> &'static str {
+            "TestVec"
+        }
+    }
 
     struct TestUnsizedKey(&'static str);
     impl UnsizedCacheKey for TestUnsizedKey {
@@ -250,5 +301,42 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn test_session_cache_keys() {
+        let session = Session::new(10_000, 10_000, Default::default());
+
+        session
+            .index_cache
+            .insert_with_key(&TestKey("index-key"), Arc::new(vec![1]))
+            .await;
+        session
+            .metadata_cache
+            .0
+            .insert_with_key(&TestKey("metadata-key"), Arc::new(vec![2]))
+            .await;
+
+        let index_keys = session
+            .index_cache_keys()
+            .await
+            .unwrap()
+            .collect::<Vec<_>>();
+        assert_eq!(index_keys.len(), 1);
+        assert_eq!(index_keys[0].prefix(), "");
+        assert_eq!(index_keys[0].key(), "index-key");
+        assert_eq!(index_keys[0].type_name(), "TestVec");
+
+        let metadata_keys = session
+            .metadata_cache_keys()
+            .await
+            .unwrap()
+            .collect::<Vec<_>>();
+        assert_eq!(metadata_keys.len(), 1);
+        assert_eq!(metadata_keys[0].prefix(), "");
+        assert_eq!(metadata_keys[0].key(), "metadata-key");
+        assert_eq!(metadata_keys[0].type_name(), "TestVec");
+
+        assert_ne!(index_keys, metadata_keys);
     }
 }


### PR DESCRIPTION
## Summary

- expose optional cache key inventory on cache backends and LanceCache
- implement Moka key snapshot support
- add Session helpers for index and metadata cache keys