### PR TITLE
Draft: Improve V2 scan pipeline for cuVS index builds

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3206,7 +3206,7 @@ class LanceDataset(pa.dataset.Dataset):
                         sample_rate=kwargs.get("sample_rate", 256),
                         max_iters=kwargs.get("max_iters", 50),
                         num_bits=kwargs.get("num_bits", 8),
-                        batch_size=1024 * 128,
+                        batch_size=kwargs.get("cuvs_batch_size", 1024 * 128),
                         filter_nan=filter_nan,
                     )
                 )

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1473,12 +1473,11 @@ impl BatchDecodeStream {
                     // Real decode work happens inside into_batch, which can block the current
                     // thread for a long time. By spawning it as a new task, we allow Tokio's
                     // worker threads to keep making progress.
-                    let (batch, _data_size) =
-                        tokio::spawn(
-                            async move { next_task.into_batch(emitted_batch_size_warning) },
-                        )
-                        .await
-                        .map_err(|err| Error::wrapped(err.into()))??;
+                    let (batch, _data_size) = tokio::task::spawn_blocking(move || {
+                        next_task.into_batch(emitted_batch_size_warning)
+                    })
+                    .await
+                    .map_err(|err| Error::wrapped(err.into()))??;
                     Ok(batch)
                 };
                 (task, num_rows)
