### PR TITLE
feat: add local SpillStore for index scratch

### DIFF
--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -169,6 +169,16 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+    #[snafu(display(
+        "Disk spill quota exceeded: cap={cap_bytes} bytes, used={used_bytes} bytes, requested={requested_bytes} bytes, {location}"
+    ))]
+    DiskCapExceeded {
+        cap_bytes: u64,
+        used_bytes: u64,
+        requested_bytes: u64,
+        #[snafu(implicit)]
+        location: Location,
+    },
     #[snafu(display("LanceError(Index): {message}, {location}"))]
     Index {
         message: String,
@@ -264,6 +274,16 @@ impl Error {
     #[track_caller]
     pub fn io_source(source: BoxedError) -> Self {
         IOSnafu.into_error(source)
+    }
+
+    #[track_caller]
+    pub fn disk_cap_exceeded(cap_bytes: u64, used_bytes: u64, requested_bytes: u64) -> Self {
+        DiskCapExceededSnafu {
+            cap_bytes,
+            used_bytes,
+            requested_bytes,
+        }
+        .build()
     }
 
     #[track_caller]
@@ -512,7 +532,16 @@ impl From<&ArrowError> for Error {
 impl From<std::io::Error> for Error {
     #[track_caller]
     fn from(e: std::io::Error) -> Self {
-        Self::io_source(box_error(e))
+        if e.get_ref().is_some() {
+            match e.into_inner().expect("io error source checked above") {
+                source => match source.downcast::<Self>() {
+                    Ok(lance_err) => *lance_err,
+                    Err(source) => Self::io_source(source),
+                },
+            }
+        } else {
+            Self::io_source(box_error(e))
+        }
     }
 }
 

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -789,6 +789,58 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
         })
     }
 
