### PR TITLE
docs: clarify Lance format stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,14 @@ For more details, see the full [Lance format specification](https://lance.org/fo
 > [!TIP]
 > Lance is in active development and we welcome contributions. Please see our [contributing guide](https://lance.org/community/contributing/) for more information.
 
-## Format stability
+## File format stability
 
-Lance releases frequently because the SDKs, integrations, and performance work are moving quickly. This does not mean the Lance format changes incompatibly in every release. The Lance format is identified by the `data_storage_version` stored in each dataset and stable storage versions are a long-term compatibility contract.
+Lance releases frequently because the SDKs, integrations, and performance work are moving quickly. This does not mean the Lance file format changes incompatibly in every release. The Lance file format is identified by the `data_storage_version` stored in each dataset, and stable storage versions are a long-term compatibility contract.
 
 * Once a dataset is written with a stable `data_storage_version`, future Lance releases will continue to support reading that storage version.
-* A dataset's `data_storage_version` is fixed when the dataset is created. Later appends and updates keep using that dataset's storage version.
-* SDK and API compatibility is separate from format compatibility. SDK/API changes follow semantic versioning and are documented in the [migration guide](https://lance.org/guide/migration/).
-* Older Lance releases may not understand storage versions introduced later. If you run mixed Lance versions, pin `data_storage_version` for deterministic writes.
-* The `next` format alias is unstable and should only be used for experimentation, never for production data.
+* SDK and API compatibility is separate from file format compatibility. SDK/API changes follow semantic versioning and are documented in the [migration guide](https://lance.org/guide/migration/).
+* Older Lance releases may not understand file format versions introduced later. If you run mixed Lance versions, pin `data_storage_version` for deterministic writes.
+* The `next` file format alias is unstable and should only be used for experimentation, never for production data.
 
 For production, write data with a stable `data_storage_version`. See the [format versioning guide](https://lance.org/format/file/versioning/) for the current compatibility matrix.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ For more details, see the full [Lance format specification](https://lance.org/fo
 > [!TIP]
 > Lance is in active development and we welcome contributions. Please see our [contributing guide](https://lance.org/community/contributing/) for more information.
 
+## Format stability
+
+Lance releases frequently because the SDKs, integrations, and performance work are moving quickly. This does not mean the Lance format changes incompatibly in every release. The Lance format is identified by the `data_storage_version` stored in each dataset and stable storage versions are a long-term compatibility contract.
+
+* Once a dataset is written with a stable `data_storage_version`, future Lance releases will continue to support reading that storage version.
+* A dataset's `data_storage_version` is fixed when the dataset is created. Later appends and updates keep using that dataset's storage version.
+* SDK and API compatibility is separate from format compatibility. SDK/API changes follow semantic versioning and are documented in the [migration guide](https://lance.org/guide/migration/).
+* Older Lance releases may not understand storage versions introduced later. If you run mixed Lance versions, pin `data_storage_version` for deterministic writes.
+* The `next` format alias is unstable and should only be used for experimentation, never for production data.
+
+For production, write data with a stable `data_storage_version`. See the [format versioning guide](https://lance.org/format/file/versioning/) for the current compatibility matrix.
+
 ## Quick Start
 
 **Installation**


### PR DESCRIPTION
Lance releases frequently, which can make users worry that the Lance format itself is unstable. This PR updates the README to distinguish SDK/API release cadence from the dataset `data_storage_version` compatibility contract.

It explicitly states that stable storage versions remain readable by future Lance releases, that a dataset's storage version is fixed at creation, and that `next` is only for experimentation.
