### PR TITLE
perf: batch fragment-reuse index remap into a single rebuild + commit

### DIFF
--- a/rust/lance/src/dataset/index/frag_reuse.rs
+++ b/rust/lance/src/dataset/index/frag_reuse.rs
@@ -243,4 +243,91 @@ mod tests {
             Err(Error::RetryableCommitConflict { .. })
         ));
     }
+
+    /// With more than one index on the table, remapping every index must catch
+    /// all of them up so the reuse index can be trimmed.
+    ///
+    /// Regression: `remap_column_index` used to decide whether to remap an
+    /// index's data from the presence of the old fragments in its fragment
+    /// bitmap. But `load_indices` coverage-remaps the bitmap onto the new
+    /// fragments in memory, and remapping the *first* index commits a manifest
+    /// that persists that cleaned bitmap for the others — so remapping the
+    /// remaining indexes became a silent no-op (their data was never remapped
+    /// and their `dataset_version` never advanced), and the reuse index could
+    /// never be trimmed.
+    #[tokio::test]
+    async fn test_cleanup_frag_reuse_index_multiple_indices() {
+        let mut dataset = lance_datagen::gen_batch()
+            .col("i", lance_datagen::array::step::<Int32Type>())
+            .col("j", lance_datagen::array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(6), FragmentRowCount::from(1000))
+            .await
+            .unwrap();
+
+        for col in ["i", "j"] {
+            dataset
+                .create_index(
+                    &[col],
+                    IndexType::Scalar,
+                    Some(format!("{col}_idx")),
+                    &ScalarIndexParams::default(),
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        compact_files(
+            &mut dataset,
+            CompactionOptions {
+                target_rows_per_fragment: 2_000,
+                defer_index_remap: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        let frag_reuse_index_meta = dataset
+            .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+            .await
+            .unwrap()
+            .expect("Fragment reuse index must be available");
+        let frag_reuse_details = load_frag_reuse_index_details(&dataset, &frag_reuse_index_meta)
+            .await
+            .unwrap();
+        assert_eq!(frag_reuse_details.versions.len(), 1);
+
+        for col in ["i", "j"] {
+            remapping::remap_column_index(&mut dataset, &[col], Some(format!("{col}_idx")))
+                .await
+                .unwrap();
+        }
+
+        // Every index must now be caught up (data remapped, version advanced).
+        let indices = dataset.load_indices().await.unwrap();
+        for col in ["i", "j"] {
+            let index = indices
+                .iter()
+                .find(|idx| idx.name == format!("{col}_idx"))
+                .unwrap();
+            assert!(
+                is_index_remap_caught_up(&frag_reuse_details.versions[0], index).unwrap(),
+                "index {col}_idx was not caught up after remap"
+            );
+        }
+
+        // ... so the reuse index trims down to zero versions.
+        cleanup_frag_reuse_index(&mut dataset).await.unwrap();
+        let frag_reuse_index_meta = dataset
+            .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+            .await
+            .unwrap()
+            .expect("Fragment reuse index must be available");
+        let frag_reuse_details = load_frag_reuse_index_details(&dataset, &frag_reuse_index_meta)
+            .await
+            .unwrap();
+        assert_eq!(frag_reuse_details.versions.len(), 0);
+    }
 }

--- a/rust/lance/src/dataset/index/frag_reuse.rs
+++ b/rust/lance/src/dataset/index/frag_reuse.rs
@@ -330,4 +330,85 @@ mod tests {
             .unwrap();
         assert_eq!(frag_reuse_details.versions.len(), 0);
     }
+
+    /// When the reuse index has accumulated several versions, a single remap
+    /// must compose them and rebuild + commit the index exactly ONCE, not once
+    /// per version.
+    #[tokio::test]
+    async fn test_remap_index_batches_multiple_reuse_versions() {
+        let mut dataset = lance_datagen::gen_batch()
+            .col("i", lance_datagen::array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(8), FragmentRowCount::from(1000))
+            .await
+            .unwrap();
+        dataset
+            .create_index(
+                &["i"],
+                IndexType::Scalar,
+                Some("i_idx".into()),
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+
+        // Accumulate multiple reuse versions: each round deletes a prefix, which
+        // shrinks fragments below target and forces another deferred compaction.
+        let options = CompactionOptions {
+            target_rows_per_fragment: 4_000,
+            defer_index_remap: true,
+            ..Default::default()
+        };
+        for round in 0..4 {
+            dataset
+                .delete(&format!("i < {}", 1_000 * (round + 1)))
+                .await
+                .unwrap();
+            compact_files(&mut dataset, options.clone(), None)
+                .await
+                .unwrap();
+        }
+
+        let frag_reuse_index_meta = dataset
+            .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+            .await
+            .unwrap()
+            .expect("Fragment reuse index must be available");
+        let num_versions = load_frag_reuse_index_details(&dataset, &frag_reuse_index_meta)
+            .await
+            .unwrap()
+            .versions
+            .len();
+        assert!(
+            num_versions >= 2,
+            "test needs multiple reuse versions to exercise batching, got {num_versions}"
+        );
+
+        // A single remap must commit exactly once, regardless of version count.
+        let version_before = dataset.manifest.version;
+        remapping::remap_column_index(&mut dataset, &["i"], Some("i_idx".into()))
+            .await
+            .unwrap();
+        let commits = dataset.manifest.version - version_before;
+        assert_eq!(
+            commits, 1,
+            "batched remap must commit once, not once per reuse version ({num_versions})"
+        );
+
+        // ... and the reuse index then trims to zero.
+        cleanup_frag_reuse_index(&mut dataset).await.unwrap();
+        let frag_reuse_index_meta = dataset
+            .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+            .await
+            .unwrap()
+            .expect("Fragment reuse index must be available");
+        assert_eq!(
+            load_frag_reuse_index_details(&dataset, &frag_reuse_index_meta)
+                .await
+                .unwrap()
+                .versions
+                .len(),
+            0
+        );
+    }
 }

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -235,6 +235,13 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
         .find(|idx| idx.uuid == curr_index_id)
         .unwrap();
 
+        // Whether the index data predates this reuse version, i.e. its stored
+        // row addresses still point at the compacted-away fragments. The
+        // fragment bitmap alone cannot tell us this: `load_indices`
+        // coverage-remaps the bitmap onto the new fragments in memory, and a
+        // later commit can persist that cleaned bitmap to disk without the index
+        // data ever being remapped (e.g. while remapping a *sibling* index).
+        let data_predates_version = curr_index_meta.dataset_version < version.dataset_version;
         let maybe_index_bitmap = curr_index_meta.fragment_bitmap.clone();
         let (should_remap, bitmap_after_remap) = match maybe_index_bitmap {
             Some(mut index_frag_bitmap) => {
@@ -260,6 +267,19 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                         }
                         index_frag_bitmap
                             .extend(group.new_frags.clone().into_iter().map(|f| f.id as u32));
+                        should_remap = true;
+                    } else if data_predates_version
+                        && group
+                            .new_frags
+                            .iter()
+                            .any(|new_frag| index_frag_bitmap.contains(new_frag.id as u32))
+                    {
+                        // The bitmap was already coverage-remapped onto this
+                        // group's new fragments and persisted before the data was
+                        // remapped, so the old fragments are gone from the bitmap
+                        // but the index data still needs remapping. Without this
+                        // the data remap is silently skipped and the reuse index
+                        // can never be trimmed.
                         should_remap = true;
                     }
                 }

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -220,32 +220,33 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
         return Ok(());
     }
 
-    // Sequentially apply the row addr maps from oldest to latest
-    let mut curr_index_id = *index_id;
-    for (i, row_id_map) in frag_reuse_index.row_id_maps.iter().enumerate() {
-        let version = &frag_reuse_index.details.versions[i];
-        // load on-disk index metadata before auto-remap
-        let curr_index_meta = read_manifest_indexes(
-            &dataset.object_store,
-            &dataset.manifest_location,
-            &dataset.manifest,
-        )
-        .await?
-        .into_iter()
-        .find(|idx| idx.uuid == curr_index_id)
-        .unwrap();
+    // Read the index's on-disk metadata once. Its stored row addresses are at
+    // this baseline; we compose all reuse versions into a single remap so the
+    // index file is rebuilt and committed exactly once, rather than once per
+    // version (the reuse index can accumulate many versions before remap runs).
+    let curr_index_meta = read_manifest_indexes(
+        &dataset.object_store,
+        &dataset.manifest_location,
+        &dataset.manifest,
+    )
+    .await?
+    .into_iter()
+    .find(|idx| idx.uuid == *index_id)
+    .unwrap();
 
-        // Whether the index data predates this reuse version, i.e. its stored
-        // row addresses still point at the compacted-away fragments. The
-        // fragment bitmap alone cannot tell us this: `load_indices`
-        // coverage-remaps the bitmap onto the new fragments in memory, and a
-        // later commit can persist that cleaned bitmap to disk without the index
-        // data ever being remapped (e.g. while remapping a *sibling* index).
-        let data_predates_version = curr_index_meta.dataset_version < version.dataset_version;
-        let maybe_index_bitmap = curr_index_meta.fragment_bitmap.clone();
-        let (should_remap, bitmap_after_remap) = match maybe_index_bitmap {
-            Some(mut index_frag_bitmap) => {
-                let mut should_remap = false;
+    // Compose the coverage (fragment bitmap) remap across every reuse version in
+    // one pass. Chaining is automatic: a version inserts its new fragments,
+    // which a later version then sees as its old fragments. `data_predates_version`
+    // is evaluated against the fixed baseline (there are no intermediate
+    // commits), and the new-fragment branch handles a bitmap that was already
+    // coverage-remapped + persisted before the data was remapped (e.g. while
+    // remapping a *sibling* index).
+    let baseline_version = curr_index_meta.dataset_version;
+    let (should_remap, bitmap_after_remap) = match curr_index_meta.fragment_bitmap.clone() {
+        Some(mut index_frag_bitmap) => {
+            let mut should_remap = false;
+            for version in frag_reuse_index.details.versions.iter() {
+                let data_predates_version = baseline_version < version.dataset_version;
                 for group in version.groups.iter() {
                     let mut old_frag_in_index = 0;
                     for old_frag in group.old_frags.iter() {
@@ -265,8 +266,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                                 group.old_frags
                             )));
                         }
-                        index_frag_bitmap
-                            .extend(group.new_frags.clone().into_iter().map(|f| f.id as u32));
+                        index_frag_bitmap.extend(group.new_frags.iter().map(|f| f.id as u32));
                         should_remap = true;
                     } else if data_predates_version
                         && group
@@ -277,68 +277,82 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                         // The bitmap was already coverage-remapped onto this
                         // group's new fragments and persisted before the data was
                         // remapped, so the old fragments are gone from the bitmap
-                        // but the index data still needs remapping. Without this
-                        // the data remap is silently skipped and the reuse index
-                        // can never be trimmed.
+                        // but the index data still needs remapping.
                         should_remap = true;
                     }
                 }
-                (should_remap, Some(index_frag_bitmap))
             }
-            // if there is no fragment bitmap for the index,
-            // we attempt remapping but will not update the fragment bitmap.
-            None => (true, None),
-        };
-
-        if should_remap {
-            let remap_result = index::remap_index(dataset, &curr_index_id, row_id_map).await?;
-
-            let new_index_meta = match remap_result {
-                RemapResult::Drop => continue,
-                RemapResult::Keep(new_id) => IndexMetadata {
-                    uuid: new_id,
-                    name: curr_index_meta.name.clone(),
-                    fields: curr_index_meta.fields.clone(),
-                    dataset_version: dataset.manifest.version,
-                    fragment_bitmap: bitmap_after_remap,
-                    index_details: curr_index_meta.index_details.clone(),
-                    index_version: curr_index_meta.index_version,
-                    created_at: curr_index_meta.created_at,
-                    base_id: None,
-                    files: curr_index_meta.files.clone(),
-                },
-                RemapResult::Remapped(remapped_index) => IndexMetadata {
-                    uuid: remapped_index.new_id,
-                    name: curr_index_meta.name.clone(),
-                    fields: curr_index_meta.fields.clone(),
-                    dataset_version: dataset.manifest.version,
-                    fragment_bitmap: bitmap_after_remap,
-                    index_details: Some(Arc::new(remapped_index.index_details)),
-                    index_version: remapped_index.index_version as i32,
-                    created_at: curr_index_meta.created_at,
-                    base_id: None,
-                    files: remapped_index.files,
-                },
-            };
-
-            let new_id = new_index_meta.uuid;
-
-            let transaction = Transaction::new(
-                dataset.manifest.version,
-                Operation::CreateIndex {
-                    new_indices: vec![new_index_meta],
-                    removed_indices: vec![curr_index_meta.clone()],
-                },
-                None,
-            );
-
-            dataset
-                .apply_commit(transaction, &Default::default(), &Default::default())
-                .await?;
-
-            curr_index_id = new_id;
+            (should_remap, Some(index_frag_bitmap))
         }
