### PR TITLE
fix(mem-wal): apply cross-generation block-list to in-memory scan arms

### DIFF
--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -181,7 +181,6 @@ impl LsmFtsSearchPlanner {
         let arm_inputs: Vec<_> = sources
             .iter()
             .map(|source| {
-                let is_active = matches!(source, LsmDataSource::ActiveMemTable { .. });
                 let blocked = block_lists.get(&(source.shard_id(), source.generation()));
                 // Over-fetch a blocked source so the post-filter still yields k live
                 // rows. The active arm returns all matches (no builder limit), so its
@@ -191,36 +190,36 @@ impl LsmFtsSearchPlanner {
                 } else {
                     k
                 };
-                (source, is_active, blocked, fetch_k)
+                (source, blocked, fetch_k)
             })
             .collect();
         let built =
-            futures::future::try_join_all(arm_inputs.iter().map(|(source, _, _, fetch_k)| {
+            futures::future::try_join_all(arm_inputs.iter().map(|(source, _, fetch_k)| {
                 Box::pin(self.build_source_plan(source, column, &query, *fetch_k, projection))
             }))
             .await?;
 
         let mut per_source_plans: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(sources.len());
-        for ((_, is_active, blocked, _), plan) in arm_inputs.iter().zip(built) {
-            let is_active = *is_active;
+        for ((_source, blocked, _), plan) in arm_inputs.iter().zip(built) {
             let blocked = *blocked;
-            // Dedup, mirroring LsmVectorSearchPlanner:
-            //  * active: already wrapped in `NewestPkFilterExec` inside
+            // Within-generation dedup is already applied per source:
+            //  * active/frozen in-memory: `NewestPkFilterExec` inside
             //    `build_source_plan` (drops predicate-crossing stale hits, which a
             //    result-set dedup can't catch).
-            //  * flushed/base: drop rows superseded by a newer generation via the
-            //    block-list (within-gen is handled by the flushed deletion vector).
-            let deduped = if is_active {
-                plan
-            } else if let Some(set) = blocked {
-                Arc::new(PkBlockFilterExec::new(
+            //  * flushed: the on-disk deletion vector.
+            // Cross-generation supersession (a newer gen's write or tombstone) is
+            // applied uniformly here via the block-list — including frozen
+            // in-memory generations, whose per-gen recency filter can't see a
+            // newer gen. The newest generation of each shard has no newer gen
+            // (`blocked` is None) and is unaffected.
+            let deduped = match blocked {
+                Some(set) => Arc::new(PkBlockFilterExec::new(
                     plan,
                     self.pk_columns.clone(),
                     set.clone(),
                     k,
-                )) as Arc<dyn ExecutionPlan>
-            } else {
-                plan
+                )) as Arc<dyn ExecutionPlan>,
+                None => plan,
             };
 
             // Normalize to canonical. This also drops the active arm's _rowid,
@@ -843,6 +842,95 @@ mod tests {
         assert!(
             ids.contains(&2),
             "live pk=2 ('alpha foo') must still match 'alpha'; got ids={ids:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_gen_stale_update_blocked_by_newer_memtable() {
+        // The cross-generation analog of `active_stale_update_predicate_crossing_leaks`:
+        // pk=1's stale "alpha" version lives in a FROZEN memtable and its fresh
+        // "beta" version in the ACTIVE one. The frozen arm's recency filter is
+        // per-generation and can't see the newer gen, so only the cross-gen
+        // block-list can drop the stale "alpha" hit. The cluster constantly
+        // freezes memtables, so an insert and its later update/delete split
+        // across in-memory generations — this is the residual fuzz phantom.
+        let schema = fts_schema();
+
+        // Frozen gen=1: pk=1 "alpha lance" (matches), pk=2 "alpha foo" (live).
+        let frozen_store = Arc::new(BatchStore::with_capacity(16));
+        let mut frozen_idx = IndexStore::new();
+        frozen_idx.enable_pk_index(&[("id".to_string(), 0)]);
+        frozen_idx.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let fb = make_batch(&schema, &[1, 2], &["alpha lance", "alpha foo"]);
+        let (bp, off, _) = frozen_store.append(fb.clone()).unwrap();
+        frozen_idx.insert_with_batch_position(&fb, off, Some(bp)).unwrap();
+
+        // Active gen=2: pk=1 updated to "beta lance" (no longer matches "alpha").
+        let active_store = Arc::new(BatchStore::with_capacity(16));
+        let mut active_idx = IndexStore::new();
+        active_idx.enable_pk_index(&[("id".to_string(), 0)]);
+        active_idx.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let ab = make_batch(&schema, &[1], &["beta lance"]);
+        let (bp, off, _) = active_store.append(ab.clone()).unwrap();
+        active_idx.insert_with_batch_position(&ab, off, Some(bp)).unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                uuid::Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store: active_store,
+                        index_store: Arc::new(active_idx),
+                        schema: schema.clone(),
+                        generation: 2,
+                    },
+                    frozen: vec![InMemoryMemTableRef {
+                        batch_store: frozen_store,
+                        index_store: Arc::new(frozen_idx),
+                        schema: schema.clone(),
+                        generation: 1,
+                    }],
+                },
+            );
+
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+        let plan = planner
+            .plan_search(
+                "text",
+                FullTextSearchQuery::new("alpha".to_string()),
+                10,
+                None,
+            )
+            .await
+            .expect("planner should produce a plan");
+
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+
+        let mut ids: Vec<i32> = Vec::new();
+        for b in &batches {
+            let col = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                ids.push(col.value(i));
+            }
+        }
+
+        assert!(
+            !ids.contains(&1),
+            "stale frozen pk=1 ('alpha lance', now 'beta lance' in the active gen) \
+             leaked on an 'alpha' search; got ids={ids:?}"
+        );
+        assert!(
+            ids.contains(&2),
+            "live pk=2 ('alpha foo', only in the frozen gen) must still match; got ids={ids:?}"
         );
     }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -193,11 +193,10 @@ impl LsmFtsSearchPlanner {
                 (source, blocked, fetch_k)
             })
             .collect();
-        let built =
-            futures::future::try_join_all(arm_inputs.iter().map(|(source, _, fetch_k)| {
-                Box::pin(self.build_source_plan(source, column, &query, *fetch_k, projection))
-            }))
-            .await?;
+        let built = futures::future::try_join_all(arm_inputs.iter().map(|(source, _, fetch_k)| {
+            Box::pin(self.build_source_plan(source, column, &query, *fetch_k, projection))
+        }))
+        .await?;
 
         let mut per_source_plans: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(sources.len());
         for ((_source, blocked, _), plan) in arm_inputs.iter().zip(built) {
@@ -863,7 +862,9 @@ mod tests {
         frozen_idx.add_fts("text_fts".to_string(), 1, "text".to_string());
         let fb = make_batch(&schema, &[1, 2], &["alpha lance", "alpha foo"]);
         let (bp, off, _) = frozen_store.append(fb.clone()).unwrap();
-        frozen_idx.insert_with_batch_position(&fb, off, Some(bp)).unwrap();
+        frozen_idx
+            .insert_with_batch_position(&fb, off, Some(bp))
+            .unwrap();
 
         // Active gen=2: pk=1 updated to "beta lance" (no longer matches "alpha").
         let active_store = Arc::new(BatchStore::with_capacity(16));
@@ -872,7 +873,9 @@ mod tests {
         active_idx.add_fts("text_fts".to_string(), 1, "text".to_string());
         let ab = make_batch(&schema, &[1], &["beta lance"]);
         let (bp, off, _) = active_store.append(ab.clone()).unwrap();
-        active_idx.insert_with_batch_position(&ab, off, Some(bp)).unwrap();
+        active_idx
+            .insert_with_batch_position(&ab, off, Some(bp))
+            .unwrap();
 
         let tmp = tempfile::tempdir().unwrap();
         let base_uri = format!("{}/base", tmp.path().to_str().unwrap());

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -306,16 +306,32 @@ impl LsmVectorSearchPlanner {
                     } => (batch_store.clone(), index_store.clone()),
                     _ => unreachable!("is_active implies ActiveMemTable"),
                 };
-                let filtered: Arc<dyn ExecutionPlan> =
-                    Arc::new(super::exec::NewestPkFilterExec::new(
+                let filtered: Arc<dyn ExecutionPlan> = Arc::new(
+                    super::exec::NewestPkFilterExec::new(
                         knn,
                         self.pk_columns.clone(),
                         lance_core::ROW_ID,
                         index_store,
                         batch_store,
                         active_max_visible.expect("active arm returns its max_visible snapshot"),
-                    ));
-                sort_by_distance(filtered, k)?
+                    ),
+                );
+                // Cross-generation supersession: a frozen (older) in-memory
+                // generation can be superseded by a newer generation's write or
+                // tombstone. The recency filter above is within-generation only;
+                // the block-list is the sole cross-gen mechanism. The newest
+                // active memtable has no newer generation (`blocked` is None), so
+                // this is a no-op there — only older frozen gens are filtered.
+                let blocked_filtered: Arc<dyn ExecutionPlan> = match blocked {
+                    Some(set) => Arc::new(super::exec::PkBlockFilterExec::new(
+                        filtered,
+                        self.pk_columns.clone(),
+                        set.clone(),
+                        k,
+                    )),
+                    None => filtered,
+                };
+                sort_by_distance(blocked_filtered, k)?
             } else {
                 match blocked {
                     Some(set) => Arc::new(super::exec::PkBlockFilterExec::new(
@@ -622,6 +638,26 @@ mod tests {
         .unwrap()
     }
 
+    /// One row with an explicit `(id, vector)` — unlike [`create_test_batch`],
+    /// the vector is not derived from `id`, so the same PK can carry different
+    /// vectors across generations (an update / move-out-of-neighborhood).
+    fn create_id_vector_batch(schema: &ArrowSchema, id: i32, vector: [f32; 4]) -> RecordBatch {
+        use arrow_array::builder::Float32Builder;
+        let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), 4);
+        for v in vector {
+            builder.values().append_value(v);
+        }
+        builder.append(true);
+        RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(vec![id])),
+                Arc::new(builder.finish()),
+            ],
+        )
+        .unwrap()
+    }
+
     async fn create_dataset(uri: &str, batches: Vec<RecordBatch>) -> Dataset {
         let schema = batches[0].schema();
         let has_id = schema.column_with_name("id").is_some();
@@ -806,6 +842,128 @@ mod tests {
             "expected near-zero distance for self-match, got {}",
             dist_col.value(0)
         );
+    }
+
+    #[tokio::test]
+    async fn cross_gen_stale_version_blocked_by_newer_memtable() {
+        // A PK updated ACROSS a freeze boundary: its old (near) version lives in
+        // a frozen memtable, its new (far) version in the active one. Both are
+        // in-memory `ActiveMemTable` sources, so each gets only a per-generation
+        // recency filter (`NewestPkFilterExec`) — which can't see the newer gen.
+        // The cross-generation block-list is the only thing that can drop the
+        // stale near copy; if the active arm discards it, the frozen near version
+        // leaks as a phantom near-neighbor. This is the residual wallop fuzz
+        // delete/update phantom: the cluster constantly freezes memtables
+        // (flush_interval ~250ms), so an insert and its later delete/update split
+        // across in-memory generations.
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
+        use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+        use datafusion::prelude::SessionContext;
+        use futures::TryStreamExt;
+
+        let schema = create_vector_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
+        // Base seed far from the query; id=1 is not in the base.
+        let base_dataset =
+            Arc::new(create_dataset(&base_uri, vec![create_test_batch(&schema, &[99])]).await);
+
+        // One in-memory memtable holding `id` at `vector`, with a PK + HNSW index.
+        let make_gen = |id: i32, vector: [f32; 4], generation: u64| {
+            let batch_store = Arc::new(BatchStore::with_capacity(16));
+            let mut index_store = IndexStore::new();
+            index_store.enable_pk_index(&[("id".to_string(), 0)]);
+            index_store.add_hnsw(
+                "vector_hnsw".to_string(),
+                1,
+                "vector".to_string(),
+                lance_linalg::distance::DistanceType::L2,
+                64,
+                8,
+            );
+            let batch = create_id_vector_batch(&schema, id, vector);
+            batch_store.append(batch.clone()).unwrap();
+            index_store
+                .insert_with_batch_position(&batch, 0, Some(0))
+                .unwrap();
+            InMemoryMemTableRef {
+                batch_store,
+                index_store: Arc::new(index_store),
+                schema: schema.clone(),
+                generation,
+            }
+        };
+
+        // Frozen gen=1: id=1 @ the query vector (distance ~0).
+        let frozen = make_gen(1, [0.1, 0.2, 0.3, 0.4], 1);
+        // Active gen=2: id=1 moved FAR — the newest version of the PK.
+        let active = make_gen(1, [9.0, 9.0, 9.0, 9.0], 2);
+
+        let shard_id = uuid::Uuid::new_v4();
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![])
+            .with_in_memory_memtables(
+                shard_id,
+                InMemoryMemTables {
+                    active,
+                    frozen: vec![frozen],
+                },
+            );
+
+        let planner = LsmVectorSearchPlanner::new(
+            collector,
+            vec!["id".to_string()],
+            schema,
+            "vector".to_string(),
+            lance_linalg::distance::DistanceType::L2,
+        );
+
+        let query = create_query_vector();
+        let plan = planner
+            .plan_search(&query, 3, 1, None, false, 1.0)
+            .await
+            .expect("planner should produce a plan");
+        let ctx = SessionContext::new();
+        let batches: Vec<RecordBatch> = plan
+            .execute(0, ctx.task_ctx())
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        let mut id1_distances = Vec::new();
+        for b in &batches {
+            let ids = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let dist = b
+                .column_by_name(DISTANCE_COLUMN)
+                .unwrap()
+                .as_any()
+                .downcast_ref::<arrow_array::Float32Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                if ids.value(i) == 1 {
+                    id1_distances.push(dist.value(i));
+                }
+            }
+        }
+
+        // id=1 must surface at most once, and only at its NEWEST (far) distance —
+        // never the stale near ~0 copy the frozen generation still indexes.
+        assert!(
+            id1_distances.len() <= 1,
+            "id=1 leaked its stale frozen copy (appears {} times): {id1_distances:?}",
+            id1_distances.len()
+        );
+        if let Some(d) = id1_distances.first() {
+            assert!(
+                *d > 1.0,
+                "id=1 surfaced at the stale near distance {d}; its newest version is far"
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -306,16 +306,15 @@ impl LsmVectorSearchPlanner {
                     } => (batch_store.clone(), index_store.clone()),
                     _ => unreachable!("is_active implies ActiveMemTable"),
                 };
-                let filtered: Arc<dyn ExecutionPlan> = Arc::new(
-                    super::exec::NewestPkFilterExec::new(
+                let filtered: Arc<dyn ExecutionPlan> =
+                    Arc::new(super::exec::NewestPkFilterExec::new(
                         knn,
                         self.pk_columns.clone(),
                         lance_core::ROW_ID,
                         index_store,
                         batch_store,
                         active_max_visible.expect("active arm returns its max_visible snapshot"),
-                    ),
-                );
+                    ));
                 // Cross-generation supersession: a frozen (older) in-memory
                 // generation can be superseded by a newer generation's write or
                 // tombstone. The recency filter above is within-generation only;
@@ -900,14 +899,13 @@ mod tests {
         let active = make_gen(1, [9.0, 9.0, 9.0, 9.0], 2);
 
         let shard_id = uuid::Uuid::new_v4();
-        let collector = LsmDataSourceCollector::new(base_dataset, vec![])
-            .with_in_memory_memtables(
-                shard_id,
-                InMemoryMemTables {
-                    active,
-                    frozen: vec![frozen],
-                },
-            );
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_in_memory_memtables(
+            shard_id,
+            InMemoryMemTables {
+                active,
+                frozen: vec![frozen],
+            },
+        );
 
         let planner = LsmVectorSearchPlanner::new(
             collector,


### PR DESCRIPTION
## What

The WAL fresh-tier vector and FTS search arms apply a per-generation recency filter (`NewestPkFilterExec`) to every in-memory memtable — but they only apply the cross-generation block-list (`PkBlockFilterExec`) to flushed/base sources, never to in-memory ones. This PR applies the block-list to in-memory arms too.

## Why

`LsmDataSourceCollector::in_memory_sources` emits **both** the live active memtable **and** every frozen-awaiting-flush memtable as `ActiveMemTable` sources, each with its own `index_store`. The recency filter queries only *that generation's* PK index, so it is purely within-generation.

When a PK is inserted in one generation and later deleted or updated in a **newer** in-memory generation, the older (frozen) generation's arm keeps the stale matching row: the newer generation's tombstone/update lives in a different `index_store` the frozen arm never consults. This happens whenever an insert and its later delete/update straddle a freeze boundary — common under a short flush interval, which freezes memtables continuously.

The cross-generation block-list (`NEWER(G)`) is the only mechanism that resolves this, and `compute_source_block_lists` already computes it for in-memory sources (snapshot-bounded by each generation's `max_visible_row`, so a not-yet-visible write can't over-block). The arms just discarded it.

## Change

- `vector_search.rs`: after `NewestPkFilterExec`, also wrap in `PkBlockFilterExec` when the source has a non-empty block set.
- `fts_search.rs`: unify the dedup loop so every source applies the block-list when blocked; the within-generation recency filter is already applied inside `build_source_plan` for in-memory sources.

The newest memtable per shard has no newer generation, so its block set is empty (`None`) and it is unaffected — only older frozen generations are now filtered. Each in-memory generation gets both within-generation recency and cross-generation supersession.

## Tests

- `cross_gen_stale_version_blocked_by_newer_memtable` (vector): a PK at a near vector in a frozen generation and at a far vector in the active generation. Before the fix the stale near copy leaks alongside the newest far version; after, only the newest survives.
- `cross_gen_stale_update_blocked_by_newer_memtable` (FTS): a PK matching "alpha" in a frozen generation, updated to "beta" in the active generation; an "alpha" search must not return the stale frozen row.

Both fail before this change and pass after. The existing single-generation recency tests (`keeps_only_the_newest_visible_position_per_pk`, `active_stale_update_predicate_crossing_leaks`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
