### PR TITLE
fix(arrow): preserve inner nulls in convert_to_floating_point

### DIFF
--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -291,7 +291,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                         field.is_nullable(),
                     )),
                     *size,
-                    Arc::new(Float32Array::from_iter_values(
+                    Arc::new(Float32Array::from_iter(
                         self.values()
                             .as_any()
                             .downcast_ref::<Int8Array>()
@@ -299,7 +299,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                                 "Fail to cast primitive array to Int8Type".to_string(),
                             ))?
                             .into_iter()
-                            .filter_map(|x| x.map(|y| y as f32)),
+                            .map(|x| x.map(|y| y as f32)),
                     )),
                     self.nulls().cloned(),
                 )),
@@ -310,7 +310,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                         field.is_nullable(),
                     )),
                     *size,
-                    Arc::new(Float32Array::from_iter_values(
+                    Arc::new(Float32Array::from_iter(
                         self.values()
                             .as_any()
                             .downcast_ref::<Int16Array>()
@@ -318,7 +318,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                                 "Fail to cast primitive array to Int16Type".to_string(),
                             ))?
                             .into_iter()
-                            .filter_map(|x| x.map(|y| y as f32)),
+                            .map(|x| x.map(|y| y as f32)),
                     )),
                     self.nulls().cloned(),
                 )),
@@ -329,7 +329,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                         field.is_nullable(),
                     )),
                     *size,
-                    Arc::new(Float32Array::from_iter_values(
+                    Arc::new(Float32Array::from_iter(
                         self.values()
                             .as_any()
                             .downcast_ref::<Int32Array>()
@@ -337,7 +337,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                                 "Fail to cast primitive array to Int32Type".to_string(),
                             ))?
                             .into_iter()
-                            .filter_map(|x| x.map(|y| y as f32)),
+                            .map(|x| x.map(|y| y as f32)),
                     )),
                     self.nulls().cloned(),
                 )),
@@ -348,7 +348,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                         field.is_nullable(),
                     )),
                     *size,
-                    Arc::new(Float64Array::from_iter_values(
+                    Arc::new(Float64Array::from_iter(
                         self.values()
                             .as_any()
                             .downcast_ref::<Int64Array>()
@@ -356,7 +356,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                                 "Fail to cast primitive array to Int64Type".to_string(),
                             ))?
                             .into_iter()
-                            .filter_map(|x| x.map(|y| y as f64)),
+                            .map(|x| x.map(|y| y as f64)),
                     )),
                     self.nulls().cloned(),
                 )),
@@ -367,7 +367,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                         field.is_nullable(),
                     )),
                     *size,
-                    Arc::new(Float64Array::from_iter_values(
+                    Arc::new(Float64Array::from_iter(
                         self.values()
                             .as_any()
                             .downcast_ref::<UInt8Array>()
@@ -375,7 +375,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                                 "Fail to cast primitive array to UInt8Type".to_string(),
                             ))?
                             .into_iter()
-                            .filter_map(|x| x.map(|y| y as f64)),
+                            .map(|x| x.map(|y| y as f64)),
                     )),
                     self.nulls().cloned(),
                 )),
@@ -386,7 +386,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                         field.is_nullable(),
                     )),
                     *size,
-                    Arc::new(Float64Array::from_iter_values(
+                    Arc::new(Float64Array::from_iter(
                         self.values()
                             .as_any()
                             .downcast_ref::<UInt32Array>()
@@ -394,7 +394,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
                                 "Fail to cast primitive array to UInt32Type".to_string(),
                             ))?
                             .into_iter()
-                            .filter_map(|x| x.map(|y| y as f64)),
+                            .map(|x| x.map(|y| y as f64)),
                     )),
                     self.nulls().cloned(),
                 )),
