### PR TITLE
fix: relax DataReplacement conflict with concurrent Delete/Update

### DIFF
--- a/docs/src/format/table/transaction.md
+++ b/docs/src/format/table/transaction.md
@@ -445,20 +445,26 @@ Replaces data in specific column regions with new data files.
 #### DataReplacement Compatibility
 
 A DataReplacement operation only replaces a single column's worth of data. As a result, it can be safer and simpler than Merge
-or Update operations. Here are the operations that conflict with DataReplacement:
+or Update operations. It rewrites a column file positionally against the fragments it targets, so a concurrent operation only
+conflicts when it removes one of those fragments or invalidates the rows the column file covers. Here are the operations that
+conflict with DataReplacement (non-retryable):
 
 - Overwrite
 - Restore
 - UpdateMemWalState
+- Delete (only if it removes a target fragment outright)
+- Update (only if it removes a target fragment outright)
 
 The following operations are retryable conflicts with DataReplacement:
 
 - DataReplacement (only if same field and overlapping fragments)
 - CreateIndex (only if the field being replaced is being indexed)
 - Rewrite (only if overlapping fragments)
-- Update (only if overlapping fragments)
-- Delete (only if overlapping fragments)
+- Update (only if it rewrites rows out of a target fragment, or rewrites one of the replaced fields in place)
 - Merge (always)
+
+A concurrent Delete or Update that only adds a deletion vector to a target fragment (without removing it) is compatible: the
+positional column file stays aligned and the rebase preserves the deletion vector.
 
 ### UpdateMemWalState
 

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -7,7 +7,7 @@ use crate::index::mem_wal::{load_mem_wal_index_details, new_mem_wal_index_meta};
 use crate::io::deletion::read_dataset_deletion_file;
 use crate::{
     Dataset,
-    dataset::transaction::{Operation, Transaction},
+    dataset::transaction::{Operation, Transaction, UpdateMode},
 };
 use futures::{StreamExt, TryStreamExt};
 use lance_core::{Error, Result, utils::deletion::DeletionVector};
