### PR TITLE
feat(index): write zone map seeds into data file footers during append

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4794,6 +4794,7 @@ dependencies = [
  "arrow",
  "arrow-arith",
  "arrow-array",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3967,6 +3967,7 @@ dependencies = [
  "arrow",
  "arrow-arith",
  "arrow-array",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",

--- a/protos/index_old.proto
+++ b/protos/index_old.proto
@@ -30,11 +30,14 @@ message ZoneMapIndexDetails {
   // is created for the index.
   optional uint64 rows_per_zone = 1;
   // Whether seed-based incremental updates are enabled for this index.
-  // Absent (old datasets) or false: seeds disabled.
-  // true: seeds enabled; the index will embed per-fragment seed buffers in
-  // data files and harvest them during incremental updates to skip full scans.
-  // Defaults to true for variable-length column types (strings, binary) and
-  // fixed-width types wider than 8 bytes when not explicitly set by the user.
+  // On-disk semantics: absent means seeds are disabled (old datasets written
+  // before this field was added). Present false means explicitly disabled.
+  // Present true means seeds are enabled: the index will embed per-fragment
+  // seed buffers in data files and harvest them during incremental updates
+  // to skip full column scans.
+  // Creation-time default: index creation code sets this to true for
+  // variable-length types (strings, binary) and fixed-width types wider than
+  // 8 bytes, and to false for narrow fixed-width types (e.g. Int64, Float64).
   optional bool use_seeds = 2;
 }
 message InvertedIndexDetails {

--- a/protos/index_old.proto
+++ b/protos/index_old.proto
@@ -24,7 +24,19 @@ message BTreeIndexDetails {}
 message BitmapIndexDetails {}
 message LabelListIndexDetails {}
 message NGramIndexDetails {}
-message ZoneMapIndexDetails {}
+message ZoneMapIndexDetails {
+  // Number of rows per zone. Optional for backwards compatibility: absent on
+  // datasets written before this field was added. When absent, no seed writer
+  // is created for the index.
+  optional uint64 rows_per_zone = 1;
+  // Whether seed-based incremental updates are enabled for this index.
+  // Absent (old datasets) or false: seeds disabled.
+  // true: seeds enabled; the index will embed per-fragment seed buffers in
+  // data files and harvest them during incremental updates to skip full scans.
+  // Defaults to true for variable-length column types (strings, binary) and
+  // fixed-width types wider than 8 bytes when not explicitly set by the user.
+  optional bool use_seeds = 2;
+}
 message InvertedIndexDetails {
   message CodeTokenizerConfig {
     // Split one lexical identifier into subwords, e.g. getUserName ->

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4292,6 +4292,7 @@ dependencies = [
  "arrow",
  "arrow-arith",
  "arrow-array",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",

--- a/python/python/benchmarks/zone_map_seeds.py
+++ b/python/python/benchmarks/zone_map_seeds.py
@@ -167,7 +167,8 @@ def print_comparison(title: str, no_seeds: dict, with_seeds: dict) -> None:
     print(f"  {title}")
     print(f"{'=' * 70}")
     print(
-        f"  {'Phase':<20} {'No Seeds':>{col_w}} {'With Seeds':>{col_w}} {'Speedup':>{col_w}}"
+        f"  {'Phase':<20} {'No Seeds':>{col_w}} "
+        + f"{'With Seeds':>{col_w}} {'Speedup':>{col_w}}"
     )
     print(f"  {'-' * (20 + col_w * 3 + 6)}")
     for phase in phases:

--- a/python/python/benchmarks/zone_map_seeds.py
+++ b/python/python/benchmarks/zone_map_seeds.py
@@ -315,7 +315,10 @@ def main() -> None:
 
     if args.tmpdir is not None:
         args.tmpdir.mkdir(parents=True, exist_ok=True)
-        run(args.tmpdir)
+        with tempfile.TemporaryDirectory(
+            prefix="lance_zonemap_bench_", dir=args.tmpdir
+        ) as tmp:
+            run(Path(tmp))
     else:
         with tempfile.TemporaryDirectory(prefix="lance_zonemap_bench_") as tmp:
             run(Path(tmp))

--- a/python/python/benchmarks/zone_map_seeds.py
+++ b/python/python/benchmarks/zone_map_seeds.py
@@ -88,10 +88,14 @@ def gen_fsb_batches(num_rows: int, blob_bytes: int, batch_size: int):
 def gen_large_binary_batches(num_rows: int, blob_bytes: int, batch_size: int):
     for start in range(0, num_rows, batch_size):
         n = min(batch_size, num_rows - start)
-        yield pa.table({"value": pa.array(
-            [os.urandom(blob_bytes) for _ in range(n)],
-            type=pa.large_binary(),
-        )})
+        yield pa.table(
+            {
+                "value": pa.array(
+                    [os.urandom(blob_bytes) for _ in range(n)],
+                    type=pa.large_binary(),
+                )
+            }
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -104,8 +108,8 @@ def run_scenario(
     schema: pa.Schema,
     seed_rows: int,
     seed_batch_size: int,
-    gen_seed_batches,       # () -> Iterator[pa.Table] for the initial write
-    gen_bulk_batches,       # () -> Iterator[pa.Table] for the appended data
+    gen_seed_batches,  # () -> Iterator[pa.Table] for the initial write
+    gen_bulk_batches,  # () -> Iterator[pa.Table] for the appended data
     use_seeds: bool,
 ) -> dict:
     """
@@ -196,13 +200,19 @@ def bench_integers(base: Path, num_rows: int) -> None:
     schema = pa.schema([pa.field("value", pa.int64())])
 
     no_seeds = run_scenario(
-        base / "int_no_seeds", schema, seed_rows, seed_bs,
+        base / "int_no_seeds",
+        schema,
+        seed_rows,
+        seed_bs,
         lambda: gen_int_batches(seed_rows, seed_bs),
         lambda: gen_int_batches(bulk_rows, bulk_bs),
         use_seeds=False,
     )
     with_seeds = run_scenario(
-        base / "int_with_seeds", schema, seed_rows, seed_bs,
+        base / "int_with_seeds",
+        schema,
+        seed_rows,
+        seed_bs,
         lambda: gen_int_batches(seed_rows, seed_bs),
         lambda: gen_int_batches(bulk_rows, bulk_bs),
         use_seeds=True,
@@ -225,13 +235,19 @@ def bench_vectors(base: Path, num_rows: int) -> None:
     schema = pa.schema([pa.field("value", pa.binary(blob_bytes))])
 
     no_seeds = run_scenario(
-        base / "vec_no_seeds", schema, seed_rows, seed_bs,
+        base / "vec_no_seeds",
+        schema,
+        seed_rows,
+        seed_bs,
         lambda: gen_fsb_batches(seed_rows, blob_bytes, seed_bs),
         lambda: gen_fsb_batches(bulk_rows, blob_bytes, bulk_bs),
         use_seeds=False,
     )
     with_seeds = run_scenario(
-        base / "vec_with_seeds", schema, seed_rows, seed_bs,
+        base / "vec_with_seeds",
+        schema,
+        seed_rows,
+        seed_bs,
         lambda: gen_fsb_batches(seed_rows, blob_bytes, seed_bs),
         lambda: gen_fsb_batches(bulk_rows, blob_bytes, bulk_bs),
         use_seeds=True,
@@ -258,13 +274,19 @@ def bench_large_binary(base: Path, num_rows: int) -> None:
     schema = pa.schema([pa.field("value", pa.large_binary())])
 
     no_seeds = run_scenario(
-        base / "bin_no_seeds", schema, seed_rows, seed_bs,
+        base / "bin_no_seeds",
+        schema,
+        seed_rows,
+        seed_bs,
         lambda: gen_large_binary_batches(seed_rows, blob_bytes, seed_bs),
         lambda: gen_large_binary_batches(bulk_rows, blob_bytes, bulk_bs),
         use_seeds=False,
     )
     with_seeds = run_scenario(
-        base / "bin_with_seeds", schema, seed_rows, seed_bs,
+        base / "bin_with_seeds",
+        schema,
+        seed_rows,
+        seed_bs,
         lambda: gen_large_binary_batches(seed_rows, blob_bytes, seed_bs),
         lambda: gen_large_binary_batches(bulk_rows, blob_bytes, bulk_bs),
         use_seeds=True,

--- a/python/python/benchmarks/zone_map_seeds.py
+++ b/python/python/benchmarks/zone_map_seeds.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+"""
+Benchmark: Zone Map Index Seeds vs. No Seeds
+
+Measures the time to update a zone map index when new data is appended to an
+already-indexed dataset, with and without use_seeds.
+
+Seeds allow Lance to embed per-zone min/max statistics in data files at write
+time.  When optimize_indices() runs, it harvests those pre-computed stats
+instead of re-scanning the full column, which eliminates the read I/O for
+wide data types.
+
+WHY the workflow matters
+------------------------
+Seeds only engage when merging new unindexed fragments into an existing
+non-empty index segment.  A first optimize_indices() call on a freshly
+created empty-index always does a full rebuild (no old fragments to merge
+against), so seeds would never be used.
+
+Correct workflow:
+  1. Write an initial batch of data and build the zone map index on it.
+     This creates a non-empty indexed segment; all subsequent writes will
+     embed seed buffers in their data files (when use_seeds=True).
+  2. Append the bulk of the data in multiple batches.
+  3. optimize_indices() — harvests seeds (phase 2 data) and merges them into
+     the segment from phase 1.  Without seeds, phase 3 must re-read all of
+     the phase-2 data from disk.
+
+Phases timed:
+  initial_write   write seed_fraction of total rows + create/build index
+  ingest          append remaining rows (seeds collected here when enabled)
+  update_index    optimize_indices() — seed harvest happens here
+  total           sum of the three phases above
+
+Three scenarios:
+  int64                    10 M rows   ~80 MB on disk
+  FixedSizeBinary(4096)    10 M rows   ~38 GB on disk
+  LargeBinary(20 KiB)       1 M rows   ~19 GB on disk
+
+Usage:
+    uv run python python/benchmarks/zone_map_seeds.py
+    uv run python python/benchmarks/zone_map_seeds.py --tmpdir /fast/nvme/bench
+    uv run python python/benchmarks/zone_map_seeds.py --scale 0.01
+"""
+
+import argparse
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import lance
+import numpy as np
+import pyarrow as pa
+from lance.indices import IndexConfig
+
+KiB = 1024
+
+# Fraction of total rows written in the initial indexed batch.
+SEED_FRACTION = 0.1
+
+
+# ---------------------------------------------------------------------------
+# Data generators (yield pa.Table one batch at a time)
+# ---------------------------------------------------------------------------
+
+
+def gen_int_batches(num_rows: int, batch_size: int):
+    rng = np.random.default_rng()
+    for start in range(0, num_rows, batch_size):
+        n = min(batch_size, num_rows - start)
+        yield pa.table({"value": pa.array(rng.integers(0, 2**31, n, dtype=np.int64))})
+
+
+def gen_fsb_batches(num_rows: int, blob_bytes: int, batch_size: int):
+    for start in range(0, num_rows, batch_size):
+        n = min(batch_size, num_rows - start)
+        raw = os.urandom(n * blob_bytes)
+        arr = pa.FixedSizeBinaryArray.from_buffers(
+            pa.binary(blob_bytes), n, [None, pa.py_buffer(raw)]
+        )
+        yield pa.table({"value": arr})
+
+
+def gen_large_binary_batches(num_rows: int, blob_bytes: int, batch_size: int):
+    for start in range(0, num_rows, batch_size):
+        n = min(batch_size, num_rows - start)
+        yield pa.table({"value": pa.array(
+            [os.urandom(blob_bytes) for _ in range(n)],
+            type=pa.large_binary(),
+        )})
+
+
+# ---------------------------------------------------------------------------
+# Core benchmark runner
+# ---------------------------------------------------------------------------
+
+
+def run_scenario(
+    dataset_path: Path,
+    schema: pa.Schema,
+    seed_rows: int,
+    seed_batch_size: int,
+    gen_seed_batches,       # () -> Iterator[pa.Table] for the initial write
+    gen_bulk_batches,       # () -> Iterator[pa.Table] for the appended data
+    use_seeds: bool,
+) -> dict:
+    """
+    Run one full scenario and return per-phase timings.
+
+    Seeds are only engaged by optimize_indices() when there is at least one
+    previously indexed fragment.  This scenario ensures that by writing
+    seed_rows of data and building the index before any bulk ingest.
+    """
+    if dataset_path.exists():
+        shutil.rmtree(dataset_path)
+
+    index_config = IndexConfig(
+        index_type="ZONEMAP", parameters={"use_seeds": use_seeds}
+    )
+    timings = {}
+
+    # Phase 1: initial write + index build
+    t0 = time.perf_counter()
+    ds = None
+    for batch in gen_seed_batches():
+        if ds is None:
+            ds = lance.write_dataset(batch, dataset_path, schema=schema)
+        else:
+            ds = lance.write_dataset(batch, dataset_path, mode="append")
+    ds.create_scalar_index("value", index_type=index_config, replace=True)
+    timings["initial_write"] = time.perf_counter() - t0
+
+    # Phase 2: bulk ingest — seeds are collected per-batch when enabled
+    t0 = time.perf_counter()
+    for batch in gen_bulk_batches():
+        ds = lance.write_dataset(batch, dataset_path, mode="append")
+    timings["ingest"] = time.perf_counter() - t0
+
+    # Phase 3: index update — seed harvest happens here
+    t0 = time.perf_counter()
+    ds.optimize.optimize_indices()
+    timings["update_index"] = time.perf_counter() - t0
+
+    timings["total"] = sum(timings.values())
+    shutil.rmtree(dataset_path)
+    return timings
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def print_comparison(title: str, no_seeds: dict, with_seeds: dict) -> None:
+    phases = ["initial_write", "ingest", "update_index", "total"]
+    col_w = 13
+
+    print(f"\n{'=' * 70}")
+    print(f"  {title}")
+    print(f"{'=' * 70}")
+    print(
+        f"  {'Phase':<20} {'No Seeds':>{col_w}} {'With Seeds':>{col_w}} {'Speedup':>{col_w}}"
+    )
+    print(f"  {'-' * (20 + col_w * 3 + 6)}")
+    for phase in phases:
+        t_no = no_seeds[phase]
+        t_yes = with_seeds[phase]
+        speedup = t_no / t_yes if t_yes > 0 else float("inf")
+        marker = "* " if phase == "total" else "  "
+        print(
+            f"{marker}{phase:<20} {t_no:>{col_w}.2f}s"
+            f" {t_yes:>{col_w}.2f}s"
+            f" {speedup:>{col_w - 1}.2f}x"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-type benchmark wrappers
+# ---------------------------------------------------------------------------
+
+
+def bench_integers(base: Path, num_rows: int) -> None:
+    seed_rows = max(1, int(num_rows * SEED_FRACTION))
+    bulk_rows = num_rows - seed_rows
+    # ~400 KB per seed batch; ~4 MB per bulk batch → ~20 bulk fragments
+    seed_bs = max(1, seed_rows // 5)
+    bulk_bs = max(1, bulk_rows // 20)
+    print(
+        f"\nInteger (int64): {num_rows:,} rows "
+        f"(initial={seed_rows:,}, bulk={bulk_rows:,}) ..."
+    )
+    schema = pa.schema([pa.field("value", pa.int64())])
+
+    no_seeds = run_scenario(
+        base / "int_no_seeds", schema, seed_rows, seed_bs,
+        lambda: gen_int_batches(seed_rows, seed_bs),
+        lambda: gen_int_batches(bulk_rows, bulk_bs),
+        use_seeds=False,
+    )
+    with_seeds = run_scenario(
+        base / "int_with_seeds", schema, seed_rows, seed_bs,
+        lambda: gen_int_batches(seed_rows, seed_bs),
+        lambda: gen_int_batches(bulk_rows, bulk_bs),
+        use_seeds=True,
+    )
+    print_comparison(f"int64  —  {num_rows:,} rows", no_seeds, with_seeds)
+
+
+def bench_vectors(base: Path, num_rows: int) -> None:
+    blob_bytes = 4 * KiB
+    seed_rows = max(1, int(num_rows * SEED_FRACTION))
+    bulk_rows = num_rows - seed_rows
+    total_gb = num_rows * blob_bytes / (1024**3)
+    # ~200 MB per batch to stay memory-friendly
+    seed_bs = max(1, (200 * KiB * KiB) // blob_bytes)
+    bulk_bs = seed_bs
+    print(
+        f"\nVector (FixedSizeBinary {blob_bytes // KiB} KiB): {num_rows:,} rows"
+        f"  (~{total_gb:.1f} GB)  (initial={seed_rows:,}, bulk={bulk_rows:,}) ..."
+    )
+    schema = pa.schema([pa.field("value", pa.binary(blob_bytes))])
+
+    no_seeds = run_scenario(
+        base / "vec_no_seeds", schema, seed_rows, seed_bs,
+        lambda: gen_fsb_batches(seed_rows, blob_bytes, seed_bs),
+        lambda: gen_fsb_batches(bulk_rows, blob_bytes, bulk_bs),
+        use_seeds=False,
+    )
+    with_seeds = run_scenario(
+        base / "vec_with_seeds", schema, seed_rows, seed_bs,
+        lambda: gen_fsb_batches(seed_rows, blob_bytes, seed_bs),
+        lambda: gen_fsb_batches(bulk_rows, blob_bytes, bulk_bs),
+        use_seeds=True,
+    )
+    print_comparison(
+        f"FixedSizeBinary({blob_bytes // KiB} KiB)  —  {num_rows:,} rows",
+        no_seeds,
+        with_seeds,
+    )
+
+
+def bench_large_binary(base: Path, num_rows: int) -> None:
+    blob_bytes = 20 * KiB
+    seed_rows = max(1, int(num_rows * SEED_FRACTION))
+    bulk_rows = num_rows - seed_rows
+    total_gb = num_rows * blob_bytes / (1024**3)
+    # ~200 MB per batch
+    seed_bs = max(1, (200 * KiB * KiB) // blob_bytes)
+    bulk_bs = seed_bs
+    print(
+        f"\nLargeBinary ({blob_bytes // KiB} KiB blobs): {num_rows:,} rows"
+        f"  (~{total_gb:.1f} GB)  (initial={seed_rows:,}, bulk={bulk_rows:,}) ..."
+    )
+    schema = pa.schema([pa.field("value", pa.large_binary())])
+
+    no_seeds = run_scenario(
+        base / "bin_no_seeds", schema, seed_rows, seed_bs,
+        lambda: gen_large_binary_batches(seed_rows, blob_bytes, seed_bs),
+        lambda: gen_large_binary_batches(bulk_rows, blob_bytes, bulk_bs),
+        use_seeds=False,
+    )
+    with_seeds = run_scenario(
+        base / "bin_with_seeds", schema, seed_rows, seed_bs,
+        lambda: gen_large_binary_batches(seed_rows, blob_bytes, seed_bs),
+        lambda: gen_large_binary_batches(bulk_rows, blob_bytes, bulk_bs),
+        use_seeds=True,
+    )
+    print_comparison(
+        f"LargeBinary({blob_bytes // KiB} KiB)  —  {num_rows:,} rows",
+        no_seeds,
+        with_seeds,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--tmpdir",
+        type=Path,
+        default=None,
+        help="Directory for benchmark datasets (default: system temp dir)",
+    )
+    parser.add_argument(
+        "--scale",
+        type=float,
+        default=1.0,
+        help="Row-count scale factor (default 1.0; use 0.01 for a quick smoke test)",
+    )
+    args = parser.parse_args()
+
+    int_rows = max(2, int(10_000_000 * args.scale))
+    vec_rows = max(2, int(10_000_000 * args.scale))
+    bin_rows = max(2, int(1_000_000 * args.scale))
+
+    print(
+        f"Scale: {args.scale}  →  "
+        f"{int_rows:,} int / {vec_rows:,} vector / {bin_rows:,} binary rows"
+    )
+
+    def run(tmp_dir: Path) -> None:
+        bench_integers(tmp_dir, int_rows)
+        bench_vectors(tmp_dir, vec_rows)
+        bench_large_binary(tmp_dir, bin_rows)
+
+    if args.tmpdir is not None:
+        args.tmpdir.mkdir(parents=True, exist_ok=True)
+        run(args.tmpdir)
+    else:
+        with tempfile.TemporaryDirectory(prefix="lance_zonemap_bench_") as tmp:
+            run(Path(tmp))
+
+
+if __name__ == "__main__":
+    main()

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -15,6 +15,7 @@ rust-version.workspace = true
 arc-swap.workspace = true
 arrow.workspace = true
 arrow-array.workspace = true
+arrow-ipc.workspace = true
 arrow-ord.workspace = true
 arrow-schema.workspace = true
 arrow-select.workspace = true

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -43,6 +43,7 @@ pub mod ngram;
 pub mod registry;
 #[cfg(feature = "geo")]
 pub mod rtree;
+pub mod seed;
 pub mod zoned;
 pub mod zonemap;
 

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -4,7 +4,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use arrow_schema::Field;
+use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::future::BoxFuture;
@@ -242,6 +242,55 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
     fn details_as_json(&self, _details: &prost_types::Any) -> Result<serde_json::Value> {
         // Return an empty JSON object as the default implementation
         Ok(serde_json::json!({}))
+    }
+
+    /// Optionally create a seed writer for the given column.
+    ///
+    /// A seed writer observes column values during data file writes, accumulates
+    /// compact statistics in memory, and serializes them as a global buffer
+    /// embedded in the data file footer. The buffer is later harvested during
+    /// index updates to skip a full column scan.
+    ///
+    /// All parameters needed to construct the writer must be derivable from
+    /// `index_details` — this method must not perform any I/O. Return `Ok(None)`
+    /// if this index type does not support seed writing.
+    async fn create_seed_writer(
+        &self,
+        _field_path: &str,
+        _data_type: &DataType,
+        _index_details: &prost_types::Any,
+    ) -> Result<Option<Box<dyn super::seed::IndexSeedWriter>>> {
+        Ok(None)
+    }
+
+    /// Returns true if this index type may have seed buffers embedded in data
+    /// files for the given index configuration.
+    ///
+    /// When false the caller can skip opening data files to look for seeds
+    /// entirely, avoiding I/O for index types or configurations that never
+    /// write seeds.
+    fn might_use_seeds(&self, _index_details: &prost_types::Any) -> bool {
+        false
+    }
+
+    /// Attempt to update `reference_index` using pre-harvested `seeds` instead
+    /// of re-scanning column data.
+    ///
+    /// Each [`FragmentSeed`](super::seed::FragmentSeed) carries the raw bytes
+    /// written by the corresponding [`IndexSeedWriter`](super::seed::IndexSeedWriter)
+    /// and the original `metadata_value` stored in the data file, which the plugin
+    /// can use for compatibility validation (e.g. confirming `rows_per_zone`).
+    ///
+    /// Return `Ok(Some(created))` if the seed-based update succeeded, or
+    /// `Ok(None)` to signal that the caller should fall back to a full column scan.
+    async fn update_from_seeds(
+        &self,
+        _seeds: Vec<super::seed::FragmentSeed>,
+        _reference_index: Arc<dyn ScalarIndex>,
+        _index_details: &prost_types::Any,
+        _dest_store: &dyn IndexStore,
+    ) -> Result<Option<CreatedIndex>> {
+        Ok(None)
     }
 }
 

--- a/rust/lance-index/src/scalar/seed.rs
+++ b/rust/lance-index/src/scalar/seed.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Index seed writers — compact per-fragment summaries embedded in data files.
+//!
+//! A seed writer observes column values as they are written to a data file,
+//! accumulates compact statistics in memory, and serializes them to a byte
+//! buffer that is embedded in the data file footer as a global buffer.
+//!
+//! The buffer can later be read back during index updates to reconstruct index
+//! statistics without re-scanning the column data.
+
+use arrow_array::ArrayRef;
+use bytes::Bytes;
+use lance_core::Result;
+
+/// Schema metadata key prefix for all seed buffers: `"lance.seed.<column_name>"`.
+pub const SEED_META_KEY_PREFIX: &str = "lance.seed.";
+
+/// A hook registered during data file writes that observes column values batch
+/// by batch, accumulates compact statistics in memory, and serializes them to
+/// a byte buffer that is embedded in the data file footer as a global buffer.
+///
+/// The buffer can later be read back during index updates to reconstruct index
+/// statistics without re-scanning the column data.
+pub trait IndexSeedWriter: Send + std::fmt::Debug {
+    /// The column this writer is interested in.
+    fn column_name(&self) -> &str;
+
+    /// Observe a slice of column values as they are written to the current fragment.
+    /// Called once per batch.
+    fn observe_batch(&mut self, values: &ArrayRef) -> Result<()>;
+
+    /// Serialize accumulated state to bytes and reset for the next fragment.
+    /// Returns `None` if no data was observed (empty fragment).
+    fn finish(&mut self) -> Result<Option<Bytes>>;
+
+    /// Schema metadata key used to record that a seed buffer was written.
+    /// Convention: `"lance.seed.<column_name>"`.
+    fn schema_metadata_key(&self) -> String;
+
+    /// Create a string to store in the file's schema metadata. This will normally
+    /// contain the buffer index (provided by the caller after `add_global_buffer`)
+    /// as well as any other information needed to validate or understand the seed
+    /// (e.g. `rows_per_zone` for zone map seeds).
+    fn schema_metadata_value(&self, buf_index: u32) -> String;
+}
+
+/// A pre-harvested seed buffer from a single fragment's data file.
+#[derive(Debug, Clone)]
+pub struct FragmentSeed {
+    pub fragment_id: u64,
+    pub bytes: Bytes,
+    /// The raw value that was stored in the data file's schema metadata under
+    /// the seed key (i.e. the output of [`IndexSeedWriter::schema_metadata_value`]).
+    /// Plugins can inspect this to validate that the seed is compatible with the
+    /// current index configuration before consuming `bytes`.
+    pub metadata_value: String,
+}

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -764,12 +764,12 @@ impl ZoneMapIndex {
             self.data_type.clone(),
         )?;
         builder.maps = new_zones;
-        let file = builder.write_index(dest_store).await?;
+        let files = builder.write_index(dest_store).await?;
 
         Ok(Some(CreatedIndex {
             index_details: make_zone_map_index_details(self.rows_per_zone, self.use_seeds),
             index_version: ZONEMAP_INDEX_VERSION,
-            files: vec![file],
+            files,
         }))
     }
 }
@@ -1288,10 +1288,11 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
         if !details.as_ref().and_then(|d| d.use_seeds).unwrap_or(false) {
             return Ok(None);
         }
-        match ZoneMapSeedWriter::new(field_path, rows_per_zone, data_type.clone()) {
-            Ok(writer) => Ok(Some(Box::new(writer))),
-            Err(_) => Ok(None),
-        }
+        Ok(Some(Box::new(ZoneMapSeedWriter::new(
+            field_path,
+            rows_per_zone,
+            data_type.clone(),
+        )?)))
     }
 
     async fn update_from_seeds(
@@ -1385,12 +1386,16 @@ impl ZoneMapSeedWriter {
             arrow_array::UInt32Array::from_iter_values(zones.iter().map(|s| s.null_count));
         let nan_counts =
             arrow_array::UInt32Array::from_iter_values(zones.iter().map(|s| s.nan_count));
+        let zone_lengths = arrow_array::UInt64Array::from_iter_values(
+            zones.iter().map(|s| s.bound.length as u64),
+        );
 
         let schema = Arc::new(arrow_schema::Schema::new(vec![
             Field::new("min", data_type.clone(), true),
             Field::new("max", data_type.clone(), true),
             Field::new("null_count", DataType::UInt32, false),
             Field::new("nan_count", DataType::UInt32, false),
+            Field::new("zone_length", DataType::UInt64, false),
         ]));
 
         let columns: Vec<ArrayRef> = vec![
@@ -1398,6 +1403,7 @@ impl ZoneMapSeedWriter {
             maxs,
             Arc::new(null_counts) as ArrayRef,
             Arc::new(nan_counts) as ArrayRef,
+            Arc::new(zone_lengths) as ArrayRef,
         ];
         Ok(arrow_array::RecordBatch::try_new(schema, columns)?)
     }
@@ -1452,15 +1458,20 @@ impl ZoneMapSeedWriter {
             .as_any()
             .downcast_ref::<arrow_array::UInt32Array>()
             .ok_or_else(|| lance_core::Error::invalid_input("seed 'nan_count' is not UInt32"))?;
+        let zone_length_col = batch
+            .column_by_name("zone_length")
+            .ok_or_else(|| {
+                lance_core::Error::invalid_input("seed batch missing 'zone_length' column")
+            })?
+            .as_any()
+            .downcast_ref::<arrow_array::UInt64Array>()
+            .ok_or_else(|| lance_core::Error::invalid_input("seed 'zone_length' is not UInt64"))?;
 
         let num_zones = batch.num_rows();
         let mut zones = Vec::with_capacity(num_zones);
         for i in 0..num_zones {
             let zone_start = i as u64 * rows_per_zone;
-            // Last zone may be shorter; but for reconstruction we don't know the
-            // exact row count here so we use rows_per_zone as a sentinel. The
-            // actual length is only needed for zone-map lookups, not for appending.
-            let zone_length = rows_per_zone as usize;
+            let zone_length = zone_length_col.value(i) as usize;
             zones.push(ZoneMapStatistics {
                 min: datafusion_common::ScalarValue::try_from_array(min_col, i)?,
                 max: datafusion_common::ScalarValue::try_from_array(max_col, i)?,
@@ -1673,7 +1684,7 @@ mod tests {
         .await
         .unwrap();
 
-        ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+        ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
             .await
             .expect("Failed to load ZoneMapIndex")
     }
@@ -3343,6 +3354,7 @@ mod tests {
                 &cache,
                 10,
                 Some(modern_null_rows), // modern: complete bitmap
+                false,
             )
             .unwrap(),
         );
@@ -3378,6 +3390,7 @@ mod tests {
                 &cache,
                 10,
                 None, // legacy: null positions unknown
+                false,
             )
             .unwrap(),
         );
@@ -3398,7 +3411,7 @@ mod tests {
         .await
         .unwrap();
 
-        let merged = ZoneMapIndex::load(dest_store.clone(), None, &LanceCache::no_cache())
+        let merged = ZoneMapIndex::load(dest_store.clone(), None, &LanceCache::no_cache(), false)
             .await
             .unwrap();
 
@@ -3470,7 +3483,7 @@ mod tests {
         // Write a legacy index with one zone that has nulls but no null bitmap.
         write_legacy_zonemap(store.as_ref(), 10).await;
 
-        let index = ZoneMapIndex::load(store, None, &LanceCache::no_cache())
+        let index = ZoneMapIndex::load(store, None, &LanceCache::no_cache(), false)
             .await
             .expect("failed to load legacy zonemap");
 
@@ -3536,10 +3549,15 @@ mod tests {
         assert_eq!(zones[1].min, ScalarValue::Int32(Some(10)));
         assert_eq!(zones[1].max, ScalarValue::Int32(Some(13)));
 
-        // Zone 2: values 20..22 -> min=20, max=21
+        // Zone 2: values 20..22 -> min=20, max=21, partial zone of 2 rows
         assert_eq!(zones[2].bound.start, 8);
+        assert_eq!(zones[2].bound.length, 2, "partial zone length must be exact");
         assert_eq!(zones[2].min, ScalarValue::Int32(Some(20)));
         assert_eq!(zones[2].max, ScalarValue::Int32(Some(21)));
+
+        // Full zones must have the full rows_per_zone length
+        assert_eq!(zones[0].bound.length, rows_per_zone as usize);
+        assert_eq!(zones[1].bound.length, rows_per_zone as usize);
     }
 
     #[tokio::test]
@@ -3566,12 +3584,15 @@ mod tests {
         );
 
         // Zone 0: rows 0..5
+        assert_eq!(zones[0].bound.length, 5);
         assert_eq!(zones[0].min, ScalarValue::Int32(Some(0)));
         assert_eq!(zones[0].max, ScalarValue::Int32(Some(4)));
         // Zone 1: rows 5..10
+        assert_eq!(zones[1].bound.length, 5);
         assert_eq!(zones[1].min, ScalarValue::Int32(Some(5)));
         assert_eq!(zones[1].max, ScalarValue::Int32(Some(9)));
         // Zone 2: rows 10..12 (partial)
+        assert_eq!(zones[2].bound.length, 2, "partial zone length must be 2");
         assert_eq!(zones[2].min, ScalarValue::Int32(Some(10)));
         assert_eq!(zones[2].max, ScalarValue::Int32(Some(11)));
     }

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -17,6 +17,7 @@ use crate::scalar::expression::{SargableQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
     BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
 };
+use crate::scalar::seed::IndexSeedWriter;
 use crate::scalar::{
     BuiltinIndexType, CreatedIndex, IndexFile, SargableQuery, ScalarIndexParams, UpdateCriteria,
     compute_next_prefix,
@@ -56,7 +57,7 @@ const ZONEMAP_INDEX_VERSION: u32 = 0;
 
 /// Basic stats about zonemap index
 #[derive(Debug, PartialEq, Clone)]
-struct ZoneMapStatistics {
+pub(crate) struct ZoneMapStatistics {
     min: ScalarValue,
     max: ScalarValue,
     null_count: u32,
@@ -109,6 +110,7 @@ pub struct ZoneMapIndex {
     data_type: DataType,
     // The maximum rows per zone provided by user
     rows_per_zone: u64,
+    use_seeds: bool,
     store: Arc<dyn IndexStore>,
     fri: Option<Arc<dyn RowIdRemapper>>,
     index_cache: WeakLanceCache,
@@ -123,6 +125,7 @@ impl std::fmt::Debug for ZoneMapIndex {
             .field("zones", &self.zones)
             .field("data_type", &self.data_type)
             .field("rows_per_zone", &self.rows_per_zone)
+            .field("use_seeds", &self.use_seeds)
             .field("store", &self.store)
             .field("fri", &self.fri)
             .field("index_cache", &self.index_cache)
@@ -137,6 +140,11 @@ impl DeepSizeOf for ZoneMapIndex {
 }
 
 impl ZoneMapIndex {
+    /// Returns the rows-per-zone parameter for this index.
+    pub fn rows_per_zone(&self) -> u64 {
+        self.rows_per_zone
+    }
+
     fn scalar_is_nan(value: &ScalarValue) -> bool {
         match value {
             ScalarValue::Float16(Some(value)) => value.is_nan(),
@@ -451,6 +459,7 @@ impl ZoneMapIndex {
         store: Arc<dyn IndexStore>,
         fri: Option<Arc<dyn RowIdRemapper>>,
         index_cache: &LanceCache,
+        use_seeds: bool,
     ) -> Result<Arc<Self>>
     where
         Self: Sized,
@@ -484,6 +493,7 @@ impl ZoneMapIndex {
             index_cache,
             rows_per_zone,
             null_rows,
+            use_seeds,
         )?))
     }
 
@@ -494,6 +504,7 @@ impl ZoneMapIndex {
         index_cache: &LanceCache,
         rows_per_zone: u64,
         null_rows: Option<RowAddrTreeMap>,
+        use_seeds: bool,
     ) -> Result<Self> {
         // The RecordBatch should have columns: min, max, null_count
         let min_col = data
@@ -552,6 +563,7 @@ impl ZoneMapIndex {
                 zones: Vec::new(),
                 data_type,
                 rows_per_zone,
+                use_seeds,
                 store,
                 fri,
                 index_cache: WeakLanceCache::from(index_cache),
@@ -584,6 +596,7 @@ impl ZoneMapIndex {
             zones,
             data_type,
             rows_per_zone,
+            use_seeds,
             store,
             fri,
             index_cache: WeakLanceCache::from(index_cache),
@@ -702,8 +715,7 @@ impl ScalarIndex for ZoneMapIndex {
         let files = builder.write_index(dest_store).await?;
 
         Ok(CreatedIndex {
-            index_details: prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails::default())
-                .unwrap(),
+            index_details: make_zone_map_index_details(self.rows_per_zone, self.use_seeds),
             index_version: ZONEMAP_INDEX_VERSION,
             files,
         })
@@ -716,7 +728,10 @@ impl ScalarIndex for ZoneMapIndex {
     }
 
     fn derive_index_params(&self) -> Result<ScalarIndexParams> {
-        let params = serde_json::to_value(ZoneMapIndexBuilderParams::new(self.rows_per_zone))?;
+        let params = serde_json::to_value(ZoneMapIndexBuilderParams {
+            rows_per_zone: self.rows_per_zone,
+            use_seeds: Some(self.use_seeds),
+        })?;
         Ok(ScalarIndexParams::for_builtin(BuiltinIndexType::ZoneMap).with_params(&params))
     }
 
@@ -724,6 +739,38 @@ impl ScalarIndex for ZoneMapIndex {
     /// [`value_range_over`](Self::value_range_over) for the full contract.
     fn value_range(&self) -> Option<(ScalarValue, ScalarValue)> {
         Self::value_range_over([self])
+    }
+}
+
+impl ZoneMapIndex {
+    async fn try_update_with_seeds(
+        &self,
+        seeds: &[crate::scalar::seed::FragmentSeed],
+        dest_store: &dyn IndexStore,
+    ) -> Result<Option<CreatedIndex>> {
+        let mut new_zones = self.zones.clone();
+        for seed in seeds {
+            let mut zones = ZoneMapSeedWriter::deserialize_seed(
+                seed.fragment_id,
+                &seed.bytes,
+                self.rows_per_zone,
+            )?;
+            new_zones.append(&mut zones);
+        }
+        new_zones.sort_by_key(|z| (z.bound.fragment_id, z.bound.start));
+
+        let mut builder = ZoneMapIndexBuilder::try_new(
+            ZoneMapIndexBuilderParams::new(self.rows_per_zone),
+            self.data_type.clone(),
+        )?;
+        builder.maps = new_zones;
+        let file = builder.write_index(dest_store).await?;
+
+        Ok(Some(CreatedIndex {
+            index_details: make_zone_map_index_details(self.rows_per_zone, self.use_seeds),
+            index_version: ZONEMAP_INDEX_VERSION,
+            files: vec![file],
+        }))
     }
 }
 
@@ -737,6 +784,7 @@ pub async fn merge_zonemap_indices(
         Error::invalid_input("merge_zonemap_indices requires at least one source index")
     })?;
     let rows_per_zone = first.rows_per_zone;
+    let use_seeds = first.use_seeds;
     let data_type = first.data_type.clone();
 
     let mut zones = Vec::new();
@@ -785,7 +833,7 @@ pub async fn merge_zonemap_indices(
     let files = builder.write_index(dest_store).await?;
 
     Ok(CreatedIndex {
-        index_details: prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails::default()).unwrap(),
+        index_details: make_zone_map_index_details(rows_per_zone, use_seeds),
         index_version: ZONEMAP_INDEX_VERSION,
         files,
     })
@@ -799,6 +847,12 @@ fn default_rows_per_zone() -> u64 {
 pub struct ZoneMapIndexBuilderParams {
     #[serde(default = "default_rows_per_zone")]
     rows_per_zone: u64,
+    /// Whether to embed per-fragment seed buffers in data files for use during
+    /// incremental index updates. `None` means auto-detect based on column type
+    /// (see [`default_use_seeds`]). Resolved to a concrete `bool` during
+    /// training in [`ZoneMapIndexPlugin::new_training_request`].
+    #[serde(default)]
+    use_seeds: Option<bool>,
 }
 
 static DEFAULT_ROWS_PER_ZONE: LazyLock<u64> = LazyLock::new(|| {
@@ -812,13 +866,17 @@ impl Default for ZoneMapIndexBuilderParams {
     fn default() -> Self {
         Self {
             rows_per_zone: *DEFAULT_ROWS_PER_ZONE,
+            use_seeds: None,
         }
     }
 }
 
 impl ZoneMapIndexBuilderParams {
     pub fn new(rows_per_zone: u64) -> Self {
-        Self { rows_per_zone }
+        Self {
+            rows_per_zone,
+            use_seeds: None,
+        }
     }
 
     pub fn rows_per_zone(&self) -> u64 {
@@ -945,6 +1003,7 @@ impl ZoneMapIndexBuilder {
 
 /// Index-specific processor that computes min/max statistics for each zone while the
 /// trainer takes care of chunking and fragment boundaries.
+#[derive(Debug)]
 struct ZoneMapProcessor {
     data_type: DataType,
     statistics: StatisticsAccumulator,
@@ -1036,6 +1095,37 @@ impl ZoneProcessor for ZoneMapProcessor {
     }
 }
 
+fn make_zone_map_index_details(rows_per_zone: u64, use_seeds: bool) -> prost_types::Any {
+    prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails {
+        rows_per_zone: Some(rows_per_zone),
+        use_seeds: Some(use_seeds),
+    })
+    .unwrap()
+}
+
+/// Returns true when seed-based incremental updates should be enabled by
+/// default for the given column type.
+///
+/// Seeds pay off for variable-length types (strings, binary) — which can be
+/// arbitrarily wide — and fixed-width types wider than 8 bytes (e.g.
+/// Decimal128, FixedSizeBinary tensors). Fixed-width types ≤ 8 bytes (Int64,
+/// Float64, …) scan fast enough that the seed overhead is not worth it.
+fn default_use_seeds(data_type: &DataType) -> bool {
+    match data_type {
+        // Variable-length: width is unbounded, skipping scans is always valuable.
+        DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Utf8View
+        | DataType::Binary
+        | DataType::LargeBinary
+        | DataType::BinaryView => true,
+        // Fixed-width types wider than 8 bytes.
+        DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => true,
+        DataType::FixedSizeBinary(n) => *n > 8,
+        _ => false,
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct ZoneMapIndexPlugin;
 
@@ -1091,7 +1181,11 @@ impl BasicTrainer for ZoneMapIndexPlugin {
             ));
         }
 
-        let params = serde_json::from_str::<ZoneMapIndexBuilderParams>(params)?;
+        let mut params = serde_json::from_str::<ZoneMapIndexBuilderParams>(params)?;
+        // Resolve None → type-based default so train_index always sees Some(bool).
+        if params.use_seeds.is_none() {
+            params.use_seeds = Some(default_use_seeds(field.data_type()));
+        }
 
         Ok(Box::new(ZoneMapIndexTrainingRequest::new(params)))
     }
@@ -1111,10 +1205,11 @@ impl BasicTrainer for ZoneMapIndexPlugin {
                     "must provide training request created by new_training_request".into(),
                 )
             })?;
+        let rows_per_zone = request.params.rows_per_zone;
+        let use_seeds = request.params.use_seeds.unwrap_or(false);
         let files = Self::train_zonemap_index(data, index_store, Some(request.params)).await?;
         Ok(CreatedIndex {
-            index_details: prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails::default())
-                .unwrap(),
+            index_details: make_zone_map_index_details(rows_per_zone, use_seeds),
             index_version: ZONEMAP_INDEX_VERSION,
             files,
         })
@@ -1154,11 +1249,322 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
     async fn load_index(
         &self,
         index_store: Arc<dyn IndexStore>,
-        _index_details: &prost_types::Any,
+        index_details: &prost_types::Any,
         frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
         cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>> {
-        Ok(ZoneMapIndex::load(index_store, frag_reuse_index, cache).await? as Arc<dyn ScalarIndex>)
+        let use_seeds = index_details
+            .to_msg::<pbold::ZoneMapIndexDetails>()
+            .ok()
+            .and_then(|d| d.use_seeds)
+            .unwrap_or(false);
+        Ok(
+            ZoneMapIndex::load(index_store, frag_reuse_index, cache, use_seeds).await?
+                as Arc<dyn ScalarIndex>,
+        )
+    }
+
+    fn might_use_seeds(&self, index_details: &prost_types::Any) -> bool {
+        index_details
+            .to_msg::<pbold::ZoneMapIndexDetails>()
+            .ok()
+            .and_then(|d| d.use_seeds)
+            .unwrap_or(false)
+    }
+
+    async fn create_seed_writer(
+        &self,
+        field_path: &str,
+        data_type: &DataType,
+        index_details: &prost_types::Any,
+    ) -> Result<Option<Box<dyn crate::scalar::seed::IndexSeedWriter>>> {
+        if data_type.is_nested() {
+            return Ok(None);
+        }
+        let details = index_details.to_msg::<pbold::ZoneMapIndexDetails>().ok();
+        let Some(rows_per_zone) = details.as_ref().and_then(|d| d.rows_per_zone) else {
+            return Ok(None);
+        };
+        if !details.as_ref().and_then(|d| d.use_seeds).unwrap_or(false) {
+            return Ok(None);
+        }
+        match ZoneMapSeedWriter::new(field_path, rows_per_zone, data_type.clone()) {
+            Ok(writer) => Ok(Some(Box::new(writer))),
+            Err(_) => Ok(None),
+        }
+    }
+
+    async fn update_from_seeds(
+        &self,
+        seeds: Vec<crate::scalar::seed::FragmentSeed>,
+        reference_index: Arc<dyn ScalarIndex>,
+        index_details: &prost_types::Any,
+        dest_store: &dyn IndexStore,
+    ) -> Result<Option<CreatedIndex>> {
+        let Some(rows_per_zone) = index_details
+            .to_msg::<pbold::ZoneMapIndexDetails>()
+            .ok()
+            .and_then(|d| d.rows_per_zone)
+        else {
+            return Ok(None);
+        };
+
+        // Validate each seed was written with the same rows_per_zone.
+        for seed in &seeds {
+            let rpz_in_seed = seed
+                .metadata_value
+                .split_once(':')
+                .and_then(|(_, rpz)| rpz.parse::<u64>().ok());
+            if rpz_in_seed != Some(rows_per_zone) {
+                return Ok(None);
+            }
+        }
+
+        let Some(zone_map) = reference_index.as_any().downcast_ref::<ZoneMapIndex>() else {
+            return Ok(None);
+        };
+        zone_map.try_update_with_seeds(&seeds, dest_store).await
+    }
+}
+
+/// A seed writer that observes column values during data file writes and
+/// accumulates zone map statistics for later harvest during index updates.
+///
+/// Zone statistics are serialized as Arrow IPC bytes and embedded in the data
+/// file footer as a global buffer, keyed by `"lance.seed.<column_name>"`.
+#[derive(Debug)]
+pub struct ZoneMapSeedWriter {
+    column_name: String,
+    rows_per_zone: u64,
+    data_type: DataType,
+    completed_zones: Vec<ZoneMapStatistics>,
+    processor: ZoneMapProcessor,
+    rows_in_current_zone: u64,
+    next_zone_start: u64,
+}
+
+impl ZoneMapSeedWriter {
+    /// Create a new `ZoneMapSeedWriter` for the given column.
+    pub fn new(
+        column_name: impl Into<String>,
+        rows_per_zone: u64,
+        data_type: DataType,
+    ) -> Result<Self> {
+        if rows_per_zone == 0 {
+            return Err(lance_core::Error::invalid_input(
+                "rows_per_zone must be greater than zero",
+            ));
+        }
+        let processor = ZoneMapProcessor::new(data_type.clone())?;
+        Ok(Self {
+            column_name: column_name.into(),
+            rows_per_zone,
+            data_type,
+            completed_zones: Vec::new(),
+            processor,
+            rows_in_current_zone: 0,
+            next_zone_start: 0,
+        })
+    }
+
+    fn seed_batch_from_zones(
+        zones: &[ZoneMapStatistics],
+        data_type: &DataType,
+    ) -> Result<arrow_array::RecordBatch> {
+        let mins = if zones.is_empty() {
+            arrow_array::new_empty_array(data_type)
+        } else {
+            datafusion_common::ScalarValue::iter_to_array(zones.iter().map(|s| s.min.clone()))?
+        };
+        let maxs = if zones.is_empty() {
+            arrow_array::new_empty_array(data_type)
+        } else {
+            datafusion_common::ScalarValue::iter_to_array(zones.iter().map(|s| s.max.clone()))?
+        };
+        let null_counts =
+            arrow_array::UInt32Array::from_iter_values(zones.iter().map(|s| s.null_count));
+        let nan_counts =
+            arrow_array::UInt32Array::from_iter_values(zones.iter().map(|s| s.nan_count));
+
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            Field::new("min", data_type.clone(), true),
+            Field::new("max", data_type.clone(), true),
+            Field::new("null_count", DataType::UInt32, false),
+            Field::new("nan_count", DataType::UInt32, false),
+        ]));
+
+        let columns: Vec<ArrayRef> = vec![
+            mins,
+            maxs,
+            Arc::new(null_counts) as ArrayRef,
+            Arc::new(nan_counts) as ArrayRef,
+        ];
+        Ok(arrow_array::RecordBatch::try_new(schema, columns)?)
+    }
+
+    /// Deserialize zone map seed bytes (Arrow IPC) into zone statistics.
+    ///
+    /// Returns a list of `ZoneMapStatistics` with bounds reconstructed from
+    /// the sequential layout (zone `i` starts at `i * rows_per_zone`).
+    pub(crate) fn deserialize_seed(
+        fragment_id: u64,
+        bytes: &bytes::Bytes,
+        rows_per_zone: u64,
+    ) -> Result<Vec<ZoneMapStatistics>> {
+        use arrow_ipc::reader::FileReader;
+        use std::io::Cursor;
+
+        let cursor = Cursor::new(bytes.as_ref());
+        let mut reader = FileReader::try_new(cursor, None).map_err(|e| {
+            lance_core::Error::invalid_input(format!("failed to read zone map seed IPC: {}", e))
+        })?;
+
+        let batch = match reader.next() {
+            Some(Ok(batch)) => batch,
+            Some(Err(e)) => {
+                return Err(lance_core::Error::invalid_input(format!(
+                    "failed to read zone map seed batch: {}",
+                    e
+                )));
+            }
+            None => return Ok(Vec::new()),
+        };
+
+        let min_col = batch
+            .column_by_name("min")
+            .ok_or_else(|| lance_core::Error::invalid_input("seed batch missing 'min' column"))?;
+        let max_col = batch
+            .column_by_name("max")
+            .ok_or_else(|| lance_core::Error::invalid_input("seed batch missing 'max' column"))?;
+        let null_count_col = batch
+            .column_by_name("null_count")
+            .ok_or_else(|| {
+                lance_core::Error::invalid_input("seed batch missing 'null_count' column")
+            })?
+            .as_any()
+            .downcast_ref::<arrow_array::UInt32Array>()
+            .ok_or_else(|| lance_core::Error::invalid_input("seed 'null_count' is not UInt32"))?;
+        let nan_count_col = batch
+            .column_by_name("nan_count")
+            .ok_or_else(|| {
+                lance_core::Error::invalid_input("seed batch missing 'nan_count' column")
+            })?
+            .as_any()
+            .downcast_ref::<arrow_array::UInt32Array>()
+            .ok_or_else(|| lance_core::Error::invalid_input("seed 'nan_count' is not UInt32"))?;
+
+        let num_zones = batch.num_rows();
+        let mut zones = Vec::with_capacity(num_zones);
+        for i in 0..num_zones {
+            let zone_start = i as u64 * rows_per_zone;
+            // Last zone may be shorter; but for reconstruction we don't know the
+            // exact row count here so we use rows_per_zone as a sentinel. The
+            // actual length is only needed for zone-map lookups, not for appending.
+            let zone_length = rows_per_zone as usize;
+            zones.push(ZoneMapStatistics {
+                min: datafusion_common::ScalarValue::try_from_array(min_col, i)?,
+                max: datafusion_common::ScalarValue::try_from_array(max_col, i)?,
+                null_count: null_count_col.value(i),
+                nan_count: nan_count_col.value(i),
+                bound: ZoneBound {
+                    fragment_id,
+                    start: zone_start,
+                    length: zone_length,
+                },
+            });
+        }
+        Ok(zones)
+    }
+}
+
+impl IndexSeedWriter for ZoneMapSeedWriter {
+    fn column_name(&self) -> &str {
+        &self.column_name
+    }
+
+    fn observe_batch(&mut self, values: &ArrayRef) -> lance_core::Result<()> {
+        let mut offset = 0usize;
+
+        while offset < values.len() {
+            let remaining_in_zone = self.rows_per_zone - self.rows_in_current_zone;
+            let chunk_len = ((values.len() as u64 - offset as u64).min(remaining_in_zone)) as usize;
+            let chunk = values.slice(offset, chunk_len);
+            self.processor.process_chunk(&chunk)?;
+            self.rows_in_current_zone += chunk_len as u64;
+            offset += chunk_len;
+
+            if self.rows_in_current_zone >= self.rows_per_zone {
+                let bound = ZoneBound {
+                    fragment_id: 0,
+                    start: self.next_zone_start,
+                    length: self.rows_per_zone as usize,
+                };
+                let stats = self.processor.finish_zone(bound)?;
+                self.processor.reset()?;
+                self.completed_zones.push(stats);
+                self.next_zone_start += self.rows_per_zone;
+                self.rows_in_current_zone = 0;
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> lance_core::Result<Option<bytes::Bytes>> {
+        use arrow_ipc::writer::FileWriter;
+        use std::io::Cursor;
+
+        // Flush partial final zone
+        if self.rows_in_current_zone > 0 {
+            let bound = ZoneBound {
+                fragment_id: 0,
+                start: self.next_zone_start,
+                length: self.rows_in_current_zone as usize,
+            };
+            let stats = self.processor.finish_zone(bound)?;
+            self.processor.reset()?;
+            self.completed_zones.push(stats);
+            self.next_zone_start += self.rows_in_current_zone;
+            self.rows_in_current_zone = 0;
+        }
+
+        if self.completed_zones.is_empty() {
+            return Ok(None);
+        }
+
+        let batch = Self::seed_batch_from_zones(&self.completed_zones, &self.data_type)?;
+
+        // Serialize to Arrow IPC
+        let mut buf = Cursor::new(Vec::new());
+        {
+            let mut writer = FileWriter::try_new(&mut buf, batch.schema_ref()).map_err(|e| {
+                lance_core::Error::invalid_input(format!("failed to create IPC writer: {}", e))
+            })?;
+            writer.write(&batch).map_err(|e| {
+                lance_core::Error::invalid_input(format!("failed to write IPC batch: {}", e))
+            })?;
+            writer.finish().map_err(|e| {
+                lance_core::Error::invalid_input(format!("failed to finish IPC writer: {}", e))
+            })?;
+        }
+
+        // Reset state for next fragment
+        self.completed_zones.clear();
+        self.next_zone_start = 0;
+        self.processor = ZoneMapProcessor::new(self.data_type.clone())?;
+
+        Ok(Some(bytes::Bytes::from(buf.into_inner())))
+    }
+
+    fn schema_metadata_key(&self) -> String {
+        format!(
+            "{}{}",
+            crate::scalar::seed::SEED_META_KEY_PREFIX,
+            self.column_name
+        )
+    }
+
+    fn schema_metadata_value(&self, buf_index: u32) -> String {
+        format!("{}:{}", buf_index, self.rows_per_zone)
     }
 }
 
@@ -1372,7 +1778,7 @@ mod tests {
         log::debug!("Successfully wrote the index file");
 
         // Read the index file back and check its contents
-        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
             .await
             .expect("Failed to load ZoneMapIndex");
         assert_eq!(index.zones.len(), 0);
@@ -1416,7 +1822,7 @@ mod tests {
         log::debug!("Successfully wrote the index file");
 
         // Read the index file back and check its contents
-        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
             .await
             .expect("Failed to load ZoneMapIndex");
         assert_eq!(index.zones.len(), 10);
@@ -1468,9 +1874,10 @@ mod tests {
             .unwrap();
 
         // Verify the updated index has more zones
-        let updated_index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
-            .await
-            .expect("Failed to load updated ZoneMapIndex");
+        let updated_index =
+            ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
+                .await
+                .expect("Failed to load updated ZoneMapIndex");
 
         // Should have original 10 zones + 1 new zone (5000 rows with zone size 5000)
         assert_eq!(updated_index.zones.len(), 11);
@@ -1539,7 +1946,7 @@ mod tests {
             .unwrap();
 
         let cache = LanceCache::with_capacity(1024 * 1024);
-        let index = ZoneMapIndex::load(store.clone(), None, &cache)
+        let index = ZoneMapIndex::load(store.clone(), None, &cache, false)
             .await
             .unwrap();
 
@@ -1642,7 +2049,7 @@ mod tests {
         .unwrap();
 
         // Load the index
-        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
             .await
             .expect("Failed to load ZoneMapIndex");
 
@@ -1877,7 +2284,7 @@ mod tests {
         assert_eq!(metadata.get(ZONEMAP_SIZE_META_KEY).unwrap(), "100");
 
         // Read the index file back and check its contents
-        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
             .await
             .expect("Failed to load ZoneMapIndex");
         assert_eq!(index.zones.len(), 2);
@@ -2040,7 +2447,7 @@ mod tests {
         log::debug!("Successfully wrote the index file");
 
         // Read the index file back and check its contents
-        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
             .await
             .expect("Failed to load ZoneMapIndex");
         assert_eq!(index.zones.len(), 3);
@@ -2200,9 +2607,10 @@ mod tests {
             .unwrap();
 
             // Read the index file back and check its contents
-            let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
-                .await
-                .expect("Failed to load ZoneMapIndex");
+            let index =
+                ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
+                    .await
+                    .expect("Failed to load ZoneMapIndex");
             assert_eq!(index.zones.len(), 5);
             assert_eq!(
                 index.zones,
@@ -2408,9 +2816,10 @@ mod tests {
             .unwrap();
 
             // Read the index file back and check its contents
-            let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
-                .await
-                .expect("Failed to load ZoneMapIndex");
+            let index =
+                ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
+                    .await
+                    .expect("Failed to load ZoneMapIndex");
             assert_eq!(index.zones.len(), 3);
             assert_eq!(
                 index.zones,
@@ -2483,9 +2892,10 @@ mod tests {
             .unwrap();
 
             // Read the index file back and check its contents
-            let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
-                .await
-                .expect("Failed to load ZoneMapIndex");
+            let index =
+                ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache(), false)
+                    .await
+                    .expect("Failed to load ZoneMapIndex");
             assert_eq!(index.zones.len(), 3);
             assert_eq!(
                 index.zones,
@@ -2679,6 +3089,7 @@ mod tests {
             zones,
             data_type: DataType::Utf8,
             rows_per_zone: ROWS_PER_ZONE_DEFAULT,
+            use_seeds: false,
             store: test_store,
             fri: None,
             index_cache: WeakLanceCache::from(&LanceCache::no_cache()),
@@ -2752,6 +3163,7 @@ mod tests {
             zones,
             data_type: DataType::Utf8,
             rows_per_zone: ROWS_PER_ZONE_DEFAULT,
+            use_seeds: false,
             store: test_store,
             fri: None,
             index_cache: WeakLanceCache::from(&LanceCache::no_cache()),
@@ -2820,6 +3232,7 @@ mod tests {
             zones,
             data_type: DataType::LargeUtf8,
             rows_per_zone: ROWS_PER_ZONE_DEFAULT,
+            use_seeds: false,
             store: test_store,
             fri: None,
             index_cache: WeakLanceCache::from(&LanceCache::no_cache()),
@@ -3075,5 +3488,101 @@ mod tests {
             !result.is_exact(),
             "IS NULL on a legacy index should not be exact"
         );
+    }
+
+    #[tokio::test]
+    async fn test_zone_map_seed_writer_round_trip() {
+        use crate::scalar::seed::IndexSeedWriter;
+        use crate::scalar::zonemap::ZoneMapSeedWriter;
+        use arrow_array::{ArrayRef, Int32Array};
+        use datafusion_common::ScalarValue;
+
+        let rows_per_zone = 4u64;
+        let data_type = DataType::Int32;
+        let mut writer = ZoneMapSeedWriter::new("test_col", rows_per_zone, data_type).unwrap();
+
+        // Batch 1: values 0..4 (fills exactly one zone)
+        let batch1: ArrayRef = Arc::new(Int32Array::from_iter_values(0..4));
+        writer.observe_batch(&batch1).unwrap();
+
+        // Batch 2: values 10..14 (fills a second zone exactly)
+        let batch2: ArrayRef = Arc::new(Int32Array::from_iter_values(10..14));
+        writer.observe_batch(&batch2).unwrap();
+
+        // Batch 3: values 20..22 (partial final zone)
+        let batch3: ArrayRef = Arc::new(Int32Array::from_iter_values(20..22));
+        writer.observe_batch(&batch3).unwrap();
+
+        let bytes = writer.finish().unwrap().expect("should produce bytes");
+
+        // Check schema metadata key/value format
+        assert_eq!(writer.schema_metadata_key(), "lance.seed.test_col");
+        let meta_val = writer.schema_metadata_value(3);
+        assert_eq!(meta_val, "3:4");
+
+        // Deserialize and verify
+        let zones = ZoneMapSeedWriter::deserialize_seed(42, &bytes, rows_per_zone).unwrap();
+        assert_eq!(zones.len(), 3, "expected 3 zones");
+
+        // Zone 0: values 0..4 -> min=0, max=3
+        assert_eq!(zones[0].bound.fragment_id, 42);
+        assert_eq!(zones[0].bound.start, 0);
+        assert_eq!(zones[0].min, ScalarValue::Int32(Some(0)));
+        assert_eq!(zones[0].max, ScalarValue::Int32(Some(3)));
+        assert_eq!(zones[0].null_count, 0);
+
+        // Zone 1: values 10..14 -> min=10, max=13
+        assert_eq!(zones[1].bound.start, 4);
+        assert_eq!(zones[1].min, ScalarValue::Int32(Some(10)));
+        assert_eq!(zones[1].max, ScalarValue::Int32(Some(13)));
+
+        // Zone 2: values 20..22 -> min=20, max=21
+        assert_eq!(zones[2].bound.start, 8);
+        assert_eq!(zones[2].min, ScalarValue::Int32(Some(20)));
+        assert_eq!(zones[2].max, ScalarValue::Int32(Some(21)));
+    }
+
+    #[tokio::test]
+    async fn test_zone_map_seed_writer_spanning_batches() {
+        use crate::scalar::seed::IndexSeedWriter;
+        use crate::scalar::zonemap::ZoneMapSeedWriter;
+        use arrow_array::{ArrayRef, Int32Array};
+        use datafusion_common::ScalarValue;
+
+        let rows_per_zone = 5u64;
+        let data_type = DataType::Int32;
+        let mut writer = ZoneMapSeedWriter::new("val", rows_per_zone, data_type).unwrap();
+
+        // Single batch with 12 values -> should produce 2 complete zones + 1 partial
+        let batch: ArrayRef = Arc::new(Int32Array::from_iter_values(0..12));
+        writer.observe_batch(&batch).unwrap();
+
+        let bytes = writer.finish().unwrap().expect("should produce bytes");
+        let zones = ZoneMapSeedWriter::deserialize_seed(1, &bytes, rows_per_zone).unwrap();
+        assert_eq!(
+            zones.len(),
+            3,
+            "expected 3 zones from 12 rows with zone size 5"
+        );
+
+        // Zone 0: rows 0..5
+        assert_eq!(zones[0].min, ScalarValue::Int32(Some(0)));
+        assert_eq!(zones[0].max, ScalarValue::Int32(Some(4)));
+        // Zone 1: rows 5..10
+        assert_eq!(zones[1].min, ScalarValue::Int32(Some(5)));
+        assert_eq!(zones[1].max, ScalarValue::Int32(Some(9)));
+        // Zone 2: rows 10..12 (partial)
+        assert_eq!(zones[2].min, ScalarValue::Int32(Some(10)));
+        assert_eq!(zones[2].max, ScalarValue::Int32(Some(11)));
+    }
+
+    #[tokio::test]
+    async fn test_zone_map_seed_writer_empty() {
+        use crate::scalar::seed::IndexSeedWriter;
+        use crate::scalar::zonemap::ZoneMapSeedWriter;
+
+        let mut writer = ZoneMapSeedWriter::new("col", 8, DataType::Int32).unwrap();
+        let result = writer.finish().unwrap();
+        assert!(result.is_none(), "empty fragment should return None");
     }
 }

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -1386,9 +1386,8 @@ impl ZoneMapSeedWriter {
             arrow_array::UInt32Array::from_iter_values(zones.iter().map(|s| s.null_count));
         let nan_counts =
             arrow_array::UInt32Array::from_iter_values(zones.iter().map(|s| s.nan_count));
-        let zone_lengths = arrow_array::UInt64Array::from_iter_values(
-            zones.iter().map(|s| s.bound.length as u64),
-        );
+        let zone_lengths =
+            arrow_array::UInt64Array::from_iter_values(zones.iter().map(|s| s.bound.length as u64));
 
         let schema = Arc::new(arrow_schema::Schema::new(vec![
             Field::new("min", data_type.clone(), true),
@@ -3551,7 +3550,10 @@ mod tests {
 
         // Zone 2: values 20..22 -> min=20, max=21, partial zone of 2 rows
         assert_eq!(zones[2].bound.start, 8);
-        assert_eq!(zones[2].bound.length, 2, "partial zone length must be exact");
+        assert_eq!(
+            zones[2].bound.length, 2,
+            "partial zone length must be exact"
+        );
         assert_eq!(zones[2].min, ScalarValue::Int32(Some(20)));
         assert_eq!(zones[2].max, ScalarValue::Int32(Some(21)));
 

--- a/rust/lance/src/dataset/fragment/write.rs
+++ b/rust/lance/src/dataset/fragment/write.rs
@@ -250,6 +250,7 @@ impl<'a> FragmentCreateBuilder<'a> {
             params,
             version,
             target_bases_info,
+            Vec::new(),
         )
         .await
     }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -41,8 +41,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use tracing::{info, instrument};
 
-use crate::index::DatasetIndexExt;
-use crate::index::scalar::{IndexDetails, fetch_index_details};
 use crate::Dataset;
 use crate::blob::normalize_prepared_blob_schema;
 use crate::dataset::blob::{
@@ -50,6 +48,8 @@ use crate::dataset::blob::{
     blob_dedicated_threshold_from_metadata, blob_inline_threshold_from_metadata,
     blob_pack_file_threshold_from_metadata, preprocess_blob_batches,
 };
+use crate::index::DatasetIndexExt;
+use crate::index::scalar::{IndexDetails, fetch_index_details};
 use crate::session::Session;
 
 use super::DATA_DIR;
@@ -743,8 +743,13 @@ pub async fn do_write_fragments(
     if let Some(mut writer) = writer.take() {
         if let Err(e) = flush_seed_writers(writer.as_mut(), &mut seed_writers).await {
             drop(writer);
-            cleanup_data_fragments(&object_store, base_dir, cleanup_bases.as_deref(), &fragments)
-                .await;
+            cleanup_data_fragments(
+                &object_store,
+                base_dir,
+                cleanup_bases.as_deref(),
+                &fragments,
+            )
+            .await;
             return Err(e);
         }
         match writer.finish().await {

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -30,7 +30,7 @@ use lance_file::writer::{self as current_writer, FileWriterOptions};
 use lance_io::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreRegistry, parse_base_scoped_key,
 };
-use lance_table::format::{BasePath, DataFile, Fragment};
+use lance_table::format::{BasePath, DataFile, Fragment, IndexMetadata};
 use lance_table::io::commit::{CommitHandler, commit_handler_from_url};
 use lance_table::io::manifest::ManifestDescribing;
 use object_store::path::Path;
@@ -41,6 +41,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use tracing::{info, instrument};
 
+use crate::index::DatasetIndexExt;
+use crate::index::scalar::{IndexDetails, fetch_index_details};
 use crate::Dataset;
 use crate::blob::normalize_prepared_blob_schema;
 use crate::dataset::blob::{
@@ -741,7 +743,8 @@ pub async fn do_write_fragments(
     if let Some(mut writer) = writer.take() {
         if let Err(e) = flush_seed_writers(writer.as_mut(), &mut seed_writers).await {
             drop(writer);
-            cleanup_data_fragments(&object_store, base_dir, &fragments).await;
+            cleanup_data_fragments(&object_store, base_dir, cleanup_bases.as_deref(), &fragments)
+                .await;
             return Err(e);
         }
         match writer.finish().await {
@@ -1385,10 +1388,6 @@ async fn create_seed_writers(
     params: &WriteParams,
     storage_version: LanceFileVersion,
 ) -> Result<Vec<Box<dyn lance_index::scalar::seed::IndexSeedWriter>>> {
-    use crate::index::DatasetIndexExt;
-    use crate::index::scalar::{IndexDetails, fetch_index_details};
-    use lance_table::format::IndexMetadata;
-
     // Seeds only make sense when appending to an existing dataset with V2 files.
     if storage_version == LanceFileVersion::Legacy {
         return Ok(Vec::new());
@@ -4276,6 +4275,7 @@ mod tests {
             },
             LanceFileVersion::V2_1,
             Some(target_bases),
+            vec![],
         )
         .await;
 
@@ -4590,6 +4590,7 @@ mod tests {
             .flat_map(|f| f.metadata.files.iter().map(|file| file.base_id))
             .collect();
         assert_eq!(file_bases, vec![None, Some(1), Some(2)]);
+    }
 
     #[tokio::test]
     async fn test_zone_map_seeds_used_during_update() {
@@ -4615,8 +4616,9 @@ mod tests {
             .into_reader_rows(RowCount::from(100), BatchCount::from(1));
         let mut dataset = Dataset::write(reader, uri, None).await.unwrap();
 
-        // Step 2: Create a zone map index
-        let params = ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::ZoneMap);
+        // Step 2: Create a zone map index with seeds explicitly enabled (Int32 defaults to off).
+        let params = ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::ZoneMap)
+            .with_params(&serde_json::json!({"use_seeds": true}));
         dataset
             .create_index(&["val"], IndexType::ZoneMap, None, &params, false)
             .await

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use arrow_array::RecordBatch;
+use bytes::Bytes;
 use chrono::TimeDelta;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
@@ -604,6 +605,7 @@ pub async fn do_write_fragments(
     params: WriteParams,
     storage_version: LanceFileVersion,
     target_bases_info: Option<Vec<TargetBaseInfo>>,
+    mut seed_writers: Vec<Box<dyn lance_index::scalar::seed::IndexSeedWriter>>,
 ) -> Result<Vec<Fragment>> {
     let adapter = SchemaAdapter::new(data.schema());
     let data = adapter.to_physical_stream(data);
@@ -669,6 +671,14 @@ pub async fn do_write_fragments(
             }
 
             writer.as_mut().unwrap().write(&batch_chunk).await?;
+            for seed_writer in seed_writers.iter_mut() {
+                let col_name = seed_writer.column_name().to_owned();
+                for batch in &batch_chunk {
+                    if let Some(col) = batch.column_by_name(&col_name) {
+                        seed_writer.observe_batch(col)?;
+                    }
+                }
+            }
             for batch in &batch_chunk {
                 num_rows_in_current_file += batch.num_rows() as u32;
             }
@@ -685,7 +695,9 @@ pub async fn do_write_fragments(
             if num_rows_in_current_file >= params.max_rows_per_file as u32
                 || writer.as_mut().unwrap().tell().await? >= params.max_bytes_per_file as u64
             {
-                let (num_rows, data_file) = writer.take().unwrap().finish().await?;
+                let mut w = writer.take().unwrap();
+                flush_seed_writers(w.as_mut(), &mut seed_writers).await?;
+                let (num_rows, data_file) = w.finish().await?;
                 info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
                 debug_assert_eq!(num_rows, num_rows_in_current_file);
                 bytes_completed += data_file.file_size_bytes.get().map_or(0, |s| s.get());
@@ -727,6 +739,11 @@ pub async fn do_write_fragments(
 
     // Complete the final writer
     if let Some(mut writer) = writer.take() {
+        if let Err(e) = flush_seed_writers(writer.as_mut(), &mut seed_writers).await {
+            drop(writer);
+            cleanup_data_fragments(&object_store, base_dir, &fragments).await;
+            return Err(e);
+        }
         match writer.finish().await {
             Ok((num_rows, data_file)) => {
                 info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
@@ -759,6 +776,23 @@ pub async fn do_write_fragments(
     }
 
     Ok(fragments)
+}
+
+/// Flush all seed writers into the given file writer, embedding seed buffers
+/// and schema metadata before `finish()` is called.
+async fn flush_seed_writers(
+    writer: &mut dyn GenericWriter,
+    seed_writers: &mut [Box<dyn lance_index::scalar::seed::IndexSeedWriter>],
+) -> Result<()> {
+    for seed_writer in seed_writers.iter_mut() {
+        if let Some(bytes) = seed_writer.finish()? {
+            let buf_index = writer.add_global_buffer(bytes).await?;
+            let key = seed_writer.schema_metadata_key();
+            let value = seed_writer.schema_metadata_value(buf_index);
+            writer.add_schema_metadata(key, value);
+        }
+    }
+    Ok(())
 }
 
 /// Best-effort cleanup of data files for fragments that were written but not committed.
@@ -1328,6 +1362,8 @@ pub async fn write_fragments_internal(
         )));
     }
 
+    let seed_writers = create_seed_writers(dataset, &params, storage_version).await?;
+
     let fragments = do_write_fragments(
         dataset,
         object_store,
@@ -1337,10 +1373,64 @@ pub async fn write_fragments_internal(
         params,
         storage_version,
         target_bases_info,
+        seed_writers,
     )
     .await?;
 
     Ok((fragments, schema))
+}
+
+async fn create_seed_writers(
+    dataset: Option<&Dataset>,
+    params: &WriteParams,
+    storage_version: LanceFileVersion,
+) -> Result<Vec<Box<dyn lance_index::scalar::seed::IndexSeedWriter>>> {
+    use crate::index::DatasetIndexExt;
+    use crate::index::scalar::{IndexDetails, fetch_index_details};
+    use lance_table::format::IndexMetadata;
+
+    // Seeds only make sense when appending to an existing dataset with V2 files.
+    if storage_version == LanceFileVersion::Legacy {
+        return Ok(Vec::new());
+    }
+    if !matches!(params.mode, WriteMode::Append) {
+        return Ok(Vec::new());
+    }
+    let Some(dataset) = dataset else {
+        return Ok(Vec::new());
+    };
+
+    let indices: Arc<Vec<IndexMetadata>> = dataset.load_indices().await?;
+    let mut writers: Vec<Box<dyn lance_index::scalar::seed::IndexSeedWriter>> = Vec::new();
+
+    for index in indices.iter() {
+        if index.fields.len() != 1 {
+            continue;
+        }
+        let field_id = index.fields[0];
+        let Ok(field_path) = dataset.schema().field_path(field_id) else {
+            continue;
+        };
+        let Some(data_type) = dataset.schema().field(&field_path).map(|f| f.data_type()) else {
+            continue;
+        };
+
+        let Ok(index_details) = fetch_index_details(dataset, &field_path, index).await else {
+            continue;
+        };
+        let details = IndexDetails(index_details.clone());
+        let Ok(plugin) = details.get_plugin() else {
+            continue;
+        };
+        if let Some(writer) = plugin
+            .create_seed_writer(&field_path, &data_type, &index_details)
+            .await?
+        {
+            writers.push(writer);
+        }
+    }
+
+    Ok(writers)
 }
 
 fn legacy_blob_field_path(schema: &Schema) -> Option<String> {
@@ -1367,6 +1457,16 @@ pub trait GenericWriter: Send {
     async fn tell(&mut self) -> Result<u64>;
     /// Finish writing the file (flush the remaining data and write footer)
     async fn finish(&mut self) -> Result<(u32, DataFile)>;
+
+    /// Add a global buffer to the current file. Returns the 1-based buffer index.
+    /// Must be called before `finish`. No-op on legacy (V1) files (returns `Ok(1)`).
+    async fn add_global_buffer(&mut self, _buffer: Bytes) -> Result<u32> {
+        Ok(1)
+    }
+
+    /// Add a key-value pair to the file's schema metadata.
+    /// Must be called before `finish`. No-op on legacy (V1) files.
+    fn add_schema_metadata(&mut self, _key: String, _value: String) {}
 }
 
 struct V1WriterAdapter<M>
@@ -1462,6 +1562,14 @@ impl GenericWriter for V2WriterAdapter {
             self.base_id,
         );
         Ok((write_summary.num_rows as u32, data_file))
+    }
+
+    async fn add_global_buffer(&mut self, buffer: Bytes) -> Result<u32> {
+        self.writer.add_global_buffer(buffer).await
+    }
+
+    fn add_schema_metadata(&mut self, key: String, value: String) {
+        self.writer.add_schema_metadata(key, value);
     }
 }
 
@@ -3880,6 +3988,7 @@ mod tests {
             WriteParams::default(),
             LanceFileVersion::V2_1,
             None,
+            Vec::new(),
         )
         .await;
 
@@ -3940,6 +4049,7 @@ mod tests {
             },
             LanceFileVersion::V2_1,
             None,
+            Vec::new(),
         )
         .await;
 
@@ -4480,5 +4590,115 @@ mod tests {
             .flat_map(|f| f.metadata.files.iter().map(|file| file.base_id))
             .collect();
         assert_eq!(file_bases, vec![None, Some(1), Some(2)]);
+
+    #[tokio::test]
+    async fn test_zone_map_seeds_used_during_update() {
+        use crate::Dataset;
+        use crate::index::DatasetIndexExt;
+        use crate::index::scalar::open_scalar_index;
+        use arrow::datatypes::Int32Type;
+        use lance_datagen::{BatchCount, RowCount};
+        use lance_datagen::{array, gen_batch};
+        use lance_file::reader::FileReaderOptions;
+        use lance_index::metrics::NoOpMetricsCollector;
+        use lance_index::scalar::seed::SEED_META_KEY_PREFIX;
+        use lance_index::{IndexType, scalar::ScalarIndexParams};
+        use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+        use lance_io::utils::CachedFileSize;
+
+        let tmpdir = lance_core::utils::tempfile::TempStrDir::default();
+        let uri = tmpdir.as_str();
+
+        // Step 1: Create initial dataset
+        let reader = gen_batch()
+            .col("val", array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(100), BatchCount::from(1));
+        let mut dataset = Dataset::write(reader, uri, None).await.unwrap();
+
+        // Step 2: Create a zone map index
+        let params = ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::ZoneMap);
+        dataset
+            .create_index(&["val"], IndexType::ZoneMap, None, &params, false)
+            .await
+            .unwrap();
+        // Step 3: Append new data - seeds should be written automatically
+        let reader = gen_batch()
+            .col("val", array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(50), BatchCount::from(1));
+        let dataset = Dataset::write(
+            reader,
+            uri,
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                data_storage_version: Some(lance_file::version::LanceFileVersion::V2_1),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Step 4: Verify that the newly appended fragment has a seed embedded
+        let fragments = dataset.fragments();
+        let new_fragment = fragments.last().unwrap();
+        let data_file = new_fragment.files.first().unwrap();
+
+        let scheduler = ScanScheduler::new(
+            dataset.object_store.clone(),
+            SchedulerConfig::max_bandwidth(&dataset.object_store),
+        );
+        let path = dataset
+            .base
+            .clone()
+            .join(super::DATA_DIR)
+            .join(data_file.path.as_str());
+        let file_scheduler = scheduler
+            .open_file(&path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+        let reader = lance_file::reader::FileReader::try_open(
+            file_scheduler,
+            None,
+            Default::default(),
+            &dataset.metadata_cache.file_metadata_cache(&path),
+            FileReaderOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let meta_key = format!("{}val", SEED_META_KEY_PREFIX);
+        let has_seed = reader
+            .metadata()
+            .file_schema
+            .metadata
+            .contains_key(&meta_key);
+        assert!(
+            has_seed,
+            "Newly appended fragment should have a zone map seed in metadata"
+        );
+
+        // Step 5: Optimize the index (should use seeds)
+        let mut dataset = Dataset::open(uri).await.unwrap();
+        dataset.optimize_indices(&Default::default()).await.unwrap();
+
+        // Step 6: Query the updated index to verify it's correct
+        let dataset = Dataset::open(uri).await.unwrap();
+        let indices = dataset.load_indices().await.unwrap();
+        assert!(
+            !indices.is_empty(),
+            "Dataset should still have an index after optimization"
+        );
+
+        // Verify the index is a ZoneMap and covers all fragments
+        let index = indices.iter().find(|i| i.name.contains("val")).unwrap();
+        let scalar_index = open_scalar_index(&dataset, "val", index, &NoOpMetricsCollector)
+            .await
+            .unwrap();
+        assert_eq!(
+            scalar_index.index_type(),
+            IndexType::ZoneMap,
+            "Index should still be a ZoneMap after optimization"
+        );
+        let frags = scalar_index.calculate_included_frags().await.unwrap();
+        assert_eq!(frags.len(), 2, "Index should cover both fragments");
     }
 }

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -242,7 +242,10 @@ async fn try_harvest_seeds(
         };
 
         // The buf_index is always the portion before the first ':'.
-        let Ok(buf_index) = meta_value.split(':').next().unwrap().parse::<u32>() else {
+        let Some(buf_index_str) = meta_value.split(':').next() else {
+            return Ok(None);
+        };
+        let Ok(buf_index) = buf_index_str.parse::<u32>() else {
             return Ok(None);
         };
 

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use futures::{FutureExt, TryStreamExt};
 use lance_core::{Error, Result};
+use lance_file::reader::FileReaderOptions;
 use lance_index::{
     INDEX_FILE_NAME, IndexType,
     metrics::NoOpMetricsCollector,
@@ -12,9 +13,14 @@ use lance_index::{
     progress::NoopIndexBuildProgress,
     scalar::{
         CreatedIndex, OldIndexDataFilter, ScalarIndex, index_files_to_table,
-        inverted::InvertedIndex, lance_format::LanceIndexStore, table_files_to_index,
+        inverted::InvertedIndex,
+        lance_format::LanceIndexStore,
+        seed::{FragmentSeed, SEED_META_KEY_PREFIX},
+        table_files_to_index,
     },
 };
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use lance_io::utils::CachedFileSize;
 use lance_select::{RowAddrTreeMap, RowSetOps};
 use lance_table::format::{Fragment, IndexMetadata};
 use roaring::RoaringBitmap;
@@ -26,7 +32,7 @@ use super::vector::ivf::{optimize_vector_indices, select_segment_for_single_reba
 use crate::dataset::Dataset;
 use crate::dataset::index::LanceIndexStoreExt;
 use crate::dataset::rowids::load_row_id_sequences;
-use crate::index::scalar::load_training_data;
+use crate::index::scalar::{IndexDetails, fetch_index_details, load_training_data};
 use crate::index::vector_index_details_default;
 
 #[derive(Debug, Clone)]
@@ -173,6 +179,85 @@ pub async fn build_per_segment_filters(
         filters.push(build_old_data_filter(dataset, &effective, &deleted).await?);
     }
     Ok((effective_union, filters))
+}
+
+/// Attempt to read seed buffers for `column_name` from `fragments`' data files.
+///
+/// Returns `Some(vec)` only if every fragment has a seed entry; returns `None`
+/// if any fragment is missing a seed or its data file cannot be opened.
+/// Index-type-specific validation (e.g. `rows_per_zone` checks) is left to the
+/// caller via [`FragmentSeed::metadata_value`].
+async fn try_harvest_seeds(
+    dataset: &Dataset,
+    fragments: &[Fragment],
+    column_name: &str,
+) -> Result<Option<Vec<FragmentSeed>>> {
+    if fragments.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let meta_key = format!("{}{}", SEED_META_KEY_PREFIX, column_name);
+    let mut seeds = Vec::with_capacity(fragments.len());
+
+    let scheduler = ScanScheduler::new(
+        dataset.object_store.clone(),
+        SchedulerConfig::max_bandwidth(&dataset.object_store),
+    );
+
+    for fragment in fragments {
+        let Some(data_file) = fragment.files.first() else {
+            return Ok(None);
+        };
+
+        let path = dataset
+            .base
+            .clone()
+            .join(crate::dataset::DATA_DIR)
+            .join(data_file.path.as_str());
+        let Ok(file_scheduler) = scheduler.open_file(&path, &CachedFileSize::unknown()).await
+        else {
+            return Ok(None);
+        };
+
+        let Ok(reader) = lance_file::reader::FileReader::try_open(
+            file_scheduler,
+            None,
+            Default::default(),
+            &dataset.metadata_cache.file_metadata_cache(&path),
+            FileReaderOptions::default(),
+        )
+        .await
+        else {
+            return Ok(None);
+        };
+
+        let Some(meta_value) = reader
+            .metadata()
+            .file_schema
+            .metadata
+            .get(&meta_key)
+            .cloned()
+        else {
+            return Ok(None);
+        };
+
+        // The buf_index is always the portion before the first ':'.
+        let Ok(buf_index) = meta_value.split(':').next().unwrap().parse::<u32>() else {
+            return Ok(None);
+        };
+
+        let Ok(bytes) = reader.read_global_buffer(buf_index).await else {
+            return Ok(None);
+        };
+
+        seeds.push(FragmentSeed {
+            fragment_id: fragment.id,
+            bytes,
+            metadata_value: meta_value,
+        });
+    }
+
+    Ok(Some(seeds))
 }
 
 async fn load_unindexed_training_data(
@@ -356,38 +441,67 @@ async fn merge_scalar_indices<'a>(
         )
         .await?
     } else {
-        let new_data_stream =
-            load_unindexed_training_data(dataset.as_ref(), field_path, &update_criteria, unindexed)
-                .await?;
         let new_store = LanceIndexStore::from_dataset_for_new(&dataset, &new_uuid)?;
 
-        match index_type {
-            IndexType::BTree => {
-                let (_, old_data_filters) =
-                    build_per_segment_filters(dataset.as_ref(), &selected_old_indices).await?;
-                crate::index::scalar::btree::open_and_merge_segments(
-                    dataset.as_ref(),
-                    field_path,
-                    &selected_old_indices,
-                    new_data_stream,
-                    &new_store,
-                    &old_data_filters,
-                )
-                .await?
-            }
-            // NOTE: IndexType::Inverted never reaches here -- it is handled by the
-            // dedicated arm in merge_indices_with_unindexed_frags before this
-            // function is called.
-            _ => {
-                let old_data_filter = build_old_data_filter(
-                    dataset.as_ref(),
-                    &effective_old_frags,
-                    &deleted_old_frags,
-                )
-                .await?;
-                reference_index
-                    .update(new_data_stream, &new_store, old_data_filter)
+        // Try a seed-based update before falling back to a full column scan.
+        // Seeds are only available if every unindexed fragment had a seed buffer
+        // written during its data file write, and the plugin validates that the
+        // seeds are compatible with the current index configuration.
+        let index_details =
+            fetch_index_details(dataset.as_ref(), field_path, reference_idx).await?;
+        let details = IndexDetails(index_details.clone());
+        let plugin = details.get_plugin()?;
+        // Only open data files looking for seeds when the plugin confirms this
+        // index type and configuration can actually produce them.
+        let maybe_created = if plugin.might_use_seeds(&index_details) {
+            if let Some(seeds) = try_harvest_seeds(dataset.as_ref(), unindexed, column_name).await?
+            {
+                plugin
+                    .update_from_seeds(seeds, reference_index.clone(), &index_details, &new_store)
                     .await?
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(created) = maybe_created {
+            created
+        } else {
+            let new_data_stream = load_unindexed_training_data(
+                dataset.as_ref(),
+                field_path,
+                &update_criteria,
+                unindexed,
+            )
+            .await?;
+
+            match index_type {
+                IndexType::BTree => {
+                    let (_, old_data_filters) =
+                        build_per_segment_filters(dataset.as_ref(), &selected_old_indices).await?;
+                    crate::index::scalar::btree::open_and_merge_segments(
+                        dataset.as_ref(),
+                        field_path,
+                        &selected_old_indices,
+                        new_data_stream,
+                        &new_store,
+                        &old_data_filters,
+                    )
+                    .await?
+                }
+                _ => {
+                    let old_data_filter = build_old_data_filter(
+                        dataset.as_ref(),
+                        &effective_old_frags,
+                        &deleted_old_frags,
+                    )
+                    .await?;
+                    reference_index
+                        .update(new_data_stream, &new_store, old_data_filter)
+                        .await?
+                }
             }
         }
     };


### PR DESCRIPTION
This PR introduces the concept of "index seeds".  Indexes can opt-in to planting seeds during ingestion.  The seeds are placed into the data files as global buffers.  Later, when updating the index to include these data files, we can harvest the seeds instead of scanning the data itself.

This is primarily intended to avoid a potentially expensive data scan to update the index.  As an example this PR adds index seeds for wide (binary, fixed-size-list, string) columns when creating a zone map index.  Now we calculate the min/max/nulls during ingestion, when the data is already present and flowing through the system.  Then, when we go to update the index, all we are doing is reading back those counts and adding them to the index (instead of scanning the large column all over again).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zone-map indexes can now use stored seed statistics to accelerate incremental updates.
  * Zone-map configuration now supports optional `rows-per-zone` and seed usage (`use-seeds`) with backward-compatible behavior when omitted.
  * When appending to existing datasets, the system can persist zone-map seed metadata for eligible indexes.
  * Added a benchmark to compare incremental update performance with and without seeds.
* **Bug Fixes**
  * Incremental updates automatically fall back to full processing when seed data is unavailable or can’t be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->