### PR TITLE
fix(index): implement with_io_priority for FailNewFileStore test store

### DIFF
--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -2604,6 +2604,34 @@ mod tests {
         assert!(format!("{err}").contains("injected FMIndex write failure"));
     }
 
+    #[tokio::test]
+    async fn test_fail_new_file_store_with_io_priority_preserves_failure() {
+        // `with_io_priority` re-wraps in `FailNewFileStore`, so the reprioritized
+        // store must keep injecting the `new_index_file` failure.
+        let tempdir = tempfile::tempdir().unwrap();
+        let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
+        let inner = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            index_dir,
+            Arc::new(LanceCache::no_cache()),
+        )) as Arc<dyn IndexStore>;
+        let store = FailNewFileStore { inner };
+
+        let reprioritized = store.with_io_priority(7);
+
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "x",
+            DataType::UInt64,
+            false,
+        )]));
+        let err = reprioritized
+            .new_index_file("test", schema)
+            .await
+            .err()
+            .expect("new_index_file should fail");
+        assert!(format!("{err}").contains("injected FMIndex write failure"));
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_plugin_train_streams_multiple_partitions() {
         fn training_batch(

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -2002,6 +2002,12 @@ mod tests {
             self.inner.io_parallelism()
         }
 
+        fn with_io_priority(&self, io_priority: u64) -> Arc<dyn IndexStore> {
+            Arc::new(Self {
+                inner: self.inner.with_io_priority(io_priority),
+            })
+        }
+
         async fn new_index_file(
             &self,
             _name: &str,


### PR DESCRIPTION
## What

The `lance-index` **test build** is currently broken on `main`: `error[E0046]: not all trait items implemented, missing: with_io_priority` at `rust/lance-index/src/scalar/fmindex.rs`.

`with_io_priority` was added to the `IndexStore` trait in #7449. The `FailNewFileStore` test fixture was added later in #7422 (which branched before #7449 landed), so it never implemented the new method. Each PR was green on its own; together on `main` the test build fails — a semantic merge conflict. It only surfaces in the `Build tests` step because the fixture is `#[cfg(test)]`.

## Fix

Implement `with_io_priority` on `FailNewFileStore` by delegating to the inner store and re-wrapping, mirroring how the fixture already delegates its other read methods while keeping the injected `new_index_file` failure.

## Verification

- `cargo check -p lance-index --tests` — compiles (was failing on `main`).
- `cargo test -p lance-index --lib fmindex` — 24 passed.
- `cargo fmt -p lance-index -- --check` and `cargo clippy -p lance-index --tests` — clean.
