### PR TITLE
perf(index): add exact null-row bitmap to zone map and bloom filter

### DIFF
--- a/docs/src/format/index/scalar/bloom_filter.md
+++ b/docs/src/format/index/scalar/bloom_filter.md
@@ -4,6 +4,9 @@ Bloom filters are probabilistic data structures that allow for fast membership t
 They are space-efficient and can test whether an element is a member of a set.
 It's an inexact filter - they may include false positives but never false negatives.
 
+In addition, since finding NULLs is a common query pattern, the index also maintains a
+bitmap of null rows which allows it to return exact results for IS NULL queries.
+
 ## Index Details
 
 ```protobuf
@@ -32,6 +35,13 @@ The bloom filter index stores zone-based bloom filters in a single file:
 |---------------------------|--------|-------------------------------------------------------------|
 | `bloomfilter_item`        | String | Expected number of items per zone (default: "8192")         |
 | `bloomfilter_probability` | String | False positive probability (default: "0.00057", ~1 in 1754) |
+| `null_bitmap`             | UInt32 | Index of null bitmap global buffer                          |
+
+### Global Buffers
+
+| Metadata Key        | Description                                                |
+|---------------------|------------------------------------------------------------|
+| `null_bitmap`       | A serialized RowAddrTreeMap specifying which rows are null |
 
 ## Bloom Filter Spec
 
@@ -122,10 +132,11 @@ Offset 60-63:  Block 1, Word 7 (32-bit LE)
 
 ## Accelerated Queries
 
-The bloom filter index provides inexact results for the following query types:
+The bloom filter index provides inexact results for the following query types (nullability queries
+return exact results):
 
 | Query Type | Description               | Operation                                 | Result Type |
 |------------|---------------------------|-------------------------------------------|-------------|
 | **Equals** | `column = value`          | Tests if value exists in bloom filter     | AtMost      |
 | **IsIn**   | `column IN (v1, v2, ...)` | Tests if any value exists in bloom filter | AtMost      |
-| **IsNull** | `column IS NULL`          | Returns zones where has_null is true      | AtMost      |
+| **IsNull** | `column IS NULL`          | Returns zones where has_null is true      | Exact       |

--- a/docs/src/format/index/scalar/zonemap.md
+++ b/docs/src/format/index/scalar/zonemap.md
@@ -8,6 +8,9 @@ zones that cannot contain matching values.
 Zone maps are "inexact" filters - they can definitively exclude zones but may include
 false positives that require rechecking.
 
+In addition, since finding NULLs is a common query pattern, the index also maintains a
+bitmap of null rows which allows it to return exact results for IS NULL queries.
+
 ## Index Details
 
 ```protobuf
@@ -34,17 +37,25 @@ The zone map index stores zone statistics in a single file:
 
 ### Schema Metadata
 
-| Key             | Type   | Description                               |
-|-----------------|--------|-------------------------------------------|
-| `rows_per_zone` | String | Number of rows per zone (default: "8192") |
+| Key                 | Type   | Description                               |
+|---------------------|--------|-------------------------------------------|
+| `rows_per_zone`     | String | Number of rows per zone (default: "8192") |
+| `null_bitmap`       | UInt32 | Index of null bitmap global buffer        |
+
+### Global Buffers
+
+| Metadata Key        | Description                                                |
+|---------------------|------------------------------------------------------------|
+| `null_bitmap`       | A serialized RowAddrTreeMap specifying which rows are null |
 
 ## Accelerated Queries
 
-The zone map index provides inexact results for the following query types:
+The zone map index provides inexact results for the following query types (nullability queries
+return exact results):
 
 | Query Type | Description               | Operation                                   | Result Type |
 |------------|---------------------------|---------------------------------------------|-------------|
 | **Equals** | `column = value`          | Includes zones where min ≤ value ≤ max      | AtMost      |
 | **Range**  | `column BETWEEN a AND b`  | Includes zones where ranges overlap         | AtMost      |
 | **IsIn**   | `column IN (v1, v2, ...)` | Includes zones that could contain any value | AtMost      |