@@ -176,6 +176,22 @@ impl<'a> TransactionRebase<'a> {
             format!(
                 "This {} transaction is incompatible with concurrent transaction {} at version {}.",
                 self.transaction.operation, other_transaction.operation, other_version
+            )
+            .into(),
+        )
+    }
+
+    #[track_caller]
+    fn data_replacement_target_removed_err(
+        &self,
+        fragment_id: u64,
+        other_transaction: &Transaction,
+        other_version: u64,
+    ) -> Error {
+        Error::incompatible_transaction_source(
+            format!(
+                "DataReplacement target fragment {} was removed by concurrent {} at version {}.",
+                fragment_id, other_transaction.operation, other_version
             )
             .into(),
         )
@@ -913,26 +929,56 @@ impl<'a> TransactionRebase<'a> {
                     // (symmetric with check_merge_txn).
                     Err(self.retryable_conflict_err(other_transaction, other_version))
                 }
-                Operation::Update {
-                    updated_fragments,
-                    removed_fragment_ids,
-                    ..
-                }
-                | Operation::Delete {
-                    updated_fragments,
-                    deleted_fragment_ids: removed_fragment_ids,
+                Operation::Delete {
+                    deleted_fragment_ids,
                     ..
                 } => {
-                    // A concurrent Update/Delete that changed one of our target
-                    // fragments makes our positional column file stale; conflict so
-                    // the committer rebuilds (lance otherwise accepts it silently).
+                    // A delete only tombstones rows (deletion vector); our positional
+                    // file stays aligned and the rebase preserves the deletion vector.
+                    // Conflict only if our target fragment was removed outright.
                     for replacement in replacements {
-                        let touches_our_fragment = updated_fragments
+                        if deleted_fragment_ids.contains(&replacement.0) {
+                            return Err(self.data_replacement_target_removed_err(
+                                replacement.0,
+                                other_transaction,
+                                other_version,
+                            ));
+                        }
+                    }
+                    Ok(())
+                }
+                Operation::Update {
+                    removed_fragment_ids,
+                    updated_fragments,
+                    new_fragments,
+                    fields_modified,
+                    update_mode,
+                    ..
+                } => {
+                    for replacement in replacements {
+                        if removed_fragment_ids.contains(&replacement.0) {
+                            return Err(self.data_replacement_target_removed_err(
+                                replacement.0,
+                                other_transaction,
+                                other_version,
+                            ));
+                        }
+                        if !updated_fragments.iter().any(|f| f.id == replacement.0) {
+                            continue;
+                        }
+                        // A row-rewriting update moves the matched rows out to
+                        // new_fragments our positional file does not cover; a horizontal
+                        // update may rewrite one of our fields in place. Either makes the
+                        // file stale. (RewriteColumns new_fragments are unrelated inserts,
+                        // not moved rows, so they stay aligned.)
+                        let moved_rows = !new_fragments.is_empty()
+                            && matches!(update_mode, Some(UpdateMode::RewriteRows) | None);
+                        let field_rewritten = replacement
+                            .1
+                            .fields
                             .iter()
-                            .map(|f| f.id)
-                            .chain(removed_fragment_ids.iter().copied())
-                            .any(|id| id == replacement.0);
-                        if touches_our_fragment {
+                            .any(|f| *f >= 0 && fields_modified.contains(&(*f as u32)));
+                        if moved_rows || field_rewritten {
                             return Err(
                                 self.retryable_conflict_err(other_transaction, other_version)
                             );
@@ -1736,6 +1782,7 @@ fn wrong_operation_err(op: &Operation) -> Error {
 mod tests {
     use std::{num::NonZero, sync::Arc};
 
+    use crate::dataset::transaction::UpdateMode::{RewriteColumns, RewriteRows};
     use arrow_array::{Int32Array, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
     use lance_core::Error;
@@ -3299,10 +3346,11 @@ mod tests {
                 },
                 Compatible,
             ),
-            // A concurrent Update/Delete on a fragment we replace a column in must
-            // conflict, else the stale positional file is applied silently.
+            // A concurrent Update/Delete only invalidates our positional file when it
+            // removes our target fragment outright, or (a horizontal update) rewrites
+            // one of our fields. A deletion-vector-only change stays aligned.
             (
-                "DataReplacement vs Update on same fragment",
+                "DataReplacement vs Update (RewriteColumns) on a different field",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
                 },
@@ -3310,23 +3358,78 @@ mod tests {
                     updated_fragments: vec![Fragment::new(0)],
                     removed_fragment_ids: vec![],
                     new_fragments: vec![],
-                    fields_modified: vec![],
+                    fields_modified: vec![2],
                     merged_generations: Vec::new(),
                     fields_for_preserving_frag_bitmap: vec![],
-                    update_mode: None,
+                    update_mode: Some(RewriteColumns),
+                    inserted_rows_filter: None,
+                    updated_fragment_offsets: None,
+                },
+                Compatible,
+            ),
+            (
+                // RewriteColumns new_fragments are unrelated inserts, not moved rows.
+                "DataReplacement vs Update (RewriteColumns) with inserts on a different field",
+                Operation::DataReplacement {
+                    replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                },
+                Operation::Update {
+                    updated_fragments: vec![Fragment::new(0)],
+                    removed_fragment_ids: vec![],
+                    new_fragments: vec![Fragment::new(5)],
+                    fields_modified: vec![2],
+                    merged_generations: Vec::new(),
+                    fields_for_preserving_frag_bitmap: vec![],
+                    update_mode: Some(RewriteColumns),
+                    inserted_rows_filter: None,
+                    updated_fragment_offsets: None,
+                },
+                Compatible,
+            ),
+            (
+                "DataReplacement vs Update (RewriteColumns) that rewrote one of our fields",
+                Operation::DataReplacement {
+                    replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                },
+                Operation::Update {
+                    updated_fragments: vec![Fragment::new(0)],
+                    removed_fragment_ids: vec![],
+                    new_fragments: vec![],
+                    fields_modified: vec![1],
+                    merged_generations: Vec::new(),
+                    fields_for_preserving_frag_bitmap: vec![],
+                    update_mode: Some(RewriteColumns),
                     inserted_rows_filter: None,
                     updated_fragment_offsets: None,
                 },
                 Retryable,
             ),
             (
-                "DataReplacement vs Update on different fragment",
+                "DataReplacement vs Update (RewriteRows) that moved our rows",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
                 },
                 Operation::Update {
-                    updated_fragments: vec![Fragment::new(1)],
+                    updated_fragments: vec![Fragment::new(0)],
                     removed_fragment_ids: vec![],
+                    new_fragments: vec![Fragment::new(5)],
+                    fields_modified: vec![],
+                    merged_generations: Vec::new(),
+                    fields_for_preserving_frag_bitmap: vec![],
+                    update_mode: Some(RewriteRows),
+                    inserted_rows_filter: None,
+                    updated_fragment_offsets: None,
+                },
+                Retryable,
+            ),
+            (
+                "DataReplacement vs Update that removed our fragment",
+                Operation::DataReplacement {
+                    replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                },
+                Operation::Update {
+                    updated_fragments: vec![],
+                    removed_fragment_ids: vec![0],
                     new_fragments: vec![],
                     fields_modified: vec![],
                     merged_generations: Vec::new(),
@@ -3335,10 +3438,28 @@ mod tests {
                     inserted_rows_filter: None,
                     updated_fragment_offsets: None,
                 },
+                NotCompatible,
+            ),
+            (
+                "DataReplacement vs Update (RewriteRows) that moved a different fragment's rows",
+                Operation::DataReplacement {
+                    replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                },
+                Operation::Update {
+                    updated_fragments: vec![Fragment::new(1)],
+                    removed_fragment_ids: vec![],
+                    new_fragments: vec![Fragment::new(5)],
+                    fields_modified: vec![],
+                    merged_generations: Vec::new(),
+                    fields_for_preserving_frag_bitmap: vec![],
+                    update_mode: Some(RewriteRows),
+                    inserted_rows_filter: None,
+                    updated_fragment_offsets: None,
+                },
                 Compatible,
             ),
             (
-                "DataReplacement vs Delete on same fragment",
+                "DataReplacement vs Delete (deletion-vector only) on same fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
                 },
@@ -3347,7 +3468,7 @@ mod tests {
                     updated_fragments: vec![Fragment::new(0)],
                     predicate: "a > 0".to_string(),
                 },
-                Retryable,
+                Compatible,
             ),
             (
                 "DataReplacement vs Delete that removes the fragment",
@@ -3359,7 +3480,7 @@ mod tests {
                     updated_fragments: vec![],
                     predicate: "a > 0".to_string(),
                 },
-                Retryable,
+                NotCompatible,
             ),
             // Merge rewrites the whole fragment list -> always conflicts.
             (
@@ -3399,8 +3520,10 @@ mod tests {
                     );
                 }
                 NotCompatible => {
+                    // Removal returns a non-retryable IncompatibleTransaction so the
+                    // caller can drop the fragment instead of retrying.
                     assert!(
-                        matches!(result, Err(Error::CommitConflict { .. })),
+                        matches!(result, Err(Error::IncompatibleTransaction { .. })),
                         "{}: expected NotCompatible but got {:?}",
                         description,
                         result


### PR DESCRIPTION
#7373 made a DataReplacement conflict with any concurrent Update/Delete that touched a target fragment. That is too conservative: a delete that only adds a deletion vector leaves the positional column file aligned, and build_manifest rebases the replacement onto the current fragment, preserving the deletion vector.

A DataReplacement vs a concurrent Delete/Update now conflicts only when:
- the target fragment is removed outright -- returns a non-retryable IncompatibleTransaction so the caller can drop it and commit the rest;
- a row-rewriting (RewriteRows) update moves the matched rows out to new fragments the positional file does not cover; or
- the update rewrote one of the replaced fields in place (fields_modified).

Deletion-vector-only deletes/updates and non-overlapping column rewrites are now allowed.