### PR TITLE
feat: support mixed-language FTS stop words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5102,6 +5102,7 @@ dependencies = [
  "lindera",
  "rust-stemmers",
  "serde",
+ "stop-words",
  "unicode-normalization",
 ]
 
@@ -8413,6 +8414,15 @@ name = "stfu8"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
+name = "stop-words"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68df56303396bcfb639455b3c166804aeb7994005010aab5e9e8a1277b8871d"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "str_stack"

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4622,6 +4622,7 @@ dependencies = [
  "lindera",
  "rust-stemmers",
  "serde",
+ "stop-words",
  "unicode-normalization",
 ]
 
@@ -7544,6 +7545,15 @@ name = "stfu8"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
+name = "stop-words"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68df56303396bcfb639455b3c166804aeb7994005010aab5e9e8a1277b8871d"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "strsim"

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -868,6 +868,51 @@ def test_fts_custom_stop_words(tmp_path):
     assert len(results["_rowid"].to_pylist()) == 1
 
 
+def test_fts_stop_words_respect_language_for_simple_tokenizer(tmp_path):
+    data = pa.table({"text": ["the lance data", "的 lance data"]})
+    ds = lance.write_dataset(data, tmp_path, mode="overwrite")
+    ds.create_scalar_index(
+        "text",
+        "INVERTED",
+        base_tokenizer="simple",
+        stem=False,
+    )
+
+    results = ds.to_table(full_text_query="the", with_row_id=True)
+    assert results.num_rows == 0
+
+    results = ds.to_table(full_text_query="的", with_row_id=True)
+    assert results["text"].to_pylist() == ["的 lance data"]
+
+
+def test_fts_icu_stop_words_are_all_or_none(tmp_path):
+    data = pa.table({"text": ["the 的 lance data", "useful data"]})
+    ds = lance.write_dataset(data, tmp_path / "enabled", mode="overwrite")
+    ds.create_scalar_index(
+        "text",
+        "INVERTED",
+        base_tokenizer="icu",
+        stem=False,
+        remove_stop_words=True,
+    )
+
+    assert ds.to_table(full_text_query="the", with_row_id=True).num_rows == 0
+    assert ds.to_table(full_text_query="的", with_row_id=True).num_rows == 0
+    assert ds.to_table(full_text_query="lance", with_row_id=True).num_rows == 1
+
+    ds = lance.write_dataset(data, tmp_path / "disabled", mode="overwrite")
+    ds.create_scalar_index(
+        "text",
+        "INVERTED",
+        base_tokenizer="icu",
+        stem=False,
+        remove_stop_words=False,
+    )
+
+    assert ds.to_table(full_text_query="the", with_row_id=True).num_rows == 1
+    assert ds.to_table(full_text_query="的", with_row_id=True).num_rows == 1
+
+
 def test_rowid_order(dataset):
     dataset.create_scalar_index("doc", index_type="INVERTED", with_position=False)
     results = dataset.scanner(

--- a/rust/lance-index/src/scalar/inverted/tokenizer.rs
+++ b/rust/lance-index/src/scalar/inverted/tokenizer.rs
@@ -355,16 +355,7 @@ impl InvertedIndexParams {
             builder = builder.filter_dynamic(Stemmer::new(self.language));
         }
         if self.remove_stop_words {
-            let stop_word_filter = match &self.custom_stop_words {
-                Some(words) => StopWordFilter::remove(words.iter().cloned()),
-                None => StopWordFilter::new(self.language).ok_or_else(|| {
-                    Error::invalid_input(format!(
-                        "removing stop words for language {:?} is not supported yet",
-                        self.language
-                    ))
-                })?,
-            };
-            builder = builder.filter_dynamic(stop_word_filter);
+            builder = builder.filter_dynamic(self.stop_word_filter()?);
         }
         if self.ascii_folding {
             builder = builder.filter_dynamic(AsciiFoldingFilter);
@@ -379,6 +370,19 @@ impl InvertedIndexParams {
                 "unknown lance tokenizer {}",
                 self.lance_tokenizer.as_ref().unwrap()
             ))),
