### PR TITLE
fix(index): sort JSON-path values before btree training (#7485)

### DIFF
--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -2332,6 +2332,42 @@ def test_json_index():
     )
 
 
+def test_json_index_negative_floats():
+    # A JSON float-path btree index must agree with the un-indexed scan even when
+    # the path holds negative values. The extracted values were not sorted before
+    # btree training, so a page's recorded min/max were taken from storage order
+    # and a negative value corrupted range / boundary-equality lookups (#7485).
+    vals = [
+        '{"v": 10.5}',
+        '{"v": 40.1}',
+        '{"v": -3.2}',
+        '{"v": 0.5}',
+        '{"v": -100.0}',
+    ]
+    tbl = pa.table({"data": pa.array(vals, pa.json_())})
+    ds = lance.write_dataset(tbl, "memory://test")
+    ds.create_scalar_index(
+        "data",
+        IndexConfig(
+            index_type="json", parameters={"target_index_type": "btree", "path": "v"}
+        ),
+    )
+
+    for predicate in [
+        "json_get_float(data, 'v') > 0",
+        "json_get_float(data, 'v') < 0",
+        "json_get_float(data, 'v') >= 10.5",
+        "json_get_float(data, 'v') = 40.1",
+        "json_get_float(data, 'v') = -3.2",
+        "json_get_float(data, 'v') = -100.0",
+        "json_get_float(data, 'v') != 0.5",
+    ]:
+        assert "ScalarIndexQuery" in ds.scanner(filter=predicate).explain_plan()
+        assert ds.to_table(filter=predicate) == ds.to_table(
+            filter=predicate, use_scalar_index=False
+        ), predicate
+
+
 def test_null_handling():
     tbl = pa.table(
         {

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -8,17 +8,17 @@ use std::{
 };
 
 use arrow_array::{Array, LargeBinaryArray, RecordBatch, StructArray, UInt8Array};
-use arrow_schema::{DataType, Field, Field as ArrowField, Schema};
+use arrow_schema::{DataType, Field, Field as ArrowField, Schema, SortOptions};
 use async_trait::async_trait;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::{
     execution::SendableRecordBatchStream,
-    physical_plan::{ExecutionPlan, projection::ProjectionExec},
+    physical_plan::{ExecutionPlan, projection::ProjectionExec, sorts::sort::SortExec},
 };
 use datafusion_common::{ScalarValue, config::ConfigOptions};
 use datafusion_expr::{Expr, Operator, ScalarUDF};
 use datafusion_physical_expr::{
-    PhysicalExpr, ScalarFunctionExpr,
+    PhysicalExpr, PhysicalSortExpr, ScalarFunctionExpr,
     expressions::{Column, Literal},
 };
 use futures::StreamExt;
@@ -663,6 +663,35 @@ impl JsonIndexPlugin {
             futures::stream::iter(converted_batches.into_iter().map(Ok)),
         )))
     }
+
+    /// Sort a `(value, row_id)` stream ascending by value before sub-index training.
+    ///
+    /// The btree sub-index trainer assumes its input is globally sorted by value: it
+    /// records each page's min/max as the first/last element of the page. The normal
+    /// scalar-index path sorts the column upstream, but the JSON path extracts the
+    /// typed values here, so the extracted stream is in storage order, not value order.
+    /// Without this sort the page min/max are wrong and range/equality queries skip
+    /// valid pages (e.g. a negative float, whose storage order differs from its value
+    /// order, makes a page's recorded `max` smaller than real values it contains).
+    async fn sort_stream_by_value(
+        data: SendableRecordBatchStream,
+    ) -> Result<SendableRecordBatchStream> {
+        let input = Arc::new(OneShotExec::new(data));
+        let value_idx = input.schema().index_of(VALUE_COLUMN_NAME)?;
+        let sort_expr = PhysicalSortExpr {
+            expr: Arc::new(Column::new(VALUE_COLUMN_NAME, value_idx)),
+            options: SortOptions {
+                descending: false,
+                nulls_first: true,
+            },
+        };
+        let sorted = Arc::new(SortExec::new([sort_expr].into(), input));
+        let ctx = get_session_context(&LanceExecutionOptions {
+            use_spilling: true,
+            ..Default::default()
+        });
+        Ok(sorted.execute(0, ctx.task_ctx())?)
+    }
 }
 
 #[async_trait]
