### PR TITLE
feat(scalar): expose LogicalScalarIndex::try_new and load_named_scalar_segments

### DIFF
--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -12,6 +12,8 @@ pub(crate) mod zonemap;
 
 pub use inverted::{load_segment_details, load_segments};
 
+pub use crate::index::scalar_logical::{LogicalScalarIndex, load_named_scalar_segments};
+
 use std::sync::{Arc, LazyLock};
 
 use uuid::Uuid;

--- a/rust/lance/src/index/scalar_logical.rs
+++ b/rust/lance/src/index/scalar_logical.rs
@@ -31,7 +31,17 @@ pub struct LogicalScalarIndex {
 }
 
 impl LogicalScalarIndex {
-    fn try_new(name: String, column: String, segments: Vec<Arc<dyn ScalarIndex>>) -> Result<Self> {
+    /// Merge several already-opened segments of one scalar index into a single
+    /// searchable [`ScalarIndex`].
+    ///
+    /// Used internally by `open_named_scalar_index`, and exposed so a
+    /// distributed query engine can open an explicit subset of a scalar
+    /// index's segments and present them as one index.
+    pub fn try_new(
+        name: String,
+        column: String,
+        segments: Vec<Arc<dyn ScalarIndex>>,
+    ) -> Result<Self> {
         let Some(first) = segments.first() else {
             return Err(Error::invalid_input(format!(
                 "LogicalScalarIndex '{}' on column '{}' must contain at least one segment",
@@ -210,7 +220,14 @@ fn index_intersects_dataset(index: &IndexMetadata, dataset: &Dataset) -> bool {
         .is_some_and(|index_bitmap| index_bitmap.intersection_len(&dataset.fragment_bitmap) > 0)
 }
 
-async fn load_named_scalar_segments(
+/// List the committed, dataset-intersecting segments of a named scalar index.
+///
+/// Returns one [`IndexMetadata`] per usable segment. The result length is the
+/// segment count: `1` means a single (non-segmented) index, `> 1` means the
+/// index is split across multiple segments that a distributed engine may route
+/// to different executors. All returned segments are validated to share the
+/// same underlying index type.
+pub async fn load_named_scalar_segments(
     dataset: &Dataset,
     column: &str,
     index_name: &str,


### PR DESCRIPTION
## What

Make two existing scalar-index building blocks `pub` and re-export them from `index::scalar`:

- `LogicalScalarIndex::try_new` — public constructor that merges several already-opened segments of one scalar index into a single searchable `ScalarIndex`.
- `load_named_scalar_segments` — list the committed, dataset-intersecting segments of a named scalar index (length `1` = a single non-segmented index, `> 1` = an index split across multiple segments).

## Why

A distributed query engine needs to (1) discover how many segments a named scalar index has and (2) open an explicit subset of those segments on each executor, then present them as one index. Both capabilities already exist inside lance — `load_named_scalar_segments` lists segments, and `LogicalScalarIndex` already unions per-segment search results and fragment coverage — they were just private.

The actual "open this UUID subset" helper stays in the calling engine; it is pure glue over these two plus the already-public `Dataset::open_scalar_index`, so it does not need to live in lance.

## Notes

- Purely additive. No behavior change to existing callers (`open_named_scalar_index` and `scalar_index_fragment_bitmap` already used both).
- `index_intersects_dataset` and `Dataset::fragment_bitmap` remain private.
- `cargo check`, `clippy`, and `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)