-| **IsNull** | `column IS NULL`          | Includes zones where null_count > 0         | AtMost      |
+| **IsNull** | `column IS NULL`          | Includes zones where null_count > 0         | Exact       |

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -17,13 +17,14 @@ use crate::scalar::{
 use crate::{Any, pb};
 use arrow_array::{Array, UInt64Array};
 use arrow_schema::{DataType, Field};
-use lance_select::RowAddrTreeMap;
 use lance_arrow_stats::StatisticsAccumulator;
 use lance_core::utils::bloomfilter::as_bytes;
 use lance_core::utils::bloomfilter::sbbf::{Sbbf, SbbfBuilder};
 use lance_core::utils::row_addr_remap::RowAddrRemap;
+use lance_select::RowAddrTreeMap;
 use serde::{Deserialize, Serialize};
 
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use datafusion::execution::SendableRecordBatchStream;
@@ -432,11 +433,12 @@ impl ScalarIndex for BloomFilterIndex {
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<BloomFilterQuery>().unwrap();
-        if let BloomFilterQuery::IsNull() = query {
-            if let Some(null_rows) = &self.null_rows {
-                return Ok(SearchResult::exact(null_rows.clone()));
-            }
+        if let BloomFilterQuery::IsNull() = query
+            && let Some(null_rows) = &self.null_rows
+        {
+            return Ok(SearchResult::exact(null_rows.clone()));
         }
+
         search_zones(&self.zones, metrics, |block| {
             self.evaluate_block_against_query(block, query)
         })
@@ -472,9 +474,15 @@ impl ScalarIndex for BloomFilterIndex {
         let trainer = ZoneTrainer::new(processor, params.number_of_items)?;
         let (updated_blocks, new_null_rows) = rebuild_zones(&self.zones, trainer, new_data).await?;
 
-        // Merge existing and new null rows
-        let mut merged_null_rows = self.null_rows.clone().unwrap_or_default();
-        merged_null_rows |= &new_null_rows;
+        // Merge existing and new null rows.  If the existing index had no null bitmap
+        // (legacy format — null positions unknown), preserve that None: updating cannot
+        // recover the missing information, and claiming the result has zero nulls would
+        // be a false negative.  Only a full retrain produces a fresh, complete bitmap.
+        let merged_null_rows = self.null_rows.as_ref().map(|existing| {
+            let mut merged = existing.clone();
+            merged |= &new_null_rows;
+            merged
+        });
 
         // Write the combined zones back to storage
         let mut builder = BloomFilterIndexBuilder::try_new(params)?;
@@ -569,7 +577,10 @@ impl BloomFilterIndexBuilderParams {
 pub struct BloomFilterIndexBuilder {
     params: BloomFilterIndexBuilderParams,
     blocks: Vec<BloomFilterStatistics>,
-    null_rows: RowAddrTreeMap,
+    // None means "legacy index — null positions unknown"; Some means a complete bitmap.
+    // write_index omits the null-bitmap global buffer when this is None, preserving the
+    // legacy format so that downstream searches remain conservative.
+    null_rows: Option<RowAddrTreeMap>,
 }
 
 impl BloomFilterIndexBuilder {
@@ -577,7 +588,7 @@ impl BloomFilterIndexBuilder {
         Ok(Self {
             params,
             blocks: Vec::new(),
-            null_rows: RowAddrTreeMap::new(),
+            null_rows: None,
         })
     }
 
@@ -589,7 +600,7 @@ impl BloomFilterIndexBuilder {
         let trainer = ZoneTrainer::new(processor, self.params.number_of_items)?;
         let (blocks, null_rows) = trainer.train(batches_source).await?;
         self.blocks = blocks;
-        self.null_rows = null_rows;
+        self.null_rows = Some(null_rows);
         Ok(())
     }
 
@@ -664,18 +675,21 @@ impl BloomFilterIndexBuilder {
             .await?;
         index_file.write_record_batch(record_batch).await?;
 
-        let mut null_bitmap_bytes = Vec::with_capacity(self.null_rows.serialized_size());
-        self.null_rows.serialize_into(&mut null_bitmap_bytes)?;
-        let null_bitmap_idx = index_file
-            .add_global_buffer(bytes::Bytes::from(null_bitmap_bytes))
-            .await?;
-
-        let bloomfilter_file = index_file
-            .finish_with_metadata(HashMap::from([(
-                NULL_BITMAP_META_KEY.to_string(),
-                null_bitmap_idx.to_string(),
-            )]))
-            .await?;
+        let bloomfilter_file = if let Some(null_rows) = self.null_rows {
+            let mut null_bitmap_bytes = Vec::with_capacity(null_rows.serialized_size());
+            null_rows.serialize_into(&mut null_bitmap_bytes)?;
+            let null_bitmap_idx = index_file
+                .add_global_buffer(bytes::Bytes::from(null_bitmap_bytes))
+                .await?;
+            index_file
+                .finish_with_metadata(HashMap::from([(
+                    NULL_BITMAP_META_KEY.to_string(),
+                    null_bitmap_idx.to_string(),
+                )]))
+                .await?
+        } else {
+            index_file.finish_with_metadata(HashMap::new()).await?
+        };
 
         Ok(vec![bloomfilter_file])
     }
@@ -2181,10 +2195,10 @@ mod tests {
     // Writes a bloomfilter file in the legacy format (no null bitmap global buffer),
     // simulating an index created before the null bitmap feature was added.
     async fn write_legacy_bloomfilter(store: &dyn IndexStore, has_null: bool) {
-        use arrow_array::BooleanArray;
         use crate::scalar::bloomfilter::{
             BLOOMFILTER_FILENAME, BLOOMFILTER_ITEM_META_KEY, BLOOMFILTER_PROBABILITY_META_KEY,
         };
+        use arrow_array::BooleanArray;
         let schema = Arc::new(Schema::new(vec![
             Field::new("fragment_id", DataType::UInt64, false),
             Field::new("zone_start", DataType::UInt64, false),
@@ -2207,15 +2221,92 @@ mod tests {
         file_schema
             .metadata
             .insert(BLOOMFILTER_ITEM_META_KEY.to_string(), "1000".to_string());
-        file_schema
-            .metadata
-            .insert(BLOOMFILTER_PROBABILITY_META_KEY.to_string(), "0.01".to_string());
+        file_schema.metadata.insert(
+            BLOOMFILTER_PROBABILITY_META_KEY.to_string(),
+            "0.01".to_string(),
+        );
         let mut writer = store
             .new_index_file(BLOOMFILTER_FILENAME, Arc::new(file_schema))
             .await
             .unwrap();
         writer.write_record_batch(batch).await.unwrap();
         writer.finish().await.unwrap();
+    }
+
+    // Updating a legacy (null_rows = None) index must not silently treat None as
+    // "no nulls".  The bug: `self.null_rows.clone().unwrap_or_default()` collapses
+    // None into an empty RowAddrTreeMap; after the merge the updated index has
+    // `null_rows = Some(empty)`, so an IsNull search returns `exact(empty)` — a
+    // false negative even though the legacy zone recorded has_null = true.
+    #[tokio::test]
+    async fn test_update_legacy_none_null_rows_not_treated_as_no_nulls() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        // Write a legacy-format index (no null bitmap) with has_null=true in its zone.
+        write_legacy_bloomfilter(store.as_ref(), true).await;
+
+        let index = BloomFilterIndex::load(store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        assert!(
+            index.null_rows.is_none(),
+            "precondition: legacy null_rows is None"
+        );
+
+        // Update with new data from fragment 1 (no nulls).  The destination is the
+        // same store so we can reload from it afterwards.
+        let new_schema = Arc::new(Schema::new(vec![
+            Field::new(VALUE_COLUMN_NAME, DataType::Int32, true),
+            Field::new(ROW_ADDR, DataType::UInt64, false),
+        ]));
+        let new_batch = RecordBatch::try_new(
+            new_schema.clone(),
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![
+                    Some(10i32),
+                    Some(20),
+                    Some(30),
+                ])) as _,
+                Arc::new(UInt64Array::from_iter_values(
+                    (0u64..3).map(|i| (1u64 << 32) | i),
+                )) as _,
+            ],
+        )
+        .unwrap();
+        let new_stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            new_schema,
+            stream::once(std::future::ready(Ok(new_batch))),
+        ));
+
+        index
+            .update(new_stream, store.as_ref(), None)
+            .await
+            .unwrap();
+
+        let updated_index = BloomFilterIndex::load(store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+
+        // The legacy zone had has_null=true, so there ARE nulls at unknown positions.
+        // An IsNull search on the updated index must NOT claim "no nulls" (exact empty).
+        // It must be conservative and return AtMost, falling back to the has_null scan.
+        let result = updated_index
+            .search(&BloomFilterQuery::IsNull(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+
+        // With the bug: null_rows = Some(empty) → returns exact(empty) ← FALSE NEGATIVE
+        // With the fix: null_rows = None        → falls through to has_null scan → AtMost
+        assert!(
+            !result.is_exact(),
+            "IsNull on an updated legacy index must not return exact(empty); \
+             the legacy zone had has_null=true so nulls exist at unknown positions"
+        );
     }
 
     #[tokio::test]
@@ -2233,7 +2324,10 @@ mod tests {
             .await
             .expect("failed to load legacy bloomfilter");
 
-        assert!(index.null_rows.is_none(), "legacy index should have no null bitmap");
+        assert!(
+            index.null_rows.is_none(),
+            "legacy index should have no null bitmap"
+        );
 
         // IS NULL should fall back to the has_null zone scan and return AtMost, not Exact.
         let result = index

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -17,6 +17,7 @@ use crate::scalar::{
 use crate::{Any, pb};
 use arrow_array::{Array, UInt64Array};
 use arrow_schema::{DataType, Field};
+use lance_select::RowAddrTreeMap;
 use lance_arrow_stats::StatisticsAccumulator;
 use lance_core::utils::bloomfilter::as_bytes;
 use lance_core::utils::bloomfilter::sbbf::{Sbbf, SbbfBuilder};
@@ -44,6 +45,7 @@ use super::zoned::{ZoneBound, ZoneProcessor, ZoneTrainer, rebuild_zones, search_
 
 const BLOOMFILTER_FILENAME: &str = "bloomfilter.lance";
 const BLOOMFILTER_ITEM_META_KEY: &str = "bloomfilter_item";
+const NULL_BITMAP_META_KEY: &str = "lance:null_bitmap";
 const BLOOMFILTER_PROBABILITY_META_KEY: &str = "bloomfilter_probability";
 const BLOOMFILTER_INDEX_VERSION: u32 = 0;
 
@@ -80,11 +82,13 @@ pub struct BloomFilterIndex {
     number_of_items: u64,
     // Probability of false positives, fraction between 0 and 1
     probability: f64,
+    // Exact set of null row addresses; None for older indices without this bitmap.
+    null_rows: Option<RowAddrTreeMap>,
 }
 
 impl DeepSizeOf for BloomFilterIndex {
     fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
-        self.zones.deep_size_of_children(context)
+        self.zones.deep_size_of_children(context) + self.null_rows.deep_size_of_children(context)
     }
 }
 
@@ -112,10 +116,21 @@ impl BloomFilterIndex {
             .and_then(|bs| bs.parse().ok())
             .unwrap_or(*DEFAULT_PROBABILITY);
 
+        let null_rows = if let Some(idx_str) = file_schema.metadata.get(NULL_BITMAP_META_KEY) {
+            let idx = idx_str.parse::<u32>().map_err(|e| {
+                Error::invalid_input(format!("invalid null bitmap buffer index: {e}"))
+            })?;
+            let bytes = index_file.read_global_buffer(idx).await?;
+            Some(RowAddrTreeMap::deserialize_from(bytes.as_ref())?)
+        } else {
+            None
+        };
+
         Ok(Arc::new(Self::try_from_serialized(
             bloom_data,
             number_of_items,
             probability,
+            null_rows,
         )?))
     }
 
@@ -123,13 +138,14 @@ impl BloomFilterIndex {
         data: RecordBatch,
         number_of_items: u64,
         probability: f64,
+        null_rows: Option<RowAddrTreeMap>,
     ) -> Result<Self> {
         if data.num_rows() == 0 {
-            // Return empty index for empty data
             return Ok(Self {
                 zones: Vec::new(),
                 number_of_items,
                 probability,
+                null_rows,
             });
         }
 
@@ -210,6 +226,7 @@ impl BloomFilterIndex {
             zones: blocks,
             number_of_items,
             probability,
+            null_rows,
         })
     }
 
@@ -415,6 +432,11 @@ impl ScalarIndex for BloomFilterIndex {
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<BloomFilterQuery>().unwrap();
+        if let BloomFilterQuery::IsNull() = query {
+            if let Some(null_rows) = &self.null_rows {
+                return Ok(SearchResult::exact(null_rows.clone()));
+            }
+        }
         search_zones(&self.zones, metrics, |block| {
             self.evaluate_block_against_query(block, query)
         })
@@ -448,18 +470,23 @@ impl ScalarIndex for BloomFilterIndex {
 
         let processor = BloomFilterProcessor::new(params.clone())?;
         let trainer = ZoneTrainer::new(processor, params.number_of_items)?;
-        let updated_blocks = rebuild_zones(&self.zones, trainer, new_data).await?;
+        let (updated_blocks, new_null_rows) = rebuild_zones(&self.zones, trainer, new_data).await?;
+
+        // Merge existing and new null rows
+        let mut merged_null_rows = self.null_rows.clone().unwrap_or_default();
+        merged_null_rows |= &new_null_rows;
 
         // Write the combined zones back to storage
         let mut builder = BloomFilterIndexBuilder::try_new(params)?;
         builder.blocks = updated_blocks;
-        let file = builder.write_index(dest_store).await?;
+        builder.null_rows = merged_null_rows;
+        let files = builder.write_index(dest_store).await?;
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default())
                 .unwrap(),
             index_version: BLOOMFILTER_INDEX_VERSION,
-            files: vec![file],
+            files,
         })
     }
 
@@ -542,6 +569,7 @@ impl BloomFilterIndexBuilderParams {
 pub struct BloomFilterIndexBuilder {
     params: BloomFilterIndexBuilderParams,
     blocks: Vec<BloomFilterStatistics>,
+    null_rows: RowAddrTreeMap,
 }
 
 impl BloomFilterIndexBuilder {
@@ -549,6 +577,7 @@ impl BloomFilterIndexBuilder {
         Ok(Self {
             params,
             blocks: Vec::new(),
+            null_rows: RowAddrTreeMap::new(),
         })
     }
 
@@ -558,7 +587,9 @@ impl BloomFilterIndexBuilder {
     pub async fn train(&mut self, batches_source: SendableRecordBatchStream) -> Result<()> {
         let processor = BloomFilterProcessor::new(self.params.clone())?;
         let trainer = ZoneTrainer::new(processor, self.params.number_of_items)?;
-        self.blocks = trainer.train(batches_source).await?;
+        let (blocks, null_rows) = trainer.train(batches_source).await?;
+        self.blocks = blocks;
+        self.null_rows = null_rows;
         Ok(())
     }
 
@@ -615,7 +646,7 @@ impl BloomFilterIndexBuilder {
         Ok(RecordBatch::try_new(schema, columns)?)
     }
 
-    pub async fn write_index(self, index_store: &dyn IndexStore) -> Result<IndexFile> {
+    pub async fn write_index(self, index_store: &dyn IndexStore) -> Result<Vec<IndexFile>> {
         let record_batch = self.bloomfilter_stats_as_batch()?;
 
         let mut file_schema = record_batch.schema().as_ref().clone();
@@ -623,7 +654,6 @@ impl BloomFilterIndexBuilder {
             BLOOMFILTER_ITEM_META_KEY.to_string(),
             self.params.number_of_items.to_string(),
         );
-
         file_schema.metadata.insert(
             BLOOMFILTER_PROBABILITY_META_KEY.to_string(),
             self.params.probability.to_string(),
@@ -633,7 +663,21 @@ impl BloomFilterIndexBuilder {
             .new_index_file(BLOOMFILTER_FILENAME, Arc::new(file_schema))
             .await?;
         index_file.write_record_batch(record_batch).await?;
-        index_file.finish().await
+
+        let mut null_bitmap_bytes = Vec::with_capacity(self.null_rows.serialized_size());
+        self.null_rows.serialize_into(&mut null_bitmap_bytes)?;
+        let null_bitmap_idx = index_file
+            .add_global_buffer(bytes::Bytes::from(null_bitmap_bytes))
+            .await?;
+
+        let bloomfilter_file = index_file
+            .finish_with_metadata(HashMap::from([(
+                NULL_BITMAP_META_KEY.to_string(),
+                null_bitmap_idx.to_string(),
+            )]))
+            .await?;
+
+        Ok(vec![bloomfilter_file])
     }
 }
 
@@ -980,7 +1024,7 @@ impl BloomFilterIndexPlugin {
         batches_source: SendableRecordBatchStream,
         index_store: &dyn IndexStore,
         options: Option<BloomFilterIndexBuilderParams>,
-    ) -> Result<IndexFile> {
+    ) -> Result<Vec<IndexFile>> {
         let mut builder = BloomFilterIndexBuilder::try_new(options.unwrap_or_default())?;
 
         builder.train(batches_source).await?;
@@ -1065,12 +1109,12 @@ impl BasicTrainer for BloomFilterIndexPlugin {
                     "must provide training request created by new_training_request".into(),
                 )
             })?;
-        let file = Self::train_bloomfilter_index(data, index_store, Some(request.params)).await?;
+        let files = Self::train_bloomfilter_index(data, index_store, Some(request.params)).await?;
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default())
                 .unwrap(),
             index_version: BLOOMFILTER_INDEX_VERSION,
-            files: vec![file],
+            files,
         })
     }
 }
@@ -1169,7 +1213,7 @@ mod tests {
     use lance_select::RowAddrTreeMap;
 
     use crate::scalar::{
-        BloomFilterQuery, ScalarIndex, SearchResult,
+        BloomFilterQuery, IndexStore, ScalarIndex, SearchResult,
         bloomfilter::{BloomFilterIndex, BloomFilterIndexBuilderParams},
         lance_format::LanceIndexStore,
     };
@@ -2037,10 +2081,10 @@ mod tests {
         expected.insert_range(500..750); // Should match the zone containing 500
         assert_eq!(result, SearchResult::at_most(expected));
 
-        // Test IsNull query
+        // Test IsNull query (no nulls in data, should return exact empty set)
         let query = BloomFilterQuery::IsNull();
         let result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
-        assert_eq!(result, SearchResult::at_most(RowAddrTreeMap::new())); // No nulls in the data
+        assert_eq!(result, SearchResult::exact(RowAddrTreeMap::new()));
 
         // Test IsIn query
         let query = BloomFilterQuery::IsIn(vec![
@@ -2132,5 +2176,73 @@ mod tests {
             }
             _ => panic!("Expected AtMost search result from bloomfilter"),
         }
+    }
+
+    // Writes a bloomfilter file in the legacy format (no null bitmap global buffer),
+    // simulating an index created before the null bitmap feature was added.
+    async fn write_legacy_bloomfilter(store: &dyn IndexStore, has_null: bool) {
+        use arrow_array::BooleanArray;
+        use crate::scalar::bloomfilter::{
+            BLOOMFILTER_FILENAME, BLOOMFILTER_ITEM_META_KEY, BLOOMFILTER_PROBABILITY_META_KEY,
+        };
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("fragment_id", DataType::UInt64, false),
+            Field::new("zone_start", DataType::UInt64, false),
+            Field::new("zone_length", DataType::UInt64, false),
+            Field::new("has_null", DataType::Boolean, false),
+            Field::new("bloom_filter_data", DataType::Binary, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![3u64])) as _,
+                Arc::new(BooleanArray::from(vec![has_null])) as _,
+                Arc::new(arrow_array::BinaryArray::from_vec(vec![b"".as_ref()])) as _,
+            ],
+        )
+        .unwrap();
+        let mut file_schema = schema.as_ref().clone();
+        file_schema
+            .metadata
+            .insert(BLOOMFILTER_ITEM_META_KEY.to_string(), "1000".to_string());
+        file_schema
+            .metadata
+            .insert(BLOOMFILTER_PROBABILITY_META_KEY.to_string(), "0.01".to_string());
+        let mut writer = store
+            .new_index_file(BLOOMFILTER_FILENAME, Arc::new(file_schema))
+            .await
+            .unwrap();
+        writer.write_record_batch(batch).await.unwrap();
+        writer.finish().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_legacy_bloomfilter_no_null_bitmap() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        write_legacy_bloomfilter(store.as_ref(), true).await;
+
+        let index = BloomFilterIndex::load(store, None, &LanceCache::no_cache())
+            .await
+            .expect("failed to load legacy bloomfilter");
+
+        assert!(index.null_rows.is_none(), "legacy index should have no null bitmap");
+
+        // IS NULL should fall back to the has_null zone scan and return AtMost, not Exact.
+        let result = index
+            .search(&BloomFilterQuery::IsNull(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert!(
+            !result.is_exact(),
+            "IS NULL on a legacy index should not be exact"
+        );
     }
 }

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -46,7 +46,7 @@ use super::zoned::{ZoneBound, ZoneProcessor, ZoneTrainer, rebuild_zones, search_
 
 const BLOOMFILTER_FILENAME: &str = "bloomfilter.lance";
 const BLOOMFILTER_ITEM_META_KEY: &str = "bloomfilter_item";
-const NULL_BITMAP_META_KEY: &str = "lance:null_bitmap";
+const NULL_BITMAP_META_KEY: &str = "null_bitmap";
 const BLOOMFILTER_PROBABILITY_META_KEY: &str = "bloomfilter_probability";
 const BLOOMFILTER_INDEX_VERSION: u32 = 0;
 

--- a/rust/lance-index/src/scalar/zoned.rs
+++ b/rust/lance-index/src/scalar/zoned.rs
@@ -92,13 +92,14 @@ where
     pub async fn train(
         mut self,
         stream: SendableRecordBatchStream,
-    ) -> Result<Vec<P::ZoneStatistics>> {
+    ) -> Result<(Vec<P::ZoneStatistics>, RowAddrTreeMap)> {
         let zone_size = usize::try_from(self.zone_capacity).map_err(|_| {
             Error::invalid_input("zone capacity does not fit into usize on this platform")
         })?;
 
         let mut batches = chunk_concat_stream(stream, zone_size);
         let mut zones = Vec::new();
+        let mut null_rows = RowAddrTreeMap::new();
         let mut current_fragment_id: Option<u64> = None;
         let mut current_zone_len: usize = 0;
         let mut zone_start_offset: Option<u64> = None;
@@ -155,6 +156,16 @@ where
                 self.processor
                     .process_chunk(&values.slice(batch_offset, take))?;
 
+                // Record exact row addresses for null values in this chunk.
+                let chunk = values.slice(batch_offset, take);
+                if chunk.null_count() > 0 {
+                    for i in 0..take {
+                        if values.is_null(batch_offset + i) {
+                            null_rows.insert(row_addr_col.value(batch_offset + i));
+                        }
+                    }
+                }
+
                 // Track the first and last row offsets to handle non-contiguous offsets
                 // after deletions. Zone length (offset span) is computed as (last - first + 1),
                 // not the actual row count.
@@ -200,7 +211,7 @@ where
             }
         }
 
-        Ok(zones)
+        Ok((zones, null_rows))
     }
 
     /// Flushes a non-empty zone and resets the processor state.
@@ -266,21 +277,21 @@ where
 }
 
 /// Helper that retrains zones from `stream` and appends them to the existing
-/// statistics. Useful for index update paths that need to merge new fragments
-/// into an existing zone list.
+/// statistics. Returns the combined zone list and the null-row bitmap for the
+/// new data only — callers are responsible for merging with any existing bitmap.
 pub async fn rebuild_zones<P>(
     existing: &[P::ZoneStatistics],
     trainer: ZoneTrainer<P>,
     stream: SendableRecordBatchStream,
-) -> Result<Vec<P::ZoneStatistics>>
+) -> Result<(Vec<P::ZoneStatistics>, RowAddrTreeMap)>
 where
     P: ZoneProcessor,
     P::ZoneStatistics: Clone,
 {
     let mut combined = existing.to_vec();
-    let mut new_zones = trainer.train(stream).await?;
+    let (mut new_zones, null_rows) = trainer.train(stream).await?;
     combined.append(&mut new_zones);
-    Ok(combined)
+    Ok((combined, null_rows))
 }
 
 #[cfg(test)]
@@ -362,7 +373,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 4).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // Three zones: offsets [0..=3], [4..=7], [8..=9]
         assert_eq!(stats.len(), 3);
@@ -393,7 +404,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 10).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // Two zones, one per fragment (capacity=10 is large enough)
         assert_eq!(stats.len(), 2);
@@ -447,7 +458,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 10).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // One zone containing the 3 valid rows (empty batches skipped)
         assert_eq!(stats.len(), 1);
@@ -469,7 +480,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 1).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // Three zones, one per row (capacity=1)
         assert_eq!(stats.len(), 3);
