### PR TITLE
fix: default FTS format from create params

### DIFF
--- a/python/python/tests/compat/compat_sequence.py
+++ b/python/python/tests/compat/compat_sequence.py
@@ -18,8 +18,7 @@ comparison is skipped rather than failed (uninformative, not a regression). FTS 
 "ignore the index" mode to diff against, so its oracle reconstructs ground truth from a
 full scan: tokenize every live row, then require an FTS search for a spread of sampled
 terms to return exactly the rows that contain them. The FTS scenarios run under both
-on-disk format versions (LANCE_FTS_FORMAT_VERSION 1 and 2), which take different merge
-paths.
+on-disk format versions, which take different merge paths.
 
 The op vocabulary and bounds are deliberately small so the search is runnable; this is
 exhaustive over the maintenance-lifecycle grammar up to the configured lengths, not over
@@ -63,11 +62,12 @@ ALL_KINDS = ["INVERTED", *SCALAR_KINDS]
 class IndexScenario:
     """A picklable, kind-parameterized scenario run across a version split."""
 
-    def __init__(self, kind, path, setup_ops, exercise_ops):
+    def __init__(self, kind, path, setup_ops, exercise_ops, fts_version=None):
         self.kind = kind
         self.path = str(path)
         self.setup_ops = list(setup_ops)
         self.exercise_ops = list(exercise_ops)
+        self.fts_version = fts_version
         self.next_idx = 0
 
     # --- in-venv helpers (only lance + pyarrow available) ---
@@ -123,6 +123,8 @@ class IndexScenario:
 
     def _op_I(self):
         kwargs = {"with_position": True} if self.kind == "INVERTED" else {}
+        if self.kind == "INVERTED" and self.fts_version is not None:
+            kwargs["format_version"] = int(self.fts_version)
         self._open().create_scalar_index("key", self._index_type(), **kwargs)
 
     def _op_D(self):
