### PR TITLE
perf: batch fragment-reuse index remap into a single rebuild + commit

### DIFF
--- a/rust/lance/src/dataset/index/frag_reuse.rs
+++ b/rust/lance/src/dataset/index/frag_reuse.rs
@@ -329,5 +329,112 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(frag_reuse_details.versions.len(), 0);
+
+        // Data correctness, not just version bookkeeping: with the reuse index
+        // trimmed there is no auto-remap safety net, so each index must resolve
+        // to LIVE rows. An index whose data was not actually remapped (e.g. one
+        // whose bitmap was coverage-remapped by a sibling's commit before its
+        // own data remap) points at compacted-away fragments and errors on take.
+        use futures::TryStreamExt;
+        for col in ["i", "j"] {
+            let rows: usize = dataset
+                .scan()
+                .filter(&format!("{col} >= 2000 AND {col} < 3000"))
+                .unwrap()
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap()
+                .iter()
+                .map(|b| b.num_rows())
+                .sum();
+            assert_eq!(
+                rows, 1000,
+                "index {col}_idx must resolve to live rows after remap+trim"
+            );
+        }
+    }
+
+    /// When the reuse index has accumulated several versions, a single remap
+    /// must compose them and rebuild + commit the index exactly ONCE, not once
+    /// per version.
+    #[tokio::test]
+    async fn test_remap_index_batches_multiple_reuse_versions() {
+        let mut dataset = lance_datagen::gen_batch()
+            .col("i", lance_datagen::array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(8), FragmentRowCount::from(1000))
+            .await
+            .unwrap();
+        dataset
+            .create_index(
+                &["i"],
+                IndexType::Scalar,
+                Some("i_idx".into()),
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+
+        // Accumulate multiple reuse versions: each round deletes a prefix, which
+        // shrinks fragments below target and forces another deferred compaction.
+        let options = CompactionOptions {
+            target_rows_per_fragment: 4_000,
+            defer_index_remap: true,
+            ..Default::default()
+        };
+        for round in 0..4 {
+            dataset
+                .delete(&format!("i < {}", 1_000 * (round + 1)))
+                .await
+                .unwrap();
+            compact_files(&mut dataset, options.clone(), None)
+                .await
+                .unwrap();
+        }
+
+        let frag_reuse_index_meta = dataset
+            .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+            .await
+            .unwrap()
+            .expect("Fragment reuse index must be available");
+        let num_versions = load_frag_reuse_index_details(&dataset, &frag_reuse_index_meta)
+            .await
+            .unwrap()
+            .versions
+            .len();
+        assert!(
+            num_versions >= 2,
+            "test needs multiple reuse versions to exercise batching, got {num_versions}"
+        );
+
+        // A single remap must commit exactly once, regardless of version count.
+        let version_before = dataset.manifest.version;
+        remapping::remap_column_index(&mut dataset, &["i"], Some("i_idx".into()))
+            .await
+            .unwrap();
+        let commits = dataset.manifest.version - version_before;
+        assert_eq!(
+            commits, 1,
+            "batched remap must commit once, not once per reuse version ({num_versions})"
+        );
+
+        // ... and the reuse index then trims to zero.
+        cleanup_frag_reuse_index(&mut dataset).await.unwrap();
+        let frag_reuse_index_meta = dataset
+            .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+            .await
+            .unwrap()
+            .expect("Fragment reuse index must be available");
+        assert_eq!(
+            load_frag_reuse_index_details(&dataset, &frag_reuse_index_meta)
+                .await
+                .unwrap()
+                .versions
+                .len(),
+            0
+        );
     }
 }

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -220,32 +220,37 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
         return Ok(());
     }
 