+        // if there is no fragment bitmap for the index,
+        // we attempt remapping but will not update the fragment bitmap.
+        None => (true, None),
+    };
+
+    if !should_remap {
+        return Ok(());
     }
+
+    // Compose the row-address remap across all versions. `remap_row_id` already
+    // chains every version (and passes through addresses a version does not
+    // touch), so mapping the union of all versions' keys yields a single
+    // baseline -> final address map applied in one rebuild. Restrict the keys to
+    // fragments this index covers: only those can appear in its stored
+    // addresses, so dropping the rest keeps the map small when the reuse index
+    // also spans fragments this index never indexed.
+    let composed_row_id_map: HashMap<u64, Option<u64>> = frag_reuse_index
+        .row_id_maps
+        .iter()
+        .flat_map(|row_id_map| row_id_map.keys().copied())
+        .filter(|&old_addr| match &curr_index_meta.fragment_bitmap {
+            Some(bitmap) => bitmap.contains(RowAddress::new_from_u64(old_addr).fragment_id()),
+            None => true,
+        })
+        .map(|old_addr| (old_addr, frag_reuse_index.remap_row_id(old_addr)))
+        .collect();
+
+    let remap_result = index::remap_index(dataset, index_id, &composed_row_id_map).await?;
+
+    let new_index_meta = match remap_result {
+        RemapResult::Drop => return Ok(()),
+        RemapResult::Keep(new_id) => IndexMetadata {
+            uuid: new_id,
+            name: curr_index_meta.name.clone(),
+            fields: curr_index_meta.fields.clone(),
+            dataset_version: dataset.manifest.version,
+            fragment_bitmap: bitmap_after_remap,
+            index_details: curr_index_meta.index_details.clone(),
+            index_version: curr_index_meta.index_version,
+            created_at: curr_index_meta.created_at,
+            base_id: None,
+            files: curr_index_meta.files.clone(),
+        },
+        RemapResult::Remapped(remapped_index) => IndexMetadata {
+            uuid: remapped_index.new_id,
+            name: curr_index_meta.name.clone(),
+            fields: curr_index_meta.fields.clone(),
+            dataset_version: dataset.manifest.version,
+            fragment_bitmap: bitmap_after_remap,
+            index_details: Some(Arc::new(remapped_index.index_details)),
+            index_version: remapped_index.index_version as i32,
+            created_at: curr_index_meta.created_at,
+            base_id: None,
+            files: remapped_index.files,
+        },
+    };
+
+    let transaction = Transaction::new(
+        dataset.manifest.version,
+        Operation::CreateIndex {
+            new_indices: vec![new_index_meta],
+            removed_indices: vec![curr_index_meta],
+        },
+        None,
+    );
+
+    dataset
+        .apply_commit(transaction, &Default::default(), &Default::default())
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
> 🟡 **DRAFT, stacked on #7286.** This branch is based on #7286, so the diff shows that fix's commit plus the one new `perf:` commit here — review the **`perf: batch fragment-reuse index remap…`** commit. I'll rebase to drop the #7286 commit once it merges.

