### PR TITLE
test(index): make test_query_delta_indices deterministic

### DIFF
--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -879,7 +879,7 @@ mod tests {
         vector::{ivf::IvfBuildParams, pq::PQBuildParams},
     };
     use lance_linalg::distance::MetricType;
-    use lance_testing::datagen::generate_random_array;
+    use lance_testing::datagen::{generate_random_array, generate_random_array_with_seed};
     use rstest::rstest;
 
     use crate::dataset::builder::DatasetBuilder;
@@ -1101,6 +1101,30 @@ mod tests {
         );
     }
 
+    /// Vector dimension used by `test_query_delta_indices`. Shared by the test
+    /// body and `deterministic_ivf_centroids` so the supplied centroids always
+    /// match the generated data.
+    const DELTA_INDEX_DIM: usize = 64;
+
+    /// Fixed IVF centroids for the IVF_HNSW_SQ case of `test_query_delta_indices`.
+    ///
+    /// Supplying centroids makes the delta-index build fully deterministic:
+    /// `try_with_centroids` skips IVF centroid training, which is the only
+    /// non-deterministic step left on this path (it draws a random training-data
+    /// sample and runs unseeded k-means init). HNSW level assignment is already
+    /// seeded and SQ does not sample here, so with seeded input data the whole
+    /// build is reproducible and the exact neighbor-id assertion no longer flakes
+    /// (issue #2125, PR #6953).
+    fn deterministic_ivf_centroids() -> Arc<FixedSizeListArray> {
+        Arc::new(
+            FixedSizeListArray::try_new_from_values(
+                generate_random_array_with_seed::<Float32Type>(2 * DELTA_INDEX_DIM, [7; 32]),
+                DELTA_INDEX_DIM as i32,
+            )
+            .unwrap(),
+        )
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_query_delta_indices(
@@ -1108,20 +1132,20 @@ mod tests {
             VectorIndexParams::ivf_pq(2, 8, 4, MetricType::L2, 2),
             VectorIndexParams::with_ivf_hnsw_sq_params(
                 MetricType::L2,
-                IvfBuildParams::new(2),
+                IvfBuildParams::try_with_centroids(2, deterministic_ivf_centroids()).unwrap(),
                 HnswBuildParams::default(),
                 SQBuildParams::default()
             )
         )]
         index_params: VectorIndexParams,
     ) {
-        const DIM: usize = 64;
+        const DIM: usize = DELTA_INDEX_DIM;
         const TOTAL: usize = 1000;
 
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
 
-        let vectors = generate_random_array(TOTAL * DIM);
+        let vectors = generate_random_array_with_seed::<Float32Type>(TOTAL * DIM, [13; 32]);
 
         let schema = Arc::new(Schema::new(vec![
             Field::new(


### PR DESCRIPTION
## Problem

`test_query_delta_indices` (`rust/lance/src/index/append.rs`) is a recurring flake on its IVF_HNSW_SQ case, previously tracked by #2125 and partially addressed by #6953. It surfaced again as an unrelated CI failure on #7310: https://github.com/lance-format/lance/actions/runs/27660888625/job/81804843234 (`assertion left == right failed, left: [116, 1000], right: [0, 1000]`).

The test writes 1000 random vectors, appends the same vectors with shifted ids (so row `i` and row `i+1000` share a vector), builds two delta index segments, and asserts the top-2 nearest to `vector[0]` are exactly `[0, 1000]` (one exact hit per segment). The IVF_HNSW_SQ build is non-deterministic at three points that all feed the trained centroids -> partition split -> per-partition HNSW graph -> whether the approximate search keeps the exact match:

- input vectors come from the unseeded `generate_random_array`;
- IVF centroid training samples a random 512-of-1000 subset with unseeded RNGs;
- k-means centroid init is unseeded.

So the search occasionally drops the exact match (id 0) and returns a near neighbor instead.

## Fix

Test-only change, no production behavior change:

- seed the input vectors with `generate_random_array_with_seed`;
- supply fixed IVF centroids for the SQ case via `IvfBuildParams::try_with_centroids`, which skips IVF centroid training entirely (both the random sample and the unseeded k-means init).

HNSW level assignment is already seeded (`HNSW_LEVEL_RNG_SEED`) and SQ does not sample at this size (sample_size `256 * 2^8` >> 1000), so with seeded data and fixed centroids the whole build is reproducible. The 2 IVF partitions, `nprobes(2)`, all structural assertions, and the exact `[0, 1000]` assertion are unchanged. The `ivf_pq` case is left as-is; it was never the flaky case.

## Tests

Ran `test_query_delta_indices` (both parametrized cases) 300x with zero failures; the SQ case now returns `[0, 1000]` identically on every run.