@@ -234,14 +236,11 @@ def search(
     """Search index-maintenance sequences up to `max_length` ops for one `kind`, across
     (from_ref -> to_ref). Runs only scenarios in this shard (i % num_shards == shard) so
     the space can be split across parallel workers. For INVERTED, `fts_version` ("1" or
-    "2") pins the on-disk FTS format (LANCE_FTS_FORMAT_VERSION) on both sides; both are
-    Fst token sets and exercise distinct merge paths. Returns failures; stops on the
-    first when `stop_on_first`."""
+    "2") pins the on-disk FTS format on both sides; both are Fst token sets and exercise
+    distinct merge paths. Returns failures; stops on the first when `stop_on_first`."""
     from_venv = venv_factory.get_venv(from_ref)
     to_venv = venv_factory.get_venv(to_ref)
     env = {}
-    if kind == "INVERTED" and fts_version is not None:
-        env["LANCE_FTS_FORMAT_VERSION"] = str(fts_version)
     base = Path(base_path)
     failures = []
     # Each setup's aged dataset is built once under from_ref and snapshotted; every
@@ -256,7 +255,7 @@ def search(
             if key not in snapshots:
                 snap = base / f"snap_{kind}_{len(snapshots)}"
                 shutil.rmtree(snap, ignore_errors=True)
-                builder = IndexScenario(kind, snap, setup_tail, [])
+                builder = IndexScenario(kind, snap, setup_tail, [], fts_version)
                 try:
                     next_idx = from_venv.execute_method(builder, "setup", env)
                     snapshots[key] = (snap, next_idx)
@@ -277,7 +276,7 @@ def search(
             ex_path = base / f"ex_{kind}_{i}"
             shutil.rmtree(ex_path, ignore_errors=True)
             shutil.copytree(snap, ex_path)
-            scenario = IndexScenario(kind, ex_path, setup_tail, exercise)
+            scenario = IndexScenario(kind, ex_path, setup_tail, exercise, fts_version)
             scenario.next_idx = next_idx
             label = describe(kind, from_ref, to_ref, setup_tail, exercise, fts_version)
             try:

--- a/python/python/tests/compat/test_scalar_indices.py
+++ b/python/python/tests/compat/test_scalar_indices.py
@@ -320,7 +320,9 @@ class FtsIndex(UpgradeDowngradeTest):
             max_rows_per_file=100,
             data_storage_version=safe_data_storage_version(self.compat_version),
         )
-        dataset.create_scalar_index("text", "INVERTED", with_position=True)
+        dataset.create_scalar_index(
+            "text", "INVERTED", with_position=True, format_version=1
+        )
 
     def check_read(self):
         """Verify FTS index can be queried."""
@@ -348,10 +350,3 @@ class FtsIndex(UpgradeDowngradeTest):
 
     def skip_downgrade(self, version: str) -> bool:
         return version.startswith("0.")
-
-    def current_env(self, method_name: str) -> dict[str, str]:
-        if method_name == "create":
-            return {"LANCE_FTS_FORMAT_VERSION": "1"}
-        if method_name == "check_write":
-            return {"LANCE_FTS_FORMAT_VERSION": "2"}
-        return {}

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -4802,9 +4802,8 @@ def test_json_inverted_match_query(tmp_path):
     assert results.num_rows == 1
 
 
-@pytest.mark.parametrize("fts_format_version", ["1", "2"])
-def test_describe_indices(tmp_path, monkeypatch, fts_format_version):
-    monkeypatch.setenv("LANCE_FTS_FORMAT_VERSION", fts_format_version)
+@pytest.mark.parametrize("fts_format_version", [1, 2])
+def test_describe_indices(tmp_path, fts_format_version):
     data = pa.table(
         {
             "id": range(100),
@@ -4820,7 +4819,9 @@ def test_describe_indices(tmp_path, monkeypatch, fts_format_version):
         }
     )
     ds = lance.write_dataset(data, tmp_path)
-    ds.create_scalar_index("text", index_type="INVERTED")
+    ds.create_scalar_index(
+        "text", index_type="INVERTED", format_version=fts_format_version
+    )
     indices = ds.describe_indices()
     assert len(indices) == 1
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -76,7 +76,10 @@ use lance_index::{
     FtsPrewarmOptions, IndexParams, IndexType, PrewarmOptions,
     optimize::OptimizeOptions,
     progress::{IndexBuildProgress, NoopIndexBuildProgress},
-    scalar::{FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams},
+    scalar::{
+        FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams,
+        inverted::InvertedListFormatVersion,
+    },
     vector::{
         ApproxMode, DEFAULT_QUERY_PARALLELISM, Query as VectorQuery,
         hnsw::builder::HnswBuildParams, ivf::IvfBuildParams, pq::PQBuildParams,
@@ -2291,6 +2294,12 @@ impl Dataset {
                     }
                     if let Some(prefix_only) = kwargs.get_item("prefix_only")? {
                         params = params.ngram_prefix_only(prefix_only.extract()?);
+                    }
+                    if let Some(format_version) = kwargs.get_item("format_version")? {
+                        let format_version =
+                            InvertedListFormatVersion::try_from(format_version.extract::<u32>()?)
+                                .map_err(PyValueError::new_err)?;
+                        params = params.with_format_version(format_version);
                     }
                     if let Some(memory_limit) = kwargs.get_item("memory_limit")? {
                         params = params.memory_limit_mb(memory_limit.extract()?);

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -148,13 +148,14 @@ impl InvertedIndexPlugin {
         });
 
         let details = pbold::InvertedIndexDetails::try_from(&params)?;
+        let format_version = params.format_version();
         let mut inverted_index =
             InvertedIndexBuilder::new_with_fragment_mask(params, fragment_mask)
                 .with_progress(progress);
         let files = inverted_index.update(data, index_store, None).await?;
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&details).unwrap(),
-            index_version: current_fts_format_version().index_version(),
+            index_version: format_version.index_version(),
             files,
         })
     }

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -247,14 +247,14 @@ impl InvertedIndexBuilder {
         deleted_fragments: RoaringBitmap,
     ) -> Self {
         Self {
+            posting_tail_codec: params.format_version().posting_tail_codec(),
+            format_version: params.format_version(),
             params,
             partitions,
             new_partitions: Vec::new(),
             src_store: store,
             token_set_format,
             fragment_mask,
-            format_version: current_fts_format_version(),
-            posting_tail_codec: current_fts_format_version().posting_tail_codec(),
             progress: noop_progress(),
             deleted_fragments,
         }

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -48,6 +48,7 @@ use lance_core::utils::tracing::{IO_TYPE_LOAD_SCALAR_PART, TRACE_IO_EVENTS};
 use lance_core::{Error, ROW_ID, ROW_ID_FIELD, Result};
 use lance_select::{RowAddrMask, RowAddrTreeMap};
 use roaring::RoaringBitmap;
+use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 use tokio::{sync::OnceCell, task::spawn_blocking};
 use tracing::{info, instrument};
@@ -133,26 +134,41 @@ pub static FTS_SCHEMA: LazyLock<SchemaRef> =
 static ROW_ID_SCHEMA: LazyLock<SchemaRef> =
     LazyLock::new(|| Arc::new(Schema::new(vec![ROW_ID_FIELD.clone()])));
 
-fn resolve_fts_format_version(
-    value: Option<&str>,
-) -> std::result::Result<InvertedListFormatVersion, Error> {
-    value.unwrap_or("1").parse()
-}
-
 pub fn current_fts_format_version() -> InvertedListFormatVersion {
-    resolve_fts_format_version(std::env::var("LANCE_FTS_FORMAT_VERSION").ok().as_deref())
-        .expect("failed to parse LANCE_FTS_FORMAT_VERSION")
+    InvertedListFormatVersion::V2
 }
 
 pub fn max_supported_fts_format_version() -> InvertedListFormatVersion {
     InvertedListFormatVersion::V2
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(into = "u32", try_from = "u32")]
 pub enum InvertedListFormatVersion {
-    #[default]
     V1,
+    #[default]
     V2,
+}
+
+impl From<InvertedListFormatVersion> for u32 {
+    fn from(value: InvertedListFormatVersion) -> Self {
+        value.index_version()
+    }
+}
+
+impl TryFrom<u32> for InvertedListFormatVersion {
+    type Error = String;
+
+    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+        match value {
+            INVERTED_INDEX_VERSION_V1 => Ok(Self::V1),
+            INVERTED_INDEX_VERSION_V2 => Ok(Self::V2),
+            other => Err(format!(
+                "unsupported FTS format version {}, expected 1 or 2",
+                other
+            )),
+        }
+    }
 }
 
 impl InvertedListFormatVersion {
@@ -5964,13 +5980,14 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_fts_format_version_defaults_to_v1() {
+    fn test_current_fts_format_version_defaults_to_v2() {
+        assert_eq!(current_fts_format_version(), InvertedListFormatVersion::V2);
         assert_eq!(
-            resolve_fts_format_version(None).unwrap(),
+            InvertedListFormatVersion::try_from(1).unwrap(),
             InvertedListFormatVersion::V1
         );
         assert_eq!(
-            resolve_fts_format_version(Some("2")).unwrap(),
+            InvertedListFormatVersion::try_from(2).unwrap(),
             InvertedListFormatVersion::V2
         );
     }

--- a/rust/lance-index/src/scalar/inverted/tokenizer.rs
+++ b/rust/lance-index/src/scalar/inverted/tokenizer.rs
@@ -18,6 +18,7 @@ use jieba::JiebaTokenizerBuilder;
 #[cfg(feature = "tokenizer-lindera")]
 use lindera::LinderaTokenizerBuilder;
 
+use super::index::InvertedListFormatVersion;
 use crate::pbold;
 use crate::scalar::inverted::tokenizer::document_tokenizer::{
     JsonTokenizer, LanceTokenizer, TextTokenizer,
@@ -97,6 +98,10 @@ pub struct InvertedIndexParams {
     #[serde(default)]
     pub(crate) prefix_only: bool,
 
+    /// On-disk FTS inverted-list format version for newly created index segments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) format_version: Option<InvertedListFormatVersion>,
+
     /// Total memory limit in MiB for the build stage.
     ///
     /// This is split evenly across FTS workers at build time. By default Lance
@@ -164,6 +169,7 @@ impl TryFrom<&pbold::InvertedIndexDetails> for InvertedIndexParams {
             min_ngram_length: details.min_ngram_length,
             max_ngram_length: details.max_ngram_length,
             prefix_only: details.prefix_only,
+            format_version: None,
             memory_limit_mb: defaults.memory_limit_mb,
             num_workers: defaults.num_workers,
         })
@@ -218,6 +224,7 @@ impl InvertedIndexParams {
             min_ngram_length: default_min_ngram_length(),
             max_ngram_length: default_max_ngram_length(),
             prefix_only: false,
+            format_version: Some(InvertedListFormatVersion::V2),
             memory_limit_mb: None,
             num_workers: None,
         }
@@ -253,6 +260,15 @@ impl InvertedIndexParams {
     /// Get whether positions are stored in this index.
     pub fn has_positions(&self) -> bool {
         self.with_position
+    }
+
+    pub fn with_format_version(mut self, format_version: InvertedListFormatVersion) -> Self {
+        self.format_version = Some(format_version);
+        self
+    }
+
+    pub fn format_version(&self) -> InvertedListFormatVersion {
+        self.format_version.unwrap_or(InvertedListFormatVersion::V2)
     }
 
     pub fn max_token_length(mut self, max_token_length: Option<usize>) -> Self {
@@ -492,6 +508,34 @@ mod tests {
             Some(&serde_json::Value::from(4096))
         );
         assert_eq!(json.get("num_workers"), Some(&serde_json::Value::from(3)));
+    }
+
+    #[test]
+    fn test_format_version_defaults_to_v2_for_new_params() {
+        let params = InvertedIndexParams::default();
+        assert_eq!(
+            params.format_version(),
+            super::InvertedListFormatVersion::V2
+        );
+
+        let json = serde_json::to_value(&params).unwrap();
+        assert_eq!(
+            json.get("format_version"),
+            Some(&serde_json::Value::from(2))
+        );
+    }
+
+    #[test]
+    fn test_missing_format_version_deserializes_without_override() {
+        let mut json = serde_json::to_value(InvertedIndexParams::default()).unwrap();
+        json.as_object_mut().unwrap().remove("format_version");
+
+        let params: InvertedIndexParams = serde_json::from_value(json).unwrap();
+        assert_eq!(params.format_version, None);
+        assert_eq!(
+            params.format_version(),
+            super::InvertedListFormatVersion::V2
+        );
     }
 
     #[test]


### PR DESCRIPTION
Default new FTS params to format v2 without a process env flag. Preserve explicit format versions in serialized params and expose a Python create-index kwarg for compatibility tests.