### PR TITLE
perf(index): reuse WAND doc info

### DIFF
--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -976,41 +976,37 @@ impl<'a, S: Scorer> Wand<'a, S> {
                 continue;
             }
 
-            let Some(doc) = self.lead.first().and_then(|posting| posting.doc()) else {
+            let Some(first_doc) = self.lead.first().and_then(|posting| posting.doc()) else {
                 self.push_back_leads(target + 1);
                 continue;
             };
-            let doc_length = match &doc {
+            let doc_length = match &first_doc {
                 DocInfo::Raw(doc) => self.docs.num_tokens(doc.doc_id),
                 DocInfo::Located(doc) => self.docs.num_tokens_by_row_id(doc.row_id),
             };
-            let mut lead_score = self
-                .lead
-                .iter()
-                .filter_map(|posting| {
-                    posting.doc().map(|lead_doc| {
-                        posting.score(&self.scorer, lead_doc.frequency(), doc_length)
-                    })
-                })
-                .sum::<f32>();
+            let mut lead_score = 0.0;
+            if let Some(first_posting) = self.lead.first() {
+                lead_score += first_posting.score(&self.scorer, first_doc.frequency(), doc_length);
+            }
+            for posting in self.lead.iter().skip(1) {
+                if let Some(lead_doc) = posting.doc() {
+                    lead_score += posting.score(&self.scorer, lead_doc.frequency(), doc_length);
+                }
+            }
 
             while lead_score <= self.threshold {
                 if lead_score + self.tail_max_score <= self.threshold {
-                    self.push_back_leads(doc.doc_id() + 1);
+                    self.push_back_leads(first_doc.doc_id() + 1);
                     break;
                 }
                 if !self.advance_tail_top(target, doc_length, &mut lead_score) {
-                    self.push_back_leads(doc.doc_id() + 1);
+                    self.push_back_leads(first_doc.doc_id() + 1);
                     break;
                 }
             }
 
             if !self.lead.is_empty() {
-                return Ok(self
-                    .lead
-                    .first()
-                    .and_then(|posting| posting.doc())
-                    .map(|doc| (doc, lead_score)));
+                return Ok(Some((first_doc, lead_score)));
             }
         }
 
@@ -1401,10 +1397,9 @@ impl<'a, S: Scorer> Wand<'a, S> {
         };
         self.tail_max_score -= upper_bound;
         posting.next(target);
-        match posting.doc().map(|doc| doc.doc_id()) {
-            Some(doc_id) if doc_id == target => {
-                let frequency = posting.doc().expect("posting must exist").frequency();
-                *lead_score += posting.score(&self.scorer, frequency, doc_length);
+        match posting.doc() {
+            Some(doc) if doc.doc_id() == target => {
+                *lead_score += posting.score(&self.scorer, doc.frequency(), doc_length);
                 self.lead.push(posting);
             }
             Some(_) => self.push_head(posting),
@@ -1427,14 +1422,10 @@ impl<'a, S: Scorer> Wand<'a, S> {
         for tail_posting in tail.into_vec() {
             let mut posting = tail_posting.posting;
             posting.next(target);
-            match posting.doc().map(|doc| doc.doc_id()) {
-                Some(doc_id) if doc_id == target => {
+            match posting.doc() {
+                Some(doc) if doc.doc_id() == target => {
                     if let (Some(doc_length), Some(score)) = (doc_length, score.as_deref_mut()) {
-                        let frequency = posting
-                            .doc()
-                            .expect("posting moved to target should have doc")
-                            .frequency();
-                        *score += posting.score(&self.scorer, frequency, doc_length);
+                        *score += posting.score(&self.scorer, doc.frequency(), doc_length);
                     }
                     self.lead.push(posting)
                 }


### PR DESCRIPTION
## Performance Improvement

This PR removes redundant `PostingIterator::doc()` calls in the WAND lead/tail scoring paths without changing `PostingIterator`, `HeadPosting`, heap ordering, public APIs, docs, or wire formats.

The existing `HeadPosting` doc id cache remains unchanged. The refactor reuses already-read `DocInfo` values where the iterator position is known to be the same:

- reuse the first lead posting's `DocInfo` in `Wand::next` for doc length, first lead score, and the returned candidate
- call `posting.doc()` once in `advance_tail_top` after `posting.next(target)` and reuse it for target matching and scoring
- apply the same single-`doc()` pattern per tail posting in `advance_all_tail`

## Benchmark

Fresh GCP VM run with `search-benchmark` FTS static suite, `lance_fts`, `match`, `query_length=5`, `k=10`, `num_queries=1000`, `prewarm_index=true`, `with_position=false`, dataset `gs://fts-bench/yang-db/wikipedia-bench-v2-20260327.lance`.

Search-benchmark commit: `8d05d5680f2fbac38c1642380dc98b8a2bb2140f`.

Measured baseline/candidate SHAs from the pre-rebase benchmark branch:

- baseline: `8743fbaf9ce0dce15373629a7574e14d5c6c9367`
- candidate: `6ac7b2c061d34142838c340fb2dbda509506da63`

Results from one run:

- QPS: 274.768 -> 279.352 (+1.668%)
- avg latency: 28.936 ms -> 28.495 ms (-1.523%)
- p50: 21.703 ms -> 22.259 ms (+2.562% slower)
- p90: 59.845 ms -> 59.059 ms (-1.313%)
- p99: 131.076 ms -> 113.052 ms (-13.751%)

The benchmark was run before rebasing this PR onto the latest `main`; the PR commit contains the same WAND code change rebased onto `c4e65645d75b17c572fee62809b013b3730370bb`.

## Validation

On the rebased PR branch:

- `cargo fmt --all --check`
- `cargo test -p lance-index scalar::inverted::wand`
- `cargo check -p lance-index --tests`
- `cargo clippy --all --tests --benches -- -D warnings`