### PR TITLE
fix: improve FM index query performance

### DIFF
--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -54,6 +54,7 @@ const FMINDEX_INDEX_VERSION: u32 = 10;
 const BLOCK_WORDS: usize = 4096;
 const PARTITION_SIZE: usize = 10_000;
 const DEFAULT_PARTITION_SIZE_BYTES: usize = 16 * 1024 * 1024;
+const PREWARM_CHUNK_TARGET_BYTES: usize = 128 * 1024 * 1024;
 const SENTINEL_BYTE: u8 = 0xFF;
 
 /// SA sampling rate. Store every D-th SA entry. Locate walks at most D LF steps.
@@ -478,13 +479,68 @@ impl LazyRankBitVec {
     /// Pre-load all blocks into memory. Call this before sync rank/access operations
     /// to avoid the need for `block_in_place` during queries.
     async fn load_all_blocks(&self) -> Result<()> {
-        for (idx, lock) in self.blocks.iter().enumerate() {
-            if lock.get().is_none() {
-                let words = self.load_block(idx).await?;
-                let _ = lock.set(words);
+        let chunk_rows = (PREWARM_CHUNK_TARGET_BYTES / (BLOCK_WORDS * 8)).max(1);
+        let mut start = 0;
+        while start < self.blocks.len() {
+            let end = (start + chunk_rows).min(self.blocks.len());
+            if self.blocks[start..end]
+                .iter()
+                .all(|lock| lock.get().is_some())
+            {
+                start = end;
+                continue;
             }
+
+            let batch = self
+                .reader
+                .read_range(
+                    self.block_row_offset + start..self.block_row_offset + end,
+                    Some(&["words"]),
+                )
+                .await?;
+            if batch.num_rows() != end - start {
+                return Err(Error::index(format!(
+                    "expected {} FM-Index block rows, got {}",
+                    end - start,
+                    batch.num_rows()
+                )));
+            }
+            let col = Self::words_column(&batch)?;
+            for row in 0..batch.num_rows() {
+                let block_idx = start + row;
+                if self.blocks[block_idx].get().is_none() {
+                    let words = Self::decode_words(col.value(row));
+                    let _ = self.blocks[block_idx].set(words);
+                }
+            }
+            start = end;
         }
         Ok(())
+    }
+
+    async fn load_block_if_needed(&self, idx: usize) -> Result<()> {
+        if idx >= self.blocks.len() {
+            return Err(Error::index(format!(
+                "FM-Index block {idx} is out of range for {} blocks",
+                self.blocks.len()
+            )));
+        }
+        if self.blocks[idx].get().is_none() {
+            let words = self.load_block(idx).await?;
+            let _ = self.blocks[idx].set(words);
+        }
+        Ok(())
+    }
+
+    async fn load_block_for_rank(&self, pos: usize) -> Result<()> {
+        if pos == 0 || pos.is_multiple_of(BLOCK_BITS) {
+            return Ok(());
+        }
+        self.load_block_if_needed(pos / BLOCK_BITS).await
+    }
+
+    async fn load_block_for_access(&self, pos: usize) -> Result<()> {
+        self.load_block_if_needed(pos / BLOCK_BITS).await
     }
 
     #[inline]
@@ -503,16 +559,22 @@ impl LazyRankBitVec {
             .reader
             .read_range(row..row + 1, Some(&["words"]))
             .await?;
-        let col = batch
+        let col = Self::words_column(&batch)?;
+        Ok(Self::decode_words(col.value(0)))
+    }
+
+    fn words_column(batch: &RecordBatch) -> Result<&arrow_array::LargeBinaryArray> {
+        batch
             .column(0)
             .as_any()
             .downcast_ref::<arrow_array::LargeBinaryArray>()
-            .ok_or_else(|| Error::invalid_input("expected LargeBinary words column"))?;
-        Ok(col
-            .value(0)
-            .chunks_exact(8)
+            .ok_or_else(|| Error::invalid_input("expected LargeBinary words column"))
+    }
+
+    fn decode_words(raw: &[u8]) -> Vec<u64> {
+        raw.chunks_exact(8)
             .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
-            .collect())
+            .collect()
     }
 
     #[inline]
@@ -611,6 +673,31 @@ impl LazyHuffmanWaveletTree {
         }
     }
 
+    async fn access_async(&self, mut pos: usize) -> Result<u8> {
+        if self.nodes.is_empty() {
+            return Ok(0);
+        }
+        let mut node_idx = 0;
+        loop {
+            self.nodes[node_idx].load_block_for_access(pos).await?;
+            let bit = self.nodes[node_idx].get(pos);
+            let (ref left, ref right) = self.children[node_idx];
+            if bit {
+                pos = self.nodes[node_idx].rank1(pos);
+                match right {
+                    WaveletChild::Leaf(b) => return Ok(*b),
+                    WaveletChild::Node(next) => node_idx = *next,
+                }
+            } else {
+                pos = self.nodes[node_idx].rank0(pos);
+                match left {
+                    WaveletChild::Leaf(b) => return Ok(*b),
+                    WaveletChild::Node(next) => node_idx = *next,
+                }
+            }
+        }
+    }
+
     #[inline]
     fn rank(&self, c: u8, pos: usize) -> usize {
         let code = &self.codes[c as usize];
@@ -628,6 +715,26 @@ impl LazyHuffmanWaveletTree {
             }
         }
         hi - lo
+    }
+
+    async fn rank_async(&self, c: u8, pos: usize) -> Result<usize> {
+        let code = &self.codes[c as usize];
+        if code.length == 0 {
+            return Ok(0);
+        }
+        let (mut lo, mut hi) = (0, pos);
+        for (level, &nid) in code.node_path.iter().enumerate() {
+            self.nodes[nid].load_block_for_rank(lo).await?;
+            self.nodes[nid].load_block_for_rank(hi).await?;
+            if (code.bits >> (code.length - 1 - level as u8)) & 1 == 0 {
+                lo = self.nodes[nid].rank0(lo);
+                hi = self.nodes[nid].rank0(hi);
+            } else {
+                lo = self.nodes[nid].rank1(lo);
+                hi = self.nodes[nid].rank1(hi);
+            }
+        }
+        Ok(hi - lo)
     }
 
     #[inline]
@@ -649,6 +756,29 @@ impl LazyHuffmanWaveletTree {
             }
         }
         (l - s, h - s)
+    }
+
+    async fn rank_pair_async(&self, c: u8, lo: usize, hi: usize) -> Result<(usize, usize)> {
+        let code = &self.codes[c as usize];
+        if code.length == 0 {
+            return Ok((0, 0));
+        }
+        let (mut s, mut l, mut h) = (0, lo, hi);
+        for (level, &nid) in code.node_path.iter().enumerate() {
+            self.nodes[nid].load_block_for_rank(s).await?;
+            self.nodes[nid].load_block_for_rank(l).await?;
+            self.nodes[nid].load_block_for_rank(h).await?;
+            if (code.bits >> (code.length - 1 - level as u8)) & 1 == 0 {
+                s = self.nodes[nid].rank0(s);
+                l = self.nodes[nid].rank0(l);
+                h = self.nodes[nid].rank0(h);
+            } else {
+                s = self.nodes[nid].rank1(s);
+                l = self.nodes[nid].rank1(l);
+                h = self.nodes[nid].rank1(h);
+            }
+        }
+        Ok((l - s, h - s))
     }
 
     fn deep_size(&self) -> usize {
@@ -1030,6 +1160,23 @@ impl LazyFMIndex {
         (lo, hi)
     }
 
+    async fn backward_search_async(&self, pattern: &[u8]) -> Result<(usize, usize)> {
+        if pattern.is_empty() || self.wavelet.len == 0 {
+            return Ok((0, 0));
+        }
+        let (mut lo, mut hi) = (0, self.wavelet.len);
+        for &b in pattern.iter().rev() {
+            let c = self.c_table[b as usize];
+            let (occ_lo, occ_hi) = self.wavelet.rank_pair_async(b, lo, hi).await?;
+            lo = c + occ_lo;
+            hi = c + occ_hi;
+            if lo >= hi {
+                return Ok((0, 0));
+            }
+        }
+        Ok((lo, hi))
+    }
+
     #[inline]
     fn locate(&self, mut pos: usize) -> usize {
         let mut steps = 0;
@@ -1045,6 +1192,24 @@ impl LazyFMIndex {
             if steps >= n {
                 log::warn!("FM-Index SA locate exceeded {n} steps, possible index corruption");
                 return 0;
+            }
+        }
+    }
+
+    async fn locate_async(&self, mut pos: usize) -> Result<usize> {
+        let mut steps = 0;
+        let n = self.wavelet.len;
+        loop {
+            if pos.is_multiple_of(SA_SAMPLE_RATE) && (pos / SA_SAMPLE_RATE) < self.sa_samples.len()
+            {
+                return Ok((self.sa_samples[pos / SA_SAMPLE_RATE] as usize + steps) % n);
+            }
+            let c = self.wavelet.access_async(pos).await?;
+            pos = self.c_table[c as usize] + self.wavelet.rank_async(c, pos).await?;
+            steps += 1;
+            if steps >= n {
+                log::warn!("FM-Index SA locate exceeded {n} steps, possible index corruption");
+                return Ok(0);
             }
         }
     }
@@ -1090,6 +1255,24 @@ impl LazyFMIndex {
             }
         }
         result
