### PR TITLE
docs: add feature maturity info to versioning & FTS docs

### DIFF
--- a/docs/src/format/index/scalar/fts.md
+++ b/docs/src/format/index/scalar/fts.md
@@ -9,6 +9,25 @@ It's designed for high-performance text search with support for various scoring 
 %%% proto.message.InvertedIndexDetails %%%
 ```
 
+## Format Versions
+
+The FTS index has gone through several on-disk format generations. A reader transparently
+reads any generation at or below the version it supports; the format only matters when
+*building* an index, and is selected per index build. Changing an existing index's format
+requires dropping and rebuilding it.
+
+| Version | Minimal Lance Version | Maximum Lance Version | Description |
+|---------|-----------------------|-----------------------|-------------|
+| Legacy (Arrow token set) | 0.14.1 (2024-07-11) | Any (read) | Original inverted index using the Arrow `TokenSetFormat`. |
+| v1 (FST token set + compression) | 0.28.0 (2025-05-26) | Any | FST-based token dictionary with compressed posting lists and per-document compressed positions. Current default. |
+| v2 (shared position streams) | 6.0.0 (2026-05-11) | Any | Shared posting-list position streams and a new phrase-query algorithm. |
+
+To build a new index in v2, set `LANCE_FTS_FORMAT_VERSION=2`; the default is v1. This
+environment variable is currently the only way to select the format version — there is no
+per-index creation parameter. It affects only newly built indices: a reader on 6.0.0 or
+later reads both v1 and v2 indices automatically. A v2 index cannot be read by any release
+before 6.0.0.
+
 ## Storage Layout
 
 The FTS index consists of multiple files storing the token dictionary, document information, and posting lists:

--- a/docs/src/format/table/versioning.md
+++ b/docs/src/format/table/versioning.md
@@ -15,20 +15,62 @@ they should return an "unsupported" error on any read or write operation.
 .feature-flags-table th:nth-child(2),
 .feature-flags-table td:nth-child(2) {
   white-space: nowrap;
-  min-width: 250px;
 }
 </style>
 
 <div class="feature-flags-table" markdown="1">
 
-| Flag Bit | Flag Name                       | Reader Required | Writer Required | Description                                                                                                 |
-|----------|---------------------------------|-----------------|-----------------|-------------------------------------------------------------------------------------------------------------|
-| 1        | `FLAG_DELETION_FILES`           | Yes             | Yes             | Fragments may contain deletion files, which record the tombstones of soft-deleted rows.                     |
-| 2        | `FLAG_STABLE_ROW_IDS`           | Yes             | Yes             | Row IDs are stable for both moves and updates. Fragments contain an index mapping row IDs to row addresses. |
-| 4        | `FLAG_USE_V2_FORMAT_DEPRECATED` | No              | No              | Files are written with the new v2 format. This flag is deprecated and no longer used.                       |
-| 8        | `FLAG_TABLE_CONFIG`             | No              | Yes             | Table config is present in the manifest.                                                                    |
-| 16       | `FLAG_BASE_PATHS`               | Yes             | Yes             | Dataset uses multiple base paths (for shallow clones or multi-base datasets).                               |
+| Flag Bit | Flag Name                       | Reader Required | Writer Required | Introduced          | Enabled by                                                      | Description                                                                                                 |
+|----------|---------------------------------|-----------------|-----------------|---------------------|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| 1        | `FLAG_DELETION_FILES`           | Yes             | Yes             | v0.5.0 (2023-06-23) | Automatic when rows are soft-deleted                           | Fragments may contain deletion files, which record the tombstones of soft-deleted rows.                     |
+| 2        | `FLAG_STABLE_ROW_IDS`           | Yes             | Yes             | v0.12.0 (2024-06-04) | Opt-in: `enable_stable_row_ids=true` at dataset creation       | Row IDs are stable for both moves and updates. Fragments contain an index mapping row IDs to row addresses. |
+| 4        | `FLAG_USE_V2_FORMAT_DEPRECATED` | No              | No              | —                   | Deprecated; no longer used                                     | Files are written with the new v2 format. This flag is deprecated and no longer used.                       |
+| 8        | `FLAG_TABLE_CONFIG`             | No              | Yes             | v0.19.1 (2024-10-21) | Automatic when table config is set (`update_config`)           | Table config is present in the manifest.                                                                    |
+| 16       | `FLAG_BASE_PATHS`               | Yes             | Yes             | v0.34.0 (2025-08-26) | Automatic when a dataset uses base paths (e.g. shallow clone)  | Dataset uses multiple base paths (for shallow clones or multi-base datasets).                               |
+| 32       | `FLAG_DISABLE_TRANSACTION_FILE` | No              | Yes             | v1.0.0 (2025-12-12) | Reserved — not yet exposed via any public API                 | The transaction is written inline in the manifest instead of in a separate `_transactions/` file.          |
 
 </div>
 
-Flags with bit values 32 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.
+Flags with bit values 64 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.
+
+## Feature Maturity
+
+The **Introduced** column above records the first stable release that supports each flag,
+with that release's date. Feature flags are the format's compatibility contract: a reader
+or writer that does not recognize a flag rejects the dataset rather than risk
+misinterpreting it. The **Introduced** version is therefore also the *downgrade floor* —
+the oldest release that can open a dataset using that feature. This table serves two
+purposes:
+
+- **Users** deciding when it is safe to turn a feature on: only enable it once every reader
+  and writer in your deployment is at or above the Introduced version, so a rollback stays
+  readable.
+- **Maintainers** deciding when to make a feature the default. The rule of thumb is to wait
+  until a feature has been released and stable for roughly 3–6 months, so most of the user
+  base can already read data written with it before it becomes the write-time default.
+
+Only features that affect on-disk read/write compatibility get a feature flag. Higher-level
+capabilities that do not change how existing data is interpreted (tags, branches, MemTable
+& WAL, change data feed) have no flag and impose no downgrade floor. If a feature *would*
+break older readers but lacks a flag, that is a bug in the feature, not an omission here.
+
+How the flags behave:
+
+- **Automatic** flags are set by the writer whenever the underlying data is present (a
+  deletion file exists, the manifest config is non-empty, base paths are present). They are
+  in effect from their Introduced version onward and clear again if that data is later
+  removed (for example, after compaction materializes deletes).
+- **`FLAG_STABLE_ROW_IDS`** is opt-in and off by default. It must be set at dataset creation
+  and cannot be toggled on or off afterward. It landed in v0.12.0 but only became usable
+  end-to-end with secondary indices and compaction in v0.16.1 (2024-08-09); the write
+  parameter was named `enable_move_stable_row_ids` until v0.34.0.
+- **`FLAG_BASE_PATHS`** was introduced as `FLAG_SHALLOW_CLONE` in v0.34.0 and
+  renamed/generalized to multi-base datasets in v0.38.3 (2025-10-28); the bit value is
+  unchanged.
+- **`FLAG_DISABLE_TRANSACTION_FILE`** is reserved: the flag and the commit-path support
+  exist, but no public API sets it yet. Every commit currently writes the transaction both
+  inline in the manifest (`transaction_section`) *and* to a separate `_transactions/` file;
+  wiring this flag on would let writers skip the now-redundant external file.
+
+For index (e.g. full-text search) format versions, see the
+[Full Text Search Index](../index/scalar/fts.md#format-versions) page.


### PR DESCRIPTION
Adds version/maturity information to the existing per-layer versioning docs, rather than a standalone page, so each fact lives next to the spec it concerns and nothing is duplicated.

**`table/versioning.md`** — folds maturity data into the existing reader/writer feature-flags table:

- New **Introduced** column (release version + date) and **Enabled by** column for each flag.
- A *Feature Maturity* section explaining that the Introduced version is the downgrade floor (oldest release that can open a dataset using the flag), the ~3–6 month rule of thumb for defaulting, and the per-flag enable/opt-in/reserved behavior.

Only feature-flag-gated capabilities are tracked: feature flags are the format's downgrade-safety contract, so anything that would break older readers should *have* a flag. Non-flag capabilities (tags, branches, MemTable & WAL, change data feed) impose no downgrade floor and are intentionally omitted.

**`index/scalar/fts.md`** — adds a *Format Versions* table for the FTS index's legacy / v1 / v2 on-disk generations, mirroring the file-format versioning table's columns. Notes that v2 is selected only via `LANCE_FTS_FORMAT_VERSION=2` (no index-creation parameter yet) and that v2's downgrade floor is 6.0.0.

Version/date data was derived from git history (intro commit → first stable `vX.Y.Z` tag → release date).

Also corrects `table/versioning.md`: adds the missing `FLAG_DISABLE_TRANSACTION_FILE` (bit 32) row and fixes the unknown-flag threshold (64, not 32).

Related findings captured while writing this, tracked separately:
- Inline transactions: every commit writes the transaction both inline and to a separate `_transactions/` file; the flag to skip the redundant file is unwired — #7486 (expose a toggle), #7487 (default it once 1.0.0+ readers are widespread).