### PR TITLE
fix(index): use global BM25 scorer for WAND pruning

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -63,7 +63,7 @@ use super::{
     },
     iter::PlainPostingListIterator,
     query::*,
-    scorer::{B, IndexBM25Scorer, K1, Scorer, idf},
+    scorer::{B, K1, Scorer, idf},
 };
 use super::{
     builder::{InnerBuilder, PositionRecorder},
@@ -751,19 +751,16 @@ impl InvertedIndex {
         metrics: Arc<dyn MetricsCollector>,
         base_scorer: Option<&MemBM25Scorer>,
     ) -> Result<(Vec<u64>, Vec<f32>)> {
-        // The wand only consults `scorer.doc_weight`, which is metadata-free.
-        // The outer aggregation below consults `scorer.query_weight`, which
-        // hits per-token `posting_len`; building a `MemBM25Scorer` with
-        // precomputed per-term IDFs avoids the v2 bulk metadata pull.
-        let local_scorer;
-        let scorer: &dyn Scorer = if let Some(base_scorer) = base_scorer {
-            base_scorer
+        // Use one corpus-wide scorer for every score-space consumer in this
+        // query. Shared WAND thresholds and block pruning are correct only when
+        // WAND scoring, final aggregation, and upper bounds all use these same
+        // BM25 statistics.
+        let scorer = Arc::new(if let Some(base_scorer) = base_scorer {
+            base_scorer.clone()
         } else {
-            local_scorer = self
-                .bm25_base_scorer(tokens.as_ref(), params.as_ref())
-                .await?;
-            &local_scorer
-        };
+            self.bm25_base_scorer(tokens.as_ref(), params.as_ref())
+                .await?
+        });
 
         let limit = params.limit.unwrap_or(usize::MAX);
         if limit == 0 {
@@ -801,8 +798,10 @@ impl InvertedIndex {
         let mut candidates = BinaryHeap::new();
         // Shared top-k floor across this query's partitions. Seeded to -inf so
         // the first real score wins; each partition publishes its local k-th
-        // and prunes against the running global k-th (a lower bound on the true
-        // global k-th — see `Wand::shared_threshold`).
+        // and prunes against the running global k-th. Correctness depends on
+        // every partition using the same active BM25 scorer for scores and
+        // block upper bounds; grouped fuzzy expansions keep a private floor
+        // because WAND uses a conservative union proxy before exact rescoring.
         let shared_threshold = Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()));
         let parts = self
             .partitions
@@ -814,6 +813,7 @@ impl InvertedIndex {
                 let mask = mask.clone();
                 let metrics = metrics.clone();
                 let shared_threshold = shared_threshold.clone();
+                let scorer = scorer.clone();
                 async move {
                     let loaded_postings = part
                         .load_posting_lists(
@@ -821,6 +821,7 @@ impl InvertedIndex {
                             params.as_ref(),
                             operator,
                             metrics.as_ref(),
+                            scorer.as_ref(),
                         )
                         .await?;
                     let LoadedPostings {
@@ -862,6 +863,7 @@ impl InvertedIndex {
                     } else {
                         shared_threshold
                     };
+                    let scorer = scorer.clone();
                     let candidates = spawn_cpu(move || {
                         let candidates = part_for_wand.bm25_search(
                             docs_for_wand.as_ref(),
@@ -871,6 +873,7 @@ impl InvertedIndex {
                             postings,
                             metrics.as_ref(),
                             partition_threshold,
+                            scorer,
                         )?;
                         std::result::Result::<_, Error>::Ok(candidates)
                     })
@@ -1601,6 +1604,7 @@ impl InvertedPartition {
         params: &FtsSearchParams,
         operator: Operator,
         metrics: &dyn MetricsCollector,
+        scorer: &dyn Scorer,
     ) -> Result<LoadedPostings> {
         let is_fuzzy = matches!(params.fuzziness, Some(n) if n != 0);
         let is_phrase_query = params.phrase_slop.is_some();
@@ -1681,7 +1685,7 @@ impl InvertedPartition {
                 postings: loaded_postings
                     .into_iter()
                     .map(|(token_id, token, position, posting)| {
-                        let query_weight = idf(posting.len(), num_docs);
+                        let query_weight = scorer.query_weight(&token);
                         PostingIterator::with_query_weight(
                             token,
                             token_id,
@@ -1718,6 +1722,14 @@ impl InvertedPartition {
                 group.push((token_id, token, posting));
             }
 
+            // The union posting is only a WAND proxy; final scoring below
+            // rescans the exact matched expansion terms. Summing the expansion
+            // query weights keeps the proxy score an upper bound for documents
+            // that match multiple expansions at this original query position.
+            let query_weight = group
+                .iter()
+                .map(|(_, token, _)| scorer.query_weight(token))
+                .sum::<f32>();
             let (token_id, token, posting) = if group.len() == 1 {
                 group.pop().expect("single-item group must exist")
             } else {
@@ -1746,7 +1758,6 @@ impl InvertedPartition {
                 return Ok(LoadedPostings::empty());
             }
 
-            let query_weight = idf(posting.len(), num_docs);
             grouped_postings.push(PostingIterator::with_query_weight(
                 token,
                 token_id,
@@ -1777,6 +1788,7 @@ impl InvertedPartition {
         postings: Vec<PostingIterator>,
         metrics: &dyn MetricsCollector,
         shared_threshold: Arc<AtomicU32>,
+        scorer: Arc<MemBM25Scorer>,
     ) -> Result<Vec<DocCandidate>> {
         if postings.is_empty() {
             return Ok(Vec::new());
@@ -1785,7 +1797,10 @@ impl InvertedPartition {
         // Caller selects the DocSet shape via `LazyDocSet::docs_for_wand`
         // and passes it in here; wand uses `docs.has_row_ids()` to
         // handle the num_tokens-only case.
-        let scorer = IndexBM25Scorer::new(std::iter::once(self));
+        let mut postings = postings;
+        for posting in &mut postings {
+            posting.recompute_upper_bounds(docs, scorer.as_ref());
+        }
         let mut wand = Wand::new(operator, postings.into_iter(), docs, scorer)
             .with_shared_threshold(shared_threshold);
         let hits = wand.search(params, mask, metrics)?;
@@ -7644,6 +7659,142 @@ mod tests {
                 expected_idf
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_bm25_search_shared_threshold_keeps_global_bm25_winner() {
+        async fn search_partition_with_shared_floor(
+            partition: Arc<InvertedPartition>,
+            tokens: &Tokens,
+            params: &FtsSearchParams,
+            shared_threshold: Arc<AtomicU32>,
+            scorer: Arc<MemBM25Scorer>,
+        ) -> Vec<DocCandidate> {
+            let metrics = NoOpMetricsCollector;
+            let loaded = partition
+                .load_posting_lists(tokens, params, Operator::Or, &metrics, scorer.as_ref())
+                .await
+                .unwrap();
+            assert!(loaded.grouped_expansions.is_empty());
+
+            let mask = Arc::new(RowAddrMask::all_rows());
+            let docs_for_wand = partition.docs.docs_for_wand(mask.as_ref()).await.unwrap();
+            let mut candidates = partition
+                .bm25_search(
+                    docs_for_wand.as_ref(),
+                    params,
+                    Operator::Or,
+                    mask,
+                    loaded.postings,
+                    &metrics,
+                    shared_threshold,
+                    scorer,
+                )
+                .unwrap();
+            resolve_deferred_candidates(partition.docs.as_ref(), &mut candidates)
+                .await
+                .unwrap();
+            candidates
+        }
+
+        fn candidate_row_ids(candidates: &[DocCandidate]) -> Vec<u64> {
+            candidates
+                .iter()
+                .map(|candidate| match candidate.addr {
+                    CandidateAddr::RowId(row_id) => row_id,
+                    CandidateAddr::Pending(doc_id) => {
+                        panic!("candidate doc_id {doc_id} should have been resolved")
+                    }
+                })
+                .collect()
+        }
+
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        // Partition 0 has a rare single-frequency hit. Its partition-local BM25
+        // score is high enough to raise the shared WAND floor first.
+        let mut builder0 = InnerBuilder::new(0, false, TokenSetFormat::default());
+        builder0.tokens.add("alpha".to_owned());
+        builder0.posting_lists.push(PostingListBuilder::new(false));
+        builder0.posting_lists[0].add(0, PositionRecorder::Count(1));
+        for doc_id in 0..10 {
+            builder0.docs.append(1_000 + doc_id as u64, 1_000);
+        }
+        builder0.write(store.as_ref()).await.unwrap();
+
+        // Partition 1 has alpha in every document, making its partition-local
+        // IDF and block upper bound small. Globally, doc 2000 should still win
+        // because its frequency dominates after applying the global scorer.
+        let mut builder1 = InnerBuilder::new(1, false, TokenSetFormat::default());
+        builder1.tokens.add("alpha".to_owned());
+        builder1.posting_lists.push(PostingListBuilder::new(false));
+        for doc_id in 0..10 {
+            let freq = if doc_id == 0 { 100 } else { 1 };
+            builder1.posting_lists[0].add(doc_id, PositionRecorder::Count(freq));
+            builder1.docs.append(2_000 + doc_id as u64, 100);
+        }
+        builder1.write(store.as_ref()).await.unwrap();
+
+        write_test_metadata(&store, vec![0, 1], InvertedIndexParams::default()).await;
+        let cache = Arc::new(LanceCache::with_capacity(4096));
+        let index = InvertedIndex::load(store.clone(), None, cache.as_ref())
+            .await
+            .unwrap();
+        let first_partition = index
+            .partitions
+            .iter()
+            .find(|partition| partition.id() == 0)
+            .unwrap()
+            .clone();
+        let second_partition = index
+            .partitions
+            .iter()
+            .find(|partition| partition.id() == 1)
+            .unwrap()
+            .clone();
+
+        let tokens = Tokens::new(vec!["alpha".to_owned()], DocType::Text);
+        let params = FtsSearchParams::new().with_limit(Some(1));
+        let global_scorer = Arc::new(index.bm25_base_scorer(&tokens, &params).await.unwrap());
+        let first_global_score =
+            global_scorer.query_weight("alpha") * global_scorer.doc_weight(1, 1_000);
+        let second_global_score =
+            global_scorer.query_weight("alpha") * global_scorer.doc_weight(100, 100);
+        assert!(
+            second_global_score > first_global_score,
+            "test setup must make row 2000 the global winner: \
+             first={first_global_score}, second={second_global_score}"
+        );
+
+        let shared_threshold = Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()));
+        let first_candidates = search_partition_with_shared_floor(
+            first_partition,
+            &tokens,
+            &params,
+            shared_threshold.clone(),
+            global_scorer.clone(),
+        )
+        .await;
+        assert_eq!(candidate_row_ids(&first_candidates), vec![1_000]);
+
+        let second_candidates = search_partition_with_shared_floor(
+            second_partition,
+            &tokens,
+            &params,
+            shared_threshold,
+            global_scorer,
+        )
+        .await;
+        assert_eq!(
+            candidate_row_ids(&second_candidates),
+            vec![2_000],
+            "shared WAND threshold must not prune the row that wins under global BM25"
+        );
     }
 
     async fn write_test_metadata(

--- a/rust/lance-index/src/scalar/inverted/lazy_docset.rs
+++ b/rust/lance-index/src/scalar/inverted/lazy_docset.rs
@@ -9,10 +9,9 @@
 //! cold object storage that's tens of GiB of IO before a query has even
 //! checked whether a partition contains the term it's looking for.
 //!
-//! [`LazyDocSet`] defers the load. Cheap sync getters (`len`,
-//! `total_tokens_cached`) work without IO; async getters fetch on
-//! demand and cache. Wand scoring still needs per-doc num_tokens, but
-//! only partitions that actually contribute hits pay
+//! [`LazyDocSet`] defers the load. The cheap sync getter (`len`) works
+//! without IO; async getters fetch on demand and cache. Wand scoring
+//! still needs per-doc num_tokens, but only partitions that actually contribute hits pay
 //! `ensure_num_tokens_loaded`/`ensure_loaded`.
 
 use std::sync::Arc;
@@ -153,18 +152,6 @@ impl LazyDocSet {
         match self {
             Self::Loaded(l) => l.num_rows,
             Self::Deferred(d) => d.num_rows,
-        }
-    }
-
-    /// Sync read of cached `total_tokens`. Returns `None` for a
-    /// `Deferred` LazyDocSet that hasn't yet had any of
-    /// `total_tokens_num` / `ensure_num_tokens_loaded` / `ensure_loaded`
-    /// run. Used by sync scoring code that has already paid for one
-    /// of those async calls.
-    pub fn total_tokens_cached(&self) -> Option<u64> {
-        match self {
-            Self::Loaded(l) => Some(l.total_tokens),
-            Self::Deferred(d) => d.total_tokens.get().copied(),
         }
     }
 

--- a/rust/lance-index/src/scalar/inverted/scorer.rs
+++ b/rust/lance-index/src/scalar/inverted/scorer.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use super::InvertedPartition;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 // the Scorer trait is used to calculate the score of a token in a document
 // in general, the score is calculated as:
@@ -10,6 +10,16 @@ use std::collections::HashMap;
 pub trait Scorer: Send + Sync {
     fn query_weight(&self, token: &str) -> f32;
     fn doc_weight(&self, freq: u32, doc_tokens: u32) -> f32;
+}
+
+impl<T: Scorer + ?Sized> Scorer for Arc<T> {
+    fn query_weight(&self, token: &str) -> f32 {
+        self.as_ref().query_weight(token)
+    }
+
+    fn doc_weight(&self, freq: u32, doc_tokens: u32) -> f32 {
+        self.as_ref().doc_weight(freq, doc_tokens)
+    }
 }
 
 // BM25 parameters
@@ -80,70 +90,6 @@ impl Scorer for MemBM25Scorer {
         let freq = freq as f32;
         let doc_tokens = doc_tokens as f32;
         let doc_norm = K1 * (1.0 - B + B * doc_tokens / self.avg_doc_length());
-        (K1 + 1.0) * freq / (freq + doc_norm)
-    }
-}
-
-pub struct IndexBM25Scorer<'a> {
-    partitions: Vec<&'a InvertedPartition>,
-    num_docs: usize,
-    avg_doc_length: f32,
-}
-
-impl<'a> IndexBM25Scorer<'a> {
-    /// Sync constructor. Reads each partition's cached `total_tokens` via
-    /// `LazyDocSet::total_tokens_cached()`; callers must have already
-    /// populated it (via `ensure_loaded`, `ensure_num_tokens_loaded`, or
-    /// `total_tokens_num`). Panics with a clear message otherwise — this
-    /// is the wand-scoring path where the contract is statically known.
-    pub fn new(partitions: impl Iterator<Item = &'a InvertedPartition>) -> Self {
-        let partitions = partitions.collect::<Vec<_>>();
-        let num_docs = partitions.iter().map(|p| p.docs.len()).sum();
-        let total_tokens: u64 = partitions
-            .iter()
-            .map(|p| {
-                p.docs.total_tokens_cached().expect(
-                    "IndexBM25Scorer::new requires each partition's total_tokens to be \
-                     cached; call `ensure_loaded` / `ensure_num_tokens_loaded` / \
-                     `total_tokens_num` first",
-                )
-            })
-            .sum();
-        let avgdl = total_tokens as f32 / num_docs as f32;
-        Self {
-            partitions,
-            num_docs,
-            avg_doc_length: avgdl,
-        }
-    }
-
-    pub fn num_docs_containing_token(&self, token: &str) -> usize {
-        self.partitions
-            .iter()
-            .map(|part| {
-                if let Some(token_id) = part.tokens.get(token) {
-                    part.inverted_list.posting_len(token_id)
-                } else {
-                    0
-                }
-            })
-            .sum()
-    }
-}
-
-impl Scorer for IndexBM25Scorer<'_> {
-    fn query_weight(&self, token: &str) -> f32 {
-        let token_docs = self.num_docs_containing_token(token);
-        if token_docs == 0 {
-            return 0.0;
-        }
-        idf(token_docs, self.num_docs)
-    }
-
-    fn doc_weight(&self, freq: u32, doc_tokens: u32) -> f32 {
-        let freq = freq as f32;
-        let doc_tokens = doc_tokens as f32;
-        let doc_norm = K1 * (1.0 - B + B * doc_tokens / self.avg_doc_length);
         (K1 + 1.0) * freq / (freq + doc_norm)
     }
 }

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -56,6 +56,7 @@ pub struct PostingIterator {
     // the index of current block, this can be changed by `next() and shallow_next()`
     block_idx: usize,
     approximate_upper_bound: f32,
+    block_upper_bounds: Option<Vec<f32>>,
 
     // for compressed posting list
     compressed: Option<UnsafeCell<CompressedState>>,
@@ -150,6 +151,7 @@ impl BlockMaxWindow {
     fn max_score_up_to(
         &mut self,
         list: &CompressedPostingList,
+        block_upper_bounds: Option<&[f32]>,
         start_block_idx: usize,
         up_to: u64,
     ) -> BlockMaxScore {
@@ -182,7 +184,9 @@ impl BlockMaxWindow {
         while self.next_block_idx < list.blocks.len()
             && list.block_least_doc_id(self.next_block_idx) as u64 <= up_to
         {
-            let score = list.block_max_score(self.next_block_idx);
+            let score = block_upper_bounds
+                .and_then(|scores| scores.get(self.next_block_idx).copied())
+                .unwrap_or_else(|| list.block_max_score(self.next_block_idx));
             while matches!(self.max_scores.back(), Some((_, old_score)) if *old_score <= score) {
                 self.max_scores.pop_back();
             }
@@ -319,7 +323,57 @@ impl PostingIterator {
             index: 0,
             block_idx: 0,
             approximate_upper_bound,
+            block_upper_bounds: None,
             compressed: is_compressed.then(|| UnsafeCell::new(CompressedState::new())),
+        }
+    }
+
+    pub(crate) fn recompute_upper_bounds<S: Scorer>(&mut self, docs: &DocSet, scorer: &S) {
+        match self.list {
+            PostingList::Compressed(ref list) => {
+                let mut block_upper_bounds = Vec::with_capacity(list.blocks.len());
+                let mut doc_ids = Vec::with_capacity(BLOCK_SIZE);
+                let mut freqs = Vec::with_capacity(BLOCK_SIZE);
+                let mut buffer = Box::new([0; BLOCK_SIZE]);
+                let remainder = list.length as usize % BLOCK_SIZE;
+
+                for block_idx in 0..list.blocks.len() {
+                    doc_ids.clear();
+                    freqs.clear();
+                    let block = list.blocks.value(block_idx);
+                    let is_remainder_block = remainder != 0 && block_idx + 1 == list.blocks.len();
+                    if is_remainder_block {
+                        decompress_posting_remainder(
+                            block,
+                            remainder,
+                            list.posting_tail_codec,
+                            &mut doc_ids,
+                            &mut freqs,
+                        );
+                    } else {
+                        decompress_posting_block(block, &mut buffer, &mut doc_ids, &mut freqs);
+                    }
+
+                    let block_upper_bound = doc_ids
+                        .iter()
+                        .zip(freqs.iter())
+                        .map(|(&doc_id, &freq)| {
+                            self.query_weight * scorer.doc_weight(freq, docs.num_tokens(doc_id))
+                        })
+                        .fold(0.0, f32::max);
+                    block_upper_bounds.push(block_upper_bound);
+                }
+                self.approximate_upper_bound =
+                    block_upper_bounds.iter().copied().fold(0.0, f32::max);
+                self.block_upper_bounds = Some(block_upper_bounds);
+            }
+            PostingList::Plain(_) => {
+                // Plain / legacy postings do not carry scorer-space impacts we
+                // can recompute by block here, so use the BM25 doc-weight
+                // ceiling as a conservative bound.
+                self.approximate_upper_bound = self.query_weight * (K1 + 1.0);
+                self.block_upper_bounds = None;
+            }
         }
     }
 
@@ -496,7 +550,11 @@ impl PostingIterator {
     #[inline]
     fn block_max_score(&self) -> f32 {
         match self.list {
-            PostingList::Compressed(ref list) => list.block_max_score(self.block_idx),
+            PostingList::Compressed(ref list) => self
+                .block_upper_bounds
+                .as_ref()
+                .and_then(|scores| scores.get(self.block_idx).copied())
+                .unwrap_or_else(|| list.block_max_score(self.block_idx)),
             PostingList::Plain(_) => self.approximate_upper_bound,
         }
     }
@@ -506,9 +564,12 @@ impl PostingIterator {
         match self.list {
             PostingList::Compressed(ref list) => {
                 let compressed = unsafe { &mut *self.compressed_state_ptr() };
-                compressed
-                    .block_max_window
-                    .max_score_up_to(list, self.block_idx, up_to)
+                compressed.block_max_window.max_score_up_to(
+                    list,
+                    self.block_upper_bounds.as_deref(),
+                    self.block_idx,
+                    up_to,
+                )
             }
             PostingList::Plain(_) => BlockMaxScore {
                 score: self.approximate_upper_bound,
@@ -728,8 +789,9 @@ pub struct Wand<'a, S: Scorer> {
     docs: &'a DocSet,
     scorer: S,
     // Shared cross-partition top-k floor. Each partition publishes its local
-    // k-th score (`atomic_store_max_f32`) and prunes against the running value
-    // -- a lower bound on the global k-th, so it never drops a real top-k doc.
+    // k-th score (`atomic_store_max_f32`) and prunes against the running value.
+    // This is correct only when WAND exact scoring, final aggregation, and all
+    // block / tail upper bounds are expressed in the same BM25 score space.
     shared_threshold: Option<Arc<AtomicU32>>,
 }
 
@@ -1210,7 +1272,8 @@ impl<'a, S: Scorer> Wand<'a, S> {
             }
 
             // Block-Max WAND pruning: skip the whole window when its score upper
-            // bound cannot reach the top-k threshold.
+            // bound cannot reach the top-k threshold. The bound and threshold
+            // must be in the same BM25 score space.
             if self.threshold > 0.0 && self.or_block_window_max() <= self.threshold {
                 // On the final block `up_to` is the `u64::MAX` sentinel; step once
                 // there to avoid seeking past the valid doc id range.
@@ -1978,7 +2041,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
-    use crate::scalar::inverted::scorer::IndexBM25Scorer;
     use crate::{
         metrics::{MetricsCollector, NoOpMetricsCollector},
         scalar::inverted::{
@@ -2238,8 +2300,7 @@ mod tests {
             ),
         ];
 
-        let bm25 = IndexBM25Scorer::new(std::iter::empty());
-        let mut wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        let mut wand = Wand::new(Operator::And, postings.into_iter(), &docs, UnitScorer);
         // This should trigger the bug when the second posting list becomes empty
         let result = wand
             .search(
@@ -2364,8 +2425,7 @@ mod tests {
             ),
         ];
 
-        let bm25 = IndexBM25Scorer::new(std::iter::empty());
-        let mut wand = Wand::new(Operator::Or, postings.into_iter(), &docs, bm25);
+        let mut wand = Wand::new(Operator::Or, postings.into_iter(), &docs, UnitScorer);
 
         // set a threshold that the sum of max scores can hit,
         // but the sum of block max scores is less than the threshold,
@@ -3393,8 +3453,7 @@ mod tests {
             ),
         ];
 
-        let bm25 = IndexBM25Scorer::new(std::iter::empty());
-        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, UnitScorer);
         assert!(wand.check_exact_positions());
         assert!(wand.check_positions(0));
     }
@@ -3431,8 +3490,7 @@ mod tests {
             ),
         ];
 
-        let bm25 = IndexBM25Scorer::new(std::iter::empty());
-        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, UnitScorer);
         assert!(wand.check_exact_positions());
         assert!(wand.check_positions(0));
     }


### PR DESCRIPTION
## Bug Fix

### What is the bug?
Partition WAND candidate generation used partition-local BM25 statistics while final indexed FTS scoring used the global BM25 scorer. Because WAND also shares a top-k floor across partitions, one partition could publish a threshold in a different score space and cause another partition to prune a candidate that should win under the global scorer.

### What incorrect behavior does this cause?
Multi-partition FTS queries could drop the correct global top-k result when local term distributions differ from global term distributions.

### How does this PR fix the problem?
- Materializes one active `MemBM25Scorer` for each indexed BM25 search and threads it through posting loading, WAND scoring, and final aggregation.
- Computes posting query weights from the active scorer instead of partition-local IDF.
- Recomputes compressed posting block upper bounds in the active scorer's score space before WAND pruning.
- Uses a conservative BM25 ceiling for plain postings without usable scorer-space impacts.
- Removes the obsolete partition-local `IndexBM25Scorer` path.
- Adds a regression test where a shared threshold previously pruned the row that wins under global BM25.

Linear: https://linear.app/lancedb/issue/OSS-1345/use-global-bm25-scorer-for-partition-wand-pruning

## Validation

- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/tmp/lance-target-oss-1345 cargo test -p lance-index test_bm25_search_shared_threshold_keeps_global_bm25_winner -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/lance-target-oss-1345 cargo test -p lance-index scalar::inverted::wand::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/lance-target-oss-1345 cargo test -p lance io::exec::fts::tests::test_match_query_exec_with_base_scorer_matches_baseline -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/lance-target-oss-1345 cargo test -p lance-index fuzzy_and -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/lance-target-oss-1345 cargo clippy -p lance-index -p lance --tests -- -D warnings`