### PR TITLE
fix: restore blanks for empty batches and split oversized writes in updater

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1856,6 +1856,43 @@ def test_merge_with_commit(tmp_path: Path):
     assert tbl == expected
 
 
+def test_merge_columns_with_deleted_batch_commit(tmp_path: Path):
+    base_dir = tmp_path / "test"
+    table = pa.table({"id": range(150), "value": range(150)})
+    dataset = lance.write_dataset(table, base_dir, max_rows_per_file=200)
+
+    dataset.delete("id >= 50 AND id < 100")
+    assert dataset.count_rows() == 100
+
+    merged_frags = []
+    schema = None
+    for frag in dataset.get_fragments():
+        live_ids = frag.scanner(columns=["id"]).to_table()["id"].to_pylist()
+        right_table = pa.table(
+            {
+                "merged": pa.array([row_id * 10 for row_id in live_ids], pa.int64()),
+            }
+        )
+        merged, schema = frag.merge_columns(right_table, batch_size=50)
+        merged_frags.append(merged)
+
+    dataset = lance.LanceDataset.commit(
+        dataset.uri,
+        lance.LanceOperation.Merge(merged_frags, schema),
+        read_version=dataset.version,
+    )
+    dataset.validate()
+
+    expected_ids = list(range(50)) + list(range(100, 150))
+    assert dataset.to_table() == pa.table(
+        {
+            "id": expected_ids,
+            "value": expected_ids,
+            "merged": [row_id * 10 for row_id in expected_ids],
+        }
+    )
+
+
 def test_merge_with_schema_holes(tmp_path: Path):
     # Create table with 3 cols
     table = pa.table({"a": range(10)})

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -1764,6 +1764,64 @@ mod test {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_add_columns_with_middle_fully_deleted_batch() -> Result<()> {
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "i",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..150))],
+        )?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+
+        let test_dir = TempStrDir::default();
+        let test_uri = &test_dir;
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 200,
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+        dataset.delete("i >= 50 AND i < 100").await?;
+        assert_eq!(dataset.count_rows(None).await?, 100);
+
+        let new_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "j",
+            DataType::Int32,
+            false,
+        )]));
+        let new_batch = RecordBatch::try_new(
+            new_schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..100))],
+        )?;
+        let reader = RecordBatchIterator::new(vec![Ok(new_batch)], new_schema.clone());
+
+        dataset
+            .add_columns(NewColumnTransform::Reader(Box::new(reader)), None, Some(50))
+            .await?;
+        dataset.validate().await?;
+
+        let data = dataset.scan().try_into_batch().await?;
+        assert_eq!(data.num_rows(), 100);
+        assert_eq!(
+            data.column_by_name("i").unwrap().as_ref(),
+            &Int32Array::from_iter_values((0..50).chain(100..150))
+        );
+        assert_eq!(
+            data.column_by_name("j").unwrap().as_ref(),
+            &Int32Array::from_iter_values(0..100)
+        );
+
+        Ok(())
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_append_columns_udf(

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use arrow_array::{RecordBatch, UInt32Array};
+use arrow_array::{new_null_array, RecordBatch, UInt32Array};
 use futures::StreamExt;
 use lance_core::datatypes::{OnMissing, OnTypeMismatch};
 use lance_core::utils::deletion::DeletionVector;
@@ -49,6 +49,8 @@ pub struct Updater {
     finished: bool,
 
     deletion_restorer: DeletionRestorer,
+
+    write_batch_size: Option<u32>,
 }
 
 impl Updater {
@@ -97,6 +99,7 @@ impl Updater {
             schema_adapter: None,
             finished: false,
             deletion_restorer: DeletionRestorer::new(deletion_vector, legacy_batch_size),
+            write_batch_size: Some(batch_size),
         })
     }
 
