### PR TITLE
ci: fix v8 release branch CI baseline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,8 +96,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup rust toolchain
         run: |
-          rustup toolchain install nightly
-          rustup default nightly
+          rustup toolchain install nightly-2026-06-24
+          rustup default nightly-2026-06-24
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - name: Install dependencies
@@ -111,7 +111,7 @@ jobs:
       - name: Run tests
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc -e slow_tests | sort | uniq | paste -s -d "," -`
-          cargo +nightly llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
+          cargo +nightly-2026-06-24 llvm-cov --profile ci --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:

--- a/python/python/lance/indices/builder.py
+++ b/python/python/lance/indices/builder.py
@@ -150,7 +150,7 @@ class IndicesBuilder:
                 max_iters=max_iters,
             )
             num_dims = ivf_centroids.shape[1]
-            ivf_centroids.shape = -1
+            ivf_centroids = ivf_centroids.reshape(-1)
             flat_centroids_array = pa.array(ivf_centroids)
             centroids_array = pa.FixedSizeListArray.from_arrays(
                 flat_centroids_array, num_dims

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -25,7 +25,7 @@ SMALL_NUM_ROWS = SMALL_ROWS_PER_FRAGMENT * NUM_FRAGMENTS
 
 def make_ds(num_rows: int, rows_per_frag: int, tmpdir: pathlib.Path, dtype: str):
     vectors = np.random.randn(num_rows, DIMENSION).astype(dtype)
-    vectors.shape = -1
+    vectors = vectors.reshape(-1)
     vectors = pa.FixedSizeListArray.from_arrays(vectors, DIMENSION)
     table = pa.Table.from_arrays([vectors], names=["vectors"])
     uri = str(tmpdir / "dataset")
@@ -53,7 +53,7 @@ def small_rand_dataset(tmpdir, request):
 @pytest.fixture
 def mostly_null_dataset(tmpdir, request):
     vectors = np.random.randn(NUM_ROWS, DIMENSION).astype(np.float32)
-    vectors.shape = -1
+    vectors = vectors.reshape(-1)
     vectors = pa.FixedSizeListArray.from_arrays(vectors, DIMENSION)
     vectors = vectors.to_pylist()
     vectors = [vec if i % 10 == 0 else None for i, vec in enumerate(vectors)]
@@ -219,7 +219,7 @@ def test_ivf_centroids_fragment_ids(tmpdir):
         ],
         axis=0,
     )
-    vectors.shape = -1
+    vectors = vectors.reshape(-1)
     table = pa.Table.from_arrays(
         [pa.FixedSizeListArray.from_arrays(vectors, DIMENSION)], names=["vectors"]
     )


### PR DESCRIPTION
## Summary

This PR fixes CI-only issues on the `release/v8.0` branch so the v8 backport validation PRs can run against a healthy baseline.

## What changed

- Backports #7384 to replace deprecated NumPy 2.5 `array.shape = -1` assignments with `reshape(-1)`.
- Pins the Rust `linux-build` coverage job to `nightly-2026-06-24`, matching the nightly that passed for `v8.0.0-rc.2`.

## Why

- The Python failures on #7519 match the existing `release/v8.0` rc2 failure mode: NumPy 2.5 emits `DeprecationWarning` for setting `array.shape`, and pytest treats warnings as errors.
- The Rust `linux-build` failure on #7519 reproduces after rerun and is a nightly rustc ICE with `nightly-2026-06-30`; rc2 passed with `nightly-2026-06-24`.

## Validation

- `cargo fmt --all`
- `git diff --check origin/release/v8.0...HEAD`
- `cargo fmt --all --check`

Local Python targeted validation was attempted with `uv run pytest python/tests/test_indices.py -q`, but it stalled in the editable `pylance` build step before reaching pytest output. The PR CI will run the full Python matrix.