@@ -494,7 +505,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 10000).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // One zone containing all 100 rows (capacity is large enough)
         assert_eq!(stats.len(), 1);
@@ -530,7 +541,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 4).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // Two zones: first 4 rows, then remaining 2 rows
         assert_eq!(stats.len(), 2);
@@ -561,7 +572,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 3).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // Three zones: frag 0 full zone, frag 0 partial (flushed at boundary), frag 1
         assert_eq!(stats.len(), 3);
@@ -602,7 +613,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 4).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // Should create 2 zones (capacity=4):
         // Zone 0: rows at offsets [0, 1, 5, 7] (4 rows)
@@ -637,7 +648,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 10).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // One zone with 3 rows, but offset span [0..=200] so length=201 due to large gaps
         assert_eq!(stats.len(), 1);
@@ -663,7 +674,7 @@ mod tests {
 
         let processor = MockProcessor::new();
         let trainer = ZoneTrainer::new(processor, 10).unwrap();
-        let stats = trainer.train(stream).await.unwrap();
+        let (stats, _) = trainer.train(stream).await.unwrap();
 
         // Should create 3 zones (one per fragment)
         assert_eq!(stats.len(), 3);
@@ -810,7 +821,7 @@ mod tests {
         ));
 
         let trainer = ZoneTrainer::new(MockProcessor::new(), 2).unwrap();