@@ -200,7 +203,25 @@ impl Updater {
 
         let writer = self.writer.as_mut().unwrap();
 
-        writer.write(&[batch]).await?;
+        if let Some(batch_size) = self.write_batch_size {
+            let batch_size = batch_size as usize;
+            if batch.num_rows() > batch_size {
+                let batches = (0..batch.num_rows())
+                    .step_by(batch_size)
+                    .map(|offset| {
+                        let len = std::cmp::min(batch_size, batch.num_rows() - offset);
+                        batch.slice(offset, len)
+                    })
+                    .collect::<Vec<_>>();
+                for batch in batches {
+                    writer.write(&[batch]).await?;
+                }
+            } else {
+                writer.write(&[batch]).await?;
+            }
+        } else {
+            writer.write(&[batch]).await?;
+        }
 
         Ok(())
     }
@@ -390,11 +411,13 @@ pub(crate) fn add_blanks(batch: RecordBatch, batch_offsets: &[u32]) -> Result<Re
     }
 
     if batch.num_rows() == 0 {
-        // TODO: implement adding blanks for an empty batch.
-        // This is difficult because we need to create a batch for arbitrary schemas.
-        return Err(Error::not_supported_source(
-            "Missing too many rows in merge, run compaction to materialize deletions first".into(),
-        ));
+        let arrays = batch
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| new_null_array(field.data_type(), batch_offsets.len()))
+            .collect();
+        return Ok(RecordBatch::try_new(batch.schema(), arrays)?);
     }
 
     let mut selection_vector = Vec::<u32>::with_capacity(batch.num_rows() + batch_offsets.len());
@@ -428,7 +451,13 @@ pub(crate) fn add_blanks(batch: RecordBatch, batch_offsets: &[u32]) -> Result<Re
 
 #[cfg(test)]
 mod tests {
-    use arrow::{array::AsArray, datatypes::Int32Type};
+    use std::sync::Arc;
+
+    use arrow::{
+        array::{Array, AsArray},
+        datatypes::{DataType, Field as ArrowField, Int32Type, Schema as ArrowSchema},
+    };
+    use arrow_array::RecordBatch;
     use lance_datagen::RowCount;
 
     use super::add_blanks;
@@ -504,5 +533,25 @@ mod tests {
             assert_eq!(values.value(i), (i - 1) as i32);
         }
         assert_eq!(values.value(11), 0);
+    }
+
+    #[test]
+    fn test_add_blanks_to_empty_batch() {
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "x",
+            DataType::Int32,
+            true,
+        )]));
+        let batch = RecordBatch::new_empty(schema.clone());
+
+        let with_blanks = add_blanks(batch, &[0, 1, 2]).unwrap();
+
+        assert_eq!(with_blanks.num_rows(), 3);
+        assert_eq!(with_blanks.schema(), schema);
+        let values = with_blanks.column(0).as_primitive::<Int32Type>();
+        assert_eq!(values.len(), 3);
+        assert!(values.is_null(0));
+        assert!(values.is_null(1));
+        assert!(values.is_null(2));
     }
 }


### PR DESCRIPTION
## What

Follow-up to #7233. Fixes two more failures that occur when a fully deleted batch sits in the **middle** of a fragment and columns are added/merged (e.g. via `Fragment::merge_columns` + `LanceOperation::Merge`).

## Root cause

After #7233 handled the 0-row batch at a read boundary, two related issues remain in `updater.rs`:

1. **`add_blanks` rejects empty batches.** `DeletionRestorer` walks the deletion vector and may need to insert blanks for deleted rows that land on a batch whose live rows are all elsewhere, producing an empty input batch with non-empty offsets. `add_blanks` returned `NotSupported` ("Missing too many rows in merge, run compaction to materialize deletions first") in that case.
2. **Restored batches can exceed `batch_size`.** `DeletionRestorer` greedily appends trailing deleted rows to the preceding batch, so the restored batch can be larger than the requested `batch_size`, producing oversized output file batches.

## Fix

1. `add_blanks` now builds null rows via `new_null_array` for an empty input batch instead of erroring.
2. `Updater::update` slices the restored batch back down to the write batch size before writing.

## Tests

- `add_blanks` unit test on an empty batch.
- `add_columns` Rust test with a middle fully-deleted batch.
- Python regression test exercising `merge_columns` + commit over a dataset with a deletion file.
