### PR TITLE
perf(arrow): avoid per-element allocation in BFloat16Array::from

### DIFF
--- a/rust/lance-arrow/src/bfloat16.rs
+++ b/rust/lance-arrow/src/bfloat16.rs
@@ -161,12 +161,12 @@ impl From<Vec<bf16>> for BFloat16Array {
     fn from(data: Vec<bf16>) -> Self {
         let mut buffer = MutableBuffer::with_capacity(data.len() * 2);
 
-        let bytes = data.iter().flat_map(|val| {
-            let bytes = val.to_bits().to_le_bytes();
-            bytes.to_vec()
-        });
+        // Write each value's little-endian bytes straight into the buffer. Going
+        // through an intermediate `Vec` per element would allocate once per value.
+        for val in &data {
+            buffer.extend_from_slice(&val.to_bits().to_le_bytes());
+        }
 
-        buffer.extend(bytes);
         let array_data = ArrayData::builder(DataType::FixedSizeBinary(2))
             .len(data.len())
             .add_buffer(buffer.into());


### PR DESCRIPTION
## What

`impl From<Vec<bf16>> for BFloat16Array` built its byte buffer with:

```rust
let bytes = data.iter().flat_map(|val| {
    let bytes = val.to_bits().to_le_bytes();  // [u8; 2] on the stack
    bytes.to_vec()                            // heap allocation per element
});
buffer.extend(bytes);
```

`to_vec()` heap-allocates a 2-byte `Vec` for **every** element. On the vector-ingestion path (`coerce_float_vector` → `BFloat16Array::from`) that is ~2M tiny allocations for a 4096×512 bf16 batch.

## Fix

Write each value's little-endian bytes straight into the pre-sized `MutableBuffer`:

```rust
for val in &data {
    buffer.extend_from_slice(&val.to_bits().to_le_bytes());
}
```

No per-element allocation; the bytes produced are identical.

## Test

Behavior-preserving — the existing `test_basics` already asserts `BFloat16Array::from(values) == BFloat16Array::from_iter_values(values)` and checks the decoded values, and `test_nulls` / `test_coerce_float_vector_bfloat16` cover the surrounding paths. All pass. `cargo clippy -p lance-arrow --tests -- -D warnings` and `cargo fmt -- --check` are green.
