### PR TITLE
fix: avoid nightly rustc coverage ICE from nested opaque streams

### DIFF
--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -30,7 +30,7 @@ use arrow_array::{BinaryArray, RecordBatch, UInt32Array};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
-use futures::{FutureExt, Stream, StreamExt, TryStreamExt, stream};
+use futures::{FutureExt, Stream, StreamExt, TryStreamExt, stream, stream::BoxStream};
 use lance_arrow::iter_str_array;
 use lance_core::cache::{CacheKey, LanceCache, WeakLanceCache};
 use lance_core::deepsize::DeepSizeOf;
@@ -966,12 +966,16 @@ impl NGramIndexBuilder {
         Ok(())
     }
 
+    // Returns a boxed stream rather than `impl Stream` on purpose: nesting an opaque
+    // `impl Stream` inside an `async fn`'s opaque future triggers a rustc ICE under coverage
+    // instrumentation (the `dyn IndexReader` well-formedness check), so we hand back a concrete
+    // type instead. The body has no `await`, so this does not need to be async.
     fn stream_spill_reader(
         reader: Arc<dyn IndexReader>,
-    ) -> Result<impl Stream<Item = Result<NGramIndexSpillState>>> {
+    ) -> BoxStream<'static, Result<NGramIndexSpillState>> {
         let num_rows = reader.num_rows();
 
-        Ok(stream::try_unfold(0, move |offset| {
+        stream::try_unfold(0, move |offset| {
             let reader = reader.clone();
             async move {
                 // These are small batches but, in the worst case scenario, each row could
@@ -986,17 +990,18 @@ impl NGramIndexBuilder {
                 Ok(Some((state, new_offset)))
             }
             .boxed()
-        }))
+        })
+        .boxed()
     }
 
     async fn stream_spill(
         spill_store: Arc<dyn IndexStore>,
         id: usize,
-    ) -> Result<impl Stream<Item = Result<NGramIndexSpillState>>> {
+    ) -> Result<BoxStream<'static, Result<NGramIndexSpillState>>> {
         let reader = spill_store
             .open_index_file(&Self::spill_filename(id))
             .await?;
-        Self::stream_spill_reader(reader)
+        Ok(Self::stream_spill_reader(reader))
     }
 
     fn merge_spill_states(
@@ -1202,7 +1207,7 @@ impl NGramIndexBuilder {
 
         let left_stream = Self::stream_spill(self.spill_store.clone(), new_data_num).await?;
         let old_reader = old_index.open_index_file(POSTINGS_FILENAME).await?;
-        let right_stream = Self::stream_spill_reader(old_reader)?;
+        let right_stream = Self::stream_spill_reader(old_reader);
 
         Self::merge_spill_streams(left_stream, right_stream, writer.as_mut()).await?;
 

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -94,8 +94,8 @@ use datafusion::{
 };
 use datafusion_physical_expr::expressions::Column;
 use futures::{
-    Stream, StreamExt, TryStreamExt,
-    stream::{self},
+    StreamExt, TryStreamExt,
+    stream::{self, BoxStream},
 };
 use lance_arrow::{RecordBatchExt, SchemaExt, interleave_batches};
 use lance_core::datatypes::NullabilityComparison;
@@ -2377,10 +2377,13 @@ impl Merger {
     //
     // Returns 0, 1, or 2 batches
     // Potentially updates (as a side-effect) the deleted rows vec
+    // Returns a boxed stream rather than `impl Stream` on purpose: nesting an opaque
+    // `impl Stream` inside an `async fn`'s opaque future triggers a rustc ICE under coverage
+    // instrumentation (096694416, 2026-06-29), so we hand back a concrete type instead.
     async fn execute_batch(
         self,
         batch: RecordBatch,
-    ) -> datafusion::common::Result<impl Stream<Item = datafusion::common::Result<RecordBatch>>>
+    ) -> datafusion::common::Result<BoxStream<'static, datafusion::common::Result<RecordBatch>>>
     {
         let mut merge_statistics = self.merge_stats.lock().unwrap();
         let num_fields = batch.schema().fields.len();
@@ -2604,7 +2607,7 @@ impl Merger {
             WhenNotMatchedBySource::Keep => {}
         }
 
-        Ok(stream::iter(batches))
+        Ok(stream::iter(batches).boxed())
     }
 }
 

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -1075,6 +1075,10 @@ impl FilteredReadStream {
 
     // Reads a single fragment into a stream of batch tasks
     #[instrument(name = "read_fragment", skip_all)]
+    // Returns a boxed stream rather than `impl Stream` on purpose: nesting an opaque
+    // `impl Stream` inside an `async fn`'s opaque future triggers a rustc ICE under coverage
+    // instrumentation (096694416, 2026-06-29), so we hand back a concrete type instead. The
+    // stream is already boxed below, so this does not change runtime behavior.
     async fn read_fragment(
         mut fragment_read_task: ScopedFragmentRead,
         global_metrics: Arc<FilteredReadGlobalMetrics>,


### PR DESCRIPTION
## Summary

Nightly rustc (096694416, 2026-06-29) ICEs during well-formedness checks when
building under `-C instrument-coverage`, breaking the coverage CI job. The crash
is triggered whenever an `async fn` returns `Result<impl Stream<...>>`: the
opaque `impl Stream` gets nested inside the async fn's own opaque future
(`{opaque#0}::{opaque#0}`), which the trait solver mishandles.

This PR removes that nesting by having the affected async fns hand back a
concrete `BoxStream` instead of `impl Stream`. The streams are already boxed
internally, so there is no change in runtime behavior.

Functions fixed:

- `lance-index`: `NGramIndexBuilder::stream_spill_reader` / `stream_spill`
  (the reader has no `await`, so it becomes a synchronous `fn` returning a
  concrete `BoxStream`).
- `lance`: `FilteredReadStream::read_fragment`, `FragmentScanner::scan`,
  and `Merger::execute_batch` now return `Result<BoxStream<..>>`.

## Test plan

- [x] `cargo check -p lance --tests`
- [x] `cargo clippy -p lance --tests` (no warnings under `-D warnings`)
- [x] `cargo fmt --all`
- [ ] Coverage CI job (`cargo test --tests` under `-C instrument-coverage`) no
      longer ICEs and completes.