### PR TITLE
refactor!: rename FMIndexIndexDetails to FMIndexDetails

### DIFF
--- a/protos/index.proto
+++ b/protos/index.proto
@@ -248,4 +248,4 @@ message BloomFilterIndexDetails {}
 
 message RTreeIndexDetails {}
 
-message FMIndexIndexDetails {}
+message FMIndexDetails {}

--- a/rust/lance-index/src/registry.rs
+++ b/rust/lance-index/src/registry.rs
@@ -44,12 +44,7 @@ impl IndexPluginRegistry {
     fn get_plugin_name_from_details_name(&self, details_name: &str) -> String {
         let details_name = Self::normalize_plugin_name(details_name);
         if details_name.ends_with("indexdetails") {
-            let plugin_name = details_name.replace("indexdetails", "");
-            if plugin_name == "fmindex" {
-                "fm".to_string()
-            } else {
-                plugin_name
-            }
+            details_name.replace("indexdetails", "")
         } else {
             details_name
         }
@@ -87,7 +82,7 @@ impl IndexPluginRegistry {
         registry.add_plugin::<pb::BloomFilterIndexDetails, BloomFilterIndexPlugin>();
         registry.add_plugin::<pbold::InvertedIndexDetails, InvertedIndexPlugin>();
         registry.add_plugin::<pb::JsonIndexDetails, JsonIndexPlugin>();
-        registry.add_plugin::<pb::FmIndexIndexDetails, FMIndexPlugin>();
+        registry.add_plugin::<pb::FmIndexDetails, FMIndexPlugin>();
         #[cfg(feature = "geo")]
         registry.add_plugin::<pb::RTreeIndexDetails, RTreeIndexPlugin>();
 

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -1740,9 +1740,7 @@ impl ScalarIndexPlugin for FMIndexPlugin {
         fri: Option<Arc<FragReuseIndex>>,
         cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>> {
-        let _ = details
-            .to_msg::<pb::FmIndexDetails>()
-            .unwrap_or_default();
+        let _ = details.to_msg::<pb::FmIndexDetails>().unwrap_or_default();
         Ok(FMIndexScalarIndex::load(store, fri, cache).await? as Arc<dyn ScalarIndex>)
     }
     async fn load_statistics(

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -1378,7 +1378,7 @@ impl ScalarIndex for FMIndexScalarIndex {
     ) -> Result<CreatedIndex> {
         let files = write_partitioned_fmindex_stream(new_data, dest).await?;
         Ok(CreatedIndex {
-            index_details: prost_types::Any::from_msg(&pb::FmIndexIndexDetails {}).unwrap(),
+            index_details: prost_types::Any::from_msg(&pb::FmIndexDetails {}).unwrap(),
             index_version: FMINDEX_INDEX_VERSION,
             files,
         })
@@ -1708,7 +1708,7 @@ impl ScalarIndexPlugin for FMIndexPlugin {
     ) -> Result<CreatedIndex> {
         let files = write_partitioned_fmindex_stream(data, store).await?;
         Ok(CreatedIndex {
-            index_details: prost_types::Any::from_msg(&pb::FmIndexIndexDetails {}).unwrap(),
+            index_details: prost_types::Any::from_msg(&pb::FmIndexDetails {}).unwrap(),
             index_version: FMINDEX_INDEX_VERSION,
             files,
         })
@@ -1741,7 +1741,7 @@ impl ScalarIndexPlugin for FMIndexPlugin {
         cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>> {
         let _ = details
-            .to_msg::<pb::FmIndexIndexDetails>()
+            .to_msg::<pb::FmIndexDetails>()
             .unwrap_or_default();
         Ok(FMIndexScalarIndex::load(store, fri, cache).await? as Arc<dyn ScalarIndex>)
     }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -289,7 +289,7 @@ fn segment_has_fmindex_details(segment: &IndexMetadata) -> bool {
     segment
         .index_details
         .as_ref()
-        .is_some_and(|details| details.type_url.ends_with("FMIndexIndexDetails"))
+        .is_some_and(|details| details.type_url.ends_with("FMIndexDetails"))
 }
 
 // Cache keys for different index types
@@ -458,7 +458,7 @@ fn legacy_type_name(index_uri: &str, index_type_hint: Option<&str>) -> String {
         "BloomFilter" => IndexType::BloomFilter.to_string(),
         "RTree" => IndexType::RTree.to_string(),
         "Inverted" => IndexType::Inverted.to_string(),
-        "FMIndex" => IndexType::Fm.to_string(),
+        "FMIndex" | "FM" => IndexType::Fm.to_string(),
         "Json" => IndexType::Scalar.to_string(),
         "Flat" | "Vector" => IndexType::Vector.to_string(),
         other if other.contains("Vector") => IndexType::Vector.to_string(),


### PR DESCRIPTION
I'm not sure if the original naming was intentional or not.  However, it required a special case in `get_plugin_name_from_details_name` to rename `fmindex` to `fm` so I'm guessing it was accidental?

We are trying to convert indexes to be "generic plugins" and this means we cannot have special cases lying around.

An index's short-name is the name of the type URL minus the suffix `IndexDetails`.  So if we want `fm` then it should be `FmIndexDetails` (which this PR implements).  If we want `fmindex` then it should be `FmIndexIndexDetails` (which it had before).  If we want both then we should invent some kind of formal alias mechanism where an index plugin can register potential aliases.  However, I think it'd be simplest to avoid that.

This change would be a breaking change to any existing FM indexes!  That index type has not (AFAIK) been formally released yet so I think this is ok.  However, if this misses the 8.0.0 release then we will probably need to find a different way (and possibly forever be locked into carrying around this special case).