+    }
+
+    async fn search_row_addrs_async(&self, pattern: &[u8]) -> Result<Vec<u64>> {
+        let (lo, hi) = self.backward_search_async(pattern).await?;
+        if lo >= hi {
+            return Ok(Vec::new());
+        }
+        let mut seen = std::collections::HashSet::new();
+        let mut result = Vec::new();
+        for i in lo..hi {
+            let text_pos = self.locate_async(i).await?;
+            let doc_idx = self.doc_for_position(text_pos);
+            let row_addr = self.row_ids[doc_idx];
+            if seen.insert(row_addr) {
+                result.push(row_addr);
+            }
+        }
+        Ok(result)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1362,11 +1545,14 @@ impl FMIndexScalarIndex {
             .map(|partition| {
                 let pattern = Arc::clone(&pattern);
                 async move {
-                    partition.fm.prewarm().await?;
-                    spawn_cpu(move || {
-                        Result::<Vec<u64>>::Ok(partition.fm.search_row_addrs(pattern.as_ref()))
-                    })
-                    .await
+                    if partition.fm.fully_prewarmed.load(Ordering::Acquire) {
+                        spawn_cpu(move || {
+                            Result::<Vec<u64>>::Ok(partition.fm.search_row_addrs(pattern.as_ref()))
+                        })
+                        .await
+                    } else {
+                        partition.fm.search_row_addrs_async(pattern.as_ref()).await
+                    }
                 }
             })
             .buffer_unordered(self.partition_parallelism())
@@ -2542,6 +2728,62 @@ mod tests {
             _ => panic!("expected exact result"),
         }
         assert_eq!(loaded_wavelet_blocks(index.as_ref()), total_blocks);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_contains_search_does_not_full_prewarm_partitions() {
+        let docs: Vec<Vec<u8>> = (0..30)
+            .map(|i| format!("document {i} hello world test data").into_bytes())
+            .collect();
+        let texts: Vec<(u64, Vec<u8>)> = docs
+            .into_iter()
+            .enumerate()
+            .map(|(i, d)| (i as u64, d))
+            .collect();
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            index_dir,
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        write_partitioned_fmindex(&texts, store.as_ref())
+            .await
+            .unwrap();
+
+        let index = FMIndexScalarIndex::load(store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        assert_eq!(loaded_wavelet_blocks(index.as_ref()), 0);
+        assert!(
+            index
+                .partitions
+                .iter()
+                .all(|partition| !partition.fm.fully_prewarmed.load(Ordering::Acquire))
+        );
+
+        let r = index
+            .search(
+                &TextQuery::StringContains("document 15".to_string()),
+                &crate::metrics::NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        match r {
+            SearchResult::Exact(set) => {
+                assert_eq!(set.len(), Some(1));
+            }
+            _ => panic!("expected exact result"),
+        }
+
+        assert!(
+            index
+                .partitions
+                .iter()
+                .all(|partition| !partition.fm.fully_prewarmed.load(Ordering::Acquire))
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -54,7 +54,7 @@ const FMINDEX_INDEX_VERSION: u32 = 10;
 const BLOCK_WORDS: usize = 4096;
 const PARTITION_SIZE: usize = 10_000;
 const DEFAULT_PARTITION_SIZE_BYTES: usize = 16 * 1024 * 1024;
-const PREWARM_CHUNK_TARGET_BYTES: usize = 128 * 1024 * 1024;
+const DEFAULT_PREWARM_CHUNK_TARGET_BYTES: usize = 8 * 1024 * 1024;
 const SENTINEL_BYTE: u8 = 0xFF;
 
 /// SA sampling rate. Store every D-th SA entry. Locate walks at most D LF steps.
@@ -85,6 +85,20 @@ static LANCE_FMINDEX_WRITE_QUEUE_SIZE: std::sync::LazyLock<usize> =
             .parse()
             .expect("failed to parse LANCE_FMINDEX_WRITE_QUEUE_SIZE")
     });
+static LANCE_FMINDEX_PREWARM_CHUNK_BYTES: std::sync::LazyLock<usize> =
+    std::sync::LazyLock::new(|| {
+        std::env::var("LANCE_FMINDEX_PREWARM_CHUNK_BYTES")
+            .unwrap_or_else(|_| DEFAULT_PREWARM_CHUNK_TARGET_BYTES.to_string())
+            .parse()
+            .expect("failed to parse LANCE_FMINDEX_PREWARM_CHUNK_BYTES")
+    });
+static LANCE_FMINDEX_PREWARM_CHUNK_CONCURRENCY: std::sync::LazyLock<usize> =
+    std::sync::LazyLock::new(|| {
+        std::env::var("LANCE_FMINDEX_PREWARM_CHUNK_CONCURRENCY")
+            .unwrap_or_else(|_| "1".to_string())
+            .parse()
+            .expect("failed to parse LANCE_FMINDEX_PREWARM_CHUNK_CONCURRENCY")
+    });
 
 fn fmindex_partition_path(partition_id: u64) -> String {
     format!("part_{partition_id}_fm.lance")
@@ -104,6 +118,14 @@ fn fmindex_partition_bytes() -> usize {
 
 fn fmindex_write_queue_size() -> usize {
     (*LANCE_FMINDEX_WRITE_QUEUE_SIZE).max(1)
+}
+
+fn fmindex_prewarm_chunk_bytes() -> usize {
+    (*LANCE_FMINDEX_PREWARM_CHUNK_BYTES).max(BLOCK_WORDS * 8)
+}
+
+fn fmindex_prewarm_chunk_concurrency() -> usize {
+    (*LANCE_FMINDEX_PREWARM_CHUNK_CONCURRENCY).max(1)
 }
 
 // ── Bitvector with O(1) rank ─────────────────────────────────────────────────
@@ -626,6 +648,7 @@ impl LazyHuffmanWaveletTree {
         let Some(total_rows) = ranges.iter().map(|range| range.end).max() else {
             return Ok(());
         };
+        let ranges = Arc::new(ranges);
 
         let chunk_loaded = |start: usize, end: usize| {
             ranges.iter().all(|range| {
@@ -641,47 +664,62 @@ impl LazyHuffmanWaveletTree {
             })
         };
 
-        let chunk_rows = (PREWARM_CHUNK_TARGET_BYTES / (BLOCK_WORDS * 8)).max(1);
+        let chunk_rows = (fmindex_prewarm_chunk_bytes() / (BLOCK_WORDS * 8)).max(1);
         let reader = Arc::clone(&self.nodes[0].reader);
-        let mut start = 0;
-        while start < total_rows {
-            let end = (start + chunk_rows).min(total_rows);
-            if chunk_loaded(start, end) {
-                start = end;
-                continue;
-            }
+        let chunks = (0..total_rows)
+            .step_by(chunk_rows)
+            .map(|start| {
+                let end = (start + chunk_rows).min(total_rows);
+                (start, end)
+            })
+            .filter(|(start, end)| !chunk_loaded(*start, *end))
+            .collect::<Vec<_>>();
 
-            let batch = reader.read_range(start..end, Some(&["words"])).await?;
-            if batch.num_rows() != end - start {
-                return Err(Error::index(format!(
-                    "expected {} FM-Index block rows, got {}",
-                    end - start,
-                    batch.num_rows()
-                )));
-            }
-
-            let col = LazyRankBitVec::words_column(&batch)?;
-            let mut range_idx = ranges.partition_point(|range| range.end <= start);
-            for row in 0..batch.num_rows() {
-                let absolute_row = start + row;
-                while range_idx < ranges.len() && absolute_row >= ranges[range_idx].end {
-                    range_idx += 1;
+        futures::stream::iter(chunks)
+            .map(|(start, end)| {
+                let reader = Arc::clone(&reader);
+                async move {
+                    let batch = reader.read_range(start..end, Some(&["words"])).await?;
+                    Result::<_>::Ok((start, end, batch))
                 }
-                if range_idx == ranges.len() || absolute_row < ranges[range_idx].start {
-                    continue;
-                }
+            })
+            .buffer_unordered(fmindex_prewarm_chunk_concurrency())
+            .try_for_each(|(start, end, batch)| {
+                let ranges = Arc::clone(&ranges);
+                let nodes = &self.nodes;
+                async move {
+                    if batch.num_rows() != end - start {
+                        return Err(Error::index(format!(
+                            "expected {} FM-Index block rows, got {}",
+                            end - start,
+                            batch.num_rows()
+                        )));
+                    }
 
-                let range = ranges[range_idx];
-                let block_idx = absolute_row - range.start;
-                let node = &self.nodes[range.node_idx];
-                if node.blocks[block_idx].get().is_none() {
-                    let words = LazyRankBitVec::decode_words(col.value(row));
-                    let _ = node.blocks[block_idx].set(words);
-                }
-            }
+                    let col = LazyRankBitVec::words_column(&batch)?;
+                    let mut range_idx = ranges.partition_point(|range| range.end <= start);
+                    for row in 0..batch.num_rows() {
+                        let absolute_row = start + row;
+                        while range_idx < ranges.len() && absolute_row >= ranges[range_idx].end {
+                            range_idx += 1;
+                        }
+                        if range_idx == ranges.len() || absolute_row < ranges[range_idx].start {
+                            continue;
+                        }
 
-            start = end;
-        }
+                        let range = ranges[range_idx];
+                        let block_idx = absolute_row - range.start;
+                        let node = &nodes[range.node_idx];
+                        if node.blocks[block_idx].get().is_none() {
+                            let words = LazyRankBitVec::decode_words(col.value(row));
+                            let _ = node.blocks[block_idx].set(words);
+                        }
+                    }
+
+                    Ok(())
+                }
+            })
+            .await?;
 
         Ok(())
     }

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -476,48 +476,6 @@ impl LazyRankBitVec {
         }
     }
 
-    /// Pre-load all blocks into memory. Call this before sync rank/access operations
-    /// to avoid the need for `block_in_place` during queries.
-    async fn load_all_blocks(&self) -> Result<()> {
-        let chunk_rows = (PREWARM_CHUNK_TARGET_BYTES / (BLOCK_WORDS * 8)).max(1);
-        let mut start = 0;
-        while start < self.blocks.len() {
-            let end = (start + chunk_rows).min(self.blocks.len());
-            if self.blocks[start..end]
-                .iter()
-                .all(|lock| lock.get().is_some())
-            {
-                start = end;
-                continue;
-            }
-
-            let batch = self
-                .reader
-                .read_range(
-                    self.block_row_offset + start..self.block_row_offset + end,
-                    Some(&["words"]),
-                )
-                .await?;
-            if batch.num_rows() != end - start {
-                return Err(Error::index(format!(
-                    "expected {} FM-Index block rows, got {}",
-                    end - start,
-                    batch.num_rows()
-                )));
-            }
-            let col = Self::words_column(&batch)?;
-            for row in 0..batch.num_rows() {
-                let block_idx = start + row;
-                if self.blocks[block_idx].get().is_none() {
-                    let words = Self::decode_words(col.value(row));
-                    let _ = self.blocks[block_idx].set(words);
-                }
-            }
-            start = end;
-        }
-        Ok(())
-    }
-
     async fn load_block_if_needed(&self, idx: usize) -> Result<()> {
         if idx >= self.blocks.len() {
             return Err(Error::index(format!(
@@ -642,9 +600,89 @@ impl std::fmt::Debug for LazyHuffmanWaveletTree {
 impl LazyHuffmanWaveletTree {
     /// Pre-load all wavelet tree blocks into memory.
     async fn load_all(&self) -> Result<()> {
-        for node in &self.nodes {
-            node.load_all_blocks().await?;
+        if self.nodes.is_empty() {
+            return Ok(());
         }
+
+        #[derive(Clone, Copy)]
+        struct RowRange {
+            start: usize,
+            end: usize,
+            node_idx: usize,
+        }
+
+        let mut ranges = self
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| !node.blocks.is_empty())
+            .map(|(node_idx, node)| RowRange {
+                start: node.block_row_offset,
+                end: node.block_row_offset + node.blocks.len(),
+                node_idx,
+            })
+            .collect::<Vec<_>>();
+        ranges.sort_by_key(|range| range.start);
+        let Some(total_rows) = ranges.iter().map(|range| range.end).max() else {
+            return Ok(());
+        };
+
+        let chunk_loaded = |start: usize, end: usize| {
+            ranges.iter().all(|range| {
+                let overlap_start = start.max(range.start);
+                let overlap_end = end.min(range.end);
+                if overlap_start >= overlap_end {
+                    return true;
+                }
+                let node = &self.nodes[range.node_idx];
+                node.blocks[overlap_start - range.start..overlap_end - range.start]
+                    .iter()
+                    .all(|block| block.get().is_some())
+            })
+        };
+
+        let chunk_rows = (PREWARM_CHUNK_TARGET_BYTES / (BLOCK_WORDS * 8)).max(1);
+        let reader = Arc::clone(&self.nodes[0].reader);
+        let mut start = 0;
+        while start < total_rows {
+            let end = (start + chunk_rows).min(total_rows);
+            if chunk_loaded(start, end) {
+                start = end;
+                continue;
+            }
+
+            let batch = reader.read_range(start..end, Some(&["words"])).await?;
+            if batch.num_rows() != end - start {
+                return Err(Error::index(format!(
+                    "expected {} FM-Index block rows, got {}",
+                    end - start,
+                    batch.num_rows()
+                )));
+            }
+
+            let col = LazyRankBitVec::words_column(&batch)?;
+            let mut range_idx = ranges.partition_point(|range| range.end <= start);
+            for row in 0..batch.num_rows() {
+                let absolute_row = start + row;
+                while range_idx < ranges.len() && absolute_row >= ranges[range_idx].end {
+                    range_idx += 1;
+                }
+                if range_idx == ranges.len() || absolute_row < ranges[range_idx].start {
+                    continue;
+                }
+
+                let range = ranges[range_idx];
+                let block_idx = absolute_row - range.start;
+                let node = &self.nodes[range.node_idx];
+                if node.blocks[block_idx].get().is_none() {
+                    let words = LazyRankBitVec::decode_words(col.value(row));
+                    let _ = node.blocks[block_idx].set(words);
+                }
+            }
+
+            start = end;
+        }
+
         Ok(())
     }
 

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -56,6 +56,7 @@ const PARTITION_SIZE: usize = 10_000;
 const DEFAULT_PARTITION_SIZE_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_DEMAND_PAGE_TARGET_BYTES: usize = 512 * 1024;
 const DEFAULT_PREWARM_CHUNK_TARGET_BYTES: usize = 8 * 1024 * 1024;
+const FMINDEX_PARTITION_FINGERPRINT_KEY: &str = "partition_fingerprint";
 const SENTINEL_BYTE: u8 = 0xFF;
 
 /// SA sampling rate. Store every D-th SA entry. Locate walks at most D LF steps.
@@ -586,7 +587,22 @@ impl LazyRankBitVec {
     }
 
     async fn load_block_for_rank(&self, pos: usize) -> Result<()> {
-        if pos == 0 || pos.is_multiple_of(BLOCK_BITS) {
+        if pos > self.len {
+            return Err(Error::invalid_input(format!(
+                "FM-Index rank position {pos} exceeds bitvector length {}",
+                self.len
+            )));
+        }
+        if pos == 0 {
+            return Ok(());
+        }
+        if pos == self.len && pos.is_multiple_of(BLOCK_BITS) {
+            if let Some(last_idx) = self.blocks.len().checked_sub(1) {
+                return self.load_block_if_needed(last_idx).await;
+            }
+            return Ok(());
+        }
+        if pos.is_multiple_of(BLOCK_BITS) {
             return Ok(());
         }
         self.load_block_if_needed(pos / BLOCK_BITS).await
@@ -630,15 +646,42 @@ impl LazyRankBitVec {
             .collect()
     }
 
+    fn terminal_rank1(&self) -> usize {
+        if self.len == 0 {
+            return 0;
+        }
+        let Some(last_idx) = self.blocks.len().checked_sub(1) else {
+            return 0;
+        };
+        let mut count = self.prefix_ranks.get(last_idx).copied().unwrap_or(0) as usize;
+        let block = self.ensure_block(last_idx);
+        let local = self.len - last_idx * BLOCK_BITS;
+        let full_words = local / 64;
+        let trailing_bits = local % 64;
+        for w in &block[..full_words] {
+            count += w.count_ones() as usize;
+        }
+        if trailing_bits > 0 {
+            count += (block[full_words] & ((1u64 << trailing_bits) - 1)).count_ones() as usize;
+        }
+        count
+    }
+
     #[inline]
     fn rank1(&self, pos: usize) -> usize {
+        debug_assert!(pos <= self.len);
         if pos == 0 {
             return 0;
         }
         let bi = pos / BLOCK_BITS;
         let local = pos % BLOCK_BITS;
         if local == 0 {
-            return self.prefix_ranks[bi] as usize;
+            if let Some(prefix_rank) = self.prefix_ranks.get(bi) {
+                return *prefix_rank as usize;
+            }
+            if pos == self.len {
+                return self.terminal_rank1();
+            }
         }
         let mut count = self.prefix_ranks[bi] as usize;
         let block = self.ensure_block(bi);
@@ -660,6 +703,7 @@ impl LazyRankBitVec {
 
     #[inline]
     fn get(&self, pos: usize) -> bool {
+        debug_assert!(pos < self.len);
         let bi = pos / BLOCK_BITS;
         let local = pos % BLOCK_BITS;
         let block = self.ensure_block(bi);
@@ -1947,12 +1991,15 @@ async fn write_partitioned_fmindex_stream_with_config(
                     ) {
                         finish_fmindex_partition(
                             &sender,
+                            store.as_ref(),
                             &mut partition,
                             &mut partition_bytes,
                             partition_id,
                             config.max_rows,
-                            &mut completed_files,
-                            &mut files,
+                            &mut FMIndexPartitionResumeState {
+                                completed_files: &mut completed_files,
+                                output_files: &mut files,
+                            },
                         )
                         .await?;
                         partition_id += 1;
@@ -1964,12 +2011,15 @@ async fn write_partitioned_fmindex_stream_with_config(
         if !partition.is_empty() {
             finish_fmindex_partition(
                 &sender,
+                store.as_ref(),
                 &mut partition,
                 &mut partition_bytes,
                 partition_id,
                 config.max_rows,
-                &mut completed_files,
-                &mut files,
+                &mut FMIndexPartitionResumeState {
+                    completed_files: &mut completed_files,
+                    output_files: &mut files,
+                },
             )
             .await?;
         }
@@ -2001,6 +2051,14 @@ async fn write_partitioned_fmindex_stream_with_config(
         return Err(err);
     }
     producer_result?;
+
+    for (partition_id, file) in completed_files.drain() {
+        log::info!(
+            "deleting stale FMIndex partition {partition_id} from previous build: {}",
+            file.path
+        );
+        store.delete_index_file(&file.path).await?;
+    }
     if files.is_empty() {
         return Ok(vec![write_empty_fmindex_partition(store.as_ref()).await?]);
     }
@@ -2022,20 +2080,33 @@ fn fmindex_partition_limit_reached(
     rows >= max_rows || bytes >= max_bytes
 }
 
+struct FMIndexPartitionResumeState<'a> {
+    completed_files: &'a mut HashMap<u64, IndexFile>,
+    output_files: &'a mut Vec<(u64, IndexFile)>,
+}
+
 async fn finish_fmindex_partition(
     sender: &async_channel::Sender<FMIndexPartitionJob>,
+    store: &dyn IndexStore,
     partition: &mut Vec<(u64, Vec<u8>)>,
     partition_bytes: &mut usize,
     partition_id: u64,
     max_rows: usize,
-    completed_files: &mut HashMap<u64, IndexFile>,
-    output_files: &mut Vec<(u64, IndexFile)>,
+    resume_state: &mut FMIndexPartitionResumeState<'_>,
 ) -> Result<()> {
     let texts = std::mem::replace(partition, Vec::with_capacity(max_rows.min(PARTITION_SIZE)));
     *partition_bytes = 0;
-    if let Some(file) = completed_files.remove(&partition_id) {
-        output_files.push((partition_id, file));
-        return Ok(());
+    if let Some(file) = resume_state.completed_files.remove(&partition_id) {
+        let fingerprint = fmindex_partition_fingerprint(&texts);
+        if fmindex_partition_matches(store, &file, &fingerprint).await? {
+            resume_state.output_files.push((partition_id, file));
+            return Ok(());
+        }
+        log::info!(
+            "rebuilding stale FMIndex partition {partition_id}: {}",
+            file.path
+        );
+        store.delete_index_file(&file.path).await?;
     }
     sender
         .send(FMIndexPartitionJob {
@@ -2048,6 +2119,41 @@ async fn finish_fmindex_partition(
                 "failed to schedule FMIndex partition {partition_id}: {err}"
             ))
         })
+}
+
+fn fmindex_partition_fingerprint(texts: &[(u64, Vec<u8>)]) -> String {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    fn update(hash: &mut u64, bytes: &[u8]) {
+        for byte in bytes {
+            *hash ^= *byte as u64;
+            *hash = hash.wrapping_mul(FNV_PRIME);
+        }
+    }
+
+    let mut hash = FNV_OFFSET;
+    update(&mut hash, b"lance-fmindex-partition-v1");
+    update(&mut hash, &(texts.len() as u64).to_le_bytes());
+    for (row_id, bytes) in texts {
+        update(&mut hash, &row_id.to_le_bytes());
+        update(&mut hash, &(bytes.len() as u64).to_le_bytes());
+        update(&mut hash, bytes);
+    }
+    format!("{hash:016x}")
+}
+
+async fn fmindex_partition_matches(
+    store: &dyn IndexStore,
+    file: &IndexFile,
+    expected_fingerprint: &str,
+) -> Result<bool> {
+    let reader = store.open_index_file(&file.path).await?;
+    Ok(reader
+        .schema()
+        .metadata
+        .get(FMINDEX_PARTITION_FINGERPRINT_KEY)
+        .is_some_and(|fingerprint| fingerprint == expected_fingerprint))
 }
 
 fn sanitize_text_bytes(bytes: &[u8]) -> Vec<u8> {
@@ -2177,7 +2283,12 @@ fn hex_decode(s: &str) -> Result<Vec<u8>> {
 ///   - Wavelet block rows (BWT nodes)
 ///   - SA sample blocks (packed u64 in LargeBinary)
 ///   - Metadata: c_table, huffman_codes, tree_topology, row_ids, doc_start_positions
-async fn write_fmindex(fm: &FMIndex, store: &dyn IndexStore, filename: &str) -> Result<IndexFile> {
+async fn write_fmindex(
+    fm: &FMIndex,
+    store: &dyn IndexStore,
+    filename: &str,
+    partition_fingerprint: Option<&str>,
+) -> Result<IndexFile> {
     let schema = Arc::new(FMIndex::block_schema());
 
     let mut writer = store.new_index_file(filename, schema.clone()).await?;
@@ -2227,6 +2338,12 @@ async fn write_fmindex(fm: &FMIndex, store: &dyn IndexStore, filename: &str) -> 
     metadata.insert("total_wavelet_rows".into(), nw.to_string());
     metadata.insert("sa_sample_rate".into(), SA_SAMPLE_RATE.to_string());
     metadata.insert("alphabet_size".into(), fm.alphabet_size.to_string());
+    if let Some(fingerprint) = partition_fingerprint {
+        metadata.insert(
+            FMINDEX_PARTITION_FINGERPRINT_KEY.into(),
+            fingerprint.to_string(),
+        );
+    }
     metadata.insert("c_table".into(), hex_encode(&fm.serialize_c_table()));
     metadata.insert(
         "huffman_codes".into(),
@@ -2271,9 +2388,16 @@ async fn write_fmindex_partition(
     store: &dyn IndexStore,
     partition_id: u64,
 ) -> Result<IndexFile> {
+    let fingerprint = fmindex_partition_fingerprint(texts);
     let refs: Vec<(u64, &[u8])> = texts.iter().map(|(id, t)| (*id, t.as_slice())).collect();
     let fm = FMIndex::build(&refs)?;
-    write_fmindex(&fm, store, &fmindex_partition_path(partition_id)).await
+    write_fmindex(
+        &fm,
+        store,
+        &fmindex_partition_path(partition_id),
+        Some(&fingerprint),
+    )
+    .await
 }
 
 async fn write_fmindex_partition_owned(
@@ -2281,18 +2405,26 @@ async fn write_fmindex_partition_owned(
     store: Arc<dyn IndexStore>,
     partition_id: u64,
 ) -> Result<(u64, IndexFile)> {
+    let fingerprint = fmindex_partition_fingerprint(&texts);
     let fm = spawn_cpu(move || {
         let refs: Vec<(u64, &[u8])> = texts.iter().map(|(id, t)| (*id, t.as_slice())).collect();
         FMIndex::build(&refs)
     })
     .await?;
-    let file = write_fmindex(&fm, store.as_ref(), &fmindex_partition_path(partition_id)).await?;
+    let file = write_fmindex(
+        &fm,
+        store.as_ref(),
+        &fmindex_partition_path(partition_id),
+        Some(&fingerprint),
+    )
+    .await?;
     Ok((partition_id, file))
 }
 
 async fn write_empty_fmindex_partition(store: &dyn IndexStore) -> Result<IndexFile> {
     let fm = FMIndex::build(&[])?;
-    write_fmindex(&fm, store, &fmindex_partition_path(0)).await
+    let fingerprint = fmindex_partition_fingerprint(&[]);
+    write_fmindex(&fm, store, &fmindex_partition_path(0), Some(&fingerprint)).await
 }
 
 // ── Plugin ───────────────────────────────────────────────────────────────────
@@ -2770,7 +2902,7 @@ mod tests {
         ));
 
         // Write
-        write_fmindex(&fm, store.as_ref(), &fmindex_partition_path(0))
+        write_fmindex(&fm, store.as_ref(), &fmindex_partition_path(0), None)
             .await
             .unwrap();
 
@@ -2912,6 +3044,39 @@ mod tests {
             _ => panic!("expected exact result"),
         }
         assert_eq!(loaded_wavelet_blocks(index.as_ref()), total_blocks);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_lazy_rank_terminal_block_boundary() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            index_dir,
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let schema = Arc::new(arrow_schema::Schema::new(vec![Field::new(
+            "words",
+            DataType::LargeBinary,
+            false,
+        )]));
+        let words = vec![u64::MAX; BLOCK_WORDS];
+        let bytes = FMIndex::u64_to_bytes(&words);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(LargeBinaryArray::from(vec![bytes.as_slice()]))],
+        )
+        .unwrap();
+        let mut writer = store.new_index_file("rank.lance", schema).await.unwrap();
+        writer.write_record_batch(batch).await.unwrap();
+        writer.finish().await.unwrap();
+
+        let reader = store.open_index_file("rank.lance").await.unwrap();
+        let bitvec = LazyRankBitVec::new(vec![0], 1, reader, 0, BLOCK_BITS);
+        bitvec.load_block_for_rank(BLOCK_BITS).await.unwrap();
+
+        assert_eq!(bitvec.rank1(BLOCK_BITS), BLOCK_BITS);
+        assert_eq!(bitvec.rank0(BLOCK_BITS), 0);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -3195,6 +3360,111 @@ mod tests {
             SearchResult::Exact(set) => {
                 assert_eq!(set.len(), Some(2));
             }
+            _ => panic!("expected exact result"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stream_train_rebuilds_stale_resume_partitions() {
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new(
+                crate::scalar::registry::VALUE_COLUMN_NAME,
+                DataType::Utf8,
+                false,
+            ),
+            arrow_schema::Field::new(ROW_ADDR, DataType::UInt64, false),
+        ]));
+        let tempdir = tempfile::tempdir().unwrap();
+        let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            index_dir,
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let stale_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["stale zero", "stale one"])),
+                Arc::new(UInt64Array::from(vec![0, 1])),
+            ],
+        )
+        .unwrap();
+        let stale_stream =
+            RecordBatchStreamAdapter::new(schema.clone(), stream::iter(vec![Ok(stale_batch)]));
+        write_partitioned_fmindex_stream_with_config(
+            Box::pin(stale_stream),
+            store.as_ref(),
+            FMIndexPartitionConfig {
+                num_workers: 1,
+                max_rows: 1,
+                max_bytes: 1024,
+                queue_size: 1,
+                resume_existing: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let fresh_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["fresh zero"])),
+                Arc::new(UInt64Array::from(vec![0])),
+            ],
+        )
+        .unwrap();
+        let fresh_stream =
+            RecordBatchStreamAdapter::new(schema.clone(), stream::iter(vec![Ok(fresh_batch)]));
+        let fresh_files = write_partitioned_fmindex_stream_with_config(
+            Box::pin(fresh_stream),
+            store.as_ref(),
+            FMIndexPartitionConfig {
+                num_workers: 1,
+                max_rows: 10,
+                max_bytes: 1024,
+                queue_size: 1,
+                resume_existing: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(fresh_files.len(), 1);
+        assert_eq!(fresh_files[0].path, fmindex_partition_path(0));
+        let remaining_paths = store
+            .list_files_with_sizes()
+            .await
+            .unwrap()
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(remaining_paths, vec![fmindex_partition_path(0)]);
+
+        let index = FMIndexScalarIndex::load(store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let r = index
+            .search(
+                &TextQuery::StringContains("fresh zero".to_string()),
+                &crate::metrics::NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        match r {
+            SearchResult::Exact(set) => assert_eq!(set.len(), Some(1)),
+            _ => panic!("expected exact result"),
+        }
+
+        let r = index
+            .search(
+                &TextQuery::StringContains("stale one".to_string()),
+                &crate::metrics::NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        match r {
+            SearchResult::Exact(set) => assert_eq!(set.len(), Some(0)),
             _ => panic!("expected exact result"),
         }
     }

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -54,6 +54,7 @@ const FMINDEX_INDEX_VERSION: u32 = 10;
 const BLOCK_WORDS: usize = 4096;
 const PARTITION_SIZE: usize = 10_000;
 const DEFAULT_PARTITION_SIZE_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_DEMAND_PAGE_TARGET_BYTES: usize = 512 * 1024;
 const DEFAULT_PREWARM_CHUNK_TARGET_BYTES: usize = 8 * 1024 * 1024;
 const SENTINEL_BYTE: u8 = 0xFF;
 
@@ -92,6 +93,13 @@ static LANCE_FMINDEX_PREWARM_CHUNK_BYTES: std::sync::LazyLock<usize> =
             .parse()
             .expect("failed to parse LANCE_FMINDEX_PREWARM_CHUNK_BYTES")
     });
+static LANCE_FMINDEX_DEMAND_PAGE_BYTES: std::sync::LazyLock<usize> =
+    std::sync::LazyLock::new(|| {
+        std::env::var("LANCE_FMINDEX_DEMAND_PAGE_BYTES")
+            .unwrap_or_else(|_| DEFAULT_DEMAND_PAGE_TARGET_BYTES.to_string())
+            .parse()
+            .expect("failed to parse LANCE_FMINDEX_DEMAND_PAGE_BYTES")
+    });
 static LANCE_FMINDEX_PREWARM_CHUNK_CONCURRENCY: std::sync::LazyLock<usize> =
     std::sync::LazyLock::new(|| {
         std::env::var("LANCE_FMINDEX_PREWARM_CHUNK_CONCURRENCY")
@@ -122,6 +130,14 @@ fn fmindex_write_queue_size() -> usize {
 
 fn fmindex_prewarm_chunk_bytes() -> usize {
     (*LANCE_FMINDEX_PREWARM_CHUNK_BYTES).max(BLOCK_WORDS * 8)
+}
+
+fn fmindex_demand_page_bytes() -> usize {
+    (*LANCE_FMINDEX_DEMAND_PAGE_BYTES).max(BLOCK_WORDS * 8)
+}
+
+fn fmindex_demand_page_rows() -> usize {
+    (fmindex_demand_page_bytes() / (BLOCK_WORDS * 8)).max(1)
 }
 
 fn fmindex_prewarm_chunk_concurrency() -> usize {
@@ -506,8 +522,44 @@ impl LazyRankBitVec {
             )));
         }
         if self.blocks[idx].get().is_none() {
-            let words = self.load_block(idx).await?;
-            let _ = self.blocks[idx].set(words);
+            self.load_page_containing(idx).await?;
+        }
+        Ok(())
+    }
+
+    async fn load_page_containing(&self, idx: usize) -> Result<()> {
+        let page_rows = fmindex_demand_page_rows();
+        let start = (idx / page_rows) * page_rows;
+        let end = (start + page_rows).min(self.blocks.len());
+        if self.blocks[start..end]
+            .iter()
+            .all(|block| block.get().is_some())
+        {
+            return Ok(());
+        }
+
+        let batch = self
+            .reader
+            .read_range(
+                self.block_row_offset + start..self.block_row_offset + end,
+                Some(&["words"]),
+            )
+            .await?;
+        if batch.num_rows() != end - start {
+            return Err(Error::index(format!(
+                "expected {} FM-Index block rows, got {}",
+                end - start,
+                batch.num_rows()
+            )));
+        }
+
+        let col = Self::words_column(&batch)?;
+        for row in 0..batch.num_rows() {
+            let block_idx = start + row;
+            if self.blocks[block_idx].get().is_none() {
+                let words = Self::decode_words(col.value(row));
+                let _ = self.blocks[block_idx].set(words);
+            }
         }
         Ok(())
     }
@@ -1588,15 +1640,26 @@ impl FMIndexScalarIndex {
             return Err(Error::invalid_input("no FM-Index partition files found"));
         }
         pfiles.sort_by_key(|(id, _)| *id);
-        let mut parts = Vec::with_capacity(pfiles.len());
-        for (id, name) in &pfiles {
-            parts.push(Arc::new(
-                Self::load_partition(store.as_ref(), name, *id).await?,
-            ));
-        }
+        let io_parallelism = store.io_parallelism().max(1);
+        let mut parts = futures::stream::iter(pfiles.into_iter())
+            .map(|(id, name)| {
+                let store = Arc::clone(&store);
+                async move {
+                    let partition = Self::load_partition(store.as_ref(), &name, id).await?;
+                    Result::<_>::Ok((id, Arc::new(partition)))
+                }
+            })
+            .buffer_unordered(io_parallelism)
+            .try_collect::<Vec<_>>()
+            .await?;
+        parts.sort_by_key(|(id, _)| *id);
+        let parts = parts
+            .into_iter()
+            .map(|(_, partition)| partition)
+            .collect::<Vec<_>>();
         Ok(Arc::new(Self {
             partitions: parts,
-            io_parallelism: store.io_parallelism().max(1),
+            io_parallelism,
         }))
     }
 

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -86,6 +86,17 @@ static LANCE_FMINDEX_WRITE_QUEUE_SIZE: std::sync::LazyLock<usize> =
             .parse()
             .expect("failed to parse LANCE_FMINDEX_WRITE_QUEUE_SIZE")
     });
+static LANCE_FMINDEX_RESUME_EXISTING_PARTITIONS: std::sync::LazyLock<bool> =
+    std::sync::LazyLock::new(|| {
+        std::env::var("LANCE_FMINDEX_RESUME_EXISTING_PARTITIONS")
+            .map(|value| {
+                matches!(
+                    value.as_str(),
+                    "1" | "true" | "TRUE" | "True" | "yes" | "YES"
+                )
+            })
+            .unwrap_or(false)
+    });
 static LANCE_FMINDEX_PREWARM_CHUNK_BYTES: std::sync::LazyLock<usize> =
     std::sync::LazyLock::new(|| {
         std::env::var("LANCE_FMINDEX_PREWARM_CHUNK_BYTES")
@@ -112,6 +123,12 @@ fn fmindex_partition_path(partition_id: u64) -> String {
     format!("part_{partition_id}_fm.lance")
 }
 
+fn fmindex_partition_id_from_path(path: &str) -> Option<u64> {
+    path.strip_prefix("part_")
+        .and_then(|r| r.strip_suffix("_fm.lance"))
+        .and_then(|s| s.parse::<u64>().ok())
+}
+
 fn fmindex_num_workers() -> usize {
     (*LANCE_FMINDEX_NUM_WORKERS).max(1)
 }
@@ -126,6 +143,10 @@ fn fmindex_partition_bytes() -> usize {
 
 fn fmindex_write_queue_size() -> usize {
     (*LANCE_FMINDEX_WRITE_QUEUE_SIZE).max(1)
+}
+
+fn fmindex_resume_existing_partitions() -> bool {
+    *LANCE_FMINDEX_RESUME_EXISTING_PARTITIONS
 }
 
 fn fmindex_prewarm_chunk_bytes() -> usize {
@@ -1627,12 +1648,7 @@ impl FMIndexScalarIndex {
         let files = store.list_files_with_sizes().await?;
         let mut pfiles: Vec<(u64, String)> = Vec::new();
         for f in &files {
-            if let Some(id) = f
-                .path
-                .strip_prefix("part_")
-                .and_then(|r| r.strip_suffix("_fm.lance"))
-                .and_then(|s| s.parse::<u64>().ok())
-            {
+            if let Some(id) = fmindex_partition_id_from_path(&f.path) {
                 pfiles.push((id, f.path.clone()));
             }
         }
@@ -1813,6 +1829,7 @@ struct FMIndexPartitionConfig {
     max_rows: usize,
     max_bytes: usize,
     queue_size: usize,
+    resume_existing: bool,
 }
 
 impl FMIndexPartitionConfig {
@@ -1822,6 +1839,7 @@ impl FMIndexPartitionConfig {
             max_rows: fmindex_partition_rows(),
             max_bytes: fmindex_partition_bytes(),
             queue_size: fmindex_write_queue_size(),
+            resume_existing: fmindex_resume_existing_partitions(),
         }
     }
 
@@ -1831,6 +1849,7 @@ impl FMIndexPartitionConfig {
             max_rows: self.max_rows.max(1),
             max_bytes: self.max_bytes.max(1),
             queue_size: self.queue_size.max(1),
+            resume_existing: self.resume_existing,
         }
     }
 }
@@ -1861,6 +1880,23 @@ async fn write_partitioned_fmindex_stream_with_config(
         async_channel::Receiver<FMIndexPartitionJob>,
     ) = async_channel::bounded(config.queue_size);
     let store = store.clone_arc();
+    let mut completed_files = if config.resume_existing {
+        store
+            .list_files_with_sizes()
+            .await?
+            .into_iter()
+            .filter_map(|file| fmindex_partition_id_from_path(&file.path).map(|id| (id, file)))
+            .collect::<HashMap<_, _>>()
+    } else {
+        HashMap::new()
+    };
+    if !completed_files.is_empty() {
+        log::info!(
+            "resuming FMIndex build with {} existing partition files",
+            completed_files.len()
+        );
+    }
+    let mut files = Vec::new();
     let mut worker_tasks = Vec::with_capacity(config.num_workers);
     for _ in 0..config.num_workers {
         let receiver = receiver.clone();
@@ -1909,12 +1945,14 @@ async fn write_partitioned_fmindex_stream_with_config(
                         config.max_rows,
                         config.max_bytes,
                     ) {
-                        send_fmindex_partition(
+                        finish_fmindex_partition(
                             &sender,
                             &mut partition,
                             &mut partition_bytes,
                             partition_id,
                             config.max_rows,
+                            &mut completed_files,
+                            &mut files,
                         )
                         .await?;
                         partition_id += 1;
@@ -1924,12 +1962,14 @@ async fn write_partitioned_fmindex_stream_with_config(
         }
 
         if !partition.is_empty() {
-            send_fmindex_partition(
+            finish_fmindex_partition(
                 &sender,
                 &mut partition,
                 &mut partition_bytes,
                 partition_id,
                 config.max_rows,
+                &mut completed_files,
+                &mut files,
             )
             .await?;
         }
@@ -1939,7 +1979,6 @@ async fn write_partitioned_fmindex_stream_with_config(
     .await;
     drop(sender);
 
-    let mut files = Vec::new();
     let mut worker_error = None;
     for worker_task in worker_tasks {
         match worker_task.await {
@@ -1983,15 +2022,21 @@ fn fmindex_partition_limit_reached(
     rows >= max_rows || bytes >= max_bytes
 }
 
-async fn send_fmindex_partition(
+async fn finish_fmindex_partition(
     sender: &async_channel::Sender<FMIndexPartitionJob>,
     partition: &mut Vec<(u64, Vec<u8>)>,
     partition_bytes: &mut usize,
     partition_id: u64,
     max_rows: usize,
+    completed_files: &mut HashMap<u64, IndexFile>,
+    output_files: &mut Vec<(u64, IndexFile)>,
 ) -> Result<()> {
     let texts = std::mem::replace(partition, Vec::with_capacity(max_rows.min(PARTITION_SIZE)));
     *partition_bytes = 0;
+    if let Some(file) = completed_files.remove(&partition_id) {
+        output_files.push((partition_id, file));
+        return Ok(());
+    }
     sender
         .send(FMIndexPartitionJob {
             partition_id,
@@ -3027,6 +3072,7 @@ mod tests {
                 max_rows: 100,
                 max_bytes: 5,
                 queue_size: 1,
+                resume_existing: false,
             },
         )
         .await
@@ -3050,6 +3096,104 @@ mod tests {
         match r {
             SearchResult::Exact(set) => {
                 assert_eq!(set.len(), Some(1));
+            }
+            _ => panic!("expected exact result"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_stream_train_resumes_existing_partitions() {
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new(
+                crate::scalar::registry::VALUE_COLUMN_NAME,
+                DataType::Utf8,
+                false,
+            ),
+            arrow_schema::Field::new(ROW_ADDR, DataType::UInt64, false),
+        ]));
+        let tempdir = tempfile::tempdir().unwrap();
+        let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            index_dir,
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        let first_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["first partition"])),
+                Arc::new(UInt64Array::from(vec![0])),
+            ],
+        )
+        .unwrap();
+        let first_stream =
+            RecordBatchStreamAdapter::new(schema.clone(), stream::iter(vec![Ok(first_batch)]));
+        let first_files = write_partitioned_fmindex_stream_with_config(
+            Box::pin(first_stream),
+            store.as_ref(),
+            FMIndexPartitionConfig {
+                num_workers: 1,
+                max_rows: 1,
+                max_bytes: 1024,
+                queue_size: 1,
+                resume_existing: false,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(first_files.len(), 1);
+        assert_eq!(first_files[0].path, fmindex_partition_path(0));
+
+        let resumed_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "first partition",
+                    "second partition",
+                ])),
+                Arc::new(UInt64Array::from(vec![0, 1])),
+            ],
+        )
+        .unwrap();
+        let resumed_stream =
+            RecordBatchStreamAdapter::new(schema.clone(), stream::iter(vec![Ok(resumed_batch)]));
+        let resumed_files = write_partitioned_fmindex_stream_with_config(
+            Box::pin(resumed_stream),
+            store.as_ref(),
+            FMIndexPartitionConfig {
+                num_workers: 1,
+                max_rows: 1,
+                max_bytes: 1024,
+                queue_size: 1,
+                resume_existing: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let resumed_paths = resumed_files
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            resumed_paths,
+            vec![fmindex_partition_path(0), fmindex_partition_path(1)]
+        );
+
+        let index = FMIndexScalarIndex::load(store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let r = index
+            .search(
+                &TextQuery::StringContains("partition".to_string()),
+                &crate::metrics::NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        match r {
+            SearchResult::Exact(set) => {
+                assert_eq!(set.len(), Some(2));
             }
             _ => panic!("expected exact result"),
         }
@@ -3092,6 +3236,7 @@ mod tests {
                 max_rows: 1,
                 max_bytes: 1024,
                 queue_size: 1,
+                resume_existing: false,
             },
         )
         .await

--- a/rust/lance-index/src/scalar/fmindex.rs
+++ b/rust/lance-index/src/scalar/fmindex.rs
@@ -22,13 +22,14 @@
 
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use arrow_array::RecordBatch;
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use lance_core::cache::LanceCache;
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_cpu};
@@ -998,12 +999,18 @@ struct LazyFMIndex {
     sa_samples: Vec<u64>,
     doc_start_positions: Vec<u64>,
     c_table: Vec<usize>,
+    fully_prewarmed: AtomicBool,
 }
 
 impl LazyFMIndex {
     /// Pre-load all wavelet tree blocks before sync search operations.
     async fn prewarm(&self) -> Result<()> {
-        self.wavelet.load_all().await
+        if self.fully_prewarmed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        self.wavelet.load_all().await.inspect(|_| {
+            self.fully_prewarmed.store(true, Ordering::Release);
+        })
     }
 
     fn backward_search(&self, pattern: &[u8]) -> (usize, usize) {
@@ -1196,6 +1203,7 @@ impl LazyFMIndex {
             sa_samples,
             doc_start_positions,
             c_table,
+            fully_prewarmed: AtomicBool::new(false),
         })
     }
 
@@ -1220,6 +1228,7 @@ struct FMIndexPartition {
 #[derive(Debug)]
 pub struct FMIndexScalarIndex {
     partitions: Vec<Arc<FMIndexPartition>>,
+    io_parallelism: usize,
 }
 
 impl DeepSizeOf for FMIndexScalarIndex {
@@ -1326,7 +1335,53 @@ impl FMIndexScalarIndex {
                 Self::load_partition(store.as_ref(), name, *id).await?,
             ));
         }
-        Ok(Arc::new(Self { partitions: parts }))
+        Ok(Arc::new(Self {
+            partitions: parts,
+            io_parallelism: store.io_parallelism().max(1),
+        }))
+    }
+
+    fn partition_parallelism(&self) -> usize {
+        self.io_parallelism.max(1).min(self.partitions.len().max(1))
+    }
+
+    async fn prewarm_partitions(&self) -> Result<()> {
+        futures::stream::iter(self.partitions.iter().cloned())
+            .map(|partition| async move { partition.fm.prewarm().await })
+            .buffer_unordered(self.partition_parallelism())
+            .try_collect::<Vec<_>>()
+            .await?;
+        Ok(())
+    }
+
+    async fn search_string_contains(&self, pattern: &[u8]) -> Result<SearchResult> {
+        use lance_select::RowAddrTreeMap;
+
+        let pattern: Arc<[u8]> = Arc::from(pattern);
+        let tree = futures::stream::iter(self.partitions.iter().cloned())
+            .map(|partition| {
+                let pattern = Arc::clone(&pattern);
+                async move {
+                    partition.fm.prewarm().await?;
+                    spawn_cpu(move || {
+                        Result::<Vec<u64>>::Ok(partition.fm.search_row_addrs(pattern.as_ref()))
+                    })
+                    .await
+                }
+            })
+            .buffer_unordered(self.partition_parallelism())
+            .try_fold(RowAddrTreeMap::new(), |mut tree, row_addrs| async move {
+                for row_addr in row_addrs {
+                    tree.insert(row_addr);
+                }
+                Result::Ok(tree)
+            })
+            .await?;
+
+        Ok(SearchResult::Exact(lance_select::NullableRowAddrSet::new(
+            tree,
+            Default::default(),
+        )))
     }
 }
 
@@ -1339,7 +1394,7 @@ impl Index for FMIndexScalarIndex {
         self
     }
     async fn prewarm(&self) -> Result<()> {
-        Ok(())
+        self.prewarm_partitions().await
     }
     fn statistics(&self) -> Result<serde_json::Value> {
         Ok(serde_json::json!({
@@ -1376,19 +1431,7 @@ impl ScalarIndex for FMIndexScalarIndex {
             .ok_or_else(|| Error::invalid_input("Fm only supports TextQuery"))?;
         match tq {
             TextQuery::StringContains(pattern) => {
-                let pb = pattern.as_bytes();
-                use lance_select::RowAddrTreeMap;
-                let mut tree = RowAddrTreeMap::new();
-                for p in &self.partitions {
-                    p.fm.prewarm().await?;
-                    for row_addr in p.fm.search_row_addrs(pb) {
-                        tree.insert(row_addr);
-                    }
-                }
-                Ok(SearchResult::Exact(lance_select::NullableRowAddrSet::new(
-                    tree,
-                    Default::default(),
-                )))
+                self.search_string_contains(pattern.as_bytes()).await
             }
             // Regex queries are routed only to the ngram index (the FM-index's
             // query parser advertises `supports_regex = false`), so this is
@@ -2043,6 +2086,29 @@ mod tests {
         }
     }
 
+    fn loaded_wavelet_blocks(index: &FMIndexScalarIndex) -> usize {
+        index
+            .partitions
+            .iter()
+            .flat_map(|partition| partition.fm.wavelet.nodes.iter())
+            .map(|node| {
+                node.blocks
+                    .iter()
+                    .filter(|block| block.get().is_some())
+                    .count()
+            })
+            .sum()
+    }
+
+    fn total_wavelet_blocks(index: &FMIndexScalarIndex) -> usize {
+        index
+            .partitions
+            .iter()
+            .flat_map(|partition| partition.fm.wavelet.nodes.iter())
+            .map(|node| node.blocks.len())
+            .sum()
+    }
+
     #[test]
     fn test_fmindex_build_and_search() {
         let texts: Vec<(u64, &[u8])> = vec![
@@ -2427,6 +2493,55 @@ mod tests {
             }
             _ => panic!("expected exact result"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_public_prewarm_loads_lazy_blocks() {
+        let docs: Vec<Vec<u8>> = (0..30)
+            .map(|i| format!("document {i} hello world test data").into_bytes())
+            .collect();
+        let texts: Vec<(u64, Vec<u8>)> = docs
+            .into_iter()
+            .enumerate()
+            .map(|(i, d)| (i as u64, d))
+            .collect();
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            index_dir,
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        write_partitioned_fmindex(&texts, store.as_ref())
+            .await
+            .unwrap();
+
+        let index = FMIndexScalarIndex::load(store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let total_blocks = total_wavelet_blocks(index.as_ref());
+        assert!(total_blocks > 0);
+        assert_eq!(loaded_wavelet_blocks(index.as_ref()), 0);
+
+        index.prewarm().await.unwrap();
+        assert_eq!(loaded_wavelet_blocks(index.as_ref()), total_blocks);
+
+        let r = index
+            .search(
+                &TextQuery::StringContains("hello world".to_string()),
+                &crate::metrics::NoOpMetricsCollector,
+            )
+            .await
+            .unwrap();
+        match r {
+            SearchResult::Exact(set) => {
+                assert_eq!(set.len(), Some(30));
+            }
+            _ => panic!("expected exact result"),
+        }
+        assert_eq!(loaded_wavelet_blocks(index.as_ref()), total_blocks);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -171,6 +171,10 @@ slow_tests = []
 name = "lq"
 required-features = ["cli"]
 
+[[bin]]
+name = "fm_contains_bench"
+required-features = ["cli"]
+
 [[bench]]
 name = "scalar_index"
 harness = false

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -175,6 +175,10 @@ required-features = ["cli"]
 name = "fm_contains_bench"
 required-features = ["cli"]
 
+[[bin]]
+name = "fm_index_tool"
+required-features = ["cli"]
+
 [[bench]]
 name = "scalar_index"
 harness = false

--- a/rust/lance/src/bin/fm_contains_bench.rs
+++ b/rust/lance/src/bin/fm_contains_bench.rs
@@ -1,0 +1,609 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+#![allow(clippy::print_stdout)]
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow_array::{Array, LargeStringArray, RecordBatch, StringArray, UInt64Array};
+use clap::Parser;
+use futures::future::join_all;
+use lance::dataset::builder::DatasetBuilder;
+use lance::dataset::{Dataset, ReadParams};
+use lance::index::DatasetIndexExt;
+use lance::{Error, Result};
+use lance_io::object_store::{ObjectStoreParams, StorageOptionsAccessor};
+use serde::Serialize;
+use tokio::sync::Semaphore;
+use tokio::time::timeout;
+
+const ROW_ID_COLUMN: &str = "_rowid";
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(
+        long,
+        default_value = "az://datasets/mmlb/mmlb_100m_fts_en_fm_20260626.lance"
+    )]
+    uri: String,
+
+    #[arg(long, default_value = "full_content_idx")]
+    index_name: String,
+
+    #[arg(long, default_value = "full_content")]
+    text_column: String,
+
+    #[arg(long, default_value = "summary_in_image")]
+    pattern_source_column: String,
+
+    #[arg(long, default_value = "oailancepub")]
+    storage_account: String,
+
+    #[arg(long, value_parser = parse_storage_option)]
+    storage_option: Vec<(String, String)>,
+
+    #[arg(long, default_value_t = 1_099_511_627_776)]
+    index_cache_bytes: usize,
+
+    #[arg(long, default_value_t = 8_589_934_592)]
+    metadata_cache_bytes: usize,
+
+    #[arg(long, default_value_t = 5_000)]
+    sample_rows: usize,
+
+    #[arg(long, default_value_t = 5)]
+    query_term_count: usize,
+
+    #[arg(long, default_value_t = 100)]
+    k: i64,
+
+    #[arg(long, default_value_t = 0)]
+    warmup: usize,
+
+    #[arg(long, default_value_t = 4)]
+    queries: usize,
+
+    #[arg(long, value_parser = parse_threads, default_value = "1 2 4 8")]
+    threads: Vec<usize>,
+
+    #[arg(long, default_value_t = 60.0)]
+    query_timeout_secs: f64,
+
+    #[arg(long, default_value_t = false)]
+    skip_prewarm: bool,
+
+    #[arg(long, default_value_t = true)]
+    explain: bool,
+
+    #[arg(long)]
+    output_json: String,
+
+    #[arg(long)]
+    output_csv: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct QueryPattern {
+    query_id: String,
+    pattern: String,
+    filter_sql: String,
+}
+
+#[derive(Debug, Serialize)]
+struct QueryResult {
+    query_id: String,
+    pattern: String,
+    filter_sql: String,
+    success: bool,
+    error: Option<String>,
+    elapsed_ms: f64,
+    result_count: usize,
+    checksum: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct BatchSummary {
+    round_type: String,
+    threads: usize,
+    queries: usize,
+    successes: usize,
+    success_rate: f64,
+    wall_s: f64,
+    qps: f64,
+    mean_ms: f64,
+    p50_ms: f64,
+    p95_ms: f64,
+    p99_ms: f64,
+    avg_result_count: f64,
+    max_result_count: usize,
+    checksum: u64,
+    results: Vec<QueryResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct BenchmarkOutput {
+    uri: String,
+    index_name: String,
+    text_column: String,
+    pattern_source_column: String,
+    sample_rows: usize,
+    query_term_count: usize,
+    k: i64,
+    warmup: usize,
+    queries: usize,
+    threads: Vec<usize>,
+    query_timeout_secs: f64,
+    index_cache_bytes: usize,
+    metadata_cache_bytes: usize,
+    prewarm_ms: Option<f64>,
+    explain_plan: Option<String>,
+    summaries: Vec<BatchSummary>,
+}
+
+fn parse_threads(value: &str) -> std::result::Result<Vec<usize>, String> {
+    let mut threads = Vec::new();
+    for part in value.replace(',', " ").split_whitespace() {
+        let thread_count = part
+            .parse::<usize>()
+            .map_err(|err| format!("invalid thread count {part:?}: {err}"))?;
+        if thread_count == 0 {
+            return Err("thread counts must be greater than zero".to_string());
+        }
+        threads.push(thread_count);
+    }
+    if threads.is_empty() {
+        return Err("at least one thread count is required".to_string());
+    }
+    Ok(threads)
+}
+
+fn parse_storage_option(value: &str) -> std::result::Result<(String, String), String> {
+    let Some((key, val)) = value.split_once('=') else {
+        return Err("storage options must be key=value".to_string());
+    };
+    if key.is_empty() {
+        return Err("storage option key cannot be empty".to_string());
+    }
+    Ok((key.to_string(), val.to_string()))
+}
+
+fn sql_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn query_terms_from_text(text: &str, term_count: usize) -> Result<String> {
+    let terms = text.split_whitespace().take(term_count).collect::<Vec<_>>();
+    if terms.len() < term_count {
+        return Err(Error::invalid_input(format!(
+            "sampled query text has {} terms, but requested {}",
+            terms.len(),
+            term_count
+        )));
+    }
+    Ok(terms.join(" "))
+}
+
+fn string_value(batch: &RecordBatch, column: &str, row: usize) -> Result<Option<String>> {
+    let array = batch
+        .column_by_name(column)
+        .ok_or_else(|| Error::invalid_input(format!("column {column:?} not found")))?;
+    if array.is_null(row) {
+        return Ok(None);
+    }
+    if let Some(strings) = array.as_any().downcast_ref::<StringArray>() {
+        return Ok(Some(strings.value(row).to_string()));
+    }
+    if let Some(strings) = array.as_any().downcast_ref::<LargeStringArray>() {
+        return Ok(Some(strings.value(row).to_string()));
+    }
+    Err(Error::invalid_input(format!(
+        "column {column:?} must be Utf8 or LargeUtf8, got {:?}",
+        array.data_type()
+    )))
+}
+
+async fn open_dataset(args: &Args) -> Result<Dataset> {
+    let mut options = HashMap::from([("account_name".to_string(), args.storage_account.clone())]);
+    for (key, val) in &args.storage_option {
+        options.insert(key.clone(), val.clone());
+    }
+    let read_params = ReadParams {
+        index_cache_size_bytes: args.index_cache_bytes,
+        metadata_cache_size_bytes: args.metadata_cache_bytes,
+        store_options: Some(ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                options,
+            ))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    DatasetBuilder::from_uri(&args.uri)
+        .with_read_params(read_params)
+        .load()
+        .await
+}
+
+async fn sample_patterns(dataset: &Dataset, args: &Args) -> Result<Vec<QueryPattern>> {
+    let total = args.warmup + args.queries;
+    let mut scanner = dataset.scan();
+    scanner
+        .project(&[args.pattern_source_column.as_str()])?
+        .limit(Some(args.sample_rows as i64), None)?;
+    let batch = scanner.try_into_batch().await?;
+    let mut patterns = Vec::with_capacity(total);
+    let mut seen = std::collections::HashSet::new();
+
+    for row in 0..batch.num_rows() {
+        let Some(text) = string_value(&batch, &args.pattern_source_column, row)? else {
+            continue;
+        };
+        let pattern = query_terms_from_text(&text, args.query_term_count)?;
+        if seen.insert(pattern.clone()) {
+            let filter_sql = format!(
+                "contains({}, {})",
+                args.text_column,
+                sql_quote(pattern.as_str())
+            );
+            patterns.push(QueryPattern {
+                query_id: format!("Q{:06}", patterns.len() + 1),
+                pattern,
+                filter_sql,
+            });
+            if patterns.len() == total {
+                return Ok(patterns);
+            }
+        }
+    }
+
+    Err(Error::invalid_input(format!(
+        "sampled only {} unique patterns, need {}; increase --sample-rows",
+        patterns.len(),
+        total
+    )))
+}
+
+async fn explain_first_query(
+    dataset: &Dataset,
+    pattern: &QueryPattern,
+    args: &Args,
+) -> Result<String> {
+    let mut scanner = dataset.scan();
+    scanner
+        .with_row_id()
+        .project::<&str>(&[])?
+        .filter(&pattern.filter_sql)?
+        .limit(Some(args.k), None)?;
+    scanner.explain_plan(false).await
+}
+
+async fn execute_query(
+    dataset: Arc<Dataset>,
+    pattern: &QueryPattern,
+    args: &Args,
+) -> Result<QueryResult> {
+    let start = Instant::now();
+    let mut scanner = dataset.scan();
+    scanner
+        .with_row_id()
+        .project::<&str>(&[])?
+        .filter(&pattern.filter_sql)?
+        .limit(Some(args.k), None)?;
+    let batch = scanner.try_into_batch().await?;
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let row_ids = batch
+        .column_by_name(ROW_ID_COLUMN)
+        .ok_or_else(|| Error::invalid_input(format!("{ROW_ID_COLUMN} column missing")))?;
+    let row_ids = row_ids
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .ok_or_else(|| Error::invalid_input(format!("{ROW_ID_COLUMN} must be UInt64")))?;
+    let mut checksum = 0_u64;
+    for row in 0..row_ids.len() {
+        if !row_ids.is_null(row) {
+            checksum ^= row_ids.value(row);
+        }
+    }
+    Ok(QueryResult {
+        query_id: pattern.query_id.clone(),
+        pattern: pattern.pattern.clone(),
+        filter_sql: pattern.filter_sql.clone(),
+        success: true,
+        error: None,
+        elapsed_ms,
+        result_count: batch.num_rows(),
+        checksum,
+    })
+}
+
+async fn run_one(dataset: Arc<Dataset>, pattern: QueryPattern, args: Arc<Args>) -> QueryResult {
+    let start = Instant::now();
+    let result = if args.query_timeout_secs > 0.0 {
+        timeout(
+            Duration::from_secs_f64(args.query_timeout_secs),
+            execute_query(dataset, &pattern, &args),
+        )
+        .await
+        .map_err(|_| {
+            Error::io(format!(
+                "query timed out after {}s",
+                args.query_timeout_secs
+            ))
+        })
+        .and_then(|inner| inner)
+    } else {
+        execute_query(dataset, &pattern, &args).await
+    };
+
+    match result {
+        Ok(result) => result,
+        Err(err) => QueryResult {
+            query_id: pattern.query_id,
+            pattern: pattern.pattern,
+            filter_sql: pattern.filter_sql,
+            success: false,
+            error: Some(err.to_string()),
+            elapsed_ms: start.elapsed().as_secs_f64() * 1000.0,
+            result_count: 0,
+            checksum: 0,
+        },
+    }
+}
+
+async fn run_batch(
+    dataset: Arc<Dataset>,
+    args: Arc<Args>,
+    patterns: &[QueryPattern],
+    thread_count: usize,
+    round_type: &str,
+) -> BatchSummary {
+    let wall_start = Instant::now();
+    let semaphore = Arc::new(Semaphore::new(thread_count));
+    let tasks = patterns
+        .iter()
+        .map(|pattern| {
+            let pattern = pattern.clone();
+            let dataset = Arc::clone(&dataset);
+            let args = Arc::clone(&args);
+            let semaphore = Arc::clone(&semaphore);
+            tokio::spawn(async move {
+                let _permit = semaphore.acquire_owned().await.expect("semaphore closed");
+                run_one(dataset, pattern, args).await
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let results = join_all(tasks)
+        .await
+        .into_iter()
+        .map(|result| match result {
+            Ok(query_result) => query_result,
+            Err(err) => QueryResult {
+                query_id: "join_error".to_string(),
+                pattern: String::new(),
+                filter_sql: String::new(),
+                success: false,
+                error: Some(err.to_string()),
+                elapsed_ms: 0.0,
+                result_count: 0,
+                checksum: 0,
+            },
+        })
+        .collect::<Vec<_>>();
+    summarize(round_type, thread_count, results, wall_start.elapsed())
+}
+
+fn percentile(values: &[f64], pct: usize) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut ordered = values.to_vec();
+    ordered.sort_by(|left, right| left.total_cmp(right));
+    let idx = ((ordered.len() * pct).div_ceil(100)).saturating_sub(1);
+    ordered[idx.min(ordered.len() - 1)]
+}
+
+fn summarize(
+    round_type: &str,
+    threads: usize,
+    results: Vec<QueryResult>,
+    wall: Duration,
+) -> BatchSummary {
+    let successes = results.iter().filter(|result| result.success).count();
+    let latencies = results
+        .iter()
+        .filter(|result| result.success)
+        .map(|result| result.elapsed_ms)
+        .collect::<Vec<_>>();
+    let result_counts = results
+        .iter()
+        .filter(|result| result.success)
+        .map(|result| result.result_count)
+        .collect::<Vec<_>>();
+    let wall_s = wall.as_secs_f64();
+    BatchSummary {
+        round_type: round_type.to_string(),
+        threads,
+        queries: results.len(),
+        successes,
+        success_rate: if results.is_empty() {
+            0.0
+        } else {
+            successes as f64 / results.len() as f64
+        },
+        wall_s,
+        qps: if wall_s == 0.0 {
+            0.0
+        } else {
+            successes as f64 / wall_s
+        },
+        mean_ms: if latencies.is_empty() {
+            0.0
+        } else {
+            latencies.iter().sum::<f64>() / latencies.len() as f64
+        },
+        p50_ms: percentile(&latencies, 50),
+        p95_ms: percentile(&latencies, 95),
+        p99_ms: percentile(&latencies, 99),
+        avg_result_count: if result_counts.is_empty() {
+            0.0
+        } else {
+            result_counts.iter().sum::<usize>() as f64 / result_counts.len() as f64
+        },
+        max_result_count: result_counts.into_iter().max().unwrap_or(0),
+        checksum: results
+            .iter()
+            .filter(|result| result.success)
+            .map(|result| result.checksum)
+            .fold(0, |acc, checksum| acc ^ checksum),
+        results,
+    }
+}
+
+fn write_csv(path: &str, summaries: &[BatchSummary]) -> Result<()> {
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    writeln!(
+        writer,
+        "round_type,threads,queries,successes,success_rate,wall_s,qps,mean_ms,p50_ms,p95_ms,p99_ms,avg_result_count,max_result_count,checksum"
+    )?;
+    for summary in summaries {
+        writeln!(
+            writer,
+            "{},{},{},{},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{},{}",
+            csv_escape(&summary.round_type),
+            summary.threads,
+            summary.queries,
+            summary.successes,
+            summary.success_rate,
+            summary.wall_s,
+            summary.qps,
+            summary.mean_ms,
+            summary.p50_ms,
+            summary.p95_ms,
+            summary.p99_ms,
+            summary.avg_result_count,
+            summary.max_result_count,
+            summary.checksum
+        )?;
+    }
+    Ok(())
+}
+
+fn csv_escape(value: &str) -> String {
+    if value.contains([',', '"', '\n']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Arc::new(Args::parse());
+    if args.k <= 0 {
+        return Err(Error::invalid_input("--k must be greater than zero"));
+    }
+    if args.query_term_count == 0 {
+        return Err(Error::invalid_input(
+            "--query-term-count must be greater than zero",
+        ));
+    }
+    if args.query_timeout_secs < 0.0 {
+        return Err(Error::invalid_input(
+            "--query-timeout-secs must be non-negative",
+        ));
+    }
+
+    println!("opening dataset {}", args.uri);
+    let dataset = Arc::new(open_dataset(&args).await?);
+    println!("dataset version {}", dataset.version().version);
+
+    let patterns = sample_patterns(&dataset, &args).await?;
+    println!("sampled {} patterns", patterns.len());
+
+    let explain_plan = if args.explain {
+        Some(explain_first_query(&dataset, &patterns[0], &args).await?)
+    } else {
+        None
+    };
+
+    let prewarm_ms = if args.skip_prewarm {
+        None
+    } else {
+        println!("prewarming index {}", args.index_name);
+        let start = Instant::now();
+        dataset.prewarm_index(&args.index_name).await?;
+        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+        println!("prewarm finished in {:.3} ms", elapsed_ms);
+        Some(elapsed_ms)
+    };
+
+    let warmup_patterns = &patterns[..args.warmup];
+    let query_patterns = &patterns[args.warmup..];
+    let mut summaries = Vec::new();
+    for thread_count in args.threads.iter().copied() {
+        if !warmup_patterns.is_empty() {
+            summaries.push(
+                run_batch(
+                    Arc::clone(&dataset),
+                    Arc::clone(&args),
+                    warmup_patterns,
+                    thread_count,
+                    "warmup",
+                )
+                .await,
+            );
+        }
+        let summary = run_batch(
+            Arc::clone(&dataset),
+            Arc::clone(&args),
+            query_patterns,
+            thread_count,
+            "test",
+        )
+        .await;
+        println!(
+            "test threads={} queries={} successes={} wall_s={:.3} qps={:.3} mean_ms={:.3} p95_ms={:.3}",
+            summary.threads,
+            summary.queries,
+            summary.successes,
+            summary.wall_s,
+            summary.qps,
+            summary.mean_ms,
+            summary.p95_ms
+        );
+        summaries.push(summary);
+    }
+
+    let output = BenchmarkOutput {
+        uri: args.uri.clone(),
+        index_name: args.index_name.clone(),
+        text_column: args.text_column.clone(),
+        pattern_source_column: args.pattern_source_column.clone(),
+        sample_rows: args.sample_rows,
+        query_term_count: args.query_term_count,
+        k: args.k,
+        warmup: args.warmup,
+        queries: args.queries,
+        threads: args.threads.clone(),
+        query_timeout_secs: args.query_timeout_secs,
+        index_cache_bytes: args.index_cache_bytes,
+        metadata_cache_bytes: args.metadata_cache_bytes,
+        prewarm_ms,
+        explain_plan,
+        summaries,
+    };
+
+    let mut json = serde_json::to_string_pretty(&output)?;
+    json.push('\n');
+    std::fs::write(&args.output_json, json)?;
+    write_csv(&args.output_csv, &output.summaries)?;
+    Ok(())
+}

--- a/rust/lance/src/bin/fm_contains_bench.rs
+++ b/rust/lance/src/bin/fm_contains_bench.rs
@@ -68,8 +68,8 @@ struct Args {
     #[arg(long, default_value_t = 4)]
     queries: usize,
 
-    #[arg(long, value_parser = parse_threads, default_value = "1 2 4 8")]
-    threads: Vec<usize>,
+    #[arg(long, default_value = "1 2 4 8")]
+    threads: String,
 
     #[arg(long, default_value_t = 60.0)]
     query_timeout_secs: f64,
@@ -507,6 +507,7 @@ fn csv_escape(value: &str) -> String {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Arc::new(Args::parse());
+    let thread_counts = parse_threads(&args.threads).map_err(Error::invalid_input)?;
     if args.k <= 0 {
         return Err(Error::invalid_input("--k must be greater than zero"));
     }
@@ -548,7 +549,7 @@ async fn main() -> Result<()> {
     let warmup_patterns = &patterns[..args.warmup];
     let query_patterns = &patterns[args.warmup..];
     let mut summaries = Vec::new();
-    for thread_count in args.threads.iter().copied() {
+    for thread_count in thread_counts.iter().copied() {
         if !warmup_patterns.is_empty() {
             summaries.push(
                 run_batch(
@@ -592,7 +593,7 @@ async fn main() -> Result<()> {
         k: args.k,
         warmup: args.warmup,
         queries: args.queries,
-        threads: args.threads.clone(),
+        threads: thread_counts,
         query_timeout_secs: args.query_timeout_secs,
         index_cache_bytes: args.index_cache_bytes,
         metadata_cache_bytes: args.metadata_cache_bytes,

--- a/rust/lance/src/bin/fm_index_tool.rs
+++ b/rust/lance/src/bin/fm_index_tool.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+#![allow(clippy::print_stdout)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use clap::{Parser, ValueEnum};
+use lance::dataset::ReadParams;
+use lance::dataset::builder::DatasetBuilder;
+use lance::index::DatasetIndexExt;
+use lance::{Error, Result};
+use lance_index::scalar::{BuiltinIndexType, ScalarIndexParams};
+use lance_io::object_store::{ObjectStoreParams, StorageOptionsAccessor};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(value_enum)]
+    action: Action,
+
+    #[arg(
+        long,
+        default_value = "az://datasets/mmlb/mmlb_100m_fts_en_fm_20260626.lance"
+    )]
+    uri: String,
+
+    #[arg(long, default_value = "full_content_idx")]
+    index_name: String,
+
+    #[arg(long, default_value = "full_content")]
+    column: String,
+
+    #[arg(long, default_value = "oailancepub")]
+    storage_account: String,
+
+    #[arg(long, value_parser = parse_storage_option)]
+    storage_option: Vec<(String, String)>,
+
+    #[arg(long, default_value_t = 1)]
+    num_segments: u32,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum Action {
+    List,
+    Drop,
+    Create,
+}
+
+fn parse_storage_option(value: &str) -> std::result::Result<(String, String), String> {
+    let Some((key, val)) = value.split_once('=') else {
+        return Err("storage options must be key=value".to_string());
+    };
+    if key.is_empty() {
+        return Err("storage option key cannot be empty".to_string());
+    }
+    Ok((key.to_string(), val.to_string()))
+}
+
+async fn open_dataset(args: &Args) -> Result<lance::Dataset> {
+    let mut options = HashMap::from([("account_name".to_string(), args.storage_account.clone())]);
+    for (key, val) in &args.storage_option {
+        options.insert(key.clone(), val.clone());
+    }
+    let read_params = ReadParams {
+        store_options: Some(ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                options,
+            ))),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    DatasetBuilder::from_uri(&args.uri)
+        .with_read_params(read_params)
+        .load()
+        .await
+}
+
+fn fm_params(num_segments: u32) -> ScalarIndexParams {
+    let params = ScalarIndexParams::for_builtin(BuiltinIndexType::Fm);
+    if num_segments == 1 {
+        params
+    } else {
+        params.with_params(&serde_json::json!({ "num_segments": num_segments }))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    if args.num_segments == 0 {
+        return Err(Error::invalid_input(
+            "--num-segments must be greater than 0",
+        ));
+    }
+
+    println!("opening dataset {}", args.uri);
+    let mut dataset = open_dataset(&args).await?;
+    println!("dataset version {}", dataset.version().version);
+
+    match args.action {
+        Action::List => {
+            let indices = dataset.load_indices().await?;
+            println!("indices={}", indices.len());
+            for index in indices.iter() {
+                println!(
+                    "name={} uuid={} version={} fields={:?} fragments={}",
+                    index.name,
+                    index.uuid,
+                    index.index_version,
+                    index.fields,
+                    index
+                        .fragment_bitmap
+                        .as_ref()
+                        .map(|bitmap| bitmap.len())
+                        .unwrap_or(0)
+                );
+            }
+        }
+        Action::Drop => {
+            let start = Instant::now();
+            dataset.drop_index(&args.index_name).await?;
+            println!(
+                "dropped index {} in {:.3}s; new version {}",
+                args.index_name,
+                start.elapsed().as_secs_f64(),
+                dataset.version().version
+            );
+        }
+        Action::Create => {
+            let params = fm_params(args.num_segments);
+            let start = Instant::now();
+            let metadata = dataset
+                .create_index(
+                    &[args.column.as_str()],
+                    lance_index::IndexType::Fm,
+                    Some(args.index_name.clone()),
+                    &params,
+                    true,
+                )
+                .await?;
+            println!(
+                "created index {} uuid={} in {:.3}s; new version {}",
+                metadata.name,
+                metadata.uuid,
+                start.elapsed().as_secs_f64(),
+                dataset.version().version
+            );
+        }
+    }
+    Ok(())
+}

--- a/rust/lance/src/bin/fm_index_tool.rs
+++ b/rust/lance/src/bin/fm_index_tool.rs
@@ -10,10 +10,11 @@ use std::time::Instant;
 use clap::{Parser, ValueEnum};
 use lance::dataset::ReadParams;
 use lance::dataset::builder::DatasetBuilder;
-use lance::index::DatasetIndexExt;
+use lance::index::{CreateIndexBuilder, DatasetIndexExt};
 use lance::{Error, Result};
 use lance_index::scalar::{BuiltinIndexType, ScalarIndexParams};
 use lance_io::object_store::{ObjectStoreParams, StorageOptionsAccessor};
+use uuid::Uuid;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -41,6 +42,9 @@ struct Args {
 
     #[arg(long, default_value_t = 1)]
     num_segments: u32,
+
+    #[arg(long)]
+    index_uuid: Option<Uuid>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
@@ -135,15 +139,18 @@ async fn main() -> Result<()> {
         Action::Create => {
             let params = fm_params(args.num_segments);
             let start = Instant::now();
-            let metadata = dataset
-                .create_index(
-                    &[args.column.as_str()],
-                    lance_index::IndexType::Fm,
-                    Some(args.index_name.clone()),
-                    &params,
-                    true,
-                )
-                .await?;
+            let mut builder = CreateIndexBuilder::new(
+                &mut dataset,
+                &[args.column.as_str()],
+                lance_index::IndexType::Fm,
+                &params,
+            )
+            .name(args.index_name.clone())
+            .replace(true);
+            if let Some(index_uuid) = args.index_uuid {
+                builder = builder.index_uuid(index_uuid);
+            }
+            let metadata = builder.await?;
             println!(
                 "created index {} uuid={} in {:.3}s; new version {}",
                 metadata.name,

--- a/rust/lance/src/bin/fm_index_tool.rs
+++ b/rust/lance/src/bin/fm_index_tool.rs
@@ -22,10 +22,7 @@ struct Args {
     #[arg(value_enum)]
     action: Action,
 
-    #[arg(
-        long,
-        default_value = "az://datasets/mmlb/mmlb_100m_fts_en_fm_20260626.lance"
-    )]
+    #[arg(long)]
     uri: String,
 
     #[arg(long, default_value = "full_content_idx")]


### PR DESCRIPTION
Summary:
- Improve FM `contains` queries so normal reads demand-load needed wavelet blocks and page nearby blocks instead of prewarming whole partitions.
- Add chunked explicit FM prewarm, parallel partition loading/search, and resumable partition builds.
- Add FM `contains` benchmark and FM index management tooling.

Optimizations applied:
- Parallel FM search across partitions/segments.
- Removed query-time full-partition prewarm; explicit prewarm still fully warms the index.
- Chunked contiguous wavelet-row prewarm with `LANCE_FMINDEX_PREWARM_CHUNK_BYTES` and `LANCE_FMINDEX_PREWARM_CHUNK_CONCURRENCY`.
- Cold-read demand paging with `LANCE_FMINDEX_DEMAND_PAGE_BYTES` to reduce object-store RPS.
- Parallelized FM metadata/partition loading.
- Added resumable FM partition creation and explicit `--index-uuid` recovery support.
- Final benchmark layout: 1 logical FM segment, `LANCE_FMINDEX_PARTITION_ROWS=100000`, large partition-byte cap, 1,000 partitions.

Performance:
Dataset: 100M-row `az://datasets/mmlb/mmlb_100m_fts_en_fm_20260626.lance`.
Query workload: 4 sampled 5-term patterns from `summary_in_image`, `contains(full_content, pattern)`, `k=100`, `_rowid` only (`projection=[]`, `row_id=true`).

| Run | Index layout | Prewarm | Query result |
| --- | --- | --- | --- |
| Baseline | 6 segments / 10k partitions | 6,525s / 108.8m | 1t: 1.58 qps, mean 633ms, p95 768ms; 8t: 12.48 qps, mean 320ms, p95 320ms |
| Demand-load + chunked prewarm | 6 segments / 10k partitions | 2,182s / 36.4m, 3.0x faster | 1t: 5.38 qps, mean 185ms, p95 307ms; 8t: 12.12 qps, mean 326ms, p95 330ms |
| Single segment | 1 segment / 100k-row partitions | 356s / 5.94m, 18.3x faster than baseline | 1t: 22.38 qps, mean 44.6ms, p95 54.4ms; 8t: 84.40 qps, mean 42.8ms, p95 47.3ms |

Index size:
- Final FM index UUID `78600545-625f-40e2-8790-204f35097ec0`: 1,000 partition files, 920,064,767,792 bytes / 856.9 GiB / 0.837 TiB.
- Previous 6-segment FM layout was 920,202,650,467 bytes / 857.0 GiB, so the final relayout is effectively size-neutral.