### PR TITLE
fix: don't quote column names in list_indices

### DIFF
--- a/python/python/tests/test_column_names.py
+++ b/python/python/tests/test_column_names.py
@@ -349,7 +349,7 @@ class TestSpecialCharacterColumnNames:
 
         indices = special_char_dataset.describe_indices()
         assert len(indices) == 1
-        assert indices[0].field_names == ["`user-id`"]
+        assert indices[0].field_names == ["user-id"]
         assert indices[0].name == "user-id_idx"
 
         # Query using the indexed column (requires backticks in filter)
@@ -576,7 +576,7 @@ class TestNestedFieldColumnNames:
 
         indices = nested_special_char_dataset.describe_indices()
         assert len(indices) == 1
-        assert indices[0].field_names == ["`meta-data`.`user-id`"]
+        assert indices[0].field_names == ["meta-data.user-id"]
         assert indices[0].name == "meta-data.user-id_idx"
 
         # Query using the indexed column (backticks required in filter)
@@ -600,7 +600,7 @@ class TestNestedFieldColumnNames:
 
         indices = nested_special_char_dataset.describe_indices()
         assert len(indices) == 1
-        assert indices[0].field_names == ["`row-id`"]
+        assert indices[0].field_names == ["row-id"]
 
         result = nested_special_char_dataset.to_table(filter="`row-id` = 50")
         assert result.num_rows == 1

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -708,7 +708,7 @@ impl PyIndexDescription {
             .map(|field| {
                 dataset
                     .schema()
-                    .field_path(*field as i32)
+                    .field_path_minimal(*field as i32)
                     .unwrap_or_else(|_| "<unknown>".to_string())
             })
             .collect();

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -24,7 +24,7 @@ pub use field::{
 };
 pub use schema::{
     BlobHandling, FieldRef, OnMissing, Projectable, Projection, Schema,
-    escape_field_path_for_project, format_field_path, parse_field_path,
+    escape_field_path_for_project, format_field_path, format_field_path_minimal, parse_field_path,
     validate_fixed_size_list_dimensions,
 };
 

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -762,11 +762,36 @@ impl Schema {
 
     /// Returns the properly formatted path from root to the field.
     /// Field names containing dots are quoted (e.g., struct.`field.with.dot`)
+    ///
+    /// The result is suitable for SQL parsing. For a human-readable path
+    /// (e.g. for display in index metadata), use [`Self::field_path_minimal`].
     pub fn field_path(&self, field_id: i32) -> Result<String> {
         self.field_ancestry_by_id(field_id)
             .map(|ancestry| {
                 let field_refs: Vec<&str> = ancestry.iter().map(|f| f.name.as_str()).collect();
                 format_field_path(&field_refs)
+            })
+            .ok_or_else(|| {
+                Error::index(format!("Could not find field ancestry for id {}", field_id))
+            })
+    }
+
+    /// Returns the path from root to the field using *minimal* quoting.
+    ///
+    /// A segment is wrapped in backticks only when it contains a character that
+    /// [`parse_field_path`] treats specially (a `.` separator or a `` ` `` quote);
+    /// any other character — including hyphens — is left bare. Unlike
+    /// [`Self::field_path`] (which quotes for SQL-expression safety and so wraps
+    /// e.g. `my-col` in backticks), the result here is both human-readable and
+    /// round-trips back through `parse_field_path`, so it is safe to feed into
+    /// field-path APIs such as `drop_columns` / `update_field_metadata`.
+    ///
+    /// This is what should be exposed as the column name in index metadata.
+    pub fn field_path_minimal(&self, field_id: i32) -> Result<String> {
+        self.field_ancestry_by_id(field_id)
+            .map(|ancestry| {
+                let field_refs: Vec<&str> = ancestry.iter().map(|f| f.name.as_str()).collect();
+                format_field_path_minimal(&field_refs)
             })
             .ok_or_else(|| {
                 Error::index(format!("Could not find field ancestry for id {}", field_id))
@@ -1621,6 +1646,33 @@ pub fn format_field_path(fields: &[&str]) -> String {
             let needs_quoting = field.chars().any(|c| !c.is_alphanumeric() && c != '_');
             if needs_quoting {
                 // Escape backticks by doubling them (PostgreSQL style)
+                let escaped = field.replace('`', "``");
+                format!("`{}`", escaped)
+            } else {
+                field.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+/// Like [`format_field_path`], but quotes a segment only when strictly required
+/// for the result to round-trip back through [`parse_field_path`].
+///
+/// `parse_field_path` only treats `.` (segment separator) and `` ` `` (quote)
+/// specially, so those are the only characters that force quoting here. Notably
+/// a hyphen does NOT force quoting (`my-col` stays `my-col`), unlike
+/// `format_field_path` which quotes any non-identifier character for
+/// SQL-expression safety. Use this for human-readable, round-trippable paths
+/// (e.g. column names in index metadata); use `format_field_path` when the
+/// result will be embedded in a SQL expression.
+pub fn format_field_path_minimal(fields: &[&str]) -> String {
+    fields
+        .iter()
+        .map(|field| {
+            let needs_quoting = field.contains('.') || field.contains('`');
+            if needs_quoting {
+                // Escape embedded backticks by doubling them, matching parse_field_path.
                 let escaped = field.replace('`', "``");
                 format!("`{}`", escaped)
             } else {
@@ -2801,6 +2853,64 @@ mod tests {
         assert!(paths.contains(&"id".to_string()));
         assert!(paths.contains(&"vector".to_string()));
         assert!(paths.contains(&"name".to_string()));
+    }
+
+    #[test]
+    fn test_field_path_minimal() {
+        // A struct child whose own NAME contains a dot is the case that makes
+        // "just strip all backticks" wrong: it must stay quoted to round-trip.
+        let arrow_schema = ArrowSchema::new(vec![
+            ArrowField::new("mycol", ArrowDataType::Int32, false),
+            ArrowField::new("my_col", ArrowDataType::Int32, false),
+            ArrowField::new("my-col", ArrowDataType::Int32, false),
+            ArrowField::new(
+                "parent",
+                ArrowDataType::Struct(ArrowFields::from(vec![
+                    ArrowField::new("child-field", ArrowDataType::Int32, true),
+                    ArrowField::new("child.x", ArrowDataType::Int32, true),
+                ])),
+                true,
+            ),
+        ]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+        let id_of = |path: &str| schema.field(path).unwrap().id;
+        let child_id = |name: &str| {
+            schema
+                .field("parent")
+                .unwrap()
+                .children
+                .iter()
+                .find(|c| c.name == name)
+                .unwrap()
+                .id
+        };
+
+        // Plain identifiers: unchanged by either method.
+        assert_eq!(schema.field_path_minimal(id_of("mycol")).unwrap(), "mycol");
+        assert_eq!(schema.field_path_minimal(id_of("my_col")).unwrap(), "my_col");
+
+        // Hyphen is NOT special to parse_field_path, so minimal quoting leaves it
+        // bare (field_path would quote it for SQL safety).
+        assert_eq!(schema.field_path(id_of("my-col")).unwrap(), "`my-col`");
+        assert_eq!(
+            schema.field_path_minimal(id_of("my-col")).unwrap(),
+            "my-col"
+        );
+
+        // Nested hyphenated leaf: bare under minimal quoting.
+        assert_eq!(
+            schema.field_path_minimal(child_id("child-field")).unwrap(),
+            "parent.child-field"
+        );
+
+        // Nested leaf whose NAME contains a dot: MUST stay quoted so it
+        // round-trips through parse_field_path (this is the regression guard).
+        let dotted = schema.field_path_minimal(child_id("child.x")).unwrap();
+        assert_eq!(dotted, "parent.`child.x`");
+        assert_eq!(
+            parse_field_path(&dotted).unwrap(),
+            vec!["parent".to_string(), "child.x".to_string()]
+        );
     }
 
     #[test]

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -787,6 +787,35 @@ impl Schema {
     /// field-path APIs such as `drop_columns` / `update_field_metadata`.
     ///
     /// This is what should be exposed as the column name in index metadata.
+    ///
+    /// ```
+    /// use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema};
+    /// use lance_core::datatypes::{parse_field_path, Schema};
+    ///
+    /// let arrow = ArrowSchema::new(vec![
+    ///     Field::new("my-col", DataType::Int32, false),
+    ///     Field::new(
+    ///         "parent",
+    ///         DataType::Struct(Fields::from(vec![Field::new("child.x", DataType::Int32, true)])),
+    ///         true,
+    ///     ),
+    /// ]);
+    /// let schema = Schema::try_from(&arrow).unwrap();
+    ///
+    /// // A hyphen is not special to `parse_field_path`, so it is left bare
+    /// // (unlike `field_path`, which would quote it as `` `my-col` ``).
+    /// let hyphen_id = schema.field("my-col").unwrap().id;
+    /// assert_eq!(schema.field_path_minimal(hyphen_id).unwrap(), "my-col");
+    ///
+    /// // A `.` in a segment forces quoting so the path still round-trips.
+    /// let dotted_id = schema.field("parent").unwrap().children[0].id;
+    /// let path = schema.field_path_minimal(dotted_id).unwrap();
+    /// assert_eq!(path, "parent.`child.x`");
+    /// assert_eq!(
+    ///     parse_field_path(&path).unwrap(),
+    ///     vec!["parent".to_string(), "child.x".to_string()],
+    /// );
+    /// ```
     pub fn field_path_minimal(&self, field_id: i32) -> Result<String> {
         self.field_ancestry_by_id(field_id)
             .map(|ancestry| {
@@ -1666,6 +1695,23 @@ pub fn format_field_path(fields: &[&str]) -> String {
 /// SQL-expression safety. Use this for human-readable, round-trippable paths
 /// (e.g. column names in index metadata); use `format_field_path` when the
 /// result will be embedded in a SQL expression.
+///
+/// ```
+/// use lance_core::datatypes::{format_field_path_minimal, parse_field_path};
+///
+/// // Plain identifiers and hyphenated names are left bare.
+/// assert_eq!(format_field_path_minimal(&["parent", "my-col"]), "parent.my-col");
+/// // A `.` in a segment forces quoting.
+/// assert_eq!(format_field_path_minimal(&["parent", "child.x"]), "parent.`child.x`");
+/// // Embedded backticks are escaped by doubling them.
+/// assert_eq!(format_field_path_minimal(&["child`x"]), "`child``x`");
+///
+/// // Whatever it produces round-trips back through `parse_field_path`.
+/// for segments in [vec!["parent", "my-col"], vec!["parent", "child.x"], vec!["child`x"]] {
+///     let path = format_field_path_minimal(&segments);
+///     assert_eq!(parse_field_path(&path).unwrap(), segments);
+/// }
+/// ```
 pub fn format_field_path_minimal(fields: &[&str]) -> String {
     fields
         .iter()
@@ -2868,6 +2914,7 @@ mod tests {
                 ArrowDataType::Struct(ArrowFields::from(vec![
                     ArrowField::new("child-field", ArrowDataType::Int32, true),
                     ArrowField::new("child.x", ArrowDataType::Int32, true),
+                    ArrowField::new("child`x", ArrowDataType::Int32, true),
                 ])),
                 true,
             ),
@@ -2887,7 +2934,10 @@ mod tests {
 
         // Plain identifiers: unchanged by either method.
         assert_eq!(schema.field_path_minimal(id_of("mycol")).unwrap(), "mycol");
-        assert_eq!(schema.field_path_minimal(id_of("my_col")).unwrap(), "my_col");
+        assert_eq!(
+            schema.field_path_minimal(id_of("my_col")).unwrap(),
+            "my_col"
+        );
 
         // Hyphen is NOT special to parse_field_path, so minimal quoting leaves it
         // bare (field_path would quote it for SQL safety).
@@ -2910,6 +2960,15 @@ mod tests {
         assert_eq!(
             parse_field_path(&dotted).unwrap(),
             vec!["parent".to_string(), "child.x".to_string()]
+        );
+
+        // Nested leaf whose NAME contains a backtick: it must be quoted AND the
+        // backtick doubled so it round-trips through parse_field_path.
+        let backticked = schema.field_path_minimal(child_id("child`x")).unwrap();
+        assert_eq!(backticked, "parent.`child``x`");
+        assert_eq!(
+            parse_field_path(&backticked).unwrap(),
+            vec!["parent".to_string(), "child`x".to_string()]
         );
     }
 

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -3951,7 +3951,7 @@ impl LanceNamespace for DirectoryNamespace {
                         .map(|field_id| {
                         dataset
                             .schema()
-                            .field_path(i32::try_from(*field_id).map_err(|e| {
+                            .field_path_minimal(i32::try_from(*field_id).map_err(|e| {
                                 lance_core::Error::from(NamespaceError::Internal {
                                     message: format!(
                                         "Field id {} does not fit in i32 for table '{}': {}",


### PR DESCRIPTION
The bug: have a column with a hyphen, like "col-3". Build an index on it. Call list_indices, get a value that's double-quoted, like:
```
{'name': 'col-3_idx', 'type': 'BTree', 'uuid': '5db8a52c-1398-437a-9d1f-9b2570dd1b19', 'fields': ['`col-3`'], 'version': 3, 'fragment_ids': {0}, 'base_id': None}
```
The fix: use `field_path_minimal` to only quote the value if it has a dot or a backtick in it (and therefore needs it - otherwise it's impossible to tell if `my_loc.coords.lat` is `{my_loc: {coords: {lat: ...}}}` or `{my_loc: {"coords.lat": }}`

I think this change is purely cosmetic, because calls like `drop_column` and `update_field_metadata` seem to work even when passed
```
"`col-3`"
```
So I am fine with either merging this or not (and prettifying it on the UI side e.g. if I display these results)