### PR TITLE
refactor(index): extract BasicTrainer trait from ScalarIndexPlugin

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"23aa895c-8c08-462b-ae20-e4ad399e466f","pid":1,"procStart":"52028919","acquiredAt":1782134409076}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"23aa895c-8c08-462b-ae20-e4ad399e466f","pid":1,"procStart":"52028919","acquiredAt":1782134409076}

--- a/rust/lance-index/benches/geo.rs
+++ b/rust/lance-index/benches/geo.rs
@@ -15,7 +15,7 @@ use geoarrow_schema::Dimension;
 use lance_core::cache::LanceCache;
 use lance_core::{Error, ROW_ID};
 use lance_index::scalar::lance_format::LanceIndexStore;
-use lance_index::scalar::registry::TrainsOnColumnStream;
+use lance_index::scalar::registry::BasicTrainer;
 use lance_index::scalar::rtree::{BoundingBox, RTreeIndex, RTreeIndexPlugin, RTreeTrainingRequest};
 use lance_index::scalar::{GeoQuery, RelationQuery, ScalarIndex};
 use lance_io::object_store::ObjectStore;

--- a/rust/lance-index/benches/geo.rs
+++ b/rust/lance-index/benches/geo.rs
@@ -15,7 +15,7 @@ use geoarrow_schema::Dimension;
 use lance_core::cache::LanceCache;
 use lance_core::{Error, ROW_ID};
 use lance_index::scalar::lance_format::LanceIndexStore;
-use lance_index::scalar::registry::ScalarIndexPlugin;
+use lance_index::scalar::registry::TrainsOnColumnStream;
 use lance_index::scalar::rtree::{BoundingBox, RTreeIndex, RTreeIndexPlugin, RTreeTrainingRequest};
 use lance_index::scalar::{GeoQuery, RelationQuery, ScalarIndex};
 use lance_io::object_store::ObjectStore;

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -1772,7 +1772,7 @@ impl BasicTrainer for BitmapIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for BitmapIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -48,8 +48,8 @@ use crate::{
         CreatedIndex, UpdateCriteria,
         expression::SargableQueryParser,
         registry::{
-            ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-            BasicTrainer, VALUE_COLUMN_NAME,
+            BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+            VALUE_COLUMN_NAME,
         },
     },
 };

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -49,7 +49,7 @@ use crate::{
         expression::SargableQueryParser,
         registry::{
             ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-            TrainsOnColumnStream, VALUE_COLUMN_NAME,
+            BasicTrainer, VALUE_COLUMN_NAME,
         },
     },
 };
@@ -1708,7 +1708,7 @@ pub async fn merge_bitmap_indices(
 }
 
 #[async_trait]
-impl TrainsOnColumnStream for BitmapIndexPlugin {
+impl BasicTrainer for BitmapIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -1772,7 +1772,7 @@ impl TrainsOnColumnStream for BitmapIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for BitmapIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -1772,7 +1772,7 @@ impl TrainsOnColumnStream for BitmapIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for BitmapIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -49,7 +49,7 @@ use crate::{
         expression::SargableQueryParser,
         registry::{
             ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-            VALUE_COLUMN_NAME,
+            TrainsOnColumnStream, VALUE_COLUMN_NAME,
         },
     },
 };
@@ -1708,11 +1708,7 @@ pub async fn merge_bitmap_indices(
 }
 
 #[async_trait]
-impl ScalarIndexPlugin for BitmapIndexPlugin {
-    fn name(&self) -> &str {
-        "Bitmap"
-    }
-
+impl TrainsOnColumnStream for BitmapIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -1729,27 +1725,6 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
             serde_json::from_str::<BitmapParameters>(params)?
         };
         Ok(Box::new(BitmapTrainingRequest::new(params)))
