### PR TITLE
fix(rowids): tolerate sparse overlapping chunks in the stable row id index

### DIFF
--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -5,10 +5,10 @@ use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use super::{RowIdSequence, U64Segment};
-use lance_core::Result;
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::deletion::DeletionVector;
+use lance_core::{Error, Result};
 use rangemap::RangeInclusiveMap;
 
 /// An index of row ids
@@ -46,18 +46,10 @@ impl RowIdIndex {
                 RawIndexChunk::NonOverlapping(chunk) => {
                     final_chunks.push(chunk);
                 }
-                RawIndexChunk::Overlapping(range, overlapping_chunks) => {
-                    debug_assert_eq!(
-                        range.end() - range.start() + 1,
-                        overlapping_chunks
-                            .iter()
-                            .map(|(_, (seq, _))| seq.len() as u64)
-                            .sum::<u64>(),
-                        "Wrong range for {:?}, chunks: {:?}",
-                        range,
-                        overlapping_chunks,
-                    );
-                    // Merge overlapping chunks.
+                RawIndexChunk::Overlapping(_range, overlapping_chunks) => {
+                    // Intersecting row-id ranges don't imply intersecting id sets;
+                    // sparse ids and deletion holes leave the union short of the span.
+                    // The real invariant (no id in two fragments) is checked in the merge.
                     let merged_chunk = merge_overlapping_chunks(overlapping_chunks)?;
                     final_chunks.push(merged_chunk);
                 }
@@ -357,6 +349,14 @@ fn merge_overlapping_chunks(overlapping_chunks: Vec<IndexChunk>) -> Result<Index
         values.extend(row_ids.iter().zip(row_addrs.iter()));
     }
     values.sort_by_key(|(row_id, _)| *row_id);
+    // A duplicate row id here means two fragments claim the same live id: a
+    // corrupt index, not a resolvable sparse-coverage case.
+    if let Some(w) = values.windows(2).find(|w| w[0].0 == w[1].0) {
+        return Err(Error::internal(format!(
+            "row id index corrupt: stable row id {} is live in multiple fragments",
+            w[0].0
+        )));
+    }
     let row_id_segment = U64Segment::from_iter(values.iter().map(|(row_id, _)| *row_id));
     let address_segment = U64Segment::from_iter(values.iter().map(|(_, row_addr)| *row_addr));
 
@@ -522,6 +522,41 @@ mod tests {
         assert_eq!(index.get(50), Some(RowAddress::new_from_parts(1, 0)));
         assert_eq!(index.get(51), Some(RowAddress::new_from_parts(0, 50)));
         assert_eq!(index.get(99), Some(RowAddress::new_from_parts(0, 98)));
+    }
+
+    #[test]
+    fn test_overlapping_chunks_sparse_with_deletions() {
+        // Interleaved (overlapping) id ranges plus a deletion that leaves a hole,
+        // so the union doesn't tile the span. Every live id must still resolve.
+        let fragment_indices = vec![
+            FragmentRowIdIndex {
+                fragment_id: 10,
+                row_id_sequence: Arc::new(RowIdSequence(vec![U64Segment::SortedArray(
+                    vec![1, 3, 5, 7, 9].into(),
+                )])),
+                deletion_vector: Arc::new(DeletionVector::default()),
+            },
+            FragmentRowIdIndex {
+                fragment_id: 20,
+                row_id_sequence: Arc::new(RowIdSequence(vec![U64Segment::SortedArray(
+                    vec![0, 2, 4, 6, 8].into(),
+                )])),
+                // Delete offset 2 (id 4) -> a hole in the span.
+                deletion_vector: Arc::new(DeletionVector::from_iter(vec![2])),
+            },
+        ];
+
+        let index = RowIdIndex::new(&fragment_indices).unwrap();
+
+        assert_eq!(index.get(0), Some(RowAddress::new_from_parts(20, 0)));
+        assert_eq!(index.get(1), Some(RowAddress::new_from_parts(10, 0)));
+        assert_eq!(index.get(2), Some(RowAddress::new_from_parts(20, 1)));
+        assert_eq!(index.get(3), Some(RowAddress::new_from_parts(10, 1)));
+        assert_eq!(index.get(4), None);
+        // Surviving ids keep their original offsets (the hole is not compacted).
+        assert_eq!(index.get(6), Some(RowAddress::new_from_parts(20, 3)));
+        assert_eq!(index.get(8), Some(RowAddress::new_from_parts(20, 4)));
+        assert_eq!(index.get(9), Some(RowAddress::new_from_parts(10, 4)));
     }
 
     #[test]

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -2541,6 +2541,127 @@ mod tests {
         t
     }
 
+    // An update-style merge_insert leaves the source and new fragments with
+    // overlapping id ranges; a scattered delete punches holes in that range. A
+    // filtered `with_row_id` scan must still resolve every id (round-tripped via take).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn merge_insert_then_delete_resolves_overlapping_row_ids() {
+        use arrow_array::ArrayRef;
+        use arrow_array::types::UInt64Type;
+        let dir = TempStrDir::default();
+        let uri = dir.as_str();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("slug", DataType::Utf8, false),
+            Field::new("title", DataType::Utf8, false),
+            Field::new("category", DataType::Utf8, false),
+        ]));
+        let mk = |slugs: Vec<String>, titles: Vec<String>| {
+            let cats: Vec<String> = (0..slugs.len())
+                .map(|i| ["A", "B", "C", "D", "E"][i % 5].to_string())
+                .collect();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(slugs)) as ArrayRef,
+                    Arc::new(StringArray::from(titles)) as ArrayRef,
+                    Arc::new(StringArray::from(cats)) as ArrayRef,
+                ],
+            )
+            .unwrap()
+        };
+
+        // Empty dataset with stable row ids; write-seed 40 rows (ids 0..40).
+        let params = WriteParams {
+            mode: WriteMode::Create,
+            enable_stable_row_ids: true,
+            ..Default::default()
+        };
+        let mut ds = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(mk(vec![], vec![]))], schema.clone()),
+            uri,
+            Some(params),
+        )
+        .await
+        .unwrap();
+        ds.append(
+            RecordBatchIterator::new(
+                vec![Ok(mk(
+                    (1..=40).map(|i| format!("t{i}")).collect(),
+                    (1..=40).map(|i| format!("r{i}")).collect(),
+                ))],
+                schema.clone(),
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Update every other row (so the new fragment's ids interleave with -- and
+        // its range overlaps -- the source's) plus a few inserts.
+        let mut slugs: Vec<String> = (1..=40).step_by(2).map(|i| format!("t{i}")).collect();
+        let mut titles: Vec<String> = (1..=40).step_by(2).map(|i| format!("e{i}")).collect();
+        for i in 41..=45 {
+            slugs.push(format!("t{i}"));
+            titles.push(format!("e{i}"));
+        }
+        let mut b = MergeInsertBuilder::try_new(Arc::new(ds), vec!["slug".into()]).unwrap();
+        b.when_matched(WhenMatched::UpdateAll);
+        b.when_not_matched(WhenNotMatched::InsertAll);
+        let (ds, _) = b
+            .try_build()
+            .unwrap()
+            .execute_reader(RecordBatchIterator::new(
+                vec![Ok(mk(slugs, titles))],
+                schema.clone(),
+            ))
+            .await
+            .unwrap();
+
+        // Scattered delete -> interior holes in the overlapped id range.
+        let mut ds = (*ds).clone();
+        let ds = (*ds.delete("category = 'A'").await.unwrap().new_dataset).clone();
+
+        // The `with_row_id` scan builds the RowIdIndex; every scanned id must
+        // round-trip through take_rows.
+        let batches: Vec<RecordBatch> = ds
+            .scan()
+            .with_row_id()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let row_ids: Vec<u64> = batches
+            .iter()
+            .flat_map(|b| {
+                b.column_by_name(ROW_ID)
+                    .unwrap()
+                    .as_primitive::<UInt64Type>()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        let scanned_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        let taken = ds.take_rows(&row_ids, ds.schema().clone()).await.unwrap();
+        assert_eq!(taken.num_rows(), scanned_rows);
+
+        // A point lookup on a surviving row resolves to exactly one row.
+        let filtered: Vec<RecordBatch> = ds
+            .scan()
+            .with_row_id()
+            .filter("slug = 't30'")
+            .unwrap()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let n: usize = filtered.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(n, 1, "expected exactly one row for slug='t30'");
+    }
+
     async fn check_then_refresh_dataset(
         new_data: RecordBatch,
         mut job: MergeInsertJob,


### PR DESCRIPTION
An update-style merge_insert under stable row ids leaves the source fragment's id range overlapping the new fragment's, and a later delete punches holes in that range. RowIdIndex::new wrongly asserted that overlapping chunks densely tile their range, so a filtered with_row_id scan panicked under debug assertions. Overlap of ranges is not overlap of id sets: drop the assert and instead hard-error on the real invariant -- the same live id present in two fragments.