### PR TITLE
docs: correct file-format version matrix for 2.2 stable / 2.3 unstable

### DIFF
--- a/docs/src/format/file/versioning.md
+++ b/docs/src/format/file/versioning.md
@@ -11,7 +11,7 @@ no longer readable by any newer versions of Lance. The `next` version should onl
 benchmarking upcoming features.
 
 The `stable` and `next` aliases are resolved by the specific Lance release you are using. During a format rollout
-(for example, 2.2), prefer explicit version pinning for deterministic behavior across environments.
+(for example, 2.3), prefer explicit version pinning for deterministic behavior across environments.
 
 The following values are supported:
 
@@ -20,7 +20,8 @@ The following values are supported:
 | 0.1            | Any                   | 0.34 (write)          | This is the initial Lance format. It is no longer writable. |
 | 2.0            | 0.16.0                | Any                   | Rework of the Lance file format that removed row groups and introduced null support for lists, fixed size lists, and primitives |
 | 2.1            | 0.38.1                | Any                   | Enhances integer and string compression, adds support for nulls in struct fields, and improves random access performance with nested fields. |
-| 2.2 (unstable) | None                  | Any                   | Adds support for newer nested type/encoding capabilities (including map support) and 2.2-era storage features. |
+| 2.2            | None                  | Any                   | Adds support for newer nested type/encoding capabilities (including map support) and 2.2-era storage features. |
+| 2.3 (unstable) | None                  | Any                   | Adds experimental encodings for upcoming features. |
 | legacy         | N/A                   | N/A                   | Alias for 0.1 |
-| stable         | N/A                   | N/A                   | Alias for the latest stable version in the Lance release you are running. |
+| stable         | N/A                   | N/A                   | Alias for the default version for new datasets in the Lance release you are running. |
 | next           | N/A                   | N/A                   | Alias for the latest unstable version in the Lance release you are running.|


### PR DESCRIPTION
## What

`docs/src/format/file/versioning.md`'s version matrix drifted out of sync with the code after #6088 ("mark 2.2 as stable and add 2.3 as the next file format version"). This corrects it to match `LanceFileVersion` (`is_unstable() = self >= Next`, `Next` resolves to 2.3, `Stable` resolves to the default 2.1):

- **2.2** — drop the stale `(unstable)` label; `V2_2.is_unstable()` is `false`.
- **2.3** — add the missing `2.3 (unstable)` row, which is what the `next` alias resolves to.
- **`stable` alias** — was described as "the latest stable version", but it resolves to `default()` = 2.1, so describe it as "the default version for new datasets".
- **Rollout example** — update "(for example, 2.2)" → "2.3" (2.3 is the current unstable rollout).

Documentation only; no code changes.

## Out of scope (potential follow-ups)

- The `2.2 | None` *Minimal Lance Version* cell may now be stale (2.2 shipped stable in #6088), but the exact minimal release is left unchanged here to avoid guessing across the version-number renumbering.
- `Dataset.getLanceFileFormatVersion()`'s Javadoc enumerates return values up to 2.2 and should also mention 2.3 (pre-existing, separate file).