-    // Sequentially apply the row addr maps from oldest to latest
-    let mut curr_index_id = *index_id;
-    for (i, row_id_map) in frag_reuse_index.row_id_maps.iter().enumerate() {
-        let version = &frag_reuse_index.details.versions[i];
-        // load on-disk index metadata before auto-remap
-        let curr_index_meta = read_manifest_indexes(
-            &dataset.object_store,
-            &dataset.manifest_location,
-            &dataset.manifest,
-        )
-        .await?
-        .into_iter()
-        .find(|idx| idx.uuid == curr_index_id)
-        .unwrap();
+    // Read the index's on-disk metadata once. Its stored row addresses are at
+    // this baseline; we compose all reuse versions into a single remap so the
+    // index file is rebuilt and committed exactly once, rather than once per
+    // version (the reuse index can accumulate many versions before remap runs).
+    let curr_index_meta = read_manifest_indexes(
+        &dataset.object_store,
+        &dataset.manifest_location,
+        &dataset.manifest,
+    )
+    .await?
+    .into_iter()
+    .find(|idx| idx.uuid == *index_id)
+    .ok_or_else(|| {
+        Error::index(format!(
+            "index {index_id} not found in manifest; it may have been concurrently dropped"
+        ))
+    })?;
 
-        // Whether the index data predates this reuse version, i.e. its stored
-        // row addresses still point at the compacted-away fragments. The
-        // fragment bitmap alone cannot tell us this: `load_indices`
-        // coverage-remaps the bitmap onto the new fragments in memory, and a
-        // later commit can persist that cleaned bitmap to disk without the index
-        // data ever being remapped (e.g. while remapping a *sibling* index).
-        let data_predates_version = curr_index_meta.dataset_version < version.dataset_version;
-        let maybe_index_bitmap = curr_index_meta.fragment_bitmap.clone();
-        let (should_remap, bitmap_after_remap) = match maybe_index_bitmap {
-            Some(mut index_frag_bitmap) => {
-                let mut should_remap = false;
+    // Compose the coverage (fragment bitmap) remap across every reuse version in
+    // one pass. Chaining is automatic: a version inserts its new fragments,
+    // which a later version then sees as its old fragments. `data_predates_version`
+    // is evaluated against the fixed baseline (there are no intermediate
+    // commits), and the new-fragment branch handles a bitmap that was already
+    // coverage-remapped + persisted before the data was remapped (e.g. while
+    // remapping a *sibling* index).
+    let baseline_version = curr_index_meta.dataset_version;
+    let (should_remap, bitmap_after_remap) = match curr_index_meta.fragment_bitmap.clone() {
+        Some(mut index_frag_bitmap) => {
+            let mut should_remap = false;
+            for version in frag_reuse_index.details.versions.iter() {
+                let data_predates_version = baseline_version < version.dataset_version;
                 for group in version.groups.iter() {
                     let mut old_frag_in_index = 0;
                     for old_frag in group.old_frags.iter() {
@@ -265,8 +270,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                                 group.old_frags
                             )));
                         }
-                        index_frag_bitmap
-                            .extend(group.new_frags.clone().into_iter().map(|f| f.id as u32));
+                        index_frag_bitmap.extend(group.new_frags.iter().map(|f| f.id as u32));
                         should_remap = true;
                     } else if data_predates_version
                         && group
@@ -277,68 +281,86 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                         // The bitmap was already coverage-remapped onto this
                         // group's new fragments and persisted before the data was
                         // remapped, so the old fragments are gone from the bitmap
-                        // but the index data still needs remapping. Without this
-                        // the data remap is silently skipped and the reuse index
-                        // can never be trimmed.
+                        // but the index data still needs remapping.
                         should_remap = true;
                     }
                 }
-                (should_remap, Some(index_frag_bitmap))
             }
-            // if there is no fragment bitmap for the index,
-            // we attempt remapping but will not update the fragment bitmap.
-            None => (true, None),
-        };
-
-        if should_remap {
-            let remap_result = index::remap_index(dataset, &curr_index_id, row_id_map).await?;
-
-            let new_index_meta = match remap_result {
-                RemapResult::Drop => continue,
-                RemapResult::Keep(new_id) => IndexMetadata {
-                    uuid: new_id,
-                    name: curr_index_meta.name.clone(),
-                    fields: curr_index_meta.fields.clone(),
-                    dataset_version: dataset.manifest.version,
-                    fragment_bitmap: bitmap_after_remap,
-                    index_details: curr_index_meta.index_details.clone(),
-                    index_version: curr_index_meta.index_version,
-                    created_at: curr_index_meta.created_at,
-                    base_id: None,
-                    files: curr_index_meta.files.clone(),
-                },
-                RemapResult::Remapped(remapped_index) => IndexMetadata {
-                    uuid: remapped_index.new_id,
-                    name: curr_index_meta.name.clone(),
-                    fields: curr_index_meta.fields.clone(),
-                    dataset_version: dataset.manifest.version,
-                    fragment_bitmap: bitmap_after_remap,
-                    index_details: Some(Arc::new(remapped_index.index_details)),
-                    index_version: remapped_index.index_version as i32,
-                    created_at: curr_index_meta.created_at,
-                    base_id: None,
-                    files: remapped_index.files,
-                },
-            };
-
-            let new_id = new_index_meta.uuid;
-
-            let transaction = Transaction::new(
-                dataset.manifest.version,
-                Operation::CreateIndex {
-                    new_indices: vec![new_index_meta],
-                    removed_indices: vec![curr_index_meta.clone()],
-                },
-                None,
-            );
-
-            dataset
-                .apply_commit(transaction, &Default::default(), &Default::default())
-                .await?;
-
-            curr_index_id = new_id;
+            (should_remap, Some(index_frag_bitmap))
         }
+        // if there is no fragment bitmap for the index,
+        // we attempt remapping but will not update the fragment bitmap.
+        None => (true, None),
+    };
+
+    if !should_remap {
+        return Ok(());
     }