+        }
+    }
+
+    fn stop_word_filter(&self) -> Result<StopWordFilter> {
+        match &self.custom_stop_words {
+            Some(words) => Ok(StopWordFilter::remove(words.iter().cloned())),
+            None if self.base_tokenizer == "icu" => Ok(StopWordFilter::all()),
+            None => StopWordFilter::new(self.language).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "removing stop words for language {:?} is not supported yet",
+                    self.language
+                ))
+            }),
         }
     }
 
@@ -502,5 +506,53 @@ mod tests {
         let mut tokens = Vec::new();
         stream.process(&mut |token| tokens.push(token.text.clone()));
         assert_eq!(tokens, vec!["hello", "こんにちは", "世界"]);
+    }
+
+    #[test]
+    fn test_remove_stop_words_respects_language_for_non_icu_tokenizer() {
+        let mut tokenizer = InvertedIndexParams::default()
+            .stem(false)
+            .base_tokenizer("simple".to_string())
+            .build()
+            .unwrap();
+        let mut stream = tokenizer.token_stream_for_search("the 的 lance data");
+        let mut tokens = Vec::new();
+        while let Some(token) = stream.next() {
+            tokens.push(token.text.clone());
+        }
+        assert_eq!(
+            tokens,
+            vec!["的".to_string(), "lance".to_string(), "data".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_custom_stop_words_replace_language_builtins() {
+        let mut tokenizer = InvertedIndexParams::default()
+            .stem(false)
+            .custom_stop_words(Some(vec!["lance".to_string()]))
+            .build()
+            .unwrap();
+        let mut stream = tokenizer.token_stream_for_search("the lance data");
+        let mut tokens = Vec::new();
+        while let Some(token) = stream.next() {
+            tokens.push(token.text.clone());
+        }
+        assert_eq!(tokens, vec!["the".to_string(), "data".to_string()]);
+    }
+
+    #[test]
+    fn test_icu_stop_words_use_all_builtin_lists() {
+        let mut tokenizer = InvertedIndexParams::default()
+            .stem(false)
+            .base_tokenizer("icu".to_string())
+            .build()
+            .unwrap();
+        let mut stream = tokenizer.token_stream_for_search("the 的 lance data");
+        let mut tokens = Vec::new();
+        while let Some(token) = stream.next() {
+            tokens.push(token.text.clone());
+        }
+        assert_eq!(tokens, vec!["lance".to_string(), "data".to_string()]);
     }
 }

--- a/rust/lance-tokenizer/Cargo.toml
+++ b/rust/lance-tokenizer/Cargo.toml
@@ -17,6 +17,7 @@ jieba-rs = { workspace = true, optional = true }
 lindera = { workspace = true, optional = true }
 rust-stemmers = "1.2.0"
 serde = { workspace = true, features = ["derive"] }
+stop-words = { version = "0.10.0", default-features = false, features = ["iso", "nltk"] }
 unicode-normalization = "0.1.25"
 
 [features]

--- a/rust/lance-tokenizer/src/stop_word_filter.rs
+++ b/rust/lance-tokenizer/src/stop_word_filter.rs
@@ -12,6 +12,34 @@ use std::sync::Arc;
 
 use crate::{Language, Token, TokenFilter, TokenStream, Tokenizer};
 
+fn all_stop_words() -> impl Iterator<Item = &'static str> {
+    [
+        stop_words::get("ar"),
+        stopwords::DANISH,
+        stopwords::DUTCH,
+        stopwords::ENGLISH,
+        stopwords::FINNISH,
+        stopwords::FRENCH,
+        stopwords::GERMAN,
+        stop_words::get("el"),
+        stopwords::HUNGARIAN,
+        stopwords::ITALIAN,
+        stopwords::NORWEGIAN,
+        stopwords::PORTUGUESE,
+        stop_words::get("ro"),
+        stopwords::RUSSIAN,
+        stopwords::SPANISH,
+        stopwords::SWEDISH,
+        stop_words::get("ta"),
+        stop_words::get("tr"),
+        stop_words::get("zh"),
+        stop_words::get("ja"),
+        stop_words::get("ko"),
+    ]
+    .into_iter()
+    .flat_map(|words| words.iter().copied())
+}
+
 #[derive(Clone)]
 pub struct StopWordFilter {
     words: Arc<HashSet<String>>,
@@ -20,31 +48,71 @@ pub struct StopWordFilter {
 impl StopWordFilter {
     pub fn new(language: Language) -> Option<Self> {
         let words = match language {
+            Language::Arabic => stop_words::get("ar"),
             Language::Danish => stopwords::DANISH,
             Language::Dutch => stopwords::DUTCH,
-            Language::English => &[
-                "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into",
-                "is", "it", "no", "not", "of", "on", "or", "such", "that", "the", "their", "then",
-                "there", "these", "they", "this", "to", "was", "will", "with",
-            ],
+            Language::English => stopwords::ENGLISH,
             Language::Finnish => stopwords::FINNISH,
             Language::French => stopwords::FRENCH,
             Language::German => stopwords::GERMAN,
+            Language::Greek => stop_words::get("el"),
             Language::Hungarian => stopwords::HUNGARIAN,
             Language::Italian => stopwords::ITALIAN,
             Language::Norwegian => stopwords::NORWEGIAN,
             Language::Portuguese => stopwords::PORTUGUESE,
+            Language::Romanian => stop_words::get("ro"),
             Language::Russian => stopwords::RUSSIAN,
             Language::Spanish => stopwords::SPANISH,
             Language::Swedish => stopwords::SWEDISH,
-            _ => return None,
+            Language::Tamil => stop_words::get("ta"),
+            Language::Turkish => stop_words::get("tr"),
         };
         Some(Self::remove(words.iter().map(|word| (*word).to_owned())))
+    }
+
+    pub fn all() -> Self {
+        Self::remove(all_stop_words().map(str::to_owned))
     }
 
     pub fn remove<W: IntoIterator<Item = String>>(words: W) -> Self {
         Self {
             words: Arc::new(words.into_iter().collect()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::all_stop_words;
+    use crate::StopWordFilter;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_external_stop_word_lists_are_available() {
+        let words = all_stop_words().collect::<HashSet<_>>();
+        for word in ["إلى", "και", "acesta", "அவர்", "ama", "的", "ある", "그리고"]
+        {
+            assert!(
+                words.contains(word),
+                "built-in stop words should contain {word}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_language_stop_word_lists_are_available() {
+        for (language, word) in [
+            (crate::Language::Arabic, "إلى"),
+            (crate::Language::Greek, "και"),
+            (crate::Language::Romanian, "acesta"),
+            (crate::Language::Tamil, "அவர்"),
+            (crate::Language::Turkish, "ama"),
+        ] {
+            let filter = StopWordFilter::new(language).unwrap();
+            assert!(
+                filter.words.contains(word),
+                "{language:?} should contain {word}"
+            );
         }
     }
 }

--- a/rust/lance-tokenizer/src/stop_word_filter/stopwords.rs
+++ b/rust/lance-tokenizer/src/stop_word_filter/stopwords.rs
@@ -37,6 +37,12 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+pub const ENGLISH: &[&str] = &[
+    "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it",
+    "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "there", "these",
+    "they", "this", "to", "was", "will", "with",
+];
+
 pub const DANISH: &[&str] = &[
     "og", "i", "jeg", "det", "at", "en", "den", "til", "er", "som", "på", "de", "med", "han", "af",
     "for", "ikke", "der", "var", "mig", "sig", "men", "et", "har", "om", "vi", "min", "havde",


### PR DESCRIPTION
This PR extends FTS stop-word handling so ICU tokenization can remove built-in stop words across supported languages, while non-ICU tokenizers continue to use the configured language and existing custom stop-word override behavior. It also fills the missing built-in stop-word lists for languages already exposed by `Language`, without changing the public API or index protobuf format.