-    }
-
-    fn provides_exact_answer(&self) -> bool {
-        true
-    }
-
-    fn version(&self) -> u32 {
-        BITMAP_INDEX_VERSION
-    }
-
-    fn new_query_parser(
-        &self,
-        index_name: String,
-        _index_details: &prost_types::Any,
-    ) -> Option<Box<dyn ScalarQueryParser>> {
-        // Bitmap indexes cannot answer `LikePrefix` queries (see `search`), so the parser
-        // is configured to skip them and let such predicates fall back to ordinary filtering.
-        Some(Box::new(
-            SargableQueryParser::new(index_name, self.name().to_string(), false)
-                .without_like_prefix(),
-        ))
     }
 
     async fn train_index(
@@ -1792,6 +1767,38 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
             index_version: BITMAP_INDEX_VERSION,
             files: vec![file],
         })
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for BitmapIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
+
+    fn name(&self) -> &str {
+        "Bitmap"
+    }
+
+    fn provides_exact_answer(&self) -> bool {
+        true
+    }
+
+    fn version(&self) -> u32 {
+        BITMAP_INDEX_VERSION
+    }
+
+    fn new_query_parser(
+        &self,
+        index_name: String,
+        _index_details: &prost_types::Any,
+    ) -> Option<Box<dyn ScalarQueryParser>> {
+        // Bitmap indexes cannot answer `LikePrefix` queries (see `search`), so the parser
+        // is configured to skip them and let such predicates fall back to ordinary filtering.
+        Some(Box::new(
+            SargableQueryParser::new(index_name, self.name().to_string(), false)
+                .without_like_prefix(),
+        ))
     }
 
     /// Load an index from storage

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -9,7 +9,7 @@
 
 use crate::scalar::expression::{BloomFilterQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, BasicTrainer,
+    BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
 };
 use crate::scalar::{
     BloomFilterQuery, BuiltinIndexType, CreatedIndex, IndexFile, ScalarIndexParams, UpdateCriteria,

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -9,7 +9,7 @@
 
 use crate::scalar::expression::{BloomFilterQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, TrainsOnColumnStream,
 };
 use crate::scalar::{
     BloomFilterQuery, BuiltinIndexType, CreatedIndex, IndexFile, ScalarIndexParams, UpdateCriteria,
@@ -988,11 +988,7 @@ impl BloomFilterIndexPlugin {
 }
 
 #[async_trait]
-impl ScalarIndexPlugin for BloomFilterIndexPlugin {
-    fn name(&self) -> &str {
-        "BloomFilter"
-    }
-
+impl TrainsOnColumnStream for BloomFilterIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -1075,6 +1071,13 @@ impl ScalarIndexPlugin for BloomFilterIndexPlugin {
             files: vec![file],
         })
     }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for BloomFilterIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
 
     fn provides_exact_answer(&self) -> bool {
         false
@@ -1082,6 +1085,10 @@ impl ScalarIndexPlugin for BloomFilterIndexPlugin {
 
     fn version(&self) -> u32 {
         BLOOMFILTER_INDEX_VERSION
+    }
+
+    fn name(&self) -> &str {
+        "BloomFilter"
     }
 
     fn new_query_parser(

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -1075,7 +1075,7 @@ impl BasicTrainer for BloomFilterIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for BloomFilterIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -9,7 +9,7 @@
 
 use crate::scalar::expression::{BloomFilterQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, TrainsOnColumnStream,
+    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, BasicTrainer,
 };
 use crate::scalar::{
     BloomFilterQuery, BuiltinIndexType, CreatedIndex, IndexFile, ScalarIndexParams, UpdateCriteria,
@@ -988,7 +988,7 @@ impl BloomFilterIndexPlugin {
 }
 
 #[async_trait]
-impl TrainsOnColumnStream for BloomFilterIndexPlugin {
+impl BasicTrainer for BloomFilterIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -1075,7 +1075,7 @@ impl TrainsOnColumnStream for BloomFilterIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for BloomFilterIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -1075,7 +1075,7 @@ impl TrainsOnColumnStream for BloomFilterIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for BloomFilterIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -3260,7 +3260,7 @@ impl BasicTrainer for BTreeIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for BTreeIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -23,7 +23,7 @@ use crate::{
     scalar::{
         CreatedIndex, UpdateCriteria,
         expression::{SargableQueryParser, ScalarQueryParser},
-        registry::{ScalarIndexPlugin, TrainingOrdering, TrainingRequest, VALUE_COLUMN_NAME},
+        registry::{ScalarIndexPlugin, TrainingOrdering, TrainingRequest, TrainsOnColumnStream, VALUE_COLUMN_NAME},
     },
 };
 use crate::{metrics::NoOpMetricsCollector, scalar::registry::TrainingCriteria};
@@ -3196,11 +3196,7 @@ impl TrainingRequest for BTreeTrainingRequest {
 pub struct BTreeIndexPlugin;
 
 #[async_trait]
-impl ScalarIndexPlugin for BTreeIndexPlugin {
-    fn name(&self) -> &str {
-        "BTree"
-    }
-
+impl TrainsOnColumnStream for BTreeIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -3214,26 +3210,6 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
 
         let params = serde_json::from_str::<BTreeParameters>(params)?;
         Ok(Box::new(BTreeTrainingRequest::new(params)))
-    }
-
-    fn provides_exact_answer(&self) -> bool {
-        true
-    }
-
-    fn version(&self) -> u32 {
-        BTREE_INDEX_VERSION
-    }
-
-    fn new_query_parser(
-        &self,
-        index_name: String,
-        _index_details: &prost_types::Any,
-    ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(SargableQueryParser::new(
-            index_name,
-            self.name().to_string(),
-            false,
-        )))
     }
 
     async fn train_index(
@@ -3279,6 +3255,37 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
             index_version: BTREE_INDEX_VERSION,
             files,
         })
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for BTreeIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
+
+    fn name(&self) -> &str {
+        "BTree"
+    }
+
+    fn provides_exact_answer(&self) -> bool {
+        true
+    }
+
+    fn version(&self) -> u32 {
+        BTREE_INDEX_VERSION
+    }
+
+    fn new_query_parser(
+        &self,
+        index_name: String,
+        _index_details: &prost_types::Any,
+    ) -> Option<Box<dyn ScalarQueryParser>> {
+        Some(Box::new(SargableQueryParser::new(
+            index_name,
+            self.name().to_string(),
+            false,
+        )))
     }
 
     async fn load_index(

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -3260,7 +3260,7 @@ impl TrainsOnColumnStream for BTreeIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for BTreeIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -23,7 +23,9 @@ use crate::{
     scalar::{
         CreatedIndex, UpdateCriteria,
         expression::{SargableQueryParser, ScalarQueryParser},
-        registry::{ScalarIndexPlugin, TrainingOrdering, TrainingRequest, BasicTrainer, VALUE_COLUMN_NAME},
+        registry::{
+            BasicTrainer, ScalarIndexPlugin, TrainingOrdering, TrainingRequest, VALUE_COLUMN_NAME,
+        },
     },
 };
 use crate::{metrics::NoOpMetricsCollector, scalar::registry::TrainingCriteria};

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -23,7 +23,7 @@ use crate::{
     scalar::{
         CreatedIndex, UpdateCriteria,
         expression::{SargableQueryParser, ScalarQueryParser},
-        registry::{ScalarIndexPlugin, TrainingOrdering, TrainingRequest, TrainsOnColumnStream, VALUE_COLUMN_NAME},
+        registry::{ScalarIndexPlugin, TrainingOrdering, TrainingRequest, BasicTrainer, VALUE_COLUMN_NAME},
     },
 };
 use crate::{metrics::NoOpMetricsCollector, scalar::registry::TrainingCriteria};
@@ -3196,7 +3196,7 @@ impl TrainingRequest for BTreeTrainingRequest {
 pub struct BTreeIndexPlugin;
 
 #[async_trait]
-impl TrainsOnColumnStream for BTreeIndexPlugin {
+impl BasicTrainer for BTreeIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -3260,7 +3260,7 @@ impl TrainsOnColumnStream for BTreeIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for BTreeIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -2471,7 +2471,7 @@ impl BasicTrainer for FMIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for FMIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -2471,7 +2471,7 @@ impl TrainsOnColumnStream for FMIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for FMIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -42,7 +42,7 @@ use crate::pb;
 use crate::scalar::expression::{ScalarQueryParser, TextQueryParser};
 use crate::scalar::registry::{
     DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    VALUE_COLUMN_NAME,
+    TrainsOnColumnStream, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{
     AnyQuery, BuiltinIndexType, CreatedIndex, IndexFile, IndexStore, OldIndexDataFilter,
@@ -2433,10 +2433,7 @@ async fn write_empty_fmindex_partition(store: &dyn IndexStore) -> Result<IndexFi
 pub struct FMIndexPlugin;
 
 #[async_trait]
-impl ScalarIndexPlugin for FMIndexPlugin {
-    fn name(&self) -> &str {
-        "Fm"
-    }
+impl TrainsOnColumnStream for FMIndexPlugin {
     fn new_training_request(
         &self,
         _params: &str,
@@ -2469,6 +2466,17 @@ impl ScalarIndexPlugin for FMIndexPlugin {
             index_version: FMINDEX_INDEX_VERSION,
             files,
         })
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for FMIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
+
+    fn name(&self) -> &str {
+        "Fm"
     }
     fn provides_exact_answer(&self) -> bool {
         true
@@ -2521,6 +2529,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::scalar::lance_format::LanceIndexStore;
+    use crate::scalar::registry::TrainsOnColumnStream;
 
     #[derive(Debug, Clone)]
     struct FailNewFileStore {

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -42,7 +42,7 @@ use crate::pb;
 use crate::scalar::expression::{ScalarQueryParser, TextQueryParser};
 use crate::scalar::registry::{
     DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    TrainsOnColumnStream, VALUE_COLUMN_NAME,
+    BasicTrainer, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{
     AnyQuery, BuiltinIndexType, CreatedIndex, IndexFile, IndexStore, OldIndexDataFilter,
@@ -2433,7 +2433,7 @@ async fn write_empty_fmindex_partition(store: &dyn IndexStore) -> Result<IndexFi
 pub struct FMIndexPlugin;
 
 #[async_trait]
-impl TrainsOnColumnStream for FMIndexPlugin {
+impl BasicTrainer for FMIndexPlugin {
     fn new_training_request(
         &self,
         _params: &str,
@@ -2471,7 +2471,7 @@ impl TrainsOnColumnStream for FMIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for FMIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 
@@ -2529,7 +2529,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::scalar::lance_format::LanceIndexStore;
-    use crate::scalar::registry::TrainsOnColumnStream;
+    use crate::scalar::registry::BasicTrainer;
 
     #[derive(Debug, Clone)]
     struct FailNewFileStore {

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -41,8 +41,8 @@ use crate::metrics::MetricsCollector;
 use crate::pb;
 use crate::scalar::expression::{ScalarQueryParser, TextQueryParser};
 use crate::scalar::registry::{
-    DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    BasicTrainer, VALUE_COLUMN_NAME,
+    BasicTrainer, DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering,
+    TrainingRequest, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{
     AnyQuery, BuiltinIndexType, CreatedIndex, IndexFile, IndexStore, OldIndexDataFilter,

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -119,7 +119,7 @@ use crate::{
     scalar::{
         CreatedIndex, ScalarIndex,
         expression::{FtsQueryParser, ScalarQueryParser},
-        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, TrainsOnColumnStream},
+        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, BasicTrainer},
     },
 };
 
@@ -194,7 +194,7 @@ impl TrainingRequest for InvertedIndexTrainingRequest {
 }
 
 #[async_trait]
-impl TrainsOnColumnStream for InvertedIndexPlugin {
+impl BasicTrainer for InvertedIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -254,7 +254,7 @@ impl TrainsOnColumnStream for InvertedIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for InvertedIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -254,7 +254,7 @@ impl TrainsOnColumnStream for InvertedIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for InvertedIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -119,7 +119,9 @@ use crate::{
     scalar::{
         CreatedIndex, ScalarIndex,
         expression::{FtsQueryParser, ScalarQueryParser},
-        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, BasicTrainer},
+        registry::{
+            BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+        },
     },
 };
 

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -254,7 +254,7 @@ impl BasicTrainer for InvertedIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for InvertedIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -119,7 +119,7 @@ use crate::{
     scalar::{
         CreatedIndex, ScalarIndex,
         expression::{FtsQueryParser, ScalarQueryParser},
-        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest},
+        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, TrainsOnColumnStream},
     },
 };
 
@@ -194,11 +194,7 @@ impl TrainingRequest for InvertedIndexTrainingRequest {
 }
 
 #[async_trait]
-impl ScalarIndexPlugin for InvertedIndexPlugin {
-    fn name(&self) -> &str {
-        "Inverted"
-    }
-
+impl TrainsOnColumnStream for InvertedIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -218,33 +214,6 @@ impl ScalarIndexPlugin for InvertedIndexPlugin {
 
         let params = serde_json::from_str::<InvertedIndexParams>(params)?;
         Ok(Box::new(InvertedIndexTrainingRequest::new(params)))
-    }
-
-    fn provides_exact_answer(&self) -> bool {
-        false
-    }
-
-    fn version(&self) -> u32 {
-        max_supported_fts_format_version().index_version()
-    }
-
-    fn new_query_parser(
-        &self,
-        index_name: String,
-        _index_details: &prost_types::Any,
-    ) -> Option<Box<dyn ScalarQueryParser>> {
-        let Ok(index_details) = _index_details.to_msg::<pbold::InvertedIndexDetails>() else {
-            return None;
-        };
-
-        if Self::can_accelerate_queries(&index_details) {
-            Some(Box::new(FtsQueryParser::new(
-                index_name,
-                self.name().to_string(),
-            )))
-        } else {
-            None
-        }
     }
 
     /// Train a new index
@@ -280,6 +249,44 @@ impl ScalarIndexPlugin for InvertedIndexPlugin {
             progress,
         )
         .await
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for InvertedIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
+
+    fn name(&self) -> &str {
+        "Inverted"
+    }
+
+    fn provides_exact_answer(&self) -> bool {
+        false
+    }
+
+    fn version(&self) -> u32 {
+        max_supported_fts_format_version().index_version()
+    }
+
+    fn new_query_parser(
+        &self,
+        index_name: String,
+        _index_details: &prost_types::Any,
+    ) -> Option<Box<dyn ScalarQueryParser>> {
+        let Ok(index_details) = _index_details.to_msg::<pbold::InvertedIndexDetails>() else {
+            return None;
+        };
+
+        if Self::can_accelerate_queries(&index_details) {
+            Some(Box::new(FtsQueryParser::new(
+                index_name,
+                self.name().to_string(),
+            )))
+        } else {
+            None
+        }
     }
 
     /// Load an index from storage

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -39,7 +39,7 @@ use crate::{
     scalar::{
         AnyQuery, CreatedIndex, IndexStore, ScalarIndex, SearchResult, UpdateCriteria,
         expression::{IndexedExpression, ScalarIndexExpr, ScalarIndexSearch, ScalarQueryParser},
-        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingRequest, TrainsOnColumnStream, VALUE_COLUMN_NAME},
+        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingRequest, BasicTrainer, VALUE_COLUMN_NAME},
     },
 };
 
@@ -666,7 +666,7 @@ impl JsonIndexPlugin {
 }
 
 #[async_trait]
-impl TrainsOnColumnStream for JsonIndexPlugin {
+impl BasicTrainer for JsonIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -761,7 +761,7 @@ impl TrainsOnColumnStream for JsonIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for JsonIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -39,7 +39,7 @@ use crate::{
     scalar::{
         AnyQuery, CreatedIndex, IndexStore, ScalarIndex, SearchResult, UpdateCriteria,
         expression::{IndexedExpression, ScalarIndexExpr, ScalarIndexSearch, ScalarQueryParser},
-        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingRequest, VALUE_COLUMN_NAME},
+        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingRequest, TrainsOnColumnStream, VALUE_COLUMN_NAME},
     },
 };
 
@@ -666,11 +666,7 @@ impl JsonIndexPlugin {
 }
 
 #[async_trait]
-impl ScalarIndexPlugin for JsonIndexPlugin {
-    fn name(&self) -> &str {
-        "Json"
-    }
-
+impl TrainsOnColumnStream for JsonIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -688,12 +684,89 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
         let params = serde_json::from_str::<JsonIndexParameters>(params)?;
         let registry = self.registry()?;
         let target_plugin = registry.get_plugin_by_name(&params.target_index_type)?;
-        let target_request = target_plugin.new_training_request(
+        let target_trainer = target_plugin.as_trainer().ok_or_else(|| {
+            Error::invalid_input_source(
+                format!("The '{}' index type does not support training", params.target_index_type).into(),
+            )
+        })?;
+        let target_request = target_trainer.new_training_request(
             params.target_index_parameters.as_deref().unwrap_or("{}"),
             &Field::new("", target_type, true),
         )?;
 
         Ok(Box::new(JsonTrainingRequest::new(params, target_request)))
+    }
+
+    async fn train_index(
+        &self,
+        data: SendableRecordBatchStream,
+        index_store: &dyn IndexStore,
+        request: Box<dyn TrainingRequest>,
+        fragment_ids: Option<Vec<u32>>,
+        progress: Arc<dyn crate::progress::IndexBuildProgress>,
+    ) -> Result<CreatedIndex> {
+        let request = (request as Box<dyn std::any::Any>)
+            .downcast::<JsonTrainingRequest>()
+            .unwrap();
+        let path = request.parameters.path.clone();
+
+        // Extract JSON with type information
+        let (data_stream, inferred_type) =
+            Self::extract_json_with_type_info(data, path.clone()).await?;
+
+        // Convert the stream to properly typed values based on inferred type
+        let converted_stream =
+            Self::convert_stream_by_type(data_stream, inferred_type.clone()).await?;
+
+        // Update the target request with inferred type
+        let registry = self.registry()?;
+        let target_plugin = registry.get_plugin_by_name(&request.parameters.target_index_type)?;
+
+        // Create a new training request with the inferred type
+        let target_trainer = target_plugin.as_trainer().ok_or_else(|| {
+            Error::invalid_input_source(
+                format!("The '{}' index type does not support training", request.parameters.target_index_type).into(),
+            )
+        })?;
+        let target_request = target_trainer.new_training_request(
+            request
+                .parameters
+                .target_index_parameters
+                .as_deref()
+                .unwrap_or("{}"),
+            &Field::new("", inferred_type, true),
+        )?;
+
+        let target_index = target_trainer
+            .train_index(
+                converted_stream,
+                index_store,
+                target_request,
+                fragment_ids,
+                progress,
+            )
+            .await?;
+
+        let index_details = crate::pb::JsonIndexDetails {
+            path,
+            target_details: Some(target_index.index_details),
+        };
+        Ok(CreatedIndex {
+            index_details: prost_types::Any::from_msg(&index_details)?,
+            index_version: JSON_INDEX_VERSION,
+            files: target_index.files,
+        })
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for JsonIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
+
+    fn name(&self) -> &str {
+        "Json"
     }
 
     fn provides_exact_answer(&self) -> bool {
@@ -727,62 +800,6 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
             json_details.path.clone(),
             target_parser,
         )) as Box<dyn ScalarQueryParser>)
-    }
-
-    async fn train_index(
-        &self,
-        data: SendableRecordBatchStream,
-        index_store: &dyn IndexStore,
-        request: Box<dyn TrainingRequest>,
-        fragment_ids: Option<Vec<u32>>,
-        progress: Arc<dyn crate::progress::IndexBuildProgress>,
-    ) -> Result<CreatedIndex> {
-        let request = (request as Box<dyn std::any::Any>)
-            .downcast::<JsonTrainingRequest>()
-            .unwrap();
-        let path = request.parameters.path.clone();
-
-        // Extract JSON with type information
-        let (data_stream, inferred_type) =
-            Self::extract_json_with_type_info(data, path.clone()).await?;
-
-        // Convert the stream to properly typed values based on inferred type
-        let converted_stream =
-            Self::convert_stream_by_type(data_stream, inferred_type.clone()).await?;
-
-        // Update the target request with inferred type
-        let registry = self.registry()?;
-        let target_plugin = registry.get_plugin_by_name(&request.parameters.target_index_type)?;
-
-        // Create a new training request with the inferred type
-        let target_request = target_plugin.new_training_request(
-            request
-                .parameters
-                .target_index_parameters
-                .as_deref()
-                .unwrap_or("{}"),
-            &Field::new("", inferred_type, true),
-        )?;
-
-        let target_index = target_plugin
-            .train_index(
-                converted_stream,
-                index_store,
-                target_request,
-                fragment_ids,
-                progress,
-            )
-            .await?;
-
-        let index_details = crate::pb::JsonIndexDetails {
-            path,
-            target_details: Some(target_index.index_details),
-        };
-        Ok(CreatedIndex {
-            index_details: prost_types::Any::from_msg(&index_details)?,
-            index_version: JSON_INDEX_VERSION,
-            files: target_index.files,
-        })
     }
 
     async fn load_index(

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -686,7 +686,7 @@ impl BasicTrainer for JsonIndexPlugin {
         let target_plugin = registry.get_plugin_by_name(&params.target_index_type)?;
         let target_trainer = target_plugin.basic_trainer().ok_or_else(|| {
             Error::invalid_input_source(
-                format!("The '{}' index type does not support training", params.target_index_type).into(),
+                format!("The '{}' index type does not support basic training, please refer to the index's documentation for more details on how to create this index.", params.target_index_type).into(),
             )
         })?;
         let target_request = target_trainer.new_training_request(
@@ -725,7 +725,7 @@ impl BasicTrainer for JsonIndexPlugin {
         // Create a new training request with the inferred type
         let target_trainer = target_plugin.basic_trainer().ok_or_else(|| {
             Error::invalid_input_source(
-                format!("The '{}' index type does not support training", request.parameters.target_index_type).into(),
+                format!("The '{}' index type does not support basic training, please refer to the index's documentation for more details on how to create this index.", request.parameters.target_index_type).into(),
             )
         })?;
         let target_request = target_trainer.new_training_request(

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -684,7 +684,7 @@ impl BasicTrainer for JsonIndexPlugin {
         let params = serde_json::from_str::<JsonIndexParameters>(params)?;
         let registry = self.registry()?;
         let target_plugin = registry.get_plugin_by_name(&params.target_index_type)?;
-        let target_trainer = target_plugin.simple_trainer().ok_or_else(|| {
+        let target_trainer = target_plugin.basic_trainer().ok_or_else(|| {
             Error::invalid_input_source(
                 format!("The '{}' index type does not support training", params.target_index_type).into(),
             )
@@ -723,7 +723,7 @@ impl BasicTrainer for JsonIndexPlugin {
         let target_plugin = registry.get_plugin_by_name(&request.parameters.target_index_type)?;
 
         // Create a new training request with the inferred type
-        let target_trainer = target_plugin.simple_trainer().ok_or_else(|| {
+        let target_trainer = target_plugin.basic_trainer().ok_or_else(|| {
             Error::invalid_input_source(
                 format!("The '{}' index type does not support training", request.parameters.target_index_type).into(),
             )
@@ -761,7 +761,7 @@ impl BasicTrainer for JsonIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for JsonIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -684,7 +684,7 @@ impl TrainsOnColumnStream for JsonIndexPlugin {
         let params = serde_json::from_str::<JsonIndexParameters>(params)?;
         let registry = self.registry()?;
         let target_plugin = registry.get_plugin_by_name(&params.target_index_type)?;
-        let target_trainer = target_plugin.as_trainer().ok_or_else(|| {
+        let target_trainer = target_plugin.simple_trainer().ok_or_else(|| {
             Error::invalid_input_source(
                 format!("The '{}' index type does not support training", params.target_index_type).into(),
             )
@@ -723,7 +723,7 @@ impl TrainsOnColumnStream for JsonIndexPlugin {
         let target_plugin = registry.get_plugin_by_name(&request.parameters.target_index_type)?;
 
         // Create a new training request with the inferred type
-        let target_trainer = target_plugin.as_trainer().ok_or_else(|| {
+        let target_trainer = target_plugin.simple_trainer().ok_or_else(|| {
             Error::invalid_input_source(
                 format!("The '{}' index type does not support training", request.parameters.target_index_type).into(),
             )
@@ -761,7 +761,7 @@ impl TrainsOnColumnStream for JsonIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for JsonIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -39,7 +39,9 @@ use crate::{
     scalar::{
         AnyQuery, CreatedIndex, IndexStore, ScalarIndex, SearchResult, UpdateCriteria,
         expression::{IndexedExpression, ScalarIndexExpr, ScalarIndexSearch, ScalarQueryParser},
-        registry::{ScalarIndexPlugin, TrainingCriteria, TrainingRequest, BasicTrainer, VALUE_COLUMN_NAME},
+        registry::{
+            BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingRequest, VALUE_COLUMN_NAME,
+        },
     },
 };
 

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -744,7 +744,7 @@ impl TrainsOnColumnStream for LabelListIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for LabelListIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -744,7 +744,7 @@ impl BasicTrainer for LabelListIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for LabelListIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -40,7 +40,7 @@ use crate::scalar::bitmap::{BitmapIndexPlugin, BitmapIndexState};
 use crate::scalar::expression::{LabelListQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
     DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    VALUE_COLUMN_NAME,
+    TrainsOnColumnStream, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{CreatedIndex, UpdateCriteria};
 use crate::{Index, IndexType};
@@ -664,11 +664,7 @@ impl CacheKey for LabelListIndexStateKey {
 pub struct LabelListIndexPlugin;
 
 #[async_trait]
-impl ScalarIndexPlugin for LabelListIndexPlugin {
-    fn name(&self) -> &str {
-        "LabelList"
-    }
-
+impl TrainsOnColumnStream for LabelListIndexPlugin {
     fn new_training_request(
         &self,
         _params: &str,
@@ -687,25 +683,6 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
 
         Ok(Box::new(DefaultTrainingRequest::new(
             TrainingCriteria::new(TrainingOrdering::None).with_row_id(),
-        )))
-    }
-
-    fn provides_exact_answer(&self) -> bool {
-        true
-    }
-
-    fn version(&self) -> u32 {
-        LABEL_LIST_INDEX_VERSION
-    }
-
-    fn new_query_parser(
-        &self,
-        index_name: String,
-        _index_details: &prost_types::Any,
-    ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(LabelListQueryParser::new(
-            index_name,
-            self.name().to_string(),
         )))
     }
 
@@ -762,6 +739,36 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
             index_version: LABEL_LIST_INDEX_VERSION,
             files: vec![file],
         })
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for LabelListIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
+
+    fn name(&self) -> &str {
+        "LabelList"
+    }
+
+    fn provides_exact_answer(&self) -> bool {
+        true
+    }
+
+    fn version(&self) -> u32 {
+        LABEL_LIST_INDEX_VERSION
+    }
+
+    fn new_query_parser(
+        &self,
+        index_name: String,
+        _index_details: &prost_types::Any,
+    ) -> Option<Box<dyn ScalarQueryParser>> {
+        Some(Box::new(LabelListQueryParser::new(
+            index_name,
+            self.name().to_string(),
+        )))
     }
 
     /// Load an index from storage

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -40,7 +40,7 @@ use crate::scalar::bitmap::{BitmapIndexPlugin, BitmapIndexState};
 use crate::scalar::expression::{LabelListQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
     DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    TrainsOnColumnStream, VALUE_COLUMN_NAME,
+    BasicTrainer, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{CreatedIndex, UpdateCriteria};
 use crate::{Index, IndexType};
@@ -664,7 +664,7 @@ impl CacheKey for LabelListIndexStateKey {
 pub struct LabelListIndexPlugin;
 
 #[async_trait]
-impl TrainsOnColumnStream for LabelListIndexPlugin {
+impl BasicTrainer for LabelListIndexPlugin {
     fn new_training_request(
         &self,
         _params: &str,
@@ -744,7 +744,7 @@ impl TrainsOnColumnStream for LabelListIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for LabelListIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -39,8 +39,8 @@ use crate::pbold;
 use crate::scalar::bitmap::{BitmapIndexPlugin, BitmapIndexState};
 use crate::scalar::expression::{LabelListQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    BasicTrainer, VALUE_COLUMN_NAME,
+    BasicTrainer, DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering,
+    TrainingRequest, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{CreatedIndex, UpdateCriteria};
 use crate::{Index, IndexType};

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -569,7 +569,7 @@ mod tests {
     use crate::scalar::bitmap::BitmapIndexPlugin;
     use crate::scalar::btree::{BTreeIndexPlugin, BTreeParameters};
     use crate::scalar::label_list::LabelListIndexPlugin;
-    use crate::scalar::registry::{ScalarIndexPlugin, TrainsOnColumnStream, VALUE_COLUMN_NAME};
+    use crate::scalar::registry::{ScalarIndexPlugin, BasicTrainer, VALUE_COLUMN_NAME};
     use crate::scalar::{
         LabelListQuery, SargableQuery, ScalarIndex, SearchResult,
         bitmap::BitmapIndex,

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -569,7 +569,7 @@ mod tests {
     use crate::scalar::bitmap::BitmapIndexPlugin;
     use crate::scalar::btree::{BTreeIndexPlugin, BTreeParameters};
     use crate::scalar::label_list::LabelListIndexPlugin;
-    use crate::scalar::registry::{ScalarIndexPlugin, VALUE_COLUMN_NAME};
+    use crate::scalar::registry::{ScalarIndexPlugin, TrainsOnColumnStream, VALUE_COLUMN_NAME};
     use crate::scalar::{
         LabelListQuery, SargableQuery, ScalarIndex, SearchResult,
         bitmap::BitmapIndex,

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -569,7 +569,7 @@ mod tests {
     use crate::scalar::bitmap::BitmapIndexPlugin;
     use crate::scalar::btree::{BTreeIndexPlugin, BTreeParameters};
     use crate::scalar::label_list::LabelListIndexPlugin;
-    use crate::scalar::registry::{ScalarIndexPlugin, BasicTrainer, VALUE_COLUMN_NAME};
+    use crate::scalar::registry::{BasicTrainer, ScalarIndexPlugin, VALUE_COLUMN_NAME};
     use crate::scalar::{
         LabelListQuery, SargableQuery, ScalarIndex, SearchResult,
         bitmap::BitmapIndex,

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -20,8 +20,8 @@ use crate::metrics::NoOpMetricsCollector;
 use crate::pbold;
 use crate::scalar::expression::{ScalarQueryParser, TextQueryParser};
 use crate::scalar::registry::{
-    DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    BasicTrainer, VALUE_COLUMN_NAME,
+    BasicTrainer, DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering,
+    TrainingRequest, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{CreatedIndex, UpdateCriteria};
 use crate::{Index, IndexType};

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -1323,7 +1323,7 @@ impl BasicTrainer for NGramIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for NGramIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -21,7 +21,7 @@ use crate::pbold;
 use crate::scalar::expression::{ScalarQueryParser, TextQueryParser};
 use crate::scalar::registry::{
     DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    TrainsOnColumnStream, VALUE_COLUMN_NAME,
+    BasicTrainer, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{CreatedIndex, UpdateCriteria};
 use crate::{Index, IndexType};
@@ -1279,7 +1279,7 @@ impl NGramIndexPlugin {
 }
 
 #[async_trait]
-impl TrainsOnColumnStream for NGramIndexPlugin {
+impl BasicTrainer for NGramIndexPlugin {
     fn new_training_request(
         &self,
         _params: &str,
@@ -1323,7 +1323,7 @@ impl TrainsOnColumnStream for NGramIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for NGramIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -21,7 +21,7 @@ use crate::pbold;
 use crate::scalar::expression::{ScalarQueryParser, TextQueryParser};
 use crate::scalar::registry::{
     DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    VALUE_COLUMN_NAME,
+    TrainsOnColumnStream, VALUE_COLUMN_NAME,
 };
 use crate::scalar::{CreatedIndex, UpdateCriteria};
 use crate::{Index, IndexType};
@@ -1279,11 +1279,7 @@ impl NGramIndexPlugin {
 }
 
 #[async_trait]
-impl ScalarIndexPlugin for NGramIndexPlugin {
-    fn name(&self) -> &str {
-        "NGram"
-    }
-
+impl TrainsOnColumnStream for NGramIndexPlugin {
     fn new_training_request(
         &self,
         _params: &str,
@@ -1298,29 +1294,6 @@ impl ScalarIndexPlugin for NGramIndexPlugin {
         }
         Ok(Box::new(DefaultTrainingRequest::new(
             TrainingCriteria::new(TrainingOrdering::None).with_row_id(),
-        )))
-    }
-
-    fn provides_exact_answer(&self) -> bool {
-        false
-    }
-
-    fn version(&self) -> u32 {
-        NGRAM_INDEX_VERSION
-    }
-
-    fn new_query_parser(
-        &self,
-        index_name: String,
-        _index_details: &prost_types::Any,
-    ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(TextQueryParser::new(
-            index_name,
-            self.name().to_string(),
-            // needs_recheck: ngram results are an inexact candidate superset.
-            true,
-            // supports_regex: the ngram index can answer regex queries.
-            true,
         )))
     }
 
@@ -1345,6 +1318,40 @@ impl ScalarIndexPlugin for NGramIndexPlugin {
             index_version: NGRAM_INDEX_VERSION,
             files: vec![file],
         })
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for NGramIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
+
+    fn name(&self) -> &str {
+        "NGram"
+    }
+
+    fn provides_exact_answer(&self) -> bool {
+        false
+    }
+
+    fn version(&self) -> u32 {
+        NGRAM_INDEX_VERSION
+    }
+
+    fn new_query_parser(
+        &self,
+        index_name: String,
+        _index_details: &prost_types::Any,
+    ) -> Option<Box<dyn ScalarQueryParser>> {
+        Some(Box::new(TextQueryParser::new(
+            index_name,
+            self.name().to_string(),
+            // needs_recheck: ngram results are an inexact candidate superset.
+            true,
+            // supports_regex: the ngram index can answer regex queries.
+            true,
+        )))
     }
 
     async fn load_index(

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -1323,7 +1323,7 @@ impl TrainsOnColumnStream for NGramIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for NGramIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -60,9 +60,9 @@ impl TrainingCriteria {
 
 /// A trait object for plugin-specific training parameters and data requirements.
 ///
-/// Returned by [`TrainsOnColumnStream::new_training_request`]. The caller uses
+/// Returned by [`BasicTrainer::new_training_request`]. The caller uses
 /// [`criteria`](Self::criteria) to prepare the training data stream, then passes
-/// the request back to [`TrainsOnColumnStream::train_index`], which may downcast
+/// the request back to [`BasicTrainer::train_index`], which may downcast
 /// it to the plugin-specific concrete type to recover parsed parameters.
 pub trait TrainingRequest: std::any::Any + Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any;
@@ -101,13 +101,14 @@ impl TrainingRequest for DefaultTrainingRequest {
 /// Any scalar index plugin that builds from a column data stream should implement
 /// this trait.
 #[async_trait]
-pub trait TrainsOnColumnStream: Send + Sync {
+pub trait BasicTrainer: Send + Sync {
     /// Creates a new training request from the given parameters.
     ///
     /// The returned request specifies the criteria the training data must satisfy.
     /// It is the caller's responsibility to prepare data that meets those criteria
     /// before calling [`train_index`](Self::train_index).
-    fn new_training_request(&self, params: &str, field: &Field) -> Result<Box<dyn TrainingRequest>>;
+    fn new_training_request(&self, params: &str, field: &Field)
+    -> Result<Box<dyn TrainingRequest>>;
 
     /// Train a new index from a prepared data stream.
     ///
@@ -131,11 +132,27 @@ pub trait TrainsOnColumnStream: Send + Sync {
 /// A trait for scalar index plugins
 #[async_trait]
 pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
-    /// Returns this plugin's [`TrainsOnColumnStream`] implementation, if any.
+    /// Returns this plugin's [`BasicTrainer`] implementation, if any.
     ///
-    /// Plugins that support training on a stream of column data should override
-    /// this to return `Some(self)`.
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    /// Training an index can be a complex process.  For example, a btree index might
+    /// be trained using a distributed shuffler on a distributed OLAP system such as
+    /// Spark or Ray.  A vector index can be trained by sampling the column to create
+    /// a kmenas model and then streaming the vectors to assign partitions.  Encapsulating
+    /// the entire set of possible approches is beyond what this trait can model.
+    ///
+    /// However, in many cases, an index can be trained on a (potentially sorted) stream
+    /// of column data.  There is also significant utility in being able to provide users
+    /// with a simple generic "create an index" API.
+    ///
+    /// This method is a compromise.  Indexes that support training on a stream of column
+    /// data should override this to return `Some(self)`.  Indexes that need their own
+    /// individualized training approaches should return `None` and provide their own
+    /// methods for training.
+    ///
+    /// An index can even take both approaches.  Providing a simple (but maybe less
+    /// efficient) stream-based trainer while also providing more specialized index
+    /// creation methods elsewhere.
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         None
     }
 

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -154,7 +154,7 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
     /// An index can take both approaches.  Providing a simple (but maybe less
     /// efficient) stream-based trainer while also providing more specialized index
     /// creation methods elsewhere.
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         None
     }
 

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -138,7 +138,7 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
     /// be trained using a shuffler from a distributed OLAP system such as
     /// Spark or Ray.  A vector index can be trained by sampling the column to create
     /// a kmeans model and then streaming the vectors to assign partitions.  Encapsulating
-    /// the entire set of possible approches is beyond what this trait can model.
+    /// the entire set of possible approaches is beyond what this trait can model.
     /// This is especially true because this is a low-level crate with no concept of a table
     /// or a dataset.
     ///

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -135,7 +135,7 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
     ///
     /// Plugins that support training on a stream of column data should override
     /// this to return `Some(self)`.
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         None
     }
 

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -58,15 +58,12 @@ impl TrainingCriteria {
     }
 }
 
-/// A trait that describes what criteria is needed to train an index
+/// A trait object for plugin-specific training parameters and data requirements.
 ///
-/// The training process has two steps.  First, the parameters are given to the
-/// plugin and it creates a TrainingRequest.  Then, the caller prepares the training
-/// data and calls train_index.
-///
-/// The call to train_index will include the training request.  This allows the plugin
-/// to stash any deserialized parameter info in the request and fetch it later during
-/// training by downcasting to the appropriate type.
+/// Returned by [`TrainsOnColumnStream::new_training_request`]. The caller uses
+/// [`criteria`](Self::criteria) to prepare the training data stream, then passes
+/// the request back to [`TrainsOnColumnStream::train_index`], which may downcast
+/// it to the plugin-specific concrete type to recover parsed parameters.
 pub trait TrainingRequest: std::any::Any + Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any;
     fn criteria(&self) -> &TrainingCriteria;
@@ -93,26 +90,34 @@ impl TrainingRequest for DefaultTrainingRequest {
     }
 }
 
-/// A trait for scalar index plugins
+/// Implemented by indexes that can train on a stream of column data.
+///
+/// The training process has two stages. In the first stage, the caller provides
+/// index parameters and receives a [`TrainingRequest`] that describes what criteria
+/// the training data must satisfy (e.g. sort order, row-ID availability). In the
+/// second stage, the caller prepares the data accordingly and calls
+/// [`train_index`](Self::train_index).
+///
+/// Any scalar index plugin that builds from a column data stream should implement
+/// this trait.
 #[async_trait]
-pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
-    /// Creates a new training request from the given parameters
+pub trait TrainsOnColumnStream: Send + Sync {
+    /// Creates a new training request from the given parameters.
     ///
-    /// This training request specifies the criteria that the data must satisfy to train the index.
-    /// For example, does the index require the input data to be sorted?
-    fn new_training_request(&self, params: &str, field: &Field)
-    -> Result<Box<dyn TrainingRequest>>;
+    /// The returned request specifies the criteria the training data must satisfy.
+    /// It is the caller's responsibility to prepare data that meets those criteria
+    /// before calling [`train_index`](Self::train_index).
+    fn new_training_request(&self, params: &str, field: &Field) -> Result<Box<dyn TrainingRequest>>;
 
-    /// Train a new index
+    /// Train a new index from a prepared data stream.
     ///
-    /// The provided data must fulfill all the criteria returned by `training_criteria`.
-    /// It is the caller's responsibility to ensure this.
+    /// The provided data must fulfill all the criteria returned by
+    /// [`new_training_request`](Self::new_training_request). It is the caller's
+    /// responsibility to ensure this.
     ///
-    /// Returns index details that describe the index.  These details can potentially be
-    /// useful for planning (although this will currently require inside information on
-    /// the index type) and they will need to be provided when loading the index.
-    ///
-    /// It is the caller's responsibility to store these details somewhere.
+    /// Returns index details describing the index. These details may be useful for
+    /// planning and must be provided when loading the index. It is the caller's
+    /// responsibility to store them.
     async fn train_index(
         &self,
         data: SendableRecordBatchStream,
@@ -121,6 +126,18 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
         fragment_ids: Option<Vec<u32>>,
         progress: Arc<dyn IndexBuildProgress>,
     ) -> Result<CreatedIndex>;
+}
+
+/// A trait for scalar index plugins
+#[async_trait]
+pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
+    /// Returns this plugin's [`TrainsOnColumnStream`] implementation, if any.
+    ///
+    /// Plugins that support training on a stream of column data should override
+    /// this to return `Some(self)`.
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        None
+    }
 
     /// A short name for the index
     ///

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -135,10 +135,12 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
     /// Returns this plugin's [`BasicTrainer`] implementation, if any.
     ///
     /// Training an index can be a complex process.  For example, a btree index might
-    /// be trained using a distributed shuffler on a distributed OLAP system such as
+    /// be trained using a shuffler from a distributed OLAP system such as
     /// Spark or Ray.  A vector index can be trained by sampling the column to create
-    /// a kmenas model and then streaming the vectors to assign partitions.  Encapsulating
+    /// a kmeans model and then streaming the vectors to assign partitions.  Encapsulating
     /// the entire set of possible approches is beyond what this trait can model.
+    /// This is especially true because this is a low-level crate with no concept of a table
+    /// or a dataset.
     ///
     /// However, in many cases, an index can be trained on a (potentially sorted) stream
     /// of column data.  There is also significant utility in being able to provide users
@@ -149,7 +151,7 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
     /// individualized training approaches should return `None` and provide their own
     /// methods for training.
     ///
-    /// An index can even take both approaches.  Providing a simple (but maybe less
+    /// An index can take both approaches.  Providing a simple (but maybe less
     /// efficient) stream-based trainer while also providing more specialized index
     /// creation methods elsewhere.
     fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {

--- a/rust/lance-index/src/scalar/rtree.rs
+++ b/rust/lance-index/src/scalar/rtree.rs
@@ -6,7 +6,7 @@ use crate::metrics::{MetricsCollector, NoOpMetricsCollector};
 use crate::scalar::expression::{GeoQueryParser, ScalarQueryParser};
 use crate::scalar::lance_format::LanceIndexStore;
 use crate::scalar::registry::{
-    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, TrainsOnColumnStream,
 };
 use crate::scalar::rtree::sort::Sorter;
 use crate::scalar::{
@@ -908,11 +908,7 @@ impl RTreeIndexPlugin {
 }
 
 #[async_trait]
-impl ScalarIndexPlugin for RTreeIndexPlugin {
-    fn name(&self) -> &str {
-        "RTree"
-    }
-
+impl TrainsOnColumnStream for RTreeIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -965,6 +961,17 @@ impl ScalarIndexPlugin for RTreeIndexPlugin {
             index_version: RTREE_INDEX_VERSION,
             files,
         })
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for RTreeIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
+
+    fn name(&self) -> &str {
+        "RTree"
     }
 
     fn provides_exact_answer(&self) -> bool {

--- a/rust/lance-index/src/scalar/rtree.rs
+++ b/rust/lance-index/src/scalar/rtree.rs
@@ -966,7 +966,7 @@ impl BasicTrainer for RTreeIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for RTreeIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/rtree.rs
+++ b/rust/lance-index/src/scalar/rtree.rs
@@ -966,7 +966,7 @@ impl TrainsOnColumnStream for RTreeIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for RTreeIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/rtree.rs
+++ b/rust/lance-index/src/scalar/rtree.rs
@@ -6,7 +6,7 @@ use crate::metrics::{MetricsCollector, NoOpMetricsCollector};
 use crate::scalar::expression::{GeoQueryParser, ScalarQueryParser};
 use crate::scalar::lance_format::LanceIndexStore;
 use crate::scalar::registry::{
-    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, BasicTrainer,
+    BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
 };
 use crate::scalar::rtree::sort::Sorter;
 use crate::scalar::{

--- a/rust/lance-index/src/scalar/rtree.rs
+++ b/rust/lance-index/src/scalar/rtree.rs
@@ -6,7 +6,7 @@ use crate::metrics::{MetricsCollector, NoOpMetricsCollector};
 use crate::scalar::expression::{GeoQueryParser, ScalarQueryParser};
 use crate::scalar::lance_format::LanceIndexStore;
 use crate::scalar::registry::{
-    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, TrainsOnColumnStream,
+    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, BasicTrainer,
 };
 use crate::scalar::rtree::sort::Sorter;
 use crate::scalar::{
@@ -908,7 +908,7 @@ impl RTreeIndexPlugin {
 }
 
 #[async_trait]
-impl TrainsOnColumnStream for RTreeIndexPlugin {
+impl BasicTrainer for RTreeIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -966,7 +966,7 @@ impl TrainsOnColumnStream for RTreeIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for RTreeIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -16,7 +16,7 @@ use crate::Any;
 use crate::pbold;
 use crate::scalar::expression::{SargableQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, BasicTrainer,
+    BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
 };
 use crate::scalar::{
     BuiltinIndexType, CreatedIndex, IndexFile, SargableQuery, ScalarIndexParams, UpdateCriteria,

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -1005,7 +1005,7 @@ impl TrainsOnColumnStream for ZoneMapIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for ZoneMapIndexPlugin {
-    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -1005,7 +1005,7 @@ impl BasicTrainer for ZoneMapIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for ZoneMapIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
+    fn basic_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -16,7 +16,7 @@ use crate::Any;
 use crate::pbold;
 use crate::scalar::expression::{SargableQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, TrainsOnColumnStream,
+    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, BasicTrainer,
 };
 use crate::scalar::{
     BuiltinIndexType, CreatedIndex, IndexFile, SargableQuery, ScalarIndexParams, UpdateCriteria,
@@ -961,7 +961,7 @@ impl TrainingRequest for ZoneMapIndexTrainingRequest {
 }
 
 #[async_trait]
-impl TrainsOnColumnStream for ZoneMapIndexPlugin {
+impl BasicTrainer for ZoneMapIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -1005,7 +1005,7 @@ impl TrainsOnColumnStream for ZoneMapIndexPlugin {
 
 #[async_trait]
 impl ScalarIndexPlugin for ZoneMapIndexPlugin {
-    fn simple_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+    fn simple_trainer(&self) -> Option<&dyn BasicTrainer> {
         Some(self)
     }
 

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -16,7 +16,7 @@ use crate::Any;
 use crate::pbold;
 use crate::scalar::expression::{SargableQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
+    ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, TrainsOnColumnStream,
 };
 use crate::scalar::{
     BuiltinIndexType, CreatedIndex, IndexFile, SargableQuery, ScalarIndexParams, UpdateCriteria,
@@ -961,11 +961,7 @@ impl TrainingRequest for ZoneMapIndexTrainingRequest {
 }
 
 #[async_trait]
-impl ScalarIndexPlugin for ZoneMapIndexPlugin {
-    fn name(&self) -> &str {
-        "ZoneMap"
-    }
-
+impl TrainsOnColumnStream for ZoneMapIndexPlugin {
     fn new_training_request(
         &self,
         params: &str,
@@ -980,26 +976,6 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
         let params = serde_json::from_str::<ZoneMapIndexBuilderParams>(params)?;
 
         Ok(Box::new(ZoneMapIndexTrainingRequest::new(params)))
-    }
-
-    fn provides_exact_answer(&self) -> bool {
-        false
-    }
-
-    fn version(&self) -> u32 {
-        ZONEMAP_INDEX_VERSION
-    }
-
-    fn new_query_parser(
-        &self,
-        index_name: String,
-        _index_details: &prost_types::Any,
-    ) -> Option<Box<dyn ScalarQueryParser>> {
-        Some(Box::new(SargableQueryParser::new(
-            index_name,
-            self.name().to_string(),
-            true,
-        )))
     }
 
     async fn train_index(
@@ -1024,6 +1000,37 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
             index_version: ZONEMAP_INDEX_VERSION,
             files: vec![file],
         })
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for ZoneMapIndexPlugin {
+    fn as_trainer(&self) -> Option<&dyn TrainsOnColumnStream> {
+        Some(self)
+    }
+
+    fn name(&self) -> &str {
+        "ZoneMap"
+    }
+
+    fn provides_exact_answer(&self) -> bool {
+        false
+    }
+
+    fn version(&self) -> u32 {
+        ZONEMAP_INDEX_VERSION
+    }
+
+    fn new_query_parser(
+        &self,
+        index_name: String,
+        _index_details: &prost_types::Any,
+    ) -> Option<Box<dyn ScalarQueryParser>> {
+        Some(Box::new(SargableQueryParser::new(
+            index_name,
+            self.name().to_string(),
+            true,
+        )))
     }
 
     async fn load_index(

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -35,7 +35,7 @@ use lance_core::{Error, ROW_ID, Result, box_error};
 use lance_index::progress::noop_progress;
 use lance_index::registry::IndexPluginRegistry;
 use lance_index::scalar::lance_format::LanceIndexStore;
-use lance_index::scalar::registry::VALUE_COLUMN_NAME;
+use lance_index::scalar::registry::{BasicTrainer, VALUE_COLUMN_NAME};
 use lance_index::scalar::{BuiltinIndexType, CreatedIndex, ScalarIndexParams};
 use lance_io::object_store::{ObjectStore, ObjectStoreParams};
 use lance_io::stream::RecordBatchStream as LanceRecordBatchStream;
@@ -1179,10 +1179,21 @@ impl ManifestNamespace {
         index_uuid: Uuid,
     ) -> Result<ManifestTrainedIndex> {
         let index_store = LanceIndexStore::from_dataset_for_new(dataset, &index_uuid)?;
-        let plugin = registry.get_plugin_by_name(&input.params.index_type)?;
-        let training_request = plugin
+        let trainer = registry
+            .get_plugin_by_name(&input.params.index_type)?
+            .basic_trainer()
+            .ok_or_else(|| {
+                lance_core::Error::invalid_input_source(
+                    format!(
+                        "The '{}' index type does not support basic training, please refer to the index's documentation for more details on how to create this index.",
+                        input.params.index_type
+                    )
+                    .into(),
+                )
+            })?;
+        let training_request = trainer
             .new_training_request(input.params.params.as_deref().unwrap_or("{}"), &input.field)?;
-        let created_index = plugin
+        let created_index = trainer
             .train_index(
                 input.stream,
                 &index_store,

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -35,7 +35,7 @@ use lance_core::{Error, ROW_ID, Result, box_error};
 use lance_index::progress::noop_progress;
 use lance_index::registry::IndexPluginRegistry;
 use lance_index::scalar::lance_format::LanceIndexStore;
-use lance_index::scalar::registry::{BasicTrainer, VALUE_COLUMN_NAME};
+use lance_index::scalar::registry::VALUE_COLUMN_NAME;
 use lance_index::scalar::{BuiltinIndexType, CreatedIndex, ScalarIndexParams};
 use lance_io::object_store::{ObjectStore, ObjectStoreParams};
 use lance_io::stream::RecordBatchStream as LanceRecordBatchStream;

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -297,7 +297,7 @@ pub(super) async fn build_scalar_index(
     let index_store = LanceIndexStore::from_dataset_for_new(dataset, &uuid)?;
 
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
-    let trainer = plugin.simple_trainer().ok_or_else(|| {
+    let trainer = plugin.basic_trainer().ok_or_else(|| {
         Error::invalid_input_source(
             format!("The '{}' index type does not support training", params.index_type).into(),
         )
@@ -359,7 +359,7 @@ pub(super) async fn build_bitmap_index_segment(
 
     let params = ScalarIndexParams::for_builtin(BuiltinIndexType::Bitmap);
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
-    let trainer = plugin.simple_trainer().ok_or_else(|| {
+    let trainer = plugin.basic_trainer().ok_or_else(|| {
         Error::invalid_input_source(
             format!("The '{}' index type does not support training", params.index_type).into(),
         )

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -297,7 +297,7 @@ pub(super) async fn build_scalar_index(
     let index_store = LanceIndexStore::from_dataset_for_new(dataset, &uuid)?;
 
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
-    let trainer = plugin.as_trainer().ok_or_else(|| {
+    let trainer = plugin.simple_trainer().ok_or_else(|| {
         Error::invalid_input_source(
             format!("The '{}' index type does not support training", params.index_type).into(),
         )
@@ -359,7 +359,7 @@ pub(super) async fn build_bitmap_index_segment(
 
     let params = ScalarIndexParams::for_builtin(BuiltinIndexType::Bitmap);
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
-    let trainer = plugin.as_trainer().ok_or_else(|| {
+    let trainer = plugin.simple_trainer().ok_or_else(|| {
         Error::invalid_input_source(
             format!("The '{}' index type does not support training", params.index_type).into(),
         )

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -299,7 +299,7 @@ pub(super) async fn build_scalar_index(
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
     let trainer = plugin.basic_trainer().ok_or_else(|| {
         Error::invalid_input_source(
-            format!("The '{}' index type does not support training", params.index_type).into(),
+            format!("The '{}' index type does not support basic training, please refer to the index's documentation for more details on how to create this index.", params.index_type).into(),
         )
     })?;
     let training_request =
@@ -361,7 +361,7 @@ pub(super) async fn build_bitmap_index_segment(
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
     let trainer = plugin.basic_trainer().ok_or_else(|| {
         Error::invalid_input_source(
-            format!("The '{}' index type does not support training", params.index_type).into(),
+            format!("The '{}' index type does not support basic training, please refer to the index's documentation for more details on how to create this index.", params.index_type).into(),
         )
     })?;
     let training_request =

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -297,8 +297,13 @@ pub(super) async fn build_scalar_index(
     let index_store = LanceIndexStore::from_dataset_for_new(dataset, &uuid)?;
 
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
+    let trainer = plugin.as_trainer().ok_or_else(|| {
+        Error::invalid_input_source(
+            format!("The '{}' index type does not support training", params.index_type).into(),
+        )
+    })?;
     let training_request =
-        plugin.new_training_request(params.params.as_deref().unwrap_or("{}"), &field)?;
+        trainer.new_training_request(params.params.as_deref().unwrap_or("{}"), &field)?;
 
     progress.stage_start("load_data", None, "rows").await?;
     let training_data = match preprocessed_data {
@@ -317,7 +322,7 @@ pub(super) async fn build_scalar_index(
     };
     progress.stage_complete("load_data").await?;
 
-    let created_index = plugin
+    let created_index = trainer
         .train_index(
             training_data,
             &index_store,
@@ -354,8 +359,13 @@ pub(super) async fn build_bitmap_index_segment(
 
     let params = ScalarIndexParams::for_builtin(BuiltinIndexType::Bitmap);
     let plugin = SCALAR_INDEX_PLUGIN_REGISTRY.get_plugin_by_name(&params.index_type)?;
+    let trainer = plugin.as_trainer().ok_or_else(|| {
+        Error::invalid_input_source(
+            format!("The '{}' index type does not support training", params.index_type).into(),
+        )
+    })?;
     let training_request =
-        plugin.new_training_request(params.params.as_deref().unwrap_or("{}"), &field)?;
+        trainer.new_training_request(params.params.as_deref().unwrap_or("{}"), &field)?;
     let criteria = training_request.criteria();
 
     progress.stage_start("load_data", None, "rows").await?;
@@ -364,7 +374,7 @@ pub(super) async fn build_bitmap_index_segment(
     progress.stage_complete("load_data").await?;
 
     let index_store = LanceIndexStore::from_dataset_for_new(dataset, &uuid)?;
-    plugin
+    trainer
         .train_index(
             training_data,
             &index_store,


### PR DESCRIPTION
Move the two-stage training API (new_training_request + train_index) out of ScalarIndexPlugin into a new BasicTrainer trait. ScalarIndexPlugin gains a basic_trainer() accessor (default: None) so callers can opt into training without coupling the core plugin interface to it.