-        let rebuilt = rebuild_zones(&existing, trainer, stream).await.unwrap();
+        let (rebuilt, _) = rebuild_zones(&existing, trainer, stream).await.unwrap();
         // Existing zone should remain unchanged and new stats appended afterwards
         assert_eq!(rebuilt.len(), 2);
         assert_eq!(rebuilt[0].sum, 50);
@@ -840,7 +851,7 @@ mod tests {
         ));
 
         let trainer = ZoneTrainer::new(MockProcessor::new(), 2).unwrap();
-        let rebuilt = rebuild_zones(&existing, trainer, stream).await.unwrap();
+        let (rebuilt, _) = rebuild_zones(&existing, trainer, stream).await.unwrap();
         // Existing zone plus two new fragments should yield three total zones
         assert_eq!(rebuilt.len(), 3);
         assert_eq!(rebuilt[0].bound.fragment_id, 0);

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -51,7 +51,7 @@ const ROWS_PER_ZONE_DEFAULT: u64 = 8192; // 1 zone every two batches
 
 const ZONEMAP_FILENAME: &str = "zonemap.lance";
 const ZONEMAP_SIZE_META_KEY: &str = "rows_per_zone";
-const NULL_BITMAP_META_KEY: &str = "lance:null_bitmap";
+const NULL_BITMAP_META_KEY: &str = "null_bitmap";
 const ZONEMAP_INDEX_VERSION: u32 = 0;
 
 /// Basic stats about zonemap index
