### PR TITLE
perf(fts): prewarm larger chunks concurrently

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1153,9 +1153,6 @@ const PREWARM_CHUNK_TARGET_BYTES: u64 = 128 << 20;
 /// Cap on token rows per chunk, bounding the built `Vec` when posting lists are tiny.
 const PREWARM_MAX_CHUNK_TOKENS: usize = 256 * 1024;
 
-/// Number of chunks to read/build concurrently inside one partition.
-const PREWARM_CHUNK_CONCURRENCY: usize = 4;
-
 /// Floor on token rows per chunk, so a partition always makes progress.
 const PREWARM_MIN_CHUNK_TOKENS: usize = 1;
 
@@ -1232,9 +1229,10 @@ fn group_range_for_start_index(starts: &[u32], token_count: usize, group_idx: us
 impl InvertedIndex {
     pub async fn prewarm_with_options(&self, options: &FtsPrewarmOptions) -> Result<()> {
         let with_position = options.with_position;
+        let chunk_concurrency = self.store.io_parallelism().max(1);
         for part in &self.partitions {
             part.inverted_list
-                .prewarm_posting_lists(with_position)
+                .prewarm_posting_lists(with_position, chunk_concurrency)
                 .await?;
             // Materialize the deferred DocSet too: prewarm's contract is
             // that subsequent queries do no IO, so the per-doc row_ids /
@@ -2763,8 +2761,12 @@ impl PostingListReader {
         Ok(batch)
     }
 
-    async fn prewarm_posting_lists(&self, with_position: bool) -> Result<()> {
-        self.prewarm_posting_lists_chunked(with_position, None)
+    async fn prewarm_posting_lists(
+        &self,
+        with_position: bool,
+        chunk_concurrency: usize,
+    ) -> Result<()> {
+        self.prewarm_posting_lists_chunked(with_position, None, chunk_concurrency)
             .await?;
         Ok(())
     }
@@ -2776,6 +2778,7 @@ impl PostingListReader {
         &self,
         with_position: bool,
         chunk_tokens_override: Option<usize>,
+        chunk_concurrency: usize,
     ) -> Result<usize> {
         if with_position && !self.has_positions() {
             return Err(Error::invalid_input(
@@ -2800,6 +2803,7 @@ impl PostingListReader {
             .max(1);
         let chunk_ranges = prewarm_chunk_ranges(group_starts.as_deref(), token_count, chunk_tokens);
         let chunk_count = chunk_ranges.len();
+        let chunk_concurrency = chunk_concurrency.max(1);
 
         let read_build_start = Instant::now();
         stream::iter(chunk_ranges)
@@ -2822,7 +2826,7 @@ impl PostingListReader {
                     Result::Ok(())
                 }
             })
-            .buffer_unordered(PREWARM_CHUNK_CONCURRENCY)
+            .buffer_unordered(chunk_concurrency)
             .try_collect::<()>()
             .await?;
         let read_build_elapsed = read_build_start.elapsed();
@@ -2833,7 +2837,7 @@ impl PostingListReader {
             token_count,
             chunk_count,
             chunk_tokens,
-            chunk_concurrency = PREWARM_CHUNK_CONCURRENCY,
+            chunk_concurrency,
             posting_data_size_bytes,
             read_build_ms = read_build_elapsed.as_secs_f64() * 1000.0,
             "posting list prewarm timing"
@@ -6478,7 +6482,7 @@ mod tests {
             "test should use modern posting layout"
         );
 
-        inverted_list.prewarm_posting_lists(false).await.unwrap();
+        inverted_list.prewarm_posting_lists(false, 2).await.unwrap();
 
         // The two tiny tokens land in a single cache group [0, 2) (issue
         // #7040); both postings are read out of that group entry.
@@ -6666,7 +6670,7 @@ mod tests {
         // CHUNK_TOKENS < NUM_TOKENS each chunk is bounded below the whole partition.
         const CHUNK_TOKENS: usize = 6;
         let chunk_count = inverted_list
-            .prewarm_posting_lists_chunked(false, Some(CHUNK_TOKENS))
+            .prewarm_posting_lists_chunked(false, Some(CHUNK_TOKENS), 2)
             .await
             .unwrap();
 
@@ -6784,7 +6788,7 @@ mod tests {
 
         const CHUNK_TOKENS: usize = 5;
         let chunk_count = inverted_list
-            .prewarm_posting_lists_chunked(true, Some(CHUNK_TOKENS))
+            .prewarm_posting_lists_chunked(true, Some(CHUNK_TOKENS), 2)
             .await
             .unwrap();
         assert!(
@@ -8801,7 +8805,10 @@ mod tests {
             "fixture should span multiple groups",
         );
 
-        posting_reader.prewarm_posting_lists(false).await.unwrap();
+        posting_reader
+            .prewarm_posting_lists(false, 2)
+            .await
+            .unwrap();
 
         for token in 0..num_tokens {
             let (start, end) = posting_reader.group_range_for_token(token).unwrap();
@@ -8946,7 +8953,10 @@ mod tests {
         let posting_reader = PostingListReader::try_new(stripped, &cache).await.unwrap();
         assert!(posting_reader.group_starts.is_none());
 
-        posting_reader.prewarm_posting_lists(false).await.unwrap();
+        posting_reader
+            .prewarm_posting_lists(false, 2)
+            .await
+            .unwrap();
 
         for token_id in 0..num_tokens {
             assert!(

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1232,26 +1232,16 @@ fn group_range_for_start_index(starts: &[u32], token_count: usize, group_idx: us
 impl InvertedIndex {
     pub async fn prewarm_with_options(&self, options: &FtsPrewarmOptions) -> Result<()> {
         let with_position = options.with_position;
-        let io_parallelism = self.store.io_parallelism();
-        let prewarm_futures = self
-            .partitions
-            .iter()
-            .map(Arc::clone)
-            .map(|part| async move {
-                part.inverted_list
-                    .prewarm_posting_lists(with_position)
-                    .await?;
-                // Materialize the deferred DocSet too: prewarm's contract is
-                // that subsequent queries do no IO, so the per-doc row_ids /
-                // num_tokens must be resident, not lazily faulted in at query
-                // time. `ensure_loaded` opens, reads, and drops the reader.
-                part.docs.ensure_loaded().await?;
-                Result::Ok(())
-            });
-        stream::iter(prewarm_futures)
-            .buffer_unordered(io_parallelism)
-            .try_collect::<Vec<_>>()
-            .await?;
+        for part in &self.partitions {
+            part.inverted_list
+                .prewarm_posting_lists(with_position)
+                .await?;
+            // Materialize the deferred DocSet too: prewarm's contract is
+            // that subsequent queries do no IO, so the per-doc row_ids /
+            // num_tokens must be resident, not lazily faulted in at query
+            // time. `ensure_loaded` opens, reads, and drops the reader.
+            part.docs.ensure_loaded().await?;
+        }
         Ok(())
     }
     /// Search docs match the input text.

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1174,21 +1174,36 @@ fn group_aligned_chunk_end(
     tok_start: usize,
     desired_end: usize,
 ) -> usize {
-    let fit = starts
-        .iter()
-        .map(|&s| s as usize)
-        .chain(std::iter::once(token_count))
-        .filter(|&b| b > tok_start && b <= desired_end)
-        .max();
-    if let Some(end) = fit {
-        return end;
+    if desired_end >= token_count {
+        return token_count;
     }
+
+    let first_after_start = starts.partition_point(|&start| start as usize <= tok_start);
+    let first_after_desired = starts.partition_point(|&start| start as usize <= desired_end);
+    if first_after_desired > first_after_start {
+        return starts[first_after_desired - 1] as usize;
+    }
+
     // Oversized group: extend to its end so it runs as one chunk.
     starts
-        .iter()
-        .map(|&s| s as usize)
-        .find(|&b| b > tok_start)
+        .get(first_after_start)
+        .map(|&start| start as usize)
         .unwrap_or(token_count)
+}
+
+fn group_start_indices_for_chunk(starts: &[u32], tok_start: usize, tok_end: usize) -> Range<usize> {
+    let first = starts.partition_point(|&start| (start as usize) < tok_start);
+    let end = starts.partition_point(|&start| (start as usize) < tok_end);
+    first..end
+}
+
+fn group_range_for_start_index(starts: &[u32], token_count: usize, group_idx: usize) -> (u32, u32) {
+    let start = starts[group_idx];
+    let end = starts
+        .get(group_idx + 1)
+        .copied()
+        .unwrap_or(token_count as u32);
+    (start, end)
 }
 
 impl InvertedIndex {
@@ -2922,12 +2937,9 @@ impl PostingListReader {
                 // in it; `chunk_postings[i]` is token `tok_start + i`. The last
                 // group's `end` derives from `token_count`, matching the read path
                 // so both produce identical `PostingListGroupKey`s.
-                for (k, &start) in starts.iter().enumerate() {
+                for group_idx in group_start_indices_for_chunk(starts, tok_start, tok_end) {
+                    let (start, end) = group_range_for_start_index(starts, token_count, group_idx);
                     let start_usize = start as usize;
-                    if start_usize < tok_start || start_usize >= tok_end {
-                        continue;
-                    }
-                    let end = starts.get(k + 1).copied().unwrap_or(token_count as u32);
                     let lo = start_usize - tok_start;
                     let hi = end as usize - tok_start;
                     let group = PostingListGroup::new(chunk_postings[lo..hi].to_vec());
@@ -6472,6 +6484,65 @@ mod tests {
             alpha.blocks.values().as_ptr(),
             beta.blocks.values().as_ptr(),
             "prewarm should not leave cached posting lists sharing the same values buffer"
+        );
+    }
+
+    #[test]
+    fn test_group_aligned_chunk_end_boundary_cases() {
+        let starts = [0, 3, 7, 10];
+        let token_count = 13;
+
+        assert_eq!(
+            group_aligned_chunk_end(&starts, token_count, 0, 5),
+            3,
+            "chunk should snap back to the largest group boundary that fits"
+        );
+        assert_eq!(
+            group_aligned_chunk_end(&starts, token_count, 3, 6),
+            7,
+            "oversized groups should run as one chunk"
+        );
+        assert_eq!(
+            group_aligned_chunk_end(&starts, token_count, 7, 10),
+            10,
+            "an exact next group boundary should be selected"
+        );
+        assert_eq!(
+            group_aligned_chunk_end(&starts, token_count, 10, 12),
+            13,
+            "the last group should extend to token_count"
+        );
+        assert_eq!(
+            group_aligned_chunk_end(&starts, token_count, 7, 13),
+            13,
+            "token_count should act as the final boundary"
+        );
+    }
+
+    #[test]
+    fn test_group_start_indices_for_chunk_boundary_cases() {
+        let starts = [0, 3, 7, 10];
+        let token_count = 13;
+        let ranges_for_chunk = |tok_start, tok_end| {
+            group_start_indices_for_chunk(&starts, tok_start, tok_end)
+                .map(|group_idx| group_range_for_start_index(&starts, token_count, group_idx))
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(
+            ranges_for_chunk(0, 7),
+            vec![(0, 3), (3, 7)],
+            "publish should include only groups that start in the chunk"
+        );
+        assert_eq!(
+            ranges_for_chunk(7, 13),
+            vec![(7, 10), (10, 13)],
+            "publish should include the final group ending at token_count"
+        );
+        assert_eq!(
+            ranges_for_chunk(3, 10),
+            vec![(3, 7), (7, 10)],
+            "publish selection should work for an interior chunk"
         );
     }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -2833,7 +2833,7 @@ impl PostingListReader {
                 }
             })
             .buffer_unordered(PREWARM_CHUNK_CONCURRENCY)
-            .try_collect::<Vec<_>>()
+            .try_collect::<()>()
             .await?;
         let read_build_elapsed = read_build_start.elapsed();
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1154,7 +1154,7 @@ const PREWARM_CHUNK_TARGET_BYTES: u64 = 128 << 20;
 const PREWARM_MAX_CHUNK_TOKENS: usize = 256 * 1024;
 
 /// Number of chunks to read/build concurrently inside one partition.
-const PREWARM_CHUNK_CONCURRENCY: usize = 2;
+const PREWARM_CHUNK_CONCURRENCY: usize = 4;
 
 /// Floor on token rows per chunk, so a partition always makes progress.
 const PREWARM_MIN_CHUNK_TOKENS: usize = 1;

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -10,6 +10,7 @@ use std::{
 };
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    fs,
     ops::Range,
     time::Instant,
 };
@@ -1155,6 +1156,14 @@ const PREWARM_MAX_CHUNK_TOKENS: usize = 4096;
 /// Floor on token rows per chunk, so a partition always makes progress.
 const PREWARM_MIN_CHUNK_TOKENS: usize = 1;
 
+/// Fraction of available memory a single whole-file posting prewarm may use.
+/// Prewarm can run partitions concurrently and the decoded cache is larger
+/// than the raw file, so keep this below the full available-memory envelope.
+const PREWARM_WHOLE_FILE_AVAILABLE_MEMORY_DIVISOR: u64 = 4;
+
+/// Fallback available-memory estimate when the host cannot report one.
+const PREWARM_WHOLE_FILE_FALLBACK_AVAILABLE_MEMORY_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
 /// Token rows per chunk: byte target / average bytes-per-token, clamped to `[MIN, MAX]`.
 fn prewarm_chunk_tokens(token_count: usize, file_size_bytes: u64) -> usize {
     if token_count == 0 {
@@ -1163,6 +1172,45 @@ fn prewarm_chunk_tokens(token_count: usize, file_size_bytes: u64) -> usize {
     let bytes_per_token = (file_size_bytes / token_count as u64).max(1); // >= 1: no div-by-zero
     let by_bytes = (PREWARM_CHUNK_TARGET_BYTES / bytes_per_token) as usize;
     by_bytes.clamp(PREWARM_MIN_CHUNK_TOKENS, PREWARM_MAX_CHUNK_TOKENS)
+}
+
+fn prewarm_whole_file_budget_bytes_for_available(available_memory_bytes: u64) -> u64 {
+    available_memory_bytes / PREWARM_WHOLE_FILE_AVAILABLE_MEMORY_DIVISOR
+}
+
+fn should_prewarm_whole_file_for_budget(
+    posting_data_size_bytes: u64,
+    whole_file_budget_bytes: u64,
+) -> bool {
+    posting_data_size_bytes < whole_file_budget_bytes
+}
+
+fn prewarm_whole_file_budget_bytes() -> u64 {
+    let available_memory_bytes = cgroup_memory_limit_bytes()
+        .or_else(proc_mem_total_bytes)
+        .unwrap_or(PREWARM_WHOLE_FILE_FALLBACK_AVAILABLE_MEMORY_BYTES);
+    prewarm_whole_file_budget_bytes_for_available(available_memory_bytes)
+}
+
+fn cgroup_memory_limit_bytes() -> Option<u64> {
+    let value = fs::read_to_string("/sys/fs/cgroup/memory.max").ok()?;
+    let value = value.trim();
+    if value == "max" {
+        return None;
+    }
+    match value.parse::<u64>() {
+        Ok(limit) if limit > 0 && limit < (u64::MAX >> 1) => Some(limit),
+        _ => None,
+    }
+}
+
+fn proc_mem_total_bytes() -> Option<u64> {
+    let contents = fs::read_to_string("/proc/meminfo").ok()?;
+    contents.lines().find_map(|line| {
+        let value = line.strip_prefix("MemTotal:")?;
+        let kib = value.split_whitespace().next()?.parse::<u64>().ok()?;
+        Some(kib.saturating_mul(1024))
+    })
 }
 
 /// Snap a chunk's exclusive token end back to a posting-group boundary so no group
@@ -2781,8 +2829,48 @@ impl PostingListReader {
         // groups. Without grouping, chunks are plain token ranges.
         let group_starts = self.group_starts.clone();
         let token_count = self.len();
+        let posting_data_size_bytes = self.posting_data_size_bytes();
+        let whole_file_budget_bytes = prewarm_whole_file_budget_bytes();
+        if token_count > 0
+            && chunk_tokens_override.is_none()
+            && should_prewarm_whole_file_for_budget(
+                posting_data_size_bytes,
+                whole_file_budget_bytes,
+            )
+        {
+            let read_build_start = Instant::now();
+            let posting_lists = self
+                .build_whole_file_postings(with_position, &state)
+                .await?;
+            self.publish_chunk_postings(
+                posting_lists,
+                group_starts.as_deref(),
+                0,
+                token_count,
+                token_count,
+                with_position,
+            )
+            .await;
+            let read_build_elapsed = read_build_start.elapsed();
+
+            info!(
+                legacy_layout = self.is_legacy_layout(),
+                with_position,
+                token_count,
+                chunk_count = 1usize,
+                chunk_tokens = token_count,
+                mode = "whole_file",
+                posting_data_size_bytes,
+                whole_file_budget_bytes,
+                read_build_ms = read_build_elapsed.as_secs_f64() * 1000.0,
+                "posting list prewarm timing"
+            );
+
+            return Ok(1);
+        }
+
         let chunk_tokens = chunk_tokens_override
-            .unwrap_or_else(|| prewarm_chunk_tokens(token_count, self.posting_data_size_bytes()))
+            .unwrap_or_else(|| prewarm_chunk_tokens(token_count, posting_data_size_bytes))
             .max(1);
 
         let mut chunk_count = 0usize;
@@ -2819,6 +2907,9 @@ impl PostingListReader {
             token_count,
             chunk_count,
             chunk_tokens,
+            mode = "chunked",
+            posting_data_size_bytes,
+            whole_file_budget_bytes,
             read_build_ms = read_build_elapsed.as_secs_f64() * 1000.0,
             "posting list prewarm timing"
         );
@@ -2908,6 +2999,53 @@ impl PostingListReader {
                 .iter()
                 .enumerate()
                 .all(|(i, (token_id, _))| *token_id as usize == tok_start + i)
+        );
+        Ok(posting_lists)
+    }
+
+    /// Read the whole posting file and build all posting lists off the runtime
+    /// thread. This restores the single range-read behavior for partitions that
+    /// fit within the configured prewarm memory budget.
+    async fn build_whole_file_postings(
+        &self,
+        with_position: bool,
+        state: &ChunkBuildState,
+    ) -> Result<Vec<(u32, PostingList)>> {
+        let token_count = self.len();
+        let chunk_batch = self.read_batch(with_position).await?;
+        let chunk_offsets = state.offsets.clone();
+        let chunk_end_row = self.reader.num_rows();
+        let max_scores = state.max_scores.clone();
+        let lengths = state.lengths.clone();
+        let posting_tail_codec = state.posting_tail_codec;
+        let positions_layout = state.positions_layout;
+        let posting_lists = spawn_blocking(move || {
+            let ctx = PrewarmBuildCtx {
+                max_scores: max_scores.as_deref().map(|v| v.as_slice()),
+                lengths: lengths.as_deref().map(|v| v.as_slice()),
+                posting_tail_codec,
+                positions_layout,
+            };
+            let chunk = PrewarmChunk {
+                tok_start: 0,
+                token_count,
+                offsets: chunk_offsets.as_deref().map(|v| v.as_slice()),
+                end_row: chunk_end_row,
+            };
+            Self::build_prewarm_posting_lists_chunk(chunk_batch, chunk, &ctx)
+        })
+        .await
+        .map_err(|err| {
+            Error::internal(format!(
+                "Failed to build prewarm posting lists in blocking task: {err}"
+            ))
+        })??;
+        debug_assert_eq!(posting_lists.len(), token_count);
+        debug_assert!(
+            posting_lists
+                .iter()
+                .enumerate()
+                .all(|(i, (token_id, _))| *token_id as usize == i)
         );
         Ok(posting_lists)
     }
@@ -6462,7 +6600,14 @@ mod tests {
             "test should use modern posting layout"
         );
 
-        inverted_list.prewarm_posting_lists(false).await.unwrap();
+        let chunk_count = inverted_list
+            .prewarm_posting_lists_chunked(false, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            chunk_count, 1,
+            "small posting file should use the whole-file prewarm fast path"
+        );
 
         // The two tiny tokens land in a single cache group [0, 2) (issue
         // #7040); both postings are read out of that group entry.
@@ -6544,6 +6689,27 @@ mod tests {
             vec![(3, 7), (7, 10)],
             "publish selection should work for an interior chunk"
         );
+    }
+
+    #[test]
+    fn test_prewarm_whole_file_budget_helpers() {
+        let available_memory_bytes = 8 * 1024 * 1024 * 1024;
+        let budget = prewarm_whole_file_budget_bytes_for_available(available_memory_bytes);
+        assert_eq!(budget, 2 * 1024 * 1024 * 1024);
+
+        assert!(
+            should_prewarm_whole_file_for_budget(budget - 1, budget),
+            "posting data smaller than the budget should use whole-file prewarm"
+        );
+        assert!(
+            !should_prewarm_whole_file_for_budget(budget, budget),
+            "posting data equal to the budget should stay on the bounded chunked path"
+        );
+        assert!(
+            !should_prewarm_whole_file_for_budget(budget + 1, budget),
+            "posting data larger than the budget should stay on the bounded chunked path"
+        );
+        assert_eq!(prewarm_whole_file_budget_bytes_for_available(3), 0);
     }
 
     /// Prewarming a large partition in multiple chunks must end up holding exactly the
@@ -7554,17 +7720,45 @@ mod tests {
             .unwrap();
         writer.finish_with_metadata(metadata).await.unwrap();
 
-        let cache = Arc::new(LanceCache::with_capacity(4096));
+        let cache = Arc::new(LanceCache::with_capacity(1 << 20));
         let index = InvertedIndex::load(store, None, cache.as_ref())
             .await
             .unwrap();
-        index
-            .prewarm_with_options(&FtsPrewarmOptions::new().with_position(true))
+        let inverted_list = &index.partitions[0].inverted_list;
+        let chunk_count = inverted_list
+            .prewarm_posting_lists_chunked(true, None)
             .await
             .unwrap();
+        assert_eq!(
+            chunk_count, 1,
+            "small posting file with positions should use whole-file prewarm"
+        );
 
-        let actual = index.partitions[0]
-            .inverted_list
+        let (start, end) = inverted_list.group_range_for_token(0).unwrap();
+        let group = inverted_list
+            .index_cache
+            .get_with_key(&PostingListGroupKey { start, end })
+            .await
+            .unwrap();
+        assert!(
+            !group.get(0).unwrap().has_position(),
+            "whole-file prewarm must keep posting cache entries positions-free"
+        );
+
+        let positions = inverted_list
+            .index_cache
+            .get_with_key(&PositionKey { token_id: 0 })
+            .await
+            .unwrap();
+        assert!(
+            matches!(
+                positions.as_ref().0,
+                CompressedPositionStorage::SharedStream(_)
+            ),
+            "whole-file prewarm should store v2 positions in the dedicated position cache"
+        );
+
+        let actual = inverted_list
             .posting_list(0, true, &NoOpMetricsCollector)
             .await
             .unwrap()

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -10,7 +10,6 @@ use std::{
 };
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    fs,
     ops::Range,
     time::Instant,
 };
@@ -1146,23 +1145,19 @@ impl Index for InvertedIndex {
     }
 }
 
-/// Target on-disk size of one prewarm chunk; a partition is streamed in chunks of
-/// ~this size so its peak resident set is one chunk, not the whole `invert.lance`.
-const PREWARM_CHUNK_TARGET_BYTES: u64 = 32 << 20;
+/// Target on-disk size of one prewarm chunk. Keep this large enough that cloud
+/// stores do not spend prewarm time on thousands of tiny range reads, but still
+/// bounded so one large partition is not materialized all at once.
+const PREWARM_CHUNK_TARGET_BYTES: u64 = 128 << 20;
 
 /// Cap on token rows per chunk, bounding the built `Vec` when posting lists are tiny.
-const PREWARM_MAX_CHUNK_TOKENS: usize = 4096;
+const PREWARM_MAX_CHUNK_TOKENS: usize = 256 * 1024;
+
+/// Number of chunks to read/build concurrently inside one partition.
+const PREWARM_CHUNK_CONCURRENCY: usize = 2;
 
 /// Floor on token rows per chunk, so a partition always makes progress.
 const PREWARM_MIN_CHUNK_TOKENS: usize = 1;
-
-/// Fraction of available memory a single whole-file posting prewarm may use.
-/// Prewarm can run partitions concurrently and the decoded cache is larger
-/// than the raw file, so keep this below the full available-memory envelope.
-const PREWARM_WHOLE_FILE_AVAILABLE_MEMORY_DIVISOR: u64 = 4;
-
-/// Fallback available-memory estimate when the host cannot report one.
-const PREWARM_WHOLE_FILE_FALLBACK_AVAILABLE_MEMORY_BYTES: u64 = 4 * 1024 * 1024 * 1024;
 
 /// Token rows per chunk: byte target / average bytes-per-token, clamped to `[MIN, MAX]`.
 fn prewarm_chunk_tokens(token_count: usize, file_size_bytes: u64) -> usize {
@@ -1172,45 +1167,6 @@ fn prewarm_chunk_tokens(token_count: usize, file_size_bytes: u64) -> usize {
     let bytes_per_token = (file_size_bytes / token_count as u64).max(1); // >= 1: no div-by-zero
     let by_bytes = (PREWARM_CHUNK_TARGET_BYTES / bytes_per_token) as usize;
     by_bytes.clamp(PREWARM_MIN_CHUNK_TOKENS, PREWARM_MAX_CHUNK_TOKENS)
-}
-
-fn prewarm_whole_file_budget_bytes_for_available(available_memory_bytes: u64) -> u64 {
-    available_memory_bytes / PREWARM_WHOLE_FILE_AVAILABLE_MEMORY_DIVISOR
-}
-
-fn should_prewarm_whole_file_for_budget(
-    posting_data_size_bytes: u64,
-    whole_file_budget_bytes: u64,
-) -> bool {
-    posting_data_size_bytes < whole_file_budget_bytes
-}
-
-fn prewarm_whole_file_budget_bytes() -> u64 {
-    let available_memory_bytes = cgroup_memory_limit_bytes()
-        .or_else(proc_mem_total_bytes)
-        .unwrap_or(PREWARM_WHOLE_FILE_FALLBACK_AVAILABLE_MEMORY_BYTES);
-    prewarm_whole_file_budget_bytes_for_available(available_memory_bytes)
-}
-
-fn cgroup_memory_limit_bytes() -> Option<u64> {
-    let value = fs::read_to_string("/sys/fs/cgroup/memory.max").ok()?;
-    let value = value.trim();
-    if value == "max" {
-        return None;
-    }
-    match value.parse::<u64>() {
-        Ok(limit) if limit > 0 && limit < (u64::MAX >> 1) => Some(limit),
-        _ => None,
-    }
-}
-
-fn proc_mem_total_bytes() -> Option<u64> {
-    let contents = fs::read_to_string("/proc/meminfo").ok()?;
-    contents.lines().find_map(|line| {
-        let value = line.strip_prefix("MemTotal:")?;
-        let kib = value.split_whitespace().next()?.parse::<u64>().ok()?;
-        Some(kib.saturating_mul(1024))
-    })
 }
 
 /// Snap a chunk's exclusive token end back to a posting-group boundary so no group
@@ -1237,6 +1193,25 @@ fn group_aligned_chunk_end(
         .get(first_after_start)
         .map(|&start| start as usize)
         .unwrap_or(token_count)
+}
+
+fn prewarm_chunk_ranges(
+    group_starts: Option<&[u32]>,
+    token_count: usize,
+    chunk_tokens: usize,
+) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut tok_start = 0usize;
+    while tok_start < token_count {
+        let mut tok_end = (tok_start + chunk_tokens).min(token_count);
+        // `tok_start` is always a group boundary; snap `tok_end` back to one too.
+        if let Some(starts) = group_starts {
+            tok_end = group_aligned_chunk_end(starts, token_count, tok_start, tok_end);
+        }
+        ranges.push((tok_start, tok_end));
+        tok_start = tok_end;
+    }
+    ranges
 }
 
 fn group_start_indices_for_chunk(starts: &[u32], tok_start: usize, tok_end: usize) -> Range<usize> {
@@ -2830,75 +2805,36 @@ impl PostingListReader {
         let group_starts = self.group_starts.clone();
         let token_count = self.len();
         let posting_data_size_bytes = self.posting_data_size_bytes();
-        let whole_file_budget_bytes = prewarm_whole_file_budget_bytes();
-        if token_count > 0
-            && chunk_tokens_override.is_none()
-            && should_prewarm_whole_file_for_budget(
-                posting_data_size_bytes,
-                whole_file_budget_bytes,
-            )
-        {
-            let read_build_start = Instant::now();
-            let posting_lists = self
-                .build_whole_file_postings(with_position, &state)
-                .await?;
-            self.publish_chunk_postings(
-                posting_lists,
-                group_starts.as_deref(),
-                0,
-                token_count,
-                token_count,
-                with_position,
-            )
-            .await;
-            let read_build_elapsed = read_build_start.elapsed();
-
-            info!(
-                legacy_layout = self.is_legacy_layout(),
-                with_position,
-                token_count,
-                chunk_count = 1usize,
-                chunk_tokens = token_count,
-                mode = "whole_file",
-                posting_data_size_bytes,
-                whole_file_budget_bytes,
-                read_build_ms = read_build_elapsed.as_secs_f64() * 1000.0,
-                "posting list prewarm timing"
-            );
-
-            return Ok(1);
-        }
-
         let chunk_tokens = chunk_tokens_override
             .unwrap_or_else(|| prewarm_chunk_tokens(token_count, posting_data_size_bytes))
             .max(1);
+        let chunk_ranges = prewarm_chunk_ranges(group_starts.as_deref(), token_count, chunk_tokens);
+        let chunk_count = chunk_ranges.len();
 
-        let mut chunk_count = 0usize;
         let read_build_start = Instant::now();
-        let mut tok_start = 0usize;
-        while tok_start < token_count {
-            let mut tok_end = (tok_start + chunk_tokens).min(token_count);
-            // `tok_start` is always a group boundary; snap `tok_end` back to one too.
-            if let Some(starts) = group_starts.as_ref() {
-                tok_end = group_aligned_chunk_end(starts, token_count, tok_start, tok_end);
-            }
-            chunk_count += 1;
-
-            let posting_lists = self
-                .build_chunk_postings(tok_start, tok_end, with_position, &state)
-                .await?;
-            self.publish_chunk_postings(
-                posting_lists,
-                group_starts.as_deref(),
-                tok_start,
-                tok_end,
-                token_count,
-                with_position,
-            )
-            .await;
-
-            tok_start = tok_end;
-        }
+        stream::iter(chunk_ranges)
+            .map(|(tok_start, tok_end)| {
+                let state = &state;
+                let group_starts = group_starts.as_deref();
+                async move {
+                    let posting_lists = self
+                        .build_chunk_postings(tok_start, tok_end, with_position, state)
+                        .await?;
+                    self.publish_chunk_postings(
+                        posting_lists,
+                        group_starts,
+                        tok_start,
+                        tok_end,
+                        token_count,
+                        with_position,
+                    )
+                    .await;
+                    Result::Ok(())
+                }
+            })
+            .buffer_unordered(PREWARM_CHUNK_CONCURRENCY)
+            .try_collect::<Vec<_>>()
+            .await?;
         let read_build_elapsed = read_build_start.elapsed();
 
         info!(
@@ -2907,9 +2843,8 @@ impl PostingListReader {
             token_count,
             chunk_count,
             chunk_tokens,
-            mode = "chunked",
+            chunk_concurrency = PREWARM_CHUNK_CONCURRENCY,
             posting_data_size_bytes,
-            whole_file_budget_bytes,
             read_build_ms = read_build_elapsed.as_secs_f64() * 1000.0,
             "posting list prewarm timing"
         );
@@ -2999,53 +2934,6 @@ impl PostingListReader {
                 .iter()
                 .enumerate()
                 .all(|(i, (token_id, _))| *token_id as usize == tok_start + i)
-        );
-        Ok(posting_lists)
-    }
-
-    /// Read the whole posting file and build all posting lists off the runtime
-    /// thread. This restores the single range-read behavior for partitions that
-    /// fit within the configured prewarm memory budget.
-    async fn build_whole_file_postings(
-        &self,
-        with_position: bool,
-        state: &ChunkBuildState,
-    ) -> Result<Vec<(u32, PostingList)>> {
-        let token_count = self.len();
-        let chunk_batch = self.read_batch(with_position).await?;
-        let chunk_offsets = state.offsets.clone();
-        let chunk_end_row = self.reader.num_rows();
-        let max_scores = state.max_scores.clone();
-        let lengths = state.lengths.clone();
-        let posting_tail_codec = state.posting_tail_codec;
-        let positions_layout = state.positions_layout;
-        let posting_lists = spawn_blocking(move || {
-            let ctx = PrewarmBuildCtx {
-                max_scores: max_scores.as_deref().map(|v| v.as_slice()),
-                lengths: lengths.as_deref().map(|v| v.as_slice()),
-                posting_tail_codec,
-                positions_layout,
-            };
-            let chunk = PrewarmChunk {
-                tok_start: 0,
-                token_count,
-                offsets: chunk_offsets.as_deref().map(|v| v.as_slice()),
-                end_row: chunk_end_row,
-            };
-            Self::build_prewarm_posting_lists_chunk(chunk_batch, chunk, &ctx)
-        })
-        .await
-        .map_err(|err| {
-            Error::internal(format!(
-                "Failed to build prewarm posting lists in blocking task: {err}"
-            ))
-        })??;
-        debug_assert_eq!(posting_lists.len(), token_count);
-        debug_assert!(
-            posting_lists
-                .iter()
-                .enumerate()
-                .all(|(i, (token_id, _))| *token_id as usize == i)
         );
         Ok(posting_lists)
     }
@@ -6600,14 +6488,7 @@ mod tests {
             "test should use modern posting layout"
         );
 
-        let chunk_count = inverted_list
-            .prewarm_posting_lists_chunked(false, None)
-            .await
-            .unwrap();
-        assert_eq!(
-            chunk_count, 1,
-            "small posting file should use the whole-file prewarm fast path"
-        );
+        inverted_list.prewarm_posting_lists(false).await.unwrap();
 
         // The two tiny tokens land in a single cache group [0, 2) (issue
         // #7040); both postings are read out of that group entry.
@@ -6692,24 +6573,18 @@ mod tests {
     }
 
     #[test]
-    fn test_prewarm_whole_file_budget_helpers() {
-        let available_memory_bytes = 8 * 1024 * 1024 * 1024;
-        let budget = prewarm_whole_file_budget_bytes_for_available(available_memory_bytes);
-        assert_eq!(budget, 2 * 1024 * 1024 * 1024);
-
-        assert!(
-            should_prewarm_whole_file_for_budget(budget - 1, budget),
-            "posting data smaller than the budget should use whole-file prewarm"
+    fn test_prewarm_chunk_ranges_preserve_group_boundaries() {
+        let starts = [0, 3, 7, 10];
+        assert_eq!(
+            prewarm_chunk_ranges(Some(&starts), 13, 5),
+            vec![(0, 3), (3, 7), (7, 10), (10, 13)],
+            "grouped chunk ranges must never split a posting cache group"
         );
-        assert!(
-            !should_prewarm_whole_file_for_budget(budget, budget),
-            "posting data equal to the budget should stay on the bounded chunked path"
+        assert_eq!(
+            prewarm_chunk_ranges(None, 13, 5),
+            vec![(0, 5), (5, 10), (10, 13)],
+            "ungrouped chunk ranges should use plain token ranges"
         );
-        assert!(
-            !should_prewarm_whole_file_for_budget(budget + 1, budget),
-            "posting data larger than the budget should stay on the bounded chunked path"
-        );
-        assert_eq!(prewarm_whole_file_budget_bytes_for_available(3), 0);
     }
 
     /// Prewarming a large partition in multiple chunks must end up holding exactly the
@@ -7720,45 +7595,17 @@ mod tests {
             .unwrap();
         writer.finish_with_metadata(metadata).await.unwrap();
 
-        let cache = Arc::new(LanceCache::with_capacity(1 << 20));
+        let cache = Arc::new(LanceCache::with_capacity(4096));
         let index = InvertedIndex::load(store, None, cache.as_ref())
             .await
             .unwrap();
-        let inverted_list = &index.partitions[0].inverted_list;
-        let chunk_count = inverted_list
-            .prewarm_posting_lists_chunked(true, None)
+        index
+            .prewarm_with_options(&FtsPrewarmOptions::new().with_position(true))
             .await
             .unwrap();
-        assert_eq!(
-            chunk_count, 1,
-            "small posting file with positions should use whole-file prewarm"
-        );
 
-        let (start, end) = inverted_list.group_range_for_token(0).unwrap();
-        let group = inverted_list
-            .index_cache
-            .get_with_key(&PostingListGroupKey { start, end })
-            .await
-            .unwrap();
-        assert!(
-            !group.get(0).unwrap().has_position(),
-            "whole-file prewarm must keep posting cache entries positions-free"
-        );
-
-        let positions = inverted_list
-            .index_cache
-            .get_with_key(&PositionKey { token_id: 0 })
-            .await
-            .unwrap();
-        assert!(
-            matches!(
-                positions.as_ref().0,
-                CompressedPositionStorage::SharedStream(_)
-            ),
-            "whole-file prewarm should store v2 positions in the dedicated position cache"
-        );
-
-        let actual = inverted_list
+        let actual = index.partitions[0]
+            .inverted_list
             .posting_list(0, true, &NoOpMetricsCollector)
             .await
             .unwrap()


### PR DESCRIPTION
## Performance Improvement

What is the performance issue or bottleneck?

FTS prewarm was reading posting lists in very small chunks. For large FTS indexes this can create thousands of range reads, so remote-read scheduling and per-chunk build overhead dominate prewarm time.

How does this PR improve performance?

This PR uses larger bounded chunks and bounded read/build concurrency:

- Increase the default prewarm chunk target from 32 MiB to 128 MiB.
- Increase the token cap from 4,096 tokens to 256K tokens.
- Read/build chunks concurrently within the current posting partition, using the store I/O parallelism as the concurrency limit.
- Prewarm posting partitions serially to avoid multiplying partition-level and chunk-level fanout.
- Preserve group-aligned chunk boundaries and `with_position=true` cache behavior.

This keeps prewarm bounded without using a whole-file fast path or runtime memory-budget probing.

Benchmark or measurement results:

On the large FTS prewarm benchmark used for validation:

- Old main: 434.200s.
- This PR: 35.216s and 35.165s, mean 35.191s.
- About 12.34x faster than old main.
- Prewarm wall time reduced by about 91.9%.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p lance-index prewarm -- --nocapture`
- `cargo clippy --all --tests --benches -- -D warnings`