+    async fn train_index_with_scratch(
+        &self,
+        data: SendableRecordBatchStream,
+        index_store: &dyn IndexStore,
+        request: Box<dyn TrainingRequest>,
+        fragment_ids: Option<Vec<u32>>,
+        progress: Arc<dyn crate::progress::IndexBuildProgress>,
+        scratch_store: Option<Arc<dyn IndexStore>>,
+    ) -> Result<CreatedIndex> {
+        let request = (request as Box<dyn std::any::Any>)
+            .downcast::<JsonTrainingRequest>()
+            .unwrap();
+        let path = request.parameters.path.clone();
+
+        let (data_stream, inferred_type) =
+            Self::extract_json_with_type_info(data, path.clone()).await?;
+        let converted_stream =
+            Self::convert_stream_by_type(data_stream, inferred_type.clone()).await?;
+
+        let registry = self.registry()?;
+        let target_plugin = registry.get_plugin_by_name(&request.parameters.target_index_type)?;
+        let target_request = target_plugin.new_training_request(
+            request
+                .parameters
+                .target_index_parameters
+                .as_deref()
+                .unwrap_or("{}"),
+            &Field::new("", inferred_type, true),
+        )?;
+
+        let target_index = target_plugin
+            .train_index_with_scratch(
+                converted_stream,
+                index_store,
+                target_request,
+                fragment_ids,
+                progress,
+                scratch_store,
+            )
+            .await?;
+
+        let index_details = crate::pb::JsonIndexDetails {
+            path,
+            target_details: Some(target_index.index_details),
+        };
+        Ok(CreatedIndex {
+            index_details: prost_types::Any::from_msg(&index_details)?,
+            index_version: JSON_INDEX_VERSION,
+            files: target_index.files,
+        })
+    }
+
     async fn load_index(
         &self,
         index_store: Arc<dyn IndexStore>,

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -517,8 +517,7 @@ impl IndexStore for LanceIndexStore {
     async fn rename_index_file(&self, name: &str, new_name: &str) -> Result<IndexFile> {
         let path = self.index_file_path(name)?;
         let new_path = self.index_file_path(new_name)?;
-        self.object_store.copy(&path, &new_path).await?;
-        self.object_store.delete(&path).await?;
+        self.object_store.rename(&path, &new_path).await?;
         let size_bytes = match self.file_sizes.get(name) {
             Some(size_bytes) => *size_bytes,
             None => self.object_store.size(&new_path).await?,

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -731,6 +731,15 @@ impl NGramIndexBuilder {
         Self::from_state(NGramIndexBuildState::starting(), options)
     }
 
+    pub fn try_new_with_spill_store(
+        options: NGramIndexBuilderOptions,
+        spill_store: Arc<dyn IndexStore>,
+    ) -> Result<Self> {
+        let mut builder = Self::from_state(NGramIndexBuildState::starting(), options)?;
+        builder.spill_store = spill_store;
+        Ok(builder)
+    }
+
     fn clone_worker(&self, worker_number: usize) -> Self {
         let mut bitmaps = Vec::with_capacity(36 * 36 * 36 + 1);
         // Token 0 is always the NULL bitmap
@@ -1265,7 +1274,12 @@ impl NGramIndexBuilder {
             offset += batch_size;
         }
 
-        writer.finish().await
+        let index_file = writer.finish().await?;
+        drop(reader);
+        self.spill_store
+            .delete_index_file(&Self::spill_filename(index_to_copy))
+            .await?;
+        Ok(index_file)
     }
 }
 
@@ -1354,6 +1368,39 @@ impl ScalarIndexPlugin for NGramIndexPlugin {
         })
     }
 
+    async fn train_index_with_scratch(
+        &self,
+        data: SendableRecordBatchStream,
+        index_store: &dyn IndexStore,
+        _request: Box<dyn TrainingRequest>,
+        fragment_ids: Option<Vec<u32>>,
+        _progress: Arc<dyn crate::progress::IndexBuildProgress>,
+        scratch_store: Option<Arc<dyn IndexStore>>,
+    ) -> Result<CreatedIndex> {
+        if fragment_ids.is_some() {
+            return Err(Error::invalid_input_source(
+                "NGram index does not support fragment training".into(),
+            ));
+        }
+
+        let mut builder = match scratch_store {
+            Some(scratch_store) => NGramIndexBuilder::try_new_with_spill_store(
+                NGramIndexBuilderOptions::default(),
+                scratch_store,
+            )?,
+            None => NGramIndexBuilder::try_new(NGramIndexBuilderOptions::default())?,
+        };
+        let spill_files = builder.train(data).await?;
+        let file = builder.write_index(index_store, spill_files, None).await?;
+
+        Ok(CreatedIndex {
+            index_details: prost_types::Any::from_msg(&pbold::NGramIndexDetails::default())
+                .unwrap(),
+            index_version: NGRAM_INDEX_VERSION,
+            files: vec![file],
+        })
+    }
+
     async fn load_index(
         &self,
         index_store: Arc<dyn IndexStore>,
@@ -1383,7 +1430,7 @@ mod tests {
     use itertools::Itertools;
     use lance_core::{ROW_ID, cache::LanceCache, utils::tempfile::TempDir};
     use lance_datagen::{BatchCount, ByteCount, RowCount};
-    use lance_io::object_store::ObjectStore;
+    use lance_io::{object_store::ObjectStore, object_writer::DiskQuota};
     use lance_select::RowAddrTreeMap;
     use lance_tokenizer::TextAnalyzer;
 
@@ -1880,5 +1927,41 @@ mod tests {
         let (index, _tmpdir) = do_train(builder, data).await;
 
         assert_eq!(index.tokens.len(), 29012);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_ngram_index_uses_quota_backed_spill_store() {
+        let (data, schema) = lance_datagen::gen_batch()
+            .col(
+                VALUE_COLUMN_NAME,
+                lance_datagen::array::rand_utf8(ByteCount::from(50), false),
+            )
+            .col(ROW_ID, lance_datagen::array::step::<UInt64Type>())
+            .into_reader_stream(RowCount::from(128), BatchCount::from(32));
+
+        let data = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            data.map_err(|arrow_err| DataFusionError::ArrowError(Box::new(arrow_err), None)),
+        ));
+
+        let quota = DiskQuota::new(16 * 1024 * 1024);
+        let tmpdir = Arc::new(TempDir::default());
+        let spill_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local_with_disk_quota(quota.clone())),
+            tmpdir.obj_path(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let builder = NGramIndexBuilder::try_new_with_spill_store(
+            NGramIndexBuilderOptions {
+                tokens_per_spill: 100,
+            },
+            spill_store,
+        )
+        .unwrap();
+
+        let (index, _tmpdir) = do_train(builder, data).await;
+
+        assert_eq!(index.tokens.len(), 29012);
+        assert_eq!(quota.used_bytes(), 0);
     }
 }

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -122,6 +122,21 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
         progress: Arc<dyn IndexBuildProgress>,
     ) -> Result<CreatedIndex>;
 
+    /// Train a new index with a caller-provided scratch store for temporary
+    /// build files. Plugins that do not need scratch storage can ignore it.
+    async fn train_index_with_scratch(
+        &self,
+        data: SendableRecordBatchStream,
+        index_store: &dyn IndexStore,
+        request: Box<dyn TrainingRequest>,
+        fragment_ids: Option<Vec<u32>>,
+        progress: Arc<dyn IndexBuildProgress>,
+        _scratch_store: Option<Arc<dyn IndexStore>>,
+    ) -> Result<CreatedIndex> {
+        self.train_index(data, index_store, request, fragment_ids, progress)
+            .await
+    }
+
     /// A short name for the index
     ///
     /// This is a friendly name for display purposes and also can be used as an alias for

