### PR TITLE
fix(mem-wal): backport tombstone delete support to v8.0

### DIFF
--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -51,6 +51,7 @@ pub use sharding::{
     evaluate_sharding_spec, evaluate_sharding_spec_with_embedded_columns,
     evaluate_sharding_spec_with_source_columns,
 };
-pub use wal::{WalAppendResult, WalAppender, WalReadEntry, WalTailer};
+pub use wal::{BatchDurableWatcher, WalAppendResult, WalAppender, WalReadEntry, WalTailer};
 pub use write::ShardWriter;
 pub use write::ShardWriterConfig;
+pub use write::WriteResult;

--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -43,6 +43,53 @@ pub mod util;
 mod wal;
 pub mod write;
 
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+
+/// Column name for the mem_wal tombstone (delete sentinel) marker.
+///
+/// `_tombstone` is a *physical* column present only in mem_wal memtables and
+/// flushed generations — it is deliberately kept out of the base table (hard
+/// delete), so it is **not** a virtual [`is_system_column`](lance_core::is_system_column).
+/// A row with `_tombstone = true` is a delete sentinel: the newest value for
+/// its primary key, carrying null in every non-PK column, that wins
+/// newest-per-PK resolution and is then silently dropped from query results.
+///
+/// The column is owned end-to-end by lance: callers pass the base schema and
+/// lance injects the column on the write path ([`write::ShardWriter::put`] /
+/// [`write::ShardWriter::delete`]), so no caller ever constructs or names it.
+pub const TOMBSTONE: &str = "_tombstone";
+
+/// The mem_wal tombstone field appended to the base schema to form the
+/// memtable/generation schema.
+///
+/// Non-nullable: the write path always populates it (`false` for normal rows,
+/// `true` for tombstones). Non-nullability also lets the point-lookup base arm
+/// synthesize a matching `Literal(false)` column for the `CoalesceFirstExec`
+/// exact-schema check.
+pub fn tombstone_field() -> ArrowField {
+    ArrowField::new(TOMBSTONE, DataType::Boolean, false)
+}
+
+/// Extend a base schema with the trailing `_tombstone` column to form the
+/// mem_wal memtable/generation schema.
+///
+/// Idempotent: a schema that already carries `_tombstone` (a reopen/replay
+/// path) is returned unchanged. Schema-level metadata and per-field metadata
+/// (e.g. the `lance-schema:unenforced-primary-key` marker) are preserved.
+pub fn schema_with_tombstone(base: &ArrowSchema) -> Arc<ArrowSchema> {
+    if base.column_with_name(TOMBSTONE).is_some() {
+        return Arc::new(base.clone());
+    }
+    let mut fields: Vec<ArrowField> = base.fields().iter().map(|f| f.as_ref().clone()).collect();
+    fields.push(tombstone_field());
+    Arc::new(ArrowSchema::new_with_metadata(
+        fields,
+        base.metadata().clone(),
+    ))
+}
+
 pub use api::{DatasetMemWalExt, InitializeMemWalBuilder};
 pub use manifest::ShardManifestStore;
 pub use memtable::scanner::MemTableScanner;

--- a/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
+++ b/rust/lance/src/dataset/mem_wal/hnsw/storage.rs
@@ -8,7 +8,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use arrow_array::cast::AsArray;
 use arrow_array::types::Float32Type;
-use arrow_array::{Array, ArrayRef, FixedSizeListArray, Float32Array, RecordBatch, UInt64Array};
+use arrow_array::{
+    Array, ArrayRef, BooleanArray, FixedSizeListArray, Float32Array, RecordBatch, UInt64Array,
+};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema, SchemaRef};
 use lance_core::{Error, ROW_ID, Result};
 use lance_linalg::distance::{DistanceType, cosine_distance, dot_f32, l2_f32};
@@ -205,6 +207,12 @@ impl ArrowFixedSizeListVectorStore {
     }
 
     /// Append one Arrow `FixedSizeList<Float32>` batch by reference.
+    ///
+    /// Null-vector rows (e.g. tombstones, or rows written without an embedding)
+    /// are skipped — they get no graph node — matching base-table vector index
+    /// semantics. Surviving non-null rows are compacted into a contiguous node
+    /// range, but each node's `row_ids` entry preserves its *original* offset in
+    /// the input batch so search still resolves a hit back to the correct row.
     pub fn append_batch(
         &self,
         vectors: Arc<FixedSizeListArray>,
@@ -221,13 +229,39 @@ impl ArrowFixedSizeListVectorStore {
                 vectors.value_length()
             )));
         }