@@ -1562,6 +1562,63 @@ mod tests {
     use arrow_array::{Float32Array, Int32Array, NullArray, StructArray};
     use arrow_array::{ListArray, StringArray, new_empty_array, new_null_array};
     use arrow_buffer::OffsetBuffer;
+
+    #[test]
+    fn test_convert_to_floating_point_preserves_inner_nulls() {
+        // A FixedSizeList<Int8> with a null inner element must convert to a
+        // FixedSizeList<Float32> with the null kept in place. Dropping it would
+        // shorten the values array and shift every later element (and, when the
+        // remaining count is not a multiple of the list size, panic).
+        let values = Int8Array::from(vec![Some(1), None, Some(3), Some(4)]);
+        let fsl = FixedSizeListArray::new(
+            Arc::new(Field::new("item", DataType::Int8, true)),
+            2,
+            Arc::new(values),
+            None,
+        );
+
+        let converted = fsl.convert_to_floating_point().unwrap();
+
+        assert_eq!(converted.len(), 2);
+        let conv_values = converted
+            .values()
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap();
+        assert_eq!(conv_values.len(), 4);
+        assert_eq!(conv_values.value(0), 1.0);
+        assert!(conv_values.is_null(1));
+        assert_eq!(conv_values.value(2), 3.0);
+        assert_eq!(conv_values.value(3), 4.0);
+    }
+
+    #[test]
+    fn test_convert_to_floating_point_preserves_inner_nulls_f64_arm() {
+        // The Float64-producing arms (Int64/UInt8/UInt32) share the same fix as the
+        // Float32 arms; cover one representative (UInt8 -> Float64) so both branch
+        // families are exercised.
+        let values = UInt8Array::from(vec![Some(10u8), None, Some(30), Some(40)]);
+        let fsl = FixedSizeListArray::new(
+            Arc::new(Field::new("item", DataType::UInt8, true)),
+            2,
+            Arc::new(values),
+            None,
+        );
+
+        let converted = fsl.convert_to_floating_point().unwrap();
+
+        assert_eq!(converted.len(), 2);
+        let conv_values = converted
+            .values()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(conv_values.len(), 4);
+        assert_eq!(conv_values.value(0), 10.0);
+        assert!(conv_values.is_null(1));
+        assert_eq!(conv_values.value(2), 30.0);
+        assert_eq!(conv_values.value(3), 40.0);
+    }
 
     #[test]
     fn test_merge_recursive() {


### PR DESCRIPTION
## What

`FixedSizeListArrayExt::convert_to_floating_point` (used throughout the vector-indexing path — ivf, kmeans, residual, l2/dot/cosine distance) built each integer arm's float values with `from_iter_values(... .filter_map(|x| x.map(...)))`. `filter_map` **drops null inner elements**, so the values array gets shorter while the outer `FixedSizeList` null buffer is kept at full length (`self.nulls().cloned()`). For a nullable integer vector this either panics in `FixedSizeListArray::new` (when the surviving element count is not a multiple of the list size) or silently shifts every later element into the wrong list.

## Fix

Switch each arm from `from_iter_values(... filter_map(|x| x.map(...)))` to `from_iter(... map(|x| x.map(...)))`, which keeps nulls in place (same length, null positions preserved). For all-non-null data this is identical to the previous behavior, so existing callers are unaffected.

## Test

`test_convert_to_floating_point_preserves_inner_nulls` builds a `FixedSizeList<Int8>` with a null inner element and asserts the conversion keeps 2 lists / 4 values with the null still at position 1. It panics on `main` (3 surviving values, `3 % 2 != 0`) and passes with the fix.

`cargo test -p lance-arrow`, `cargo clippy -p lance-arrow --tests -- -D warnings`, and `cargo fmt -- --check` are green.

## Note

The per-type structure (Int8/16/32 → Float32, Int64/UInt8/UInt32 → Float64) is left as-is. A follow-up could collapse the whole match to `arrow_cast::cast`, but that would add an `arrow-cast` dependency to this crate, so it's intentionally kept out of this focused correctness fix.