--- a/rust/lance-index/src/scalar/rtree.rs
+++ b/rust/lance-index/src/scalar/rtree.rs
@@ -974,6 +974,57 @@ impl ScalarIndexPlugin for RTreeIndexPlugin {
         })
     }
 
+    async fn train_index_with_scratch(
+        &self,
+        data: SendableRecordBatchStream,
+        index_store: &dyn IndexStore,
+        request: Box<dyn TrainingRequest>,
+        fragment_ids: Option<Vec<u32>>,
+        _progress: Arc<dyn crate::progress::IndexBuildProgress>,
+        scratch_store: Option<Arc<dyn IndexStore>>,
+    ) -> Result<CreatedIndex> {
+        if fragment_ids.is_some() {
+            return Err(Error::invalid_input_source(
+                "RTree index does not support fragment training".into(),
+            ));
+        }
+
+        Self::validate_schema(&data.schema())?;
+
+        let request = request
+            .as_any()
+            .downcast_ref::<RTreeTrainingRequest>()
+            .unwrap();
+        let page_size = request
+            .parameters
+            .page_size
+            .unwrap_or(DEFAULT_RTREE_PAGE_SIZE);
+
+        let bbox_data = Self::convert_bbox_stream(data)?;
+        let fallback_tmpdir;
+        let spill_store = match scratch_store {
+            Some(scratch_store) => scratch_store,
+            None => {
+                fallback_tmpdir = Arc::new(TempDir::default());
+                Arc::new(LanceIndexStore::new(
+                    Arc::new(ObjectStore::local()),
+                    fallback_tmpdir.obj_path(),
+                    Arc::new(LanceCache::no_cache()),
+                ))
+            }
+        };
+        let (bbox_data, stats) =
+            Self::process_and_analyze_bbox_stream(bbox_data, page_size, spill_store).await?;
+
+        let files = Self::train_rtree_index(bbox_data, stats, page_size, index_store).await?;
+
+        Ok(CreatedIndex {
+            index_details: prost_types::Any::from_msg(&pb::RTreeIndexDetails::default())?,
+            index_version: RTREE_INDEX_VERSION,
+            files,
+        })
+    }
+
     fn provides_exact_answer(&self) -> bool {
         false
     }

--- a/rust/lance-io/src/lib.rs
+++ b/rust/lance-io/src/lib.rs
@@ -18,6 +18,7 @@ pub mod object_reader;
 pub mod object_store;
 pub mod object_writer;
 pub mod scheduler;
+pub mod spill;
 pub mod stream;
 #[cfg(test)]
 pub mod testing;

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -46,7 +46,7 @@ pub(crate) mod test_utils;
 pub mod throttle;
 mod tracing;
 use crate::object_reader::SmallReader;
-use crate::object_writer::{LocalWriter, WriteResult};
+use crate::object_writer::{DiskQuota, LocalWriter, WriteResult};
 use crate::traits::{WriteExt, Writer};
 use crate::utils::tracking_store::{IOTracker, IoStats};
 use crate::{object_reader::CloudObjectReader, object_writer::ObjectWriter, traits::Reader};