-        if vectors.null_count() > 0 {
-            return Err(Error::invalid_input(format!(
-                "null vectors are not supported, got {} null row(s)",
-                vectors.null_count()
-            )));
+
+        // Compact away null-vector rows, remembering each survivor's original
+        // offset. The all-non-null case keeps the input array as-is (offsets are
+        // the identity) to avoid a copy on the hot path.
+        let (stored_array, original_offsets): (Arc<FixedSizeListArray>, Option<Vec<u32>>) =
+            if vectors.null_count() == 0 {
+                (vectors, None)
+            } else {
+                let valid = vectors
+                    .nulls()
+                    .ok_or_else(|| Error::internal("null_count > 0 but no null buffer"))?;
+                let mask = BooleanArray::new(valid.inner().clone(), None);
+                let filtered = arrow_select::filter::filter(vectors.as_ref(), &mask)?;
+                let fsl = filtered
+                    .as_fixed_size_list_opt()
+                    .ok_or_else(|| {
+                        Error::internal("filtered vector column is not a FixedSizeList")
+                    })?
+                    .clone();
+                let offsets: Vec<u32> = (0..vectors.len() as u32)
+                    .filter(|&i| valid.is_valid(i as usize))
+                    .collect();
+                (Arc::new(fsl), Some(offsets))
+            };
+
+        let num_rows = stored_array.len();
+        if num_rows == 0 {
+            // All rows were null (e.g. an all-tombstone memtable): no graph node.
+            let start = self.committed_len.load(Ordering::Relaxed) as u32;
+            return Ok(start..start);
         }
-        let values = vectors.values();
+
+        let values = stored_array.values();
         let Some(values_f32) = values.as_primitive_opt::<Float32Type>() else {
             return Err(Error::invalid_input(format!(
                 "vector values must be Float32, got {:?}",
@@ -236,11 +270,10 @@ impl ArrowFixedSizeListVectorStore {
         };
 
         let start = self.committed_len.load(Ordering::Relaxed);
-        let end = start.checked_add(vectors.len()).ok_or_else(|| {
+        let end = start.checked_add(num_rows).ok_or_else(|| {
             Error::invalid_input(format!(
                 "vector count overflow: start={}, batch_len={}",
-                start,
-                vectors.len()
+                start, num_rows
             ))
         })?;
         if end > self.capacity {
@@ -264,19 +297,25 @@ impl ArrowFixedSizeListVectorStore {
             self.batches
                 .add(batch_idx)
                 .write(MaybeUninit::new(StoredArrowBatch {
-                    _array: vectors.clone(),
+                    _array: stored_array.clone(),
                     values_ptr: values_f32.values().as_ptr(),
                 }));
-            for offset in 0..vectors.len() {
+            for offset in 0..num_rows {
                 self.row_to_batch
                     .add(start + offset)
                     .write(MaybeUninit::new(RowLookup {
                         batch_idx: batch_idx as u32,
                         offset: offset as u32,
                     }));
+                // The node maps back to the survivor's *original* row position,
+                // so a compacted node still resolves to the right row.
+                let original = match &original_offsets {
+                    Some(offsets) => offsets[offset] as u64,
+                    None => offset as u64,
+                };
                 self.row_ids
                     .add(start + offset)
-                    .write(MaybeUninit::new(row_id_start + offset as u64));
+                    .write(MaybeUninit::new(row_id_start + original));
             }
         }
 
@@ -458,5 +497,89 @@ mod tests {
             compute_f32_distance(snapshot.vector(0), snapshot.vector(1), DistanceType::L2),
             8.0
         );
+    }
+
+    /// Build a `FixedSizeList<Float32>` where `None` rows are null at the list
+    /// level (the representation a tombstone / embedding-less row produces).
+    fn fsl_opt(rows: &[Option<Vec<f32>>], dim: usize) -> Arc<FixedSizeListArray> {
+        let mut values: Vec<f32> = Vec::new();
+        let mut validity: Vec<bool> = Vec::new();
+        for r in rows {
+            match r {
+                Some(v) => {
+                    assert_eq!(v.len(), dim);
+                    values.extend_from_slice(v);
+                    validity.push(true);
+                }
+                None => {
+                    values.extend(std::iter::repeat_n(0.0f32, dim));
+                    validity.push(false);
+                }
+            }
+        }
+        let values = Arc::new(Float32Array::from(values)) as ArrayRef;
+        let nulls = arrow_buffer::NullBuffer::new(arrow_buffer::BooleanBuffer::from(validity));
+        Arc::new(
+            FixedSizeListArray::try_new(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                dim as i32,
+                values,
+                Some(nulls),
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_append_skips_null_vectors_preserves_mapping() {
+        // Mid-batch null: rows [(1,1), null, (3,3)] → two nodes that map back to
+        // the *original* offsets 0 and 2 (no off-by-one after the skip).
+        let store =
+            Arc::new(ArrowFixedSizeListVectorStore::try_new(8, 2, 2, DistanceType::L2).unwrap());
+        let batch = fsl_opt(&[Some(vec![1.0, 1.0]), None, Some(vec![3.0, 3.0])], 2);
+        assert_eq!(
+            store.append_batch(batch, 0).unwrap(),
+            0..2,
+            "two non-null survivors → two contiguous nodes"
+        );
+        assert_eq!(store.committed_len(), 2);
+
+        // `to_record_batch` exposes each node's row id = its original offset.
+        let rb = store.to_record_batch(None).unwrap();
+        let row_ids = rb.column(0).as_any().downcast_ref::<UInt64Array>().unwrap();
+        let got: Vec<u64> = (0..row_ids.len()).map(|i| row_ids.value(i)).collect();
+        assert_eq!(got, vec![0, 2], "node→row mapping skips the null row");
+
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.vector(0), &[1.0, 1.0]);
+        assert_eq!(snapshot.vector(1), &[3.0, 3.0]);
+        assert_eq!(snapshot.row_id(0), 0);
+        assert_eq!(snapshot.row_id(1), 2);
+    }
+
+    #[test]
+    fn test_append_skips_null_vectors_offsets_with_row_id_start() {
+        // The survivor's original offset is added to `row_id_start`.
+        let store =
+            Arc::new(ArrowFixedSizeListVectorStore::try_new(8, 2, 2, DistanceType::L2).unwrap());
+        // rows at row_id_start=100: [null, (2,2)] → one node, row id 100+1.
+        let batch = fsl_opt(&[None, Some(vec![2.0, 2.0])], 2);
+        assert_eq!(store.append_batch(batch, 100).unwrap(), 0..1);
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.row_id(0), 101);
+        assert_eq!(snapshot.vector(0), &[2.0, 2.0]);
+    }
+
+    #[test]
+    fn test_append_all_null_batch_is_empty_range() {
+        // All-null batch (e.g. an all-tombstone memtable) adds no node.
+        let store =
+            Arc::new(ArrowFixedSizeListVectorStore::try_new(8, 2, 2, DistanceType::L2).unwrap());
+        let batch = fsl_opt(&[None, None], 2);
+        assert!(
+            store.append_batch(batch, 0).unwrap().is_empty(),
+            "all-null batch yields an empty node range"
+        );
+        assert_eq!(store.committed_len(), 0);
     }
 }

--- a/rust/lance/src/dataset/mem_wal/index/hnsw.rs
+++ b/rust/lance/src/dataset/mem_wal/index/hnsw.rs
@@ -237,14 +237,8 @@ impl HnswMemIndex {
                 fsl_ref.values().data_type()
             )));
         }
-        if fsl_ref.null_count() > 0 {
-            return Err(Error::invalid_input(format!(
-                "HNSW index column '{}' has {} null row(s); null vectors are not supported",
-                self.column,
-                fsl_ref.null_count()
-            )));
-        }
-
+        // Null-vector rows (e.g. tombstones) are skipped inside `append_batch`,
+        // which yields an empty range for an all-null batch — handled below.
         let dim = fsl_ref.value_length() as usize;
         let state = self.ensure_state(dim)?;
         let vectors = Arc::new(fsl_ref.clone());
@@ -290,14 +284,9 @@ impl HnswMemIndex {
                     fsl_ref.values().data_type()
                 )));
             }
-            if fsl_ref.null_count() > 0 {
-                return Err(Error::invalid_input(format!(
-                    "HNSW index column '{}' has {} null row(s); null vectors are not supported",
-                    self.column,
-                    fsl_ref.null_count()
-                )));
-            }
-
+            // Null-vector rows (e.g. tombstones) are skipped inside
+            // `append_batch`; an all-null batch yields an empty range, handled
+            // by the `id_range.is_empty()` continue below.
             let dim = fsl_ref.value_length() as usize;
             let current_state = match state {
                 Some(state) => {
@@ -675,5 +664,118 @@ mod tests {
 
         assert!(index.len() > 1);
         assert!(total_reader_iters > 0);
+    }
+
+    /// Build a 3-row batch whose middle vector row is null at the list level.
+    fn batch_with_null_middle(dim: usize) -> RecordBatch {
+        let mut values: Vec<f32> = Vec::new();
+        values.extend(std::iter::repeat_n(1.0f32, dim)); // row 0
+        values.extend(std::iter::repeat_n(0.0f32, dim)); // row 1 (null placeholder)
+        values.extend(std::iter::repeat_n(3.0f32, dim)); // row 2
+        let inner = Arc::new(Float32Array::from(values)) as arrow_array::ArrayRef;
+        let nulls = arrow_buffer::NullBuffer::new(arrow_buffer::BooleanBuffer::from(vec![
+            true, false, true,
+        ]));
+        let fsl = FixedSizeListArray::try_new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim as i32,
+            inner,
+            Some(nulls),
+        )
+        .unwrap();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    dim as i32,
+                ),
+                true,
+            ),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(vec![0, 1, 2])), Arc::new(fsl)],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_index_skips_null_vector_row() {
+        // A null vector row gets no graph node; the surviving rows keep their
+        // original positions (the tombstone-enabling fix).
+        let dim = 4;
+        let index = HnswMemIndex::with_capacity(
+            1,
+            "vector".to_string(),
+            DistanceType::L2,
+            HnswBuildParams::default().num_edges(16).ef_construction(64),
+            16,
+            16,
+        );
+        index.insert(&batch_with_null_middle(dim), 0).unwrap();
+        assert_eq!(index.len(), 2, "the null row is skipped");
+
+        let query = FixedSizeListArray::try_new_from_values(
+            Float32Array::from(vec![3.0f32; dim]),
+            dim as i32,
+        )
+        .unwrap();
+        let results = index.search(&query, 2, Some(16), u64::MAX).unwrap();
+        assert!(!results.is_empty());
+        let (best_dist, best_pos) = results[0];
+        assert!(best_dist < 1e-4, "got {}", best_dist);
+        assert_eq!(
+            best_pos, 2,
+            "row 2 resolves to its original offset, not 1, after the skip"
+        );
+        assert!(
+            results.iter().all(|(_, pos)| *pos != 1),
+            "the skipped null row must never be returned"
+        );
+    }
+
+    #[test]
+    fn test_index_all_null_batch_adds_no_nodes() {
+        // An all-null batch (e.g. an all-tombstone memtable) inserts cleanly and
+        // adds no nodes.
+        let dim = 4;
+        let index = HnswMemIndex::with_capacity(
+            1,
+            "vector".to_string(),
+            DistanceType::L2,
+            HnswBuildParams::default(),
+            8,
+            8,
+        );
+        let inner = Arc::new(Float32Array::from(vec![0.0f32; dim * 2])) as arrow_array::ArrayRef;
+        let nulls =
+            arrow_buffer::NullBuffer::new(arrow_buffer::BooleanBuffer::from(vec![false, false]));
+        let fsl = FixedSizeListArray::try_new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            dim as i32,
+            inner,
+            Some(nulls),
+        )
+        .unwrap();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    dim as i32,
+                ),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(vec![0, 1])), Arc::new(fsl)],
+        )
+        .unwrap();
+        index.insert(&batch, 0).unwrap();
+        assert_eq!(index.len(), 0, "no nodes for an all-null batch");
     }
 }

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -443,9 +443,18 @@ impl MemTableFlusher {
                 if let MemIndexConfig::Hnsw(hnsw_config) = config
                     && let Some(mem_index) = registry.get_hnsw(&hnsw_config.name)
                 {
-                    let mut index_meta = self
+                    // `None` → the generation has no indexable vectors (e.g. all
+                    // tombstones); flush the data without an HNSW index for it.
+                    let Some(mut index_meta) = self
                         .create_hnsw_index(&gen_path, hnsw_config, mem_index)
-                        .await?;
+                        .await?
+                    else {
+                        info!(
+                            "Skipped empty HNSW index '{}' on flushed generation {} (no vectors)",
+                            hnsw_config.name, generation
+                        );
+                        continue;
+                    };
 
                     let schema = dataset.schema();
                     let field_idx = schema
@@ -782,12 +791,21 @@ impl MemTableFlusher {
     /// * `gen_path` - Path to the flushed generation folder
     /// * `config` - HNSW index configuration
     /// * `mem_index` - In-memory HNSW index (snapshotted, not consumed)
+    ///
+    /// # Returns
+    ///
+    /// `Ok(None)` when the memtable holds no indexable vectors — e.g. a
+    /// generation of only tombstones (delete nulls the vector column and the
+    /// HNSW skips nulls), or an all-null vector column. The generation still
+    /// flushes its data; it simply carries no HNSW index, and an index-only
+    /// (`fast_search`) query over it returns empty — no brute-force scan.
+    /// Erroring here would fail the whole flush drain.
     async fn create_hnsw_index(
         &self,
         gen_path: &Path,
         config: &super::super::index::HnswIndexConfig,
         mem_index: &super::super::index::HnswMemIndex,
-    ) -> Result<IndexMetadata> {
+    ) -> Result<Option<IndexMetadata>> {
         use arrow_array::cast::AsArray;
         use arrow_array::types::Float32Type;
         use arrow_array::{FixedSizeListArray, Float32Array, RecordBatch as ArrowRecordBatch};
@@ -824,16 +842,16 @@ impl MemTableFlusher {
         let distance_type = mem_index.distance_type();
         let dim = mem_index.dim();
         if dim == 0 {
-            return Err(Error::invalid_input(
-                "HnswMemIndex has no inserted vectors; nothing to flush",
-            ));
+            // No vector was ever inserted (e.g. an all-tombstone generation):
+            // skip the index, keep the data flush.
+            return Ok(None);
         }
         // Forward-written data: HNSW row ids line up 1:1 with the data file, so
         // no position reversal (pass `None`).
         let Some((hnsw, flat_storage_batch)) = mem_index.to_lance_hnsw(None)? else {
-            return Err(Error::invalid_input(
-                "HnswMemIndex is empty; nothing to flush",
-            ));
+            // Every vector in the generation is null → empty graph; skip the
+            // index rather than failing the flush.
+            return Ok(None);
         };
 
         // Train SQ8 on the full memtable in one pass: learn global min/max
@@ -1014,7 +1032,7 @@ impl MemTableFlusher {
             files: None,
         };
 
-        Ok(index_meta)
+        Ok(Some(index_meta))
     }
 
     /// Update the shard manifest with the new flushed generation.

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/pk_block_filter.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/pk_block_filter.rs
@@ -266,13 +266,19 @@ impl Stream for PkBlockFilterStream {
                 }
                 Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
                 Poll::Ready(None) => {
-                    // >= k candidates in, < k out: over-fetch missed superseded rows.
+                    // >= k candidates in, < k out: over-fetch missed superseded
+                    // rows. Each is a PK shadowed by a newer generation — an
+                    // update (replaced elsewhere) or a delete (a tombstone that
+                    // emits nothing, so it is pure, uncompensated subtraction).
+                    // A burst of deletes between compactions is the likeliest
+                    // cause of repeated warnings.
                     if !this.warned && this.input_seen >= this.k && this.kept < this.k {
                         warn!(
                             k = this.k,
                             fetched = this.input_seen,
                             kept = this.kept,
-                            "LSM vector search: < k live rows survived the PK post-filter; \
+                            "LSM vector search: < k live rows survived the PK post-filter \
+                             (superseded by newer-generation updates or deletes); \
                              raise the over-fetch factor or use a true KNN prefilter."
                         );
                         this.warned = true;

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -181,7 +181,6 @@ impl LsmFtsSearchPlanner {
         let arm_inputs: Vec<_> = sources
             .iter()
             .map(|source| {
-                let is_active = matches!(source, LsmDataSource::ActiveMemTable { .. });
                 let blocked = block_lists.get(&(source.shard_id(), source.generation()));
                 // Over-fetch a blocked source so the post-filter still yields k live
                 // rows. The active arm returns all matches (no builder limit), so its
@@ -191,36 +190,35 @@ impl LsmFtsSearchPlanner {
                 } else {
                     k
                 };
-                (source, is_active, blocked, fetch_k)
+                (source, blocked, fetch_k)
             })
             .collect();
-        let built =
-            futures::future::try_join_all(arm_inputs.iter().map(|(source, _, _, fetch_k)| {
-                Box::pin(self.build_source_plan(source, column, &query, *fetch_k, projection))
-            }))
-            .await?;
+        let built = futures::future::try_join_all(arm_inputs.iter().map(|(source, _, fetch_k)| {
+            Box::pin(self.build_source_plan(source, column, &query, *fetch_k, projection))
+        }))
+        .await?;
 
         let mut per_source_plans: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(sources.len());
-        for ((_, is_active, blocked, _), plan) in arm_inputs.iter().zip(built) {
-            let is_active = *is_active;
+        for ((_source, blocked, _), plan) in arm_inputs.iter().zip(built) {
             let blocked = *blocked;
-            // Dedup, mirroring LsmVectorSearchPlanner:
-            //  * active: already wrapped in `NewestPkFilterExec` inside
+            // Within-generation dedup is already applied per source:
+            //  * active/frozen in-memory: `NewestPkFilterExec` inside
             //    `build_source_plan` (drops predicate-crossing stale hits, which a
             //    result-set dedup can't catch).
-            //  * flushed/base: drop rows superseded by a newer generation via the
-            //    block-list (within-gen is handled by the flushed deletion vector).
-            let deduped = if is_active {
-                plan
-            } else if let Some(set) = blocked {
-                Arc::new(PkBlockFilterExec::new(
+            //  * flushed: the on-disk deletion vector.
+            // Cross-generation supersession (a newer gen's write or tombstone) is
+            // applied uniformly here via the block-list — including frozen
+            // in-memory generations, whose per-gen recency filter can't see a
+            // newer gen. The newest generation of each shard has no newer gen
+            // (`blocked` is None) and is unaffected.
+            let deduped = match blocked {
+                Some(set) => Arc::new(PkBlockFilterExec::new(
                     plan,
                     self.pk_columns.clone(),
                     set.clone(),
                     k,
-                )) as Arc<dyn ExecutionPlan>
-            } else {
-                plan
+                )) as Arc<dyn ExecutionPlan>,
+                None => plan,
             };
 
             // Normalize to canonical. This also drops the active arm's _rowid,
@@ -843,6 +841,99 @@ mod tests {
         assert!(
             ids.contains(&2),
             "live pk=2 ('alpha foo') must still match 'alpha'; got ids={ids:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_gen_stale_update_blocked_by_newer_memtable() {
+        // The cross-generation analog of `active_stale_update_predicate_crossing_leaks`:
+        // pk=1's stale "alpha" version lives in a FROZEN memtable and its fresh
+        // "beta" version in the ACTIVE one. The frozen arm's recency filter is
+        // per-generation and can't see the newer gen, so only the cross-gen
+        // block-list can drop the stale "alpha" hit. The cluster constantly
+        // freezes memtables, so an insert and its later update/delete split
+        // across in-memory generations — this is the residual fuzz phantom.
+        let schema = fts_schema();
+
+        // Frozen gen=1: pk=1 "alpha lance" (matches), pk=2 "alpha foo" (live).
+        let frozen_store = Arc::new(BatchStore::with_capacity(16));
+        let mut frozen_idx = IndexStore::new();
+        frozen_idx.enable_pk_index(&[("id".to_string(), 0)]);
+        frozen_idx.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let fb = make_batch(&schema, &[1, 2], &["alpha lance", "alpha foo"]);
+        let (bp, off, _) = frozen_store.append(fb.clone()).unwrap();
+        frozen_idx
+            .insert_with_batch_position(&fb, off, Some(bp))
+            .unwrap();
+
+        // Active gen=2: pk=1 updated to "beta lance" (no longer matches "alpha").
+        let active_store = Arc::new(BatchStore::with_capacity(16));
+        let mut active_idx = IndexStore::new();
+        active_idx.enable_pk_index(&[("id".to_string(), 0)]);
+        active_idx.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let ab = make_batch(&schema, &[1], &["beta lance"]);
+        let (bp, off, _) = active_store.append(ab.clone()).unwrap();
+        active_idx
+            .insert_with_batch_position(&ab, off, Some(bp))
+            .unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                uuid::Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store: active_store,
+                        index_store: Arc::new(active_idx),
+                        schema: schema.clone(),
+                        generation: 2,
+                    },
+                    frozen: vec![InMemoryMemTableRef {
+                        batch_store: frozen_store,
+                        index_store: Arc::new(frozen_idx),
+                        schema: schema.clone(),
+                        generation: 1,
+                    }],
+                },
+            );
+
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+        let plan = planner
+            .plan_search(
+                "text",
+                FullTextSearchQuery::new("alpha".to_string()),
+                10,
+                None,
+            )
+            .await
+            .expect("planner should produce a plan");
+
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+
+        let mut ids: Vec<i32> = Vec::new();
+        for b in &batches {
+            let col = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                ids.push(col.value(i));
+            }
+        }
+
+        assert!(
+            !ids.contains(&1),
+            "stale frozen pk=1 ('alpha lance', now 'beta lance' in the active gen) \
+             leaked on an 'alpha' search; got ids={ids:?}"
+        );
+        assert!(
+            ids.contains(&2),
+            "live pk=2 ('alpha foo', only in the frozen gen) must still match; got ids={ids:?}"
         );
     }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -9,9 +9,11 @@ use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_plan::{ExecutionPlan, limit::GlobalLimitExec};
-use datafusion::prelude::Expr;
+use datafusion::prelude::{Expr, col};
 use lance_core::Result;
 use tracing::instrument;
+
+use crate::dataset::mem_wal::TOMBSTONE;
 
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
@@ -21,6 +23,17 @@ use super::projection::{
     build_scanner_projection, canonical_output_schema, null_columns, project_to_canonical,
 };
 use crate::session::Session;
+
+/// Combine the user filter (if any) with `NOT _tombstone` so tombstone rows are
+/// dropped from a WAL-arm scan. Used only for sources whose schema carries the
+/// column (active / flushed generations written since deletes existed).
+fn fold_not_tombstone(filter: Option<&Expr>) -> Expr {
+    let live = !col(TOMBSTONE);
+    match filter {
+        Some(expr) => expr.clone().and(live),
+        None => live,
+    }
+}
 
 /// Plans scan queries over LSM data.
 pub struct LsmScanPlanner {
@@ -39,6 +52,15 @@ pub struct LsmScanPlanner {
     /// Over-fetch multiple for the per-source limit pushdown: block-listed
     /// sources scan `(offset + limit) * factor` rows so cross-gen dedup drops
     /// still leave enough live rows. Clamped to `>= 1.0`.
+    ///
+    /// This headroom must also absorb deletes: a tombstone shadows the older
+    /// real row without emitting a replacement (shadow-without-replace), so it
+    /// is pure subtraction from a block-listed source. If delete density inside
+    /// a source's fetch window exceeds `factor - 1`, that source can deliver
+    /// `< k` live rows (a recall shortfall, not wrong content — see the
+    /// under-fetch `warn!` in `PkBlockFilterExec`). Steady-state this is
+    /// self-limiting because L0→base compaction drains tombstones from the
+    /// fresh tier; the exposure is a delete-heavy burst between compactions.
     overfetch_factor: f64,
 }
 
@@ -327,7 +349,19 @@ impl LsmScanPlanner {
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 scanner.with_row_address();
 
-                if let Some(expr) = filter {
+                // Drop tombstones: fold `NOT _tombstone` into the predicate so
+                // it runs before the pushdown limit (counting only live rows).
+                // The older real row a tombstone supersedes is dropped by the
+                // cross-gen block-list, not by this filter. Gen written before
+                // deletes existed lack the column → no fold, nothing to drop.
+                let folded;
+                let effective: Option<&Expr> = if dataset.schema().field(TOMBSTONE).is_some() {
+                    folded = fold_not_tombstone(filter);
+                    Some(&folded)
+                } else {
+                    filter
+                };
+                if let Some(expr) = effective {
                     scanner.filter_expr(expr.clone());
                 }
                 // Per-source limit pushdown: flushed generations are
@@ -357,8 +391,19 @@ impl LsmScanPlanner {
 
                 // The dedup scan applies the filter post-dedup; pushing it
                 // into the raw scan would resurrect older versions of PKs
-                // whose newest version fails the predicate.
-                if let Some(expr) = filter {
+                // whose newest version fails the predicate. Folding
+                // `NOT _tombstone` here is correct: a tombstone wins the
+                // position-based dedup (suppressing the older real row) and is
+                // then dropped by this predicate. A memtable without the column
+                // (legacy / test) gets no fold.
+                let folded;
+                let effective: Option<&Expr> = if schema.column_with_name(TOMBSTONE).is_some() {
+                    folded = fold_not_tombstone(filter);
+                    Some(&folded)
+                } else {
+                    filter
+                };
+                if let Some(expr) = effective {
                     scanner.filter_expr(expr.clone());
                 }
 
@@ -1898,6 +1943,208 @@ mod integration_tests {
         assert!(
             msg.contains("_rowaddr"),
             "rejection message should mention the offending column, got: {msg}",
+        );
+    }
+
+    // ----- tombstone (delete) filtered-read tests -----
+
+    /// Memtable / generation schema: base (`id`, `name`) + `_tombstone`.
+    fn ts_pk_schema() -> Arc<ArrowSchema> {
+        let mut id_metadata = HashMap::new();
+        id_metadata.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        let id = Field::new("id", DataType::Int32, false).with_metadata(id_metadata);
+        Arc::new(ArrowSchema::new(vec![
+            id,
+            Field::new("name", DataType::Utf8, true),
+            Field::new(crate::dataset::mem_wal::TOMBSTONE, DataType::Boolean, false),
+        ]))
+    }
+
+    /// Build a `_tombstone`-bearing batch from `(id, name, tombstone)` rows.
+    fn ts_batch(schema: &Arc<ArrowSchema>, rows: &[(i32, Option<&str>, bool)]) -> RecordBatch {
+        let ids: Vec<i32> = rows.iter().map(|(i, _, _)| *i).collect();
+        let names: Vec<Option<String>> = rows
+            .iter()
+            .map(|(_, n, _)| n.map(|s| s.to_string()))
+            .collect();
+        let ts: Vec<bool> = rows.iter().map(|(_, _, t)| *t).collect();
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(names)),
+                Arc::new(arrow_array::BooleanArray::from(ts)),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn collect_sorted_ids(batches: &[RecordBatch]) -> Vec<i32> {
+        let mut ids: Vec<i32> = Vec::new();
+        for b in batches {
+            let arr = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            ids.extend((0..arr.len()).map(|i| arr.value(i)));
+        }
+        ids.sort_unstable();
+        ids
+    }
+
+    #[tokio::test]
+    async fn test_lsm_scan_active_tombstone_masks_base() {
+        // Active gen tombstones id=2 (present in base) and adds real id=4. The
+        // result drops id=2 (block-list masks the base row; the active arm's
+        // folded `NOT _tombstone` drops the tombstone itself) and never
+        // surfaces the tombstone row.
+        let base_schema = create_pk_schema();
+        let mem_schema = ts_pk_schema();
+        let temp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp.path().to_str().unwrap());
+        let base = Arc::new(
+            create_dataset(
+                &base_uri,
+                vec![create_test_batch(&base_schema, &[1, 2, 3], "base")],
+            )
+            .await,
+        );
+
+        let active_batch = ts_batch(
+            &mem_schema,
+            &[(4, Some("active_4"), false), (2, None, true)],
+        );
+        let (bs, ix) = pk_indexed(&[active_batch]);
+        let scanner = LsmScanner::new(base, vec![], vec!["id".to_string()])
+            .with_in_memory_memtables(
+                Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store: bs,
+                        index_store: ix,
+                        schema: mem_schema,
+                        generation: 2,
+                    },
+                    frozen: vec![],
+                },
+            );
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            collect_sorted_ids(&batches),
+            vec![1, 3, 4],
+            "id=2 deleted; tombstone row not surfaced"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lsm_scan_flushed_tombstone_masks_base() {
+        // A tombstone living in a flushed generation masks the older base row by
+        // PK presence (block-list) and is itself dropped by the folded predicate.
+        let base_schema = create_pk_schema();
+        let mem_schema = ts_pk_schema();
+        let temp = tempfile::tempdir().unwrap();
+        let base_path = temp.path().to_str().unwrap();
+        let base_uri = format!("{}/base", base_path);
+        let base = Arc::new(
+            create_dataset(
+                &base_uri,
+                vec![create_test_batch(&base_schema, &[1, 2, 3], "base")],
+            )
+            .await,
+        );
+
+        // Flushed gen 1 holds only a tombstone for id=2 (written with the
+        // `_tombstone` schema, so the flushed arm folds `NOT _tombstone`).
+        let shard_id = Uuid::new_v4();
+        let gen1_uri = format!("{}/_mem_wal/{}/gen_1", base_uri, shard_id);
+        create_dataset(&gen1_uri, vec![ts_batch(&mem_schema, &[(2, None, true)])]).await;
+        let shard_snapshot = ShardSnapshot::new(shard_id)
+            .with_current_generation(2)
+            .with_flushed_generation(1, "gen_1".to_string());
+
+        let scanner = LsmScanner::new(base, vec![shard_snapshot], vec!["id".to_string()]);
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            collect_sorted_ids(&batches),
+            vec![1, 3],
+            "id=2 deleted via flushed-generation tombstone"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lsm_scan_tombstone_does_not_consume_limit() {
+        // A single (newest) flushed generation holds both tombstones and live
+        // rows. With LIMIT 2 the folded `NOT _tombstone` runs *before* the
+        // per-source pushdown limit, so the limit counts only live rows — we get
+        // 2 live rows, not 0 (which is what a post-limit tombstone filter, or a
+        // limit that counted the tombstones, would yield).
+        let base_schema = create_pk_schema();
+        let mem_schema = ts_pk_schema();
+        let temp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp.path().to_str().unwrap());
+
+        // gen_1 file order: two tombstones first, then two live rows.
+        let shard_id = Uuid::new_v4();
+        let gen1_uri = format!("{}/_mem_wal/{}/gen_1", base_uri, shard_id);
+        create_dataset(
+            &gen1_uri,
+            vec![ts_batch(
+                &mem_schema,
+                &[
+                    (1, None, true),
+                    (2, None, true),
+                    (3, Some("live_3"), false),
+                    (4, Some("live_4"), false),
+                ],
+            )],
+        )
+        .await;
+        let shard_snapshot = ShardSnapshot::new(shard_id)
+            .with_current_generation(2)
+            .with_flushed_generation(1, "gen_1".to_string());
+
+        let scanner = LsmScanner::without_base_table(
+            base_schema,
+            base_uri,
+            vec![shard_snapshot],
+            vec!["id".to_string()],
+        )
+        .limit(2, None);
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let ids = collect_sorted_ids(&batches);
+        assert_eq!(
+            ids.len(),
+            2,
+            "limit honored with live rows only, got {:?}",
+            ids
+        );
+        assert!(
+            !ids.contains(&1) && !ids.contains(&2),
+            "deleted ids must not appear, got {:?}",
+            ids
         );
     }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -8,14 +8,16 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow_array::{Array, RecordBatch};
-use arrow_schema::{SchemaRef, SortOptions};
+use arrow_array::{Array, BooleanArray, RecordBatch};
+use arrow_schema::{DataType, Field, Schema, SchemaRef, SortOptions};
 use datafusion::common::ScalarValue;
 use datafusion::execution::TaskContext;
-use datafusion::physical_expr::expressions::Column;
-use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
+use datafusion::physical_expr::expressions::{Column, Literal, NotExpr};
+use datafusion::physical_expr::{LexOrdering, PhysicalExpr, PhysicalSortExpr};
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::limit::GlobalLimitExec;
+use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::prelude::{Expr, SessionContext};
@@ -25,6 +27,7 @@ use lance_core::{Result, is_system_column};
 use lance_datafusion::exec::OneShotExec;
 use tracing::instrument;
 
+use crate::dataset::mem_wal::TOMBSTONE;
 use crate::dataset::mem_wal::index::IndexStore;
 use crate::dataset::mem_wal::memtable::batch_store::BatchStore;
 
@@ -33,8 +36,8 @@ use super::data_source::LsmDataSource;
 use super::exec::{BloomFilterGuardExec, CoalesceFirstExec, compute_pk_hash_from_scalars};
 use super::flushed_cache::{DatasetCache, GenerationWarmer, open_flushed_dataset};
 use super::projection::{
-    build_scanner_projection, canonical_output_schema, null_columns, project_to_canonical,
-    wants_row_address, wants_row_id,
+    DISTANCE_COLUMN, build_scanner_projection, canonical_output_schema, null_columns,
+    project_to_canonical, wants_row_address, wants_row_id,
 };
 use crate::session::Session;
 
@@ -233,13 +236,23 @@ impl LsmPointLookupPlanner {
             source_plans.push(guarded_plan);
         }
 
-        let plan: Arc<dyn ExecutionPlan> = if source_plans.len() == 1 {
-            source_plans.remove(0)
-        } else {
-            Arc::new(CoalesceFirstExec::new(source_plans))
-        };
+        // Always coalesce, even for a single source: besides picking the newest
+        // non-empty arm, `CoalesceFirstExec` normalizes child statistics to a
+        // schema-sized "unknown", which the downstream tombstone `FilterExec`
+        // needs (the in-memory mem_wal execs report empty column statistics, and
+        // datafusion's projection statistics would index out of bounds without
+        // this normalization).
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalesceFirstExec::new(source_plans));
 
-        Ok(plan)
+        // Tombstones must be dropped AFTER the coalesce, never per-source: the
+        // tombstone wins the newest-first coalesce (its source is the newest
+        // non-empty arm), so filtering it here yields "not found". Filtering
+        // per-source would empty the newest arm and let `CoalesceFirstExec`
+        // fall through to an older arm — resurrecting the deleted row. Then the
+        // carried `_tombstone` column is projected away.
+        let canonical =
+            canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false);
+        filter_tombstones_after_coalesce(coalesced, &canonical)
     }
 
     /// Resolve a single-row point lookup, returning the newest matching row (a
@@ -308,6 +321,7 @@ impl LsmPointLookupPlanner {
                             target,
                         )? {
                             Probe::Hit(batch) => Ok(Some(FastOutcome::Hit(batch))),
+                            Probe::Deleted => Ok(Some(FastOutcome::Deleted)),
                             Probe::Miss => Ok(None),
                             Probe::NoIndex => Ok(Some(FastOutcome::NeedsFallback)),
                         }
@@ -315,6 +329,9 @@ impl LsmPointLookupPlanner {
                 )?;
                 match outcome {
                     Some(FastOutcome::Hit(batch)) => return Ok(Some(batch)),
+                    // Newest version is a tombstone → deleted; do not consult
+                    // older (on-disk) sources.
+                    Some(FastOutcome::Deleted) => return Ok(None),
                     Some(FastOutcome::NeedsFallback) => { /* fall through to plan */ }
                     None => {
                         // Every in-memory memtable missed. If there is no
@@ -412,7 +429,12 @@ impl LsmPointLookupPlanner {
             for (ri, m) in refs.iter().enumerate() {
                 match probe_position(&m.batch_store, &m.index_store, pk_col, key)? {
                     ProbePos::Found { batch_idx, row } => {
-                        hits.entry((ri, batch_idx)).or_default().push(row as u32);
+                        // Newest version is a tombstone → the key is deleted:
+                        // resolve it as a miss (emit nothing) and do not fall
+                        // through to an older source.
+                        if !is_tombstone_at(&m.batch_store, batch_idx, row)? {
+                            hits.entry((ri, batch_idx)).or_default().push(row as u32);
+                        }
                         resolved = true;
                         break;
                     }
@@ -563,6 +585,10 @@ impl LsmPointLookupPlanner {
                 )
                 .await?;
                 let mut scanner = dataset.scan();
+                // Carry `_tombstone` through so the post-coalesce filter can drop
+                // a deleted key (gen written before deletes existed lack it →
+                // `project_to_carry` synthesizes `false`).
+                let cols = cols_with_tombstone(&cols, dataset.schema().field(TOMBSTONE).is_some());
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 scanner.filter_expr(filter.clone());
                 scanner.create_plan().await?
@@ -577,6 +603,9 @@ impl LsmPointLookupPlanner {
 
                 let mut scanner =
                     MemTableScanner::new(batch_store.clone(), index_store.clone(), schema.clone());
+                // Carry `_tombstone` through so the post-coalesce filter can drop
+                // a deleted key; it survives the sort below.
+                let cols = cols_with_tombstone(&cols, schema.column_with_name(TOMBSTONE).is_some());
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>());
                 scanner.filter_expr(filter.clone());
                 // Expose `_rowid` (the BatchStore row offset, monotonic with
@@ -611,7 +640,10 @@ impl LsmPointLookupPlanner {
                 null_columns(newest, &[lance_core::ROW_ID])?
             }
         };
-        project_to_canonical(scan, &target)
+        // Output carries `_tombstone` (canonical + the marker) so it survives
+        // the union/coalesce to the post-coalesce filter; base / legacy sources
+        // that lack the column get a synthesized `false`.
+        project_to_carry(scan, &target)
     }
 
     /// Create an empty execution plan with the canonical output schema.
@@ -624,10 +656,113 @@ impl LsmPointLookupPlanner {
     }
 }
 
+/// Append `_tombstone` to a scanner projection when the source carries it, so
+/// the column survives to the post-coalesce tombstone filter. Sources without
+/// it (base table, generations written before deletes existed) are left alone
+/// and have `false` synthesized by [`project_to_carry`].
+fn cols_with_tombstone(cols: &[String], present: bool) -> Vec<String> {
+    if !present {
+        return cols.to_vec();
+    }
+    let mut out = cols.to_vec();
+    if !out.iter().any(|c| c == TOMBSTONE) {
+        out.push(TOMBSTONE.to_string());
+    }
+    out
+}
+
+/// Carry schema = canonical output + a trailing non-nullable `_tombstone`
+/// Boolean. Non-nullable so the base arm's synthesized `Literal(false)` matches
+/// the WAL arms' real column under `CoalesceFirstExec`'s exact-schema check.
+fn carry_schema(canonical: &SchemaRef) -> SchemaRef {
+    let mut fields: Vec<Arc<Field>> = canonical.fields().iter().cloned().collect();
+    fields.push(Arc::new(Field::new(TOMBSTONE, DataType::Boolean, false)));
+    Arc::new(Schema::new(fields))
+}
+
+/// Project a source scan to the carry schema: existing columns are forwarded, a
+/// missing `_tombstone` becomes `false` (base table / legacy generations carry
+/// no tombstones), and missing system / `_distance` columns are NULL-filled
+/// (mirroring [`project_to_canonical`]).
+fn project_to_carry(
+    plan: Arc<dyn ExecutionPlan>,
+    canonical: &SchemaRef,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let input = plan.schema();
+    let carry = carry_schema(canonical);
+    let mut project_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> =
+        Vec::with_capacity(carry.fields().len());
+    for field in carry.fields() {
+        let name = field.name();
+        let expr: Arc<dyn PhysicalExpr> = match input.column_with_name(name) {
+            Some((idx, _)) => Arc::new(Column::new(name, idx)),
+            None if name == TOMBSTONE => Arc::new(Literal::new(ScalarValue::Boolean(Some(false)))),
+            None if is_system_column(name) => Arc::new(Literal::new(ScalarValue::UInt64(None))),
+            None if name == DISTANCE_COLUMN => Arc::new(Literal::new(ScalarValue::Float32(None))),
+            None => {
+                return Err(lance_core::Error::internal(format!(
+                    "Column '{}' missing from point-lookup carry source schema (have: {:?})",
+                    name,
+                    input
+                        .fields()
+                        .iter()
+                        .map(|f| f.name().clone())
+                        .collect::<Vec<_>>()
+                )));
+            }
+        };
+        project_exprs.push((expr, name.clone()));
+    }
+    Ok(Arc::new(
+        ProjectionExec::try_new(project_exprs, plan).map_err(|e| {
+            lance_core::Error::internal(format!("Failed to build carry ProjectionExec: {}", e))
+        })?,
+    ))
+}
+
+/// Drop tombstone rows after `CoalesceFirstExec` has already picked the newest
+/// source, then project the carried `_tombstone` column away (back to the
+/// canonical schema).
+fn filter_tombstones_after_coalesce(
+    plan: Arc<dyn ExecutionPlan>,
+    canonical: &SchemaRef,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let idx = plan.schema().index_of(TOMBSTONE).map_err(|e| {
+        lance_core::Error::internal(format!("point-lookup carry plan missing _tombstone: {}", e))
+    })?;
+    let predicate: Arc<dyn PhysicalExpr> =
+        Arc::new(NotExpr::new(Arc::new(Column::new(TOMBSTONE, idx))));
+    let filtered: Arc<dyn ExecutionPlan> =
+        Arc::new(FilterExec::try_new(predicate, plan).map_err(|e| {
+            lance_core::Error::internal(format!("Failed to build tombstone FilterExec: {}", e))
+        })?);
+    project_to_canonical(filtered, canonical)
+}
+
+/// Whether the row at `(batch_idx, row)` of `batch_store` is a tombstone.
+/// Memtables without the `_tombstone` column (legacy / direct-construction
+/// tests) are treated as carrying no tombstones.
+fn is_tombstone_at(batch_store: &BatchStore, batch_idx: usize, row: usize) -> Result<bool> {
+    let stored = batch_store.get(batch_idx).ok_or_else(|| {
+        lance_core::Error::internal("point-lookup: tombstone-check batch missing")
+    })?;
+    let Some(col) = stored.data.column_by_name(TOMBSTONE) else {
+        return Ok(false);
+    };
+    let arr = col.as_any().downcast_ref::<BooleanArray>().ok_or_else(|| {
+        lance_core::Error::internal("point-lookup: _tombstone column is not Boolean")
+    })?;
+    Ok(arr.is_valid(row) && arr.value(row))
+}
+
 /// Result of probing the in-memory memtables newest-first in `lookup()`.
 enum FastOutcome {
     /// A visible row was found; here it is, projected.
     Hit(RecordBatch),
+    /// The newest visible version of the key is a tombstone — the key is
+    /// deleted. The search stops here (no fall-through to older sources) and
+    /// resolves to "not found".
+    Deleted,
     /// A memtable could not be probed directly (no BTree on the key) — the
     /// caller must fall back to the plan path.
     NeedsFallback,
@@ -637,6 +772,9 @@ enum FastOutcome {
 enum Probe {
     /// The key was found; here is the newest visible row, projected.
     Hit(RecordBatch),
+    /// The newest visible version of the key is a tombstone — deleted. Stop the
+    /// search and return "not found".
+    Deleted,
     /// The key is not present in this memtable (but may be in an older source).
     Miss,
     /// This memtable has no BTree on the key column, so it cannot be probed
@@ -776,12 +914,20 @@ fn probe_memtable(
     match probe_position(batch_store, index_store, pk_column, pk_value)? {
         ProbePos::NoIndex => Ok(Probe::NoIndex),
         ProbePos::Miss => Ok(Probe::Miss),
-        ProbePos::Found { batch_idx, row } => Ok(Probe::Hit(gather_rows(
-            batch_store,
-            batch_idx,
-            &[row as u32],
-            target,
-        )?)),
+        ProbePos::Found { batch_idx, row } => {
+            // The newest visible version is a tombstone → the key is deleted.
+            // Stop here rather than materializing or falling through to an
+            // older source.
+            if is_tombstone_at(batch_store, batch_idx, row)? {
+                return Ok(Probe::Deleted);
+            }
+            Ok(Probe::Hit(gather_rows(
+                batch_store,
+                batch_idx,
+                &[row as u32],
+                target,
+            )?))
+        }
     }
 }
 
@@ -1773,5 +1919,187 @@ mod tests {
                 .is_none(),
             "absent key must miss"
         );
+    }
+
+    // ----- tombstone (delete) point-lookup tests -----
+
+    /// Memtable schema = base (`id`, `name`) + the `_tombstone` marker.
+    fn pk_ts_schema() -> Arc<ArrowSchema> {
+        let mut id_metadata = HashMap::new();
+        id_metadata.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        let id = Field::new("id", DataType::Int32, false).with_metadata(id_metadata);
+        Arc::new(ArrowSchema::new(vec![
+            id,
+            Field::new("name", DataType::Utf8, true),
+            Field::new(TOMBSTONE, DataType::Boolean, false),
+        ]))
+    }
+
+    fn ts_real(schema: &Arc<ArrowSchema>, ids: &[i32], prefix: &str) -> RecordBatch {
+        let names: Vec<String> = ids.iter().map(|i| format!("{}_{}", prefix, i)).collect();
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(ids.to_vec())),
+                Arc::new(StringArray::from(names)),
+                Arc::new(arrow_array::BooleanArray::from(vec![false; ids.len()])),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn ts_tomb(schema: &Arc<ArrowSchema>, ids: &[i32]) -> RecordBatch {
+        let names: Vec<Option<String>> = ids.iter().map(|_| None).collect();
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(ids.to_vec())),
+                Arc::new(StringArray::from(names)),
+                Arc::new(arrow_array::BooleanArray::from(vec![true; ids.len()])),
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Active-only planner whose memtable carries `_tombstone`; the planner's
+    /// base schema stays tombstone-free (as the base table is in production).
+    fn active_ts_planner(batches: &[RecordBatch]) -> LsmPointLookupPlanner {
+        use crate::dataset::mem_wal::scanner::collector::InMemoryMemTables;
+        let base_schema = create_pk_schema();
+        let mem_schema = pk_ts_schema();
+        let temp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp.path().to_str().unwrap());
+        let active = active_memtable_ref(&mem_schema, batches, 1);
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                Uuid::new_v4(),
+                InMemoryMemTables {
+                    active,
+                    frozen: vec![],
+                },
+            );
+        LsmPointLookupPlanner::new(collector, vec!["id".to_string()], base_schema)
+    }
+
+    #[tokio::test]
+    async fn test_lookup_tombstone_within_active_not_found() {
+        // Fast path: id=1 written then tombstoned (newer); id=2 is a control.
+        let schema = pk_ts_schema();
+        let planner = active_ts_planner(&[ts_real(&schema, &[1, 2], "v"), ts_tomb(&schema, &[1])]);
+
+        assert!(
+            planner
+                .lookup(&[ScalarValue::Int32(Some(1))], None)
+                .await
+                .unwrap()
+                .is_none(),
+            "deleted key must resolve to not-found, not the older real row"
+        );
+        let row = planner
+            .lookup(&[ScalarValue::Int32(Some(2))], None)
+            .await
+            .unwrap()
+            .expect("untouched key still found");
+        assert_eq!(id_at(&row), 2);
+    }
+
+    #[tokio::test]
+    async fn test_lookup_tombstone_then_reinsert() {
+        // delete then re-insert the same key → the re-insert is newest.
+        let schema = pk_ts_schema();
+        let planner = active_ts_planner(&[
+            ts_real(&schema, &[1], "old"),
+            ts_tomb(&schema, &[1]),
+            ts_real(&schema, &[1], "new"),
+        ]);
+        let row = planner
+            .lookup(&[ScalarValue::Int32(Some(1))], None)
+            .await
+            .unwrap()
+            .expect("re-inserted key must be found");
+        assert_eq!(name_at(&row), "new_1");
+    }
+
+    #[tokio::test]
+    async fn test_lookup_tombstone_of_absent_key_is_noop() {
+        // Deleting a key that never existed is a no-op miss.
+        let schema = pk_ts_schema();
+        let planner = active_ts_planner(&[ts_real(&schema, &[1], "v"), ts_tomb(&schema, &[99])]);
+        assert!(
+            planner
+                .lookup(&[ScalarValue::Int32(Some(99))], None)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let row = planner
+            .lookup(&[ScalarValue::Int32(Some(1))], None)
+            .await
+            .unwrap()
+            .expect("unrelated key unaffected");
+        assert_eq!(id_at(&row), 1);
+    }
+
+    #[tokio::test]
+    async fn test_lookup_tombstone_plan_path_resurrection_guard() {
+        // Force the plan path (project a system column) so the after-coalesce
+        // filter — not the fast-path short-circuit — must drop the tombstone.
+        // Real row lives in base; the newer active arm holds only its tombstone.
+        use crate::dataset::mem_wal::scanner::collector::InMemoryMemTables;
+        let base_schema = create_pk_schema();
+        let mem_schema = pk_ts_schema();
+        let temp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp.path().to_str().unwrap());
+        let base = Arc::new(
+            create_dataset(
+                &base_uri,
+                vec![create_test_batch(&base_schema, &[1, 2], "base")],
+            )
+            .await,
+        );
+        let active = active_memtable_ref(&mem_schema, &[ts_tomb(&mem_schema, &[1])], 2);
+        let collector = LsmDataSourceCollector::new(base, vec![]).with_in_memory_memtables(
+            Uuid::new_v4(),
+            InMemoryMemTables {
+                active,
+                frozen: vec![],
+            },
+        );
+        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], base_schema);
+
+        let proj = vec!["id".to_string(), "_rowid".to_string()];
+        assert!(
+            planner
+                .lookup(&[ScalarValue::Int32(Some(1))], Some(&proj))
+                .await
+                .unwrap()
+                .is_none(),
+            "plan path must not fall through to the base row for a deleted key"
+        );
+        let row = planner
+            .lookup(&[ScalarValue::Int32(Some(2))], Some(&proj))
+            .await
+            .unwrap()
+            .expect("untouched base row found");
+        assert_eq!(id_at(&row), 2);
+    }
+
+    #[tokio::test]
+    async fn test_lookup_many_skips_tombstoned_keys() {
+        // Batched lookup: a tombstoned key is omitted, others resolved.
+        let schema = pk_ts_schema();
+        let planner =
+            active_ts_planner(&[ts_real(&schema, &[1, 2, 3], "v"), ts_tomb(&schema, &[2])]);
+        let keys = [
+            ScalarValue::Int32(Some(1)),
+            ScalarValue::Int32(Some(2)),
+            ScalarValue::Int32(Some(3)),
+        ];
+        let batch = planner.lookup_many(&keys, None).await.unwrap();
+        assert_eq!(batch.num_rows(), 2, "the tombstoned key is omitted");
+        assert_eq!(sorted_ids(&batch), vec![1, 3]);
     }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -189,6 +189,33 @@ impl LsmPointLookupPlanner {
         pk_values: &[ScalarValue],
         projection: Option<&[String]>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        match self.plan_lookup_coalesced(pk_values, projection).await? {
+            // Tombstones are dropped AFTER the coalesce, never per-source: the
+            // tombstone wins the newest-first coalesce (its source is the newest
+            // non-empty arm), so filtering it here yields "not found". Filtering
+            // per-source would empty the newest arm and let `CoalesceFirstExec`
+            // fall through to an older arm — resurrecting the deleted row. Then
+            // the carried `_tombstone` column is projected away.
+            Some(coalesced) => {
+                let canonical =
+                    canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false);
+                filter_tombstones_after_coalesce(coalesced, &canonical)
+            }
+            None => self.empty_plan(projection),
+        }
+    }
+
+    /// Build the coalesced point-lookup plan: each source scanned newest-first,
+    /// unioned under `CoalesceFirstExec`, output in the *carry* schema (canonical
+    /// output + the `_tombstone` marker). `None` when there are no sources at
+    /// all. [`Self::plan_lookup`] drops the tombstone on top of this;
+    /// [`Self::lookup_keep_tombstone`] keeps it so partial-update merge can tell
+    /// a fresh-deleted key from an absent one.
+    async fn plan_lookup_coalesced(
+        &self,
+        pk_values: &[ScalarValue],
+        projection: Option<&[String]>,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
         if pk_values.len() != self.pk_columns.len() {
             return Err(lance_core::Error::invalid_input(format!(
                 "Expected {} primary key values, got {}",
@@ -202,7 +229,7 @@ impl LsmPointLookupPlanner {
         let sources = self.collector.collect()?;
 
         if sources.is_empty() {
-            return self.empty_plan(projection);
+            return Ok(None);
         }
 
         // Sort by generation DESC (newest first)
@@ -242,17 +269,60 @@ impl LsmPointLookupPlanner {
         // needs (the in-memory mem_wal execs report empty column statistics, and
         // datafusion's projection statistics would index out of bounds without
         // this normalization).
-        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalesceFirstExec::new(source_plans));
+        Ok(Some(Arc::new(CoalesceFirstExec::new(source_plans))))
+    }
 
-        // Tombstones must be dropped AFTER the coalesce, never per-source: the
-        // tombstone wins the newest-first coalesce (its source is the newest
-        // non-empty arm), so filtering it here yields "not found". Filtering
-        // per-source would empty the newest arm and let `CoalesceFirstExec`
-        // fall through to an older arm — resurrecting the deleted row. Then the
-        // carried `_tombstone` column is projected away.
+    /// Like [`Self::lookup`] but does NOT drop a tombstone: the returned 1-row
+    /// batch carries the `_tombstone` marker (`true` ⇒ the key's newest fresh
+    /// version is a delete); `None` still means the key is absent from every
+    /// source. Partial-update merge uses this to treat a fresh-deleted PK as
+    /// absent, so it never resurrects stale, not-yet-compacted base columns.
+    /// Always plans (no in-memory fast path) — used off the hot read path, on
+    /// small partial-update batches.
+    pub async fn lookup_keep_tombstone(
+        &self,
+        pk_values: &[ScalarValue],
+        projection: Option<&[String]>,
+    ) -> Result<Option<RecordBatch>> {
+        let Some(plan) = self.plan_lookup_coalesced(pk_values, projection).await? else {
+            return Ok(None);
+        };
+        let batches: Vec<RecordBatch> = plan
+            .execute(0, self.task_ctx.clone())?
+            .try_collect()
+            .await?;
+        for batch in batches {
+            if batch.num_rows() > 0 {
+                return Ok(Some(batch.slice(0, 1)));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Tombstone-preserving [`Self::lookup_many`] for single- or multi-column
+    /// keys: resolves each key with [`Self::lookup_keep_tombstone`] and
+    /// concatenates the hits in the carry schema (canonical output +
+    /// `_tombstone`); keys absent from every source are omitted. Per-key (no
+    /// batched fast path) — the partial-update batches that use it are small.
+    pub async fn lookup_many_keep_tombstone(
+        &self,
+        keys: &[Vec<ScalarValue>],
+        projection: Option<&[String]>,
+    ) -> Result<RecordBatch> {
         let canonical =
             canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false);
-        filter_tombstones_after_coalesce(coalesced, &canonical)
+        let target = carry_schema(&canonical);
+        let mut out: Vec<RecordBatch> = Vec::with_capacity(keys.len());
+        for key in keys {
+            if let Some(b) = self.lookup_keep_tombstone(key, projection).await? {
+                out.push(b);
+            }
+        }
+        match out.len() {
+            0 => Ok(RecordBatch::new_empty(target)),
+            1 => Ok(out.pop().unwrap()),
+            _ => Ok(arrow_select::concat::concat_batches(&target, &out)?),
+        }
     }
 
     /// Resolve a single-row point lookup, returning the newest matching row (a
@@ -1982,6 +2052,85 @@ mod tests {
                 },
             );
         LsmPointLookupPlanner::new(collector, vec!["id".to_string()], base_schema)
+    }
+
+    /// Read the `_tombstone` marker from row 0 of a keep-tombstone result.
+    fn tombstone_at(b: &RecordBatch) -> bool {
+        let idx = b.schema().index_of(TOMBSTONE).expect("_tombstone column");
+        b.column(idx)
+            .as_any()
+            .downcast_ref::<arrow_array::BooleanArray>()
+            .expect("_tombstone is Boolean")
+            .value(0)
+    }
+
+    #[tokio::test]
+    async fn test_lookup_keep_tombstone_returns_deleted_row_with_marker() {
+        // The tombstone-preserving variant keeps a deleted key that the filtered
+        // `lookup` would drop: id=1 deleted, id=2 live, id=99 absent.
+        let schema = pk_ts_schema();
+        let planner = active_ts_planner(&[ts_real(&schema, &[1, 2], "v"), ts_tomb(&schema, &[1])]);
+
+        // Deleted key: present with `_tombstone = true` (vs `None` from `lookup`).
+        let deleted = planner
+            .lookup_keep_tombstone(&[ScalarValue::Int32(Some(1))], None)
+            .await
+            .unwrap()
+            .expect("deleted key kept by lookup_keep_tombstone");
+        assert_eq!(id_at(&deleted), 1);
+        assert!(
+            tombstone_at(&deleted),
+            "deleted key carries _tombstone = true"
+        );
+
+        // Live key: present with `_tombstone = false`.
+        let live = planner
+            .lookup_keep_tombstone(&[ScalarValue::Int32(Some(2))], None)
+            .await
+            .unwrap()
+            .expect("live key found");
+        assert_eq!(id_at(&live), 2);
+        assert!(!tombstone_at(&live), "live key carries _tombstone = false");
+
+        // Absent key: still `None` — no fresh entry at all to distinguish.
+        assert!(
+            planner
+                .lookup_keep_tombstone(&[ScalarValue::Int32(Some(99))], None)
+                .await
+                .unwrap()
+                .is_none(),
+            "absent key has no fresh entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_lookup_many_keep_tombstone_includes_tombstoned_keys() {
+        // Batched variant: the tombstoned key is INCLUDED (carrying its marker),
+        // unlike `lookup_many` which omits it. id=2 deleted; 1 and 3 live.
+        let schema = pk_ts_schema();
+        let planner =
+            active_ts_planner(&[ts_real(&schema, &[1, 2, 3], "v"), ts_tomb(&schema, &[2])]);
+        let keys = vec![
+            vec![ScalarValue::Int32(Some(1))],
+            vec![ScalarValue::Int32(Some(2))],
+            vec![ScalarValue::Int32(Some(3))],
+        ];
+        let batch = planner
+            .lookup_many_keep_tombstone(&keys, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            batch.num_rows(),
+            3,
+            "all three keys kept, including the tombstone"
+        );
+        // Exactly one row (id=2) is marked deleted.
+        let deleted: Vec<i32> = (0..batch.num_rows())
+            .map(|r| batch.slice(r, 1))
+            .filter(tombstone_at)
+            .map(|b| id_at(&b))
+            .collect();
+        assert_eq!(deleted, vec![2], "only id=2 is marked deleted");
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -315,7 +315,22 @@ impl LsmVectorSearchPlanner {
                         batch_store,
                         active_max_visible.expect("active arm returns its max_visible snapshot"),
                     ));
-                sort_by_distance(filtered, k)?
+                // Cross-generation supersession: a frozen (older) in-memory
+                // generation can be superseded by a newer generation's write or
+                // tombstone. The recency filter above is within-generation only;
+                // the block-list is the sole cross-gen mechanism. The newest
+                // active memtable has no newer generation (`blocked` is None), so
+                // this is a no-op there — only older frozen gens are filtered.
+                let blocked_filtered: Arc<dyn ExecutionPlan> = match blocked {
+                    Some(set) => Arc::new(super::exec::PkBlockFilterExec::new(
+                        filtered,
+                        self.pk_columns.clone(),
+                        set.clone(),
+                        k,
+                    )),
+                    None => filtered,
+                };
+                sort_by_distance(blocked_filtered, k)?
             } else {
                 match blocked {
                     Some(set) => Arc::new(super::exec::PkBlockFilterExec::new(
@@ -622,6 +637,26 @@ mod tests {
         .unwrap()
     }
 
+    /// One row with an explicit `(id, vector)` — unlike [`create_test_batch`],
+    /// the vector is not derived from `id`, so the same PK can carry different
+    /// vectors across generations (an update / move-out-of-neighborhood).
+    fn create_id_vector_batch(schema: &ArrowSchema, id: i32, vector: [f32; 4]) -> RecordBatch {
+        use arrow_array::builder::Float32Builder;
+        let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), 4);
+        for v in vector {
+            builder.values().append_value(v);
+        }
+        builder.append(true);
+        RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(vec![id])),
+                Arc::new(builder.finish()),
+            ],
+        )
+        .unwrap()
+    }
+
     async fn create_dataset(uri: &str, batches: Vec<RecordBatch>) -> Dataset {
         let schema = batches[0].schema();
         let has_id = schema.column_with_name("id").is_some();
@@ -806,6 +841,127 @@ mod tests {
             "expected near-zero distance for self-match, got {}",
             dist_col.value(0)
         );
+    }
+
+    #[tokio::test]
+    async fn cross_gen_stale_version_blocked_by_newer_memtable() {
+        // A PK updated ACROSS a freeze boundary: its old (near) version lives in
+        // a frozen memtable, its new (far) version in the active one. Both are
+        // in-memory `ActiveMemTable` sources, so each gets only a per-generation
+        // recency filter (`NewestPkFilterExec`) — which can't see the newer gen.
+        // The cross-generation block-list is the only thing that can drop the
+        // stale near copy; if the active arm discards it, the frozen near version
+        // leaks as a phantom near-neighbor. This is the residual wallop fuzz
+        // delete/update phantom: the cluster constantly freezes memtables
+        // (flush_interval ~250ms), so an insert and its later delete/update split
+        // across in-memory generations.
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
+        use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+        use datafusion::prelude::SessionContext;
+        use futures::TryStreamExt;
+
+        let schema = create_vector_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
+        // Base seed far from the query; id=1 is not in the base.
+        let base_dataset =
+            Arc::new(create_dataset(&base_uri, vec![create_test_batch(&schema, &[99])]).await);
+
+        // One in-memory memtable holding `id` at `vector`, with a PK + HNSW index.
+        let make_gen = |id: i32, vector: [f32; 4], generation: u64| {
+            let batch_store = Arc::new(BatchStore::with_capacity(16));
+            let mut index_store = IndexStore::new();
+            index_store.enable_pk_index(&[("id".to_string(), 0)]);
+            index_store.add_hnsw(
+                "vector_hnsw".to_string(),
+                1,
+                "vector".to_string(),
+                lance_linalg::distance::DistanceType::L2,
+                64,
+                8,
+            );
+            let batch = create_id_vector_batch(&schema, id, vector);
+            batch_store.append(batch.clone()).unwrap();
+            index_store
+                .insert_with_batch_position(&batch, 0, Some(0))
+                .unwrap();
+            InMemoryMemTableRef {
+                batch_store,
+                index_store: Arc::new(index_store),
+                schema: schema.clone(),
+                generation,
+            }
+        };
+
+        // Frozen gen=1: id=1 @ the query vector (distance ~0).
+        let frozen = make_gen(1, [0.1, 0.2, 0.3, 0.4], 1);
+        // Active gen=2: id=1 moved FAR — the newest version of the PK.
+        let active = make_gen(1, [9.0, 9.0, 9.0, 9.0], 2);
+
+        let shard_id = uuid::Uuid::new_v4();
+        let collector = LsmDataSourceCollector::new(base_dataset, vec![]).with_in_memory_memtables(
+            shard_id,
+            InMemoryMemTables {
+                active,
+                frozen: vec![frozen],
+            },
+        );
+
+        let planner = LsmVectorSearchPlanner::new(
+            collector,
+            vec!["id".to_string()],
+            schema,
+            "vector".to_string(),
+            lance_linalg::distance::DistanceType::L2,
+        );
+
+        let query = create_query_vector();
+        let plan = planner
+            .plan_search(&query, 3, 1, None, false, 1.0)
+            .await
+            .expect("planner should produce a plan");
+        let ctx = SessionContext::new();
+        let batches: Vec<RecordBatch> = plan
+            .execute(0, ctx.task_ctx())
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+
+        let mut id1_distances = Vec::new();
+        for b in &batches {
+            let ids = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let dist = b
+                .column_by_name(DISTANCE_COLUMN)
+                .unwrap()
+                .as_any()
+                .downcast_ref::<arrow_array::Float32Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                if ids.value(i) == 1 {
+                    id1_distances.push(dist.value(i));
+                }
+            }
+        }
+
+        // id=1 must surface at most once, and only at its NEWEST (far) distance —
+        // never the stale near ~0 copy the frozen generation still indexes.
+        assert!(
+            id1_distances.len() <= 1,
+            "id=1 leaked its stale frozen copy (appears {} times): {id1_distances:?}",
+            id1_distances.len()
+        );
+        if let Some(d) = id1_distances.first() {
+            assert!(
+                *d > 1.0,
+                "id=1 surfaced at the stale near distance {d}; its newest version is far"
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock as StdRwLock};
 use std::time::{Duration, Instant};
 
-use arrow_array::RecordBatch;
+use arrow_array::{ArrayRef, BooleanArray, RecordBatch, new_null_array};
 use arrow_schema::Schema as ArrowSchema;
 use async_trait::async_trait;
 use lance_core::datatypes::Schema;
@@ -52,6 +52,7 @@ use super::wal::{
     BatchDurableWatcher, TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState, WalTailer,
     empty_flush_result,
 };
+use super::{TOMBSTONE, schema_with_tombstone};
 
 use super::manifest::ShardManifestStore;
 
@@ -850,7 +851,16 @@ async fn replay_memtable_from_wal(
                 // Fence sentinels deserialize to zero batches and are skipped
                 // here — they carry only a position, no rows.
                 if !entry.batches.is_empty() {
-                    memtable.insert_batches_only(entry.batches).await?;
+                    // Entries written before deletes existed lack `_tombstone`;
+                    // inject `false` so they match the extended memtable schema.
+                    // Normal entries already carry it and pass through unchanged.
+                    let target_schema = memtable.schema().clone();
+                    let batches = entry
+                        .batches
+                        .into_iter()
+                        .map(|b| ensure_tombstone_column(b, &target_schema))
+                        .collect::<Result<Vec<_>>>()?;
+                    memtable.insert_batches_only(batches).await?;
                 }
                 position = position.checked_add(1).ok_or_else(|| {
                     Error::io(format!(
@@ -895,6 +905,69 @@ fn pk_index_columns(pk_columns: &[String], pk_field_ids: &[i32]) -> Vec<(String,
         .cloned()
         .zip(pk_field_ids.iter().copied())
         .collect()
+}
+
+/// Ensure `batch` carries the `_tombstone` column required by the extended
+/// memtable schema, injecting `false` for every row when it is absent.
+///
+/// Used on the normal write path ([`ShardWriter::put`]) where callers pass
+/// base-shaped batches, and on WAL replay of entries written before deletes
+/// existed (legacy entries lack the column). A batch that already carries
+/// `_tombstone` (a normal replayed entry) is returned unchanged.
+fn ensure_tombstone_column(
+    batch: RecordBatch,
+    target_schema: &Arc<ArrowSchema>,
+) -> Result<RecordBatch> {
+    if batch.schema().column_with_name(TOMBSTONE).is_some() {
+        return Ok(batch);
+    }
+    let n = batch.num_rows();
+    let mut columns: Vec<ArrayRef> = batch.columns().to_vec();
+    columns.push(Arc::new(BooleanArray::from(vec![false; n])));
+    RecordBatch::try_new(target_schema.clone(), columns).map_err(|e| {
+        Error::invalid_input(format!(
+            "failed to inject _tombstone column (does the batch match the base schema?): {}",
+            e
+        ))
+    })
+}
+
+/// Build a tombstone batch from a key-only `keys` batch: the primary key
+/// columns are carried through, `_tombstone` is set to `true`, and every other
+/// column in the memtable schema is null.
+///
+/// Errors if `keys` is missing a primary key column, or if a non-PK column is
+/// non-nullable (a tombstone must null it) — surfaced via the `RecordBatch`
+/// validation.
+fn build_tombstone_batch(
+    keys: &RecordBatch,
+    target_schema: &Arc<ArrowSchema>,
+    pk_columns: &[String],
+) -> Result<RecordBatch> {
+    let n = keys.num_rows();
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(target_schema.fields().len());
+    for field in target_schema.fields() {
+        let name = field.name();
+        if name == TOMBSTONE {
+            columns.push(Arc::new(BooleanArray::from(vec![true; n])));
+        } else if pk_columns.iter().any(|c| c == name) {
+            let col = keys.column_by_name(name).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "delete keys batch is missing primary key column '{}'",
+                    name
+                ))
+            })?;
+            columns.push(col.clone());
+        } else {
+            columns.push(new_null_array(field.data_type(), n));
+        }
+    }
+    RecordBatch::try_new(target_schema.clone(), columns).map_err(|e| {
+        Error::invalid_input(format!(
+            "failed to build tombstone batch (is every non-primary-key column nullable?): {}",
+            e
+        ))
+    })
 }
 
 /// Shared state for writer operations.
@@ -1234,6 +1307,11 @@ impl ShardWriter {
             ));
         }
 
+        // Callers pass the base schema; lance owns the `_tombstone` column and
+        // appends it here so the memtable/generation schema = base + tombstone.
+        // Idempotent, so a reopen that already extended the schema is a no-op.
+        let schema = schema_with_tombstone(&schema);
+
         let base_uri = base_uri.into();
         let shard_id = config.shard_id;
         let manifest_store = Arc::new(ShardManifestStore::new(
@@ -1537,6 +1615,13 @@ impl ShardWriter {
                 writer_state,
                 backpressure,
             } => {
+                // Inject `_tombstone = false` so the batch matches the
+                // extended memtable schema; callers only ever pass base-shaped
+                // batches and never name the column.
+                let batches = batches
+                    .into_iter()
+                    .map(|b| ensure_tombstone_column(b, &writer_state.schema))
+                    .collect::<Result<Vec<_>>>()?;
                 self.put_memtable(batches, state, writer_state, backpressure)
                     .await
             }
@@ -1549,6 +1634,65 @@ impl ShardWriter {
                 self.put_wal_only(batches, state, wal_flush_tx, trigger, backpressure)
                     .await
             }
+        }
+    }
+
+    /// Delete rows by primary key.
+    ///
+    /// Each batch in `keys` must carry the shard's primary key column(s); other
+    /// columns are ignored. lance builds a tombstone row per key — the primary
+    /// key plus `_tombstone = true` and null in every other column — and
+    /// appends it like an ordinary write. The tombstone is the newest value for
+    /// its key: it wins newest-per-PK resolution (suppressing the older real
+    /// row) and is then dropped from query results.
+    ///
+    /// Only supported in memtable mode. Because a tombstone nulls every non-PK
+    /// column, those columns must be nullable in the base schema; a delete
+    /// against a schema with a non-nullable non-PK column errors.
+    ///
+    /// ```
+    /// # use lance::Result;
+    /// # use lance::dataset::mem_wal::ShardWriter;
+    /// # use arrow_array::RecordBatch;
+    /// # async fn doc(writer: &ShardWriter, keys: Vec<RecordBatch>) -> Result<()> {
+    /// writer.delete(keys).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[instrument(name = "sw_delete", level = "info", skip_all, fields(batch_count = keys.len(), shard_id = %self.config.shard_id))]
+    pub async fn delete(&self, keys: Vec<RecordBatch>) -> Result<WriteResult> {
+        if keys.is_empty() {
+            return Err(Error::invalid_input("Cannot delete with empty key list"));
+        }
+        for (i, batch) in keys.iter().enumerate() {
+            if batch.num_rows() == 0 {
+                return Err(Error::invalid_input(format!("Key batch {} is empty", i)));
+            }
+        }
+
+        match &self.mode {
+            WriterMode::MemTable {
+                state,
+                writer_state,
+                backpressure,
+            } => {
+                if writer_state.pk_columns.is_empty() {
+                    return Err(Error::invalid_input(
+                        "delete requires a primary key, but this shard has no primary key columns",
+                    ));
+                }
+                let tombstones = keys
+                    .into_iter()
+                    .map(|k| {
+                        build_tombstone_batch(&k, &writer_state.schema, &writer_state.pk_columns)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                self.put_memtable(tombstones, state, writer_state, backpressure)
+                    .await
+            }
+            WriterMode::WalOnly { .. } => Err(Error::invalid_input(
+                "delete is only supported in memtable mode (enable_memtable = true)",
+            )),
         }
     }
 
@@ -1576,6 +1720,12 @@ impl ShardWriter {
                 writer_state,
                 backpressure,
             } => {
+                // Inject `_tombstone = false` to match the extended memtable
+                // schema, mirroring `put`.
+                let batches = batches
+                    .into_iter()
+                    .map(|b| ensure_tombstone_column(b, &writer_state.schema))
+                    .collect::<Result<Vec<_>>>()?;
                 self.put_memtable_no_wait(batches, state, writer_state, backpressure)
                     .await
             }
@@ -2809,6 +2959,523 @@ mod tests {
         let uri = format!("file://{}", temp_dir.path().display());
         let (store, path) = ObjectStore::from_uri(&uri).await.unwrap();
         (store, path, uri, temp_dir)
+    }
+
+    /// Base schema with `id` marked as the unenforced primary key (delete needs
+    /// a PK). `name` is nullable so a tombstone can null it.
+    fn create_pk_test_schema() -> Arc<ArrowSchema> {
+        let mut id_metadata = std::collections::HashMap::new();
+        id_metadata.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        let id = Field::new("id", DataType::Int32, false).with_metadata(id_metadata);
+        Arc::new(ArrowSchema::new(vec![
+            id,
+            Field::new("name", DataType::Utf8, true),
+        ]))
+    }
+
+    fn id_only_keys(ids: &[i32]) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "id",
+                DataType::Int32,
+                false,
+            )])),
+            vec![Arc::new(Int32Array::from(ids.to_vec()))],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_ensure_tombstone_column_injects_false() {
+        let base = create_test_schema();
+        let target = schema_with_tombstone(&base);
+        let out = ensure_tombstone_column(create_test_batch(&base, 0, 3), &target).unwrap();
+        assert_eq!(out.schema(), target);
+        let ts = out
+            .column_by_name(TOMBSTONE)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert!(
+            (0..3).all(|i| !ts.value(i)),
+            "put injects _tombstone = false"
+        );
+        // Idempotent: a batch already carrying the column passes through.
+        let again = ensure_tombstone_column(out.clone(), &target).unwrap();
+        assert_eq!(again.schema(), out.schema());
+    }
+
+    #[test]
+    fn test_build_tombstone_batch_shape() {
+        let target = schema_with_tombstone(&create_test_schema());
+        let tomb =
+            build_tombstone_batch(&id_only_keys(&[5, 7]), &target, &["id".to_string()]).unwrap();
+        assert_eq!(tomb.schema(), target);
+        assert_eq!(tomb.num_rows(), 2);
+        let ids = tomb
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(ids.values(), &[5, 7]);
+        let name = tomb.column_by_name("name").unwrap();
+        assert!(
+            name.is_null(0) && name.is_null(1),
+            "non-PK columns are null in a tombstone"
+        );
+        let ts = tomb
+            .column_by_name(TOMBSTONE)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert!(ts.value(0) && ts.value(1), "_tombstone = true");
+    }
+
+    #[test]
+    fn test_build_tombstone_batch_missing_pk_errors() {
+        let target = schema_with_tombstone(&create_test_schema());
+        let keys = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "other",
+                DataType::Int32,
+                false,
+            )])),
+            vec![Arc::new(Int32Array::from(vec![1]))],
+        )
+        .unwrap();
+        assert!(build_tombstone_batch(&keys, &target, &["id".to_string()]).is_err());
+    }
+
+    #[test]
+    fn test_build_tombstone_batch_non_nullable_nonpk_errors() {
+        // A tombstone must null every non-PK column; a non-nullable one fails.
+        let base = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("v", DataType::Int32, false),
+        ]));
+        let target = schema_with_tombstone(&base);
+        assert!(build_tombstone_batch(&id_only_keys(&[1]), &target, &["id".to_string()]).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_shard_writer_delete_round_trip() {
+        use crate::dataset::mem_wal::scanner::LsmScanner;
+        use futures::TryStreamExt;
+
+        let (store, base_path, base_uri, _temp) = create_local_store().await;
+        let schema = create_pk_test_schema();
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            durable_write: true,
+            ..Default::default()
+        };
+        let shard_id = config.shard_id;
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri.clone(),
+            config,
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        // ids 0..5, then delete id=2.
+        writer
+            .put(vec![create_test_batch(&schema, 0, 5)])
+            .await
+            .unwrap();
+        writer.delete(vec![id_only_keys(&[2])]).await.unwrap();
+
+        let refs = writer.in_memory_memtable_refs().await.unwrap();
+        let scanner = LsmScanner::without_base_table(
+            schema.clone(),
+            base_uri,
+            vec![],
+            vec!["id".to_string()],
+        )
+        .with_in_memory_memtables(shard_id, refs);
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let mut ids: Vec<i32> = Vec::new();
+        for b in &batches {
+            let arr = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            ids.extend((0..arr.len()).map(|i| arr.value(i)));
+        }
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![0, 1, 3, 4],
+            "id=2 deleted; tombstone not surfaced"
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// Read every surviving `id` through the full LSM read path (which folds
+    /// `NOT _tombstone` per source) over the writer's *flushed* generations,
+    /// with an optional filter. Mirrors how a query reads a WAL table after a
+    /// flush — the path the wallop fuzz exercised when it caught a deleted row
+    /// resurfacing.
+    async fn read_flushed_ids_via_lsm(
+        writer: &ShardWriter,
+        schema: Arc<ArrowSchema>,
+        base_uri: &str,
+        shard_id: Uuid,
+        filter: Option<&str>,
+    ) -> Vec<i32> {
+        use crate::dataset::mem_wal::scanner::{LsmScanner, ShardSnapshot};
+        use futures::TryStreamExt;
+
+        let manifest = writer.manifest().await.unwrap().unwrap();
+        let mut snapshot =
+            ShardSnapshot::new(shard_id).with_current_generation(manifest.current_generation);
+        for fg in &manifest.flushed_generations {
+            snapshot = snapshot.with_flushed_generation(fg.generation, fg.path.clone());
+        }
+        let mut scanner = LsmScanner::without_base_table(
+            schema,
+            base_uri.to_string(),
+            vec![snapshot],
+            vec!["id".to_string()],
+        );
+        if let Some(predicate) = filter {
+            scanner = scanner.filter(predicate).unwrap();
+        }
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let mut ids: Vec<i32> = Vec::new();
+        for b in &batches {
+            let arr = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            ids.extend((0..arr.len()).map(|i| arr.value(i)));
+        }
+        ids.sort_unstable();
+        ids
+    }
+
+    fn flush_test_config(shard_id: Uuid) -> ShardWriterConfig {
+        ShardWriterConfig {
+            shard_id,
+            durable_write: false,
+            sync_indexed_write: true,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        }
+    }
+
+    /// Delete a key, then flush: the tombstone and the live row land in the
+    /// *same* flushed generation, so flush-time dedup must keep the tombstone
+    /// (newest) and the read must fold it away. Regression for the wallop
+    /// phantom (deleted row resurfacing in a filtered read after flush).
+    #[tokio::test]
+    async fn test_shard_writer_delete_then_flush_round_trip() {
+        let (store, base_path, base_uri, _temp) = create_local_store().await;
+        let schema = create_pk_test_schema();
+        let shard_id = Uuid::new_v4();
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri.clone(),
+            flush_test_config(shard_id),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        // ids 0..5, delete id=2, THEN flush (insert + tombstone in one gen).
+        writer
+            .put(vec![create_test_batch(&schema, 0, 5)])
+            .await
+            .unwrap();
+        writer.delete(vec![id_only_keys(&[2])]).await.unwrap();
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.unwrap();
+
+        assert_eq!(
+            read_flushed_ids_via_lsm(&writer, schema.clone(), &base_uri, shard_id, None).await,
+            vec![0, 1, 3, 4],
+            "id=2 deleted before flush; tombstone must not surface in a flushed-gen scan"
+        );
+        // The filtered read path (folds NOT _tombstone into the predicate) must
+        // also drop it — this is the exact wallop failure shape (`id < 3`).
+        assert_eq!(
+            read_flushed_ids_via_lsm(&writer, schema.clone(), &base_uri, shard_id, Some("id < 3"))
+                .await,
+            vec![0, 1],
+            "filtered read after flush must not resurface deleted id=2"
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// Insert+flush, then delete+flush: the tombstone lands in a *newer*
+    /// generation than the live row, so the cross-generation block-list must
+    /// mask the older row by PK. This is the wallop scenario (seed flushed,
+    /// then delete, then flush).
+    #[tokio::test]
+    async fn test_shard_writer_delete_across_flushed_generations() {
+        let (store, base_path, base_uri, _temp) = create_local_store().await;
+        let schema = create_pk_test_schema();
+        let shard_id = Uuid::new_v4();
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri.clone(),
+            flush_test_config(shard_id),
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        // gen 1: ids 0..5.
+        writer
+            .put(vec![create_test_batch(&schema, 0, 5)])
+            .await
+            .unwrap();
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.unwrap();
+
+        // gen 2: tombstone for id=0 (a later generation than the live row).
+        writer.delete(vec![id_only_keys(&[0])]).await.unwrap();
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.unwrap();
+
+        assert_eq!(
+            read_flushed_ids_via_lsm(&writer, schema.clone(), &base_uri, shard_id, None).await,
+            vec![1, 2, 3, 4],
+            "id=0 tombstoned in a newer gen must mask the older gen's live row"
+        );
+        assert_eq!(
+            read_flushed_ids_via_lsm(&writer, schema.clone(), &base_uri, shard_id, Some("id < 1"))
+                .await,
+            Vec::<i32>::new(),
+            "filtered read 'id < 1' must not resurface cross-gen deleted id=0"
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// Same as the cross-generation case, but the flushed generations carry a
+    /// BTree index on `id` (as every wallop table does). A filtered read
+    /// `id < 1` resolves through the scalar index; the `NOT _tombstone` residual
+    /// must still be applied or the deleted row leaks. This is the exact wallop
+    /// failure (BTree id + `FilteredRead 'id < 1'` resurfacing deleted id=0).
+    #[tokio::test]
+    async fn test_shard_writer_delete_across_flushed_generations_indexed() {
+        let (store, base_path, base_uri, _temp) = create_local_store().await;
+        let schema = create_pk_test_schema();
+        let shard_id = Uuid::new_v4();
+        let index_configs = vec![MemIndexConfig::BTree(BTreeIndexConfig {
+            name: "id_idx".to_string(),
+            field_id: 0,
+            column: "id".to_string(),
+        })];
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri.clone(),
+            flush_test_config(shard_id),
+            schema.clone(),
+            index_configs,
+        )
+        .await
+        .unwrap();
+
+        // gen 1: ids 0..5 (indexed). gen 2: tombstone for id=0.
+        writer
+            .put(vec![create_test_batch(&schema, 0, 5)])
+            .await
+            .unwrap();
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.unwrap();
+        writer.delete(vec![id_only_keys(&[0])]).await.unwrap();
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.unwrap();
+
+        assert_eq!(
+            read_flushed_ids_via_lsm(&writer, schema.clone(), &base_uri, shard_id, None).await,
+            vec![1, 2, 3, 4],
+            "indexed cross-gen: full scan must mask deleted id=0"
+        );
+        assert_eq!(
+            read_flushed_ids_via_lsm(&writer, schema.clone(), &base_uri, shard_id, Some("id < 1"))
+                .await,
+            Vec::<i32>::new(),
+            "indexed filtered read 'id < 1' must not resurface deleted id=0 (wallop repro)"
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_validation_errors() {
+        let (store, base_path, base_uri, _temp) = create_local_store().await;
+
+        // No primary key on the schema → delete is rejected.
+        let no_pk = create_test_schema();
+        let writer = ShardWriter::open(
+            store.clone(),
+            base_path.clone(),
+            base_uri.clone(),
+            ShardWriterConfig {
+                shard_id: Uuid::new_v4(),
+                durable_write: false,
+                ..Default::default()
+            },
+            no_pk,
+            vec![],
+        )
+        .await
+        .unwrap();
+        assert!(
+            writer.delete(vec![id_only_keys(&[1])]).await.is_err(),
+            "delete without a primary key must error"
+        );
+        // Empty key list is rejected.
+        assert!(writer.delete(vec![]).await.is_err());
+        writer.close().await.unwrap();
+    }
+
+    /// The compaction Phase-1 hard-delete primitive: a key-only `merge_insert`
+    /// with `WhenMatched::Delete` + `use_index` over a COMPOSITE join key
+    /// `(id, shard_key)` where only `id` carries a scalar index. The partial
+    /// index makes `indexed_join_keys` non-empty, so the scalar-index merge path
+    /// engages — and it must still delete exactly the `(0, 0)` row. If it
+    /// no-ops (or mismatches on the partial key), the compactor trims the WAL
+    /// tombstone while the base row survives → the wallop resurface phantom.
+    #[tokio::test]
+    async fn test_indexed_composite_key_delete_removes_row() {
+        use crate::Dataset;
+        use crate::dataset::{WhenMatched, WhenNotMatched, WhenNotMatchedBySource};
+        use crate::index::DatasetIndexExt;
+        use arrow_array::{Int64Array, RecordBatchIterator};
+        use lance_index::IndexType;
+        use lance_index::scalar::ScalarIndexParams;
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("shard_key", DataType::Int64, false),
+            Field::new("value", DataType::Int64, true),
+        ]));
+        // ids 0..5, shard_key = id % 8 (the wallop composite PK), value = id*100.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from_iter_values(0..5)),
+                Arc::new(Int64Array::from_iter_values((0..5).map(|i| i % 8))),
+                Arc::new(Int64Array::from_iter_values((0..5).map(|i| i * 100))),
+            ],
+        )
+        .unwrap();
+
+        let uri = format!("shared-memory://phase1-delete-{}/", Uuid::new_v4().simple());
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema.clone()),
+            &uri,
+            None,
+        )
+        .await
+        .unwrap();
+        // Scalar index on `id` only — `shard_key` is unindexed, mirroring the
+        // WAL base table (BTree on `id`, composite PK `(id, shard_key)`).
+        dataset
+            .create_index(
+                &["id"],
+                IndexType::BTree,
+                Some("id_btree".to_string()),
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+
+        // Phase-1 call: key-only source `(id=0, shard_key=0)`, delete-when-matched.
+        let keys = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("shard_key", DataType::Int64, false),
+            ])),
+            vec![
+                Arc::new(Int64Array::from(vec![0_i64])),
+                Arc::new(Int64Array::from(vec![0_i64])),
+            ],
+        )
+        .unwrap();
+        let mut builder = crate::dataset::MergeInsertBuilder::try_new(
+            Arc::new(dataset),
+            vec!["id".to_string(), "shard_key".to_string()],
+        )
+        .unwrap();
+        builder
+            .when_matched(WhenMatched::Delete)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .when_not_matched_by_source(WhenNotMatchedBySource::Keep)
+            .use_index(true);
+        let job = builder.try_build().unwrap();
+        let keys_schema = keys.schema();
+        let (dataset, _stats) = job
+            .execute_reader(RecordBatchIterator::new([Ok(keys)], keys_schema))
+            .await
+            .unwrap();
+
+        // id=0 must be gone — both from a full scan and from an indexed filter.
+        let all = dataset.scan().try_into_batch().await.unwrap();
+        let mut ids: Vec<i64> = all
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap()
+            .values()
+            .to_vec();
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![1, 2, 3, 4],
+            "Phase-1 must hard-delete (0, 0) from base"
+        );
+
+        let filtered = dataset
+            .scan()
+            .filter("id < 1")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(
+            filtered.num_rows(),
+            0,
+            "indexed filter must not resurface the deleted composite key"
+        );
     }
 
     fn create_test_schema() -> Arc<ArrowSchema> {
@@ -4869,6 +5536,80 @@ mod shard_writer_tests {
             .await
             .unwrap();
         assert_eq!(writer.memtable_stats().await.unwrap().row_count, 10);
+        writer.close().await.unwrap();
+    }
+
+    /// A generation of only tombstones (delete nulls the vector, and the HNSW
+    /// skips nulls) has an empty vector index. Flushing it must succeed —
+    /// writing the data with no HNSW index for that generation — not fail the
+    /// drain with "HnswMemIndex is empty". Regression for the wallop fuzz
+    /// `flush drain failed: HnswMemIndex is empty` on a delete-only memtable.
+    #[tokio::test]
+    async fn test_flush_all_tombstone_generation_skips_empty_hnsw() {
+        let vector_dim = 32;
+        let schema = create_test_schema(vector_dim);
+        // `shared-memory` (not `memory`): the flush writes the generation dataset
+        // and the drain reopens it by URI, which a plain in-memory store wouldn't
+        // share across opens. A unique authority isolates this test.
+        let uri = format!("shared-memory://tombstone-{}/", Uuid::new_v4().simple());
+
+        // Base dataset + maintained vector index, so the writer carries an HNSW
+        // mem index.
+        let initial = create_test_batch(&schema, 0, 256, vector_dim);
+        let batches = RecordBatchIterator::new([Ok(initial)], schema.clone());
+        let mut dataset = Dataset::write(batches, &uri, Some(WriteParams::default()))
+            .await
+            .unwrap();
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some("vector_idx".to_string()),
+                &VectorIndexParams::ivf_flat(1, MetricType::L2),
+                true,
+            )
+            .await
+            .unwrap();
+        dataset
+            .initialize_mem_wal()
+            .maintained_indexes(["vector_idx"])
+            .execute()
+            .await
+            .unwrap();
+
+        let shard_id = Uuid::new_v4();
+        let writer = dataset
+            .mem_wal_writer(
+                shard_id,
+                ShardWriterConfig::new(shard_id).with_durable_write(false),
+            )
+            .await
+            .unwrap();
+
+        // Delete only — the memtable holds a single tombstone with a null vector,
+        // so its HNSW index is empty.
+        let keys = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "id",
+                DataType::Int64,
+                false,
+            )])),
+            vec![Arc::new(Int64Array::from(vec![0_i64]))],
+        )
+        .unwrap();
+        writer.delete(vec![keys]).await.unwrap();
+
+        // The drain must not error on the empty HNSW.
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.unwrap();
+
+        // The tombstone-only generation still flushed (data without an HNSW index).
+        let manifest = writer.manifest().await.unwrap().expect("manifest exists");
+        assert_eq!(
+            manifest.flushed_generations.len(),
+            1,
+            "the all-tombstone generation must still flush"
+        );
         writer.close().await.unwrap();
     }
 

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -49,7 +49,8 @@ pub use super::wal::{WalEntry, WalEntryData, WalFlushResult, WalFlusher};
 use super::memtable::flush::TriggerMemTableFlush;
 use super::scanner::GenerationWarmer;
 use super::wal::{
-    TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState, WalTailer, empty_flush_result,
+    BatchDurableWatcher, TriggerWalFlush, WalAppender, WalFlushSource, WalOnlyState, WalTailer,
+    empty_flush_result,
 };
 
 use super::manifest::ShardManifestStore;