## Summary

`remap_index` (the post-deferred-compaction catch-up that physically rewrites an index's stored row addresses) applied the fragment-reuse index **one version at a time** — rebuilding the index file and committing **once per reuse version**. An index touched by K deferred compactions paid **K full index rebuilds + K commits**, even though the final state is identical to applying all K at once. This is worst exactly when it matters most: when the reuse index has accumulated many versions before remap runs.

## Change

Compose the whole chain and rebuild once:

- **Row addresses:** `FragReuseIndex::remap_row_id` already chains every version and passes through addresses a version doesn't touch, so the union of all versions' map keys mapped through it yields a single **baseline → final** address map. One `index::remap_index` call applies it.
- **Coverage (fragment bitmap):** composed in a single pass over all versions, with the same all-or-nothing / straddle-error semantics as before (chaining is automatic — a version inserts its new fragments, which the next version sees as its old ones). The `data_predates_version` check is evaluated against the fixed baseline, since there are no longer any intermediate commits.
- One `CreateIndex` commit instead of one per version.

Semantically equivalent to the previous per-version loop (applying the composed map to a stored address gives the same result as applying each version's map in sequence), just without the intermediate rebuilds/commits.

## Why this is safe

- Fragment ids are never reused, so composing the union of version keys can't collide.
- The straddle invariant (#6610) is preserved — still errors on a partially-indexed rewrite group.
- All existing `remap` / `frag_reuse` / `compaction` tests pass unchanged, including `test_remap_index_after_compaction` (a 3-version chain) which now completes in one commit.

## Test

`test_remap_index_batches_multiple_reuse_versions`: accumulates ≥2 reuse versions (delete-prefix + deferred compaction in a loop), then asserts a single `remap_column_index` advances the dataset version by **exactly 1** (one commit, not one per version) and that the reuse index trims to zero afterward.

## Note

This optimizes the *cost per catch-up*; it's complementary to running remap regularly (which keeps the version count — and thus K — small in the first place).
