### PR TITLE
fix: invalidate indices for fields rewritten by Merge

### DIFF
--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -36,7 +36,7 @@ use lance_datagen::{BatchCount, RowCount, array, gen_batch};
 use lance_file::version::LanceFileVersion;
 use lance_file::writer::FileWriter;
 use lance_io::utils::CachedFileSize;
-use lance_table::format::DataFile;
+use lance_table::format::{DataFile, Fragment};
 
 use crate::dataset::write::merge_insert::{WhenMatched, WhenNotMatched};
 use futures::TryStreamExt;
@@ -2237,6 +2237,184 @@ async fn test_data_replacement_invalidates_index_bitmap() {
     assert!(
         !effective.contains(0),
         "Fragment 0 should be removed from index bitmap after DataReplacement on indexed column"
+    );
+}
+
+/// Run a predicate over `col` twice -- once index-served, once via a forced flat scan
+/// (`use_scalar_index(false)`) -- assert the two agree, and return the matching `col`
+/// values sorted. Equality is the index-consistency invariant: a divergence means the
+/// index served rows that disagree with the underlying data.
+async fn index_consistent_values(dataset: &Dataset, col: &str, predicate: &str) -> Vec<i32> {
+    let sorted = |batch: &RecordBatch| -> Vec<i32> {
+        let mut v: Vec<i32> = batch
+            .column_by_name(col)
+            .unwrap()
+            .as_primitive::<Int32Type>()
+            .iter()
+            .flatten()
+            .collect();
+        v.sort();
+        v
+    };
+
+    let indexed = dataset
+        .scan()
+        .filter(predicate)
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let flat = dataset
+        .scan()
+        .use_scalar_index(false)
+        .filter(predicate)
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+
+    let indexed_vals = sorted(&indexed);
+    let flat_vals = sorted(&flat);
+    assert_eq!(
+        indexed_vals, flat_vals,
+        "index-served `{predicate}` disagrees with a flat scan"
+    );
+    indexed_vals
+}
+
+/// Build a Merge overlay fragment that rewrites a single `field_id` in place: tombstone
+/// (-2) the field in `prev`'s existing data files and back it with `new_file` (a new
+/// single-column file) instead. A file left with no live field is dropped. This is the
+/// manifest shape an in-place column rewrite produces when it falls back from a
+/// DataReplacement to a Merge.
+fn build_overlay_frag(prev: &Fragment, field_id: i32, new_file: &str) -> Fragment {
+    let mut overlay = prev.clone();
+    overlay.files = prev
+        .files
+        .iter()
+        .filter_map(|df| {
+            let masked: Vec<i32> = df
+                .fields
+                .iter()
+                .map(|&f| if f == field_id { -2 } else { f })
+                .collect();
+            if masked.iter().all(|&f| f == -2) {
+                return None; // file holds only the tombstoned field
+            }
+            let mut m = df.clone();
+            m.fields = masked.into();
+            Some(m)
+        })
+        .collect();
+    overlay.add_file(
+        new_file,
+        vec![field_id],
+        vec![0],
+        &LanceFileVersion::default(),
+        None,
+    );
+    overlay
+}
+
+/// A `Merge` that rewrites an indexed column's data in place must keep that column's
+/// index consistent: a query the index serves must return the same rows as a flat scan
+/// of the rewritten data. The overlay fragment tombstones (-2) the column's field id in
+/// the existing data file and appends a new file for it, so the field stays in the
+/// schema and its index is retained -- the rewritten fragment must be pruned from that
+/// index. This is the shape produced when an in-place column rewrite cannot be expressed
+/// as a DataReplacement (e.g. an `update` has merged the fragment's column files) and
+/// falls back to a Merge overlay.
+#[tokio::test]
+async fn test_merge_rewriting_indexed_column_keeps_index_consistent() {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("a", DataType::Int32, true),
+        ArrowField::new("b", DataType::Int32, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+            Arc::new(Int32Array::from(vec![10, 20, 30, 40])),
+        ],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+    let mut dataset = Dataset::write(reader, "memory://merge_index_rewrite", None)
+        .await
+        .unwrap();
+
+    dataset
+        .create_index(
+            &["a"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            false,
+        )
+        .await
+        .unwrap();
+
+    // Baseline: the index serves correct results before the rewrite.
+    assert_eq!(
+        index_consistent_values(&dataset, "a", "a >= 3").await,
+        vec![3, 4]
+    );
+
+    let a_field_id = 0i32;
+
+    // Write a new single-column file holding `a`'s replacement values.
+    let a_only = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "a",
+        DataType::Int32,
+        true,
+    )]));
+    let new_a = RecordBatch::try_new(
+        a_only.clone(),
+        vec![Arc::new(Int32Array::from(vec![91, 92, 93, 94]))],
+    )
+    .unwrap();
+    let new_a_path = dataset.data_dir().join("merge_new_a.lance");
+    let object_writer = dataset.object_store.create(&new_a_path).await.unwrap();
+    let mut writer = FileWriter::try_new(
+        object_writer,
+        a_only.as_ref().try_into().unwrap(),
+        Default::default(),
+    )
+    .unwrap();
+    writer.write_batch(&new_a).await.unwrap();
+    writer.finish().await.unwrap();
+
+    // Overlay that file onto fragment 0, rewriting `a` in place.
+    let prev = dataset.get_fragment(0).unwrap().metadata().clone();
+    let overlay = build_overlay_frag(&prev, a_field_id, "merge_new_a.lance");
+
+    let read_version = dataset.version().version;
+    let dataset = Dataset::commit(
+        WriteDestination::Dataset(Arc::new(dataset)),
+        Operation::Merge {
+            fragments: vec![overlay],
+            schema: schema.as_ref().try_into().unwrap(),
+        },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .unwrap();
+
+    // `a` now holds [91, 92, 93, 94]; an index-served query must reflect that.
+    assert_eq!(
+        index_consistent_values(&dataset, "a", "a >= 90").await,
+        vec![91, 92, 93, 94],
+        "index-served `a >= 90` must return the rewritten values"
+    );
+    assert!(
+        index_consistent_values(&dataset, "a", "a < 90")
+            .await
+            .is_empty(),
+        "no row satisfies `a < 90` after the rewrite"
     );
 }
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -2111,13 +2111,12 @@ impl Transaction {
                 final_fragments.extend(maybe_existing_fragments?.clone());
             }
             Operation::Merge { fragments, .. } => {
+                let existing_fragments = maybe_existing_fragments?;
                 let mut merged_fragments = fragments.clone();
                 if next_row_id.is_some() {
                     let new_version = current_manifest.map(|m| m.version + 1).unwrap_or(1);
-                    let prev_by_id: HashMap<u64, &Fragment> = maybe_existing_fragments?
-                        .iter()
-                        .map(|f| (f.id, f))
-                        .collect();
+                    let prev_by_id: HashMap<u64, &Fragment> =
+                        existing_fragments.iter().map(|f| (f.id, f)).collect();
                     for fragment in merged_fragments.iter_mut() {
                         match prev_by_id.get(&fragment.id) {
                             Some(prev) => {
@@ -2143,6 +2142,15 @@ impl Transaction {
                     }
                 }
                 final_fragments.extend(merged_fragments);
+
+                // A Merge can rewrite a column's data file in place; the field stays
+                // in the schema, so the index is retained -- prune its now-stale
+                // entries for the rewritten fragments.
+                Self::prune_merge_rewritten_fields_from_indices(
+                    &mut final_indices,
+                    existing_fragments,
+                    fragments,
+                );
 
                 // Some fields that have indices may have been removed, so we should
                 // remove those indices as well.
@@ -2620,6 +2628,60 @@ impl Transaction {
                     fragment_bitmap.remove(fragment_id);
                 }
             }
+        }
+    }
+
+    /// Map each (non-tombstoned) field id in a fragment to the path of the data
+    /// file that backs it.
+    fn fragment_field_paths(frag: &Fragment) -> HashMap<i32, &str> {
+        let mut map = HashMap::new();
+        for file in &frag.files {
+            for &field_id in file.fields.iter() {
+                if field_id >= 0 {
+                    map.insert(field_id, file.path.as_str());
+                }
+            }
+        }
+        map
+    }
+
+    /// A `Merge` can rewrite a column's data *in place* -- the field stays in the
+    /// schema but its backing data file changes (the overlay fragment carries a new
+    /// file for the field and tombstones its old field id). `retain_relevant_indices`
+    /// only drops indices for *removed* fields, so without this the index keeps
+    /// covering the rewritten fragments with stale entries. Remove each such fragment
+    /// from any index covering a field whose backing data file changed.
+    fn prune_merge_rewritten_fields_from_indices(
+        indices: &mut [IndexMetadata],
+        prev_fragments: &[Fragment],
+        new_fragments: &[Fragment],
+    ) {
+        let prev_by_id: HashMap<u64, &Fragment> =
+            prev_fragments.iter().map(|f| (f.id, f)).collect();
+        for new_frag in new_fragments {
+            let Some(prev) = prev_by_id.get(&new_frag.id) else {
+                continue; // brand-new fragment: nothing stale to prune
+            };
+            let prev_paths = Self::fragment_field_paths(prev);
+            let new_paths = Self::fragment_field_paths(new_frag);
+            // Fields still present whose backing file path changed == rewritten data.
+            let changed: Vec<u32> = prev_paths
+                .iter()
+                .filter(|(field_id, prev_path)| {
+                    new_paths
+                        .get(*field_id)
+                        .is_some_and(|new_path| new_path != *prev_path)
+                })
+                .map(|(field_id, _)| *field_id as u32)
+                .collect();
+            if changed.is_empty() {
+                continue;
+            }
+            Self::prune_updated_fields_from_indices(
+                indices,
+                std::slice::from_ref(new_frag),
+                &changed,
+            );
         }
     }
 


### PR DESCRIPTION
The Merge arm only dropped indices for fields removed from the schema, so a field rewritten in place (new backing data file, same field id) kept its index covering the fragment with stale entries. Index-served queries then silently returned wrong results -- a filter on the rewritten column matches the old values rather than the current data. Prune the rewritten fragment from any index over a field whose backing data file changed, reusing the same primitive the DataReplacement arm already uses.