### PR TITLE
ci: group Dependabot updates into one PR per lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    groups:
+      cargo:
+        patterns:
+          - "*"
 
   - package-ecosystem: "cargo"
     directory: "/python"
@@ -13,6 +17,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    groups:
+      cargo:
+        patterns:
+          - "*"
 
   - package-ecosystem: "cargo"
     directory: "/java/lance-jni"
@@ -20,6 +28,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    groups:
+      cargo:
+        patterns:
+          - "*"
 
   - package-ecosystem: "uv"
     directory: "/python"
@@ -27,4 +39,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
-
+    groups:
+      uv:
+        patterns:
+          - "*"


### PR DESCRIPTION
Previously Dependabot opened a separate PR for every dependency bump, which created a lot of noise. This adds a catch-all `groups` entry to each update configuration so all updates for a given lockfile are collapsed into a single PR.

Each `updates` entry already maps one-to-one to a lockfile (root `Cargo.lock`, `/python` `Cargo.lock`, `/java/lance-jni` `Cargo.lock`, and `/python` `uv.lock`), so the result is at most one version-update PR per lockfile per week. Security updates are unaffected and still come as individual PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)