@@ -146,6 +146,8 @@ pub struct ObjectStore {
     download_retry_count: usize,
     /// IO tracker for monitoring read/write operations
     io_tracker: IOTracker,
+    /// Optional local write budget used by spill stores.
+    disk_quota: Option<DiskQuota>,
     /// The datastore prefix that uniquely identifies this object store. It encodes information
     /// which usually cannot be found in the URL such as Azure account name. The prefix plus the
     /// path uniquely identifies any object inside the store.
@@ -479,6 +481,7 @@ impl ObjectStore {
                 io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
                 download_retry_count: DEFAULT_DOWNLOAD_RETRY_COUNT,
                 io_tracker,
+                disk_quota: None,
                 store_prefix,
             };
             let path = Path::parse(path.path())?;
@@ -534,6 +537,13 @@ impl ObjectStore {
             .now_or_never()
             .unwrap()
             .unwrap()
+    }
+
+    /// Local object store with a shared local write quota.
+    pub fn local_with_disk_quota(disk_quota: DiskQuota) -> Self {
+        let mut store = Self::local();
+        store.disk_quota = Some(disk_quota);
+        store
     }
 
     /// Create a in-memory object store directly for testing.
@@ -756,11 +766,36 @@ impl ObjectStore {
                         .map_err(|e| Error::io(format!("spawn_blocking failed: {}", e)))??;
                 let (std_file, temp_path) = named_temp.into_parts();
                 let file = tokio::fs::File::from_std(std_file);
-                Ok(Box::new(LocalWriter::new(
+                Ok(Box::new(LocalWriter::new_with_disk_quota(
                     file,
                     path.clone(),
                     temp_path,
                     Arc::new(self.io_tracker.clone()),
+                    self.disk_quota.clone(),
+                )))
+            }
+            "file+uring" => {
+                let local_path = super::local::to_local_path(path);
+                let local_path = std::path::PathBuf::from(&local_path);
+                if let Some(parent) = local_path.parent() {
+                    tokio::fs::create_dir_all(parent).await?;
+                }
+                let parent = local_path
+                    .parent()
+                    .expect("file path must have parent")
+                    .to_owned();
+                let named_temp =
+                    tokio::task::spawn_blocking(move || tempfile::NamedTempFile::new_in(parent))
+                        .await
+                        .map_err(|e| Error::io(format!("spawn_blocking failed: {}", e)))??;
+                let (std_file, temp_path) = named_temp.into_parts();
+                let file = tokio::fs::File::from_std(std_file);
+                Ok(Box::new(LocalWriter::new_with_disk_quota(
+                    file,
+                    path.clone(),
+                    temp_path,
+                    Arc::new(self.io_tracker.clone()),
+                    self.disk_quota.clone(),
                 )))
             }
             _ => Ok(Box::new(ObjectWriter::new(self, path).await?)),
@@ -1109,6 +1144,7 @@ impl ObjectStore {
             io_parallelism,
             download_retry_count,
             io_tracker,
+            disk_quota: None,
             store_prefix,
         }
     }

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -31,7 +31,7 @@ use providers::memory::MemoryStoreProvider;
 use tokio::io::AsyncWriteExt;
 use url::Url;
 
-use super::local::LocalObjectReader;
+use super::local::{LocalObjectReader, to_local_path};
 #[cfg(target_os = "linux")]
 use crate::uring::{UringCurrentThreadReader, UringReader};
 #[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
@@ -810,8 +810,32 @@ impl ObjectStore {
     }
 
     pub async fn delete(&self, path: &Path) -> Result<()> {
+        let local_size = if self.is_local() {
+            std::fs::metadata(to_local_path(path)).ok().map(|m| m.len())
+        } else {
+            None
+        };
         self.inner.delete(path).await?;
+        if let (Some(disk_quota), Some(size)) = (self.disk_quota.as_ref(), local_size) {
+            disk_quota.release(size);
+        }
         Ok(())
+    }
+
+    /// Rename a local file without copying so disk quota does not double during
+    /// scratch-file moves. Non-local stores keep the existing copy/delete path.
+    pub async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        if self.is_local() {
+            let from_path = to_local_path(from);
+            let to_path = to_local_path(to);
+            if let Some(parent) = std::path::Path::new(&to_path).parent() {
+                std::fs::create_dir_all(parent).map_err(Error::from)?;
+            }
+            std::fs::rename(from_path, to_path).map_err(Error::from)?;
+            return Ok(());
+        }
+        self.copy(from, to).await?;
+        self.delete(from).await
     }
 
     /// AWS S3 and GCS reject a single-shot server-side copy whose source is
@@ -1592,6 +1616,39 @@ mod tests {
         assert!(dest_file.parent().unwrap().exists());
         let copied_content = std::fs::read(&dest_file).unwrap();
         assert_eq!(copied_content, b"test content");
+    }
+
+    #[tokio::test]
+    async fn test_local_delete_releases_disk_quota() {
+        let quota = DiskQuota::new(8);
+        let store = ObjectStore::local_with_disk_quota(quota.clone());
+        let tmp = TempStdDir::default();
+        let path = Path::from_absolute_path(tmp.join("spill.bin")).unwrap();
+
+        store.put(&path, b"12345678").await.unwrap();
+        assert_eq!(quota.used_bytes(), 8);
+
+        store.delete(&path).await.unwrap();
+        assert_eq!(quota.used_bytes(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_local_rename_preserves_disk_quota() {
+        let quota = DiskQuota::new(8);
+        let store = ObjectStore::local_with_disk_quota(quota.clone());
+        let tmp = TempStdDir::default();
+        let from = Path::from_absolute_path(tmp.join("spill.tmp")).unwrap();
+        let to = Path::from_absolute_path(tmp.join("spill.bin")).unwrap();
+
+        store.put(&from, b"12345678").await.unwrap();
+        store.rename(&from, &to).await.unwrap();
+
+        assert_eq!(quota.used_bytes(), 8);
+        assert!(!tmp.join("spill.tmp").exists());
+        assert!(tmp.join("spill.bin").exists());
+
+        store.delete(&to).await.unwrap();
+        assert_eq!(quota.used_bytes(), 0);
     }
 
     /// Inner store that forwards everything to `InMemory` except single-shot

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -177,6 +177,7 @@ impl ObjectStoreProvider for AwsStoreProvider {
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count,
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
         })

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -283,6 +283,7 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count,
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
         })

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -136,6 +136,7 @@ impl ObjectStoreProvider for GcsStoreProvider {
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count,
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
         })

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -158,6 +158,7 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
         })