@@ -750,6 +779,10 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
         let converted_stream =
             Self::convert_stream_by_type(data_stream, inferred_type.clone()).await?;
 
+        // The btree sub-index trainer requires its input globally sorted by value, so
+        // sort the extracted values here (the JSON path has no upstream value sort).
+        let sorted_stream = Self::sort_stream_by_value(converted_stream).await?;
+
         // Update the target request with inferred type
         let registry = self.registry()?;
         let target_plugin = registry.get_plugin_by_name(&request.parameters.target_index_type)?;
@@ -766,7 +799,7 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
 
         let target_index = target_plugin
             .train_index(
-                converted_stream,
+                sorted_stream,
                 index_store,
                 target_request,
                 fragment_ids,


### PR DESCRIPTION
## What

Fixes #7485. A JSON-path scalar index (`target_index_type=btree`) over a float path returns wrong results once the path contains negative values: range predicates and boundary equality return empty even though the rows exist.

```python
rows = [{"v": 10.5}, {"v": 40.1}, {"v": -3.2}]
# ... write + create json/btree index on path "v" ...
ds.to_table(filter="json_get_float(data,'v') > 0")   # -> []   (expected [1, 2])
ds.to_table(filter="json_get_float(data,'v') = 40.1")# -> []   (expected [2])
```

## Diagnosis (differs from the issue)

The issue describes this as a non-exact-float problem. It isn't. After isolating the variables, the trigger is **negative values**, not float precision. Same value set, only the sign changes:

| data | predicate `> 0` | result |
| --- | --- | --- |
| `[0.5, 1.5, 2.5]` (positive, exact) | `[1,2,3]` | correct |
| `[10.5, 40.1, 3.2]` (positive, non-exact) | `[1,2,3]` | correct |
| `[0.5, 1.5, -2.5]` (negative, exact) | `[]` | wrong |
| `[10.5, 40.1, -3.2]` (negative, non-exact) | `[]` | wrong |

A non-exact but all-positive path indexes fine; an all-exact path with one negative is broken. The issue's "exact" control case happened to be all-positive, which hid the real variable.

Two more facts that pin it down:
- A plain `Float64` btree index (no JSON) over the exact same values `[0.5, 1.5, -2.5]` returns correct results. So the btree itself is fine; the problem is specific to the JSON training path.
- With `[0.5, 1.5, -2.5]`, interior equality (`= 0.5`) works, but the page min (`= -2.5`) and page max (`= 1.5`) both miss, and wide ranges (`< 100`) still return everything. That is the signature of corrupted page min/max stats, not bad values.

## Root cause

`train_btree_index` assumes its input stream is globally sorted by value: `analyze_batch` records each page's stats as `min = values[0]`, `max = values[values.len()-1]` (the first and last element of the page). The btree plugin's `train_index` does not sort; the caller is expected to pass pre-sorted data, and the normal scalar-index path sorts the column upstream.

`JsonIndexPlugin::train_index` extracts the typed values from the JSON column at training time and passes that stream straight to the target index trainer without sorting. The extracted stream is in storage order, not value order. When storage order matches numeric order (all-positive data) the first/last elements still bracket the page, so it happens to work. Introduce a negative and the page's recorded `max` can end up smaller than real values the page contains, so range and boundary lookups skip the page and return nothing.

## Fix

Sort the extracted `(value, row_id)` stream ascending by value (nulls first) before handing it to the target index trainer, mirroring what the normal column path does upstream. Implemented as `sort_stream_by_value` and called between value conversion and `target_plugin.train_index`.

## Tests

Added `test_json_index_negative_floats` in `python/tests/test_scalar_index.py`. It builds a json/btree float index over data with negatives and asserts the indexed result equals the un-indexed scan for `>`, `<`, `>=`, `=` (including equality on the negative values and on the page min/max). Fails on `main`, passes with this change.

## Note

`cargo fmt` and `cargo clippy -p lance-index --lib -D warnings` are clean; the new regression test is Python-side, since `cargo test -p lance-index` currently fails to compile on `main` for an unrelated reason (`FailNewFileStore` mock in `fmindex.rs` missing `IndexStore::with_io_priority`).
