### PR TITLE
docs: clarify local LTO guidance

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,6 +11,7 @@ lto = "thin"
 
 [profile.release-no-lto]
 inherits = "release"
+debug = true
 lto = false
 # Prioritize compile time when LTO is not relevant to the measurement.
 codegen-units = 16

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,12 @@ debug = true
 codegen-units = 16
 lto = "thin"
 
+[profile.release-no-lto]
+inherits = "release"
+lto = false
+# Prioritize compile time when LTO is not relevant to the measurement.
+codegen-units = 16
+
 [profile.bench]
 inherits = "release"
 lto = "thin"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,10 +9,13 @@ debug = true
 codegen-units = 16
 lto = "thin"
 
+# Fast optimized profile for local investigations where LTO does not affect the
+# bottleneck. This gives agents a named profile instead of changing LTO flags ad hoc.
 [profile.release-no-lto]
 inherits = "release"
 lto = false
-# Prioritize compile time when LTO is not relevant to the measurement.
+# More codegen units split each crate into more parallel LLVM codegen jobs, which
+# shortens local builds at the cost of some cross-unit optimization.
 codegen-units = 16
 
 [profile.bench]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,13 +9,10 @@ debug = true
 codegen-units = 16
 lto = "thin"
 
-# Fast optimized profile for local investigations where LTO does not affect the
-# bottleneck. This gives agents a named profile instead of changing LTO flags ad hoc.
 [profile.release-no-lto]
 inherits = "release"
 lto = false
-# More codegen units split each crate into more parallel LLVM codegen jobs, which
-# shortens local builds at the cost of some cross-unit optimization.
+# Prioritize compile time when LTO is not relevant to the measurement.
 codegen-units = 16
 
 [profile.bench]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,10 @@ Key technical traits: async-first (tokio), Arrow-native, versioned writes with m
 * Coverage: `cargo +nightly llvm-cov -q -p <crate> --branch`
 * Coverage HTML: `cargo +nightly llvm-cov -q -p <crate> --branch --html`
 * Coverage for file: `python ci/coverage.py -p <crate> -f <file_path>`
-* Do not enable LTO for local development, debugging, or performance testing. Keep LTO reserved for explicitly requested release artifact validation.
+* Use repository-defined Cargo profiles instead of ad hoc LTO overrides.
+* Use `release` or `bench` for CPU-bound benchmarks and performance numbers intended for comparison.
+* Use `release-with-debug` for optimized profiling that needs debug symbols.
+* Use `release-no-lto` only for local debugging, IO-bound benchmarks, or compile-time-sensitive performance investigation where LTO would not affect the measured bottleneck.
 
 ### Python / Java
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,7 @@ Key technical traits: async-first (tokio), Arrow-native, versioned writes with m
 * Coverage HTML: `cargo +nightly llvm-cov -q -p <crate> --branch --html`
 * Coverage for file: `python ci/coverage.py -p <crate> -f <file_path>`
 * Use repository-defined Cargo profiles instead of ad hoc LTO overrides.
-* Use `release` or `bench` for CPU-bound benchmarks and performance numbers intended for comparison.
-* Use `release-with-debug` for optimized profiling that needs debug symbols.
+* Use `release-with-debug` for benchmarks and profiling so optimized builds keep debug symbols without a rebuild.
 * Use `release-no-lto` only for local debugging, IO-bound benchmarks, or compile-time-sensitive performance investigation where LTO would not affect the measured bottleneck.
 
 ### Python / Java

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Key technical traits: async-first (tokio), Arrow-native, versioned writes with m
 * Coverage: `cargo +nightly llvm-cov -q -p <crate> --branch`
 * Coverage HTML: `cargo +nightly llvm-cov -q -p <crate> --branch --html`
 * Coverage for file: `python ci/coverage.py -p <crate> -f <file_path>`
+* Do not enable LTO for local development, debugging, or performance testing. Keep LTO reserved for explicitly requested release artifact validation.
 
 ### Python / Java
 


### PR DESCRIPTION
This clarifies the repository agent instructions for Rust local workflows.

Local development, debugging, and performance testing should avoid LTO so those workflows do not accidentally pay release-artifact build costs or benchmark a build mode that was not explicitly requested. LTO remains available when release artifact validation explicitly asks for it.
