### PR TITLE
fix: return Arrow JSON from FragmentSession.take

### DIFF
--- a/python/python/tests/test_json.py
+++ b/python/python/tests/test_json.py
@@ -861,3 +861,34 @@ def test_json_merge_insert(tmp_path: Path):
 
     result = dataset.to_table(filter="json_get_int(data, 'score') >= 35")
     assert result.num_rows == 2
+
+
+def test_json_fragment_session_take(tmp_path: Path):
+    """FragmentSession.take must return JSON columns as pa.json_(), not raw JSONB."""
+
+    dataset_path = tmp_path / "json_fragment_session.lance"
+
+    table = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4, 5], type=pa.int32()),
+            "data": pa.array(
+                [json.dumps({"name": "row", "score": v}) for v in range(5)],
+                type=pa.json_(),
+            ),
+        }
+    )
+    lance.write_dataset(table, dataset_path)
+
+    dataset = lance.dataset(dataset_path)
+    fragment = dataset.get_fragments()[0]
+    session = fragment.open_session(columns=["id", "data"])
+    result = session.take([0, 2, 4])
+
+    # JSON column must be the logical pa.json_() type, not raw LargeBinary JSONB.
+    assert result.schema.field("data").type == pa.json_()
+    assert result.column("id").to_pylist() == [1, 3, 5]
+    assert [json.loads(v) for v in result.column("data").to_pylist()] == [
+        {"name": "row", "score": 0},
+        {"name": "row", "score": 2},
+        {"name": "row", "score": 4},
+    ]

--- a/rust/lance/src/dataset/fragment/session.rs
+++ b/rust/lance/src/dataset/fragment/session.rs
@@ -54,7 +54,20 @@ impl FragmentSession {
         };
 
         // Then call take rows
-        self.take_rows(&row_ids).await
+        let batch = self.take_rows(&row_ids).await?;
+
+        // Convert Lance JSON columns (LargeBinary/JSONB) back to Arrow JSON (Utf8)
+        // for user-facing output, mirroring FileFragment::take.
+        if batch
+            .schema()
+            .fields()
+            .iter()
+            .any(|f| lance_arrow::json::is_json_field(f) || lance_arrow::json::has_json_fields(f))
+        {
+            Ok(lance_arrow::json::convert_lance_json_to_arrow(&batch)?)
+        } else {
+            Ok(batch)
+        }
     }
 
     pub(crate) async fn take_rows(&self, row_offsets: &[u32]) -> Result<RecordBatch> {
@@ -202,6 +215,78 @@ mod tests {
             batch.column_by_name(ROW_ADDR).unwrap().as_ref(),
             &UInt64Array::from(vec![(3 << 32) + 1, (3 << 32) + 5, (3 << 32) + 8])
         );
+    }
+
+    #[tokio::test]
+    async fn test_fragment_session_take_json() {
+        use arrow_array::LargeBinaryArray;
+        use lance_arrow::ARROW_EXT_NAME_KEY;
+        use lance_arrow::json::{ARROW_JSON_EXT_NAME, JsonArray, json_field};
+
+        let test_dir = TempStrDir::default();
+        let test_uri = &test_dir;
+
+        // Build a schema with a Lance JSON column (LargeBinary + lance.json metadata).
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, true),
+            json_field("j", true),
+        ]));
+
+        let json_strings = (0..10)
+            .map(|v| Some(format!("{{\"v\":{}}}", v)))
+            .collect::<Vec<_>>();
+        let jsonb = JsonArray::try_from_iter(json_strings).unwrap().into_inner();
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..10)),
+                Arc::new(jsonb),
+            ],
+        )
+        .unwrap();
+
+        let write_params = WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_2),
+            ..Default::default()
+        };
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let dataset = Dataset::write(batches, test_uri, Some(write_params))
+            .await
+            .unwrap();
+
+        let fragment = dataset.get_fragments().into_iter().next().unwrap();
+        let take_session = fragment
+            .open_session(dataset.schema(), false)
+            .await
+            .unwrap();
+        let result = take_session.take(&[0, 3, 7]).await.unwrap();
+
+        // The JSON column must be returned as Arrow JSON (Utf8 + arrow.json), not raw JSONB.
+        let field = result.schema().field_with_name("j").unwrap().clone();
+        assert_eq!(field.data_type(), &DataType::Utf8);
+        assert_eq!(
+            field.metadata().get(ARROW_EXT_NAME_KEY).map(|s| s.as_str()),
+            Some(ARROW_JSON_EXT_NAME)
+        );
+        assert!(
+            result
+                .column_by_name("j")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .is_none(),
+            "JSON column should not be raw LargeBinary JSONB"
+        );
+        let json_col = result
+            .column_by_name("j")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("JSON column should be Utf8 strings");
+        assert_eq!(json_col.value(0), "{\"v\":0}");
+        assert_eq!(json_col.value(1), "{\"v\":3}");
+        assert_eq!(json_col.value(2), "{\"v\":7}");
     }
 
     async fn create_dataset(test_uri: &str, data_storage_version: LanceFileVersion) -> Dataset {


### PR DESCRIPTION
## Problem
`FragmentSession.take` returns JSON columns as raw Lance JSONB (LargeBinary) instead of the logical Arrow JSON (`pa.json_()`) type.

## Root cause
The take path did not convert Lance JSON (LargeBinary/JSONB) back to Arrow JSON (Utf8) for user-facing output.

## Fix
Convert via `lance_arrow::json::convert_lance_json_to_arrow` when the batch contains JSON fields.

## Test
Rust `test_fragment_session_take_json`; Python `test_json_fragment_session_take`.