@@ -2923,8 +2923,8 @@ mod tests {
         )
         .unwrap();
         let mut modern_null_rows = RowAddrTreeMap::new();
-        modern_null_rows.insert(0u64 << 32 | 3); // frag 0 row 3
-        modern_null_rows.insert(0u64 << 32 | 7); // frag 0 row 7
+        modern_null_rows.insert(3); // frag 0 row 3
+        modern_null_rows.insert(7); // frag 0 row 7
         let cache = LanceCache::no_cache();
         let index_a = Arc::new(
             ZoneMapIndex::try_from_serialized(

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -28,12 +28,14 @@ use lance_core::utils::row_addr_remap::RowAddrRemap;
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 
-use arrow_array::{ArrayRef, RecordBatch, UInt32Array, UInt64Array, new_empty_array, new_null_array};
+use arrow_array::{
+    ArrayRef, RecordBatch, UInt32Array, UInt64Array, new_empty_array, new_null_array,
+};
 use arrow_schema::{DataType, Field};
-use lance_select::RowAddrTreeMap;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion_common::ScalarValue;
-use std::sync::Arc;
+use lance_select::RowAddrTreeMap;
+use std::{collections::HashMap, sync::Arc};
 
 use super::{AnyQuery, IndexStore, MetricsCollector, ScalarIndex, SearchResult};
 use crate::scalar::RowIdRemapper;
@@ -644,11 +646,12 @@ impl ScalarIndex for ZoneMapIndex {
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
-        if let SargableQuery::IsNull() = query {
-            if let Some(null_rows) = &self.null_rows {
-                return Ok(SearchResult::exact(null_rows.clone()));
-            }
+        if let SargableQuery::IsNull() = query
+            && let Some(null_rows) = &self.null_rows
+        {
+            return Ok(SearchResult::exact(null_rows.clone()));
         }
+
         search_zones(&self.zones, metrics, |zone| {
             self.evaluate_zone_against_query(zone, query)
         })
@@ -685,9 +688,15 @@ impl ScalarIndex for ZoneMapIndex {
         let trainer = ZoneTrainer::new(processor, self.rows_per_zone)?;
         let (updated_zones, new_null_rows) = rebuild_zones(&self.zones, trainer, new_data).await?;
 
-        // Merge existing and new null rows
-        let mut merged_null_rows = self.null_rows.clone().unwrap_or_default();
-        merged_null_rows |= &new_null_rows;
+        // Merge existing and new null rows.  If the existing index had no null bitmap
+        // (legacy format — null positions unknown), preserve that None: updating cannot
+        // recover the missing information, and claiming the result has zero nulls would
+        // be a false negative.  Only a full retrain produces a fresh, complete bitmap.
+        let merged_null_rows = self.null_rows.as_ref().map(|existing| {
+            let mut merged = existing.clone();
+            merged |= &new_null_rows;
+            merged
+        });
 
         // Serialize the combined zones back into the index file
         let mut builder = ZoneMapIndexBuilder::try_new(options, self.data_type.clone())?;
@@ -736,7 +745,7 @@ pub async fn merge_zonemap_indices(
 
     let mut zones = Vec::new();
     let mut merged_null_rows = RowAddrTreeMap::new();
-    let mut any_null_bitmap = false;
+    let mut any_missing_bitmap = false;
     for source in source_indices {
         if source.rows_per_zone != rows_per_zone {
             return Err(Error::invalid_input(format!(
@@ -760,11 +769,13 @@ pub async fn merge_zonemap_indices(
                 })
                 .cloned(),
         );
-        if let Some(null_rows) = &source.null_rows {
-            any_null_bitmap = true;
-            let mut filtered = null_rows.clone();
-            filtered.retain_fragments(fragment_filter.iter());
-            merged_null_rows |= &filtered;
+        match &source.null_rows {
+            Some(null_rows) => {
+                let mut filtered = null_rows.clone();
+                filtered.retain_fragments(fragment_filter.iter());
+                merged_null_rows |= &filtered;
+            }
+            None => any_missing_bitmap = true,
         }
     }
     zones.sort_by_key(|zone| (zone.bound.fragment_id, zone.bound.start));
@@ -772,8 +783,8 @@ pub async fn merge_zonemap_indices(
     let mut builder =
         ZoneMapIndexBuilder::try_new(ZoneMapIndexBuilderParams::new(rows_per_zone), data_type)?;
     builder.maps = zones;
-    if any_null_bitmap {
-        builder.null_rows = merged_null_rows;
+    if !any_missing_bitmap {
+        builder.null_rows = Some(merged_null_rows);
     }
     let files = builder.write_index(dest_store).await?;
 
@@ -825,7 +836,10 @@ pub struct ZoneMapIndexBuilder {
 
     items_type: DataType,
     maps: Vec<ZoneMapStatistics>,
-    null_rows: RowAddrTreeMap,
+    // None means "legacy index — null positions unknown"; Some means a complete bitmap.
+    // write_index omits the null-bitmap global buffer when this is None, preserving the
+    // legacy format so that downstream searches remain conservative.
+    null_rows: Option<RowAddrTreeMap>,
 }
 
 impl ZoneMapIndexBuilder {
@@ -834,7 +848,7 @@ impl ZoneMapIndexBuilder {
             options,
             items_type,
             maps: Vec::new(),
-            null_rows: RowAddrTreeMap::new(),
+            null_rows: None,
         })
     }
 
@@ -846,7 +860,7 @@ impl ZoneMapIndexBuilder {
         let trainer = ZoneTrainer::new(processor, self.options.rows_per_zone)?;
         let (maps, null_rows) = trainer.train(batches_source).await?;
         self.maps = maps;
-        self.null_rows = null_rows;
+        self.null_rows = Some(null_rows);
         Ok(())
     }
 
@@ -913,18 +927,21 @@ impl ZoneMapIndexBuilder {
             .await?;
         index_file.write_record_batch(record_batch).await?;
 
-        let mut null_bitmap_bytes = Vec::with_capacity(self.null_rows.serialized_size());
-        self.null_rows.serialize_into(&mut null_bitmap_bytes)?;
-        let null_bitmap_idx = index_file
-            .add_global_buffer(bytes::Bytes::from(null_bitmap_bytes))
-            .await?;
-
-        let zonemap_file = index_file
-            .finish_with_metadata(HashMap::from([(
-                NULL_BITMAP_META_KEY.to_string(),
-                null_bitmap_idx.to_string(),
-            )]))
-            .await?;
+        let zonemap_file = if let Some(null_rows) = self.null_rows {
+            let mut null_bitmap_bytes = Vec::with_capacity(null_rows.serialized_size());
+            null_rows.serialize_into(&mut null_bitmap_bytes)?;
+            let null_bitmap_idx = index_file
+                .add_global_buffer(bytes::Bytes::from(null_bitmap_bytes))
+                .await?;
+            index_file
+                .finish_with_metadata(HashMap::from([(
+                    NULL_BITMAP_META_KEY.to_string(),
+                    null_bitmap_idx.to_string(),
+                )]))
+                .await?
+        } else {
+            index_file.finish_with_metadata(HashMap::new()).await?
+        };
 
         Ok(vec![zonemap_file])
     }
@@ -1180,6 +1197,7 @@ mod tests {
         lance_format::LanceIndexStore,
         zonemap::{
             ZONEMAP_FILENAME, ZONEMAP_SIZE_META_KEY, ZoneMapIndex, ZoneMapIndexBuilderParams,
+            merge_zonemap_indices,
         },
     };
 
@@ -2863,6 +2881,136 @@ mod tests {
         assert_eq!(compute_next_prefix("\u{10FFFF}\u{10FFFF}"), None);
     }
 
+    // When merging zone map segments, if ANY source segment has null_rows = None
+    // (legacy — null positions unknown), the merged result must also be None.
+    // The bug: any_null_bitmap is set to true as soon as one source has Some(...),
+    // and the None sources are silently skipped.  The merged index then has
+    // null_rows = Some(partial_bitmap), so an IsNull search returns exact results
+    // that only cover the modern segment's nulls — a false negative for the legacy
+    // segment whose null positions were never tracked.
+    #[tokio::test]
+    async fn test_merge_with_legacy_none_segment_not_treated_as_no_nulls() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        use arrow_array::{Int32Array, UInt32Array};
+
+        // Index A: fragment 0, modern — has a complete null bitmap with 2 known null rows.
+        let schema_a = Arc::new(Schema::new(vec![
+            Field::new("min", DataType::Int32, true),
+            Field::new("max", DataType::Int32, true),
+            Field::new("null_count", DataType::UInt32, false),
+            Field::new("nan_count", DataType::UInt32, false),
+            Field::new("fragment_id", DataType::UInt64, false),
+            Field::new("zone_start", DataType::UInt64, false),
+            Field::new("zone_length", DataType::UInt64, false),
+        ]));
+        let batch_a = RecordBatch::try_new(
+            schema_a,
+            vec![
+                Arc::new(Int32Array::from(vec![Some(1i32)])) as _,
+                Arc::new(Int32Array::from(vec![Some(5i32)])) as _,
+                Arc::new(UInt32Array::from(vec![2u32])) as _,
+                Arc::new(UInt32Array::from(vec![0u32])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![10u64])) as _,
+            ],
+        )
+        .unwrap();
+        let mut modern_null_rows = RowAddrTreeMap::new();
+        modern_null_rows.insert(0u64 << 32 | 3); // frag 0 row 3
+        modern_null_rows.insert(0u64 << 32 | 7); // frag 0 row 7
+        let cache = LanceCache::no_cache();
+        let index_a = Arc::new(
+            ZoneMapIndex::try_from_serialized(
+                batch_a,
+                store.clone(),
+                None,
+                &cache,
+                10,
+                Some(modern_null_rows), // modern: complete bitmap
+            )
+            .unwrap(),
+        );
+
+        // Index B: fragment 1, legacy — null_rows = None despite null_count = 3.
+        let schema_b = Arc::new(Schema::new(vec![
+            Field::new("min", DataType::Int32, true),
+            Field::new("max", DataType::Int32, true),
+            Field::new("null_count", DataType::UInt32, false),
+            Field::new("nan_count", DataType::UInt32, false),
+            Field::new("fragment_id", DataType::UInt64, false),
+            Field::new("zone_start", DataType::UInt64, false),
+            Field::new("zone_length", DataType::UInt64, false),
+        ]));
+        let batch_b = RecordBatch::try_new(
+            schema_b,
+            vec![
+                Arc::new(Int32Array::from(vec![Some(10i32)])) as _,
+                Arc::new(Int32Array::from(vec![Some(20i32)])) as _,
+                Arc::new(UInt32Array::from(vec![3u32])) as _,
+                Arc::new(UInt32Array::from(vec![0u32])) as _,
+                Arc::new(UInt64Array::from(vec![1u64])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![10u64])) as _,
+            ],
+        )
+        .unwrap();
+        let index_b = Arc::new(
+            ZoneMapIndex::try_from_serialized(
+                batch_b,
+                store.clone(),
+                None,
+                &cache,
+                10,
+                None, // legacy: null positions unknown
+            )
+            .unwrap(),
+        );
+
+        let dest_tmpdir = TempObjDir::default();
+        let dest_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            dest_tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let all_frags = RoaringBitmap::from_iter([0u32, 1]);
+        merge_zonemap_indices(
+            &[index_a.as_ref(), index_b.as_ref()],
+            dest_store.as_ref(),
+            &all_frags,
+        )
+        .await
+        .unwrap();
+
+        let merged = ZoneMapIndex::load(dest_store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+
+        // Index B had null_rows = None, so the merged index cannot know all null positions.
+        // IsNull must NOT return exact — that would be a false negative for fragment 1's nulls.
+        let result = merged
+            .search(&SargableQuery::IsNull(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+
+        // With the bug: any_null_bitmap=true (from A) → null_rows=Some(A's bitmap only)
+        //              → IsNull returns exact, missing B's unknown nulls ← FALSE NEGATIVE
+        // With the fix: any_null_bitmap=false (because B is None) → null_rows=None
+        //              → IsNull falls through to zone scan → AtMost
+        assert!(
+            !result.is_exact(),
+            "IsNull on a merged index where one source had null_rows=None must not return \
+             exact; the legacy segment had null_count=3 so its nulls exist at unknown positions"
+        );
+    }
+
     // Writes a zonemap file in the legacy format (no null bitmap global buffer),
     // simulating an index created before the null bitmap feature was added.
     async fn write_legacy_zonemap(store: &dyn IndexStore, null_count: u32) {
@@ -2917,7 +3065,10 @@ mod tests {
             .await
             .expect("failed to load legacy zonemap");
 
-        assert!(index.null_rows.is_none(), "legacy index should have no null bitmap");
+        assert!(
+            index.null_rows.is_none(),
+            "legacy index should have no null bitmap"
+        );
 
         // IS NULL should fall back to the zone-scan path and return AtMost, not Exact.
         let result = index

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -28,10 +28,9 @@ use lance_core::utils::row_addr_remap::RowAddrRemap;
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 
-use arrow_array::{
-    ArrayRef, RecordBatch, UInt32Array, UInt64Array, new_empty_array, new_null_array,
-};
+use arrow_array::{ArrayRef, RecordBatch, UInt32Array, UInt64Array, new_empty_array, new_null_array};
 use arrow_schema::{DataType, Field};
+use lance_select::RowAddrTreeMap;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion_common::ScalarValue;
 use std::sync::Arc;
@@ -50,6 +49,7 @@ const ROWS_PER_ZONE_DEFAULT: u64 = 8192; // 1 zone every two batches
 
 const ZONEMAP_FILENAME: &str = "zonemap.lance";
 const ZONEMAP_SIZE_META_KEY: &str = "rows_per_zone";
+const NULL_BITMAP_META_KEY: &str = "lance:null_bitmap";
 const ZONEMAP_INDEX_VERSION: u32 = 0;
 
 /// Basic stats about zonemap index
@@ -110,6 +110,9 @@ pub struct ZoneMapIndex {
     store: Arc<dyn IndexStore>,
     fri: Option<Arc<dyn RowIdRemapper>>,
     index_cache: WeakLanceCache,
+    // Exact set of null row addresses across all zones; None when loaded from an
+    // older index that did not persist this bitmap.
+    null_rows: Option<RowAddrTreeMap>,
 }
 
 impl std::fmt::Debug for ZoneMapIndex {
@@ -127,7 +130,7 @@ impl std::fmt::Debug for ZoneMapIndex {
 
 impl DeepSizeOf for ZoneMapIndex {
     fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
-        self.zones.deep_size_of_children(context)
+        self.zones.deep_size_of_children(context) + self.null_rows.deep_size_of_children(context)
     }
 }
 
@@ -469,12 +472,24 @@ impl ZoneMapIndex {
             .get(ZONEMAP_SIZE_META_KEY)
             .and_then(|bs| bs.parse().ok())
             .unwrap_or(ROWS_PER_ZONE_DEFAULT);
+
+        let null_rows = if let Some(idx_str) = file_schema.metadata.get(NULL_BITMAP_META_KEY) {
+            let idx = idx_str.parse::<u32>().map_err(|e| {
+                Error::invalid_input(format!("invalid null bitmap buffer index: {e}"))
+            })?;
+            let bytes = index_file.read_global_buffer(idx).await?;
+            Some(RowAddrTreeMap::deserialize_from(bytes.as_ref())?)
+        } else {
+            None
+        };
+
         Ok(Arc::new(Self::try_from_serialized(
             zone_maps,
             store,
             fri,
             index_cache,
             rows_per_zone,
+            null_rows,
         )?))
     }
 
@@ -484,6 +499,7 @@ impl ZoneMapIndex {
         fri: Option<Arc<dyn RowIdRemapper>>,
         index_cache: &LanceCache,
         rows_per_zone: u64,
+        null_rows: Option<RowAddrTreeMap>,
     ) -> Result<Self> {
         // The RecordBatch should have columns: min, max, null_count
         let min_col = data
@@ -545,6 +561,7 @@ impl ZoneMapIndex {
                 store,
                 fri,
                 index_cache: WeakLanceCache::from(index_cache),
+                null_rows,
             });
         }
 
@@ -576,6 +593,7 @@ impl ZoneMapIndex {
             store,
             fri,
             index_cache: WeakLanceCache::from(index_cache),
+            null_rows,
         })
     }
 }
@@ -626,6 +644,11 @@ impl ScalarIndex for ZoneMapIndex {
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
+        if let SargableQuery::IsNull() = query {
+            if let Some(null_rows) = &self.null_rows {
+                return Ok(SearchResult::exact(null_rows.clone()));
+            }
+        }
         search_zones(&self.zones, metrics, |zone| {
             self.evaluate_zone_against_query(zone, query)
         })
@@ -660,19 +683,24 @@ impl ScalarIndex for ZoneMapIndex {
         let options = ZoneMapIndexBuilderParams::new(self.rows_per_zone);
         let processor = ZoneMapProcessor::new(value_type.clone())?;
         let trainer = ZoneTrainer::new(processor, self.rows_per_zone)?;
-        let updated_zones = rebuild_zones(&self.zones, trainer, new_data).await?;
+        let (updated_zones, new_null_rows) = rebuild_zones(&self.zones, trainer, new_data).await?;
+
+        // Merge existing and new null rows
+        let mut merged_null_rows = self.null_rows.clone().unwrap_or_default();
+        merged_null_rows |= &new_null_rows;
 
         // Serialize the combined zones back into the index file
         let mut builder = ZoneMapIndexBuilder::try_new(options, self.data_type.clone())?;
         builder.options.rows_per_zone = self.rows_per_zone;
         builder.maps = updated_zones;
-        let file = builder.write_index(dest_store).await?;
+        builder.null_rows = merged_null_rows;
+        let files = builder.write_index(dest_store).await?;
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails::default())
                 .unwrap(),
             index_version: ZONEMAP_INDEX_VERSION,
-            files: vec![file],
+            files,
         })
     }
 
@@ -707,6 +735,8 @@ pub async fn merge_zonemap_indices(
     let data_type = first.data_type.clone();
 
     let mut zones = Vec::new();
+    let mut merged_null_rows = RowAddrTreeMap::new();
+    let mut any_null_bitmap = false;
     for source in source_indices {
         if source.rows_per_zone != rows_per_zone {
             return Err(Error::invalid_input(format!(
@@ -730,18 +760,27 @@ pub async fn merge_zonemap_indices(
                 })
                 .cloned(),
         );
+        if let Some(null_rows) = &source.null_rows {
+            any_null_bitmap = true;
+            let mut filtered = null_rows.clone();
+            filtered.retain_fragments(fragment_filter.iter());
+            merged_null_rows |= &filtered;
+        }
     }
     zones.sort_by_key(|zone| (zone.bound.fragment_id, zone.bound.start));
 
     let mut builder =
         ZoneMapIndexBuilder::try_new(ZoneMapIndexBuilderParams::new(rows_per_zone), data_type)?;
     builder.maps = zones;
-    builder.write_index(dest_store).await?;
+    if any_null_bitmap {
+        builder.null_rows = merged_null_rows;
+    }
+    let files = builder.write_index(dest_store).await?;
 
     Ok(CreatedIndex {
         index_details: prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails::default()).unwrap(),
         index_version: ZONEMAP_INDEX_VERSION,
-        files: dest_store.list_files_with_sizes().await?,
+        files,
     })
 }
 
@@ -786,6 +825,7 @@ pub struct ZoneMapIndexBuilder {
 
     items_type: DataType,
     maps: Vec<ZoneMapStatistics>,
+    null_rows: RowAddrTreeMap,
 }
 
 impl ZoneMapIndexBuilder {
@@ -794,6 +834,7 @@ impl ZoneMapIndexBuilder {
             options,
             items_type,
             maps: Vec::new(),
+            null_rows: RowAddrTreeMap::new(),
         })
     }
 
@@ -803,7 +844,9 @@ impl ZoneMapIndexBuilder {
     pub async fn train(&mut self, batches_source: SendableRecordBatchStream) -> Result<()> {
         let processor = ZoneMapProcessor::new(self.items_type.clone())?;
         let trainer = ZoneTrainer::new(processor, self.options.rows_per_zone)?;
-        self.maps = trainer.train(batches_source).await?;
+        let (maps, null_rows) = trainer.train(batches_source).await?;
+        self.maps = maps;
+        self.null_rows = null_rows;
         Ok(())
     }
 
@@ -856,7 +899,7 @@ impl ZoneMapIndexBuilder {
         Ok(RecordBatch::try_new(schema, columns)?)
     }
 
-    pub async fn write_index(self, index_store: &dyn IndexStore) -> Result<IndexFile> {
+    pub async fn write_index(self, index_store: &dyn IndexStore) -> Result<Vec<IndexFile>> {
         let record_batch = self.zonemap_stats_as_batch()?;
 
         let mut file_schema = record_batch.schema().as_ref().clone();
@@ -869,7 +912,21 @@ impl ZoneMapIndexBuilder {
             .new_index_file(ZONEMAP_FILENAME, Arc::new(file_schema))
             .await?;
         index_file.write_record_batch(record_batch).await?;
-        index_file.finish().await
+
+        let mut null_bitmap_bytes = Vec::with_capacity(self.null_rows.serialized_size());
+        self.null_rows.serialize_into(&mut null_bitmap_bytes)?;
+        let null_bitmap_idx = index_file
+            .add_global_buffer(bytes::Bytes::from(null_bitmap_bytes))
+            .await?;
+
+        let zonemap_file = index_file
+            .finish_with_metadata(HashMap::from([(
+                NULL_BITMAP_META_KEY.to_string(),
+                null_bitmap_idx.to_string(),
+            )]))
+            .await?;
+
+        Ok(vec![zonemap_file])
     }
 }
 
@@ -974,8 +1031,7 @@ impl ZoneMapIndexPlugin {
         batches_source: SendableRecordBatchStream,
         index_store: &dyn IndexStore,
         options: Option<ZoneMapIndexBuilderParams>,
-    ) -> Result<IndexFile> {
-        // train_zonemap_index: calling scan_aligned_chunks
+    ) -> Result<Vec<IndexFile>> {
         let value_type = batches_source.schema().field(0).data_type().clone();
 
         let mut builder = ZoneMapIndexBuilder::try_new(options.unwrap_or_default(), value_type)?;
@@ -1042,12 +1098,12 @@ impl BasicTrainer for ZoneMapIndexPlugin {
                     "must provide training request created by new_training_request".into(),
                 )
             })?;
-        let file = Self::train_zonemap_index(data, index_store, Some(request.params)).await?;
+        let files = Self::train_zonemap_index(data, index_store, Some(request.params)).await?;
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails::default())
                 .unwrap(),
             index_version: ZONEMAP_INDEX_VERSION,
-            files: vec![file],
+            files,
         })
     }
 }
@@ -1117,7 +1173,7 @@ mod tests {
     use lance_datagen::ArrayGeneratorExt;
     use lance_datagen::{BatchCount, RowCount, array};
     use lance_io::object_store::ObjectStore;
-    use lance_select::{NullableRowAddrSet, RowAddrTreeMap};
+    use lance_select::RowAddrTreeMap;
 
     use crate::scalar::{
         SargableQuery, ScalarIndex, SearchResult,
@@ -1676,7 +1732,7 @@ mod tests {
         // Test IsNull query (should match nothing since there are no null values)
         let query = SargableQuery::IsNull();
         let result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
-        assert_eq!(result, SearchResult::AtMost(NullableRowAddrSet::empty()));
+        assert_eq!(result, SearchResult::exact(RowAddrTreeMap::new()));
 
         // Test range queries with NaN bounds
         // Range with NaN as start bound (included)
@@ -1719,7 +1775,7 @@ mod tests {
         );
         let result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
         // Should match nothing since nothing is greater than NaN
-        assert_eq!(result, SearchResult::AtMost(NullableRowAddrSet::empty()));
+        assert_eq!(result, SearchResult::at_most(RowAddrTreeMap::new()));
 
         // Test IsIn query with mixed float types (Float16, Float32, Float64)
         let query = SargableQuery::IsIn(vec![
@@ -1903,7 +1959,7 @@ mod tests {
         // 8. IsNull query (no nulls in data, should match nothing)
         let query = SargableQuery::IsNull();
         let result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
-        assert_eq!(result, SearchResult::at_most(RowAddrTreeMap::new()));
+        assert_eq!(result, SearchResult::exact(RowAddrTreeMap::new()));
         // 9. IsIn query: [0, 100, 101, 50]
         let query = SargableQuery::IsIn(vec![
             ScalarValue::Int32(Some(0)),
@@ -2612,6 +2668,7 @@ mod tests {
             store: test_store,
             fri: None,
             index_cache: WeakLanceCache::from(&LanceCache::no_cache()),
+            null_rows: None,
         };
 
         // Test LikePrefix query for "foo"
@@ -2684,6 +2741,7 @@ mod tests {
             store: test_store,
             fri: None,
             index_cache: WeakLanceCache::from(&LanceCache::no_cache()),
+            null_rows: None,
         };
 
         // Test LikePrefix "test"
@@ -2751,6 +2809,7 @@ mod tests {
             store: test_store,
             fri: None,
             index_cache: WeakLanceCache::from(&LanceCache::no_cache()),
+            null_rows: None,
         };
 
         // Test LikePrefix with LargeUtf8
@@ -2802,5 +2861,72 @@ mod tests {
         assert_eq!(compute_next_prefix("ab\u{10FFFF}"), Some("ac".to_string()));
         // All max characters
         assert_eq!(compute_next_prefix("\u{10FFFF}\u{10FFFF}"), None);
+    }
+
+    // Writes a zonemap file in the legacy format (no null bitmap global buffer),
+    // simulating an index created before the null bitmap feature was added.
+    async fn write_legacy_zonemap(store: &dyn IndexStore, null_count: u32) {
+        use arrow_array::{Int32Array, UInt32Array};
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("min", DataType::Int32, true),
+            Field::new("max", DataType::Int32, true),
+            Field::new("null_count", DataType::UInt32, false),
+            Field::new("nan_count", DataType::UInt32, false),
+            Field::new("fragment_id", DataType::UInt64, false),
+            Field::new("zone_start", DataType::UInt64, false),
+            Field::new("zone_length", DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![Some(0)])) as _,
+                Arc::new(Int32Array::from(vec![Some(99)])) as _,
+                Arc::new(UInt32Array::from(vec![null_count])) as _,
+                Arc::new(UInt32Array::from(vec![0u32])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![0u64])) as _,
+                Arc::new(UInt64Array::from(vec![100u64])) as _,
+            ],
+        )
+        .unwrap();
+        let mut file_schema = schema.as_ref().clone();
+        file_schema
+            .metadata
+            .insert(ZONEMAP_SIZE_META_KEY.to_string(), "8192".to_string());
+        let mut writer = store
+            .new_index_file(ZONEMAP_FILENAME, Arc::new(file_schema))
+            .await
+            .unwrap();
+        writer.write_record_batch(batch).await.unwrap();
+        writer.finish().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_legacy_zonemap_no_null_bitmap() {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        // Write a legacy index with one zone that has nulls but no null bitmap.
+        write_legacy_zonemap(store.as_ref(), 10).await;
+
+        let index = ZoneMapIndex::load(store, None, &LanceCache::no_cache())
+            .await
+            .expect("failed to load legacy zonemap");
+
+        assert!(index.null_rows.is_none(), "legacy index should have no null bitmap");
+
+        // IS NULL should fall back to the zone-scan path and return AtMost, not Exact.
+        let result = index
+            .search(&SargableQuery::IsNull(), &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert!(
+            !result.is_exact(),
+            "IS NULL on a legacy index should not be exact"
+        );
     }
 }

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -2304,4 +2304,70 @@ mod tests {
             "Should have 0 rows with value='banana' after deletion"
         );
     }
+
+    // End-to-end: create index → delete a whole fragment → search (via index) →
+    // update index → search again.  No deleted rows should ever appear.
+    #[tokio::test]
+    async fn test_zonemap_search_with_deleted_fragment_before_and_after_update() {
+        use arrow::datatypes::Int32Type;
+        use lance_datagen::array;
+        use lance_index::IndexType;
+        use lance_index::optimize::OptimizeOptions;
+        use lance_index::scalar::{BuiltinIndexType, ScalarIndexParams};
+
+        // 3 fragments × 10 rows: id 0-9 (frag 0), 10-19 (frag 1), 20-29 (frag 2).
+        let mut ds = lance_datagen::gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(3), FragmentRowCount::from(10))
+            .await
+            .unwrap();
+
+        let params = ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap);
+        ds.create_index(&["id"], IndexType::Scalar, None, &params, false)
+            .await
+            .unwrap();
+
+        // Delete the middle fragment entirely.
+        ds.delete("id >= 10 AND id < 20").await.unwrap();
+
+        // Helper: run a filter scan and return the sorted id values.
+        async fn live_ids(ds: &crate::Dataset) -> Vec<i32> {
+            let batch = ds
+                .scan()
+                .filter("id >= 0")
+                .unwrap()
+                .try_into_batch()
+                .await
+                .unwrap();
+            let mut ids: Vec<i32> = batch["id"]
+                .as_any()
+                .downcast_ref::<arrow_array::Int32Array>()
+                .unwrap()
+                .values()
+                .to_vec();
+            ids.sort_unstable();
+            ids
+        }
+
+        // --- Before index update ---
+        let ids = live_ids(&ds).await;
+        assert_eq!(ids.len(), 20, "expected 20 live rows before index update");
+        assert!(
+            ids.iter().all(|&id| !(10..20).contains(&id)),
+            "deleted fragment rows (id 10-19) must not appear before index update; got: {:?}",
+            ids
+        );
+
+        // Update the zone map index to reflect the deletion.
+        ds.optimize_indices(&OptimizeOptions::new()).await.unwrap();
+
+        // --- After index update ---
+        let ids = live_ids(&ds).await;
+        assert_eq!(ids.len(), 20, "expected 20 live rows after index update");
+        assert!(
+            ids.iter().all(|&id| !(10..20).contains(&id)),
+            "deleted fragment rows (id 10-19) must not appear after index update; got: {:?}",
+            ids
+        );
+    }
 }


### PR DESCRIPTION
The queries `X IS NULL` and `X IS NOT NULL` are very common queries.  Because validity is scattered throughout a file it is not actually that easy to answer this query without scanning the column.  This means very wide columns can be very slow.  Very wide columns also tend to be columns that are not good candidates for btree (too much duplicated data) or bitmap (too much cardinality).

On the flip side, a validity bitmap is pretty small, and maintaining one for each column is probably affordable, even for the lightweight zone map and bloom filter indexes.  It would be nice to have consistent `IS NULL` speedup when a column is indexed, regardless of the index type.

---

Captures a `RowAddrTreeMap` of every null row address during index training.  IS NULL queries can now be answered in O(1) by returning `SearchResult::exact(null_rows)` instead of scanning all zones, which also eliminates the downstream recheck step.

Backward-compatible: older indexes without the `null_bitmap.lance` file load with `null_rows = None` and fall back to the previous zone-scan path.
