### PR TITLE
fix: fall back to AVX2 f16 kernels on AVX-512 CPUs

### DIFF
--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -168,7 +168,7 @@ impl Cosine for f16 {
                 kernel::cosine_f16_avx512(x.as_ptr(), x_norm, y.as_ptr(), y.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
-            SimdSupport::Avx2 => unsafe {
+            SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {
                 kernel::cosine_f16_avx2(x.as_ptr(), x_norm, y.as_ptr(), y.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "loongarch64"))]

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -203,7 +203,7 @@ impl Dot for f16 {
                 kernel::dot_f16_avx512(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
-            SimdSupport::Avx2 => unsafe {
+            SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {
                 kernel::dot_f16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "loongarch64"))]

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -233,7 +233,7 @@ impl L2 for f16 {
                 kernel::l2_f16_avx512(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
-            SimdSupport::Avx2 => unsafe {
+            SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {
                 kernel::l2_f16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "loongarch64"))]

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -64,7 +64,7 @@ impl Normalize for f16 {
                 kernel::norm_l2_f16_avx512(vector.as_ptr(), vector.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
-            SimdSupport::Avx2 => unsafe {
+            SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {
                 kernel::norm_l2_f16_avx2(vector.as_ptr(), vector.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "loongarch64"))]


### PR DESCRIPTION
Fix f16 SIMD dispatch on x86 CPUs that have AVX-512F but do not have native AVX512-FP16 support.

Today, those CPUs are classified as `SimdSupport::Avx512`. The f16 dispatch for L2, dot, cosine, and norm L2 handles `Avx512FP16` and `Avx2`, but not plain `Avx512`, so it falls through to the scalar implementation. This change routes plain `Avx512` to the AVX2 f16 kernels while keeping `Avx512FP16` on the native AVX512-FP16 kernels.

This matches the existing bf16 behavior:

- L2: https://github.com/lance-format/lance/blob/52666294292e4419b8dd11a653d07d55cb8db6cb/rust/lance-linalg/src/distance/l2.rs#L183-L185
- Dot: https://github.com/lance-format/lance/blob/52666294292e4419b8dd11a653d07d55cb8db6cb/rust/lance-linalg/src/distance/dot.rs#L153-L155
- Cosine: https://github.com/lance-format/lance/blob/52666294292e4419b8dd11a653d07d55cb8db6cb/rust/lance-linalg/src/distance/cosine.rs#L119-L121
- Norm L2: https://github.com/lance-format/lance/blob/52666294292e4419b8dd11a653d07d55cb8db6cb/rust/lance-linalg/src/distance/norm_l2.rs#L118-L120