### PR TITLE
feat(python): expose fragment-reuse remap and delete-by-offset

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -994,6 +994,16 @@ class LanceDataset(pa.dataset.Dataset):
         """Returns index information for all indices in the dataset."""
         return self._ds.describe_indices()
 
+    def remap_row_addrs(self, addrs: "pa.Array") -> "Optional[pa.Array]":
+        """Remap row addresses across compactions still recorded in the
+        fragment-reuse index. Rows a compaction dropped become null. The index
+        retains only recent rounds (older ones are pruned as index remap catches
+        up), so remap promptly: an address whose round was pruned is returned
+        unchanged, not remapped. Returns ``None`` when there is no fragment-reuse
+        index.
+        """
+        return self._ds.remap_row_addrs(addrs)
+
     def index_statistics(self, index_name: str) -> Dict[str, Any]:
         warnings.warn(
             "LanceDataset.index_statistics() is deprecated, "

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     List,
     Literal,
@@ -961,6 +962,24 @@ class LanceFragment(pa.dataset.Fragment):
             doc page for an example of using this API.
         """
         raw_fragment = self._fragment.delete(predicate)
+        if raw_fragment is None:
+            return None
+        return raw_fragment.metadata()
+
+    def delete_rows(self, offsets: "Iterable[int]") -> FragmentMetadata | None:
+        """Delete rows by their local (within-fragment) physical row offsets.
+
+        Adds the given 0-based offsets to this fragment's deletion file and
+        returns a new fragment, or None if no rows are left. Unlike
+        :meth:`delete`, this deletes exactly the supplied rows without
+        re-evaluating a SQL predicate -- useful when the caller already knows
+        which rows to delete (e.g. offsets collected from a prior scan).
+
+        .. warning::
+
+            Internal API. This method is not intended to be used by end users.
+        """
+        raw_fragment = self._fragment.delete_rows([int(o) for o in offsets])
         if raw_fragment is None:
             return None
         return raw_fragment.metadata()

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -800,3 +800,30 @@ def test_fragment_update_columns_error_on_metadata_column(tmp_path):
         "metadata column" in str(exc_info.value).lower()
         or "cannot be updated" in str(exc_info.value).lower()
     )
+
+
+def test_fragment_delete_rows(tmp_path: Path):
+    # LanceFragment.delete_rows deletes by local row offset (not a predicate):
+    # exactly the given rows are removed, the rest survive, and the fragment is
+    # gone when every row is deleted.
+    data = pa.table({"a": range(100), "b": range(100)})
+    dataset = lance.write_dataset(data, tmp_path)
+    frag = dataset.get_fragment(0)
+
+    new_meta = frag.delete_rows([0, 5, 99])
+    assert new_meta is not None
+    op = LanceOperation.Delete(
+        updated_fragments=[new_meta],
+        deleted_fragment_ids=[],
+        predicate="delete_rows([0, 5, 99])",
+    )
+    dataset = lance.LanceDataset.commit(dataset.uri, op, read_version=dataset.version)
+
+    assert dataset.count_rows() == 97
+    remaining = set(dataset.to_table(columns=["a"])["a"].to_pylist())
+    assert {0, 5, 99}.isdisjoint(remaining)
+    assert {1, 98}.issubset(remaining)
+
+    # Deleting every row removes the fragment entirely (returns None).
+    frag = lance.dataset(tmp_path).get_fragment(0)
+    assert frag.delete_rows(range(100)) is None

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -574,3 +574,34 @@ def test_compaction_generates_rewrite_transaction(tmp_path: Path):
         t is not None and t.operation.__class__.__name__ == "Rewrite"
         for t in transactions
     )
+
+
+def test_remap_row_addrs(tmp_path: Path):
+    # Dataset.remap_row_addrs follows rows across a compaction via the
+    # fragment-reuse index: an address valid before the compaction maps to the
+    # row's new address after it. None when there is no fragment-reuse index.
+    base_dir = tmp_path / "dataset"
+    data = pa.table({"id": range(1_000), "v": range(1_000)})
+    ds = lance.write_dataset(data, base_dir, max_rows_per_file=100)  # 10 fragments
+
+    # No fragment-reuse index yet -> None (nothing to remap against).
+    addrs = pa.array([0, 1 << 32, (5 << 32) | 7], pa.uint64())
+    assert ds.remap_row_addrs(addrs) is None
+
+    before = ds.scanner(columns=["id"], with_row_address=True).to_table()
+    old = dict(zip(before["id"].to_pylist(), before["_rowaddr"].to_pylist()))
+
+    ds.optimize.compact_files(
+        target_rows_per_fragment=1_000, defer_index_remap=True, num_threads=1
+    )
+    ds = lance.dataset(base_dir)
+    assert any(idx.name == "__lance_frag_reuse" for idx in ds.describe_indices())
+
+    after = ds.scanner(columns=["id"], with_row_address=True).to_table()
+    new = dict(zip(after["id"].to_pylist(), after["_rowaddr"].to_pylist()))
+
+    sample = [0, 137, 999]
+    remapped = ds.remap_row_addrs(
+        pa.array([old[i] for i in sample], pa.uint64())
+    ).to_pylist()
+    assert remapped == [new[i] for i in sample]

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -60,7 +60,9 @@ use lance::dataset::{
     transaction::{Operation, Transaction},
 };
 use lance::index::vector::utils::get_vector_type;
-use lance::index::{DatasetIndexExt, IndexSegment, vector::VectorIndexParams};
+use lance::index::{
+    DatasetIndexExt, DatasetIndexInternalExt, IndexSegment, vector::VectorIndexParams,
+};
 use lance::{dataset::builder::DatasetBuilder, index::vector::IndexFileVersion};
 use lance_arrow::as_fixed_size_list_array;
 use lance_core::Error;
@@ -934,6 +936,32 @@ impl Dataset {
                     index_name, err
                 )),
             })
+    }
+
+    /// Remap row addresses across compactions still recorded in the
+    /// fragment-reuse index. Rows a compaction dropped become null. The index
+    /// retains only recent rounds (older ones are pruned as index remap catches
+    /// up), so remap promptly: an address whose round was pruned is returned
+    /// unchanged, not remapped. Returns None when there is no fragment-reuse
+    /// index.
+    fn remap_row_addrs(
+        &self,
+        py: Python,
+        addrs: PyArrowType<ArrayData>,
+    ) -> PyResult<Option<PyArrowType<ArrayData>>> {
+        use lance_index::metrics::NoOpMetricsCollector;
+
+        let array = make_array(addrs.0);
+        let frag_reuse_index = rt()
+            .block_on(
+                Some(py),
+                self.ds.open_frag_reuse_index(&NoOpMetricsCollector),
+            )?
+            .map_err(|err| {
+                PyIOError::new_err(format!("failed to open fragment reuse index: {err}"))
+            })?;
+
+        Ok(frag_reuse_index.map(|fri| PyArrowType(fri.remap_row_ids_array(array).to_data())))
     }
 
     fn serialized_manifest(&self, py: Python) -> Py<PyAny> {

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -385,6 +385,26 @@ impl FileFragment {
         }
     }
 
+    /// Delete rows by their local (within-fragment) physical row offsets.
+    ///
+    /// Adds the given 0-based offsets to this fragment's deletion vector and
+    /// writes a new deletion file. Returns the updated fragment, or None if every
+    /// row is now deleted. Unlike `delete(predicate)`, this deletes exactly the
+    /// supplied rows without re-evaluating a filter -- useful when the caller
+    /// already knows which rows to delete (e.g. offsets collected from a prior
+    /// scan), avoiding a redundant predicate evaluation.
+    fn delete_rows(&self, offsets: Vec<u32>) -> PyResult<Option<Self>> {
+        let old_fragment = self.fragment.clone();
+        let updated_fragment = rt()
+            .block_on(None, async { old_fragment.extend_deletions(offsets).await })?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?;
+
+        match updated_fragment {
+            Some(frag) => Ok(Some(Self::new(frag))),
+            None => Ok(None),
+        }
+    }
+
     fn schema<'py>(self_: PyRef<'py, Self>) -> PyResult<Bound<'py, PyAny>> {
         let schema = self_.fragment.dataset().schema();
         let logical_schema = logical_schema_from_lance(schema);


### PR DESCRIPTION
Two thin bindings, no lance-core change, that let a caller follow and prune row addresses across a compaction without relying on stable row ids:

- Dataset.remap_row_addrs(addrs): translate row addresses to their current location across the compactions a fragment-reuse index still records (wraps open_frag_reuse_index + FragReuseIndex::remap_row_ids_array). Dropped rows become null; returns None when there is no fragment-reuse index.
- LanceFragment.delete_rows(offsets): delete rows by local (within-fragment) physical offset, exactly and without re-evaluating a predicate (wraps FileFragment::extend_deletions).