+
+    // Compose the row-address remap across all versions. `remap_row_id` already
+    // chains every version (and passes through addresses a version does not
+    // touch), so mapping the union of all versions' keys yields a single
+    // baseline -> final address map applied in one rebuild.
+    //
+    // Map every old address; do NOT filter by the current `fragment_bitmap`. In
+    // the sibling-coverage-remap case the bitmap was already advanced onto the
+    // new fragments while the index data still holds old addresses, so filtering
+    // by it would drop exactly the keys this index needs and leave its data
+    // stale (an empty map makes `index::remap_index` return `Keep`). The map is
+    // bounded by the rows the reuse index touched; addresses this index does not
+    // store are simply never looked up.
+    let composed_row_id_map: HashMap<u64, Option<u64>> = frag_reuse_index
+        .row_id_maps
+        .iter()
+        .flat_map(|row_id_map| row_id_map.keys().copied())
+        .map(|old_addr| (old_addr, frag_reuse_index.remap_row_id(old_addr)))
+        .collect();
+
+    let remap_result = index::remap_index(dataset, index_id, &composed_row_id_map).await?;
+
+    let new_index_meta = match remap_result {
+        // The composed remap emptied the index (every row deleted). Matching the
+        // prior per-version behavior, leave the existing index untouched and
+        // commit nothing -- there is no remap to apply.
+        RemapResult::Drop => return Ok(()),
+        RemapResult::Keep(new_id) => IndexMetadata {
+            uuid: new_id,
+            name: curr_index_meta.name.clone(),
+            fields: curr_index_meta.fields.clone(),
+            dataset_version: dataset.manifest.version,
+            fragment_bitmap: bitmap_after_remap,
+            index_details: curr_index_meta.index_details.clone(),
+            index_version: curr_index_meta.index_version,
+            created_at: curr_index_meta.created_at,
+            base_id: None,
+            files: curr_index_meta.files.clone(),
+        },
+        RemapResult::Remapped(remapped_index) => IndexMetadata {
+            uuid: remapped_index.new_id,
+            name: curr_index_meta.name.clone(),
+            fields: curr_index_meta.fields.clone(),
+            dataset_version: dataset.manifest.version,
+            fragment_bitmap: bitmap_after_remap,
+            index_details: Some(Arc::new(remapped_index.index_details)),
+            index_version: remapped_index.index_version as i32,
+            created_at: curr_index_meta.created_at,
+            base_id: None,
+            files: remapped_index.files,
+        },
+    };
+
+    let transaction = Transaction::new(
+        dataset.manifest.version,
+        Operation::CreateIndex {
+            new_indices: vec![new_index_meta],
+            removed_indices: vec![curr_index_meta],
+        },
+        None,
+    );
+
+    dataset
+        .apply_commit(transaction, &Default::default(), &Default::default())
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`remap_index` — the catch-up that physically applies a fragment-reuse index after a deferred-remap compaction — applied the reuse index **one version at a time**, rebuilding the index file and committing **once per reuse version**. An index touched by K deferred compactions paid **K full index rebuilds + K commits** for a result identical to applying all K at once. This is worst exactly when the reuse index has accumulated many versions before a remap runs.

## Change

Compose the whole chain and rebuild once:

- **Row addresses:** `FragReuseIndex::remap_row_id` already chains every version (and passes through addresses a version does not touch), so mapping the union of all versions' keys yields a single **baseline → final** address map, applied in one rebuild.
- **Coverage bitmap:** composed in one pass with the same all-or-nothing / straddle-error semantics (chaining is automatic — a version's new fragments are the next version's old fragments). `data_predates_version` is evaluated against the fixed baseline since there are no intermediate commits.
- One `CreateIndex` commit instead of one per version.

## Why the composed map is not filtered by the fragment bitmap

A tempting way to keep the composed map small is to drop keys whose fragment isn't in the index's current `fragment_bitmap`. That optimization is **not** safe — the per-version loop never did it, and this PR keeps it that way.

In the sibling-coverage-remap case, remapping one index commits a manifest that coverage-remaps a *sibling* index's bitmap onto the new fragments and persists it *before* the sibling's own data is remapped. The sibling's on-disk bitmap then shows the new fragments while its data still holds old addresses. Filtering the map by that bitmap would drop exactly the keys the sibling needs, leaving an **empty** map — and `index::remap_index` treats an all-`None`/empty map as `RemapResult::Keep`, reusing the stale index files while the version is bumped and the reuse index trims, so the index would end up pointing at dead fragments.

So the composed map maps every old address the reuse index touched; addresses an index doesn't store are simply never looked up (the map stays bounded by the rows the reuse index touched).

## Tests

- `test_remap_index_batches_multiple_reuse_versions` — a multi-version reuse chain must rebuild + commit exactly once.
- `test_cleanup_frag_reuse_index_multiple_indices` — extended with a post-remap data-correctness scan so it asserts each remapped index resolves to **live rows**, not just that versions advance and the reuse index trims. (A bitmap-filtered map would make the sibling index return 0 of 1000 rows here.)

```
cargo test -p lance --lib frag_reuse::tests   # 3 passed
cargo test -p lance --lib remap               # 21 passed
```
