### PR TITLE
perf: speed up ICU FTS index builds by 11%

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -1319,9 +1319,8 @@ impl IndexWorker {
 
                 let mut token_stream = self.tokenizer.token_stream_for_doc(doc);
                 while token_stream.advance() {
-                    let token = token_stream.token_mut();
-                    let token_text = std::mem::take(&mut token.text);
-                    let token_id = builder.tokens.add(token_text);
+                    let token = token_stream.token();
+                    let token_id = builder.tokens.get_or_add(&token.text);
                     if token_id as usize == builder.posting_lists.len() {
                         let old_posting_lists_overhead_size = (builder.posting_lists.capacity()
                             * std::mem::size_of::<PostingListBuilder>())
@@ -1360,9 +1359,7 @@ impl IndexWorker {
 
                 let mut token_stream = self.tokenizer.token_stream_for_doc(doc);
                 while token_stream.advance() {
-                    let token = token_stream.token_mut();
-                    let token_text = std::mem::take(&mut token.text);
-                    let token_id = self.builder.tokens.add(token_text);
+                    let token_id = self.builder.tokens.get_or_add(&token_stream.token().text);
                     self.token_ids.push(token_id);
                     token_num += 1;
                 }

--- a/rust/lance-tokenizer/src/ascii_folding_filter.rs
+++ b/rust/lance-tokenizer/src/ascii_folding_filter.rs
@@ -49,9 +49,10 @@ impl<T: TokenStream> TokenStream for AsciiFoldingFilterTokenStream<'_, T> {
         if !self.tail.advance() {
             return false;
         }
-        if !self.token_mut().text.is_ascii() {
-            to_ascii(&self.tail.token().text, self.buffer);
-            mem::swap(&mut self.tail.token_mut().text, self.buffer);
+        let token = self.tail.token_mut();
+        if !token.text.is_ascii() {
+            to_ascii(&token.text, self.buffer);
+            mem::swap(&mut token.text, self.buffer);
         }
         true
     }
@@ -67,6 +68,7 @@ impl<T: TokenStream> TokenStream for AsciiFoldingFilterTokenStream<'_, T> {
 
 fn to_ascii(text: &str, output: &mut String) {
     output.clear();
+    output.reserve(text.len());
     for ch in text.chars() {
         if ch.is_ascii() {
             output.push(ch);
@@ -148,5 +150,11 @@ mod tests {
     fn test_ascii_folding_sharp_s() {
         let tokens = collect_tokens("straße");
         assert_eq!(tokens[0].text, "strasse");
+    }
+
+    #[test]
+    fn test_ascii_folding_cjk_unchanged() {
+        let tokens = collect_tokens("こんにちは世界");
+        assert_eq!(tokens[0].text, "こんにちは世界");
     }
 }

--- a/rust/lance-tokenizer/src/lower_caser.rs
+++ b/rust/lance-tokenizer/src/lower_caser.rs
@@ -47,10 +47,17 @@ pub struct LowerCaserTokenStream<'a, T> {
 
 fn to_lowercase_unicode(text: &str, output: &mut String) {
     output.clear();
-    output.reserve(50);
+    output.reserve(text.len());
     for ch in text.chars() {
         output.extend(ch.to_lowercase());
     }
+}
+
+fn is_lowercase_stable(text: &str) -> bool {
+    text.chars().all(|ch| {
+        let mut lower = ch.to_lowercase();
+        lower.next() == Some(ch) && lower.next().is_none()
+    })
 }
 
 impl<T: TokenStream> TokenStream for LowerCaserTokenStream<'_, T> {
@@ -58,11 +65,12 @@ impl<T: TokenStream> TokenStream for LowerCaserTokenStream<'_, T> {
         if !self.tail.advance() {
             return false;
         }
-        if self.token_mut().text.is_ascii() {
-            self.token_mut().text.make_ascii_lowercase();
-        } else {
-            to_lowercase_unicode(&self.tail.token().text, self.buffer);
-            mem::swap(&mut self.tail.token_mut().text, self.buffer);
+        let token = self.tail.token_mut();
+        if token.text.is_ascii() {
+            token.text.make_ascii_lowercase();
+        } else if !is_lowercase_stable(&token.text) {
+            to_lowercase_unicode(&token.text, self.buffer);
+            mem::swap(&mut token.text, self.buffer);
         }
         true
     }
@@ -73,5 +81,32 @@ impl<T: TokenStream> TokenStream for LowerCaserTokenStream<'_, T> {
 
     fn token_mut(&mut self) -> &mut Token {
         self.tail.token_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{LowerCaser, RawTokenizer, TextAnalyzer, Token};
+
+    fn collect_tokens(text: &str) -> Vec<Token> {
+        let mut analyzer = TextAnalyzer::builder(RawTokenizer::default())
+            .filter(LowerCaser)
+            .build();
+        let mut stream = analyzer.token_stream(text);
+        let mut tokens = Vec::new();
+        stream.process(&mut |token| tokens.push(token.clone()));
+        tokens
+    }
+
+    #[test]
+    fn test_lower_caser_unicode_changed() {
+        let tokens = collect_tokens("İSTANBUL");
+        assert_eq!(tokens[0].text, "i\u{307}stanbul");
+    }
+
+    #[test]
+    fn test_lower_caser_unicode_unchanged() {
+        let tokens = collect_tokens("こんにちは世界");
+        assert_eq!(tokens[0].text, "こんにちは世界");
     }
 }


### PR DESCRIPTION
This improves ICU FTS index build throughput without changing the produced index behavior.

The main cost in the 1M ICU build was allocation churn in token normalization and term registration. This keeps Unicode normalization output unchanged while avoiding unnecessary token string moves in the inverted-index builder and unnecessary Unicode lowercase rewrites for tokens that are already lowercase-stable.

Performance comparison, release build with no profiler, 1M rows, ICU tokenizer, 8 workers, memory_limit=16384:

| run | build | total | tokenize 100% |
|---|---:|---:|---:|
| baseline | 268.472s | 268.632s | 251.142s |
| this PR | 238.698s | 239.205s | 223.668s |

Compared with baseline, this saves 29.774s on build time, a 11.09% reduction. The benchmark run verified the rebuilt FTS index on 1,000,000 rows and returned results for both `the` and `中国` queries.

Local validation passed with Rust formatting, full clippy, tokenizer tests, and focused inverted-index tests.
