### PR TITLE
ci: run Index Sequence Compat nightly instead of on merge

### DIFF
--- a/.github/workflows/compat-pair.yml
+++ b/.github/workflows/compat-pair.yml
@@ -1,7 +1,7 @@
 # On-demand cross-version index compatibility run between two arbitrary refs.
 #
-# The PR path lives in python.yml (compat-sequence job), which ages the two previous
-# majors into the PR head reusing the prebuilt wheel. This workflow is the manual escape
+# The scheduled path lives in nightly_run.yml (compat-sequence job), which ages the two
+# previous majors into HEAD nightly. This workflow is the manual escape
 # hatch for any other pairing: each ref (version, sha, branch, or tag) is provisioned by
 # the framework -- a published release installs a wheel, anything else is built from a
 # worktree via maturin -- so two arbitrary refs can be compared even when neither has a

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -44,3 +44,69 @@ jobs:
           # Run only the jumbo tests in release mode with limited parallelism
           # to avoid OOM issues (these tests use >5GiB memory each)
           cargo test --release --package lance-encoding -- --ignored jumbo --test-threads=1
+
+  # Cross-version index maintenance-sequence search (see python/tests/compat/compat_sequence.py).
+  # Ages an index under the latest release of each of the two previous majors and exercises it
+  # under this commit, searching op sequences for panics or correctness divergence. The search is
+  # slow and unbounded in depth, so it runs nightly with a generous timeout rather than blocking
+  # merges; the manual escape hatch for arbitrary ref pairs lives in compat-pair.yml.
+  compat-sequence:
+    if: github.repository == 'lancedb/lance'
+    timeout-minutes: 360
+    runs-on: ubuntu-24.04
+    name: Index Sequence Compat
+    defaults:
+      run:
+        shell: bash
+        working-directory: python
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: 3.13
+      # Toolchain to build the reader (HEAD) wheel from source -- no upstream build job to
+      # borrow a wheel from here, unlike the old post-merge path in python.yml.
+      - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: python
+      - name: Install build deps
+        run: |
+          sudo apt update
+          sudo apt install -y protobuf-compiler libssl-dev
+      - name: Install host deps
+        run: pip install pytest pytest-xdist pyarrow packaging maturin
+      # Build HEAD once and feed it to the suite as the prebuilt reader, so the two writer
+      # passes below don't each recompile it.
+      - name: Build reader wheel (HEAD)
+        run: python -m maturin build --release -m Cargo.toml --out wheels
+      # Age under each of the two previous majors (writer wheels from PyPI) and read under
+      # this commit's freshly built wheel. Length 5 is the shallowest depth that reaches the
+      # ENT-1662 sequence; -n oversubscribes cores since the work is I/O-bound.
+      - name: Run sequence search (previous two majors -> HEAD)
+        env:
+          COMPAT_MAX_LENGTH: "5"
+          COMPAT_TO_REF: HEAD
+          COMPAT_PREBUILT_REF: HEAD
+        run: |
+          set -euo pipefail
+          wheel=$(ls "$PWD"/wheels/pylance-*.whl | head -1)
+          refs=$(PYTHONPATH=python/tests python -c "
+          from compat.compat_decorator import pylance_stable_versions
+          latest = {}
+          for v in pylance_stable_versions():
+              latest[v.major] = v
+          print(' '.join(str(latest[m]) for m in sorted(latest)[-2:]))
+          ")
+          echo "reader wheel: $wheel"
+          echo "writer refs : $refs"
+          status=0
+          for from_ref in $refs; do
+            echo "::group::$from_ref -> HEAD"
+            COMPAT_FROM_REF="$from_ref" COMPAT_PREBUILT_WHEEL="$wheel" \
+              python -m pytest python/tests/compat/test_index_sequence.py \
+                --run-compat -n "$(( $(nproc) * 4 ))" -v --no-header || status=1
+            echo "::endgroup::"
+          done
+          exit $status

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -162,65 +162,6 @@ jobs:
         env:
           COMPAT_TEMP_VENV: 1
 
-  # Cross-version index maintenance-sequence search (see tests/compat/compat_sequence.py).
-  # Ages an index under the latest release of each of the two previous majors and exercises
-  # it under this commit, searching op sequences for panics or correctness divergence. The
-  # reader (HEAD) reuses the wheel the `linux` job already built rather than recompiling.
-  # Post-merge only: the search is slower than the rest of the suite, so it runs on pushes
-  # to main/release rather than blocking every PR (same gating as rust-benchmark).
-  compat-sequence:
-    needs: linux
-    if: github.event_name != 'pull_request'
-    timeout-minutes: 60
-    runs-on: ubuntu-24.04
-    name: Index Sequence Compat
-    defaults:
-      run:
-        shell: bash
-        working-directory: python
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: 3.13
-      - name: Download wheels
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: linux-wheels
-          path: python/wheels
-      - name: Install host deps
-        run: pip install pytest pytest-xdist pyarrow packaging
-      # Age under each of the two previous majors (writer wheels from PyPI) and read under
-      # this commit's prebuilt wheel. Length 5 is the shallowest depth that reaches the
-      # ENT-1662 sequence; -n oversubscribes cores since the work is I/O-bound.
-      - name: Run sequence search (previous two majors -> HEAD)
-        env:
-          COMPAT_MAX_LENGTH: "5"
-          COMPAT_TO_REF: HEAD
-          COMPAT_PREBUILT_REF: HEAD
-        run: |
-          set -euo pipefail
-          wheel=$(ls "$PWD"/wheels/pylance-*.whl | head -1)
-          refs=$(PYTHONPATH=python/tests python -c "
-          from compat.compat_decorator import pylance_stable_versions
-          latest = {}
-          for v in pylance_stable_versions():
-              latest[v.major] = v
-          print(' '.join(str(latest[m]) for m in sorted(latest)[-2:]))
-          ")
-          echo "reader wheel: $wheel"
-          echo "writer refs : $refs"
-          status=0
-          for from_ref in $refs; do
-            echo "::group::$from_ref -> HEAD"
-            COMPAT_FROM_REF="$from_ref" COMPAT_PREBUILT_WHEEL="$wheel" \
-              python -m pytest python/tests/compat/test_index_sequence.py \
-                --run-compat -n "$(( $(nproc) * 4 ))" -v --no-header || status=1
-            echo "::endgroup::"
-          done
-          exit $status
-
   linux-arm:
     timeout-minutes: 45
     runs-on: ubuntu-24.04-arm64-4x


### PR DESCRIPTION
It was timing out on every merge to main. Move it from python.yml to the
nightly workflow with a 360-minute timeout; it now builds the reader wheel
in-job since needs: can't span workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