@@ -1880,9 +1879,9 @@ impl StructuralBatchDecodeStream {
                 let task = async move {
                     let next_task = next_task?;
                     let (batch, data_size) = if spawn_batch_decode_tasks {
-                        tokio::spawn(
-                            async move { next_task.into_batch(emitted_batch_size_warning) },
-                        )
+                        tokio::task::spawn_blocking(move || {
+                            next_task.into_batch(emitted_batch_size_warning)
+                        })
                         .await
                         .map_err(|err| Error::wrapped(err.into()))??
                     } else {

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -434,10 +434,20 @@ where
         return original.clone();
     }
 
+    debug_assert_eq!(original.len(), num_rows * num_columns);
     let mut transposed_codes = vec![T::default_value(); original.len()];
-    for (vec_idx, codes) in original.values().chunks_exact(num_columns).enumerate() {
-        for (sub_vec_idx, code) in codes.iter().enumerate() {
-            transposed_codes[sub_vec_idx * num_rows + vec_idx] = *code;
+    let original_values = original.values();
+    let element_size = std::mem::size_of::<T::Native>().max(1);
+    let tile_rows = (32 * 1024 / (num_columns * element_size).max(1)).clamp(16, 1024);
+
+    for row_start in (0..num_rows).step_by(tile_rows) {
+        let row_end = (row_start + tile_rows).min(num_rows);
+        for column_idx in 0..num_columns {
+            let dst_base = column_idx * num_rows + row_start;
+            for row_idx in row_start..row_end {
+                transposed_codes[dst_base + row_idx - row_start] =
+                    original_values[row_idx * num_columns + column_idx];
+            }
         }
     }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2688,9 +2688,19 @@ impl Scanner {
         fragments: Option<Arc<Vec<Fragment>>>,
         scan_range: Option<Range<u64>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        let ordered = if self.ordering.is_some() || self.nearest.is_some() {
+            false
+        } else if projection.with_row_last_updated_at_version
+            || projection.with_row_created_at_version
+        {
+            true
+        } else {
+            self.ordered
+        };
         let mut read_options = FilteredReadOptions::basic_full_read(&self.dataset)
             .with_filter_plan(filter_plan.clone())
-            .with_projection(projection);
+            .with_projection(projection)
+            .with_ordered_output(ordered);
 
         if let Some(fragments) = fragments {
             read_options = read_options.with_fragments(fragments);

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -4,6 +4,7 @@
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use std::{collections::HashMap, pin::Pin};
 
 use arrow::array::{AsArray as _, PrimitiveBuilder, UInt32Builder, UInt64Builder};
@@ -139,8 +140,9 @@ pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
     progress: Arc<dyn IndexBuildProgress>,
 }
 
+type PartitionBuildOutput<S, Q> = (<Q as Quantization>::Storage, S, f64, Duration, Duration);
 type BuildStream<S, Q> =
-    Pin<Box<dyn Stream<Item = Result<Option<(<Q as Quantization>::Storage, S, f64)>>> + Send>>;
+    Pin<Box<dyn Stream<Item = Result<Option<PartitionBuildOutput<S, Q>>>> + Send>>;
 
 impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> {
     async fn try_open_precomputed_partition_artifact_reader(
@@ -332,7 +334,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
                     let storage = part.storage.remap(&mapping)?;
                     let index = part.index.remap(&mapping, &storage)?;
-                    Result::Ok(Some((storage, index, 0.0)))
+                    Result::Ok(Some((
+                        storage,
+                        index,
+                        0.0,
+                        Duration::default(),
+                        Duration::default(),
+                    )))
                 }
             });
 
@@ -875,6 +883,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                         _ => partition,
                     };
                     async move {
+                        let take_start = Instant::now();
                         let (mut batches, loss) = if skip_existing_batches {
                             (Vec::new(), 0.0)
                         } else {
@@ -885,8 +894,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             )
                             .await?
                         };
+                        let take_elapsed = take_start.elapsed();
 
-                        spawn_cpu(move || {
+                        let build_start = Instant::now();
+                        let part = spawn_cpu(move || {
                             if let Some((assign_batch, deleted_row_ids)) = assign_batch {
                                 if !deleted_row_ids.is_empty() {
                                     let deleted_row_ids = HashSet::<u64>::from_iter(
@@ -913,7 +924,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
                             let num_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
                             if num_rows == 0 {
-                                return Ok(None);
+                                return Ok::<_, Error>(None);
                             }
 
                             let (storage, sub_index) = Self::build_index(
@@ -924,9 +935,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                                 column,
                                 frag_reuse_index,
                             )?;
-                            Ok(Some((storage, sub_index, loss)))
+                            Ok::<_, Error>(Some((storage, sub_index, loss)))
                         })
-                        .await
+                        .await?;
+                        let build_elapsed = build_start.elapsed();
+                        Ok(part.map(|(storage, sub_index, loss)| {
+                            (storage, sub_index, loss, take_elapsed, build_elapsed)
+                        }))
                     }
                 });
         Ok(stream::iter(build_iter)
@@ -1090,12 +1105,18 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
         let mut part_id = 0;
         let mut total_loss = 0.0;
+        let mut take_batches_time = Duration::default();
+        let mut build_index_time = Duration::default();
+        let mut storage_batches_time = Duration::default();
+        let mut storage_write_time = Duration::default();
+        let mut index_batch_time = Duration::default();
+        let mut index_write_time = Duration::default();
         let progress = self.progress.clone();
         log::info!("merging {} partitions", ivf.num_partitions());
         while let Some(part) = build_stream.try_next().await? {
             part_id += 1;
             progress.stage_progress("merge_partitions", part_id).await?;
-            let Some((storage, index, loss)) = part else {
+            let Some((storage, index, loss, take_elapsed, build_elapsed)) = part else {
                 log::warn!("partition {} is empty, skipping", part_id);
 
                 storage_ivf.add_partition(0);
@@ -1105,11 +1126,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 continue;
             };
             total_loss += loss;
+            take_batches_time += take_elapsed;
+            build_index_time += build_elapsed;
 
             if storage.len() == 0 {
                 storage_ivf.add_partition(0);
             } else {
-                for mut batch in storage.to_batches()? {
+                let storage_batches_start = Instant::now();
+                let storage_batches = storage.to_batches()?;
+                storage_batches_time += storage_batches_start.elapsed();
+                for mut batch in storage_batches {
                     if is_pq
                         && !self.transpose_codes
                         && batch.num_rows() > 0
@@ -1151,21 +1177,27 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             writer_options.clone(),
                         )?);
                     }
+                    let storage_write_start = Instant::now();
                     storage_writer
                         .as_mut()
                         .expect("storage writer must be initialized before write")
                         .write_batch(&batch)
                         .await?;
+                    storage_write_time += storage_write_start.elapsed();
                     storage_ivf.add_partition(batch.num_rows() as u32);
                 }
             }
 
+            let index_batch_start = Instant::now();
             let index_batch = index.to_batch()?;
+            index_batch_time += index_batch_start.elapsed();
             if index_batch.num_rows() == 0 {
                 index_ivf.add_partition(0);
                 partition_index_metadata.push(String::new());
             } else {
+                let index_write_start = Instant::now();
                 index_writer.write_batch(&index_batch).await?;
+                index_write_time += index_write_start.elapsed();
                 index_ivf.add_partition(index_batch.num_rows() as u32);
                 partition_index_metadata.push(
                     index_batch
@@ -1281,8 +1313,22 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             serde_json::to_string(&partition_index_metadata)?,
         );
 
+        let finish_start = Instant::now();
         storage_writer.finish().await?;
         index_writer.finish().await?;
+        let finish_time = finish_start.elapsed();
+
+        eprintln!(
+            "lance vector merge_partitions stages: partitions={} take_s={:.3} build_s={:.3} storage_batches_s={:.3} storage_write_s={:.3} index_batch_s={:.3} index_write_s={:.3} finish_s={:.3}",
+            ivf.num_partitions(),
+            take_batches_time.as_secs_f64(),
+            build_index_time.as_secs_f64(),
+            storage_batches_time.as_secs_f64(),
+            storage_write_time.as_secs_f64(),
+            index_batch_time.as_secs_f64(),
+            index_write_time.as_secs_f64(),
+            finish_time.as_secs_f64(),
+        );
 
         log::info!("merging {} partitions done", ivf.num_partitions());
 

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -573,7 +573,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 builder
                     .batch_readahead(get_num_compute_intensive_cpus())
                     .project(&[self.column.as_str()])?
-                    .with_row_id();
+                    .with_row_id()
+                    .scan_in_order(false)
+                    .fragment_readahead(0);
 
                 // Apply fragment filter for distributed indexing
                 if let Some(fragment_ids) = &self.fragment_filter {

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1494,6 +1494,8 @@ async fn scan_index_field_stream(
     let mut scanner = dataset.scan();
     scanner.project(&[column])?;
     scanner.with_row_id();
+    scanner.scan_in_order(false);
+    scanner.fragment_readahead(0);
     scanner.try_into_stream().await
 }
 

--- a/rust/lance/src/index/vector/partition_artifact.rs
+++ b/rust/lance/src/index/vector/partition_artifact.rs
@@ -404,10 +404,11 @@ impl PartitionArtifactBuilder {
                     _ => {}
                 }
                 partition.num_rows += end - offset;
-                partition.ranges.push(PartitionArtifactRange {
-                    offset: file_offset + offset as u64,
-                    num_rows: (end - offset) as u64,
-                });
+                append_partition_range(
+                    partition,
+                    file_offset + offset as u64,
+                    (end - offset) as u64,
+                );
                 offset = end;
             }
 
@@ -453,10 +454,7 @@ impl PartitionArtifactBuilder {
             _ => {}
         }
         partition.num_rows += total_rows;
-        partition.ranges.push(PartitionArtifactRange {
-            offset: file_offset,
-            num_rows: total_rows as u64,
-        });
+        append_partition_range(partition, file_offset, total_rows as u64);
 
         let pq_codes = FixedSizeListArray::try_new_from_values(
             UInt8Array::from(pq_values),
@@ -782,14 +780,16 @@ impl ShuffleReader for PartitionArtifactShuffleReader {
         }
 
         let reader = self.open_file_reader(path).await?;
-        let ranges = partition
-            .ranges
-            .iter()
-            .map(|range| Range {
-                start: range.offset,
-                end: range.offset + range.num_rows,
-            })
-            .collect::<Vec<_>>();
+        let ranges = merge_adjacent_ranges(
+            partition
+                .ranges
+                .iter()
+                .map(|range| Range {
+                    start: range.offset,
+                    end: range.offset + range.num_rows,
+                })
+                .collect::<Vec<_>>(),
+        );
         let schema = Arc::new(reader.schema().as_ref().into());
         Ok(Some(Box::new(RecordBatchStreamAdapter::new(
             schema,
@@ -817,6 +817,39 @@ impl ShuffleReader for PartitionArtifactShuffleReader {
     }
 }
 
+fn append_partition_range(partition: &mut PartitionArtifactPartition, offset: u64, num_rows: u64) {
+    if num_rows == 0 {
+        return;
+    }
+    if let Some(last) = partition.ranges.last_mut()
+        && last.offset + last.num_rows == offset
+    {
+        last.num_rows += num_rows;
+        return;
+    }
+    partition
+        .ranges
+        .push(PartitionArtifactRange { offset, num_rows });
+}
+
+fn merge_adjacent_ranges(mut ranges: Vec<Range<u64>>) -> Vec<Range<u64>> {
+    if ranges.len() < 2 {
+        return ranges;
+    }
+
+    let mut merged: Vec<Range<u64>> = Vec::with_capacity(ranges.len());
+    for range in ranges.drain(..) {
+        if let Some(last) = merged.last_mut()
+            && last.end == range.start
+        {
+            last.end = range.end;
+            continue;
+        }
+        merged.push(range);
+    }
+    merged
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -833,6 +866,29 @@ mod tests {
     use crate::Error;
 
     use super::*;
+
+    #[test]
+    fn partition_artifact_ranges_are_coalesced() {
+        let mut partition = PartitionArtifactPartition {
+            path: None,
+            num_rows: 0,
+            ranges: Vec::new(),
+        };
+
+        append_partition_range(&mut partition, 0, 10);
+        append_partition_range(&mut partition, 10, 5);
+        append_partition_range(&mut partition, 20, 3);
+        append_partition_range(&mut partition, 23, 7);
+
+        assert_eq!(partition.ranges.len(), 2);
+        assert_eq!(partition.ranges[0].offset, 0);
+        assert_eq!(partition.ranges[0].num_rows, 15);
+        assert_eq!(partition.ranges[1].offset, 20);
+        assert_eq!(partition.ranges[1].num_rows, 10);
+
+        let merged = merge_adjacent_ranges(vec![0..10, 10..15, 20..23, 23..30]);
+        assert_eq!(merged, vec![0..15, 20..30]);
+    }
 
     #[tokio::test]
     async fn partition_artifact_builder_compacts_runs_into_single_partition_range() {
@@ -1100,7 +1156,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn partition_artifact_builder_records_multiple_ranges_for_repeated_flushes() {
+    async fn partition_artifact_builder_coalesces_repeated_flush_ranges() {
         let tempdir = tempfile::tempdir().unwrap();
         let root_dir = tempdir.path().join("artifact");
         fs::create_dir_all(&root_dir).unwrap();
@@ -1135,14 +1191,8 @@ mod tests {
         let manifest: PartitionArtifactManifest =
             serde_json::from_slice(&fs::read(root_dir.join("manifest.json")).unwrap()).unwrap();
         assert_eq!(manifest.partitions[0].num_rows, num_rows);
-        assert_eq!(manifest.partitions[0].ranges.len(), 2);
-        assert_eq!(
-            manifest.partitions[0].ranges[0].num_rows,
-            PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS as u64
-        );
-        assert_eq!(
-            manifest.partitions[0].ranges[1].offset,
-            PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS as u64
-        );
+        assert_eq!(manifest.partitions[0].ranges.len(), 1);
+        assert_eq!(manifest.partitions[0].ranges[0].offset, 0);
+        assert_eq!(manifest.partitions[0].ranges[0].num_rows, num_rows as u64);
     }
 }

--- a/rust/lance/src/index/vector/partition_artifact.rs
+++ b/rust/lance/src/index/vector/partition_artifact.rs
@@ -14,9 +14,7 @@ use lance_arrow::FixedSizeListArrayExt;
 use lance_core::cache::LanceCache;
 use lance_core::datatypes::Schema;
 use lance_core::{Error, ROW_ID, Result};
-use lance_encoding::compression_config::{BssMode, CompressionFieldParams, CompressionParams};
 use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
-use lance_encoding::encoder::default_encoding_strategy_with_params;
 use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::LanceFileVersion;
 use lance_file::writer::{FileWriter, FileWriterOptions};
@@ -581,33 +579,17 @@ pub(crate) struct PartitionArtifactShuffleReader {
 /// The artifact uses a fixed file version so external backends and Lance
 /// finalization agree on the on-disk layout.
 fn file_writer_options() -> Result<FileWriterOptions> {
-    let format_version = PARTITION_ARTIFACT_FILE_VERSION
-        .parse::<LanceFileVersion>()
-        .map_err(|error| {
-            Error::invalid_input(format!(
-                "invalid partition artifact file version '{}': {}",
-                PARTITION_ARTIFACT_FILE_VERSION, error
-            ))
-        })?;
-    let mut compression_params = CompressionParams::new();
-    let no_compression = CompressionFieldParams {
-        compression: Some("none".to_string()),
-        bss: Some(BssMode::Off),
-        ..Default::default()
-    };
-    compression_params
-        .columns
-        .insert(ROW_ID.to_string(), no_compression.clone());
-    compression_params
-        .columns
-        .insert(PQ_CODE_COLUMN.to_string(), no_compression);
-
     Ok(FileWriterOptions {
-        encoding_strategy: Some(Arc::from(default_encoding_strategy_with_params(
-            format_version,
-            compression_params,
-        )?)),
-        format_version: Some(format_version),
+        format_version: Some(
+            PARTITION_ARTIFACT_FILE_VERSION
+                .parse::<LanceFileVersion>()
+                .map_err(|error| {
+                    Error::invalid_input(format!(
+                        "invalid partition artifact file version '{}': {}",
+                        PARTITION_ARTIFACT_FILE_VERSION, error
+                    ))
+                })?,
+        ),
         ..Default::default()
     })
 }

--- a/rust/lance/src/index/vector/partition_artifact.rs
+++ b/rust/lance/src/index/vector/partition_artifact.rs
@@ -37,8 +37,6 @@ const PARTITION_ARTIFACT_DEFAULT_BUCKETS: usize = 256;
 const PARTITION_ARTIFACT_BUCKET_PREFIX: &str = "bucket-";
 const PARTITION_ARTIFACT_FILE_VERSION: &str = "2.2";
 const PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS: usize = 32 * 1024;
-const PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS_ENV: &str =
-    "LANCE_PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS";
 
 /// Top-level manifest for a precomputed partition artifact.
 ///
@@ -144,7 +142,6 @@ pub struct PartitionArtifactBuilder {
     buffers: Vec<BucketBuffer>,
     partitions: Vec<PartitionArtifactPartition>,
     bucket_row_counts: Vec<u64>,
-    bucket_buffer_rows: usize,
     stats: PartitionArtifactBuilderStats,
 }
 
@@ -216,12 +213,6 @@ impl PartitionArtifactBuilder {
             ),
         ]));
 
-        let bucket_buffer_rows = std::env::var(PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS_ENV)
-            .ok()
-            .and_then(|value| value.parse::<usize>().ok())
-            .filter(|rows| *rows > 0)
-            .unwrap_or(PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS);
-
         Ok(Self {
             object_store,
             root_dir,
@@ -240,7 +231,6 @@ impl PartitionArtifactBuilder {
                 num_partitions
             ],
             bucket_row_counts: vec![0; num_buckets],
-            bucket_buffer_rows,
             stats: PartitionArtifactBuilderStats::default(),
         })
     }
@@ -284,7 +274,7 @@ impl PartitionArtifactBuilder {
             let start = row_idx * self.pq_code_width;
             let end = start + self.pq_code_width;
             buffer.pq_values.extend_from_slice(&pq_values[start..end]);
-            if buffer.len() >= self.bucket_buffer_rows {
+            if buffer.len() >= PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS {
                 self.flush_bucket(bucket_id).await?;
             }
         }
@@ -538,8 +528,7 @@ impl PartitionArtifactBuilder {
 
     fn log_stats(&self) {
         eprintln!(
-            "partition artifact builder stages: bucket_buffer_rows={} append_batches={} append_rows={} append_s={:.3} validate_s={:.3} extract_s={:.3} scatter_s={:.3} flushes={} flushed_rows={} single_flushes={} multi_flushes={} flush_s={:.3} final_batch_s={:.3} writer_s={:.3} finish_flush_s={:.3} writer_finish_s={:.3} manifest_s={:.3}",
-            self.bucket_buffer_rows,
+            "partition artifact builder stages: append_batches={} append_rows={} append_s={:.3} validate_s={:.3} extract_s={:.3} scatter_s={:.3} flushes={} flushed_rows={} single_flushes={} multi_flushes={} flush_s={:.3} final_batch_s={:.3} writer_s={:.3} finish_flush_s={:.3} writer_finish_s={:.3} manifest_s={:.3}",
             self.stats.append_batches,
             self.stats.append_rows,
             self.stats.append_time.as_secs_f64(),

--- a/rust/lance/src/index/vector/partition_artifact.rs
+++ b/rust/lance/src/index/vector/partition_artifact.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::mem;
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use arrow_array::cast::AsArray;
 use arrow_array::{FixedSizeListArray, RecordBatch, UInt8Array, UInt64Array};
@@ -103,6 +104,26 @@ impl BucketBuffer {
     }
 }
 
+#[derive(Default, Debug)]
+struct PartitionArtifactBuilderStats {
+    append_batches: usize,
+    append_rows: usize,
+    append_time: Duration,
+    validate_time: Duration,
+    extract_time: Duration,
+    scatter_time: Duration,
+    flushes: usize,
+    flushed_rows: usize,
+    single_partition_flushes: usize,
+    multi_partition_flushes: usize,
+    flush_time: Duration,
+    final_batch_time: Duration,
+    writer_time: Duration,
+    finish_flush_time: Duration,
+    writer_finish_time: Duration,
+    manifest_time: Duration,
+}
+
 /// Writes partition-addressable encoded rows for a later Lance finalization.
 ///
 /// The builder uses bucket-local buffering to keep append-time memory bounded.
@@ -121,6 +142,7 @@ pub struct PartitionArtifactBuilder {
     buffers: Vec<BucketBuffer>,
     partitions: Vec<PartitionArtifactPartition>,
     bucket_row_counts: Vec<u64>,
+    stats: PartitionArtifactBuilderStats,
 }
 
 impl PartitionArtifactBuilder {
@@ -209,6 +231,7 @@ impl PartitionArtifactBuilder {
                 num_partitions
             ],
             bucket_row_counts: vec![0; num_buckets],
+            stats: PartitionArtifactBuilderStats::default(),
         })
     }
 
@@ -218,8 +241,12 @@ impl PartitionArtifactBuilder {
     /// Rows are redistributed into bucket-local in-memory buffers and flushed to
     /// temporary files once they become large enough.
     pub async fn append_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        let append_start = Instant::now();
+        let validate_start = Instant::now();
         validate_input_batch(batch, self.pq_code_width)?;
+        self.stats.validate_time += validate_start.elapsed();
 
+        let extract_start = Instant::now();
         let row_ids = batch[ROW_ID].as_primitive::<arrow::datatypes::UInt64Type>();
         let part_ids = batch[PART_ID_COLUMN].as_primitive::<arrow::datatypes::UInt32Type>();
         let pq_codes = batch[PQ_CODE_COLUMN].as_fixed_size_list();
@@ -227,7 +254,9 @@ impl PartitionArtifactBuilder {
             .values()
             .as_primitive::<arrow::datatypes::UInt8Type>();
         let pq_values = pq_values.values().as_ref();
+        self.stats.extract_time += extract_start.elapsed();
 
+        let scatter_start = Instant::now();
         for row_idx in 0..batch.num_rows() {
             let partition_id = part_ids.value(row_idx) as usize;
             if partition_id >= self.num_partitions {
@@ -249,6 +278,10 @@ impl PartitionArtifactBuilder {
                 self.flush_bucket(bucket_id).await?;
             }
         }
+        self.stats.scatter_time += scatter_start.elapsed();
+        self.stats.append_batches += 1;
+        self.stats.append_rows += batch.num_rows();
+        self.stats.append_time += append_start.elapsed();
         Ok(())
     }
 
@@ -262,14 +295,18 @@ impl PartitionArtifactBuilder {
         metadata_file: &str,
         total_loss: Option<f64>,
     ) -> Result<Vec<String>> {
+        let finish_flush_start = Instant::now();
         for bucket_id in 0..self.num_buckets {
             self.flush_bucket(bucket_id).await?;
         }
+        self.stats.finish_flush_time += finish_flush_start.elapsed();
+        let writer_finish_start = Instant::now();
         for writer in self.final_writers.iter_mut() {
             if let Some(writer) = writer.as_mut() {
                 writer.finish().await?;
             }
         }
+        self.stats.writer_finish_time += writer_finish_start.elapsed();
 
         let mut artifact_files = Vec::with_capacity(self.num_buckets + 1);
         for bucket_id in 0..self.num_buckets {
@@ -285,12 +322,15 @@ impl PartitionArtifactBuilder {
             total_loss,
             partitions: self.partitions.clone(),
         };
+        let manifest_start = Instant::now();
         write_json(
             self.object_store.as_ref(),
             &self.root_dir.child(PARTITION_ARTIFACT_MANIFEST_FILE_NAME),
             &manifest,
         )
         .await?;
+        self.stats.manifest_time += manifest_start.elapsed();
+        self.log_stats();
 
         let mut files = vec![PARTITION_ARTIFACT_MANIFEST_FILE_NAME.to_string()];
         files.extend(artifact_files);
@@ -307,77 +347,84 @@ impl PartitionArtifactBuilder {
         if self.buffers[bucket_id].is_empty() {
             return Ok(());
         }
+        let flush_start = Instant::now();
 
         let buffer = &mut self.buffers[bucket_id];
         let row_ids = mem::take(&mut buffer.row_ids);
         let part_ids = mem::take(&mut buffer.partition_ids);
         let pq_values = mem::take(&mut buffer.pq_values);
         let total_rows = row_ids.len();
+        self.stats.flushes += 1;
+        self.stats.flushed_rows += total_rows;
 
-        if self.num_buckets == self.num_partitions {
+        let result = if self.num_buckets == self.num_partitions {
             debug_assert!(part_ids.is_empty());
-            return self
-                .flush_single_partition_bucket(bucket_id, row_ids, pq_values, total_rows)
-                .await;
-        }
+            self.stats.single_partition_flushes += 1;
+            self.flush_single_partition_bucket(bucket_id, row_ids, pq_values, total_rows)
+                .await
+        } else {
+            self.stats.multi_partition_flushes += 1;
 
-        let row_ids = UInt64Array::from(row_ids);
-        let pq_values = UInt8Array::from(pq_values);
-        let mut permutation = (0..total_rows).collect::<Vec<_>>();
-        permutation.sort_unstable_by_key(|&idx| part_ids[idx]);
+            let row_ids = UInt64Array::from(row_ids);
+            let pq_values = UInt8Array::from(pq_values);
+            let mut permutation = (0..total_rows).collect::<Vec<_>>();
+            permutation.sort_unstable_by_key(|&idx| part_ids[idx]);
 
-        let mut sorted_row_ids = Vec::with_capacity(total_rows);
-        let mut sorted_partition_ids = Vec::with_capacity(total_rows);
-        let mut sorted_pq_values = Vec::with_capacity(total_rows * self.pq_code_width);
-        for idx in permutation {
-            sorted_row_ids.push(row_ids.value(idx));
-            sorted_partition_ids.push(part_ids[idx]);
-            let start = idx * self.pq_code_width;
-            let end = start + self.pq_code_width;
-            sorted_pq_values.extend_from_slice(&pq_values.values()[start..end]);
-        }
-
-        let file_offset = self.bucket_row_counts[bucket_id];
-        let final_relative_path = self.final_bucket_relative_path(bucket_id);
-        let mut offset = 0usize;
-        while offset < sorted_partition_ids.len() {
-            let partition_id = sorted_partition_ids[offset] as usize;
-            let mut end = offset + 1;
-            while end < sorted_partition_ids.len()
-                && sorted_partition_ids[end] == sorted_partition_ids[offset]
-            {
-                end += 1;
+            let mut sorted_row_ids = Vec::with_capacity(total_rows);
+            let mut sorted_partition_ids = Vec::with_capacity(total_rows);
+            let mut sorted_pq_values = Vec::with_capacity(total_rows * self.pq_code_width);
+            for idx in permutation {
+                sorted_row_ids.push(row_ids.value(idx));
+                sorted_partition_ids.push(part_ids[idx]);
+                let start = idx * self.pq_code_width;
+                let end = start + self.pq_code_width;
+                sorted_pq_values.extend_from_slice(&pq_values.values()[start..end]);
             }
-            let partition = &mut self.partitions[partition_id];
-            match &partition.path {
-                Some(existing) if existing != &final_relative_path => {
-                    return Err(Error::io(format!(
-                        "partition {} is split across multiple bucket files: '{}' vs '{}'",
-                        partition_id, existing, final_relative_path
-                    )));
+
+            let file_offset = self.bucket_row_counts[bucket_id];
+            let final_relative_path = self.final_bucket_relative_path(bucket_id);
+            let mut offset = 0usize;
+            while offset < sorted_partition_ids.len() {
+                let partition_id = sorted_partition_ids[offset] as usize;
+                let mut end = offset + 1;
+                while end < sorted_partition_ids.len()
+                    && sorted_partition_ids[end] == sorted_partition_ids[offset]
+                {
+                    end += 1;
                 }
-                None => partition.path = Some(final_relative_path.clone()),
-                _ => {}
+                let partition = &mut self.partitions[partition_id];
+                match &partition.path {
+                    Some(existing) if existing != &final_relative_path => {
+                        return Err(Error::io(format!(
+                            "partition {} is split across multiple bucket files: '{}' vs '{}'",
+                            partition_id, existing, final_relative_path
+                        )));
+                    }
+                    None => partition.path = Some(final_relative_path.clone()),
+                    _ => {}
+                }
+                partition.num_rows += end - offset;
+                partition.ranges.push(PartitionArtifactRange {
+                    offset: file_offset + offset as u64,
+                    num_rows: (end - offset) as u64,
+                });
+                offset = end;
             }
-            partition.num_rows += end - offset;
-            partition.ranges.push(PartitionArtifactRange {
-                offset: file_offset + offset as u64,
-                num_rows: (end - offset) as u64,
-            });
-            offset = end;
-        }
 
-        let pq_codes = FixedSizeListArray::try_new_from_values(
-            UInt8Array::from(sorted_pq_values),
-            self.pq_code_width as i32,
-        )?;
-        self.write_bucket_batch(
-            bucket_id,
-            UInt64Array::from(sorted_row_ids),
-            pq_codes,
-            total_rows,
-        )
-        .await
+            let pq_codes = FixedSizeListArray::try_new_from_values(
+                UInt8Array::from(sorted_pq_values),
+                self.pq_code_width as i32,
+            )?;
+            self.write_bucket_batch(
+                bucket_id,
+                UInt64Array::from(sorted_row_ids),
+                pq_codes,
+                total_rows,
+            )
+            .await
+        };
+        self.stats.flush_time += flush_start.elapsed();
+        result
     }
 
     /// Flush a bucket that maps exactly to one partition.
@@ -427,12 +474,19 @@ impl PartitionArtifactBuilder {
         pq_codes: FixedSizeListArray,
         total_rows: usize,
     ) -> Result<()> {
+        let final_batch_start = Instant::now();
         let final_batch = RecordBatch::try_new(
             self.final_schema.clone(),
             vec![Arc::new(row_ids), Arc::new(pq_codes)],
         )?;
-        let writer = self.ensure_final_writer(bucket_id).await?;
-        writer.write_batch(&final_batch).await?;
+        self.stats.final_batch_time += final_batch_start.elapsed();
+
+        let writer_start = Instant::now();
+        {
+            let writer = self.ensure_final_writer(bucket_id).await?;
+            writer.write_batch(&final_batch).await?;
+        }
+        self.stats.writer_time += writer_start.elapsed();
         self.bucket_row_counts[bucket_id] += total_rows as u64;
         Ok(())
     }
@@ -470,6 +524,28 @@ impl PartitionArtifactBuilder {
         format!(
             "{PARTITION_ARTIFACT_PARTITIONS_DIR}/{PARTITION_ARTIFACT_BUCKET_PREFIX}{bucket_id:05}.lance"
         )
+    }
+
+    fn log_stats(&self) {
+        eprintln!(
+            "partition artifact builder stages: append_batches={} append_rows={} append_s={:.3} validate_s={:.3} extract_s={:.3} scatter_s={:.3} flushes={} flushed_rows={} single_flushes={} multi_flushes={} flush_s={:.3} final_batch_s={:.3} writer_s={:.3} finish_flush_s={:.3} writer_finish_s={:.3} manifest_s={:.3}",
+            self.stats.append_batches,
+            self.stats.append_rows,
+            self.stats.append_time.as_secs_f64(),
+            self.stats.validate_time.as_secs_f64(),
+            self.stats.extract_time.as_secs_f64(),
+            self.stats.scatter_time.as_secs_f64(),
+            self.stats.flushes,
+            self.stats.flushed_rows,
+            self.stats.single_partition_flushes,
+            self.stats.multi_partition_flushes,
+            self.stats.flush_time.as_secs_f64(),
+            self.stats.final_batch_time.as_secs_f64(),
+            self.stats.writer_time.as_secs_f64(),
+            self.stats.finish_flush_time.as_secs_f64(),
+            self.stats.writer_finish_time.as_secs_f64(),
+            self.stats.manifest_time.as_secs_f64(),
+        );
     }
 }
 

--- a/rust/lance/src/index/vector/partition_artifact.rs
+++ b/rust/lance/src/index/vector/partition_artifact.rs
@@ -14,7 +14,9 @@ use lance_arrow::FixedSizeListArrayExt;
 use lance_core::cache::LanceCache;
 use lance_core::datatypes::Schema;
 use lance_core::{Error, ROW_ID, Result};
+use lance_encoding::compression_config::{BssMode, CompressionFieldParams, CompressionParams};
 use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
+use lance_encoding::encoder::default_encoding_strategy_with_params;
 use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::LanceFileVersion;
 use lance_file::writer::{FileWriter, FileWriterOptions};
@@ -579,17 +581,33 @@ pub(crate) struct PartitionArtifactShuffleReader {
 /// The artifact uses a fixed file version so external backends and Lance
 /// finalization agree on the on-disk layout.
 fn file_writer_options() -> Result<FileWriterOptions> {
+    let format_version = PARTITION_ARTIFACT_FILE_VERSION
+        .parse::<LanceFileVersion>()
+        .map_err(|error| {
+            Error::invalid_input(format!(
+                "invalid partition artifact file version '{}': {}",
+                PARTITION_ARTIFACT_FILE_VERSION, error
+            ))
+        })?;
+    let mut compression_params = CompressionParams::new();
+    let no_compression = CompressionFieldParams {
+        compression: Some("none".to_string()),
+        bss: Some(BssMode::Off),
+        ..Default::default()
+    };
+    compression_params
+        .columns
+        .insert(ROW_ID.to_string(), no_compression.clone());
+    compression_params
+        .columns
+        .insert(PQ_CODE_COLUMN.to_string(), no_compression);
+
     Ok(FileWriterOptions {
-        format_version: Some(
-            PARTITION_ARTIFACT_FILE_VERSION
-                .parse::<LanceFileVersion>()
-                .map_err(|error| {
-                    Error::invalid_input(format!(
-                        "invalid partition artifact file version '{}': {}",
-                        PARTITION_ARTIFACT_FILE_VERSION, error
-                    ))
-                })?,
-        ),
+        encoding_strategy: Some(Arc::from(default_encoding_strategy_with_params(
+            format_version,
+            compression_params,
+        )?)),
+        format_version: Some(format_version),
         ..Default::default()
     })
 }

--- a/rust/lance/src/index/vector/partition_artifact.rs
+++ b/rust/lance/src/index/vector/partition_artifact.rs
@@ -37,6 +37,8 @@ const PARTITION_ARTIFACT_DEFAULT_BUCKETS: usize = 256;
 const PARTITION_ARTIFACT_BUCKET_PREFIX: &str = "bucket-";
 const PARTITION_ARTIFACT_FILE_VERSION: &str = "2.2";
 const PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS: usize = 32 * 1024;
+const PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS_ENV: &str =
+    "LANCE_PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS";
 
 /// Top-level manifest for a precomputed partition artifact.
 ///
@@ -142,6 +144,7 @@ pub struct PartitionArtifactBuilder {
     buffers: Vec<BucketBuffer>,
     partitions: Vec<PartitionArtifactPartition>,
     bucket_row_counts: Vec<u64>,
+    bucket_buffer_rows: usize,
     stats: PartitionArtifactBuilderStats,
 }
 
@@ -213,6 +216,12 @@ impl PartitionArtifactBuilder {
             ),
         ]));
 
+        let bucket_buffer_rows = std::env::var(PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS_ENV)
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|rows| *rows > 0)
+            .unwrap_or(PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS);
+
         Ok(Self {
             object_store,
             root_dir,
@@ -231,6 +240,7 @@ impl PartitionArtifactBuilder {
                 num_partitions
             ],
             bucket_row_counts: vec![0; num_buckets],
+            bucket_buffer_rows,
             stats: PartitionArtifactBuilderStats::default(),
         })
     }
@@ -274,7 +284,7 @@ impl PartitionArtifactBuilder {
             let start = row_idx * self.pq_code_width;
             let end = start + self.pq_code_width;
             buffer.pq_values.extend_from_slice(&pq_values[start..end]);
-            if buffer.len() >= PARTITION_ARTIFACT_BUCKET_BUFFER_ROWS {
+            if buffer.len() >= self.bucket_buffer_rows {
                 self.flush_bucket(bucket_id).await?;
             }
         }
@@ -528,7 +538,8 @@ impl PartitionArtifactBuilder {
 
     fn log_stats(&self) {
         eprintln!(
-            "partition artifact builder stages: append_batches={} append_rows={} append_s={:.3} validate_s={:.3} extract_s={:.3} scatter_s={:.3} flushes={} flushed_rows={} single_flushes={} multi_flushes={} flush_s={:.3} final_batch_s={:.3} writer_s={:.3} finish_flush_s={:.3} writer_finish_s={:.3} manifest_s={:.3}",
+            "partition artifact builder stages: bucket_buffer_rows={} append_batches={} append_rows={} append_s={:.3} validate_s={:.3} extract_s={:.3} scatter_s={:.3} flushes={} flushed_rows={} single_flushes={} multi_flushes={} flush_s={:.3} final_batch_s={:.3} writer_s={:.3} finish_flush_s={:.3} writer_finish_s={:.3} manifest_s={:.3}",
+            self.bucket_buffer_rows,
             self.stats.append_batches,
             self.stats.append_rows,
             self.stats.append_time.as_secs_f64(),

--- a/rust/lance/src/index/vector/partition_artifact.rs
+++ b/rust/lance/src/index/vector/partition_artifact.rs
@@ -239,7 +239,9 @@ impl PartitionArtifactBuilder {
             let bucket_id = partition_id % self.num_buckets;
             let buffer = &mut self.buffers[bucket_id];
             buffer.row_ids.push(row_ids.value(row_idx));
-            buffer.partition_ids.push(partition_id as u32);
+            if self.num_buckets != self.num_partitions {
+                buffer.partition_ids.push(partition_id as u32);
+            }
             let start = row_idx * self.pq_code_width;
             let end = start + self.pq_code_width;
             buffer.pq_values.extend_from_slice(&pq_values[start..end]);
@@ -307,11 +309,20 @@ impl PartitionArtifactBuilder {
         }
 
         let buffer = &mut self.buffers[bucket_id];
-        let row_ids = UInt64Array::from(mem::take(&mut buffer.row_ids));
+        let row_ids = mem::take(&mut buffer.row_ids);
         let part_ids = mem::take(&mut buffer.partition_ids);
-        let pq_values = UInt8Array::from(mem::take(&mut buffer.pq_values));
+        let pq_values = mem::take(&mut buffer.pq_values);
         let total_rows = row_ids.len();
 
+        if self.num_buckets == self.num_partitions {
+            debug_assert!(part_ids.is_empty());
+            return self
+                .flush_single_partition_bucket(bucket_id, row_ids, pq_values, total_rows)
+                .await;
+        }
+
+        let row_ids = UInt64Array::from(row_ids);
+        let pq_values = UInt8Array::from(pq_values);
         let mut permutation = (0..total_rows).collect::<Vec<_>>();
         permutation.sort_unstable_by_key(|&idx| part_ids[idx]);
 
@@ -360,12 +371,65 @@ impl PartitionArtifactBuilder {
             UInt8Array::from(sorted_pq_values),
             self.pq_code_width as i32,
         )?;
+        self.write_bucket_batch(
+            bucket_id,
+            UInt64Array::from(sorted_row_ids),
+            pq_codes,
+            total_rows,
+        )
+        .await
+    }
+
+    /// Flush a bucket that maps exactly to one partition.
+    ///
+    /// When the number of buckets equals the number of partitions, all rows in
+    /// one bucket already belong to the same partition. Sorting by partition id
+    /// would only add CPU work and another PQ-code copy.
+    async fn flush_single_partition_bucket(
+        &mut self,
+        bucket_id: usize,
+        row_ids: Vec<u64>,
+        pq_values: Vec<u8>,
+        total_rows: usize,
+    ) -> Result<()> {
+        let file_offset = self.bucket_row_counts[bucket_id];
+        let final_relative_path = self.final_bucket_relative_path(bucket_id);
+        let partition = &mut self.partitions[bucket_id];
+        match &partition.path {
+            Some(existing) if existing != &final_relative_path => {
+                return Err(Error::io(format!(
+                    "partition {} is split across multiple bucket files: '{}' vs '{}'",
+                    bucket_id, existing, final_relative_path
+                )));
+            }
+            None => partition.path = Some(final_relative_path),
+            _ => {}
+        }
+        partition.num_rows += total_rows;
+        partition.ranges.push(PartitionArtifactRange {
+            offset: file_offset,
+            num_rows: total_rows as u64,
+        });
+
+        let pq_codes = FixedSizeListArray::try_new_from_values(
+            UInt8Array::from(pq_values),
+            self.pq_code_width as i32,
+        )?;
+        self.write_bucket_batch(bucket_id, UInt64Array::from(row_ids), pq_codes, total_rows)
+            .await
+    }
+
+    /// Write a finalized bucket batch and update the bucket row count.
+    async fn write_bucket_batch(
+        &mut self,
+        bucket_id: usize,
+        row_ids: UInt64Array,
+        pq_codes: FixedSizeListArray,
+        total_rows: usize,
+    ) -> Result<()> {
         let final_batch = RecordBatch::try_new(
             self.final_schema.clone(),
-            vec![
-                Arc::new(UInt64Array::from(sorted_row_ids)),
-                Arc::new(pq_codes),
-            ],
+            vec![Arc::new(row_ids), Arc::new(pq_codes)],
         )?;
         let writer = self.ensure_final_writer(bucket_id).await?;
         writer.write_batch(&final_batch).await?;

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -49,7 +49,7 @@ use lance_table::format::Fragment;
 use lance_table::rowids::RowIdSequence;
 use lance_table::utils::stream::ReadBatchFut;
 use roaring::RoaringBitmap;
-use tokio::sync::{Mutex as AsyncMutex, OnceCell};
+use tokio::sync::{Mutex as AsyncMutex, OnceCell, Semaphore, mpsc};
 use tracing::{Instrument, instrument};
 
 use crate::Dataset;
@@ -354,6 +354,17 @@ struct FilteredReadStream {
     scan_range_after_filter: Option<Range<u64>>,
 }
 
+struct UnorderedFilteredReadInit {
+    scoped_fragments: Vec<ScopedFragmentRead>,
+    global_metrics: Arc<FilteredReadGlobalMetrics>,
+    worker_count: usize,
+}
+
+enum UnorderedFilteredReadState {
+    Init(Option<UnorderedFilteredReadInit>),
+    Running(mpsc::Receiver<Result<ReadBatchFut>>),
+}
+
 impl std::fmt::Debug for FilteredReadStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FilteredReadStream").finish()
@@ -431,22 +442,35 @@ impl FilteredReadStream {
             scan_scheduler.clone(),
         );
 
-        let global_metrics_clone = global_metrics.clone();
-
-        let fragment_streams = futures::stream::iter(scoped_fragments)
-            .map({
-                let scan_range_after_filter = scan_range_after_filter.clone();
-                move |scoped_fragment| {
-                    let metrics = global_metrics_clone.clone();
-                    let limit = scan_range_after_filter.as_ref().map(|r| r.end);
-                    SpawnedTask::spawn(
-                        Self::read_fragment(scoped_fragment, metrics, limit).in_current_span(),
-                    )
-                    .map(|thread_result| thread_result.unwrap())
-                }
-            })
-            .buffered(fragment_readahead);
-        let task_stream = fragment_streams.try_flatten().boxed();
+        let task_stream = if options.ordered_output || scan_range_after_filter.is_some() {
+            let global_metrics_clone = global_metrics.clone();
+            let fragment_streams = futures::stream::iter(scoped_fragments)
+                .map({
+                    let scan_range_after_filter = scan_range_after_filter.clone();
+                    move |scoped_fragment| {
+                        let metrics = global_metrics_clone.clone();
+                        let limit = scan_range_after_filter.as_ref().map(|r| r.end);
+                        SpawnedTask::spawn(
+                            Self::read_fragment(scoped_fragment, metrics, limit).in_current_span(),
+                        )
+                        .map(|thread_result| thread_result.unwrap())
+                    }
+                })
+                .buffered(fragment_readahead);
+            fragment_streams.try_flatten().boxed()
+        } else {
+            let worker_count = Self::unordered_worker_count(
+                scoped_fragments.len(),
+                options.fragment_readahead,
+                options.threading_mode,
+            );
+            log::debug!(
+                "Filtered read unordered worker backend on {} fragments with workers={}",
+                scoped_fragments.len(),
+                worker_count
+            );
+            Self::unordered_task_stream(scoped_fragments, global_metrics.clone(), worker_count)
+        };
 
         Ok(Self {
             output_schema,
@@ -457,6 +481,101 @@ impl FilteredReadStream {
             threading_mode,
             scan_range_after_filter,
         })
+    }
+
+    fn unordered_worker_count(
+        fragment_count: usize,
+        fragment_readahead: Option<usize>,
+        threading_mode: FilteredReadThreadingMode,
+    ) -> usize {
+        let default_workers = match threading_mode {
+            FilteredReadThreadingMode::OnePartitionMultipleThreads(num_threads) => num_threads,
+            FilteredReadThreadingMode::MultiplePartitions(num_partitions) => num_partitions,
+        }
+        .max(1);
+        let configured_workers = std::env::var("LANCE_V2_SCAN_WORKERS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(default_workers);
+        let readahead_cap = match fragment_readahead {
+            Some(0) | None => configured_workers,
+            Some(limit) => configured_workers.min(limit),
+        };
+
+        readahead_cap.min(fragment_count).max(1)
+    }
+
+    fn unordered_task_stream(
+        scoped_fragments: Vec<ScopedFragmentRead>,
+        global_metrics: Arc<FilteredReadGlobalMetrics>,
+        worker_count: usize,
+    ) -> BoxStream<'static, Result<ReadBatchFut>> {
+        futures::stream::unfold(
+            UnorderedFilteredReadState::Init(Some(UnorderedFilteredReadInit {
+                scoped_fragments,
+                global_metrics,
+                worker_count,
+            })),
+            |mut state| async move {
+                loop {
+                    match state {
+                        UnorderedFilteredReadState::Init(ref mut init) => {
+                            let init = init.take()?;
+                            let channel_capacity = init.worker_count.saturating_mul(2).max(1);
+                            let (tx, rx) = mpsc::channel(channel_capacity);
+                            let semaphore = Arc::new(Semaphore::new(init.worker_count.max(1)));
+
+                            for scoped_fragment in init.scoped_fragments {
+                                let tx = tx.clone();
+                                let error_tx = tx.clone();
+                                let semaphore = semaphore.clone();
+                                let metrics = init.global_metrics.clone();
+                                tokio::spawn(async move {
+                                    let result = async move {
+                                        if tx.is_closed() {
+                                            return Ok(());
+                                        }
+                                        let _permit =
+                                            semaphore.acquire_owned().await.map_err(|error| {
+                                                Error::internal(format!(
+                                                    "scan worker closed: {error}"
+                                                ))
+                                            })?;
+                                        if tx.is_closed() {
+                                            return Ok(());
+                                        }
+                                        let mut fragment_stream = Box::pin(
+                                            Self::read_fragment(scoped_fragment, metrics, None)
+                                                .await?,
+                                        );
+                                        while let Some(task) = fragment_stream.next().await {
+                                            if tx.send(task).await.is_err() {
+                                                return Ok(());
+                                            }
+                                        }
+                                        Ok::<(), Error>(())
+                                    }
+                                    .await;
+                                    if let Err(error) = result {
+                                        let _ = error_tx.send(Err(error)).await;
+                                    }
+                                });
+                            }
+                            drop(tx);
+                            state = UnorderedFilteredReadState::Running(rx);
+                        }
+                        UnorderedFilteredReadState::Running(mut rx) => {
+                            return rx
+                                .recv()
+                                .await
+                                .map(|task| (task, UnorderedFilteredReadState::Running(rx)));
+                        }
+                    }
+                }
+            },
+        )
+        .boxed()
     }
 
     async fn load_fragment(
@@ -1267,6 +1386,8 @@ pub struct FilteredReadOptions {
     pub full_filter: Option<Expr>,
     /// The threading mode to use for the scan
     pub threading_mode: FilteredReadThreadingMode,
+    /// Whether to preserve fragment order in the output stream.
+    pub ordered_output: bool,
     /// The size of the I/O buffer to use for the scan
     pub io_buffer_size_bytes: Option<u64>,
 }
@@ -1300,6 +1421,7 @@ impl FilteredReadOptions {
             threading_mode: FilteredReadThreadingMode::OnePartitionMultipleThreads(
                 get_num_compute_intensive_cpus(),
             ),
+            ordered_output: true,
         }
     }
 
@@ -1393,6 +1515,12 @@ impl FilteredReadOptions {
     /// scheduler.
     pub fn with_fragment_readahead(mut self, fragment_readahead: usize) -> Self {
         self.fragment_readahead = Some(fragment_readahead);
+        self
+    }
+
+    /// Controls whether the read should preserve fragment order.
+    pub fn with_ordered_output(mut self, ordered_output: bool) -> Self {
+        self.ordered_output = ordered_output;
         self
     }
 

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -31,6 +31,7 @@ use lance_file::reader::FileReaderOptions;
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_table::format::Fragment;
 use log::debug;
+use tokio::sync::{Semaphore, mpsc};
 use tracing::Instrument;
 
 use crate::dataset::Dataset;
@@ -67,6 +68,140 @@ async fn open_file(
 struct FragmentWithRange {
     fragment: FileFragment,
     range: Option<Range<u32>>,
+}
+
+struct V2UnorderedScanInit {
+    file_fragments: Vec<FragmentWithRange>,
+    project_schema: Arc<Schema>,
+    config: LanceScanConfig,
+    scan_scheduler: Arc<ScanScheduler>,
+    worker_count: usize,
+}
+
+enum V2UnorderedScanState {
+    Init(Option<V2UnorderedScanInit>),
+    Running(mpsc::Receiver<Result<RecordBatch>>),
+}
+
+async fn read_v2_fragment_unordered(
+    file_fragment: FragmentWithRange,
+    project_schema: Arc<Schema>,
+    config: LanceScanConfig,
+    scan_scheduler: Arc<ScanScheduler>,
+    priority: usize,
+    tx: mpsc::Sender<Result<RecordBatch>>,
+) -> Result<()> {
+    let mut frag_config = FragReadConfig::default()
+        .with_row_id(config.with_row_id)
+        .with_row_address(config.with_row_address)
+        .with_row_last_updated_at_version(config.with_row_last_updated_at_version)
+        .with_row_created_at_version(config.with_row_created_at_version);
+    if let Some(file_reader_options) = config.file_reader_options {
+        frag_config = frag_config.with_file_reader_options(file_reader_options);
+    }
+    let reader = open_file(
+        file_fragment.fragment,
+        project_schema,
+        frag_config,
+        config.with_make_deletions_null,
+        Some((scan_scheduler, priority as u32)),
+    )
+    .await?;
+    let batch_stream = if let Some(range) = file_fragment.range {
+        reader.read_range(range, config.batch_size as u32)?
+    } else {
+        reader.read_all(config.batch_size as u32)?
+    };
+    let mut batches = batch_stream.buffered(1);
+    while let Some(batch) = batches.next().await {
+        if tx.send(batch.map_err(DataFusionError::from)).await.is_err() {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+fn v2_unordered_scan_stream(init: V2UnorderedScanInit) -> BoxStream<'static, Result<RecordBatch>> {
+    stream::unfold(
+        V2UnorderedScanState::Init(Some(init)),
+        |mut state| async move {
+            loop {
+                match state {
+                    V2UnorderedScanState::Init(ref mut init) => {
+                        let init = init.take()?;
+                        let channel_capacity = init.worker_count.saturating_mul(2).max(1);
+                        let (tx, rx) = mpsc::channel(channel_capacity);
+                        let semaphore = Arc::new(Semaphore::new(init.worker_count.max(1)));
+                        for (priority, file_fragment) in init.file_fragments.into_iter().enumerate()
+                        {
+                            let permit = semaphore.clone();
+                            let tx = tx.clone();
+                            let error_tx = tx.clone();
+                            let project_schema = init.project_schema.clone();
+                            let config = init.config.clone();
+                            let scan_scheduler = init.scan_scheduler.clone();
+                            tokio::spawn(async move {
+                                let result = async move {
+                                    if tx.is_closed() {
+                                        return Ok(());
+                                    }
+                                    let _permit = permit.acquire_owned().await.map_err(|err| {
+                                        DataFusionError::Internal(format!(
+                                            "v2 scan fragment semaphore closed: {err}"
+                                        ))
+                                    })?;
+                                    if tx.is_closed() {
+                                        return Ok(());
+                                    }
+                                    read_v2_fragment_unordered(
+                                        file_fragment,
+                                        project_schema,
+                                        config,
+                                        scan_scheduler,
+                                        priority,
+                                        tx.clone(),
+                                    )
+                                    .await
+                                }
+                                .await;
+                                if let Err(error) = result {
+                                    let _ = error_tx.send(Err(error)).await;
+                                }
+                            });
+                        }
+                        drop(tx);
+                        state = V2UnorderedScanState::Running(rx);
+                    }
+                    V2UnorderedScanState::Running(mut rx) => {
+                        return rx
+                            .recv()
+                            .await
+                            .map(|batch| (batch, V2UnorderedScanState::Running(rx)));
+                    }
+                }
+            }
+        },
+    )
+    .boxed()
+}
+
+fn v2_unordered_scan_worker_count(
+    fragment_count: usize,
+    fragment_readahead: Option<usize>,
+) -> usize {
+    let default_workers = get_num_compute_intensive_cpus().max(1);
+    let configured_workers = std::env::var("LANCE_V2_SCAN_WORKERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default_workers);
+
+    let readahead_cap = match fragment_readahead {
+        Some(0) | None => configured_workers,
+        Some(limit) => configured_workers.min(limit),
+    };
+
+    readahead_cap.min(fragment_count).max(1)
 }
 
 struct ScanMetrics {
@@ -208,14 +343,8 @@ impl LanceStream {
         let frag_parallelism = config
             .fragment_readahead
             .unwrap_or((*DEFAULT_FRAGMENT_READAHEAD).unwrap_or(io_parallelism * 2))
-            // fragment_readhead=0 doesn't make sense so we just bump it to 1
+            // fragment_readahead=0 doesn't make sense for the ordered pre-open buffer.
             .max(1);
-        debug!(
-            "Given io_parallelism={} and num_columns={} we will read {} fragments at once while scanning v2 dataset",
-            io_parallelism,
-            projection.fields.len(),
-            frag_parallelism
-        );
 
         let mut file_fragments = fragments
             .iter()
@@ -267,6 +396,16 @@ impl LanceStream {
             }
             file_fragments = filtered_fragments;
         }
+        let unordered_worker_count =
+            v2_unordered_scan_worker_count(file_fragments.len(), config.fragment_readahead);
+        debug!(
+            "Given io_parallelism={} and num_columns={} we will use frag_parallelism={} ordered_output={} unordered_worker_count={} while scanning v2 dataset",
+            io_parallelism,
+            projection.fields.len(),
+            frag_parallelism,
+            config.ordered_output,
+            unordered_worker_count,
+        );
 
         let scan_scheduler = ScanScheduler::new(
             dataset.object_store.clone(),
@@ -275,73 +414,86 @@ impl LanceStream {
 
         let scan_scheduler_clone = scan_scheduler.clone();
 
-        let config_for_stream = config.clone();
-        let batches = stream::iter(file_fragments.into_iter().enumerate())
-            .map(move |(priority, file_fragment)| {
-                let project_schema = project_schema.clone();
-                let scan_scheduler = scan_scheduler.clone();
-                let config = config_for_stream.clone();
-                #[allow(clippy::type_complexity)]
-                let frag_task: BoxFuture<
-                    Result<BoxStream<Result<BoxFuture<Result<RecordBatch>>>>>,
-                > = tokio::spawn(
-                    (async move {
-                        let mut frag_config = FragReadConfig::default()
-                            .with_row_id(config.with_row_id)
-                            .with_row_address(config.with_row_address)
-                            .with_row_last_updated_at_version(
-                                config.with_row_last_updated_at_version,
+        let inner_stream = if config.ordered_output {
+            let config_for_stream = config.clone();
+            let batches = stream::iter(file_fragments.into_iter().enumerate())
+                .map(move |(priority, file_fragment)| {
+                    let project_schema = project_schema.clone();
+                    let scan_scheduler = scan_scheduler.clone();
+                    let config = config_for_stream.clone();
+                    #[allow(clippy::type_complexity)]
+                    let frag_task: BoxFuture<
+                        Result<BoxStream<Result<BoxFuture<Result<RecordBatch>>>>>,
+                    > = tokio::spawn(
+                        (async move {
+                            let mut frag_config = FragReadConfig::default()
+                                .with_row_id(config.with_row_id)
+                                .with_row_address(config.with_row_address)
+                                .with_row_last_updated_at_version(
+                                    config.with_row_last_updated_at_version,
+                                )
+                                .with_row_created_at_version(config.with_row_created_at_version);
+                            if let Some(file_reader_options) = config.file_reader_options {
+                                frag_config =
+                                    frag_config.with_file_reader_options(file_reader_options);
+                            }
+                            let reader = open_file(
+                                file_fragment.fragment,
+                                project_schema,
+                                frag_config,
+                                config.with_make_deletions_null,
+                                Some((scan_scheduler, priority as u32)),
                             )
-                            .with_row_created_at_version(config.with_row_created_at_version);
-                        if let Some(file_reader_options) = config.file_reader_options {
-                            frag_config = frag_config.with_file_reader_options(file_reader_options);
-                        }
-                        let reader = open_file(
-                            file_fragment.fragment,
-                            project_schema,
-                            frag_config,
-                            config.with_make_deletions_null,
-                            Some((scan_scheduler, priority as u32)),
-                        )
-                        .await?;
-                        let batch_stream = if let Some(range) = file_fragment.range {
-                            reader.read_range(range, config.batch_size as u32)?.boxed()
-                        } else {
-                            reader.read_all(config.batch_size as u32)?.boxed()
-                        };
-                        let batch_stream: BoxStream<Result<BoxFuture<Result<RecordBatch>>>> =
-                            batch_stream
-                                .map(|fut| {
-                                    Result::Ok(
-                                        fut.map_err(|e| DataFusionError::External(Box::new(e)))
-                                            .boxed(),
-                                    )
-                                })
-                                .boxed();
-                        Result::Ok(batch_stream)
-                    })
-                    .in_current_span(),
-                )
-                .map(|res_res| res_res.unwrap())
+                            .await?;
+                            let batch_stream = if let Some(range) = file_fragment.range {
+                                reader.read_range(range, config.batch_size as u32)?.boxed()
+                            } else {
+                                reader.read_all(config.batch_size as u32)?.boxed()
+                            };
+                            let batch_stream: BoxStream<Result<BoxFuture<Result<RecordBatch>>>> =
+                                batch_stream
+                                    .map(|fut| {
+                                        Result::Ok(
+                                            fut.map_err(|e| DataFusionError::External(Box::new(e)))
+                                                .boxed(),
+                                        )
+                                    })
+                                    .boxed();
+                            Result::Ok(batch_stream)
+                        })
+                        .in_current_span(),
+                    )
+                    .map(|res_res| res_res.unwrap())
+                    .boxed();
+                    Ok(frag_task)
+                })
+                // We need two levels of try_buffered here.  The first kicks off the tasks to read the fragments.
+                // As soon as we open the fragment we will start scheduling and that will kick off many background
+                // tasks (not tracked by this stream) to read I/O.  The limit here is really to limit how many open
+                // files we have.  It's not going to have much affect on how much RAM we are using.
+                .try_buffered(frag_parallelism)
                 .boxed();
-                Ok(frag_task)
+            batches
+                .try_flatten()
+                // The second try_buffered controls how many CPU decode tasks we kick off in parallel.
+                //
+                // TODO: Ideally this will eventually get tied into datafusion as a # of partitions.  This will let
+                // us fully fuse decode into the first half of the plan.  Currently there is likely to be a thread
+                // transfer between the two steps.
+                .try_buffered(get_num_compute_intensive_cpus())
+                .stream_in_current_span()
+                .boxed()
+        } else {
+            v2_unordered_scan_stream(V2UnorderedScanInit {
+                file_fragments,
+                project_schema,
+                config: config.clone(),
+                scan_scheduler: scan_scheduler.clone(),
+                worker_count: unordered_worker_count,
             })
-            // We need two levels of try_buffered here.  The first kicks off the tasks to read the fragments.
-            // As soon as we open the fragment we will start scheduling and that will kick off many background
-            // tasks (not tracked by this stream) to read I/O.  The limit here is really to limit how many open
-            // files we have.  It's not going to have much affect on how much RAM we are using.
-            .try_buffered(frag_parallelism)
-            .boxed();
-        let inner_stream = batches
-            .try_flatten()
-            // The second try_buffered controls how many CPU decode tasks we kick off in parallel.
-            //
-            // TODO: Ideally this will eventually get tied into datafusion as a # of partitions.  This will let
-            // us fully fuse decode into the first half of the plan.  Currently there is likely to be a thread
-            // transfer between the two steps.
-            .try_buffered(get_num_compute_intensive_cpus())
             .stream_in_current_span()
-            .boxed();
+            .boxed()
+        };
 
         timer.done();
         Ok(Self {

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -99,6 +99,7 @@ async fn read_v2_fragment_unordered(
     if let Some(file_reader_options) = config.file_reader_options {
         frag_config = frag_config.with_file_reader_options(file_reader_options);
     }
+    let range = file_fragment.range;
     let reader = open_file(
         file_fragment.fragment,
         project_schema,
@@ -107,16 +108,29 @@ async fn read_v2_fragment_unordered(
         Some((scan_scheduler, priority as u32)),
     )
     .await?;
-    let batch_stream = if let Some(range) = file_fragment.range {
-        reader.read_range(range, config.batch_size as u32)?
-    } else {
-        reader.read_all(config.batch_size as u32)?
-    };
-    let mut batches = batch_stream.buffered(1);
-    while let Some(batch) = batches.next().await {
-        if tx.send(batch.map_err(DataFusionError::from)).await.is_err() {
-            return Ok(());
+    let mut batches = None;
+    loop {
+        let permit = match tx.clone().reserve_owned().await {
+            Ok(permit) => permit,
+            Err(_) => return Ok(()),
+        };
+        if batches.is_none() {
+            let batch_stream = if let Some(range) = range.clone() {
+                reader.read_range(range, config.batch_size as u32)?
+            } else {
+                reader.read_all(config.batch_size as u32)?
+            };
+            batches = Some(batch_stream.buffered(1).boxed());
         }
+        let Some(batch) = batches
+            .as_mut()
+            .expect("v2 unordered scan batches initialized")
+            .next()
+            .await
+        else {
+            break;
+        };
+        permit.send(batch.map_err(DataFusionError::from));
     }
     Ok(())
 }
@@ -129,7 +143,11 @@ fn v2_unordered_scan_stream(init: V2UnorderedScanInit) -> BoxStream<'static, Res
                 match state {
                     V2UnorderedScanState::Init(ref mut init) => {
                         let init = init.take()?;
-                        let channel_capacity = init.worker_count.saturating_mul(2).max(1);
+                        let channel_capacity = init
+                            .config
+                            .batch_readahead
+                            .max(1)
+                            .min(init.worker_count.saturating_mul(2).max(1));
                         let (tx, rx) = mpsc::channel(channel_capacity);
                         let semaphore = Arc::new(Semaphore::new(init.worker_count.max(1)));
                         for (priority, file_fragment) in init.file_fragments.into_iter().enumerate()


### PR DESCRIPTION
## Summary

- Add a V2 scan worker backend that materializes batches through unordered blocking workers while preserving the scanner contract used by index builds.
- Add cuVS batch-size plumbing and backpressure before V2 batch materialization.
- Add partition artifact and PQ storage changes that improved the 100M cuVS IVF-PQ benchmark path.

## Benchmark context

Dataset: `paired-llama-3.2-1b-embeddings-lmsys-chat-1m`, 100M sampled rows, IVF-PQ with `num_partitions=256`, `num_sub_vectors=128`, `sample_rate=256`, `max_iters=50`, and `filter_nan=false`.

On `p4de.24xlarge` local NVMe, the best validated cuVS end-to-end result was `358.32s`; the same-machine full CPU baseline was `643.29s`, about `1.80x` faster for cuVS. Runs validated `indexed_rows_verified=100000000`, non-empty indices, and reasonable index bytes. An EBS comparison was much more IO-bound: cuVS `852.26s` vs CPU `902.90s`.

## Draft status

This is a discussion/progress PR based on `xuanwo/cuvs-partition-artifact-integration`. It is not ready as a production-shaped final stack.

Known cleanup before merge:

- Replace benchmark-only env knobs such as `LANCE_V2_SCAN_WORKERS` with supported configuration, stable defaults, or remove them.
- Remove benchmark instrumentation or convert it to `tracing`/metrics hooks.
- Squash or drop failed experiment/revert commits when shaping the final production PR.
- Re-run focused correctness and benchmark validation after cleanup.
