### PR TITLE
ci: detect Cargo.lock drift offline + harden java --locked

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -112,7 +112,7 @@ jobs:
             export CXX=clang++
             ldd --version
 
-            cargo build --release
+            cargo build --release --locked
           "
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -135,7 +135,7 @@ jobs:
         run: brew install protobuf
       - name: Build native lib
         working-directory: java/lance-jni
-        run: cargo build --release
+        run: cargo build --release --locked
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: liblance_jni_darwin_aarch64.zip

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo fmt --check
       - name: Rust Clippy
         working-directory: java/lance-jni
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --locked -- -D warnings
 
   build-and-test-java:
     runs-on: ubuntu-24.04-4x

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,16 @@ repos:
     rev: v1.26.0
     hooks:
     - id: typos
+
+  # Catch a Cargo.toml change that wasn't reflected in the matching Cargo.lock.
+  # Runs fully offline (`--frozen` = `--locked` + `--offline`) and does not compile,
+  # so it stays fast. Checks all three lockfiles since a workspace dep change can
+  # touch the excluded python/ and java/ locks too.
+  - repo: local
+    hooks:
+      - id: cargo-lock-sync
+        name: Cargo.lock in sync with Cargo.toml (offline)
+        entry: bash -c 'for m in Cargo.toml python/Cargo.toml java/lance-jni/Cargo.toml; do cargo metadata --frozen --format-version 1 --manifest-path "$m" >/dev/null 2>&1 || { echo "Cargo.lock is out of date for $m. Refresh it (e.g. cargo check --manifest-path $m) and commit the updated lockfile."; exit 1; }; done'
+        language: system
+        files: '(^|/)Cargo\.(toml|lock)$'
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ AWS_DEFAULT_REGION=us-east-1 pytest --run-integration python/tests/test_s3_ddb.p
 
 - Prefer implementing functionality with the standard library or existing workspace dependencies before adding new external crates.
 - Keep `Cargo.lock` changes intentional; revert unrelated dependency bumps. Pin broken deps with a comment linking the upstream issue.
+- The repo has three lockfiles: the root `Cargo.lock`, `python/Cargo.lock`, and `java/lance-jni/Cargo.lock` (the latter two are excluded from the workspace). A `workspace.dependencies` change must be reflected in all three — refresh the excluded ones with `cargo check --manifest-path python/Cargo.toml` and `cargo check --manifest-path java/lance-jni/Cargo.toml`, then commit the updated lockfiles. The `cargo-lock-sync` pre-commit hook catches a miss offline.
 - Gate optional/domain-specific deps behind Cargo feature flags. Prefer separate crates for domain functionality (geo, NLP).
 
 ## Testing Standards

--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -9,6 +9,12 @@ repository = "https://github.com/lance-format/lance"
 readme = "../../README.md"
 description = "JNI bindings for Lance Columnar format"
 
+# `java/lance-jni/` is excluded from the top-level workspace (see ../../Cargo.toml) and
+# keeps its own Cargo.lock. Declaring an empty workspace here makes this crate an explicit
+# workspace root, so cargo resolves it standalone even when the checkout is nested inside
+# another cargo project (e.g. a git worktree placed under the main checkout).
+[workspace]
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -8,6 +8,12 @@ rust-version = "1.91"
 exclude = ["python/lance/conftest.py"]
 publish = false
 
+# `python/` is excluded from the top-level workspace (see ../Cargo.toml) and keeps
+# its own Cargo.lock. Declaring an empty workspace here makes this crate an explicit
+# workspace root, so cargo resolves it standalone even when the checkout is nested
+# inside another cargo project (e.g. a git worktree placed under the main checkout).
+[workspace]
+
 [lib]
 name = "lance"
 crate-type = ["cdylib"]


### PR DESCRIPTION
The repo keeps three lockfiles — root `Cargo.lock`, `python/Cargo.lock`, and `java/lance-jni/Cargo.lock` (the latter two are excluded from the workspace). A `workspace.dependencies` change can leave the excluded locks stale. python CI already runs `--locked`, but java CI did not, so a stale java lock went uncaught until a release build.

Changes:
- **`cargo-lock-sync` pre-commit hook** — verifies all three lockfiles with `cargo metadata --frozen` (`--locked` + `--offline`). No network, no compilation; fails fast with a message naming the stale manifest and the fix.
- **Empty `[workspace]` tables** in `python/` and `java/lance-jni/` manifests — declares each as its own workspace root so cargo resolves it standalone instead of climbing to an enclosing checkout. Without this, `--manifest-path` (and the hook) breaks when the checkout is nested inside another cargo project, e.g. a git worktree under the main checkout. The dependency graphs and lockfiles are unchanged.
- **`--locked`** added to the java clippy step (`java.yml`, runs on PRs) and the release build steps (`java-publish.yml`).
- **AGENTS.md** documents the three-lockfile rule.

Verified: offline check passes in-sync and detects an injected stale lock with exit 1 (no network); `[workspace]` additions leave all three lockfiles byte-identical; `pre-commit validate-config` passes and the hook ran green on this commit.