--- a/rust/lance-io/src/object_store/providers/huggingface.rs
+++ b/rust/lance-io/src/object_store/providers/huggingface.rs
@@ -216,6 +216,7 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count,
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
         })

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -31,6 +31,7 @@ impl ObjectStoreProvider for FileStoreProvider {
             io_parallelism: DEFAULT_LOCAL_IO_PARALLELISM,
             download_retry_count,
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
         })

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -31,6 +31,7 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count,
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
         })

--- a/rust/lance-io/src/object_store/providers/oss.rs
+++ b/rust/lance-io/src/object_store/providers/oss.rs
@@ -144,6 +144,7 @@ impl ObjectStoreProvider for OssStoreProvider {
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
         })
     }

--- a/rust/lance-io/src/object_store/providers/tencent.rs
+++ b/rust/lance-io/src/object_store/providers/tencent.rs
@@ -100,6 +100,7 @@ impl ObjectStoreProvider for TencentStoreProvider {
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
         })
     }

--- a/rust/lance-io/src/object_store/providers/tos.rs
+++ b/rust/lance-io/src/object_store/providers/tos.rs
@@ -150,6 +150,7 @@ impl ObjectStoreProvider for TosStoreProvider {
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
+            disk_quota: None,
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
         })
     }

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -3,6 +3,7 @@
 
 use std::io;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::task::Poll;
 
@@ -518,11 +519,73 @@ pub struct LocalWriter {
     state: LocalWriteState,
 }
 
