### PR TITLE
fix(python): avoid deprecated NumPy shape assignment

### DIFF
--- a/python/python/lance/indices/builder.py
+++ b/python/python/lance/indices/builder.py
@@ -150,7 +150,7 @@ class IndicesBuilder:
                 max_iters=max_iters,
             )
             num_dims = ivf_centroids.shape[1]
-            ivf_centroids.shape = -1
+            ivf_centroids = ivf_centroids.reshape(-1)
             flat_centroids_array = pa.array(ivf_centroids)
             centroids_array = pa.FixedSizeListArray.from_arrays(
                 flat_centroids_array, num_dims

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -25,7 +25,7 @@ SMALL_NUM_ROWS = SMALL_ROWS_PER_FRAGMENT * NUM_FRAGMENTS
 
 def make_ds(num_rows: int, rows_per_frag: int, tmpdir: pathlib.Path, dtype: str):
     vectors = np.random.randn(num_rows, DIMENSION).astype(dtype)
-    vectors.shape = -1
+    vectors = vectors.reshape(-1)
     vectors = pa.FixedSizeListArray.from_arrays(vectors, DIMENSION)
     table = pa.Table.from_arrays([vectors], names=["vectors"])
     uri = str(tmpdir / "dataset")
@@ -53,7 +53,7 @@ def small_rand_dataset(tmpdir, request):
 @pytest.fixture
 def mostly_null_dataset(tmpdir, request):
     vectors = np.random.randn(NUM_ROWS, DIMENSION).astype(np.float32)
-    vectors.shape = -1
+    vectors = vectors.reshape(-1)
     vectors = pa.FixedSizeListArray.from_arrays(vectors, DIMENSION)
     vectors = vectors.to_pylist()
     vectors = [vec if i % 10 == 0 else None for i, vec in enumerate(vectors)]
@@ -219,7 +219,7 @@ def test_ivf_centroids_fragment_ids(tmpdir):
         ],
         axis=0,
     )
-    vectors.shape = -1
+    vectors = vectors.reshape(-1)
     table = pa.Table.from_arrays(
         [pa.FixedSizeListArray.from_arrays(vectors, DIMENSION)], names=["vectors"]
     )


### PR DESCRIPTION
## Bug Fix

### What is the bug?

NumPy 2.5 deprecates assigning directly to `ndarray.shape`, and the Python test configuration treats `DeprecationWarning` as an error.

### What issues or incorrect behavior does the bug cause?

Several IVF/PQ index tests fail during dataset setup or accelerator centroid flattening because `array.shape = -1` emits a deprecation warning.

### How does this PR fix the problem?

This replaces the deprecated in-place shape assignment with `reshape(-1)` in the Python index builder and affected test helpers.

## Validation

- `make install` from `python/`
- `uv run pytest python/tests/test_indices.py::test_ivf_centroids_fragment_ids`
- `uv run pytest python/tests/test_indices.py -k "ivf_centroids or num_partitions or gen_pq or pq_fragment_ids or pq_invalid_sub_vectors or gen_pq_mostly_null or vector_transform or shuffle_vectors or load_shuffled_vectors"`
- `uv run --frozen ruff format --check --diff python/lance/indices/builder.py python/tests/test_indices.py`
- `uv run --frozen ruff check python/lance/indices/builder.py python/tests/test_indices.py`