### PR TITLE
fix: stream FM index partition builds

### DIFF
--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -1370,8 +1370,7 @@ impl ScalarIndex for FMIndexScalarIndex {
         dest: &dyn IndexStore,
         _old_data_filter: Option<OldIndexDataFilter>,
     ) -> Result<CreatedIndex> {
-        let texts = collect_texts(new_data).await?;
-        let files = write_partitioned_fmindex(&texts, dest).await?;
+        let files = write_partitioned_fmindex_stream(new_data, dest).await?;
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pb::FmIndexIndexDetails {}).unwrap(),
             index_version: FMINDEX_INDEX_VERSION,
@@ -1390,8 +1389,14 @@ impl ScalarIndex for FMIndexScalarIndex {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-async fn collect_texts(mut stream: SendableRecordBatchStream) -> Result<Vec<(u64, Vec<u8>)>> {
-    let mut texts = Vec::new();
+async fn write_partitioned_fmindex_stream(
+    mut stream: SendableRecordBatchStream,
+    store: &dyn IndexStore,
+) -> Result<Vec<IndexFile>> {
+    let mut files = Vec::new();
+    let mut partition = Vec::with_capacity(PARTITION_SIZE);
+    let mut partition_id = 0;
+
     while let Some(batch) = stream.next().await {
         let batch = batch?;
         // Prefer _rowaddr (global row address) over _rowid to ensure stable,
@@ -1409,24 +1414,85 @@ async fn collect_texts(mut stream: SendableRecordBatchStream) -> Result<Vec<(u64
             .unwrap_or_else(|| batch.column(0));
         for i in 0..batch.num_rows() {
             let rid = row_addrs.value(i);
-            if let Some(bytes) = extract_text_bytes(value_col.as_ref(), i)? {
-                let sanitized: Vec<u8> = bytes
-                    .iter()
-                    .map(|&b| {
-                        if b == SENTINEL_BYTE || b == 0x00 {
-                            b' '
-                        } else {
-                            b
-                        }
-                    })
-                    .collect();
-                texts.push((rid, sanitized));
+            if let Some(bytes) = extract_sanitized_text_bytes(value_col.as_ref(), i)? {
+                partition.push((rid, bytes));
+                if partition.len() == PARTITION_SIZE {
+                    files.push(write_fmindex_partition(&partition, store, partition_id).await?);
+                    partition.clear();
+                    partition_id += 1;
+                }
             }
         }
     }
-    Ok(texts)
+
+    if !partition.is_empty() {
+        files.push(write_fmindex_partition(&partition, store, partition_id).await?);
+    } else if files.is_empty() {
+        files.push(write_empty_fmindex_partition(store).await?);
+    }
+
+    Ok(files)
 }
 
+fn sanitize_text_bytes(bytes: &[u8]) -> Vec<u8> {
+    bytes
+        .iter()
+        .map(|&b| {
+            if b == SENTINEL_BYTE || b == 0x00 {
+                b' '
+            } else {
+                b
+            }
+        })
+        .collect()
+}
+
+fn extract_sanitized_text_bytes(
+    array: &dyn arrow_array::Array,
+    index: usize,
+) -> Result<Option<Vec<u8>>> {
+    if array.is_null(index) {
+        return Ok(None);
+    }
+    match array.data_type() {
+        DataType::Utf8 => Ok(Some(sanitize_text_bytes(
+            array
+                .as_any()
+                .downcast_ref::<arrow_array::StringArray>()
+                .unwrap()
+                .value(index)
+                .as_bytes(),
+        ))),
+        DataType::LargeUtf8 => Ok(Some(sanitize_text_bytes(
+            array
+                .as_any()
+                .downcast_ref::<arrow_array::LargeStringArray>()
+                .unwrap()
+                .value(index)
+                .as_bytes(),
+        ))),
+        DataType::Binary => Ok(Some(sanitize_text_bytes(
+            array
+                .as_any()
+                .downcast_ref::<arrow_array::BinaryArray>()
+                .unwrap()
+                .value(index),
+        ))),
+        DataType::LargeBinary => Ok(Some(sanitize_text_bytes(
+            array
+                .as_any()
+                .downcast_ref::<arrow_array::LargeBinaryArray>()
+                .unwrap()
+                .value(index),
+        ))),
+        _ => Err(Error::invalid_input(format!(
+            "Fm does not support data type: {:?}",
+            array.data_type()
+        ))),
+    }
+}
+
+#[cfg(test)]
 fn extract_text_bytes(array: &dyn arrow_array::Array, index: usize) -> Result<Option<Vec<u8>>> {
     if array.is_null(index) {
         return Ok(None);
@@ -1568,23 +1634,34 @@ async fn write_fmindex(fm: &FMIndex, store: &dyn IndexStore, filename: &str) -> 
     writer.finish_with_metadata(metadata).await
 }
 
+#[cfg(test)]
 async fn write_partitioned_fmindex(
     texts: &[(u64, Vec<u8>)],
     store: &dyn IndexStore,
 ) -> Result<Vec<IndexFile>> {
-    let refs: Vec<(u64, &[u8])> = texts.iter().map(|(id, t)| (*id, t.as_slice())).collect();
-    if refs.is_empty() {
-        let fm = FMIndex::build(&[])?;
-        return Ok(vec![
-            write_fmindex(&fm, store, &fmindex_partition_path(0)).await?,
-        ]);
+    if texts.is_empty() {
+        return Ok(vec![write_empty_fmindex_partition(store).await?]);
     }
     let mut files = Vec::new();
-    for (pid, chunk) in refs.chunks(PARTITION_SIZE).enumerate() {
-        let fm = FMIndex::build(chunk)?;
-        files.push(write_fmindex(&fm, store, &fmindex_partition_path(pid as u64)).await?);
+    for (pid, chunk) in texts.chunks(PARTITION_SIZE).enumerate() {
+        files.push(write_fmindex_partition(chunk, store, pid as u64).await?);
     }
     Ok(files)
+}
+
+async fn write_fmindex_partition(
+    texts: &[(u64, Vec<u8>)],
+    store: &dyn IndexStore,
+    partition_id: u64,
+) -> Result<IndexFile> {
+    let refs: Vec<(u64, &[u8])> = texts.iter().map(|(id, t)| (*id, t.as_slice())).collect();
+    let fm = FMIndex::build(&refs)?;
+    write_fmindex(&fm, store, &fmindex_partition_path(partition_id)).await
+}
+
+async fn write_empty_fmindex_partition(store: &dyn IndexStore) -> Result<IndexFile> {
+    let fm = FMIndex::build(&[])?;
+    write_fmindex(&fm, store, &fmindex_partition_path(0)).await
 }
 
 // ── Plugin ───────────────────────────────────────────────────────────────────
@@ -1623,8 +1700,7 @@ impl ScalarIndexPlugin for FMIndexPlugin {
         _fids: Option<Vec<u32>>,
         _progress: Arc<dyn crate::progress::IndexBuildProgress>,
     ) -> Result<CreatedIndex> {
-        let texts = collect_texts(data).await?;
-        let files = write_partitioned_fmindex(&texts, store).await?;
+        let files = write_partitioned_fmindex_stream(data, store).await?;
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pb::FmIndexIndexDetails {}).unwrap(),
             index_version: FMINDEX_INDEX_VERSION,
@@ -1672,7 +1748,10 @@ impl ScalarIndexPlugin for FMIndexPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lance_core::cache::LanceCache;
+    use arrow_array::{BinaryArray, LargeBinaryArray, LargeStringArray, StringArray, UInt64Array};
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use futures::stream;
+    use lance_core::{ROW_ADDR, cache::LanceCache};
     use lance_io::object_store::ObjectStore;
     use object_store::path::Path;
     use std::sync::Arc;
@@ -1885,11 +1964,10 @@ mod tests {
 
     #[test]
     fn test_sentinel_sanitization() {
-        // Text containing \xFF should be sanitized to space
+        // Text containing \xFF should be sanitized to space during training.
         let texts: Vec<(u64, &[u8])> = vec![(0, b"hello\xFFworld")];
         let fm = FMIndex::build(&texts).unwrap();
-        // The \xFF is replaced with space during collect_texts, but here we test build directly
-        // which doesn't sanitize. The search should still work.
+        // Build itself does not sanitize, but search should still work.
         let r = fm.search(b"hello");
         assert!(r.contains(0));
     }
@@ -2061,11 +2139,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_plugin_train_and_load() {
-        use arrow_array::{StringArray, UInt64Array};
-        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-        use futures::stream;
-        use lance_core::ROW_ADDR;
-
         let docs = vec!["hello world", "hello rust", "goodbye world"];
         let row_addrs: Vec<u64> = vec![0, 1, 2];
         let schema = Arc::new(arrow_schema::Schema::new(vec![
@@ -2128,6 +2201,88 @@ mod tests {
         }
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_plugin_train_streams_multiple_partitions() {
+        fn training_batch(
+            schema: Arc<arrow_schema::Schema>,
+            start: usize,
+            len: usize,
+        ) -> RecordBatch {
+            let docs = vec!["x"; len];
+            let row_addrs: Vec<u64> = (start..start + len).map(|i| i as u64).collect();
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(StringArray::from(docs)),
+                    Arc::new(UInt64Array::from(row_addrs)),
+                ],
+            )
+            .unwrap()
+        }
+
+        let total_rows = PARTITION_SIZE + 5;
+        let first_batch_rows = PARTITION_SIZE - 3;
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new(
+                crate::scalar::registry::VALUE_COLUMN_NAME,
+                DataType::Utf8,
+                false,
+            ),
+            arrow_schema::Field::new(ROW_ADDR, DataType::UInt64, false),
+        ]));
+        let batches = vec![
+            Ok(training_batch(schema.clone(), 0, first_batch_rows)),
+            Ok(training_batch(
+                schema.clone(),
+                first_batch_rows,
+                total_rows - first_batch_rows,
+            )),
+        ];
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            index_dir,
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let stream = RecordBatchStreamAdapter::new(schema, stream::iter(batches));
+        let req = FMIndexPlugin
+            .new_training_request("", &arrow_schema::Field::new("val", DataType::Utf8, false))
+            .unwrap();
+        let created = FMIndexPlugin
+            .train_index(
+                Box::pin(stream),
+                store.as_ref(),
+                req,
+                None,
+                Arc::new(crate::progress::NoopIndexBuildProgress),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(created.files.len(), 2);
+
+        let index = FMIndexPlugin
+            .load_index(store, &created.index_details, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let r = index
+            .search(
+                &TextQuery::StringContains("x".to_string()),
+                &crate::metrics::NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        match r {
+            SearchResult::Exact(set) => {
+                assert_eq!(set.len(), Some(total_rows as u64));
+            }
+            _ => panic!("expected exact result"),
+        }
+    }
+
     #[test]
     fn test_build_wavelet_batch() {
         let texts: Vec<(u64, &[u8])> = vec![(0, b"hello world"), (1, b"test data")];
@@ -2139,8 +2294,6 @@ mod tests {
 
     #[test]
     fn test_extract_text_bytes_types() {
-        use arrow_array::{BinaryArray, LargeBinaryArray, LargeStringArray, StringArray};
-
         let utf8 = StringArray::from(vec!["hello"]);
         assert_eq!(
             extract_text_bytes(&utf8, 0).unwrap(),
@@ -2157,6 +2310,11 @@ mod tests {
         assert_eq!(
             extract_text_bytes(&binary, 0).unwrap(),
             Some(b"bytes".to_vec())
+        );
+        let binary_with_sentinels = BinaryArray::from(vec![b"a\xFFb\0c" as &[u8]]);
+        assert_eq!(
+            extract_sanitized_text_bytes(&binary_with_sentinels, 0).unwrap(),
+            Some(b"a b c".to_vec())
         );
 
         let large_binary = LargeBinaryArray::from(vec![b"large" as &[u8]]);


### PR DESCRIPTION
Streams FM index training and update input into partition-sized writes instead of materializing the full training stream first. This keeps large segmented FM builds bounded by one partition plus the current Arrow batch while preserving the existing partition file layout.