### PR TITLE
perf(fts): defer term frequency collection

### DIFF
--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -36,6 +36,13 @@ use super::{DocInfo, builder::BLOCK_SIZE};
 
 const TERMINATED_DOC_ID: u64 = u64::MAX;
 
+#[cfg(test)]
+thread_local! {
+    static TERM_FREQ_COLLECTION_DOC_CALLS: std::cell::Cell<usize> = const {
+        std::cell::Cell::new(0)
+    };
+}
+
 pub static FLAT_SEARCH_PERCENT_THRESHOLD: LazyLock<u64> = LazyLock::new(|| {
     std::env::var("LANCE_FLAT_SEARCH_PERCENT_THRESHOLD")
         .unwrap_or_else(|_| "10".to_string())
@@ -776,14 +783,15 @@ impl<'a, S: Scorer> Wand<'a, S> {
                 self.score(doc_length)
             };
 
-            let freqs = self.iter_term_freqs().collect();
             if candidates.len() < limit {
+                let freqs = self.iter_term_freqs().collect();
                 candidates.push(Reverse((ScoredDoc::new(row_id, score), freqs, doc_length)));
                 if candidates.len() == limit {
                     let kth = candidates.peek().unwrap().0.0.score.0;
                     self.update_threshold(kth, params.wand_factor);
                 }
             } else if score > candidates.peek().unwrap().0.0.score.0 {
+                let freqs = self.iter_term_freqs().collect();
                 candidates.pop();
                 candidates.push(Reverse((ScoredDoc::new(row_id, score), freqs, doc_length)));
                 let kth = candidates.peek().unwrap().0.0.score.0;
@@ -894,15 +902,16 @@ impl<'a, S: Scorer> Wand<'a, S> {
 
             self.collect_tail_matches(doc_id);
             let score = self.score(doc_length);
-            let freqs = self.iter_term_freqs().collect();
 
             if candidates.len() < limit {
+                let freqs = self.iter_term_freqs().collect();
                 candidates.push(Reverse((ScoredDoc::new(row_id, score), freqs, doc_length)));
                 if candidates.len() == limit {
                     let kth = candidates.peek().unwrap().0.0.score.0;
                     self.update_threshold(kth, params.wand_factor);
                 }
             } else if score > candidates.peek().unwrap().0.0.score.0 {
+                let freqs = self.iter_term_freqs().collect();
                 candidates.pop();
                 candidates.push(Reverse((ScoredDoc::new(row_id, score), freqs, doc_length)));
                 let kth = candidates.peek().unwrap().0.0.score.0;
@@ -939,6 +948,9 @@ impl<'a, S: Scorer> Wand<'a, S> {
     // iterate over all the preceding terms and collect the term index and frequency
     fn iter_term_freqs(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
         self.lead.iter().filter_map(|posting| {
+            #[cfg(test)]
+            TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.set(calls.get() + 1));
+
             posting
                 .doc()
                 .map(|doc| (posting.term_index(), doc.frequency()))
@@ -2009,6 +2021,78 @@ mod tests {
         assert!(
             or_scored <= 2 * BLOCK_SIZE,
             "expected pruning to skip a block, but scored {or_scored} of {total}",
+        );
+    }
+
+    #[test]
+    fn test_search_does_not_collect_freqs_for_rejected_topk_candidate() {
+        TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.set(0));
+
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        docs.append(1, 1);
+
+        let postings = vec![PostingIterator::with_query_weight(
+            String::from("term"),
+            0,
+            0,
+            1.0,
+            generate_posting_list(vec![0, 1], 1.0, None, false),
+            docs.len(),
+        )];
+
+        let mut wand = Wand::new(Operator::Or, postings.into_iter(), &docs, UnitScorer);
+        let result = wand
+            .search(
+                &FtsSearchParams::new()
+                    .with_limit(Some(1))
+                    .with_wand_factor(0.5),
+                Arc::new(RowAddrMask::default()),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.get()),
+            1,
+            "equal-score candidate rejected by top-k should not collect freqs"
+        );
+    }
+
+    #[test]
+    fn test_flat_search_does_not_collect_freqs_for_rejected_topk_candidate() {
+        TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.set(0));
+
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        docs.append(1, 1);
+
+        let postings = vec![PostingIterator::with_query_weight(
+            String::from("term"),
+            0,
+            0,
+            1.0,
+            generate_posting_list(vec![0, 1], 1.0, None, false),
+            docs.len(),
+        )];
+
+        let mut wand = Wand::new(Operator::Or, postings.into_iter(), &docs, UnitScorer);
+        let result = wand
+            .flat_search(
+                &FtsSearchParams::new()
+                    .with_limit(Some(1))
+                    .with_wand_factor(0.5),
+                Box::new([RowAddress::from(0_u64), RowAddress::from(1_u64)].into_iter()),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.get()),
+            1,
+            "equal-score candidate rejected by flat_search top-k should not collect freqs"
         );
     }
 

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -36,13 +36,6 @@ use super::{DocInfo, builder::BLOCK_SIZE};
 
 const TERMINATED_DOC_ID: u64 = u64::MAX;
 
-#[cfg(test)]
-thread_local! {
-    static TERM_FREQ_COLLECTION_DOC_CALLS: std::cell::Cell<usize> = const {
-        std::cell::Cell::new(0)
-    };
-}
-
 pub static FLAT_SEARCH_PERCENT_THRESHOLD: LazyLock<u64> = LazyLock::new(|| {
     std::env::var("LANCE_FLAT_SEARCH_PERCENT_THRESHOLD")
         .unwrap_or_else(|_| "10".to_string())
@@ -948,9 +941,6 @@ impl<'a, S: Scorer> Wand<'a, S> {
     // iterate over all the preceding terms and collect the term index and frequency
     fn iter_term_freqs(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
         self.lead.iter().filter_map(|posting| {
-            #[cfg(test)]
-            TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.set(calls.get() + 1));
-
             posting
                 .doc()
                 .map(|doc| (posting.term_index(), doc.frequency()))
@@ -2021,78 +2011,6 @@ mod tests {
         assert!(
             or_scored <= 2 * BLOCK_SIZE,
             "expected pruning to skip a block, but scored {or_scored} of {total}",
-        );
-    }
-
-    #[test]
-    fn test_search_does_not_collect_freqs_for_rejected_topk_candidate() {
-        TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.set(0));
-
-        let mut docs = DocSet::default();
-        docs.append(0, 1);
-        docs.append(1, 1);
-
-        let postings = vec![PostingIterator::with_query_weight(
-            String::from("term"),
-            0,
-            0,
-            1.0,
-            generate_posting_list(vec![0, 1], 1.0, None, false),
-            docs.len(),
-        )];
-
-        let mut wand = Wand::new(Operator::Or, postings.into_iter(), &docs, UnitScorer);
-        let result = wand
-            .search(
-                &FtsSearchParams::new()
-                    .with_limit(Some(1))
-                    .with_wand_factor(0.5),
-                Arc::new(RowAddrMask::default()),
-                &NoOpMetricsCollector,
-            )
-            .unwrap();
-
-        assert_eq!(result.len(), 1);
-        assert_eq!(
-            TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.get()),
-            1,
-            "equal-score candidate rejected by top-k should not collect freqs"
-        );
-    }
-
-    #[test]
-    fn test_flat_search_does_not_collect_freqs_for_rejected_topk_candidate() {
-        TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.set(0));
-
-        let mut docs = DocSet::default();
-        docs.append(0, 1);
-        docs.append(1, 1);
-
-        let postings = vec![PostingIterator::with_query_weight(
-            String::from("term"),
-            0,
-            0,
-            1.0,
-            generate_posting_list(vec![0, 1], 1.0, None, false),
-            docs.len(),
-        )];
-
-        let mut wand = Wand::new(Operator::Or, postings.into_iter(), &docs, UnitScorer);
-        let result = wand
-            .flat_search(
-                &FtsSearchParams::new()
-                    .with_limit(Some(1))
-                    .with_wand_factor(0.5),
-                Box::new([RowAddress::from(0_u64), RowAddress::from(1_u64)].into_iter()),
-                &NoOpMetricsCollector,
-            )
-            .unwrap();
-
-        assert_eq!(result.len(), 1);
-        assert_eq!(
-            TERM_FREQ_COLLECTION_DOC_CALLS.with(|calls| calls.get()),
-            1,
-            "equal-score candidate rejected by flat_search top-k should not collect freqs"
         );
     }
 


### PR DESCRIPTION
## Performance Improvement

### What is the performance issue or bottleneck?

WAND search eagerly collected term frequencies for each scored candidate before checking whether that candidate would enter the top-k heap. Candidates rejected by the current kth score still paid for a `Vec` allocation and `PostingIterator::doc()` calls.

### How does this PR improve performance?

This moves term-frequency collection into the two branches that actually insert or replace a top-k candidate, for both WAND search and flat search. Rejected candidates now avoid collecting frequencies entirely.

The PR also adds focused regression tests that count test-only term-frequency collection calls and verify rejected equal-score candidates do not collect frequencies.

### Benchmark

`wikipedia-40m-fts`, V2 `text_idx`, `match`, `query_length=5`, `stop_words=0`, `k=100`, `num_queries=1000`, `seed=0`.

| build | QPS | avg | p50 | p90 | p99 |
|---|---:|---:|---:|---:|---:|
| before `838f78b9` | 127.46 | 62.56ms | 57.20ms | 113.27ms | 223.31ms |
| after `4c05e1c` | 130.34 | 61.17ms | 54.65ms | 112.63ms | 219.22ms |
| delta | +2.26% | -2.22% | -4.46% | -0.56% | -1.83% |

Raw artifacts:

- suite: `/mnt/benchmark-ssd/search-benchmark/bench_suites/wikipedia_fts_wand_freqs_compare_k100_20260618.json`
- log: `/mnt/benchmark-ssd/logs/wikipedia_fts_wand_freqs_compare_k100_v2_20260618_091950.log`
- csv: `/mnt/benchmark-ssd/search-benchmark/results/results_fts_static_20260618_093407.csv`

### Validation

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/lance-target-21fd-pr-clippy cargo clippy --all --tests --benches -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/lance-target-21fd-pr-clippy cargo test -p lance-index scalar::inverted::wand::tests::`
- `git diff --check`
- `/Users/yang/.cache/uv/archive-v0/CK_YxmMYMk7DlRLAQr3It/bin/python -mpre_commit run --files rust/lance-index/src/scalar/inverted/wand.rs -v`