+/// Shared byte budget for local spill writes.
+#[derive(Debug, Clone)]
+pub struct DiskQuota {
+    cap_bytes: u64,
+    used_bytes: Arc<AtomicU64>,
+}
+
+impl DiskQuota {
+    pub fn new(cap_bytes: u64) -> Self {
+        Self {
+            cap_bytes,
+            used_bytes: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn cap_bytes(&self) -> u64 {
+        self.cap_bytes
+    }
+
+    pub fn used_bytes(&self) -> u64 {
+        self.used_bytes.load(Ordering::Acquire)
+    }
+
+    pub fn reserve(&self, requested_bytes: u64) -> Result<()> {
+        let mut used = self.used_bytes();
+        loop {
+            let Some(next_used) = used.checked_add(requested_bytes) else {
+                return Err(Error::disk_cap_exceeded(
+                    self.cap_bytes,
+                    used,
+                    requested_bytes,
+                ));
+            };
+            if next_used > self.cap_bytes {
+                return Err(Error::disk_cap_exceeded(
+                    self.cap_bytes,
+                    used,
+                    requested_bytes,
+                ));
+            }
+            match self.used_bytes.compare_exchange_weak(
+                used,
+                next_used,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(actual) => used = actual,
+            }
+        }
+    }
+
+    pub fn release(&self, bytes: u64) {
+        let _ = self
+            .used_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |used| {
+                Some(used.saturating_sub(bytes))
+            });
+    }
+}
+
 #[derive(Default)]
 enum LocalWriteState {
     Writing(WritingState),
     Finishing {
         size: usize,
+        disk_quota: Option<DiskQuota>,
         future: BoxFuture<'static, Result<WriteResult>>,
     },
     Done(WriteResult),
@@ -536,6 +599,7 @@ struct WritingState {
     /// Temp path that auto-deletes on drop. Set to `None` after `persist()`.
     temp_path: tempfile::TempPath,
     io_tracker: Arc<IOTracker>,
+    disk_quota: Option<DiskQuota>,
 }
 
 impl LocalWriter {
@@ -545,6 +609,16 @@ impl LocalWriter {
         temp_path: tempfile::TempPath,
         io_tracker: Arc<IOTracker>,
     ) -> Self {
+        Self::new_with_disk_quota(file, path, temp_path, io_tracker, None)
+    }
+
+    pub fn new_with_disk_quota(
+        file: tokio::fs::File,
+        path: Path,
+        temp_path: tempfile::TempPath,
+        io_tracker: Arc<IOTracker>,
+        disk_quota: Option<DiskQuota>,
+    ) -> Self {
         Self {
             path,
             state: LocalWriteState::Writing(WritingState {
@@ -552,6 +626,7 @@ impl LocalWriter {
                 cursor: 0,
                 temp_path,
                 io_tracker,
+                disk_quota,
             }),
         }
     }
@@ -606,9 +681,41 @@ impl AsyncWrite for LocalWriter {
         buf: &[u8],
     ) -> Poll<std::result::Result<usize, std::io::Error>> {
         if let LocalWriteState::Writing(state) = &mut self.state {
-            let poll = Pin::new(&mut state.writer).poll_write(cx, buf);
+            if buf.is_empty() {
+                return Poll::Ready(Ok(0));
+            }
+
+            let requested = if let Some(disk_quota) = state.disk_quota.as_ref() {
+                let available = disk_quota
+                    .cap_bytes()
+                    .saturating_sub(disk_quota.used_bytes())
+                    as usize;
+                let requested = available.min(buf.len());
+                if requested == 0 {
+                    let err = Error::disk_cap_exceeded(
+                        disk_quota.cap_bytes(),
+                        disk_quota.used_bytes(),
+                        buf.len() as u64,
+                    );
+                    return Poll::Ready(Err(io::Error::other(err)));
+                }
+                if let Err(err) = disk_quota.reserve(requested as u64) {
+                    return Poll::Ready(Err(io::Error::other(err)));
+                }
+                requested
+            } else {
+                buf.len()
+            };
+
+            let poll = Pin::new(&mut state.writer).poll_write(cx, &buf[..requested]);
             if let Poll::Ready(Ok(n)) = &poll {
                 state.cursor += *n;
+            }
+            if let Some(disk_quota) = state.disk_quota.as_ref() {
+                match &poll {
+                    Poll::Ready(Ok(n)) => disk_quota.release((requested - *n) as u64),
+                    Poll::Ready(Err(_)) | Poll::Pending => disk_quota.release(requested as u64),
+                }
             }
             poll
         } else {
@@ -648,6 +755,7 @@ impl AsyncWrite for LocalWriter {
                     let size = state.cursor;
                     mut_self.state = LocalWriteState::Finishing {
                         size,
+                        disk_quota: state.disk_quota,
                         future: Box::pin(Self::persist(
                             state.temp_path,
                             mut_self.path.clone(),
@@ -668,6 +776,26 @@ impl AsyncWrite for LocalWriter {
                     return Poll::Ready(Err(Self::poisoned_err(&self.path)));
                 }
             }
+        }
+    }
+}
+
+impl Drop for LocalWriter {
+    fn drop(&mut self) {
+        match &self.state {
+            LocalWriteState::Writing(state) => {
+                if let Some(disk_quota) = state.disk_quota.as_ref() {
+                    disk_quota.release(state.cursor as u64);
+                }
+            }
+            LocalWriteState::Finishing {
+                size, disk_quota, ..
+            } => {
+                if let Some(disk_quota) = disk_quota.as_ref() {
+                    disk_quota.release(*size as u64);
+                }
+            }
+            LocalWriteState::Done(_) | LocalWriteState::Poisoned => {}
         }
     }
 }

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -730,6 +730,19 @@ impl ScanScheduler {
         self.open_file_with_priority(path, 0, file_size_bytes).await
     }
 
+    /// Open a scheduler over an already-open reader.
+    pub fn open_reader(self: &Arc<Self>, reader: Arc<dyn Reader>) -> FileScheduler {
+        FileScheduler {
+            block_size: reader.block_size() as u64,
+            max_iop_size: self.object_store.max_iop_size(),
+            reader,
+            root: self.clone(),
+            base_priority: 0,
+            bypass_backpressure: false,
+            extra_stats: None,
+        }
+    }
+
     fn do_submit_request(
         &self,
         reader: Arc<dyn Reader>,

--- a/rust/lance-io/src/spill.rs
+++ b/rust/lance-io/src/spill.rs
@@ -18,6 +18,12 @@ use crate::traits::{Reader, Writer};
 
 /// Session-scoped scratch store for reclaimable intermediate files.
 pub trait SpillStore: Send + Sync + std::fmt::Debug + 'static {
+    /// Object store backing the scratch directory.
+    fn object_store(&self) -> Arc<ObjectStore>;
+
+    /// Root directory for files owned by this scratch store.
+    fn root_path(&self) -> Path;
+
     /// Create one empty scratch file. The file is deleted when the returned
     /// handle is dropped.
     fn create_spill_file(&self) -> Result<Box<dyn SpillFile>>;
@@ -75,6 +81,14 @@ impl LocalSpillStore {
 }
 
 impl SpillStore for LocalSpillStore {
+    fn object_store(&self) -> Arc<ObjectStore> {
+        self.object_store.clone()
+    }
+
+    fn root_path(&self) -> Path {
+        self.temp_dir.obj_path()
+    }
+
     fn create_spill_file(&self) -> Result<Box<dyn SpillFile>> {
         let file_id = self.next_file_id.fetch_add(1, Ordering::Relaxed);
         let path = self

--- a/rust/lance-io/src/spill.rs
+++ b/rust/lance-io/src/spill.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Temporary scratch storage for memory-budgeted builders.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use lance_core::Result;
+use lance_core::utils::tempfile::TempDir;
+use object_store::path::Path;
+
+use crate::local::to_local_path;
+use crate::object_store::ObjectStore;
+use crate::object_writer::DiskQuota;
+use crate::traits::{Reader, Writer};
+
+/// Session-scoped scratch store for reclaimable intermediate files.
+pub trait SpillStore: Send + Sync + std::fmt::Debug + 'static {
+    /// Create one empty scratch file. The file is deleted when the returned
+    /// handle is dropped.
+    fn create_spill_file(&self) -> Result<Box<dyn SpillFile>>;
+}
+
+/// A single reclaimable spill file.
+#[async_trait]
+pub trait SpillFile: Send + Sync + std::fmt::Debug {
+    /// Open a writer for this spill file.
+    async fn writer(&self) -> Result<Box<dyn Writer>>;
+
+    /// Open a reader for this spill file.
+    async fn reader(&self) -> Result<Box<dyn Reader>>;
+
+    /// Return the object-store path for diagnostics and tests.
+    fn path(&self) -> &Path;
+}
+
+/// Local-disk implementation of [`SpillStore`].
+#[derive(Debug)]
+pub struct LocalSpillStore {
+    temp_dir: Arc<TempDir>,
+    object_store: Arc<ObjectStore>,
+    disk_quota: DiskQuota,
+    next_file_id: AtomicU64,
+}
+
+impl LocalSpillStore {
+    /// Create a local spill store capped at `cap_bytes` live scratch bytes.
+    pub fn try_new(cap_bytes: u64) -> Result<Self> {
+        let temp_dir = Arc::new(TempDir::try_new()?);
+        let disk_quota = DiskQuota::new(cap_bytes);
+        Ok(Self {
+            temp_dir,
+            object_store: Arc::new(ObjectStore::local_with_disk_quota(disk_quota.clone())),
+            disk_quota,
+            next_file_id: AtomicU64::new(0),
+        })
+    }
+
+    /// Create a local spill store in the system temporary directory.
+    pub fn new(cap_bytes: u64) -> Self {
+        Self::try_new(cap_bytes).expect("failed to create local spill store")
+    }
+
+    /// Return the configured cap in bytes.
+    pub fn cap_bytes(&self) -> u64 {
+        self.disk_quota.cap_bytes()
+    }
+
+    /// Return the currently reserved spill bytes.
+    pub fn used_bytes(&self) -> u64 {
+        self.disk_quota.used_bytes()
+    }
+}
+
+impl SpillStore for LocalSpillStore {
+    fn create_spill_file(&self) -> Result<Box<dyn SpillFile>> {
+        let file_id = self.next_file_id.fetch_add(1, Ordering::Relaxed);
+        let path = self
+            .temp_dir
+            .std_path()
+            .join(format!("spill-{file_id}.bin"));
+        let path = Path::from_absolute_path(path)?;
+        Ok(Box::new(LocalSpillFile {
+            _temp_dir: self.temp_dir.clone(),
+            object_store: self.object_store.clone(),
+            disk_quota: self.disk_quota.clone(),
+            path,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct LocalSpillFile {
+    _temp_dir: Arc<TempDir>,
+    object_store: Arc<ObjectStore>,
+    disk_quota: DiskQuota,
+    path: Path,
+}
+
+#[async_trait]
+impl SpillFile for LocalSpillFile {
+    async fn writer(&self) -> Result<Box<dyn Writer>> {
+        self.object_store.create(&self.path).await
+    }
+
+    async fn reader(&self) -> Result<Box<dyn Reader>> {
+        self.object_store.open(&self.path).await
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for LocalSpillFile {
+    fn drop(&mut self) {
+        let local_path = to_local_path(&self.path);
+        if let Ok(metadata) = std::fs::metadata(&local_path) {
+            self.disk_quota.release(metadata.len());
+        }
+        if let Err(err) = std::fs::remove_file(&local_path)
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(path = %self.path, error = %err, "failed to remove spill file");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use lance_core::Error;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn local_spill_file_cleans_up_and_releases_quota() {
+        let store = LocalSpillStore::try_new(1024).unwrap();
+        let spill = store.create_spill_file().unwrap();
+        let path = spill.path().clone();
+
+        let mut writer = spill.writer().await.unwrap();
+        writer.write_all(b"hello spill").await.unwrap();
+        Writer::shutdown(&mut writer).await.unwrap();
+
+        assert_eq!(store.used_bytes(), 11);
+        assert!(std::path::Path::new(&to_local_path(&path)).exists());
+
+        let reader = spill.reader().await.unwrap();
+        assert_eq!(
+            reader.get_all().await.unwrap(),
+            Bytes::from_static(b"hello spill")
+        );
+
+        drop(spill);
+
+        assert_eq!(store.used_bytes(), 0);
+        assert!(!std::path::Path::new(&to_local_path(&path)).exists());
+    }
+
+    #[tokio::test]
+    async fn local_spill_file_returns_typed_error_on_cap_exhaustion() {
+        let store = LocalSpillStore::try_new(4).unwrap();
+        let spill = store.create_spill_file().unwrap();
+        let mut writer = spill.writer().await.unwrap();
+
+        writer.write_all(b"abcd").await.unwrap();
+        let err = writer.write_all(b"e").await.unwrap_err();
+        let err = Error::from(err);
+
+        assert!(matches!(err, Error::DiskCapExceeded { .. }));
+    }
+}

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -294,6 +294,12 @@ pub(super) async fn build_scalar_index(
     let field: arrow_schema::Field = field.into();
 
     let index_store = LanceIndexStore::from_dataset_for_new(dataset, &uuid)?;
+    let spill_store = dataset.session().spill_store();
+    let scratch_store: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
+        spill_store.object_store(),
+        spill_store.root_path().join(uuid.to_string()),
+        Arc::new(lance_core::cache::LanceCache::no_cache()),
+    ));
 
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
     let training_request =
@@ -317,12 +323,13 @@ pub(super) async fn build_scalar_index(
     progress.stage_complete("load_data").await?;
 
     let created_index = plugin
-        .train_index(
+        .train_index_with_scratch(
             training_data,
             &index_store,
             training_request,
             fragment_ids,
             progress,
+            Some(scratch_store),
         )
         .await?;
 

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -9,6 +9,7 @@ use lance_core::deepsize::DeepSizeOf;
 use lance_core::{Error, Result};
 use lance_index::IndexType;
 use lance_io::object_store::ObjectStoreRegistry;
+use lance_io::spill::{LocalSpillStore, SpillStore};
 
 use crate::dataset::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
 use crate::session::caches::GlobalMetadataCache;
@@ -53,6 +54,8 @@ pub struct Session {
     pub(crate) index_extensions: HashMap<(IndexType, String), Arc<dyn IndexExtension>>,
 
     store_registry: Arc<ObjectStoreRegistry>,
+
+    spill_store: Arc<dyn SpillStore>,
 }
 
 impl DeepSizeOf for Session {
@@ -83,6 +86,7 @@ impl std::fmt::Debug for Session {
                 "index_extensions",
                 &self.index_extensions.keys().collect::<Vec<_>>(),
             )
+            .field("spill_store", &self.spill_store)
             .finish()
     }
 }
@@ -107,6 +111,7 @@ impl Session {
             metadata_cache: GlobalMetadataCache(LanceCache::with_capacity(metadata_cache_size)),
             index_extensions: HashMap::new(),
             store_registry,
+            spill_store: Arc::new(LocalSpillStore::new(u64::MAX)),
         }
     }
 
@@ -124,7 +129,14 @@ impl Session {
             metadata_cache: GlobalMetadataCache(LanceCache::with_capacity(metadata_cache_size)),
             index_extensions: HashMap::new(),
             store_registry,
+            spill_store: Arc::new(LocalSpillStore::new(u64::MAX)),
         }
+    }
+
+    /// Set the spill store used for temporary index-build scratch.
+    pub fn with_spill_store(mut self, spill_store: Arc<dyn SpillStore>) -> Self {
+        self.spill_store = spill_store;
+        self
     }
 
     /// Register a new index extension.
@@ -193,6 +205,11 @@ impl Session {
     /// Get the object store registry.
     pub fn store_registry(&self) -> Arc<ObjectStoreRegistry> {
         self.store_registry.clone()
+    }
+
+    /// Get the session spill store.
+    pub fn spill_store(&self) -> Arc<dyn SpillStore> {
+        self.spill_store.clone()
     }
 
     /// Get a reference to the raw metadata cache (for use in index reconstruction).


### PR DESCRIPTION
## Summary

This extends the local spill store into the scalar index build path so temporary index files can use session-scoped, quota-aware scratch storage instead of ad hoc unbounded temp directories.

Changes include:
- expose the session spill store as a scratch-backed `LanceIndexStore`
- add a scratch-aware scalar plugin training hook with default fallback behavior
- wire ngram and rtree training scratch through the session spill store
- propagate scratch through JSON indexes when they delegate to another scalar plugin
- release quota on local delete and avoid copy-then-delete quota spikes during local rename
- clean up the final ngram spill file after copying it into the destination index
- add focused quota tests for local delete/rename and ngram scratch cleanup

This makes the spill primitive useful for real index builders while keeping the plugin API backward-compatible for builders that do not need scratch storage.

## Validation

- `rustup run nightly-2026-03-21 cargo fmt --all`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_BUILD_JOBS=1 rustup run nightly-2026-03-21 cargo check -p lance-io --no-default-features`

I also tried `cargo check -p lance-index --no-default-features`; it reached `lance-encoding` and stopped because this machine does not have `protoc` installed.

Refs #7300