@@ -1528,14 +1529,7 @@ impl ShardWriter {
     /// `AlreadyExists`, indicating this writer has been fenced.
     #[instrument(name = "sw_put", level = "info", skip_all, fields(batch_count = batches.len(), shard_id = %self.config.shard_id))]
     pub async fn put(&self, batches: Vec<RecordBatch>) -> Result<WriteResult> {
-        if batches.is_empty() {
-            return Err(Error::invalid_input("Cannot write empty batch list"));
-        }
-        for (i, batch) in batches.iter().enumerate() {
-            if batch.num_rows() == 0 {
-                return Err(Error::invalid_input(format!("Batch {} is empty", i)));
-            }
-        }
+        Self::validate_non_empty(&batches)?;
 
         match &self.mode {
             WriterMode::MemTable {
@@ -1558,6 +1552,51 @@ impl ShardWriter {
         }
     }
 
+    /// Like [`Self::put`], but returns the durability watcher *without* awaiting
+    /// it. The row is visible to reads on this writer the instant this returns;
+    /// the caller awaits durability via the watcher (`None` when `durable_write`
+    /// is off).
+    ///
+    /// This lets a caller hold an *external* lock across only the in-memory
+    /// read-merge-insert and await durability after releasing it, so concurrent
+    /// flushes still coalesce. The insert stays guarded by the internal
+    /// `state_lock`, so `BatchStore`'s single-writer invariant holds regardless.
+    ///
+    /// MemTable mode only; errors in WAL-only mode (no in-memory tier).
+    #[instrument(name = "sw_put_no_wait", level = "info", skip_all, fields(batch_count = batches.len(), shard_id = %self.config.shard_id))]
+    pub async fn put_no_wait(
+        &self,
+        batches: Vec<RecordBatch>,
+    ) -> Result<(WriteResult, Option<BatchDurableWatcher>)> {
+        Self::validate_non_empty(&batches)?;
+
+        match &self.mode {
+            WriterMode::MemTable {
+                state,
+                writer_state,
+                backpressure,
+            } => {
+                self.put_memtable_no_wait(batches, state, writer_state, backpressure)
+                    .await
+            }
+            WriterMode::WalOnly { .. } => Err(Error::invalid_input(
+                "put_no_wait is only supported in MemTable mode",
+            )),
+        }
+    }
+
+    fn validate_non_empty(batches: &[RecordBatch]) -> Result<()> {
+        if batches.is_empty() {
+            return Err(Error::invalid_input("Cannot write empty batch list"));
+        }
+        for (i, batch) in batches.iter().enumerate() {
+            if batch.num_rows() == 0 {
+                return Err(Error::invalid_input(format!("Batch {} is empty", i)));
+            }
+        }
+        Ok(())
+    }
+
     async fn put_memtable(
         &self,
         batches: Vec<RecordBatch>,
@@ -1565,6 +1604,26 @@ impl ShardWriter {
         writer_state: &Arc<SharedWriterState>,
         backpressure: &BackpressureController,
     ) -> Result<WriteResult> {
+        let (result, watcher) = self
+            .put_memtable_no_wait(batches, state_lock, writer_state, backpressure)
+            .await?;
+        // Wait for durability if configured (outside the lock).
+        if let Some(mut watcher) = watcher {
+            watcher.wait().await?;
+        }
+        Ok(result)
+    }
+
+    /// In-memory half of [`Self::put_memtable`]: insert under `state_lock`,
+    /// trigger the WAL flush, and return the watcher un-awaited for the caller
+    /// to wait on. `None` when `durable_write` is off. See [`Self::put_no_wait`].
+    async fn put_memtable_no_wait(
+        &self,
+        batches: Vec<RecordBatch>,
+        state_lock: &Arc<RwLock<WriterState>>,
+        writer_state: &Arc<SharedWriterState>,
+        backpressure: &BackpressureController,
+    ) -> Result<(WriteResult, Option<BatchDurableWatcher>)> {
         // Apply backpressure if needed (before acquiring main lock)
         backpressure
             .maybe_apply_backpressure(|| {
@@ -1578,7 +1637,7 @@ impl ShardWriter {
         let start = std::time::Instant::now();
 
         // Acquire write lock for entire operation (atomic approach)
-        let (batch_positions, mut durable_watcher, batch_store, indexes) = {
+        let (batch_positions, durable_watcher, batch_store, indexes) = {
             let mut state = state_lock.write().await;
 
             // 1. Insert all batches into memtable atomically
@@ -1609,8 +1668,9 @@ impl ShardWriter {
 
         self.stats.record_put(start.elapsed());
 
-        // Wait for durability if configured (outside the lock)
-        if self.config.durable_write {
+        // Trigger the flush here (outside the lock) so the watcher can resolve;
+        // only the `wait()` is the caller's to schedule.
+        let watcher = if self.config.durable_write {
             self.wal_flusher.trigger_flush(
                 WalFlushSource::BatchStore {
                     batch_store,
@@ -1619,10 +1679,12 @@ impl ShardWriter {
                 batch_positions.end,
                 None,
             )?;
-            durable_watcher.wait().await?;
-        }
+            Some(durable_watcher)
+        } else {
+            None
+        };
 
-        Ok(WriteResult { batch_positions })
+        Ok((WriteResult { batch_positions }, watcher))
     }
 
     async fn put_wal_only(
@@ -2811,6 +2873,75 @@ mod tests {
         assert_eq!(stats.batch_count, 1);
 
         // Close writer
+        writer.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_put_no_wait_durable_visible_then_durable() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            shard_spec_id: 0,
+            durable_write: true,
+            sync_indexed_write: false,
+            max_wal_buffer_size: 1024 * 1024,
+            max_wal_flush_interval: None,
+            max_memtable_size: 64 * 1024 * 1024,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        };
+
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+
+        let batch = create_test_batch(&schema, 0, 10);
+        let (result, watcher) = writer.put_no_wait(vec![batch]).await.unwrap();
+        assert_eq!(result.batch_positions, 0..1);
+
+        // Row is visible in memory before durability is awaited.
+        let stats = writer.memtable_stats().await.unwrap();
+        assert_eq!(stats.row_count, 10);
+
+        // durable_write is on, so a watcher is returned and resolves once the
+        // triggered flush lands.
+        let mut watcher = watcher.expect("durable_write returns a watcher");
+        watcher.wait().await.unwrap();
+
+        writer.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_put_no_wait_non_durable_returns_no_watcher() {
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let schema = create_test_schema();
+
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            shard_spec_id: 0,
+            durable_write: false,
+            sync_indexed_write: false,
+            max_wal_buffer_size: 1024 * 1024,
+            max_wal_flush_interval: None,
+            max_memtable_size: 64 * 1024 * 1024,
+            manifest_scan_batch_size: 2,
+            ..Default::default()
+        };
+
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+
+        let batch = create_test_batch(&schema, 0, 10);
+        let (result, watcher) = writer.put_no_wait(vec![batch]).await.unwrap();
+        assert_eq!(result.batch_positions, 0..1);
+        assert!(watcher.is_none(), "non-durable put has nothing to await");
+
+        let stats = writer.memtable_stats().await.unwrap();
+        assert_eq!(stats.row_count, 10);
+
         writer.close().await.unwrap();
     }
 

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -1661,6 +1661,26 @@ impl ShardWriter {
     /// ```
     #[instrument(name = "sw_delete", level = "info", skip_all, fields(batch_count = keys.len(), shard_id = %self.config.shard_id))]
     pub async fn delete(&self, keys: Vec<RecordBatch>) -> Result<WriteResult> {
+        let (result, watcher) = self.delete_no_wait(keys).await?;
+        // Wait for durability if configured (mirrors `put` → `put_memtable`).
+        if let Some(mut watcher) = watcher {
+            watcher.wait().await?;
+        }
+        Ok(result)
+    }
+
+    /// Like [`Self::delete`], but returns the durability watcher *without*
+    /// awaiting it — the tombstone lands in the in-memory tier the instant this
+    /// returns, but the index-driven LSM read only folds it once the watcher
+    /// resolves the flush (which advances the visibility watermark and updates
+    /// the PK index). The delete analog of [`Self::put_no_wait`], so a caller
+    /// can hold an external lock across only the in-memory insert and await
+    /// durability after releasing it. MemTable mode only.
+    #[instrument(name = "sw_delete_no_wait", level = "info", skip_all, fields(batch_count = keys.len(), shard_id = %self.config.shard_id))]
+    pub async fn delete_no_wait(
+        &self,
+        keys: Vec<RecordBatch>,
+    ) -> Result<(WriteResult, Option<BatchDurableWatcher>)> {
         if keys.is_empty() {
             return Err(Error::invalid_input("Cannot delete with empty key list"));
         }
@@ -1687,7 +1707,7 @@ impl ShardWriter {
                         build_tombstone_batch(&k, &writer_state.schema, &writer_state.pk_columns)
                     })
                     .collect::<Result<Vec<_>>>()?;
-                self.put_memtable(tombstones, state, writer_state, backpressure)
+                self.put_memtable_no_wait(tombstones, state, writer_state, backpressure)
                     .await
             }
             WriterMode::WalOnly { .. } => Err(Error::invalid_input(
@@ -1697,7 +1717,9 @@ impl ShardWriter {
     }
 
     /// Like [`Self::put`], but returns the durability watcher *without* awaiting
-    /// it. The row is visible to reads on this writer the instant this returns;
+    /// it. The row lands in the in-memory tier the instant this returns, but the
+    /// index-driven LSM read only surfaces it once the watcher resolves the
+    /// flush (which advances the visibility watermark and updates the indexes);
     /// the caller awaits durability via the watcher (`None` when `durable_write`
     /// is off).
     ///
@@ -3125,6 +3147,128 @@ mod tests {
             vec![0, 1, 3, 4],
             "id=2 deleted; tombstone not surfaced"
         );
+
+        writer.close().await.unwrap();
+    }
+
+    /// `delete_no_wait` lands the tombstone in the in-memory tier (visible at
+    /// the batch-store level the instant it returns) and hands back the
+    /// durability watcher *without* awaiting it. Index-driven LSM read
+    /// visibility — folding the tombstone out — follows once the watcher
+    /// resolves the flush that advances the visibility watermark and updates
+    /// the PK index. The delete analog of
+    /// `test_put_no_wait_durable_visible_then_durable`.
+    #[tokio::test]
+    async fn test_shard_writer_delete_no_wait_durable_visible_after_watcher() {
+        use crate::dataset::mem_wal::scanner::LsmScanner;
+        use futures::TryStreamExt;
+
+        let (store, base_path, base_uri, _temp) = create_local_store().await;
+        let schema = create_pk_test_schema();
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            durable_write: true,
+            ..Default::default()
+        };
+        let shard_id = config.shard_id;
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri.clone(),
+            config,
+            schema.clone(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        writer
+            .put(vec![create_test_batch(&schema, 0, 5)])
+            .await
+            .unwrap();
+
+        // Tombstone id=2 without blocking on durability.
+        let (_result, watcher) = writer
+            .delete_no_wait(vec![id_only_keys(&[2])])
+            .await
+            .unwrap();
+
+        // The tombstone is in the in-memory tier immediately (5 rows + 1
+        // tombstone), even though the index-driven read can't fold it until the
+        // flush behind the watcher lands. `durable_write` is on, so a watcher is
+        // returned to await.
+        assert_eq!(writer.memtable_stats().await.unwrap().row_count, 6);
+        let mut watcher = watcher.expect("durable_write returns a watcher");
+
+        // Awaiting the watcher waits for the flush, which advances the
+        // visibility watermark and updates the PK index — only then does the LSM
+        // read fold the delete.
+        watcher.wait().await.unwrap();
+
+        let refs = writer.in_memory_memtable_refs().await.unwrap();
+        let scanner = LsmScanner::without_base_table(
+            schema.clone(),
+            base_uri,
+            vec![],
+            vec!["id".to_string()],
+        )
+        .with_in_memory_memtables(shard_id, refs);
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let mut ids: Vec<i32> = Vec::new();
+        for b in &batches {
+            let arr = b
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            ids.extend((0..arr.len()).map(|i| arr.value(i)));
+        }
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![0, 1, 3, 4],
+            "delete folded by the LSM read once the watcher resolves"
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// With `durable_write` off, `delete_no_wait` returns no watcher (nothing to
+    /// await), but the tombstone still lands in the in-memory tier. The delete
+    /// analog of `test_put_no_wait_non_durable_returns_no_watcher`.
+    #[tokio::test]
+    async fn test_shard_writer_delete_no_wait_non_durable_returns_no_watcher() {
+        let (store, base_path, base_uri, _temp) = create_local_store().await;
+        let schema = create_pk_test_schema();
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            durable_write: false,
+            ..Default::default()
+        };
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+
+        writer
+            .put(vec![create_test_batch(&schema, 0, 5)])
+            .await
+            .unwrap();
+
+        let (_result, watcher) = writer
+            .delete_no_wait(vec![id_only_keys(&[2])])
+            .await
+            .unwrap();
+        assert!(watcher.is_none(), "non-durable delete has nothing to await");
+
+        // Tombstone landed in the in-memory tier (5 rows + 1 tombstone).
+        assert_eq!(writer.memtable_stats().await.unwrap().row_count, 6);
 
         writer.close().await.unwrap();
     }

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -953,9 +953,12 @@ impl MergeInsertJob {
                 WhenNotMatchedBySource::Keep
             )
         {
-            // keeping unmatched rows, no deletion
+            // keeping unmatched rows, no deletion. Use the indexed-scan path
+            // only when EVERY join column is indexed; a partially-indexed
+            // composite key under-matches there (the probe can't resolve the
+            // full tuple), so fall through to the correct full-table join.
             let indexed_keys = self.indexed_join_keys().await?;
-            if !indexed_keys.is_empty() {
+            if indexed_keys.len() == self.params.on.len() {
                 return self
                     .create_indexed_scan_joined_stream(source, indexed_keys)
                     .await;
@@ -1693,7 +1696,11 @@ impl MergeInsertJob {
                 self.params.delete_not_matched_by_source,
                 WhenNotMatchedBySource::Keep
             ) {
-            !self.indexed_join_keys().await?.is_empty()
+            // Only when EVERY join column is indexed. A partially-indexed
+            // composite key cannot be fully resolved by the index probe and the
+            // indexed-scan path then under-matches (e.g. a delete silently
+            // no-ops), so it must fall through to the correct full path.
+            self.indexed_join_keys().await?.len() == self.params.on.len()
         } else {
             false
         };


### PR DESCRIPTION
Backport of the following PRs:
- https://github.com/lance-format/lance/pull/7362
- https://github.com/lance-format/lance/pull/7417
- https://github.com/lance-format/lance/pull/7482
- https://github.com/lance-format/lance/pull/7483
- https://github.com/lance-format/lance/pull/7489

This PR backports the changes from the original PRs to the release/v8.0 branch.
