### PR TITLE
perf(fts): open fts segments as scalar indices

### DIFF
--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -65,7 +65,7 @@ async fn open_fts_segment(
     metrics: &IndexMetrics,
 ) -> Result<Arc<InvertedIndex>> {
     let index = dataset
-        .open_generic_index(column, &segment.uuid, metrics)
+        .open_scalar_index(column, &segment.uuid, metrics)
         .await?;
     let inverted = index
         .as_any()


### PR DESCRIPTION
## Performance Improvement

### What is the performance issue or bottleneck?

FTS query execution opens each committed FTS segment through the generic index open path. For FTS segments we already know the expected index kind and immediately downcast to `InvertedIndex`, so the generic open path does extra work that is not needed for this call site.

### How does this PR improve performance?

`open_fts_segment` now opens the segment with `Dataset::open_scalar_index` before the existing `InvertedIndex` downcast. This keeps the behavior and validation unchanged while avoiding the generic index open path for FTS query execution.

No public API, schema, file format, Python, or Java binding changes.

### Validation

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/lance-target-fts-direct-open-pr cargo test -p lance test_match_query_exec_with_base_scorer_matches_baseline`
- `CARGO_TARGET_DIR=/tmp/lance-target-fts-direct-open-pr cargo test -p lance test_parts_searched_metrics`
- `CARGO_TARGET_DIR=/tmp/lance-target-fts-direct-open-pr cargo clippy --all --tests --benches -- -D warnings`